### PR TITLE
fix: align composer context indicator with token usage events

### DIFF
--- a/lib/src/features/session/application/session_controller.dart
+++ b/lib/src/features/session/application/session_controller.dart
@@ -40,6 +40,7 @@ class SessionController extends StateNotifier<SessionState> {
   final SettingsService _settingsService;
   StreamSubscription<SessionRuntimeEvent>? _eventsSub;
   Timer? _commitTickTimer;
+  Timer? _interruptSafetyTimer;
 
   var _bootstrapped = false;
   static const String _localPlanFallbackQuestionId = 'implement_plan';
@@ -618,19 +619,20 @@ class SessionController extends StateNotifier<SessionState> {
     ];
 
     try {
-      final returnedTurnId = await _sessionService.steerActiveTurn(
-        sessionId: activeSessionId,
-        rawInput: message.text,
-        expectedTurnId: activeTurnId,
-        extraInputItems: extraItems,
-      );
+      final returnedTurnId = await _sessionService
+          .steerActiveTurn(
+            sessionId: activeSessionId,
+            rawInput: message.text,
+            expectedTurnId: activeTurnId,
+            extraInputItems: extraItems,
+          )
+          .timeout(const Duration(seconds: 15));
       // Mark the steering cell as completed and assign it to the turn.
       _updateTimelineCell(
         cell.id,
         (c) => c.copyWith(
           status: TimelineCellStatus.completed,
           turnId: returnedTurnId,
-          metadata: const <String, dynamic>{},
           updatedAt: DateTime.now().toUtc(),
         ),
       );
@@ -640,7 +642,6 @@ class SessionController extends StateNotifier<SessionState> {
         cell.id,
         (c) => c.copyWith(
           status: TimelineCellStatus.failed,
-          metadata: const <String, dynamic>{},
         ),
       );
       state = state.copyWith(error: e.toString());
@@ -952,7 +953,11 @@ class SessionController extends StateNotifier<SessionState> {
 
     state = state.copyWith(isInterrupting: true, clearError: true);
     try {
-      await _sessionService.interruptActiveTurn(sessionId: session.id);
+      await _sessionService.interruptActiveTurn(
+        sessionId: session.id,
+        turnIdOverride: state.activeTurnId,
+      );
+      _scheduleInterruptSafetyTimeout();
     } catch (error) {
       state = state.copyWith(
         isInterrupting: false,
@@ -960,6 +965,15 @@ class SessionController extends StateNotifier<SessionState> {
         connectionState: AppServerConnectionState.error,
       );
     }
+  }
+
+  void _scheduleInterruptSafetyTimeout() {
+    _interruptSafetyTimer?.cancel();
+    _interruptSafetyTimer = Timer(const Duration(seconds: 10), () {
+      if (state.isInterrupting) {
+        state = state.copyWith(isInterrupting: false);
+      }
+    });
   }
 
   /// Requests manual context compaction for the active session.
@@ -992,6 +1006,7 @@ class SessionController extends StateNotifier<SessionState> {
   @override
   void dispose() {
     _stopCommitTicker();
+    _interruptSafetyTimer?.cancel();
     unawaited(_eventsSub?.cancel());
     super.dispose();
   }
@@ -1100,6 +1115,10 @@ class SessionController extends StateNotifier<SessionState> {
       final shouldClearInterrupting =
           ticked.isInterrupting &&
           (event.method == 'turn/completed' || event.method == 'turn/failed');
+      if (shouldClearInterrupting) {
+        _interruptSafetyTimer?.cancel();
+        _interruptSafetyTimer = null;
+      }
 
       state = ticked.copyWith(
         sessions: _sessionService.sessions,

--- a/lib/src/features/session/application/session_controller.dart
+++ b/lib/src/features/session/application/session_controller.dart
@@ -602,7 +602,7 @@ class SessionController extends StateNotifier<SessionState> {
       createdAt: now,
       updatedAt: now,
       markdownText: message.text,
-      metadata: const <String, dynamic>{'isSteering': true},
+      metadata: const <String, dynamic>{TimelineCellMetadata.isSteeringKey: true},
     );
     state = state.copyWith(
       timelineCells: <TimelineCell>[...state.timelineCells, cell],
@@ -618,24 +618,44 @@ class SessionController extends StateNotifier<SessionState> {
     ];
 
     try {
-      await _sessionService.steerActiveTurn(
+      final returnedTurnId = await _sessionService.steerActiveTurn(
         sessionId: activeSessionId,
         rawInput: message.text,
         expectedTurnId: activeTurnId,
         extraInputItems: extraItems,
       );
+      // Mark the steering cell as completed and assign it to the turn.
+      _updateTimelineCell(
+        cell.id,
+        (c) => c.copyWith(
+          status: TimelineCellStatus.completed,
+          turnId: returnedTurnId,
+          metadata: const <String, dynamic>{},
+          updatedAt: DateTime.now().toUtc(),
+        ),
+      );
     } catch (e) {
       // Update the steering cell to failed status.
-      final cells = <TimelineCell>[...state.timelineCells];
-      final idx = cells.indexWhere((c) => c.id == cell.id);
-      if (idx != -1) {
-        cells[idx] = cells[idx].copyWith(
+      _updateTimelineCell(
+        cell.id,
+        (c) => c.copyWith(
           status: TimelineCellStatus.failed,
           metadata: const <String, dynamic>{},
-        );
-        state = state.copyWith(timelineCells: cells);
-      }
+        ),
+      );
       state = state.copyWith(error: e.toString());
+    }
+  }
+
+  void _updateTimelineCell(
+    String cellId,
+    TimelineCell Function(TimelineCell) transform,
+  ) {
+    final cells = <TimelineCell>[...state.timelineCells];
+    final idx = cells.findIndexById(cellId);
+    if (idx != -1) {
+      cells[idx] = transform(cells[idx]);
+      state = state.copyWith(timelineCells: cells);
     }
   }
 

--- a/lib/src/features/session/application/session_timeline_reducer.dart
+++ b/lib/src/features/session/application/session_timeline_reducer.dart
@@ -232,7 +232,7 @@ SessionState reduceCommitTick(
       final streamPhase = _normalizeAgentPhase(line.streamPhase);
       if (streamPhase == 'final_answer') {
         final assistantCellId = line.itemId ?? 'assistant-final-${line.turnId}';
-        final assistantIndex = _findCellById(cells, assistantCellId);
+        final assistantIndex = cells.findIndexById(assistantCellId);
         if (assistantIndex == -1) {
           cells.add(
             TimelineCell(
@@ -471,7 +471,7 @@ SessionState _onLegacyTaskComplete(
   final cellId = existingAssistant?.id ?? 'assistant-final-$turnId';
   final existingIndex = existingAssistant == null
       ? -1
-      : _findCellById(cells, existingAssistant.id);
+      : cells.findIndexById(existingAssistant.id);
 
   final metadata = <String, dynamic>{
     'streamPhase': 'final_answer',
@@ -802,9 +802,10 @@ SessionState _onTurnStarted(
       : index.pendingUserCellIdQueue.last;
 
   if (pendingUserCellId != null) {
-    final userIndex = _findCellById(cells, pendingUserCellId);
+    final userIndex = cells.findIndexById(pendingUserCellId);
     if (userIndex != -1) {
-      final wasSteering = cells[userIndex].metadata['isSteering'] == true;
+      final wasSteering =
+          cells[userIndex].metadata[TimelineCellMetadata.isSteeringKey] == true;
       cells[userIndex] = cells[userIndex].copyWith(
         turnId: turnId,
         updatedAt: timestamp,
@@ -869,10 +870,21 @@ SessionState _onTurnCompleted(
   final cells = <TimelineCell>[...nextState.timelineCells];
   for (var i = 0; i < cells.length; i++) {
     final cell = cells[i];
+    // Safety net: complete any orphaned steering cells still in-progress.
+    if (cell.kind == TimelineCellKind.userMessage &&
+        cell.status == TimelineCellStatus.inProgress &&
+        cell.metadata[TimelineCellMetadata.isSteeringKey] == true) {
+      cells[i] = cell.copyWith(
+        status: TimelineCellStatus.completed,
+        metadata: const <String, dynamic>{},
+        turnId: cell.turnId ?? turnId,
+        updatedAt: timestamp,
+      );
+      continue;
+    }
     if (cell.turnId != turnId) {
       continue;
     }
-
     if (cell.kind == TimelineCellKind.assistantMessage && cell.isStreaming) {
       cells[i] = cell.copyWith(
         isStreaming: false,
@@ -881,7 +893,6 @@ SessionState _onTurnCompleted(
       );
       continue;
     }
-
     if (cell.kind == TimelineCellKind.progressText &&
         cell.status == TimelineCellStatus.inProgress) {
       cells[i] = cell.copyWith(
@@ -890,7 +901,6 @@ SessionState _onTurnCompleted(
       );
       continue;
     }
-
     if (_isSecondaryKind(cell.kind)) {
       cells[i] = cell.copyWith(isCollapsed: true, updatedAt: timestamp);
     }
@@ -921,7 +931,7 @@ SessionState _onTurnCompleted(
   if (durationFromCells != null && durationFromCells > 0) {
     separatorMetadata['computedDurationMs'] = durationFromCells;
   }
-  final existingSeparatorIndex = _findCellById(cells, separatorId);
+  final existingSeparatorIndex = cells.findIndexById(separatorId);
   if (showWorkSeparator) {
     final separator = TimelineCell(
       id: separatorId,
@@ -981,7 +991,7 @@ SessionState _onTurnCompleted(
   var clearStreaming = false;
   final activeStreamingId = nextState.activeStreamingAssistantCellId;
   if (activeStreamingId != null) {
-    final activeIndex = _findCellById(cells, activeStreamingId);
+    final activeIndex = cells.findIndexById(activeStreamingId);
     if (activeIndex != -1 && cells[activeIndex].turnId == turnId) {
       clearStreaming = true;
     }
@@ -1595,7 +1605,7 @@ SessionState _onToolDetailsChunk(
   index = phase.index;
 
   final cellId = index.cellIdByItemId[itemId] ?? itemId;
-  final existingIndex = _findCellById(cells, cellId);
+  final existingIndex = cells.findIndexById(cellId);
 
   final isPlan = fallbackTitle == 'plan';
   final cellKind = isPlan ? TimelineCellKind.plan : TimelineCellKind.toolCall;
@@ -1710,7 +1720,7 @@ SessionState _onItemStarted(
   index = phase.index;
 
   final cellId = index.cellIdByItemId[itemId] ?? itemId;
-  final existingIndex = _findCellById(cells, cellId);
+  final existingIndex = cells.findIndexById(cellId);
   final kind = _resolveCellKind(itemType);
   final existingMetadata = existingIndex == -1
       ? const <String, dynamic>{}
@@ -1840,7 +1850,7 @@ SessionState _onItemCompleted(
   final cells = <TimelineCell>[...state.timelineCells];
   final index = _buildCellIndex(cells);
   final cellId = index.cellIdByItemId[itemId] ?? itemId;
-  final existingIndex = _findCellById(cells, cellId);
+  final existingIndex = cells.findIndexById(cellId);
   final kind = _resolveCellKind(itemType);
   final existingMetadata = existingIndex == -1
       ? const <String, dynamic>{}
@@ -2027,7 +2037,7 @@ SessionState _onAssistantItemCompleted(
   var assistantCellId = itemId;
   final indexedByItemId = index.cellIdByItemId[itemId];
   if (indexedByItemId != null) {
-    final indexedAt = _findCellById(cells, indexedByItemId);
+    final indexedAt = cells.findIndexById(indexedByItemId);
     if (indexedAt != -1 &&
         cells[indexedAt].kind == TimelineCellKind.assistantMessage) {
       assistantCellId = indexedByItemId;
@@ -2052,7 +2062,7 @@ SessionState _onAssistantItemCompleted(
     if (streamCommittedForItem) 'streamCommitted': true,
   };
 
-  final existingIndex = _findCellById(cells, assistantCellId);
+  final existingIndex = cells.findIndexById(assistantCellId);
   if (existingIndex == -1 ||
       cells[existingIndex].kind != TimelineCellKind.assistantMessage) {
     final baseText = streamCommittedForItem ? '' : finalText;
@@ -2244,7 +2254,7 @@ _SecondaryPhaseResult _startSecondaryPhase(
   var clearedAssistantStreaming = false;
   final activeProgressId = index.activeProgressTextCellIdByTurn[turnId];
   if (activeProgressId != null) {
-    final activeProgressIndex = _findCellById(cells, activeProgressId);
+    final activeProgressIndex = cells.findIndexById(activeProgressId);
     if (activeProgressIndex != -1) {
       final activeProgress = cells[activeProgressIndex];
       if (activeProgress.status == TimelineCellStatus.inProgress) {
@@ -2263,7 +2273,7 @@ _SecondaryPhaseResult _startSecondaryPhase(
 
   final assistantCellId = index.assistantCellIdByTurn[turnId];
   if (assistantCellId != null) {
-    final assistantIndex = _findCellById(cells, assistantCellId);
+    final assistantIndex = cells.findIndexById(assistantCellId);
     if (assistantIndex != -1) {
       final assistant = cells[assistantIndex];
       final assistantText = assistant.markdownText ?? '';
@@ -2334,14 +2344,6 @@ bool _isHumanFacingInterimLine(String line) {
   return true;
 }
 
-int _findCellById(List<TimelineCell> cells, String id) {
-  for (var i = 0; i < cells.length; i++) {
-    if (cells[i].id == id) {
-      return i;
-    }
-  }
-  return -1;
-}
 
 int? _computeTurnDurationFromCells(
   List<TimelineCell> cells, {
@@ -2957,7 +2959,7 @@ SessionState _onSubAgentStarted(
   );
   index = phase.index;
   final cellId = index.cellIdByItemId[itemId] ?? itemId;
-  final existingIndex = _findCellById(cells, cellId);
+  final existingIndex = cells.findIndexById(cellId);
   final fallbackTask = _asString(params['task']) ?? 'Sub-agent task';
   final arguments = params['arguments'] as Map<String, dynamic>?;
   final title = _subAgentTitle(arguments, fallbackTask);
@@ -3021,7 +3023,7 @@ SessionState _onSubAgentDelta(
   }
   final index = _buildCellIndex(state.timelineCells);
   final cellId = index.cellIdByItemId[itemId] ?? itemId;
-  final existingIndex = _findCellById(state.timelineCells, cellId);
+  final existingIndex = state.timelineCells.findIndexById(cellId);
   if (existingIndex == -1) {
     return state;
   }
@@ -3066,7 +3068,7 @@ SessionState _onSubAgentCompleted(
   }
   final index = _buildCellIndex(state.timelineCells);
   final cellId = index.cellIdByItemId[itemId] ?? itemId;
-  final existingIndex = _findCellById(state.timelineCells, cellId);
+  final existingIndex = state.timelineCells.findIndexById(cellId);
   final result = params['result'] as Map<String, dynamic>?;
   final success = result?['success'] as bool? ?? true;
   final status = success ? TimelineCellStatus.completed : TimelineCellStatus.failed;

--- a/lib/src/features/session/application/session_timeline_reducer.dart
+++ b/lib/src/features/session/application/session_timeline_reducer.dart
@@ -810,7 +810,6 @@ SessionState _onTurnStarted(
         turnId: turnId,
         updatedAt: timestamp,
         status: wasSteering ? TimelineCellStatus.completed : null,
-        metadata: wasSteering ? const <String, dynamic>{} : null,
       );
     }
   }
@@ -876,7 +875,6 @@ SessionState _onTurnCompleted(
         cell.metadata[TimelineCellMetadata.isSteeringKey] == true) {
       cells[i] = cell.copyWith(
         status: TimelineCellStatus.completed,
-        metadata: const <String, dynamic>{},
         turnId: cell.turnId ?? turnId,
         updatedAt: timestamp,
       );

--- a/lib/src/features/session/application/session_timeline_reducer.dart
+++ b/lib/src/features/session/application/session_timeline_reducer.dart
@@ -7,7 +7,6 @@ import 'package:alera/src/features/session/application/streaming/adaptive_chunki
 import 'package:alera/src/features/session/application/streaming/commit_tick_engine.dart';
 import 'package:alera/src/features/session/application/streaming/markdown_stream_collector.dart';
 import 'package:alera/src/features/session/domain/chat_timeline.dart';
-import 'package:alera/src/features/session/domain/codex_model_catalog.dart';
 import 'package:alera/src/features/session/domain/collab_agent.dart';
 import 'package:alera/src/features/session/domain/composer_attachment.dart';
 import 'package:alera/src/features/session/domain/token_usage.dart';
@@ -131,12 +130,14 @@ SessionState reduceNotification(
       return _onSubAgentDelta(next, params, timestamp);
     case 'item/subAgent/completed':
       return _onSubAgentCompleted(next, params, timestamp);
+    case 'thread/tokenUsage/updated':
+      return _onThreadTokenUsageUpdated(next, params);
+    case 'account/rateLimits/updated':
+      return _onAccountRateLimitsUpdated(next, params);
     case 'codex/event/token_count':
       return _onTokenCount(next, asMap(params['msg']));
     case 'token_count':
       return _onTokenCount(next, params);
-    case 'codex/event/context_compacted':
-      return _onContextCompacted(next, timestamp);
     case 'error':
     case 'stream/error':
     case 'stream_error':
@@ -1261,55 +1262,49 @@ SessionState _onTokenCount(SessionState state, Map<String, dynamic> params) {
   } else {
     nextMetrics['tokenInfo'] = info;
   }
+  return state.copyWith(turnRuntimeMetrics: nextMetrics);
+}
 
-  // Parse structured context usage.
-  var tokenUsageInfo = TokenUsageInfo.fromMap(info);
-  if (tokenUsageInfo.modelContextWindow == null) {
-    final windowSize = contextWindowForModel(state.activeModelId);
-    tokenUsageInfo = TokenUsageInfo(
-      totalTokenUsage: tokenUsageInfo.totalTokenUsage,
-      lastTokenUsage: tokenUsageInfo.lastTokenUsage,
-      modelContextWindow: windowSize,
-    );
+SessionState _onThreadTokenUsageUpdated(
+  SessionState state,
+  Map<String, dynamic> params,
+) {
+  final tokenUsage = asMap(params['tokenUsage']);
+  if (tokenUsage.isEmpty) {
+    return state;
   }
 
-  final rawRateLimits = params['rate_limits'] ?? params['rateLimits'];
-  final rateLimitsMap = rawRateLimits is Map
-      ? asMap(rawRateLimits)
-      : const <String, dynamic>{};
-  final rateLimits = rateLimitsMap.isNotEmpty
-      ? RateLimitSnapshot.fromMap(rateLimitsMap)
-      : state.contextUsage.rateLimits;
+  final tokenUsageInfo = TokenUsageInfo.fromMap(<String, dynamic>{
+    'totalTokenUsage': tokenUsage['total'],
+    'lastTokenUsage': tokenUsage['last'],
+    'modelContextWindow': tokenUsage['modelContextWindow'],
+  });
+  final nextMetrics = <String, dynamic>{...state.turnRuntimeMetrics};
+  nextMetrics['tokenUsage'] = tokenUsage;
+  nextMetrics['totalTokens'] = tokenUsageInfo.currentContextTokens;
 
   return state.copyWith(
     turnRuntimeMetrics: nextMetrics,
     contextUsage: state.contextUsage.copyWith(
       tokenUsageInfo: tokenUsageInfo,
-      rateLimits: rateLimits,
       isCompacting: false,
     ),
   );
 }
 
-SessionState _onContextCompacted(SessionState state, DateTime timestamp) {
-  // Signal that compaction completed; token counts will be refreshed
-  // by the next token_count event.
-  final cell = TimelineCell(
-    id: 'notice-context-compacted-${timestamp.microsecondsSinceEpoch}',
-    turnId: state.activeTurnId,
-    kind: TimelineCellKind.systemNotice,
-    status: TimelineCellStatus.info,
-    createdAt: timestamp,
-    updatedAt: timestamp,
-    markdownText: 'Context compacted',
-    metadata: const <String, dynamic>{
-      'noticeType': 'context_compacted',
-      TimelineCellMetadata.uiPlacementKey: TimelineCellMetadata.outsideWorked,
-    },
-  );
+SessionState _onAccountRateLimitsUpdated(
+  SessionState state,
+  Map<String, dynamic> params,
+) {
+  final rateLimits = asMap(params['rateLimits']);
+  if (rateLimits.isEmpty) {
+    return state;
+  }
+
   return state.copyWith(
-    timelineCells: <TimelineCell>[...state.timelineCells, cell],
-    contextUsage: state.contextUsage.copyWith(isCompacting: false),
+    contextUsage: state.contextUsage.copyWith(
+      rateLimits: RateLimitSnapshot.fromMap(rateLimits),
+    ),
   );
 }
 
@@ -1706,6 +1701,8 @@ SessionState _onItemStarted(
     return state;
   }
 
+  final isContextCompaction = itemType == 'contextCompaction';
+
   final cells = <TimelineCell>[...state.timelineCells];
   var index = _buildCellIndex(cells);
   final phase = _startSecondaryPhase(
@@ -1789,6 +1786,9 @@ SessionState _onItemStarted(
     activePlanCellId: isPlan ? cellId : state.activePlanCellId,
     clearActivePlanCellId: !isPlan && state.activePlanCellId == cellId,
     clearActiveStreamingAssistantCellId: phase.clearActiveStreamingAssistant,
+    contextUsage: isContextCompaction
+        ? state.contextUsage.copyWith(isCompacting: true)
+        : state.contextUsage,
   );
 }
 
@@ -1813,6 +1813,8 @@ SessionState _onItemCompleted(
   if (itemType == 'userMessage') {
     return state;
   }
+
+  final isContextCompaction = itemType == 'contextCompaction';
 
   if (itemType == 'agentMessage') {
     final phase = _mergeAgentPhase(
@@ -1932,6 +1934,9 @@ SessionState _onItemCompleted(
     pendingStatusRestore: itemType == 'reasoning',
     clearActiveExecCellId: state.activeExecCellId == cellId,
     clearActivePlanCellId: state.activePlanCellId == cellId,
+    contextUsage: isContextCompaction
+        ? state.contextUsage.copyWith(isCompacting: false)
+        : state.contextUsage,
   );
 }
 

--- a/lib/src/features/session/domain/chat_timeline.dart
+++ b/lib/src/features/session/domain/chat_timeline.dart
@@ -19,6 +19,9 @@ abstract class TimelineCellMetadata {
 
   /// Value for placing notice outside the "Worked..." section.
   static const String outsideWorked = 'outside_worked';
+
+  /// Key indicating a user message is a steering injection.
+  static const String isSteeringKey = 'isSteering';
 }
 
 class TimelineCell {
@@ -94,5 +97,14 @@ class TimelineCell {
       itemId: clearItemId ? null : (itemId ?? this.itemId),
       metadata: metadata ?? this.metadata,
     );
+  }
+}
+
+extension TimelineCellListExtension on List<TimelineCell> {
+  int findIndexById(String id) {
+    for (var i = 0; i < length; i++) {
+      if (this[i].id == id) return i;
+    }
+    return -1;
   }
 }

--- a/lib/src/features/session/domain/context_usage.dart
+++ b/lib/src/features/session/domain/context_usage.dart
@@ -2,7 +2,7 @@ import 'package:alera/src/features/session/domain/token_usage.dart';
 
 /// Aggregated context usage state for a session.
 ///
-/// Updated on each `token_count` event and reset on `context_compacted`.
+/// Updated on each `thread/tokenUsage/updated` event.
 class ContextUsage {
   const ContextUsage({
     this.tokenUsageInfo = TokenUsageInfo.empty,
@@ -20,7 +20,10 @@ class ContextUsage {
   final bool isCompacting;
 
   /// Total tokens currently in context.
-  int get tokensInContext => tokenUsageInfo.totalTokenUsage.totalTokens;
+  int get tokensInContext => tokenUsageInfo.currentContextTokens;
+
+  /// Accumulated blended session usage.
+  int get sessionTokensUsed => tokenUsageInfo.blendedTotalTokens;
 
   /// Maximum context window size, or null if unknown.
   int? get contextWindowSize => tokenUsageInfo.modelContextWindow;

--- a/lib/src/features/session/domain/token_usage.dart
+++ b/lib/src/features/session/domain/token_usage.dart
@@ -14,6 +14,14 @@ class TokenUsage {
   final int reasoningOutputTokens;
   final int totalTokens;
 
+  int get nonCachedInputTokens {
+    final value = inputTokens - cachedInputTokens;
+    return value > 0 ? value : 0;
+  }
+
+  int get blendedTotalTokens =>
+      nonCachedInputTokens + (outputTokens < 0 ? 0 : outputTokens);
+
   factory TokenUsage.fromMap(Map<String, dynamic> map) {
     return TokenUsage(
       inputTokens:
@@ -53,12 +61,27 @@ class TokenUsageInfo {
   /// Maximum context window size for the active model (in tokens).
   final int? modelContextWindow;
 
+  /// Tokens occupying the current context window.
+  ///
+  /// Prefer the last turn usage when present because `totalTokenUsage` is
+  /// cumulative across the session and can otherwise overstate current context.
+  int get currentContextTokens {
+    final last = lastTokenUsage.totalTokens;
+    if (last > 0) {
+      return last;
+    }
+    return totalTokenUsage.totalTokens;
+  }
+
+  /// Blended session usage for display as an accumulated "tokens used" value.
+  int get blendedTotalTokens => totalTokenUsage.blendedTotalTokens;
+
   /// Percentage of the context window remaining (0–100).
   /// Returns `null` if the context window is unknown.
   double? get percentRemaining {
     final window = modelContextWindow;
     if (window == null || window <= 0) return null;
-    final used = totalTokenUsage.totalTokens;
+    final used = currentContextTokens;
     final pct = 100.0 - (used / window * 100.0);
     return pct.clamp(0.0, 100.0);
   }
@@ -108,6 +131,8 @@ class RateLimitWindow {
           _doubleOr(map['usedPercent']) ??
           0.0,
       windowDurationMins:
+          _intOr(map['window_minutes']) ??
+          _intOr(map['windowMinutes']) ??
           _intOr(map['window_duration_mins']) ??
           _intOr(map['windowDurationMins']),
       resetsAt: _intOr(map['resets_at']) ?? _intOr(map['resetsAt']),

--- a/lib/src/features/session/presentation/widgets/chat_timeline_list.dart
+++ b/lib/src/features/session/presentation/widgets/chat_timeline_list.dart
@@ -340,7 +340,11 @@ class CompletedTurnSection extends StatelessWidget {
     for (final cell in turnCells) {
       switch (cell.kind) {
         case TimelineCellKind.userMessage:
-          users.add(cell);
+          if (cell.metadata[TimelineCellMetadata.isSteeringKey] == true) {
+            assistants.add(cell);
+          } else {
+            users.add(cell);
+          }
         case TimelineCellKind.assistantMessage:
           assistants.add(cell);
         case TimelineCellKind.progressText:

--- a/lib/src/features/session/presentation/widgets/context_usage_indicator.dart
+++ b/lib/src/features/session/presentation/widgets/context_usage_indicator.dart
@@ -135,6 +135,7 @@ class _ContextUsageIndicatorState extends State<ContextUsageIndicator> {
   Widget _buildOverlay() {
     final usage = widget.contextUsage;
     final total = usage.tokensInContext;
+    final sessionTotal = usage.sessionTokensUsed;
     final window = usage.contextWindowSize ?? 0;
     final percentUsed = window > 0 ? (total / window).clamp(0.0, 1.0) : 0.0;
     final percentLeft = ((1 - percentUsed) * 100).toInt();
@@ -194,12 +195,22 @@ class _ContextUsageIndicatorState extends State<ContextUsageIndicator> {
                   ),
                   const SizedBox(height: AleraTokens.space4),
                   Text(
-                    '${_formatTokens(total)} / ${_formatTokens(window)} tokens used',
+                    '${_formatTokens(total)} / ${_formatTokens(window)} tokens in current context',
                     style: const TextStyle(
                       color: AleraTokens.foregroundMuted,
                       fontSize: 12,
                     ),
                   ),
+                  if (sessionTotal > 0) ...<Widget>[
+                    const SizedBox(height: AleraTokens.space4),
+                    Text(
+                      '${_formatTokens(sessionTotal)} session tokens used',
+                      style: const TextStyle(
+                        color: AleraTokens.foregroundMuted,
+                        fontSize: 12,
+                      ),
+                    ),
+                  ],
                   const SizedBox(height: AleraTokens.space8),
                   // Credits info (if available).
                   if (usage.rateLimits?.credits != null &&

--- a/lib/src/features/session/presentation/widgets/message_queue_bar.dart
+++ b/lib/src/features/session/presentation/widgets/message_queue_bar.dart
@@ -153,7 +153,7 @@ class _QueueItem extends StatelessWidget {
               child: Icon(
                 Icons.edit,
                 size: 13,
-                color: AleraTokens.foregroundFaint,
+                color: AleraTokens.accent,
               ),
             ),
           ),
@@ -167,7 +167,7 @@ class _QueueItem extends StatelessWidget {
               child: Icon(
                 Icons.close,
                 size: 13,
-                color: AleraTokens.foregroundFaint,
+                color: AleraTokens.error,
               ),
             ),
           ),

--- a/lib/src/features/session/presentation/widgets/timeline_cells.dart
+++ b/lib/src/features/session/presentation/widgets/timeline_cells.dart
@@ -100,7 +100,7 @@ class _UserMessageCellState extends State<UserMessageCell> {
   }
 
   bool get _isSteering =>
-      widget.cell.metadata['isSteering'] == true &&
+      widget.cell.metadata[TimelineCellMetadata.isSteeringKey] == true &&
       widget.cell.status == TimelineCellStatus.inProgress;
 
   @override
@@ -108,7 +108,7 @@ class _UserMessageCellState extends State<UserMessageCell> {
     final messageText = widget.cell.markdownText ?? '';
     final attachments = _parseAttachments();
     final isSteering = _isSteering;
-    return Align(
+    Widget content = Align(
       alignment: Alignment.centerRight,
       child: ConstrainedBox(
         constraints: const BoxConstraints(maxWidth: 760),
@@ -232,6 +232,10 @@ class _UserMessageCellState extends State<UserMessageCell> {
         ),
       ),
     );
+    if (isSteering) {
+      content = Opacity(opacity: 0.6, child: content);
+    }
+    return content;
   }
 }
 

--- a/lib/src/features/session/presentation/widgets/timeline_cells.dart
+++ b/lib/src/features/session/presentation/widgets/timeline_cells.dart
@@ -103,11 +103,16 @@ class _UserMessageCellState extends State<UserMessageCell> {
       widget.cell.metadata[TimelineCellMetadata.isSteeringKey] == true &&
       widget.cell.status == TimelineCellStatus.inProgress;
 
+  bool get _wasSteered =>
+      widget.cell.metadata[TimelineCellMetadata.isSteeringKey] == true &&
+      widget.cell.status != TimelineCellStatus.inProgress;
+
   @override
   Widget build(BuildContext context) {
     final messageText = widget.cell.markdownText ?? '';
     final attachments = _parseAttachments();
     final isSteering = _isSteering;
+    final wasSteered = _wasSteered;
     Widget content = Align(
       alignment: Alignment.centerRight,
       child: ConstrainedBox(
@@ -205,6 +210,19 @@ class _UserMessageCellState extends State<UserMessageCell> {
                               ),
                             ),
                           ],
+                        ),
+                      ),
+                    if (wasSteered)
+                      Padding(
+                        padding: const EdgeInsets.only(
+                          top: AleraTokens.space4,
+                        ),
+                        child: const Text(
+                          'Steered',
+                          style: TextStyle(
+                            fontSize: 11,
+                            color: AleraTokens.foregroundFaint,
+                          ),
                         ),
                       ),
                   ],

--- a/lib/src/features/shell/presentation/alera_shell_page.dart
+++ b/lib/src/features/shell/presentation/alera_shell_page.dart
@@ -9,7 +9,6 @@ import 'package:alera/src/features/session/domain/composer_attachment.dart';
 import 'package:alera/src/features/session/presentation/session_workspace_view.dart';
 import 'package:alera/src/features/shell/presentation/alera_status_bar.dart';
 import 'package:alera/src/features/shell/presentation/alera_top_bar.dart';
-import 'package:alera/src/features/steer/presentation/widgets/steer_module_panel.dart';
 import 'package:alera/src/shared/presentation/toast/alera_toast.dart';
 import 'package:file_selector/file_selector.dart';
 import 'package:flutter/material.dart';
@@ -91,56 +90,38 @@ class _AleraShellPageState extends ConsumerState<AleraShellPage> {
         onAction: () => _selectWorkspace(controller),
       );
     }
-    return Row(
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: [
-        Expanded(
-          child: SessionWorkspaceView(
-            state: state,
-            onSendInput: controller.sendInput,
-            onInterruptTurn: controller.interruptActiveTurn,
-            isTurnRunning: state.runningTurnCount > 0,
-            isInterrupting: state.isInterrupting,
-            onModelChanged: controller.updateActiveSessionModel,
-            activeReasoningEffort: state.activeReasoningEffort,
-            supportedReasoningEfforts: supportedReasoningEffortsForModel(
-              state.activeModelId,
-            ),
-            onReasoningEffortChanged: controller.updateReasoningEffort,
-            isMarkdownEnabled: state.activeMarkdownEnabled,
-            onMarkdownModeChanged: controller.updateMarkdownEnabled,
-            rawLogExpanded: _rawLogExpanded,
-            onAddAttachment: () => _addAttachment(controller),
-            onPasteImage: (file) => _pasteImage(controller, file),
-            onRemoveAttachment: controller.removeAttachment,
-            onRemoveFromQueue: controller.removeFromQueue,
-            onSteerQueuedMessage: controller.steerQueuedMessage,
-            onStartEditingPendingMessage: controller.startEditingPendingMessage,
-            onUpdatePendingMessage: controller.updatePendingMessage,
-            onDeletePendingMessage: controller.removeFromQueue,
-            onFinishEditingPendingMessage: controller.finishEditingPendingMessage,
-            onPlanModeToggled: controller.togglePlanMode,
-            onImplementPlanPressed: controller.implementPlanFromChatAction,
-            onPermissionModeToggled: controller.togglePermissionMode,
-            onApproveRequest: controller.approveRequest,
-            onDeclineRequest: controller.declineRequest,
-            onSubmitUserInput: controller.submitUserInput,
-            onDismissUserInput: controller.dismissUserInput,
-            onCompact: controller.compactContext,
-          ),
-        ),
-        const Padding(
-          padding: EdgeInsets.only(
-            right: AleraTokens.space12,
-            top: AleraTokens.space12,
-            bottom: AleraTokens.space12,
-          ),
-          child: Align(
-            alignment: Alignment.topRight,
-            child: SteerModulePanel(),
-          ),
-        ),
-      ],
+    return SessionWorkspaceView(
+      state: state,
+      onSendInput: controller.sendInput,
+      onInterruptTurn: controller.interruptActiveTurn,
+      isTurnRunning: state.runningTurnCount > 0,
+      isInterrupting: state.isInterrupting,
+      onModelChanged: controller.updateActiveSessionModel,
+      activeReasoningEffort: state.activeReasoningEffort,
+      supportedReasoningEfforts: supportedReasoningEffortsForModel(
+        state.activeModelId,
+      ),
+      onReasoningEffortChanged: controller.updateReasoningEffort,
+      isMarkdownEnabled: state.activeMarkdownEnabled,
+      onMarkdownModeChanged: controller.updateMarkdownEnabled,
+      rawLogExpanded: _rawLogExpanded,
+      onAddAttachment: () => _addAttachment(controller),
+      onPasteImage: (file) => _pasteImage(controller, file),
+      onRemoveAttachment: controller.removeAttachment,
+      onRemoveFromQueue: controller.removeFromQueue,
+      onSteerQueuedMessage: controller.steerQueuedMessage,
+      onStartEditingPendingMessage: controller.startEditingPendingMessage,
+      onUpdatePendingMessage: controller.updatePendingMessage,
+      onDeletePendingMessage: controller.removeFromQueue,
+      onFinishEditingPendingMessage: controller.finishEditingPendingMessage,
+      onPlanModeToggled: controller.togglePlanMode,
+      onImplementPlanPressed: controller.implementPlanFromChatAction,
+      onPermissionModeToggled: controller.togglePermissionMode,
+      onApproveRequest: controller.approveRequest,
+      onDeclineRequest: controller.declineRequest,
+      onSubmitUserInput: controller.submitUserInput,
+      onDismissUserInput: controller.dismissUserInput,
+      onCompact: controller.compactContext,
     );
   }
 

--- a/lib/src/features/shell/presentation/alera_status_bar.dart
+++ b/lib/src/features/shell/presentation/alera_status_bar.dart
@@ -1,9 +1,7 @@
 import 'package:alera/src/app/theme/alera_tokens.dart';
 import 'package:alera/src/features/session/application/session_state.dart';
-import 'package:alera/src/features/session/domain/codex_model_catalog.dart';
 import 'package:alera/src/features/session/presentation/widgets/diff_viewer.dart';
 import 'package:alera/src/shared/models/contracts.dart';
-import 'package:alera/src/shared/utils/format_utils.dart';
 import 'package:flutter/material.dart';
 
 class AleraStatusBar extends StatelessWidget {
@@ -50,13 +48,6 @@ class AleraStatusBar extends StatelessWidget {
             _StatusChip(
               label: state.statusHeader!,
               color: AleraTokens.foregroundMuted,
-            ),
-          ],
-          if (_contextUsedTokens != null) ...<Widget>[
-            _separator(),
-            _ContextChip(
-              usedTokens: _contextUsedTokens!,
-              windowTokens: contextWindowForModel(state.activeModelId),
             ),
           ],
           const Spacer(),
@@ -136,12 +127,6 @@ class AleraStatusBar extends StatelessWidget {
     );
   }
 
-  int? get _contextUsedTokens {
-    final v = state.turnRuntimeMetrics['totalTokens'];
-    if (v is int) return v;
-    return null;
-  }
-
   Widget _separator() {
     return const Padding(
       padding: EdgeInsets.symmetric(horizontal: AleraTokens.space8),
@@ -197,61 +182,6 @@ class _StatusChip extends StatelessWidget {
           style: Theme.of(context).textTheme.labelSmall?.copyWith(color: color),
         ),
       ],
-    );
-  }
-}
-
-class _ContextChip extends StatelessWidget {
-  const _ContextChip({required this.usedTokens, required this.windowTokens});
-
-  final int usedTokens;
-  final int windowTokens;
-
-  double get _fraction => (usedTokens / windowTokens).clamp(0.0, 1.0);
-
-  int get _percent => (_fraction * 100).round();
-
-  Color get _color {
-    if (_fraction >= 0.85) return AleraTokens.error;
-    if (_fraction >= 0.6) return AleraTokens.warning;
-    return AleraTokens.success;
-  }
-
-  String _formatTokens(int t) => formatTokenCount(t);
-
-  @override
-  Widget build(BuildContext context) {
-    final color = _color;
-    final label = '$_percent% ctx';
-    final tooltip =
-        '${_formatTokens(usedTokens)} / ${_formatTokens(windowTokens)} tokens used';
-    return Tooltip(
-      message: tooltip,
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: <Widget>[
-          SizedBox(
-            width: 28,
-            height: 4,
-            child: ClipRRect(
-              borderRadius: BorderRadius.circular(AleraTokens.radiusSm),
-              child: LinearProgressIndicator(
-                value: _fraction,
-                backgroundColor: AleraTokens.border,
-                color: color,
-                minHeight: 4,
-              ),
-            ),
-          ),
-          const SizedBox(width: AleraTokens.space4),
-          Text(
-            label,
-            style: Theme.of(
-              context,
-            ).textTheme.labelSmall?.copyWith(color: color),
-          ),
-        ],
-      ),
     );
   }
 }

--- a/test/unit/session_timeline_reducer_test.dart
+++ b/test/unit/session_timeline_reducer_test.dart
@@ -287,6 +287,91 @@ void main() {
       expect(state.turnRuntimeMetrics['totalTokens'], 123);
     });
 
+    test('thread token usage updated uses last tokens for current context', () {
+      var state = const SessionState();
+      state = reduceNotification(
+        state,
+        _event('thread/tokenUsage/updated', <String, dynamic>{
+          'threadId': 'thread-1',
+          'turnId': 'turn-1',
+          'tokenUsage': <String, dynamic>{
+            'total': <String, dynamic>{'totalTokens': 205000},
+            'last': <String, dynamic>{'totalTokens': 12000},
+            'modelContextWindow': 128000,
+          },
+        }),
+      );
+
+      expect(state.contextUsage.tokensInContext, 12000);
+      expect(state.contextUsage.contextWindowSize, 128000);
+      expect(state.turnRuntimeMetrics['totalTokens'], 12000);
+    });
+
+    test('thread token usage updated falls back to total tokens when last is 0', () {
+      var state = const SessionState();
+      state = reduceNotification(
+        state,
+        _event('thread/tokenUsage/updated', <String, dynamic>{
+          'threadId': 'thread-1',
+          'turnId': 'turn-1',
+          'tokenUsage': <String, dynamic>{
+            'total': <String, dynamic>{'totalTokens': 64000},
+            'last': <String, dynamic>{'totalTokens': 0},
+            'modelContextWindow': 128000,
+          },
+        }),
+      );
+
+      expect(state.contextUsage.tokensInContext, 64000);
+      expect(state.turnRuntimeMetrics['totalTokens'], 64000);
+    });
+
+    test('account rate limits updated stores rate limits without token usage event', () {
+      var state = const SessionState();
+      state = reduceNotification(
+        state,
+        _event('account/rateLimits/updated', <String, dynamic>{
+          'rateLimits': <String, dynamic>{
+            'primary': <String, dynamic>{'usedPercent': 30, 'resetsAt': 123},
+          },
+        }),
+      );
+
+      expect(state.contextUsage.rateLimits, isNotNull);
+      expect(state.contextUsage.rateLimits!.primary, isNotNull);
+      expect(state.contextUsage.rateLimits!.primary!.usedPercent, 30);
+      expect(state.contextUsage.rateLimits!.primary!.resetsAt, 123);
+    });
+
+    test('context compaction item toggles compacting state', () {
+      var state = const SessionState();
+      state = reduceNotification(
+        state,
+        _event('item/started', <String, dynamic>{
+          'turnId': 'turn-1',
+          'item': <String, dynamic>{
+            'id': 'compact-1',
+            'type': 'contextCompaction',
+            'status': 'inProgress',
+          },
+        }),
+      );
+      expect(state.contextUsage.isCompacting, isTrue);
+
+      state = reduceNotification(
+        state,
+        _event('item/completed', <String, dynamic>{
+          'turnId': 'turn-1',
+          'item': <String, dynamic>{
+            'id': 'compact-1',
+            'type': 'contextCompaction',
+            'status': 'completed',
+          },
+        }),
+      );
+      expect(state.contextUsage.isCompacting, isFalse);
+    });
+
     test('turn completion appends separator only when there is work', () {
       var state = const SessionState();
       state = reduceNotification(

--- a/test/unit/token_usage_test.dart
+++ b/test/unit/token_usage_test.dart
@@ -1,0 +1,47 @@
+import 'package:alera/src/features/session/domain/context_usage.dart';
+import 'package:alera/src/features/session/domain/token_usage.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('token usage helpers', () {
+    test('blended total uses non-cached input plus output', () {
+      const usage = TokenUsage(
+        inputTokens: 100,
+        cachedInputTokens: 40,
+        outputTokens: 20,
+      );
+
+      expect(usage.nonCachedInputTokens, 60);
+      expect(usage.blendedTotalTokens, 80);
+    });
+
+    test('current context tokens prefer last usage when present', () {
+      const info = TokenUsageInfo(
+        totalTokenUsage: TokenUsage(totalTokens: 205000),
+        lastTokenUsage: TokenUsage(totalTokens: 12000),
+        modelContextWindow: 128000,
+      );
+
+      expect(info.currentContextTokens, 12000);
+      expect(info.percentRemaining, closeTo(90.625, 0.0001));
+    });
+
+    test('context usage falls back to total when last usage is empty', () {
+      const usage = ContextUsage(
+        tokenUsageInfo: TokenUsageInfo(
+          totalTokenUsage: TokenUsage(
+            inputTokens: 120,
+            cachedInputTokens: 20,
+            outputTokens: 30,
+            totalTokens: 64000,
+          ),
+          lastTokenUsage: TokenUsage(totalTokens: 0),
+          modelContextWindow: 128000,
+        ),
+      );
+
+      expect(usage.tokensInContext, 64000);
+      expect(usage.sessionTokensUsed, 130);
+    });
+  });
+}

--- a/test/widget/alera_status_bar_test.dart
+++ b/test/widget/alera_status_bar_test.dart
@@ -27,6 +27,31 @@ Future<void> _pumpStatusBar(
 }
 
 void main() {
+  testWidgets('status bar does not render context chip even with token metrics', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: AleraStatusBar(
+            state: const SessionState(
+              selectedWorkspacePath: '/repo',
+              turnRuntimeMetrics: <String, dynamic>{'totalTokens': 205000},
+            ),
+            rawLogExpanded: false,
+            onToggleRawLog: () {},
+            onCopyRawLog: () {},
+            canCopyRawLog: true,
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.textContaining('ctx'), findsNothing);
+    expect(find.byType(LinearProgressIndicator), findsNothing);
+  });
+
   testWidgets('copy raw log button is tappable when enabled', (tester) async {
     var copyCalls = 0;
     await _pumpStatusBar(

--- a/test/widget/context_usage_indicator_test.dart
+++ b/test/widget/context_usage_indicator_test.dart
@@ -1,0 +1,64 @@
+import 'dart:ui';
+
+import 'package:alera/src/features/session/domain/context_usage.dart';
+import 'package:alera/src/features/session/domain/token_usage.dart';
+import 'package:alera/src/features/session/presentation/widgets/context_usage_indicator.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+Future<void> _pumpIndicator(
+  WidgetTester tester, {
+  required ContextUsage usage,
+}) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Material(
+        child: Align(
+          alignment: Alignment.topLeft,
+          child: ContextUsageIndicator(
+            contextUsage: usage,
+            onCompact: () {},
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pump();
+}
+
+void main() {
+  testWidgets('popover shows current context and session usage semantics', (
+    tester,
+  ) async {
+    const usage = ContextUsage(
+      tokenUsageInfo: TokenUsageInfo(
+        totalTokenUsage: TokenUsage(
+          inputTokens: 220000,
+          cachedInputTokens: 20000,
+          outputTokens: 5000,
+          totalTokens: 205000,
+        ),
+        lastTokenUsage: TokenUsage(totalTokens: 12000),
+        modelContextWindow: 128000,
+      ),
+    );
+    await _pumpIndicator(tester, usage: usage);
+
+    final indicator = find.byType(ContextUsageIndicator);
+    expect(indicator, findsOneWidget);
+
+    final gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    await gesture.addPointer();
+    await gesture.moveTo(tester.getCenter(indicator));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Context window:'), findsOneWidget);
+    expect(find.text('12K / 128K tokens in current context'), findsOneWidget);
+    expect(find.text('205K session tokens used'), findsOneWidget);
+
+    final progress = tester.widget<CircularProgressIndicator>(
+      find.byType(CircularProgressIndicator).first,
+    );
+    expect(progress.value, closeTo(12000 / 128000, 0.0001));
+  });
+}


### PR DESCRIPTION
Summary
- remove the redundant context chip in the status bar and keep the context usage indicator focused on `thread/tokenUsage/updated` and `account/rateLimits/updated`
- ensure domain and reducer helpers calculate `currentContextTokens`/`blendedTotalTokens` per the new payloads and keep the composer ring based on the live window

Testing
- Not run (not requested)