### PR TITLE
Add steering capability for queued messages

### DIFF
--- a/lib/src/features/session/application/session_controller.dart
+++ b/lib/src/features/session/application/session_controller.dart
@@ -575,6 +575,70 @@ class SessionController extends StateNotifier<SessionState> {
     }
   }
 
+  Future<void> steerQueuedMessage(String messageId) async {
+    final message = state.pendingMessages.firstWhere(
+      (m) => m.id == messageId,
+      orElse: () => throw StateError('queued message not found: $messageId'),
+    );
+    final activeTurnId = state.activeTurnId;
+    final activeSessionId = state.activeSessionId;
+    if (activeTurnId == null || activeSessionId == null) {
+      return;
+    }
+
+    // Remove from queue.
+    state = state.copyWith(
+      pendingMessages: state.pendingMessages
+          .where((m) => m.id != messageId)
+          .toList(growable: false),
+    );
+
+    // Append optimistic user message with steering metadata.
+    final now = DateTime.now().toUtc();
+    final cell = TimelineCell(
+      id: 'user-steer-${now.microsecondsSinceEpoch}',
+      kind: TimelineCellKind.userMessage,
+      status: TimelineCellStatus.inProgress,
+      createdAt: now,
+      updatedAt: now,
+      markdownText: message.text,
+      metadata: const <String, dynamic>{'isSteering': true},
+    );
+    state = state.copyWith(
+      timelineCells: <TimelineCell>[...state.timelineCells, cell],
+    );
+
+    // Build extra input items (attachments + steer rules).
+    final attachmentItems =
+        await _buildAttachmentInputItems(message.attachments);
+    final steerItems = _buildSteerInputItems();
+    final extraItems = <Map<String, dynamic>>[
+      ...attachmentItems,
+      ...steerItems,
+    ];
+
+    try {
+      await _sessionService.steerActiveTurn(
+        sessionId: activeSessionId,
+        rawInput: message.text,
+        expectedTurnId: activeTurnId,
+        extraInputItems: extraItems,
+      );
+    } catch (e) {
+      // Update the steering cell to failed status.
+      final cells = <TimelineCell>[...state.timelineCells];
+      final idx = cells.indexWhere((c) => c.id == cell.id);
+      if (idx != -1) {
+        cells[idx] = cells[idx].copyWith(
+          status: TimelineCellStatus.failed,
+          metadata: const <String, dynamic>{},
+        );
+        state = state.copyWith(timelineCells: cells);
+      }
+      state = state.copyWith(error: e.toString());
+    }
+  }
+
   void startEditingPendingMessage(String id) {
     state = state.copyWith(editingPendingMessageId: id);
   }

--- a/lib/src/features/session/application/session_timeline_reducer.dart
+++ b/lib/src/features/session/application/session_timeline_reducer.dart
@@ -804,9 +804,12 @@ SessionState _onTurnStarted(
   if (pendingUserCellId != null) {
     final userIndex = _findCellById(cells, pendingUserCellId);
     if (userIndex != -1) {
+      final wasSteering = cells[userIndex].metadata['isSteering'] == true;
       cells[userIndex] = cells[userIndex].copyWith(
         turnId: turnId,
         updatedAt: timestamp,
+        status: wasSteering ? TimelineCellStatus.completed : null,
+        metadata: wasSteering ? const <String, dynamic>{} : null,
       );
     }
   }

--- a/lib/src/features/session/presentation/session_workspace_view.dart
+++ b/lib/src/features/session/presentation/session_workspace_view.dart
@@ -41,6 +41,7 @@ class SessionWorkspaceView extends StatefulWidget {
     this.onPasteImage,
     required this.onRemoveAttachment,
     required this.onRemoveFromQueue,
+    required this.onSteerQueuedMessage,
     required this.onStartEditingPendingMessage,
     required this.onUpdatePendingMessage,
     required this.onDeletePendingMessage,
@@ -71,6 +72,7 @@ class SessionWorkspaceView extends StatefulWidget {
   final ValueChanged<File>? onPasteImage;
   final ValueChanged<String> onRemoveAttachment;
   final ValueChanged<String> onRemoveFromQueue;
+  final ValueChanged<String> onSteerQueuedMessage;
   final ValueChanged<String> onStartEditingPendingMessage;
   final void Function(String id, String text, List<ComposerAttachment> attachments)
       onUpdatePendingMessage;
@@ -315,6 +317,8 @@ class _SessionWorkspaceViewState extends State<SessionWorkspaceView> {
                     messages: widget.state.pendingMessages,
                     onRemove: widget.onRemoveFromQueue,
                     onEdit: _handleEditQueuedMessage,
+                    onSteer: widget.onSteerQueuedMessage,
+                    canSteer: widget.isTurnRunning && !widget.isInterrupting,
                   ),
                 ),
               ),

--- a/lib/src/features/session/presentation/widgets/message_queue_bar.dart
+++ b/lib/src/features/session/presentation/widgets/message_queue_bar.dart
@@ -8,11 +8,15 @@ class MessageQueueBar extends StatelessWidget {
     required this.messages,
     required this.onRemove,
     required this.onEdit,
+    required this.onSteer,
+    required this.canSteer,
   });
 
   final List<PendingMessage> messages;
   final ValueChanged<String> onRemove;
   final ValueChanged<PendingMessage> onEdit;
