### PR TITLE
fix: context usage indicator hover error and placement fixes

### DIFF
--- a/lib/src/features/session/application/session_timeline_reducer.dart
+++ b/lib/src/features/session/application/session_timeline_reducer.dart
@@ -1294,7 +1294,10 @@ SessionState _onContextCompacted(SessionState state, DateTime timestamp) {
     createdAt: timestamp,
     updatedAt: timestamp,
     markdownText: 'Context compacted',
-    metadata: const <String, dynamic>{'noticeType': 'context_compacted'},
+    metadata: const <String, dynamic>{
+      'noticeType': 'context_compacted',
+      'uiPlacement': 'outside_worked',
+    },
   );
   return state.copyWith(
     timelineCells: <TimelineCell>[...state.timelineCells, cell],

--- a/lib/src/features/session/application/session_timeline_reducer.dart
+++ b/lib/src/features/session/application/session_timeline_reducer.dart
@@ -968,7 +968,7 @@ SessionState _onTurnCompleted(
           markdownText: 'Stopped by user',
           metadata: const <String, dynamic>{
             'noticeType': 'user_stop',
-            'uiPlacement': 'outside_worked',
+            TimelineCellMetadata.uiPlacementKey: TimelineCellMetadata.outsideWorked,
             'ephemeralInputOnly': true,
           },
         ),
@@ -1296,7 +1296,7 @@ SessionState _onContextCompacted(SessionState state, DateTime timestamp) {
     markdownText: 'Context compacted',
     metadata: const <String, dynamic>{
       'noticeType': 'context_compacted',
-      'uiPlacement': 'outside_worked',
+      TimelineCellMetadata.uiPlacementKey: TimelineCellMetadata.outsideWorked,
     },
   );
   return state.copyWith(

--- a/lib/src/features/session/domain/chat_timeline.dart
+++ b/lib/src/features/session/domain/chat_timeline.dart
@@ -12,6 +12,15 @@ enum TimelineCellKind {
 
 enum TimelineCellStatus { inProgress, completed, failed, declined, info }
 
+/// Constants for TimelineCell metadata keys and values.
+abstract class TimelineCellMetadata {
+  /// Key for UI placement of system notices.
+  static const String uiPlacementKey = 'uiPlacement';
+
+  /// Value for placing notice outside the "Worked..." section.
+  static const String outsideWorked = 'outside_worked';
+}
+
 class TimelineCell {
   const TimelineCell({
     required this.id,

--- a/lib/src/features/session/presentation/widgets/chat_timeline_list.dart
+++ b/lib/src/features/session/presentation/widgets/chat_timeline_list.dart
@@ -350,11 +350,11 @@ class CompletedTurnSection extends StatelessWidget {
         case TimelineCellKind.reasoning || TimelineCellKind.toolCall || TimelineCellKind.subAgent:
           secondary.add(cell);
         case TimelineCellKind.systemNotice:
-          final placement = (cell.metadata['uiPlacement'] ?? '')
+          final placement = (cell.metadata[TimelineCellMetadata.uiPlacementKey] ?? '')
               .toString()
               .toLowerCase()
               .trim();
-          if (placement == 'outside_worked') {
+          if (placement == TimelineCellMetadata.outsideWorked) {
             postTurnNotices.add(cell);
           } else {
             secondary.add(cell);

--- a/lib/src/features/session/presentation/widgets/context_usage_indicator.dart
+++ b/lib/src/features/session/presentation/widgets/context_usage_indicator.dart
@@ -35,7 +35,11 @@ class _ContextUsageIndicatorState extends State<ContextUsageIndicator> {
   void didUpdateWidget(covariant ContextUsageIndicator oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (_overlayEntry != null) {
-      _overlayEntry!.markNeedsBuild();
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (_overlayEntry != null && mounted) {
+          _overlayEntry!.markNeedsBuild();
+        }
+      });
     }
   }
 

--- a/test/unit/session_timeline_reducer_test.dart
+++ b/test/unit/session_timeline_reducer_test.dart
@@ -1215,7 +1215,10 @@ void main() {
       expect(notices, hasLength(1));
       expect(notices.first.markdownText, 'Stopped by user');
       expect(notices.first.metadata['noticeType'], 'user_stop');
-      expect(notices.first.metadata['uiPlacement'], 'outside_worked');
+      expect(
+        notices.first.metadata[TimelineCellMetadata.uiPlacementKey],
+        TimelineCellMetadata.outsideWorked,
+      );
       expect(notices.first.metadata['ephemeralInputOnly'], isTrue);
     });
 

--- a/test/widget/session_workspace_view_test.dart
+++ b/test/widget/session_workspace_view_test.dart
@@ -2248,7 +2248,7 @@ void main() {
             markdownText: 'Stopped by user',
             metadata: const <String, dynamic>{
               'noticeType': 'user_stop',
-              'uiPlacement': 'outside_worked',
+              TimelineCellMetadata.uiPlacementKey: TimelineCellMetadata.outsideWorked,
               'ephemeralInputOnly': true,
             },
           ),


### PR DESCRIPTION
- fix: defer markNeedsBuild to post-frame callback to prevent setState during build error on hover
- fix: show context compacted notice outside worked section
- refactor: extract uiPlacement constants to TimelineCellMetadata class