### PR TITLE
fix: allow queueing messages while a turn is running

### DIFF
--- a/lib/src/features/session/presentation/session_workspace_view.dart
+++ b/lib/src/features/session/presentation/session_workspace_view.dart
@@ -331,7 +331,6 @@ class _SessionWorkspaceViewState extends State<SessionWorkspaceView> {
                   textFieldEnabled: hasWorkspace,
                   canSend:
                       hasWorkspace &&
-                      !widget.state.isBusy &&
                       !widget.isInterrupting,
                   canStop:
                       widget.state.activeSession != null &&

--- a/lib/src/features/session/presentation/widgets/composer.dart
+++ b/lib/src/features/session/presentation/widgets/composer.dart
@@ -91,12 +91,14 @@ class ComposerState extends State<Composer> {
   Timer? _mentionDebounce;
   List<SlashCommandDef> _slashCommands = const <SlashCommandDef>[];
   int _slashSelectedIndex = 0;
+  bool _hasText = false;
 
   @override
   void initState() {
     super.initState();
     _focusNode = widget.focusNode ?? FocusNode();
     _focusNode.onKeyEvent = _handleKeyEvent;
+    _hasText = widget.controller.text.isNotEmpty;
     widget.controller.addListener(_onControllerChanged);
   }
 
@@ -139,8 +141,6 @@ class ComposerState extends State<Composer> {
       codexReasoningEffortLabel(widget.activeReasoningEffort);
 
   bool get _hasOverlay => _mentionFiles.isNotEmpty || _slashCommands.isNotEmpty;
-
-  bool get _hasComposerText => widget.controller.text.trim().isNotEmpty;
 
   KeyEventResult _handleKeyEvent(FocusNode node, KeyEvent event) {
     // Intercept Cmd+V / Ctrl+V for clipboard image pasting.
@@ -229,6 +229,12 @@ class ComposerState extends State<Composer> {
   }
 
   void _onControllerChanged() {
+    final newHasText = widget.controller.text.isNotEmpty;
+    if (newHasText != _hasText) {
+      setState(() {
+        _hasText = newHasText;
+      });
+    }
     _mentionDebounce?.cancel();
     _mentionDebounce = Timer(
       const Duration(milliseconds: 120),
@@ -414,6 +420,53 @@ class ComposerState extends State<Composer> {
       text: nextText,
       selection: TextSelection.collapsed(offset: start + 1),
       composing: TextRange.empty,
+    );
+  }
+
+  Widget _buildActionButton() {
+    final bool isSendMode = _hasText || !widget.canStop;
+    final VoidCallback? onPressed;
+    final Widget icon;
+
+    if (isSendMode) {
+      onPressed = widget.canSend ? widget.onSend : null;
+      icon = const Icon(Icons.arrow_upward, size: 16);
+    } else if (widget.isInterrupting) {
+      onPressed = null;
+      icon = const RepaintBoundary(
+        child: SizedBox(
+          width: 14,
+          height: 14,
+          child: CircularProgressIndicator(
+            strokeWidth: 1.6,
+            color: AleraTokens.onAccent,
+          ),
+        ),
+      );
+    } else {
+      onPressed = widget.onInterrupt;
+      icon = const Icon(Icons.stop, size: 18);
+    }
+
+    return IconButton(
+      key: const ValueKey<String>('composer-send-stop-button'),
+      onPressed: onPressed,
+      mouseCursor: SystemMouseCursors.click,
+      constraints: const BoxConstraints(
+        minWidth: 32,
+        minHeight: 32,
+      ),
+      padding: EdgeInsets.zero,
+      style: IconButton.styleFrom(
+        backgroundColor: (widget.canSend || widget.canStop)
+            ? AleraTokens.accent
+            : AleraTokens.surface,
+        foregroundColor: (widget.canSend || widget.canStop)
+            ? AleraTokens.onAccent
+            : AleraTokens.foregroundFaint,
+        shape: const CircleBorder(),
+      ),
+      icon: icon,
     );
   }
 
@@ -666,51 +719,7 @@ class ComposerState extends State<Composer> {
                             ),
                           ),
                           const Spacer(),
-                          IconButton(
-                            key: const ValueKey<String>(
-                              'composer-send-stop-button',
-                            ),
-                            onPressed: _hasComposerText
-                                ? (widget.canSend ? widget.onSend : null)
-                                : (widget.canStop
-                                      ? (widget.isInterrupting
-                                            ? null
-                                            : widget.onInterrupt)
-                                      : (widget.canSend ? widget.onSend : null)),
-                            mouseCursor: SystemMouseCursors.click,
-                            constraints: const BoxConstraints(
-                              minWidth: 32,
-                              minHeight: 32,
-                            ),
-                            padding: EdgeInsets.zero,
-                            style: IconButton.styleFrom(
-                              backgroundColor:
-                                  (widget.canSend || widget.canStop)
-                                  ? AleraTokens.accent
-                                  : AleraTokens.surface,
-                              foregroundColor:
-                                  (widget.canSend || widget.canStop)
-                                  ? AleraTokens.onAccent
-                                  : AleraTokens.foregroundFaint,
-                              shape: const CircleBorder(),
-                            ),
-                            icon: _hasComposerText
-                                ? const Icon(Icons.arrow_upward, size: 16)
-                                : (widget.canStop
-                                      ? (widget.isInterrupting
-                                            ? const RepaintBoundary(
-                                                child: SizedBox(
-                                                  width: 14,
-                                                  height: 14,
-                                                  child: CircularProgressIndicator(
-                                                    strokeWidth: 1.6,
-                                                    color: AleraTokens.onAccent,
-                                                  ),
-                                                ),
-                                              )
-                                            : const Icon(Icons.stop, size: 18))
-                                      : const Icon(Icons.arrow_upward, size: 16)),
-                          ),
+                          _buildActionButton(),
                         ],
                       ),
                     ),

--- a/lib/src/features/session/presentation/widgets/composer.dart
+++ b/lib/src/features/session/presentation/widgets/composer.dart
@@ -140,6 +140,8 @@ class ComposerState extends State<Composer> {
 
   bool get _hasOverlay => _mentionFiles.isNotEmpty || _slashCommands.isNotEmpty;
 
+  bool get _hasComposerText => widget.controller.text.trim().isNotEmpty;
+
   KeyEventResult _handleKeyEvent(FocusNode node, KeyEvent event) {
     // Intercept Cmd+V / Ctrl+V for clipboard image pasting.
     if (event is KeyDownEvent &&
@@ -393,7 +395,7 @@ class ComposerState extends State<Composer> {
   }
 
   void _sendFromShortcut() {
-    if (!widget.canSend || widget.canStop) {
+    if (!widget.canSend) {
       return;
     }
     widget.onSend();
@@ -668,11 +670,13 @@ class ComposerState extends State<Composer> {
                             key: const ValueKey<String>(
                               'composer-send-stop-button',
                             ),
-                            onPressed: widget.canStop
-                                ? (widget.isInterrupting
-                                      ? null
-                                      : widget.onInterrupt)
-                                : (widget.canSend ? widget.onSend : null),
+                            onPressed: _hasComposerText
+                                ? (widget.canSend ? widget.onSend : null)
+                                : (widget.canStop
+                                      ? (widget.isInterrupting
+                                            ? null
+                                            : widget.onInterrupt)
+                                      : (widget.canSend ? widget.onSend : null)),
                             mouseCursor: SystemMouseCursors.click,
                             constraints: const BoxConstraints(
                               minWidth: 32,
@@ -690,20 +694,22 @@ class ComposerState extends State<Composer> {
                                   : AleraTokens.foregroundFaint,
                               shape: const CircleBorder(),
                             ),
-                            icon: widget.canStop
-                                ? (widget.isInterrupting
-                                      ? const RepaintBoundary(
-                                          child: SizedBox(
-                                            width: 14,
-                                            height: 14,
-                                            child: CircularProgressIndicator(
-                                              strokeWidth: 1.6,
-                                              color: AleraTokens.onAccent,
-                                            ),
-                                          ),
-                                        )
-                                      : const Icon(Icons.stop, size: 18))
-                                : const Icon(Icons.arrow_upward, size: 16),
+                            icon: _hasComposerText
+                                ? const Icon(Icons.arrow_upward, size: 16)
+                                : (widget.canStop
+                                      ? (widget.isInterrupting
+                                            ? const RepaintBoundary(
+                                                child: SizedBox(
+                                                  width: 14,
+                                                  height: 14,
+                                                  child: CircularProgressIndicator(
+                                                    strokeWidth: 1.6,
+                                                    color: AleraTokens.onAccent,
+                                                  ),
+                                                ),
+                                              )
+                                            : const Icon(Icons.stop, size: 18))
+                                      : const Icon(Icons.arrow_upward, size: 16)),
                           ),
                         ],
                       ),


### PR DESCRIPTION
Allow users to queue messages while the AI is processing a turn. Previously, the composer blocked sending when `isBusy` was true and the Enter key was disabled when `canStop` was true. Now users can type and press Enter at any time to queue messages, and the send button dynamically switches between send/stop based on whether text is entered.

Changes:
- Remove `!widget.state.isBusy` from `canSend` logic in session_workspace_view.dart
- Remove `|| widget.canStop` check from `_sendFromShortcut()` in composer.dart
- Add reactive `_hasText` state to composer for dynamic button rendering
- Extract `_buildActionButton()` method for clean send/stop button logic

Co-Authored-By: Leynier Gutiérrez González <leynier41@gmail.com>