+  final ValueChanged<String> onSteer;
+  final bool canSteer;
 
   @override
   Widget build(BuildContext context) {
@@ -67,6 +71,8 @@ class MessageQueueBar extends StatelessWidget {
                 message: msg,
                 onRemove: onRemove,
                 onEdit: onEdit,
+                onSteer: onSteer,
+                canSteer: canSteer,
               );
             },
           ),
@@ -81,11 +87,15 @@ class _QueueItem extends StatelessWidget {
     required this.message,
     required this.onRemove,
     required this.onEdit,
+    required this.onSteer,
+    required this.canSteer,
   });
 
   final PendingMessage message;
   final ValueChanged<String> onRemove;
   final ValueChanged<PendingMessage> onEdit;
+  final ValueChanged<String> onSteer;
+  final bool canSteer;
 
   @override
   Widget build(BuildContext context) {
@@ -114,6 +124,22 @@ class _QueueItem extends StatelessWidget {
               style: const TextStyle(
                 fontSize: 11,
                 color: AleraTokens.foregroundFaint,
+              ),
+            ),
+          ],
+          if (canSteer) ...<Widget>[
+            const SizedBox(width: AleraTokens.space4),
+            InkWell(
+              onTap: () => onSteer(message.id),
+              borderRadius: BorderRadius.circular(AleraTokens.radiusSm),
+              mouseCursor: SystemMouseCursors.click,
+              child: const Padding(
+                padding: EdgeInsets.all(AleraTokens.space2),
+                child: Icon(
+                  Icons.arrow_upward,
+                  size: 13,
+                  color: AleraTokens.accent,
+                ),
               ),
             ),
           ],

--- a/lib/src/features/session/presentation/widgets/timeline_cells.dart
+++ b/lib/src/features/session/presentation/widgets/timeline_cells.dart
@@ -99,10 +99,15 @@ class _UserMessageCellState extends State<UserMessageCell> {
     return list;
   }
 
