### PR TITLE
fix: remove duplicate method declarations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ coverage/
 macos/Flutter/ephemeral/
 linux/flutter/ephemeral/
 windows/flutter/ephemeral/
+
+# Conductor workspace
+.context/

--- a/lib/src/features/agents/application/agent_orchestrator.dart
+++ b/lib/src/features/agents/application/agent_orchestrator.dart
@@ -292,9 +292,4 @@ class AgentOrchestrator {
   ) {
     return _client.respondUserInput(requestId: requestId, answers: answers);
   }
-
-  /// Requests manual context compaction for the given thread.
-  Future<void> compactThread({required String threadId}) {
-    return _client.compactThread(threadId: threadId);
-  }
 }

--- a/lib/src/features/agents/infrastructure/codex_app_server_client.dart
+++ b/lib/src/features/agents/infrastructure/codex_app_server_client.dart
@@ -282,14 +282,6 @@ class CodexAppServerClient {
     return _wsClient!.respondError(id: requestId, code: code, message: message);
   }
 
-  /// Requests manual context compaction for the given thread.
-  Future<Map<String, dynamic>> compactThread({required String threadId}) {
-    return _wsClient!.request(
-      'thread/compact/start',
-      params: <String, dynamic>{'threadId': threadId},
-    );
-  }
-
   Future<void> close() async {
     await _wsClient?.close();
     _process?.kill();

--- a/lib/src/features/session/application/session_service.dart
+++ b/lib/src/features/session/application/session_service.dart
@@ -335,17 +335,4 @@ class SessionService {
     }
     return compact.length <= 60 ? compact : '${compact.substring(0, 57)}...';
   }
-
-  Future<void> compactContext({required String sessionId}) async {
-    final session = _sessions[sessionId];
-    if (session == null) {
-      throw StateError('session not found: $sessionId');
-    }
-    final threadId = session.threadId;
-    if (threadId == null || threadId.isEmpty) {
-      throw StateError('session has no thread id');
-    }
-    await _ensureOrchestrator();
-    await _orchestrator.compactThread(threadId: threadId);
-  }
 }


### PR DESCRIPTION
remove duplicated `compactcontext` and `compactthread` methods that were declared twice in the same classes, causing compilation errors when running `flutter run -d macos`.

files affected:
- `session_service.dart`: removed duplicate `compactcontext`
- `agent_orchestrator.dart`: removed duplicate `compactthread`
- `codex_app_server_client.dart`: removed duplicate `compactthread`