### PR TITLE
feat: add safety mechanisms for steering and interrupts, improve queue ui

### DIFF
--- a/lib/src/features/session/application/session_controller.dart
+++ b/lib/src/features/session/application/session_controller.dart
@@ -40,6 +40,7 @@ class SessionController extends StateNotifier<SessionState> {
   final SettingsService _settingsService;
   StreamSubscription<SessionRuntimeEvent>? _eventsSub;
   Timer? _commitTickTimer;
+  Timer? _interruptSafetyTimer;
 
   var _bootstrapped = false;
   static const String _localPlanFallbackQuestionId = 'implement_plan';
@@ -618,19 +619,20 @@ class SessionController extends StateNotifier<SessionState> {
     ];
 
     try {
-      final returnedTurnId = await _sessionService.steerActiveTurn(
-        sessionId: activeSessionId,
-        rawInput: message.text,
-        expectedTurnId: activeTurnId,
-        extraInputItems: extraItems,
-      );
+      final returnedTurnId = await _sessionService
+          .steerActiveTurn(
+            sessionId: activeSessionId,
+            rawInput: message.text,
+            expectedTurnId: activeTurnId,
+            extraInputItems: extraItems,
+          )
+          .timeout(const Duration(seconds: 15));
       // Mark the steering cell as completed and assign it to the turn.
       _updateTimelineCell(
         cell.id,
         (c) => c.copyWith(
           status: TimelineCellStatus.completed,
           turnId: returnedTurnId,
-          metadata: const <String, dynamic>{},
           updatedAt: DateTime.now().toUtc(),
         ),
       );
@@ -640,7 +642,6 @@ class SessionController extends StateNotifier<SessionState> {
         cell.id,
         (c) => c.copyWith(
           status: TimelineCellStatus.failed,
-          metadata: const <String, dynamic>{},
         ),
       );
       state = state.copyWith(error: e.toString());
@@ -952,7 +953,11 @@ class SessionController extends StateNotifier<SessionState> {
 
     state = state.copyWith(isInterrupting: true, clearError: true);
     try {
-      await _sessionService.interruptActiveTurn(sessionId: session.id);
+      await _sessionService.interruptActiveTurn(
+        sessionId: session.id,
+        turnIdOverride: state.activeTurnId,
+      );
+      _scheduleInterruptSafetyTimeout();
     } catch (error) {
       state = state.copyWith(
         isInterrupting: false,
@@ -960,6 +965,15 @@ class SessionController extends StateNotifier<SessionState> {
         connectionState: AppServerConnectionState.error,
       );
     }
+  }
+
+  void _scheduleInterruptSafetyTimeout() {
+    _interruptSafetyTimer?.cancel();
+    _interruptSafetyTimer = Timer(const Duration(seconds: 10), () {
+      if (state.isInterrupting) {
+        state = state.copyWith(isInterrupting: false);
+      }
+    });
   }
 
   /// Requests manual context compaction for the active session.
@@ -992,6 +1006,7 @@ class SessionController extends StateNotifier<SessionState> {
   @override
   void dispose() {
     _stopCommitTicker();
+    _interruptSafetyTimer?.cancel();
     unawaited(_eventsSub?.cancel());
     super.dispose();
   }
@@ -1100,6 +1115,10 @@ class SessionController extends StateNotifier<SessionState> {
       final shouldClearInterrupting =
           ticked.isInterrupting &&
           (event.method == 'turn/completed' || event.method == 'turn/failed');
+      if (shouldClearInterrupting) {
+        _interruptSafetyTimer?.cancel();
+        _interruptSafetyTimer = null;
+      }
 
       state = ticked.copyWith(
         sessions: _sessionService.sessions,

--- a/lib/src/features/session/application/session_controller.dart
+++ b/lib/src/features/session/application/session_controller.dart
@@ -602,7 +602,7 @@ class SessionController extends StateNotifier<SessionState> {
       createdAt: now,
       updatedAt: now,
       markdownText: message.text,
-      metadata: const <String, dynamic>{'isSteering': true},
+      metadata: const <String, dynamic>{TimelineCellMetadata.isSteeringKey: true},
     );
     state = state.copyWith(
       timelineCells: <TimelineCell>[...state.timelineCells, cell],
@@ -618,24 +618,44 @@ class SessionController extends StateNotifier<SessionState> {
     ];
 
     try {
-      await _sessionService.steerActiveTurn(
+      final returnedTurnId = await _sessionService.steerActiveTurn(
         sessionId: activeSessionId,
         rawInput: message.text,
         expectedTurnId: activeTurnId,
         extraInputItems: extraItems,
       );
+      // Mark the steering cell as completed and assign it to the turn.
+      _updateTimelineCell(
+        cell.id,
+        (c) => c.copyWith(
+          status: TimelineCellStatus.completed,
+          turnId: returnedTurnId,
+          metadata: const <String, dynamic>{},
+          updatedAt: DateTime.now().toUtc(),
+        ),
+      );
     } catch (e) {
       // Update the steering cell to failed status.
-      final cells = <TimelineCell>[...state.timelineCells];
-      final idx = cells.indexWhere((c) => c.id == cell.id);
-      if (idx != -1) {
-        cells[idx] = cells[idx].copyWith(
+      _updateTimelineCell(
+        cell.id,
+        (c) => c.copyWith(
           status: TimelineCellStatus.failed,
           metadata: const <String, dynamic>{},
-        );
-        state = state.copyWith(timelineCells: cells);
-      }
+        ),
+      );
       state = state.copyWith(error: e.toString());
+    }
+  }
+
+  void _updateTimelineCell(
+    String cellId,
+    TimelineCell Function(TimelineCell) transform,
+  ) {
+    final cells = <TimelineCell>[...state.timelineCells];
+    final idx = cells.findIndexById(cellId);
+    if (idx != -1) {
+      cells[idx] = transform(cells[idx]);
+      state = state.copyWith(timelineCells: cells);
     }
   }
 

--- a/lib/src/features/session/application/session_timeline_reducer.dart
+++ b/lib/src/features/session/application/session_timeline_reducer.dart
@@ -232,7 +232,7 @@ SessionState reduceCommitTick(
       final streamPhase = _normalizeAgentPhase(line.streamPhase);
       if (streamPhase == 'final_answer') {
         final assistantCellId = line.itemId ?? 'assistant-final-${line.turnId}';
-        final assistantIndex = _findCellById(cells, assistantCellId);
+        final assistantIndex = cells.findIndexById(assistantCellId);
         if (assistantIndex == -1) {
           cells.add(
             TimelineCell(
@@ -471,7 +471,7 @@ SessionState _onLegacyTaskComplete(
   final cellId = existingAssistant?.id ?? 'assistant-final-$turnId';
   final existingIndex = existingAssistant == null
       ? -1
-      : _findCellById(cells, existingAssistant.id);
+      : cells.findIndexById(existingAssistant.id);
 
   final metadata = <String, dynamic>{
     'streamPhase': 'final_answer',
@@ -802,9 +802,10 @@ SessionState _onTurnStarted(
       : index.pendingUserCellIdQueue.last;
 
   if (pendingUserCellId != null) {
-    final userIndex = _findCellById(cells, pendingUserCellId);
+    final userIndex = cells.findIndexById(pendingUserCellId);
     if (userIndex != -1) {
-      final wasSteering = cells[userIndex].metadata['isSteering'] == true;
+      final wasSteering =
+          cells[userIndex].metadata[TimelineCellMetadata.isSteeringKey] == true;
       cells[userIndex] = cells[userIndex].copyWith(
         turnId: turnId,
         updatedAt: timestamp,
@@ -869,10 +870,21 @@ SessionState _onTurnCompleted(
   final cells = <TimelineCell>[...nextState.timelineCells];
   for (var i = 0; i < cells.length; i++) {
     final cell = cells[i];
+    // Safety net: complete any orphaned steering cells still in-progress.
+    if (cell.kind == TimelineCellKind.userMessage &&
+        cell.status == TimelineCellStatus.inProgress &&
+        cell.metadata[TimelineCellMetadata.isSteeringKey] == true) {
+      cells[i] = cell.copyWith(
+        status: TimelineCellStatus.completed,
+        metadata: const <String, dynamic>{},
+        turnId: cell.turnId ?? turnId,
+        updatedAt: timestamp,
+      );
+      continue;
+    }
     if (cell.turnId != turnId) {
       continue;
     }
-
     if (cell.kind == TimelineCellKind.assistantMessage && cell.isStreaming) {
       cells[i] = cell.copyWith(
         isStreaming: false,
@@ -881,7 +893,6 @@ SessionState _onTurnCompleted(
       );
       continue;
     }
-
     if (cell.kind == TimelineCellKind.progressText &&
         cell.status == TimelineCellStatus.inProgress) {
       cells[i] = cell.copyWith(
@@ -890,7 +901,6 @@ SessionState _onTurnCompleted(
       );
       continue;
     }
-
     if (_isSecondaryKind(cell.kind)) {
       cells[i] = cell.copyWith(isCollapsed: true, updatedAt: timestamp);
     }
@@ -921,7 +931,7 @@ SessionState _onTurnCompleted(
   if (durationFromCells != null && durationFromCells > 0) {
     separatorMetadata['computedDurationMs'] = durationFromCells;
   }
-  final existingSeparatorIndex = _findCellById(cells, separatorId);
+  final existingSeparatorIndex = cells.findIndexById(separatorId);
   if (showWorkSeparator) {
     final separator = TimelineCell(
       id: separatorId,
@@ -981,7 +991,7 @@ SessionState _onTurnCompleted(
   var clearStreaming = false;
   final activeStreamingId = nextState.activeStreamingAssistantCellId;
   if (activeStreamingId != null) {
-    final activeIndex = _findCellById(cells, activeStreamingId);
+    final activeIndex = cells.findIndexById(activeStreamingId);
     if (activeIndex != -1 && cells[activeIndex].turnId == turnId) {
       clearStreaming = true;
     }
@@ -1595,7 +1605,7 @@ SessionState _onToolDetailsChunk(
   index = phase.index;
 
   final cellId = index.cellIdByItemId[itemId] ?? itemId;
-  final existingIndex = _findCellById(cells, cellId);
+  final existingIndex = cells.findIndexById(cellId);
 
   final isPlan = fallbackTitle == 'plan';
   final cellKind = isPlan ? TimelineCellKind.plan : TimelineCellKind.toolCall;
@@ -1710,7 +1720,7 @@ SessionState _onItemStarted(
   index = phase.index;
 
   final cellId = index.cellIdByItemId[itemId] ?? itemId;
-  final existingIndex = _findCellById(cells, cellId);
+  final existingIndex = cells.findIndexById(cellId);
   final kind = _resolveCellKind(itemType);
   final existingMetadata = existingIndex == -1
       ? const <String, dynamic>{}
@@ -1840,7 +1850,7 @@ SessionState _onItemCompleted(
   final cells = <TimelineCell>[...state.timelineCells];
   final index = _buildCellIndex(cells);
   final cellId = index.cellIdByItemId[itemId] ?? itemId;
-  final existingIndex = _findCellById(cells, cellId);
+  final existingIndex = cells.findIndexById(cellId);
   final kind = _resolveCellKind(itemType);
   final existingMetadata = existingIndex == -1
       ? const <String, dynamic>{}
@@ -2027,7 +2037,7 @@ SessionState _onAssistantItemCompleted(
   var assistantCellId = itemId;
   final indexedByItemId = index.cellIdByItemId[itemId];
   if (indexedByItemId != null) {
-    final indexedAt = _findCellById(cells, indexedByItemId);
+    final indexedAt = cells.findIndexById(indexedByItemId);
     if (indexedAt != -1 &&
         cells[indexedAt].kind == TimelineCellKind.assistantMessage) {
       assistantCellId = indexedByItemId;
@@ -2052,7 +2062,7 @@ SessionState _onAssistantItemCompleted(
     if (streamCommittedForItem) 'streamCommitted': true,
   };
 
-  final existingIndex = _findCellById(cells, assistantCellId);
+  final existingIndex = cells.findIndexById(assistantCellId);
   if (existingIndex == -1 ||
       cells[existingIndex].kind != TimelineCellKind.assistantMessage) {
     final baseText = streamCommittedForItem ? '' : finalText;
@@ -2244,7 +2254,7 @@ _SecondaryPhaseResult _startSecondaryPhase(
   var clearedAssistantStreaming = false;
   final activeProgressId = index.activeProgressTextCellIdByTurn[turnId];
   if (activeProgressId != null) {
-    final activeProgressIndex = _findCellById(cells, activeProgressId);
+    final activeProgressIndex = cells.findIndexById(activeProgressId);
     if (activeProgressIndex != -1) {
       final activeProgress = cells[activeProgressIndex];
       if (activeProgress.status == TimelineCellStatus.inProgress) {
@@ -2263,7 +2273,7 @@ _SecondaryPhaseResult _startSecondaryPhase(
 
   final assistantCellId = index.assistantCellIdByTurn[turnId];
   if (assistantCellId != null) {
-    final assistantIndex = _findCellById(cells, assistantCellId);
+    final assistantIndex = cells.findIndexById(assistantCellId);
     if (assistantIndex != -1) {
       final assistant = cells[assistantIndex];
       final assistantText = assistant.markdownText ?? '';
@@ -2334,14 +2344,6 @@ bool _isHumanFacingInterimLine(String line) {
   return true;
 }
 
-int _findCellById(List<TimelineCell> cells, String id) {
-  for (var i = 0; i < cells.length; i++) {
-    if (cells[i].id == id) {
-      return i;
-    }
-  }
-  return -1;
-}
 
 int? _computeTurnDurationFromCells(
   List<TimelineCell> cells, {
@@ -2957,7 +2959,7 @@ SessionState _onSubAgentStarted(
   );
   index = phase.index;
   final cellId = index.cellIdByItemId[itemId] ?? itemId;
-  final existingIndex = _findCellById(cells, cellId);
+  final existingIndex = cells.findIndexById(cellId);
   final fallbackTask = _asString(params['task']) ?? 'Sub-agent task';
   final arguments = params['arguments'] as Map<String, dynamic>?;
   final title = _subAgentTitle(arguments, fallbackTask);
@@ -3021,7 +3023,7 @@ SessionState _onSubAgentDelta(
   }
   final index = _buildCellIndex(state.timelineCells);
   final cellId = index.cellIdByItemId[itemId] ?? itemId;
-  final existingIndex = _findCellById(state.timelineCells, cellId);
+  final existingIndex = state.timelineCells.findIndexById(cellId);
   if (existingIndex == -1) {
     return state;
   }
@@ -3066,7 +3068,7 @@ SessionState _onSubAgentCompleted(
   }
   final index = _buildCellIndex(state.timelineCells);
   final cellId = index.cellIdByItemId[itemId] ?? itemId;
-  final existingIndex = _findCellById(state.timelineCells, cellId);
+  final existingIndex = state.timelineCells.findIndexById(cellId);
   final result = params['result'] as Map<String, dynamic>?;
   final success = result?['success'] as bool? ?? true;
   final status = success ? TimelineCellStatus.completed : TimelineCellStatus.failed;

--- a/lib/src/features/session/application/session_timeline_reducer.dart
+++ b/lib/src/features/session/application/session_timeline_reducer.dart
@@ -810,7 +810,6 @@ SessionState _onTurnStarted(
         turnId: turnId,
         updatedAt: timestamp,
         status: wasSteering ? TimelineCellStatus.completed : null,
-        metadata: wasSteering ? const <String, dynamic>{} : null,
       );
     }
   }
@@ -876,7 +875,6 @@ SessionState _onTurnCompleted(
         cell.metadata[TimelineCellMetadata.isSteeringKey] == true) {
       cells[i] = cell.copyWith(
         status: TimelineCellStatus.completed,
-        metadata: const <String, dynamic>{},
         turnId: cell.turnId ?? turnId,
         updatedAt: timestamp,
       );

--- a/lib/src/features/session/domain/chat_timeline.dart
+++ b/lib/src/features/session/domain/chat_timeline.dart
@@ -19,6 +19,9 @@ abstract class TimelineCellMetadata {
 
   /// Value for placing notice outside the "Worked..." section.
   static const String outsideWorked = 'outside_worked';
+
+  /// Key indicating a user message is a steering injection.
+  static const String isSteeringKey = 'isSteering';
 }
 
 class TimelineCell {
@@ -94,5 +97,14 @@ class TimelineCell {
       itemId: clearItemId ? null : (itemId ?? this.itemId),
       metadata: metadata ?? this.metadata,
     );
+  }
+}
+
+extension TimelineCellListExtension on List<TimelineCell> {
+  int findIndexById(String id) {
+    for (var i = 0; i < length; i++) {
+      if (this[i].id == id) return i;
+    }
+    return -1;
   }
 }

--- a/lib/src/features/session/presentation/widgets/chat_timeline_list.dart
+++ b/lib/src/features/session/presentation/widgets/chat_timeline_list.dart
@@ -340,7 +340,11 @@ class CompletedTurnSection extends StatelessWidget {
     for (final cell in turnCells) {
       switch (cell.kind) {
         case TimelineCellKind.userMessage:
-          users.add(cell);
+          if (cell.metadata[TimelineCellMetadata.isSteeringKey] == true) {
+            assistants.add(cell);
+          } else {
+            users.add(cell);
+          }
         case TimelineCellKind.assistantMessage:
           assistants.add(cell);
         case TimelineCellKind.progressText:

--- a/lib/src/features/session/presentation/widgets/message_queue_bar.dart
+++ b/lib/src/features/session/presentation/widgets/message_queue_bar.dart
@@ -153,7 +153,7 @@ class _QueueItem extends StatelessWidget {
               child: Icon(
                 Icons.edit,
                 size: 13,
-                color: AleraTokens.foregroundFaint,
+                color: AleraTokens.accent,
               ),
             ),
           ),
@@ -167,7 +167,7 @@ class _QueueItem extends StatelessWidget {
               child: Icon(
                 Icons.close,
                 size: 13,
-                color: AleraTokens.foregroundFaint,
+                color: AleraTokens.error,
               ),
             ),
           ),

--- a/lib/src/features/session/presentation/widgets/queue_message_edit_dialog.dart
+++ b/lib/src/features/session/presentation/widgets/queue_message_edit_dialog.dart
@@ -360,16 +360,9 @@ class _QueueMessageEditDialogState extends State<QueueMessageEditDialog> {
   Widget build(BuildContext context) {
     return Dialog(
       backgroundColor: Colors.transparent,
-      child: Container(
+      child: SizedBox(
         width: 600,
-        decoration: BoxDecoration(
-          color: AleraTokens.surface,
-          borderRadius: BorderRadius.circular(AleraTokens.radiusXl),
-          border: Border.all(color: AleraTokens.border),
-        ),
-        child: Padding(
-          padding: const EdgeInsets.all(AleraTokens.space16),
-          child: Column(
+        child: Column(
             mainAxisSize: MainAxisSize.min,
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: <Widget>[
@@ -522,7 +515,6 @@ class _QueueMessageEditDialogState extends State<QueueMessageEditDialog> {
                 ],
               ),
             ],
-          ),
         ),
       ),
     );

--- a/lib/src/features/session/presentation/widgets/queue_message_edit_dialog.dart
+++ b/lib/src/features/session/presentation/widgets/queue_message_edit_dialog.dart
@@ -367,205 +367,162 @@ class _QueueMessageEditDialogState extends State<QueueMessageEditDialog> {
           borderRadius: BorderRadius.circular(AleraTokens.radiusXl),
           border: Border.all(color: AleraTokens.border),
         ),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: <Widget>[
-            // Header.
-            Padding(
-              padding: const EdgeInsets.all(AleraTokens.space16),
-              child: Row(
-                children: <Widget>[
-                  const Icon(
-                    Icons.edit_outlined,
-                    size: 18,
-                    color: AleraTokens.foregroundMuted,
-                  ),
-                  const SizedBox(width: AleraTokens.space8),
-                  const Text(
-                    'Edit queued message',
-                    style: TextStyle(
-                      fontSize: 14,
-                      fontWeight: FontWeight.w600,
-                      color: AleraTokens.foreground,
-                    ),
-                  ),
-                  const Spacer(),
-                  InkWell(
-                    onTap: _cancel,
-                    borderRadius: BorderRadius.circular(AleraTokens.radiusSm),
-                    mouseCursor: SystemMouseCursors.click,
-                    child: const Padding(
-                      padding: EdgeInsets.all(AleraTokens.space4),
-                      child: Icon(
-                        Icons.close,
-                        size: 18,
-                        color: AleraTokens.foregroundFaint,
-                      ),
-                    ),
-                  ),
-                ],
-              ),
-            ),
-            const Divider(height: 1, color: AleraTokens.border),
-            // Content.
-            Flexible(
-              child: SingleChildScrollView(
-                child: Padding(
-                  padding: const EdgeInsets.all(AleraTokens.space16),
-                  child: Column(
-                    mainAxisSize: MainAxisSize.min,
-                    crossAxisAlignment: CrossAxisAlignment.stretch,
-                    children: <Widget>[
-                      // Attachment bar.
-                      if (_attachments.isNotEmpty)
-                        Padding(
-                          padding: const EdgeInsets.only(
-                            bottom: AleraTokens.space12,
-                          ),
-                          child: AttachmentBar(
-                            attachments: _attachments,
-                            onRemove: _removeAttachment,
-                          ),
-                        ),
-                      // Text field with mention overlay.
-                      Stack(
-                        clipBehavior: Clip.none,
-                        children: [
-                          Container(
-                            decoration: BoxDecoration(
-                              color: AleraTokens.surfaceVariant,
-                              borderRadius: BorderRadius.circular(AleraTokens.radiusLg),
-                              border: Border.all(color: AleraTokens.border),
-                            ),
-                            child: TextField(
-                              controller: _textController,
-                              focusNode: _focusNode,
-                              minLines: 3,
-                              maxLines: 8,
-                              textInputAction: TextInputAction.newline,
-                              style: Theme.of(context).textTheme.bodyMedium,
-                              decoration: InputDecoration(
-                                hintText: 'Edit your message...',
-                                filled: true,
-                                fillColor: Colors.transparent,
-                                hoverColor: Colors.transparent,
-                                contentPadding: const EdgeInsets.fromLTRB(
-                                  AleraTokens.space12,
-                                  AleraTokens.space12,
-                                  AleraTokens.space12,
-                                  AleraTokens.space48,
-                                ),
-                                border: InputBorder.none,
-                                enabledBorder: InputBorder.none,
-                                focusedBorder: InputBorder.none,
-                                disabledBorder: InputBorder.none,
-                              ),
-                            ),
-                          ),
-                          // Add attachment button inside text field area.
-                          Positioned(
-                            left: AleraTokens.space8,
-                            bottom: AleraTokens.space8,
-                            child: IconButton(
-                              onPressed: _addAttachment,
-                              tooltip: 'Add photos & files',
-                              mouseCursor: SystemMouseCursors.click,
-                              constraints: const BoxConstraints(
-                                minWidth: 28,
-                                minHeight: 28,
-                              ),
-                              padding: const EdgeInsets.all(AleraTokens.space4),
-                              icon: const Icon(
-                                Icons.add,
-                                size: 18,
-                                color: AleraTokens.foregroundMuted,
-                              ),
-                            ),
-                          ),
-                          // @ mention overlay positioned above text field.
-                          if (_mentionFiles.isNotEmpty)
-                            Positioned(
-                              bottom: 60,
-                              left: 0,
-                              right: 0,
-                              child: Material(
-                                elevation: 4,
-                                color: Colors.transparent,
-                                borderRadius: BorderRadius.circular(AleraTokens.radiusLg),
-                                child: Container(
-                                  decoration: BoxDecoration(
-                                    color: AleraTokens.surfaceElevated,
-                                    borderRadius: BorderRadius.circular(AleraTokens.radiusLg),
-                                    border: Border.all(color: AleraTokens.border),
-                                    boxShadow: const [
-                                      BoxShadow(
-                                        color: AleraTokens.shadowSoft,
-                                        blurRadius: 8,
-                                        offset: Offset(0, -2),
-                                      ),
-                                    ],
-                                  ),
-                                  child: MentionFileList(
-                                    files: _mentionFiles,
-                                    selectedIndex: _mentionSelectedIndex,
-                                    onSelect: _selectMention,
-                                  ),
-                                ),
-                              ),
-                            ),
-                        ],
-                      ),
-                    ],
+        child: Padding(
+          padding: const EdgeInsets.all(AleraTokens.space16),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: <Widget>[
+              // Attachment bar.
+              if (_attachments.isNotEmpty)
+                Padding(
+                  padding: const EdgeInsets.only(bottom: AleraTokens.space12),
+                  child: AttachmentBar(
+                    attachments: _attachments,
+                    onRemove: _removeAttachment,
                   ),
                 ),
-              ),
-            ),
-            const Divider(height: 1, color: AleraTokens.border),
-            // Action bar.
-            Padding(
-              padding: const EdgeInsets.all(AleraTokens.space12),
-              child: Row(
-                children: <Widget>[
-                  // Delete button (left side).
-                  FilledButton(
-                    onPressed: _delete,
-                    style: FilledButton.styleFrom(
-                      backgroundColor: AleraTokens.error,
-                      foregroundColor: AleraTokens.onError,
-                      padding: const EdgeInsets.symmetric(
-                        horizontal: AleraTokens.space16,
-                        vertical: AleraTokens.space8,
-                      ),
-                      minimumSize: const Size(0, 34),
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(AleraTokens.radiusLg),
+              // Composer area with overlaid action buttons.
+              Stack(
+                clipBehavior: Clip.none,
+                children: [
+                  Container(
+                    decoration: BoxDecoration(
+                      color: AleraTokens.surfaceVariant,
+                      borderRadius: BorderRadius.circular(AleraTokens.radiusLg),
+                      border: Border.all(color: AleraTokens.border),
+                    ),
+                    child: TextField(
+                      controller: _textController,
+                      focusNode: _focusNode,
+                      minLines: 3,
+                      maxLines: 8,
+                      textInputAction: TextInputAction.newline,
+                      style: Theme.of(context).textTheme.bodyMedium,
+                      decoration: InputDecoration(
+                        hintText: 'Edit your message...',
+                        filled: true,
+                        fillColor: Colors.transparent,
+                        hoverColor: Colors.transparent,
+                        contentPadding: const EdgeInsets.fromLTRB(
+                          AleraTokens.space12,
+                          AleraTokens.space12,
+                          AleraTokens.space32,
+                          AleraTokens.space48,
+                        ),
+                        border: InputBorder.none,
+                        enabledBorder: InputBorder.none,
+                        focusedBorder: InputBorder.none,
+                        disabledBorder: InputBorder.none,
                       ),
                     ),
-                    child: const Text('Delete'),
                   ),
-                  const Spacer(),
-                  // Save button (right side).
-                  FilledButton(
-                    onPressed: _save,
-                    style: FilledButton.styleFrom(
-                      backgroundColor: AleraTokens.accent,
-                      foregroundColor: AleraTokens.onAccent,
-                      padding: const EdgeInsets.symmetric(
-                        horizontal: AleraTokens.space16,
-                        vertical: AleraTokens.space8,
-                      ),
-                      minimumSize: const Size(0, 34),
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(AleraTokens.radiusLg),
+                  // Close and delete buttons stacked top right.
+                  Positioned(
+                    top: AleraTokens.space8,
+                    right: AleraTokens.space8,
+                    child: Column(
+                      children: [
+                        InkWell(
+                          onTap: _cancel,
+                          borderRadius: BorderRadius.circular(AleraTokens.radiusSm),
+                          mouseCursor: SystemMouseCursors.click,
+                          child: const Padding(
+                            padding: EdgeInsets.all(AleraTokens.space4),
+                            child: Icon(
+                              Icons.close,
+                              size: 15,
+                              color: AleraTokens.foregroundFaint,
+                            ),
+                          ),
+                        ),
+                        const SizedBox(height: AleraTokens.space4),
+                        InkWell(
+                          onTap: _delete,
+                          borderRadius: BorderRadius.circular(AleraTokens.radiusSm),
+                          mouseCursor: SystemMouseCursors.click,
+                          child: const Padding(
+                            padding: EdgeInsets.all(AleraTokens.space4),
+                            child: Icon(
+                              Icons.delete_outline,
+                              size: 15,
+                              color: AleraTokens.error,
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                  // Add attachment button (bottom left).
+                  Positioned(
+                    left: AleraTokens.space8,
+                    bottom: AleraTokens.space8,
+                    child: IconButton(
+                      onPressed: _addAttachment,
+                      tooltip: 'Add photos & files',
+                      mouseCursor: SystemMouseCursors.click,
+                      constraints: const BoxConstraints(minWidth: 28, minHeight: 28),
+                      padding: const EdgeInsets.all(AleraTokens.space4),
+                      icon: const Icon(
+                        Icons.add,
+                        size: 18,
+                        color: AleraTokens.foregroundMuted,
                       ),
                     ),
-                    child: const Text('Save'),
                   ),
+                  // Save button (bottom right).
+                  Positioned(
+                    right: AleraTokens.space8,
+                    bottom: AleraTokens.space8,
+                    child: InkWell(
+                      onTap: _save,
+                      borderRadius: BorderRadius.circular(AleraTokens.radiusSm),
+                      mouseCursor: SystemMouseCursors.click,
+                      child: const Padding(
+                        padding: EdgeInsets.all(AleraTokens.space4),
+                        child: Icon(
+                          Icons.save_outlined,
+                          size: 18,
+                          color: AleraTokens.accent,
+                        ),
+                      ),
+                    ),
+                  ),
+                  // Mention overlay positioned above the composer.
+                  if (_mentionFiles.isNotEmpty)
+                    Positioned(
+                      bottom: 60,
+                      left: 0,
+                      right: 0,
+                      child: Material(
+                        elevation: 4,
+                        color: Colors.transparent,
+                        borderRadius: BorderRadius.circular(AleraTokens.radiusLg),
+                        child: Container(
+                          decoration: BoxDecoration(
+                            color: AleraTokens.surfaceElevated,
+                            borderRadius: BorderRadius.circular(AleraTokens.radiusLg),
+                            border: Border.all(color: AleraTokens.border),
+                            boxShadow: const [
+                              BoxShadow(
+                                color: AleraTokens.shadowSoft,
+                                blurRadius: 8,
+                                offset: Offset(0, -2),
+                              ),
+                            ],
+                          ),
+                          child: MentionFileList(
+                            files: _mentionFiles,
+                            selectedIndex: _mentionSelectedIndex,
+                            onSelect: _selectMention,
+                          ),
+                        ),
+                      ),
+                    ),
                 ],
               ),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );

--- a/lib/src/features/session/presentation/widgets/timeline_cells.dart
+++ b/lib/src/features/session/presentation/widgets/timeline_cells.dart
@@ -100,7 +100,7 @@ class _UserMessageCellState extends State<UserMessageCell> {
   }
 
   bool get _isSteering =>
-      widget.cell.metadata['isSteering'] == true &&
+      widget.cell.metadata[TimelineCellMetadata.isSteeringKey] == true &&
       widget.cell.status == TimelineCellStatus.inProgress;
 
   @override
@@ -108,7 +108,7 @@ class _UserMessageCellState extends State<UserMessageCell> {
     final messageText = widget.cell.markdownText ?? '';
     final attachments = _parseAttachments();
     final isSteering = _isSteering;
-    return Align(
+    Widget content = Align(
       alignment: Alignment.centerRight,
       child: ConstrainedBox(
         constraints: const BoxConstraints(maxWidth: 760),
@@ -232,6 +232,10 @@ class _UserMessageCellState extends State<UserMessageCell> {
         ),
       ),
     );
+    if (isSteering) {
+      content = Opacity(opacity: 0.6, child: content);
+    }
+    return content;
   }
 }
 

--- a/lib/src/features/session/presentation/widgets/timeline_cells.dart
+++ b/lib/src/features/session/presentation/widgets/timeline_cells.dart
@@ -103,11 +103,16 @@ class _UserMessageCellState extends State<UserMessageCell> {
       widget.cell.metadata[TimelineCellMetadata.isSteeringKey] == true &&
       widget.cell.status == TimelineCellStatus.inProgress;
 
+  bool get _wasSteered =>
+      widget.cell.metadata[TimelineCellMetadata.isSteeringKey] == true &&
+      widget.cell.status != TimelineCellStatus.inProgress;
+
   @override
   Widget build(BuildContext context) {
     final messageText = widget.cell.markdownText ?? '';
     final attachments = _parseAttachments();
     final isSteering = _isSteering;
+    final wasSteered = _wasSteered;
     Widget content = Align(
       alignment: Alignment.centerRight,
       child: ConstrainedBox(
@@ -205,6 +210,19 @@ class _UserMessageCellState extends State<UserMessageCell> {
                               ),
                             ),
                           ],
+                        ),
+                      ),
+                    if (wasSteered)
+                      Padding(
+                        padding: const EdgeInsets.only(
+                          top: AleraTokens.space4,
+                        ),
+                        child: const Text(
+                          'Steered',
+                          style: TextStyle(
+                            fontSize: 11,
+                            color: AleraTokens.foregroundFaint,
+                          ),
                         ),
                       ),
                   ],

--- a/lib/src/features/shell/presentation/alera_shell_page.dart
+++ b/lib/src/features/shell/presentation/alera_shell_page.dart
@@ -9,7 +9,6 @@ import 'package:alera/src/features/session/domain/composer_attachment.dart';
 import 'package:alera/src/features/session/presentation/session_workspace_view.dart';
 import 'package:alera/src/features/shell/presentation/alera_status_bar.dart';
 import 'package:alera/src/features/shell/presentation/alera_top_bar.dart';
-import 'package:alera/src/features/steer/presentation/widgets/steer_module_panel.dart';
 import 'package:alera/src/shared/presentation/toast/alera_toast.dart';
 import 'package:file_selector/file_selector.dart';
 import 'package:flutter/material.dart';
@@ -91,56 +90,38 @@ class _AleraShellPageState extends ConsumerState<AleraShellPage> {
         onAction: () => _selectWorkspace(controller),
       );
     }
-    return Row(
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: [
-        Expanded(
-          child: SessionWorkspaceView(
-            state: state,
-            onSendInput: controller.sendInput,
-            onInterruptTurn: controller.interruptActiveTurn,
-            isTurnRunning: state.runningTurnCount > 0,
-            isInterrupting: state.isInterrupting,
-            onModelChanged: controller.updateActiveSessionModel,
-            activeReasoningEffort: state.activeReasoningEffort,
-            supportedReasoningEfforts: supportedReasoningEffortsForModel(
-              state.activeModelId,
-            ),
-            onReasoningEffortChanged: controller.updateReasoningEffort,
-            isMarkdownEnabled: state.activeMarkdownEnabled,
-            onMarkdownModeChanged: controller.updateMarkdownEnabled,
-            rawLogExpanded: _rawLogExpanded,
-            onAddAttachment: () => _addAttachment(controller),
-            onPasteImage: (file) => _pasteImage(controller, file),
-            onRemoveAttachment: controller.removeAttachment,
-            onRemoveFromQueue: controller.removeFromQueue,
-            onSteerQueuedMessage: controller.steerQueuedMessage,
-            onStartEditingPendingMessage: controller.startEditingPendingMessage,
-            onUpdatePendingMessage: controller.updatePendingMessage,
-            onDeletePendingMessage: controller.removeFromQueue,
-            onFinishEditingPendingMessage: controller.finishEditingPendingMessage,
-            onPlanModeToggled: controller.togglePlanMode,
-            onImplementPlanPressed: controller.implementPlanFromChatAction,
-            onPermissionModeToggled: controller.togglePermissionMode,
-            onApproveRequest: controller.approveRequest,
-            onDeclineRequest: controller.declineRequest,
-            onSubmitUserInput: controller.submitUserInput,
-            onDismissUserInput: controller.dismissUserInput,
-            onCompact: controller.compactContext,
-          ),
-        ),
-        const Padding(
-          padding: EdgeInsets.only(
-            right: AleraTokens.space12,
-            top: AleraTokens.space12,
-            bottom: AleraTokens.space12,
-          ),
-          child: Align(
-            alignment: Alignment.topRight,
-            child: SteerModulePanel(),
-          ),
-        ),
-      ],
+    return SessionWorkspaceView(
+      state: state,
+      onSendInput: controller.sendInput,
+      onInterruptTurn: controller.interruptActiveTurn,
+      isTurnRunning: state.runningTurnCount > 0,
+      isInterrupting: state.isInterrupting,
+      onModelChanged: controller.updateActiveSessionModel,
+      activeReasoningEffort: state.activeReasoningEffort,
+      supportedReasoningEfforts: supportedReasoningEffortsForModel(
+        state.activeModelId,
+      ),
+      onReasoningEffortChanged: controller.updateReasoningEffort,
+      isMarkdownEnabled: state.activeMarkdownEnabled,
+      onMarkdownModeChanged: controller.updateMarkdownEnabled,
+      rawLogExpanded: _rawLogExpanded,
+      onAddAttachment: () => _addAttachment(controller),
+      onPasteImage: (file) => _pasteImage(controller, file),
+      onRemoveAttachment: controller.removeAttachment,
+      onRemoveFromQueue: controller.removeFromQueue,
+      onSteerQueuedMessage: controller.steerQueuedMessage,
+      onStartEditingPendingMessage: controller.startEditingPendingMessage,
+      onUpdatePendingMessage: controller.updatePendingMessage,
+      onDeletePendingMessage: controller.removeFromQueue,
+      onFinishEditingPendingMessage: controller.finishEditingPendingMessage,
+      onPlanModeToggled: controller.togglePlanMode,
+      onImplementPlanPressed: controller.implementPlanFromChatAction,
+      onPermissionModeToggled: controller.togglePermissionMode,
+      onApproveRequest: controller.approveRequest,
+      onDeclineRequest: controller.declineRequest,
+      onSubmitUserInput: controller.submitUserInput,
+      onDismissUserInput: controller.dismissUserInput,
+      onCompact: controller.compactContext,
     );
   }
 


### PR DESCRIPTION
## Summary

- Add safety mechanisms for steering injection and interrupt handling with 10/15-second timeouts
- Redesign queue edit dialog to embed action buttons (close/delete/save) within the composer instead of using top/bottom bars
- Update queue item button colors: edit button uses accent color, close button uses error color for consistency
- Refactor timeline cell lookup with extension method and improve steering metadata handling
- Remove steer module panel from top-right area

## Test plan

- Verify queue edit dialog displays correctly without outer card wrapper
- Test steering injection with active turn safety timeout
- Verify interrupt safety timeout resets properly after turn completion
- Check button colors in queue items match design system
- Test delete confirmation dialog still works in embedded design