+  bool get _isSteering =>
+      widget.cell.metadata['isSteering'] == true &&
+      widget.cell.status == TimelineCellStatus.inProgress;
+
   @override
   Widget build(BuildContext context) {
     final messageText = widget.cell.markdownText ?? '';
     final attachments = _parseAttachments();
+    final isSteering = _isSteering;
     return Align(
       alignment: Alignment.centerRight,
       child: ConstrainedBox(
@@ -162,10 +167,44 @@ class _UserMessageCellState extends State<UserMessageCell> {
                           borderRadius: BorderRadius.circular(
                             AleraTokens.radiusLg,
                           ),
+                          border: isSteering
+                              ? Border.all(
+                                  color: AleraTokens.accent.withValues(
+                                    alpha: 0.3,
+                                  ),
+                                )
+                              : null,
                         ),
                         child: UserBubbleContent(
                           markdownText: messageText,
                           markdownEnabled: widget.markdownEnabled,
+                        ),
+                      ),
+                    if (isSteering)
+                      Padding(
+                        padding: const EdgeInsets.only(
+                          top: AleraTokens.space4,
+                        ),
+                        child: Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: <Widget>[
+                            SizedBox(
+                              width: 10,
+                              height: 10,
+                              child: CircularProgressIndicator(
+                                strokeWidth: 1.5,
+                                color: AleraTokens.foregroundFaint,
+                              ),
+                            ),
+                            const SizedBox(width: AleraTokens.space4),
+                            const Text(
+                              'Steering...',
+                              style: TextStyle(
+                                fontSize: 11,
+                                color: AleraTokens.foregroundFaint,
+                              ),
+                            ),
+                          ],
                         ),
                       ),
                   ],

--- a/lib/src/features/shell/presentation/alera_shell_page.dart
+++ b/lib/src/features/shell/presentation/alera_shell_page.dart
@@ -114,6 +114,7 @@ class _AleraShellPageState extends ConsumerState<AleraShellPage> {
             onPasteImage: (file) => _pasteImage(controller, file),
             onRemoveAttachment: controller.removeAttachment,
             onRemoveFromQueue: controller.removeFromQueue,
+            onSteerQueuedMessage: controller.steerQueuedMessage,
             onStartEditingPendingMessage: controller.startEditingPendingMessage,
             onUpdatePendingMessage: controller.updatePendingMessage,
             onDeletePendingMessage: controller.removeFromQueue,

--- a/test/widget/session_workspace_view_test.dart
+++ b/test/widget/session_workspace_view_test.dart
@@ -92,6 +92,7 @@ Future<void> _pumpWorkspace(
           onAddAttachment: () {},
           onRemoveAttachment: (_) {},
           onRemoveFromQueue: (_) {},
+          onSteerQueuedMessage: (_) {},
           onStartEditingPendingMessage: (_) {},
           onUpdatePendingMessage: (_, __, ___) {},
           onDeletePendingMessage: (_) {},


### PR DESCRIPTION
## Summary
This PR adds the ability to "steer" queued messages by sending them as input to the currently active turn, rather than waiting for them to be sent as new messages. This allows users to provide additional context or corrections to an in-progress turn.

## Key Changes

- **New `steerQueuedMessage()` method in SessionController**: Implements the core steering logic that:
  - Removes a message from the pending queue
  - Creates an optimistic user message cell marked with `isSteering` metadata
  - Builds attachment and steering rule input items
  - Calls `_sessionService.steerActiveTurn()` to send the input
  - Handles errors by updating the cell status to failed

- **UI enhancements for steering messages**:
  - Added visual indicator (border and "Steering..." label with spinner) to user message cells during steering
  - Added "steer" button (up arrow icon) to queued message items in the message queue bar
  - Button is only enabled when a turn is actively running and not interrupting

- **Updated message queue bar**: 
  - Added `onSteer` callback and `canSteer` flag parameters
  - Displays steer button alongside existing edit and remove actions

- **Timeline state management**:
  - Updated `_onTurnStarted` reducer to mark steering cells as completed and clear their steering metadata when the turn starts

- **Integration in SessionWorkspaceView**:
  - Wired up the new `onSteerQueuedMessage` callback
  - Passes `canSteer` flag based on turn running state and interruption status

- **Test updates**: Updated widget tests to include the new `onSteerQueuedMessage` callback parameter

## Implementation Details

- Steering messages are identified by `metadata['isSteering'] == true` and `status == TimelineCellStatus.inProgress`
- The steering cell ID is generated using a timestamp-based format: `user-steer-{microsecondsSinceEpoch}`
- Steering is only available when there's an active turn and session, and the turn is not being interrupted
- Failed steering attempts update the cell status and display the error message

https://claude.ai/code/session_01RafBgfEoGjA6G1bRCDo2tC