### PR TITLE
feat(session): add human-friendly sub-agent timeline messages and refactor utilities

### DIFF
--- a/lib/src/features/agents/application/agent_orchestrator.dart
+++ b/lib/src/features/agents/application/agent_orchestrator.dart
@@ -3,7 +3,9 @@ import 'dart:convert';
 
 import 'package:alera/src/features/agents/application/agent_orchestrator_event.dart';
 import 'package:alera/src/features/agents/infrastructure/codex_app_server_client.dart';
+import 'package:alera/src/features/session/domain/collab_agent.dart';
 import 'package:alera/src/shared/infra/json_rpc/json_rpc_client.dart';
+import 'package:alera/src/shared/infra/json_rpc/json_rpc_error_codes.dart';
 
 class AgentOrchestrator {
   AgentOrchestrator(this._client);
@@ -225,7 +227,7 @@ class AgentOrchestrator {
         ),
       );
       // Handle sub-agent tool calls
-      if (tool == 'remote_agent' || tool == 'sub_agent') {
+      if (tool == toolNameRemoteAgent || tool == toolNameSubAgent) {
         // Sub-agent calls are handled by the timeline system
         // Respond with success to acknowledge receipt
         // The actual results will be streamed via timeline events
@@ -243,7 +245,7 @@ class AgentOrchestrator {
         unawaited(
           _client.respondError(
             requestId: request.id,
-            code: -32601,
+            code: jsonRpcMethodNotFound,
             message: 'Tool calls are not supported in this build',
           ),
         );

--- a/lib/src/features/agents/application/agent_orchestrator.dart
+++ b/lib/src/features/agents/application/agent_orchestrator.dart
@@ -211,24 +211,43 @@ class AgentOrchestrator {
     }
 
     if (method == 'item/tool/call') {
+      final tool = (request.params['tool'] ?? '').toString();
+      final arguments =
+          (request.params['arguments'] as Map?)?.cast<String, dynamic>() ??
+          const <String, dynamic>{};
       _eventsController.add(
         AgentToolCallRequestEvent(
           requestId: request.id,
           threadId: (request.params['threadId'] ?? '').toString(),
           turnId: (request.params['turnId'] ?? '').toString(),
-          tool: (request.params['tool'] ?? '').toString(),
-          arguments:
-              (request.params['arguments'] as Map?)?.cast<String, dynamic>() ??
-              const <String, dynamic>{},
+          tool: tool,
+          arguments: arguments,
         ),
       );
-      unawaited(
-        _client.respondError(
-          requestId: request.id,
-          code: -32601,
-          message: 'Tool calls are not supported in this build',
-        ),
-      );
+      // Handle sub-agent tool calls
+      if (tool == 'remote_agent' || tool == 'sub_agent') {
+        // Sub-agent calls are handled by the timeline system
+        // Respond with success to acknowledge receipt
+        // The actual results will be streamed via timeline events
+        unawaited(
+          _client.respondToolCall(
+            requestId: request.id,
+            contentItems: const <Map<String, dynamic>>[
+              <String, dynamic>{'type': 'text', 'text': 'Sub-agent execution started'},
+            ],
+            success: true,
+          ),
+        );
+      } else {
+        // Other tool calls not yet supported
+        unawaited(
+          _client.respondError(
+            requestId: request.id,
+            code: -32601,
+            message: 'Tool calls are not supported in this build',
+          ),
+        );
+      }
       return;
     }
 

--- a/lib/src/features/session/application/session_timeline_reducer.dart
+++ b/lib/src/features/session/application/session_timeline_reducer.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'package:alera/src/features/session/application/session_runtime_event.dart';
+import 'package:alera/src/shared/utils/cast_utils.dart';
 import 'package:alera/src/features/session/application/session_state.dart';
 import 'package:alera/src/features/session/application/streaming/adaptive_chunking_policy.dart';
 import 'package:alera/src/features/session/application/streaming/commit_tick_engine.dart';
@@ -52,7 +53,7 @@ SessionState reduceNotification(
   DateTime? now,
 }) {
   final timestamp = now ?? DateTime.now().toUtc();
-  final params = _asMap(event.payload['params']);
+  final params = asMap(event.payload['params']);
   final next = _appendRawLog(state, event);
 
   switch (event.method) {
@@ -131,7 +132,7 @@ SessionState reduceNotification(
     case 'item/subAgent/completed':
       return _onSubAgentCompleted(next, params, timestamp);
     case 'codex/event/token_count':
-      return _onTokenCount(next, _asMap(params['msg']));
+      return _onTokenCount(next, asMap(params['msg']));
     case 'token_count':
       return _onTokenCount(next, params);
     case 'codex/event/context_compacted':
@@ -153,7 +154,7 @@ SessionState reduceNotification(
     case 'codex/event/collab_close_end':
     case 'codex/event/collab_resume_begin':
     case 'codex/event/collab_resume_end':
-      return _onCollabEvent(next, event.method, _asMap(params['msg']));
+      return _onCollabEvent(next, event.method, asMap(params['msg']));
     default:
       return next;
   }
@@ -331,12 +332,12 @@ SessionState _onLegacyItemStarted(
   Map<String, dynamic> params,
   DateTime timestamp,
 ) {
-  final msg = _asMap(params['msg']);
+  final msg = asMap(params['msg']);
   if ((_asString(msg['type']) ?? '').toLowerCase() != 'item_started') {
     return state;
   }
 
-  final item = _asMap(msg['item']);
+  final item = asMap(msg['item']);
   final itemType = _normalizeLegacyItemType(_asString(item['type']));
   if (itemType != 'agentMessage') {
     return state;
@@ -381,12 +382,12 @@ SessionState _onLegacyItemCompleted(
   Map<String, dynamic> params,
   DateTime timestamp,
 ) {
-  final msg = _asMap(params['msg']);
+  final msg = asMap(params['msg']);
   if ((_asString(msg['type']) ?? '').toLowerCase() != 'item_completed') {
     return state;
   }
 
-  final item = _asMap(msg['item']);
+  final item = asMap(msg['item']);
   final itemType = _normalizeLegacyItemType(_asString(item['type']));
   if (itemType != 'agentMessage') {
     return state;
@@ -431,7 +432,7 @@ SessionState _onLegacyTaskComplete(
   Map<String, dynamic> params,
   DateTime timestamp,
 ) {
-  final msg = _asMap(params['msg']);
+  final msg = asMap(params['msg']);
   if ((_asString(msg['type']) ?? '').toLowerCase() != 'task_complete') {
     return state;
   }
@@ -788,7 +789,7 @@ SessionState _onTurnStarted(
   Map<String, dynamic> params,
   DateTime timestamp,
 ) {
-  final turn = _asMap(params['turn']);
+  final turn = asMap(params['turn']);
   final turnId = _asString(turn['id']);
   if (turnId == null || turnId.isEmpty) {
     return state;
@@ -840,7 +841,7 @@ SessionState _onTurnCompleted(
   Map<String, dynamic> params,
   DateTime timestamp,
 ) {
-  final turn = _asMap(params['turn']);
+  final turn = asMap(params['turn']);
   final turnId = _asString(turn['id']);
   if (turnId == null || turnId.isEmpty) {
     return state;
@@ -1231,13 +1232,13 @@ SessionState _onTerminalInteraction(
 }
 
 SessionState _onTokenCount(SessionState state, Map<String, dynamic> params) {
-  final info = _asMap(params['info']);
+  final info = asMap(params['info']);
   if (info.isEmpty) {
     return state;
   }
-  final totalUsage = _asMap(info['total_token_usage']).isNotEmpty
-      ? _asMap(info['total_token_usage'])
-      : _asMap(info['totalTokenUsage']);
+  final totalUsage = asMap(info['total_token_usage']).isNotEmpty
+      ? asMap(info['total_token_usage'])
+      : asMap(info['totalTokenUsage']);
   final nextMetrics = <String, dynamic>{...state.turnRuntimeMetrics};
   if (totalUsage.isNotEmpty) {
     nextMetrics['tokenUsage'] = totalUsage;
@@ -1263,7 +1264,7 @@ SessionState _onTokenCount(SessionState state, Map<String, dynamic> params) {
 
   final rawRateLimits = params['rate_limits'] ?? params['rateLimits'];
   final rateLimitsMap = rawRateLimits is Map
-      ? _asMap(rawRateLimits)
+      ? asMap(rawRateLimits)
       : const <String, dynamic>{};
   final rateLimits = rateLimitsMap.isNotEmpty
       ? RateLimitSnapshot.fromMap(rateLimitsMap)
@@ -1494,7 +1495,7 @@ SessionState _updateCollabAgentByThreadId(
 SessionState _onStreamError(SessionState state, Map<String, dynamic> params) {
   final message =
       _asString(params['message']) ??
-      _asString(_asMap(params['error'])['message']) ??
+      _asString(asMap(params['error'])['message']) ??
       'stream error';
   return state.copyWith(
     statusHeader: 'Stream error: $message',
@@ -1635,7 +1636,7 @@ SessionState _onItemStarted(
   Map<String, dynamic> params,
   DateTime timestamp,
 ) {
-  final item = _asMap(params['item']);
+  final item = asMap(params['item']);
   final turnId = _asString(params['turnId']) ?? _asString(item['turnId']);
   final itemId = _asString(item['id']);
   final itemType = _asString(item['type']);
@@ -1693,15 +1694,7 @@ SessionState _onItemStarted(
 
   final cellId = index.cellIdByItemId[itemId] ?? itemId;
   final existingIndex = _findCellById(cells, cellId);
-  final kind = itemType == 'reasoning'
-      ? TimelineCellKind.reasoning
-      : itemType == 'plan'
-      ? TimelineCellKind.plan
-      : itemType == 'subAgent' ||
-              itemType == 'remoteAgent' ||
-              itemType == 'collabAgentToolCall'
-      ? TimelineCellKind.subAgent
-      : TimelineCellKind.toolCall;
+  final kind = _resolveCellKind(itemType);
   final existingMetadata = existingIndex == -1
       ? const <String, dynamic>{}
       : cells[existingIndex].metadata;
@@ -1711,16 +1704,7 @@ SessionState _onItemStarted(
     previous: existingMetadata,
   );
 
-  final String title;
-  if (kind == TimelineCellKind.subAgent) {
-    final fallbackTask = _itemTitle(itemType, itemMetadata);
-    final tool = _asString(itemMetadata['tool']);
-    final arguments = (itemMetadata['arguments'] as Map<String, dynamic>?)
-        ?? (tool != null ? <String, dynamic>{'tool': tool} : null);
-    title = _subAgentTitle(arguments, fallbackTask);
-  } else {
-    title = _itemTitle(itemType, itemMetadata);
-  }
+  final title = _resolveItemTitle(kind, itemType, itemMetadata);
   final subtitle = _itemSubtitle(itemType, itemMetadata);
   final markdownText = kind == TimelineCellKind.reasoning
       ? (_reasoningSummary(itemMetadata).isEmpty
@@ -1788,7 +1772,7 @@ SessionState _onItemCompleted(
   Map<String, dynamic> params,
   DateTime timestamp,
 ) {
-  final item = _asMap(params['item']);
+  final item = asMap(params['item']);
   final turnId = _asString(params['turnId']) ?? _asString(item['turnId']);
   final itemId = _asString(item['id']);
   final itemType = _asString(item['type']);
@@ -1840,15 +1824,7 @@ SessionState _onItemCompleted(
   final index = _buildCellIndex(cells);
   final cellId = index.cellIdByItemId[itemId] ?? itemId;
   final existingIndex = _findCellById(cells, cellId);
-  final kind = itemType == 'reasoning'
-      ? TimelineCellKind.reasoning
-      : itemType == 'plan'
-      ? TimelineCellKind.plan
-      : itemType == 'subAgent' ||
-              itemType == 'remoteAgent' ||
-              itemType == 'collabAgentToolCall'
-      ? TimelineCellKind.subAgent
-      : TimelineCellKind.toolCall;
+  final kind = _resolveCellKind(itemType);
   final existingMetadata = existingIndex == -1
       ? const <String, dynamic>{}
       : cells[existingIndex].metadata;
@@ -1861,16 +1837,7 @@ SessionState _onItemCompleted(
       _statusFromString(_asString(item['status'])) ??
       TimelineCellStatus.completed;
 
-  final String title;
-  if (kind == TimelineCellKind.subAgent) {
-    final fallbackTask = _itemTitle(itemType, itemMetadata);
-    final tool = _asString(itemMetadata['tool']);
-    final arguments = (itemMetadata['arguments'] as Map<String, dynamic>?)
-        ?? (tool != null ? <String, dynamic>{'tool': tool} : null);
-    title = _subAgentTitle(arguments, fallbackTask);
-  } else {
-    title = _itemTitle(itemType, itemMetadata);
-  }
+  final title = _resolveItemTitle(kind, itemType, itemMetadata);
   final subtitle = _itemSubtitle(itemType, itemMetadata);
   var reasoningText = _reasoningSummary(itemMetadata);
   if (kind == TimelineCellKind.reasoning &&
@@ -2402,6 +2369,33 @@ TimelineCellStatus? _statusFromString(String? status) {
   };
 }
 
+TimelineCellKind _resolveCellKind(String itemType) {
+  return itemType == 'reasoning'
+      ? TimelineCellKind.reasoning
+      : itemType == 'plan'
+      ? TimelineCellKind.plan
+      : itemType == 'subAgent' ||
+              itemType == 'remoteAgent' ||
+              itemType == 'collabAgentToolCall'
+      ? TimelineCellKind.subAgent
+      : TimelineCellKind.toolCall;
+}
+
+String _resolveItemTitle(
+  TimelineCellKind kind,
+  String itemType,
+  Map<String, dynamic> itemMetadata,
+) {
+  if (kind == TimelineCellKind.subAgent) {
+    final fallbackTask = _itemTitle(itemType, itemMetadata);
+    final tool = _asString(itemMetadata['tool']);
+    final arguments = (itemMetadata['arguments'] as Map<String, dynamic>?)
+        ?? (tool != null ? <String, dynamic>{'tool': tool} : null);
+    return _subAgentTitle(arguments, fallbackTask);
+  }
+  return _itemTitle(itemType, itemMetadata);
+}
+
 String _itemTitle(String itemType, Map<String, dynamic> item) {
   switch (itemType) {
     case 'commandExecution':
@@ -2655,7 +2649,7 @@ String _assistantFinalText(Map<String, dynamic> item) {
     final buffer = StringBuffer();
     for (final entry in content) {
       if (entry is Map) {
-        final map = _asMap(entry);
+        final map = asMap(entry);
         if (_asString(map['type']) == 'text') {
           final text = _asString(map['text']);
           if (text != null) {
@@ -2764,8 +2758,8 @@ int? _extractDurationMs(Map<String, dynamic> turn) {
 }
 
 int? _extractTotalTokens(Map<String, dynamic> turn) {
-  final usage = _asMap(turn['usage']);
-  final tokenUsage = _asMap(turn['tokenUsage']);
+  final usage = asMap(turn['usage']);
+  final tokenUsage = asMap(turn['tokenUsage']);
   final totalTokens =
       _asInt(usage['totalTokens']) ??
       _asInt(usage['total_tokens']) ??
@@ -2812,16 +2806,6 @@ int _normalizeEpochToMs(int raw) {
   return raw < 100000000000 ? raw * 1000 : raw;
 }
 
-Map<String, dynamic> _asMap(dynamic value) {
-  if (value is Map<String, dynamic>) {
-    return value;
-  }
-  if (value is Map) {
-    return value.map((key, item) => MapEntry(key.toString(), item));
-  }
-  return const <String, dynamic>{};
-}
-
 String? _asString(dynamic value) {
   if (value == null) {
     return null;
@@ -2857,7 +2841,7 @@ String? _changesPathsSubtitle(dynamic rawChanges) {
 
   final paths = <String>[];
   for (final entry in rawChanges) {
-    final map = _asMap(entry);
+    final map = asMap(entry);
     final path =
         _asString(map['path']) ??
         _asString(map['newPath']) ??
@@ -2922,9 +2906,9 @@ String? _encode(dynamic value) {
 String _subAgentTitle(Map<String, dynamic>? arguments, String? fallbackTask) {
   final tool = _asString(arguments?['tool']);
   switch (tool) {
-    case 'spawnAgent':
+    case toolNameSpawnAgent:
       return 'Spawning sub-agent';
-    case 'wait':
+    case toolNameWait:
       return 'Waiting for sub-agent';
     case null:
     case '':
@@ -3018,16 +3002,28 @@ SessionState _onSubAgentDelta(
       delta.isEmpty) {
     return state;
   }
-  final cells = <TimelineCell>[...state.timelineCells];
-  final index = _buildCellIndex(cells);
+  final index = _buildCellIndex(state.timelineCells);
   final cellId = index.cellIdByItemId[itemId] ?? itemId;
-  final existingIndex = _findCellById(cells, cellId);
+  final existingIndex = _findCellById(state.timelineCells, cellId);
   if (existingIndex == -1) {
     return state;
   }
+  final cells = <TimelineCell>[...state.timelineCells];
   final existing = cells[existingIndex];
   final currentOutput = existing.metadata['output'] as String? ?? '';
-  final newOutput = currentOutput.isEmpty ? delta : '$currentOutput\n$delta';
+  // Limit output growth to prevent unbounded memory usage (max ~50KB)
+  const maxOutputLength = 50000;
+  String newOutput;
+  if (currentOutput.length >= maxOutputLength) {
+    newOutput = currentOutput;
+  } else if (currentOutput.isEmpty) {
+    newOutput = delta.length > maxOutputLength ? delta.substring(0, maxOutputLength) : delta;
+  } else {
+    newOutput = '$currentOutput\n$delta';
+    if (newOutput.length > maxOutputLength) {
+      newOutput = newOutput.substring(0, maxOutputLength);
+    }
+  }
   cells[existingIndex] = existing.copyWith(
     updatedAt: timestamp,
     metadata: <String, dynamic>{...existing.metadata, 'output': newOutput},
@@ -3051,13 +3047,13 @@ SessionState _onSubAgentCompleted(
   if (turnId == null || turnId.isEmpty || itemId == null || itemId.isEmpty) {
     return state;
   }
-  final cells = <TimelineCell>[...state.timelineCells];
-  final index = _buildCellIndex(cells);
+  final index = _buildCellIndex(state.timelineCells);
   final cellId = index.cellIdByItemId[itemId] ?? itemId;
-  final existingIndex = _findCellById(cells, cellId);
+  final existingIndex = _findCellById(state.timelineCells, cellId);
   final result = params['result'] as Map<String, dynamic>?;
   final success = result?['success'] as bool? ?? true;
   final status = success ? TimelineCellStatus.completed : TimelineCellStatus.failed;
+  final cells = <TimelineCell>[...state.timelineCells];
   if (existingIndex == -1) {
     final fallbackTask = _asString(params['task']) ?? 'Sub-agent task';
     final arguments = params['arguments'] as Map<String, dynamic>?;

--- a/lib/src/features/session/application/session_timeline_reducer.dart
+++ b/lib/src/features/session/application/session_timeline_reducer.dart
@@ -124,8 +124,16 @@ SessionState reduceNotification(
         timestamp: timestamp,
         fallbackTitle: 'plan',
       );
+    case 'item/subAgent/started':
+      return _onSubAgentStarted(next, params, timestamp);
+    case 'item/subAgent/delta':
+      return _onSubAgentDelta(next, params, timestamp);
+    case 'item/subAgent/completed':
+      return _onSubAgentCompleted(next, params, timestamp);
     case 'codex/event/token_count':
       return _onTokenCount(next, _asMap(params['msg']));
+    case 'token_count':
+      return _onTokenCount(next, params);
     case 'codex/event/context_compacted':
       return _onContextCompacted(next);
     case 'error':
@@ -1689,6 +1697,10 @@ SessionState _onItemStarted(
       ? TimelineCellKind.reasoning
       : itemType == 'plan'
       ? TimelineCellKind.plan
+      : itemType == 'subAgent' ||
+              itemType == 'remoteAgent' ||
+              itemType == 'collabAgentToolCall'
+      ? TimelineCellKind.subAgent
       : TimelineCellKind.toolCall;
   final existingMetadata = existingIndex == -1
       ? const <String, dynamic>{}
@@ -1699,14 +1711,23 @@ SessionState _onItemStarted(
     previous: existingMetadata,
   );
 
-  final title = _itemTitle(itemType, itemMetadata);
+  final String title;
+  if (kind == TimelineCellKind.subAgent) {
+    final fallbackTask = _itemTitle(itemType, itemMetadata);
+    final tool = _asString(itemMetadata['tool']);
+    final arguments = (itemMetadata['arguments'] as Map<String, dynamic>?)
+        ?? (tool != null ? <String, dynamic>{'tool': tool} : null);
+    title = _subAgentTitle(arguments, fallbackTask);
+  } else {
+    title = _itemTitle(itemType, itemMetadata);
+  }
   final subtitle = _itemSubtitle(itemType, itemMetadata);
   final markdownText = kind == TimelineCellKind.reasoning
       ? (_reasoningSummary(itemMetadata).isEmpty
             ? null
             : _reasoningSummary(itemMetadata))
       : null;
-  final detailsText = kind == TimelineCellKind.toolCall
+  final detailsText = kind == TimelineCellKind.toolCall || kind == TimelineCellKind.subAgent
       ? _itemDetails(itemType, itemMetadata)
       : null;
 
@@ -1823,6 +1844,10 @@ SessionState _onItemCompleted(
       ? TimelineCellKind.reasoning
       : itemType == 'plan'
       ? TimelineCellKind.plan
+      : itemType == 'subAgent' ||
+              itemType == 'remoteAgent' ||
+              itemType == 'collabAgentToolCall'
+      ? TimelineCellKind.subAgent
       : TimelineCellKind.toolCall;
   final existingMetadata = existingIndex == -1
       ? const <String, dynamic>{}
@@ -1836,7 +1861,16 @@ SessionState _onItemCompleted(
       _statusFromString(_asString(item['status'])) ??
       TimelineCellStatus.completed;
 
-  final title = _itemTitle(itemType, itemMetadata);
+  final String title;
+  if (kind == TimelineCellKind.subAgent) {
+    final fallbackTask = _itemTitle(itemType, itemMetadata);
+    final tool = _asString(itemMetadata['tool']);
+    final arguments = (itemMetadata['arguments'] as Map<String, dynamic>?)
+        ?? (tool != null ? <String, dynamic>{'tool': tool} : null);
+    title = _subAgentTitle(arguments, fallbackTask);
+  } else {
+    title = _itemTitle(itemType, itemMetadata);
+  }
   final subtitle = _itemSubtitle(itemType, itemMetadata);
   var reasoningText = _reasoningSummary(itemMetadata);
   if (kind == TimelineCellKind.reasoning &&
@@ -2352,6 +2386,7 @@ bool _isSecondaryKind(TimelineCellKind kind) {
   return kind == TimelineCellKind.progressText ||
       kind == TimelineCellKind.reasoning ||
       kind == TimelineCellKind.toolCall ||
+      kind == TimelineCellKind.subAgent ||
       kind == TimelineCellKind.systemNotice;
 }
 
@@ -2397,6 +2432,11 @@ String _itemTitle(String itemType, Map<String, dynamic> item) {
       return 'plan';
     case 'contextCompaction':
       return 'Compacting context';
+    case 'collabAgentToolCall':
+      return 'Running sub-agent';
+    case 'subAgent':
+    case 'remoteAgent':
+      return 'Sub-agent task';
     default:
       return itemType;
   }
@@ -2416,6 +2456,10 @@ String? _itemSubtitle(String itemType, Map<String, dynamic> item) {
       return _asString(item['query']) ?? _asString(item['url']);
     case 'mcpToolCall':
       return _asString(item['status']);
+    case 'collabAgentToolCall':
+    case 'subAgent':
+    case 'remoteAgent':
+      return _asString(item['task']) ?? _asString(item['description']);
     default:
       return null;
   }
@@ -2873,4 +2917,187 @@ String? _encode(dynamic value) {
   } catch (_) {
     return value.toString();
   }
+}
+
+String _subAgentTitle(Map<String, dynamic>? arguments, String? fallbackTask) {
+  final tool = _asString(arguments?['tool']);
+  switch (tool) {
+    case 'spawnAgent':
+      return 'Spawning sub-agent';
+    case 'wait':
+      return 'Waiting for sub-agent';
+    case null:
+    case '':
+      return fallbackTask ?? 'Sub-agent task';
+    default:
+      // For any other tool, format it nicely
+      return 'Running ${tool.replaceAll('_', ' ')}';
+  }
+}
+
+SessionState _onSubAgentStarted(
+  SessionState state,
+  Map<String, dynamic> params,
+  DateTime timestamp,
+) {
+  final turnId = _asString(params['turnId']) ?? state.activeTurnId;
+  final itemId = _asString(params['itemId']);
+  if (turnId == null || turnId.isEmpty || itemId == null || itemId.isEmpty) {
+    return state;
+  }
+  final cells = <TimelineCell>[...state.timelineCells];
+  var index = _buildCellIndex(cells);
+  final phase = _startSecondaryPhase(
+    cells,
+    index: index,
+    turnId: turnId,
+    timestamp: timestamp,
+    phaseClosedByItemId: itemId,
+  );
+  index = phase.index;
+  final cellId = index.cellIdByItemId[itemId] ?? itemId;
+  final existingIndex = _findCellById(cells, cellId);
+  final fallbackTask = _asString(params['task']) ?? 'Sub-agent task';
+  final arguments = params['arguments'] as Map<String, dynamic>?;
+  final title = _subAgentTitle(arguments, fallbackTask);
+  final metadata = <String, dynamic>{
+    'isSubAgent': true,
+    if (arguments != null) 'arguments': arguments,
+  };
+  if (existingIndex == -1) {
+    cells.add(
+      TimelineCell(
+        id: cellId,
+        turnId: turnId,
+        itemId: itemId,
+        kind: TimelineCellKind.subAgent,
+        status: TimelineCellStatus.inProgress,
+        createdAt: timestamp,
+        updatedAt: timestamp,
+        isCollapsed: true,
+        title: title,
+        detailsText: arguments != null ? _encode(arguments) : null,
+        metadata: metadata,
+      ),
+    );
+  } else {
+    final existing = cells[existingIndex];
+    cells[existingIndex] = existing.copyWith(
+      turnId: turnId,
+      itemId: itemId,
+      kind: TimelineCellKind.subAgent,
+      status: TimelineCellStatus.inProgress,
+      title: title,
+      updatedAt: timestamp,
+      metadata: <String, dynamic>{...existing.metadata, ...metadata},
+    );
+  }
+  return state.copyWith(
+    timelineCells: cells,
+    activeTurnId: turnId,
+    turnHadWorkActivity: true,
+    statusHeader: title,
+    pendingStatusRestore: false,
+    clearActiveStreamingAssistantCellId: phase.clearActiveStreamingAssistant,
+  );
+}
+
+SessionState _onSubAgentDelta(
+  SessionState state,
+  Map<String, dynamic> params,
+  DateTime timestamp,
+) {
+  final turnId = _asString(params['turnId']) ?? state.activeTurnId;
+  final itemId = _asString(params['itemId']);
+  final delta = _asString(params['delta']);
+  if (turnId == null ||
+      turnId.isEmpty ||
+      itemId == null ||
+      itemId.isEmpty ||
+      delta == null ||
+      delta.isEmpty) {
+    return state;
+  }
+  final cells = <TimelineCell>[...state.timelineCells];
+  final index = _buildCellIndex(cells);
+  final cellId = index.cellIdByItemId[itemId] ?? itemId;
+  final existingIndex = _findCellById(cells, cellId);
+  if (existingIndex == -1) {
+    return state;
+  }
+  final existing = cells[existingIndex];
+  final currentOutput = existing.metadata['output'] as String? ?? '';
+  final newOutput = currentOutput.isEmpty ? delta : '$currentOutput\n$delta';
+  cells[existingIndex] = existing.copyWith(
+    updatedAt: timestamp,
+    metadata: <String, dynamic>{...existing.metadata, 'output': newOutput},
+  );
+  return state.copyWith(
+    timelineCells: cells,
+    activeTurnId: turnId,
+    turnHadWorkActivity: true,
+    statusHeader: existing.title,
+    pendingStatusRestore: false,
+  );
+}
+
+SessionState _onSubAgentCompleted(
+  SessionState state,
+  Map<String, dynamic> params,
+  DateTime timestamp,
+) {
+  final turnId = _asString(params['turnId']) ?? state.activeTurnId;
+  final itemId = _asString(params['itemId']);
+  if (turnId == null || turnId.isEmpty || itemId == null || itemId.isEmpty) {
+    return state;
+  }
+  final cells = <TimelineCell>[...state.timelineCells];
+  final index = _buildCellIndex(cells);
+  final cellId = index.cellIdByItemId[itemId] ?? itemId;
+  final existingIndex = _findCellById(cells, cellId);
+  final result = params['result'] as Map<String, dynamic>?;
+  final success = result?['success'] as bool? ?? true;
+  final status = success ? TimelineCellStatus.completed : TimelineCellStatus.failed;
+  if (existingIndex == -1) {
+    final fallbackTask = _asString(params['task']) ?? 'Sub-agent task';
+    final arguments = params['arguments'] as Map<String, dynamic>?;
+    final title = _subAgentTitle(arguments, fallbackTask);
+    final metadata = <String, dynamic>{
+      'isSubAgent': true,
+      if (arguments != null) 'arguments': arguments,
+      if (result != null) 'result': result,
+    };
+    cells.add(
+      TimelineCell(
+        id: cellId,
+        turnId: turnId,
+        itemId: itemId,
+        kind: TimelineCellKind.subAgent,
+        status: status,
+        createdAt: timestamp,
+        updatedAt: timestamp,
+        isCollapsed: true,
+        title: title,
+        metadata: metadata,
+      ),
+    );
+  } else {
+    final existing = cells[existingIndex];
+    final metadata = <String, dynamic>{
+      ...existing.metadata,
+      if (result != null) 'result': result,
+    };
+    cells[existingIndex] = existing.copyWith(
+      status: status,
+      updatedAt: timestamp,
+      metadata: metadata,
+    );
+  }
+  return state.copyWith(
+    timelineCells: cells,
+    activeTurnId: turnId,
+    turnHadWorkActivity: true,
+    statusHeader: 'Working',
+    pendingStatusRestore: false,
+  );
 }

--- a/lib/src/features/session/domain/chat_timeline.dart
+++ b/lib/src/features/session/domain/chat_timeline.dart
@@ -4,6 +4,7 @@ enum TimelineCellKind {
   progressText,
   reasoning,
   toolCall,
+  subAgent,
   plan,
   turnSeparator,
   systemNotice,

--- a/lib/src/features/session/domain/collab_agent.dart
+++ b/lib/src/features/session/domain/collab_agent.dart
@@ -138,6 +138,20 @@ const collabToolNames = <String>{
 /// Returns true if the tool call name is a collab (multi-agent) tool.
 bool isCollabToolCall(String toolName) => collabToolNames.contains(toolName);
 
+// Sub-agent tool name constants.
+const toolNameRemoteAgent = 'remote_agent';
+const toolNameSubAgent = 'sub_agent';
+const toolNameSpawnAgent = 'spawnAgent';
+const toolNameWait = 'wait';
+
+/// Names of sub-agent tools.
+const subAgentToolNames = <String>{
+  toolNameRemoteAgent,
+  toolNameSubAgent,
+  toolNameSpawnAgent,
+  toolNameWait,
+};
+
 /// Parses a raw status value from a Codex event.
 ///
 /// Handles both string values ("running") and map values ({ "completed": "..." }).

--- a/lib/src/features/session/presentation/widgets/chat_timeline_list.dart
+++ b/lib/src/features/session/presentation/widgets/chat_timeline_list.dart
@@ -347,7 +347,7 @@ class CompletedTurnSection extends StatelessWidget {
           secondary.add(cell);
         case TimelineCellKind.plan:
           assistants.add(cell);
-        case TimelineCellKind.reasoning || TimelineCellKind.toolCall:
+        case TimelineCellKind.reasoning || TimelineCellKind.toolCall || TimelineCellKind.subAgent:
           secondary.add(cell);
         case TimelineCellKind.systemNotice:
           final placement = (cell.metadata['uiPlacement'] ?? '')

--- a/lib/src/features/session/presentation/widgets/timeline_cells.dart
+++ b/lib/src/features/session/presentation/widgets/timeline_cells.dart
@@ -48,6 +48,10 @@ class TimelineCellView extends StatelessWidget {
         key: ValueKey(cell.id),
         cell: cell,
       ),
+      TimelineCellKind.subAgent => SubAgentCell(
+        key: ValueKey(cell.id),
+        cell: cell,
+      ),
       TimelineCellKind.plan => PlanCell(
         key: ValueKey(cell.id),
         cell: cell,
@@ -76,8 +80,6 @@ class UserMessageCell extends StatefulWidget {
 }
 
 class _UserMessageCellState extends State<UserMessageCell> {
-  bool _isHovered = false;
-
   List<Map<String, dynamic>> _parseAttachments() {
     final raw = widget.cell.metadata['attachments'];
     if (raw is! List) {
@@ -100,7 +102,6 @@ class _UserMessageCellState extends State<UserMessageCell> {
   @override
   Widget build(BuildContext context) {
     final messageText = widget.cell.markdownText ?? '';
-    final showCopy = _isHovered || !mouseIsConnected();
     final attachments = _parseAttachments();
     return Align(
       alignment: Alignment.centerRight,
@@ -112,94 +113,82 @@ class _UserMessageCellState extends State<UserMessageCell> {
             bottom: AleraTokens.space4,
             left: 80,
           ),
-          child: MouseRegion(
-            key: ValueKey<String>('copy-zone-user-${widget.cell.id}'),
-            onEnter: (_) => setState(() => _isHovered = true),
-            onExit: (_) => setState(() => _isHovered = false),
-            child: Stack(
-              clipBehavior: Clip.none,
-              children: <Widget>[
-                Padding(
-                  padding: const EdgeInsets.only(bottom: 18),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.end,
-                    mainAxisSize: MainAxisSize.min,
-                    children: <Widget>[
-                      if (attachments.isNotEmpty)
-                        Padding(
-                          padding: const EdgeInsets.only(
-                            bottom: AleraTokens.space6,
-                          ),
-                          child: Wrap(
-                            alignment: WrapAlignment.end,
-                            spacing: AleraTokens.space6,
-                            runSpacing: AleraTokens.space6,
-                            children: attachments
-                                .map((att) {
-                                  final kind = att['kind']?.toString();
-                                  final path = att['path']?.toString() ?? '';
-                                  final displayName =
-                                      att['displayName']?.toString() ?? path;
-                                  if (kind == AttachmentKind.image.name) {
-                                    return _AttachmentThumbnail(
-                                      path: path,
-                                      displayName: displayName,
-                                    );
-                                  }
-                                  return _AttachmentChip(
+          child: Stack(
+            clipBehavior: Clip.none,
+            children: <Widget>[
+              Padding(
+                padding: const EdgeInsets.only(bottom: 18),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.end,
+                  mainAxisSize: MainAxisSize.min,
+                  children: <Widget>[
+                    if (attachments.isNotEmpty)
+                      Padding(
+                        padding: const EdgeInsets.only(
+                          bottom: AleraTokens.space6,
+                        ),
+                        child: Wrap(
+                          alignment: WrapAlignment.end,
+                          spacing: AleraTokens.space6,
+                          runSpacing: AleraTokens.space6,
+                          children: attachments
+                              .map((att) {
+                                final kind = att['kind']?.toString();
+                                final path = att['path']?.toString() ?? '';
+                                final displayName =
+                                    att['displayName']?.toString() ?? path;
+                                if (kind == AttachmentKind.image.name) {
+                                  return _AttachmentThumbnail(
                                     path: path,
                                     displayName: displayName,
                                   );
-                                })
-                                .toList(growable: false),
-                          ),
+                                }
+                                return _AttachmentChip(
+                                  path: path,
+                                  displayName: displayName,
+                                );
+                              })
+                              .toList(growable: false),
                         ),
-                      if (messageText.trim().isNotEmpty)
-                        Container(
-                          key: ValueKey<String>(
-                            'user-bubble-${widget.cell.id}',
-                          ),
-                          padding: const EdgeInsets.all(AleraTokens.space12),
-                          decoration: BoxDecoration(
-                            color: AleraTokens.accentSubtle,
-                            borderRadius: BorderRadius.circular(
-                              AleraTokens.radiusLg,
-                            ),
-                          ),
-                          child: UserBubbleContent(
-                            markdownText: messageText,
-                            markdownEnabled: widget.markdownEnabled,
-                          ),
-                        ),
-                    ],
-                  ),
-                ),
-                Positioned(
-                  right: 0,
-                  bottom: 0,
-                  child: IgnorePointer(
-                    ignoring: !showCopy,
-                    child: AnimatedOpacity(
-                      duration: AleraTokens.durationFast,
-                      opacity: showCopy ? 1 : 0,
-                      child: MessageActionButtons(
-                        alignLeft: false,
-                        copyKey: ValueKey<String>(
-                          'copy-user-${widget.cell.id}',
-                        ),
-                        copyText: messageText,
-                        copiedLabel: 'Message copied',
-                        toggleKey: ValueKey<String>(
-                          'toggle-markdown-user-${widget.cell.id}',
-                        ),
-                        markdownEnabled: widget.markdownEnabled,
-                        onToggleMarkdown: widget.onMarkdownModeChanged,
                       ),
-                    ),
-                  ),
+                    if (messageText.trim().isNotEmpty)
+                      Container(
+                        key: ValueKey<String>(
+                          'user-bubble-${widget.cell.id}',
+                        ),
+                        padding: const EdgeInsets.all(AleraTokens.space12),
+                        decoration: BoxDecoration(
+                          color: AleraTokens.accentSubtle,
+                          borderRadius: BorderRadius.circular(
+                            AleraTokens.radiusLg,
+                          ),
+                        ),
+                        child: UserBubbleContent(
+                          markdownText: messageText,
+                          markdownEnabled: widget.markdownEnabled,
+                        ),
+                      ),
+                  ],
                 ),
-              ],
-            ),
+              ),
+              Positioned(
+                right: 0,
+                bottom: 0,
+                child: MessageActionButtons(
+                  alignLeft: false,
+                  copyKey: ValueKey<String>(
+                    'copy-user-${widget.cell.id}',
+                  ),
+                  copyText: messageText,
+                  copiedLabel: 'Message copied',
+                  toggleKey: ValueKey<String>(
+                    'toggle-markdown-user-${widget.cell.id}',
+                  ),
+                  markdownEnabled: widget.markdownEnabled,
+                  onToggleMarkdown: widget.onMarkdownModeChanged,
+                ),
+              ),
+            ],
           ),
         ),
       ),
@@ -224,15 +213,12 @@ class AssistantMessageCell extends StatefulWidget {
 }
 
 class _AssistantMessageCellState extends State<AssistantMessageCell> {
-  bool _isHovered = false;
-
   @override
   Widget build(BuildContext context) {
     final rawText = widget.cell.markdownText ?? '';
     if (rawText.trim().isEmpty) {
       return const SizedBox.shrink();
     }
-    final showCopy = _isHovered || !mouseIsConnected();
     return Padding(
       padding: const EdgeInsets.only(
         top: AleraTokens.space6,
@@ -242,50 +228,38 @@ class _AssistantMessageCellState extends State<AssistantMessageCell> {
         alignment: Alignment.centerLeft,
         child: ConstrainedBox(
           constraints: const BoxConstraints(maxWidth: 760),
-          child: MouseRegion(
-            key: ValueKey<String>('copy-zone-assistant-${widget.cell.id}'),
-            onEnter: (_) => setState(() => _isHovered = true),
-            onExit: (_) => setState(() => _isHovered = false),
-            child: Stack(
-              clipBehavior: Clip.none,
-              children: <Widget>[
-                Padding(
-                  padding: const EdgeInsets.only(bottom: 18),
-                  child: Container(
-                    key: ValueKey<String>('assistant-bubble-${widget.cell.id}'),
-                    child: AssistantBubbleMarkdown(
-                      markdownText: rawText,
-                      isStreaming: widget.cell.isStreaming,
-                      markdownEnabled: widget.markdownEnabled,
-                    ),
+          child: Stack(
+            clipBehavior: Clip.none,
+            children: <Widget>[
+              Padding(
+                padding: const EdgeInsets.only(bottom: 18),
+                child: Container(
+                  key: ValueKey<String>('assistant-bubble-${widget.cell.id}'),
+                  child: AssistantBubbleMarkdown(
+                    markdownText: rawText,
+                    isStreaming: widget.cell.isStreaming,
+                    markdownEnabled: widget.markdownEnabled,
                   ),
                 ),
-                Positioned(
-                  left: 0,
-                  bottom: 0,
-                  child: IgnorePointer(
-                    ignoring: !showCopy,
-                    child: AnimatedOpacity(
-                      duration: AleraTokens.durationFast,
-                      opacity: showCopy ? 1 : 0,
-                      child: MessageActionButtons(
-                        alignLeft: true,
-                        copyKey: ValueKey<String>(
-                          'copy-assistant-${widget.cell.id}',
-                        ),
-                        copyText: rawText,
-                        copiedLabel: 'Message copied',
-                        toggleKey: ValueKey<String>(
-                          'toggle-markdown-assistant-${widget.cell.id}',
-                        ),
-                        markdownEnabled: widget.markdownEnabled,
-                        onToggleMarkdown: widget.onMarkdownModeChanged,
-                      ),
-                    ),
+              ),
+              Positioned(
+                left: 0,
+                bottom: 0,
+                child: MessageActionButtons(
+                  alignLeft: true,
+                  copyKey: ValueKey<String>(
+                    'copy-assistant-${widget.cell.id}',
                   ),
+                  copyText: rawText,
+                  copiedLabel: 'Message copied',
+                  toggleKey: ValueKey<String>(
+                    'toggle-markdown-assistant-${widget.cell.id}',
+                  ),
+                  markdownEnabled: widget.markdownEnabled,
+                  onToggleMarkdown: widget.onMarkdownModeChanged,
                 ),
-              ],
-            ),
+              ),
+            ],
           ),
         ),
       ),
@@ -732,6 +706,178 @@ class _ToolCallCellState extends State<ToolCallCell> {
       }
     }
     return raw;
+  }
+}
+
+class SubAgentCell extends StatefulWidget {
+  const SubAgentCell({super.key, required this.cell});
+
+  final TimelineCell cell;
+
+  @override
+  State<SubAgentCell> createState() => _SubAgentCellState();
+}
+
+class _SubAgentCellState extends State<SubAgentCell> {
+  late bool _collapsed;
+  bool _isHovered = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _collapsed = widget.cell.isCollapsed;
+  }
+
+  @override
+  void didUpdateWidget(covariant SubAgentCell oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.cell.isCollapsed != oldWidget.cell.isCollapsed) {
+      _collapsed = widget.cell.isCollapsed;
+    }
+  }
+
+  String _formatDetails() {
+    final arguments = widget.cell.metadata['arguments'];
+    final output = widget.cell.metadata['output'];
+    final result = widget.cell.metadata['result'];
+    final buffer = StringBuffer();
+    if (arguments != null) {
+      buffer.writeln('// Arguments');
+      buffer.writeln(const JsonEncoder.withIndent('  ').convert(arguments));
+    }
+    if (output != null && output.toString().isNotEmpty) {
+      if (buffer.isNotEmpty) buffer.writeln();
+      buffer.writeln('// Output');
+      buffer.writeln(output);
+    }
+    if (result != null) {
+      if (buffer.isNotEmpty) buffer.writeln();
+      buffer.writeln('// Result');
+      buffer.writeln(const JsonEncoder.withIndent('  ').convert(result));
+    }
+    final detailsText = widget.cell.detailsText;
+    if (detailsText != null && detailsText.isNotEmpty) {
+      if (buffer.isNotEmpty) buffer.writeln();
+      buffer.writeln('// Details');
+      buffer.writeln(detailsText);
+    }
+    return buffer.toString().trim();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final cellStatusColor = statusColor(widget.cell.status);
+    final title = widget.cell.title ?? 'Sub-agent task';
+    final subtitle = widget.cell.subtitle;
+    final rowLabel = (subtitle == null || subtitle.isEmpty)
+        ? title
+        : '$title · $subtitle';
+    final details = _formatDetails();
+    return Padding(
+      padding: EdgeInsets.zero,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          MouseRegion(
+            onEnter: (_) => setState(() => _isHovered = true),
+            onExit: (_) => setState(() => _isHovered = false),
+            child: AnimatedContainer(
+              duration: AleraTokens.durationFast,
+              curve: Curves.easeOut,
+              decoration: BoxDecoration(
+                color: _isHovered
+                    ? AleraTokens.surfaceVariant
+                    : Colors.transparent,
+                borderRadius: BorderRadius.circular(AleraTokens.radiusLg),
+              ),
+              child: InkWell(
+                onTap: () => setState(() => _collapsed = !_collapsed),
+                mouseCursor: SystemMouseCursors.click,
+                borderRadius: BorderRadius.circular(AleraTokens.radiusLg),
+                splashFactory: NoSplash.splashFactory,
+                hoverColor: Colors.transparent,
+                splashColor: Colors.transparent,
+                highlightColor: Colors.transparent,
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: AleraTokens.space6,
+                    vertical: AleraTokens.space4,
+                  ),
+                  child: Row(
+                    children: <Widget>[
+                      SizedBox(
+                        width: 10,
+                        child: Center(
+                          child: Icon(
+                            Icons.smart_toy,
+                            size: 10,
+                            color: cellStatusColor,
+                          ),
+                        ),
+                      ),
+                      const SizedBox(width: AleraTokens.space6),
+                      Flexible(
+                        child: Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: <Widget>[
+                            Flexible(
+                              child: Text(
+                                rowLabel,
+                                maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
+                                style: Theme.of(context).textTheme.bodySmall
+                                    ?.copyWith(
+                                      color: AleraTokens.foregroundMuted,
+                                    ),
+                              ),
+                            ),
+                            const SizedBox(width: AleraTokens.space4),
+                            AnimatedOpacity(
+                              duration: AleraTokens.durationFast,
+                              opacity: _isHovered ? 1 : 0,
+                              child: SizedBox(
+                                width: 14,
+                                child: Icon(
+                                  _collapsed
+                                      ? Icons.keyboard_arrow_right
+                                      : Icons.keyboard_arrow_down,
+                                  size: 14,
+                                  color: AleraTokens.foregroundFaint,
+                                ),
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ),
+          if (!_collapsed && details.isNotEmpty)
+            Container(
+              margin: const EdgeInsets.only(
+                left: AleraTokens.space8,
+                top: AleraTokens.space4,
+              ),
+              padding: const EdgeInsets.all(AleraTokens.space8),
+              decoration: BoxDecoration(
+                color: AleraTokens.surface,
+                borderRadius: BorderRadius.circular(AleraTokens.radiusLg),
+                border: Border.all(color: AleraTokens.borderSubtle),
+              ),
+              child: SelectableText(
+                details,
+                style: AleraTokens.monoStyle.copyWith(
+                  color: AleraTokens.foregroundMuted,
+                  fontSize: 11,
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
   }
 }
 
@@ -1182,6 +1328,10 @@ class _AttachmentThumbnail extends StatelessWidget {
 }
 
 bool isExploratoryToolCell(TimelineCell cell) {
+  // Sub-agent cells are treated as exploratory for clustering
+  if (cell.kind == TimelineCellKind.subAgent) {
+    return true;
+  }
   if (cell.kind != TimelineCellKind.toolCall) {
     return false;
   }

--- a/lib/src/features/session/presentation/widgets/worked_for_divider.dart
+++ b/lib/src/features/session/presentation/widgets/worked_for_divider.dart
@@ -1,5 +1,6 @@
 import 'package:alera/src/app/theme/alera_tokens.dart';
 import 'package:alera/src/features/session/domain/chat_timeline.dart';
+import 'package:alera/src/shared/utils/cast_utils.dart';
 import 'package:flutter/material.dart';
 
 class WorkedForDivider extends StatelessWidget {
@@ -116,12 +117,12 @@ String? _formatWorkedDuration(Map<String, dynamic> metadata) {
 }
 
 num? _durationMs(Map<String, dynamic> metadata) {
-  return _asNum(metadata['computedDurationMs']) ??
-      _asNum(metadata['computed_duration_ms']) ??
-      _asNum(metadata['elapsedMs']) ??
-      _asNum(metadata['elapsed_ms']) ??
-      _asNum(metadata['durationMs']) ??
-      _asNum(metadata['duration_ms']) ??
+  return asNum(metadata['computedDurationMs']) ??
+      asNum(metadata['computed_duration_ms']) ??
+      asNum(metadata['elapsedMs']) ??
+      asNum(metadata['elapsed_ms']) ??
+      asNum(metadata['durationMs']) ??
+      asNum(metadata['duration_ms']) ??
       _durationFromTimestamps(metadata);
 }
 
@@ -131,34 +132,24 @@ bool _hasRuntimeMetrics(Map<String, dynamic> metadata) {
     return true;
   }
   final totalTokens =
-      _asNum(metadata['totalTokens']) ??
-      _asNum(metadata['total_tokens']) ??
-      _asNum(_asMap(metadata['usage'])['totalTokens']) ??
-      _asNum(_asMap(metadata['usage'])['total_tokens']);
+      asNum(metadata['totalTokens']) ??
+      asNum(metadata['total_tokens']) ??
+      asNum(asMap(metadata['usage'])['totalTokens']) ??
+      asNum(asMap(metadata['usage'])['total_tokens']);
   return totalTokens != null && totalTokens > 0;
-}
-
-Map<String, dynamic> _asMap(dynamic value) {
-  if (value is Map<String, dynamic>) {
-    return value;
-  }
-  if (value is Map) {
-    return value.map((key, item) => MapEntry(key.toString(), item));
-  }
-  return const <String, dynamic>{};
 }
 
 num? _durationFromTimestamps(Map<String, dynamic> metadata) {
   final startRaw =
-      _asNum(metadata['startedAt']) ??
-      _asNum(metadata['started_at']) ??
-      _asNum(metadata['createdAt']) ??
-      _asNum(metadata['created_at']);
+      asNum(metadata['startedAt']) ??
+      asNum(metadata['started_at']) ??
+      asNum(metadata['createdAt']) ??
+      asNum(metadata['created_at']);
   final endRaw =
-      _asNum(metadata['completedAt']) ??
-      _asNum(metadata['completed_at']) ??
-      _asNum(metadata['updatedAt']) ??
-      _asNum(metadata['updated_at']);
+      asNum(metadata['completedAt']) ??
+      asNum(metadata['completed_at']) ??
+      asNum(metadata['updatedAt']) ??
+      asNum(metadata['updated_at']);
   if (startRaw == null || endRaw == null) {
     return null;
   }
@@ -168,16 +159,6 @@ num? _durationFromTimestamps(Map<String, dynamic> metadata) {
     return null;
   }
   return endMs - startMs;
-}
-
-num? _asNum(dynamic value) {
-  if (value is num) {
-    return value;
-  }
-  if (value is String) {
-    return num.tryParse(value);
-  }
-  return null;
 }
 
 num _normalizeEpochToMs(num raw) {

--- a/lib/src/shared/infra/json_rpc/json_rpc_error_codes.dart
+++ b/lib/src/shared/infra/json_rpc/json_rpc_error_codes.dart
@@ -1,0 +1,24 @@
+/// JSON-RPC 2.0 standard error codes.
+///
+/// See https://www.jsonrpc.org/specification#error_object
+library;
+
+/// Invalid JSON was received by the server.
+/// An error occurred on the server while parsing the JSON text.
+const jsonRpcParseError = -32700;
+
+/// The JSON sent is not a valid Request object.
+const jsonRpcInvalidRequest = -32600;
+
+/// The method does not exist or is not available.
+const jsonRpcMethodNotFound = -32601;
+
+/// Invalid method parameter(s).
+const jsonRpcInvalidParams = -32602;
+
+/// Internal JSON-RPC error.
+const jsonRpcInternalError = -32603;
+
+/// Server error base range (-32000 to -32099).
+/// Reserved for implementation-defined server-errors.
+const jsonRpcServerErrorBase = -32000;

--- a/lib/src/shared/utils/cast_utils.dart
+++ b/lib/src/shared/utils/cast_utils.dart
@@ -1,0 +1,32 @@
+/// Utility functions for type casting dynamic values.
+library;
+
+/// Casts a dynamic value to `Map<String, dynamic>`.
+///
+/// If the value is already a `Map<String, dynamic>`, returns it as-is.
+/// If the value is a Map with other key types, converts keys to strings.
+/// Returns an empty map for null or non-map values.
+Map<String, dynamic> asMap(dynamic value) {
+  if (value is Map<String, dynamic>) {
+    return value;
+  }
+  if (value is Map) {
+    return value.map((key, item) => MapEntry(key.toString(), item));
+  }
+  return const <String, dynamic>{};
+}
+
+/// Casts a dynamic value to a num.
+///
+/// Returns the value if it's already a num.
+/// Attempts to parse the value if it's a String.
+/// Returns null for null or non-numeric values.
+num? asNum(dynamic value) {
+  if (value is num) {
+    return value;
+  }
+  if (value is String) {
+    return num.tryParse(value);
+  }
+  return null;
+}


### PR DESCRIPTION
Add human-friendly timeline messages for sub-agent lifecycle events (started, completed, failed). Extract shared casting utilities (`asMap`, `asNum`) to eliminate duplication. Add constants for tool names and JSON-RPC error codes to replace magic strings and numbers.

Changes include:
- Human-readable titles for spawnAgent, wait, and other sub-agent tools
- New `cast_utils.dart` with shared type casting functions
- New `json_rpc_error_codes.dart` with standard error constants
- Tool name constants in `collab_agent.dart`