### PR TITLE
fix: harden assistant stream recovery

### DIFF
--- a/lib/src/features/session/application/session_controller.dart
+++ b/lib/src/features/session/application/session_controller.dart
@@ -2154,13 +2154,52 @@ class SessionController extends StateNotifier<SessionState> {
         if (phase != 'final_answer') {
           return;
         }
-        _assistantTerminalSignalsByTurn[turnId] = _AssistantTerminalSignal(
+        _recordAssistantTerminalSignal(
+          turnId,
           itemId: itemId,
           phase: phase,
           source: 'legacy_item_completed',
-          atMs: at.millisecondsSinceEpoch,
+          at: at,
         );
-        _assistantMissingTurnCompletionWarnings.remove(turnId);
+        return;
+      case 'item/completed':
+        final item = params['item'];
+        if (item is! Map<String, dynamic>) {
+          return;
+        }
+        final itemType = item['type']?.toString().trim().toLowerCase();
+        if (itemType != 'agentmessage' && itemType != 'agent_message') {
+          return;
+        }
+        final turnId = _normalizeOptionalId(
+          params['turnId']?.toString() ?? item['turnId']?.toString(),
+        );
+        if (turnId == null) {
+          return;
+        }
+        final itemId = _normalizeOptionalId(item['id']?.toString());
+        final explicitPhase = _normalizeAssistantPhase(
+          item['phase']?.toString(),
+        );
+        final phase = explicitPhase != 'unknown'
+            ? explicitPhase
+            : (itemId != null &&
+                  state.finalAnswerItemIdByTurn[turnId] == itemId)
+            ? 'final_answer'
+            : (state.activeAgentStreamTurnId == turnId &&
+                  state.activeAgentStreamItemId == itemId)
+            ? _normalizeAssistantPhase(state.activeAgentStreamPhase)
+            : 'unknown';
+        if (phase != 'final_answer') {
+          return;
+        }
+        _recordAssistantTerminalSignal(
+          turnId,
+          itemId: itemId,
+          phase: phase,
+          source: 'item_completed',
+          at: at,
+        );
         return;
       case 'codex/event/task_complete':
         final msg = params['msg'];
@@ -2176,15 +2215,31 @@ class SessionController extends StateNotifier<SessionState> {
             (state.activeAgentStreamTurnId == turnId
                 ? _normalizeOptionalId(state.activeAgentStreamItemId)
                 : null);
-        _assistantTerminalSignalsByTurn[turnId] = _AssistantTerminalSignal(
+        _recordAssistantTerminalSignal(
+          turnId,
           itemId: itemId,
           phase: 'final_answer',
           source: 'task_complete',
-          atMs: at.millisecondsSinceEpoch,
+          at: at,
         );
-        _assistantMissingTurnCompletionWarnings.remove(turnId);
         return;
     }
+  }
+
+  void _recordAssistantTerminalSignal(
+    String turnId, {
+    required String? itemId,
+    required String phase,
+    required String source,
+    required DateTime at,
+  }) {
+    _assistantTerminalSignalsByTurn[turnId] = _AssistantTerminalSignal(
+      itemId: itemId,
+      phase: phase,
+      source: source,
+      atMs: at.millisecondsSinceEpoch,
+    );
+    _assistantMissingTurnCompletionWarnings.remove(turnId);
   }
 
   void _maybeLogAssistantStreamWarnings({required DateTime at}) {

--- a/lib/src/features/session/application/session_controller.dart
+++ b/lib/src/features/session/application/session_controller.dart
@@ -32,9 +32,13 @@ class SessionController extends StateNotifier<SessionState> {
     required SessionService sessionService,
     required ProjectService projectService,
     required SettingsService settingsService,
+    DateTime Function()? now,
+    Duration assistantStreamWarningGrace = const Duration(seconds: 5),
   }) : _sessionService = sessionService,
        _projectService = projectService,
        _settingsService = settingsService,
+       _now = now ?? _defaultNow,
+       _assistantStreamWarningGrace = assistantStreamWarningGrace,
        super(const SessionState()) {
     _eventsSub = _sessionService.events.listen(_onSessionEvent);
   }
@@ -45,6 +49,8 @@ class SessionController extends StateNotifier<SessionState> {
   final SessionService _sessionService;
   final ProjectService _projectService;
   final SettingsService _settingsService;
+  final DateTime Function() _now;
+  final Duration _assistantStreamWarningGrace;
   final CommandRegistry _commandRegistry = const CommandRegistry();
   StreamSubscription<SessionRuntimeEvent>? _eventsSub;
   Timer? _commitTickTimer;
@@ -60,6 +66,8 @@ class SessionController extends StateNotifier<SessionState> {
   static const int _maxTrackedResolvedPlanTurns = 120;
   static const int _maxTrackedCompletedPlanTurns = 120;
 
+  static DateTime _defaultNow() => DateTime.now().toUtc();
+
   final Set<String> _planModeRequestedTurnIds = <String>{};
   final Set<String> _turnsWithPlanActivity = <String>{};
   final Set<String> _turnsWithUserInputRequest = <String>{};
@@ -68,6 +76,10 @@ class SessionController extends StateNotifier<SessionState> {
   final List<String> _resolvedPlanTurnOrder = <String>[];
   final List<String> _completedTurnOrder = <String>[];
   final Map<String, String> _resolvedReasonByTurn = <String, String>{};
+  final Map<String, _AssistantTerminalSignal> _assistantTerminalSignalsByTurn =
+      <String, _AssistantTerminalSignal>{};
+  final Set<String> _assistantStreamStallWarnings = <String>{};
+  final Set<String> _assistantMissingTurnCompletionWarnings = <String>{};
 
   Future<void> bootstrap() async {
     if (_bootstrapped) {
@@ -117,6 +129,7 @@ class SessionController extends StateNotifier<SessionState> {
     state = state.copyWith(isBusy: true, clearError: true);
     try {
       _stopCommitTicker();
+      _resetAssistantStreamTracking();
       final validation = await _projectService.validateGitRepository(
         normalized,
       );
@@ -155,6 +168,7 @@ class SessionController extends StateNotifier<SessionState> {
         clearActiveAgentStreamItemId: true,
         clearActiveAgentStreamTurnId: true,
         clearActiveAgentStreamPhase: true,
+        clearActiveAgentStreamLastDeltaAtMs: true,
         connectionState: AppServerConnectionState.starting,
         pendingApprovals: const <PendingApproval>[],
       );
@@ -196,6 +210,7 @@ class SessionController extends StateNotifier<SessionState> {
     }
 
     _stopCommitTicker();
+    _resetAssistantStreamTracking();
     state = state.copyWith(
       isBusy: true,
       clearError: true,
@@ -221,6 +236,7 @@ class SessionController extends StateNotifier<SessionState> {
       clearActiveAgentStreamItemId: true,
       clearActiveAgentStreamTurnId: true,
       clearActiveAgentStreamPhase: true,
+      clearActiveAgentStreamLastDeltaAtMs: true,
       pendingApprovals: const <PendingApproval>[],
     );
 
@@ -250,6 +266,7 @@ class SessionController extends StateNotifier<SessionState> {
 
   Future<void> createSession(SessionCreateRequest request) async {
     _stopCommitTicker();
+    _resetAssistantStreamTracking();
     state = state.copyWith(
       isBusy: true,
       clearError: true,
@@ -270,6 +287,7 @@ class SessionController extends StateNotifier<SessionState> {
       clearActiveAgentStreamItemId: true,
       clearActiveAgentStreamTurnId: true,
       clearActiveAgentStreamPhase: true,
+      clearActiveAgentStreamLastDeltaAtMs: true,
     );
     try {
       final session = await _sessionService.createSession(request);
@@ -936,6 +954,7 @@ class SessionController extends StateNotifier<SessionState> {
 
   void _startNewChat() {
     _stopCommitTicker();
+    _resetAssistantStreamTracking();
     state = state.copyWith(
       clearActiveSessionId: true,
       timelineCells: const <TimelineCell>[],
@@ -954,6 +973,7 @@ class SessionController extends StateNotifier<SessionState> {
       clearActiveAgentStreamItemId: true,
       clearActiveAgentStreamTurnId: true,
       clearActiveAgentStreamPhase: true,
+      clearActiveAgentStreamLastDeltaAtMs: true,
       pendingApprovals: const <PendingApproval>[],
       clearPendingUserInput: true,
       composerAttachments: const <ComposerAttachment>[],
@@ -1522,9 +1542,10 @@ class SessionController extends StateNotifier<SessionState> {
         return;
       }
 
+      final eventNow = _now();
       _trackPlanActivityFromNotification(event);
-      final reduced = reduceNotification(state, event);
-      final ticked = reduceCommitTick(reduced);
+      final reduced = reduceNotification(state, event, now: eventNow);
+      final ticked = reduceCommitTick(reduced, now: eventNow);
       final runningTurnCount = _computeRunningTurnCount(
         current: ticked.runningTurnCount,
         method: event.method,
@@ -1542,6 +1563,7 @@ class SessionController extends StateNotifier<SessionState> {
         runningTurnCount: runningTurnCount,
         isInterrupting: shouldClearInterrupting ? false : ticked.isInterrupting,
       );
+      _trackAssistantTerminalSignal(event, at: eventNow);
 
       final completedTurnId = _extractCompletedTurnId(event);
       if (completedTurnId != null) {
@@ -1564,6 +1586,7 @@ class SessionController extends StateNotifier<SessionState> {
         }
       }
 
+      _maybeLogAssistantStreamWarnings(at: eventNow);
       _updateCommitTicker();
       if (runningTurnCount == 0 &&
           (event.method == 'turn/completed' || event.method == 'turn/failed') &&
@@ -2076,6 +2099,186 @@ class SessionController extends StateNotifier<SessionState> {
     return true;
   }
 
+  void _trackAssistantTerminalSignal(
+    SessionNotificationEvent event, {
+    required DateTime at,
+  }) {
+    final params = event.payload['params'];
+    if (params is! Map<String, dynamic>) {
+      return;
+    }
+
+    switch (event.method) {
+      case 'turn/started':
+      case 'turn/completed':
+      case 'turn/failed':
+        final turn = params['turn'];
+        if (turn is! Map<String, dynamic>) {
+          return;
+        }
+        final turnId = _normalizeOptionalId(turn['id']?.toString());
+        if (turnId != null) {
+          _clearAssistantStreamTracking(turnId);
+        }
+        return;
+      case 'codex/event/item_completed':
+        final msg = params['msg'];
+        if (msg is! Map<String, dynamic>) {
+          return;
+        }
+        final item = msg['item'];
+        if (item is! Map<String, dynamic>) {
+          return;
+        }
+        final itemType = item['type']?.toString().trim().toLowerCase();
+        if (itemType != 'agentmessage' && itemType != 'agent_message') {
+          return;
+        }
+        final turnId = _normalizeOptionalId(msg['turn_id']?.toString());
+        if (turnId == null) {
+          return;
+        }
+        final itemId = _normalizeOptionalId(item['id']?.toString());
+        final explicitPhase = _normalizeAssistantPhase(
+          item['phase']?.toString(),
+        );
+        final phase = explicitPhase != 'unknown'
+            ? explicitPhase
+            : (itemId != null &&
+                  state.finalAnswerItemIdByTurn[turnId] == itemId)
+            ? 'final_answer'
+            : (state.activeAgentStreamTurnId == turnId &&
+                  state.activeAgentStreamItemId == itemId)
+            ? _normalizeAssistantPhase(state.activeAgentStreamPhase)
+            : 'unknown';
+        if (phase != 'final_answer') {
+          return;
+        }
+        _assistantTerminalSignalsByTurn[turnId] = _AssistantTerminalSignal(
+          itemId: itemId,
+          phase: phase,
+          source: 'legacy_item_completed',
+          atMs: at.millisecondsSinceEpoch,
+        );
+        _assistantMissingTurnCompletionWarnings.remove(turnId);
+        return;
+      case 'codex/event/task_complete':
+        final msg = params['msg'];
+        if (msg is! Map<String, dynamic>) {
+          return;
+        }
+        final turnId = _normalizeOptionalId(msg['turn_id']?.toString());
+        if (turnId == null) {
+          return;
+        }
+        final itemId =
+            _normalizeOptionalId(state.finalAnswerItemIdByTurn[turnId]) ??
+            (state.activeAgentStreamTurnId == turnId
+                ? _normalizeOptionalId(state.activeAgentStreamItemId)
+                : null);
+        _assistantTerminalSignalsByTurn[turnId] = _AssistantTerminalSignal(
+          itemId: itemId,
+          phase: 'final_answer',
+          source: 'task_complete',
+          atMs: at.millisecondsSinceEpoch,
+        );
+        _assistantMissingTurnCompletionWarnings.remove(turnId);
+        return;
+    }
+  }
+
+  void _maybeLogAssistantStreamWarnings({required DateTime at}) {
+    _maybeLogFinalAnswerStreamStall(at: at);
+    _maybeLogMissingTurnCompletionAfterTerminalSignal(at: at);
+  }
+
+  void _maybeLogFinalAnswerStreamStall({required DateTime at}) {
+    final turnId = _normalizeOptionalId(state.activeAgentStreamTurnId);
+    final itemId = _normalizeOptionalId(state.activeAgentStreamItemId);
+    final phase = _normalizeAssistantPhase(state.activeAgentStreamPhase);
+    final lastDeltaAtMs = state.activeAgentStreamLastDeltaAtMs;
+    if (turnId == null ||
+        itemId == null ||
+        phase != 'final_answer' ||
+        lastDeltaAtMs == null) {
+      return;
+    }
+
+    final idleMs = at.millisecondsSinceEpoch - lastDeltaAtMs;
+    if (idleMs < _assistantStreamWarningGrace.inMilliseconds) {
+      return;
+    }
+    if (_assistantTerminalSignalsByTurn.containsKey(turnId)) {
+      return;
+    }
+
+    final warningKey = '$turnId:$itemId';
+    if (_assistantStreamStallWarnings.contains(warningKey)) {
+      return;
+    }
+    _assistantStreamStallWarnings.add(warningKey);
+    _appendRuntimeLog(
+      'runtime/assistantStream stalled '
+      'turnId=$turnId '
+      'itemId=$itemId '
+      'phase=$phase '
+      'signal=none '
+      'idleMs=$idleMs',
+    );
+  }
+
+  void _maybeLogMissingTurnCompletionAfterTerminalSignal({
+    required DateTime at,
+  }) {
+    for (final entry in _assistantTerminalSignalsByTurn.entries.toList()) {
+      final turnId = entry.key;
+      if (_completedTurnIds.contains(turnId) ||
+          _assistantMissingTurnCompletionWarnings.contains(turnId)) {
+        continue;
+      }
+
+      final idleMs = at.millisecondsSinceEpoch - entry.value.atMs;
+      if (idleMs < _assistantStreamWarningGrace.inMilliseconds) {
+        continue;
+      }
+
+      _assistantMissingTurnCompletionWarnings.add(turnId);
+      _appendRuntimeLog(
+        'runtime/assistantStream missingTurnCompletion '
+        'turnId=$turnId '
+        'itemId=${entry.value.itemId ?? "<null>"} '
+        'phase=${entry.value.phase} '
+        'signal=${entry.value.source} '
+        'idleMs=$idleMs',
+      );
+    }
+  }
+
+  void _clearAssistantStreamTracking(String turnId) {
+    _assistantTerminalSignalsByTurn.remove(turnId);
+    _assistantMissingTurnCompletionWarnings.remove(turnId);
+    _assistantStreamStallWarnings.removeWhere(
+      (warningKey) => warningKey.startsWith('$turnId:'),
+    );
+  }
+
+  void _resetAssistantStreamTracking() {
+    _assistantTerminalSignalsByTurn.clear();
+    _assistantStreamStallWarnings.clear();
+    _assistantMissingTurnCompletionWarnings.clear();
+  }
+
+  String _normalizeAssistantPhase(String? raw) {
+    final normalized = raw?.trim().toLowerCase();
+    if (normalized == 'finalanswer') {
+      return 'final_answer';
+    }
+    if (normalized == 'final_answer' || normalized == 'commentary') {
+      return normalized!;
+    }
+    return 'unknown';
+  }
+
   void _appendRuntimeLog(String message) {
     final nextLog = <String>[...state.activityLog, message];
     final clipped = nextLog.length <= 200
@@ -2094,10 +2297,12 @@ class SessionController extends StateNotifier<SessionState> {
 
     _commitTickTimer ??= Timer.periodic(const Duration(milliseconds: 80), (_) {
       final current = state;
-      final next = reduceCommitTick(current);
+      final tickNow = _now();
+      final next = reduceCommitTick(current, now: tickNow);
       if (!_isCommitTickNoop(current, next)) {
         state = next;
       }
+      _maybeLogAssistantStreamWarnings(at: tickNow);
       if (next.runningTurnCount <= 0 && next.streamQueue.isEmpty) {
         _stopCommitTicker();
       }
@@ -2156,6 +2361,20 @@ class SessionController extends StateNotifier<SessionState> {
     }
     return current;
   }
+}
+
+class _AssistantTerminalSignal {
+  const _AssistantTerminalSignal({
+    required this.itemId,
+    required this.phase,
+    required this.source,
+    required this.atMs,
+  });
+
+  final String? itemId;
+  final String phase;
+  final String source;
+  final int atMs;
 }
 
 class _ParsedUserInputQuestions {

--- a/lib/src/features/session/application/session_state.dart
+++ b/lib/src/features/session/application/session_state.dart
@@ -39,6 +39,7 @@ class SessionState {
     this.activeAgentStreamItemId,
     this.activeAgentStreamTurnId,
     this.activeAgentStreamPhase,
+    this.activeAgentStreamLastDeltaAtMs,
     this.agentMessagePhaseByItemId = const <String, String>{},
     this.finalAnswerItemIdByTurn = const <String, String>{},
     this.activeExecCellId,
@@ -86,6 +87,7 @@ class SessionState {
   final String? activeAgentStreamItemId;
   final String? activeAgentStreamTurnId;
   final String? activeAgentStreamPhase;
+  final int? activeAgentStreamLastDeltaAtMs;
   final Map<String, String> agentMessagePhaseByItemId;
   final Map<String, String> finalAnswerItemIdByTurn;
   final String? activeExecCellId;
@@ -188,6 +190,8 @@ class SessionState {
     bool clearActiveAgentStreamTurnId = false,
     String? activeAgentStreamPhase,
     bool clearActiveAgentStreamPhase = false,
+    int? activeAgentStreamLastDeltaAtMs,
+    bool clearActiveAgentStreamLastDeltaAtMs = false,
     Map<String, String>? agentMessagePhaseByItemId,
     Map<String, String>? finalAnswerItemIdByTurn,
     String? activeExecCellId,
@@ -271,6 +275,10 @@ class SessionState {
       activeAgentStreamPhase: clearActiveAgentStreamPhase
           ? null
           : (activeAgentStreamPhase ?? this.activeAgentStreamPhase),
+      activeAgentStreamLastDeltaAtMs: clearActiveAgentStreamLastDeltaAtMs
+          ? null
+          : (activeAgentStreamLastDeltaAtMs ??
+                this.activeAgentStreamLastDeltaAtMs),
       agentMessagePhaseByItemId:
           agentMessagePhaseByItemId ?? this.agentMessagePhaseByItemId,
       finalAnswerItemIdByTurn:

--- a/lib/src/features/session/application/session_timeline_reducer.dart
+++ b/lib/src/features/session/application/session_timeline_reducer.dart
@@ -2088,7 +2088,7 @@ SessionState _onAssistantItemCompleted(
 
   if (phase == 'commentary') {
     if (finalText.trim().isNotEmpty &&
-        !_hasCommittedStreamTextForItem(
+        !_hasProgressTextForItem(
           cells,
           turnId: turnId,
           itemId: itemId,
@@ -2255,13 +2255,13 @@ bool _hasCommittedAssistantStreamTextForItem(
   return false;
 }
 
-bool _hasCommittedStreamTextForItem(
+bool _hasProgressTextForItem(
   List<TimelineCell> cells, {
   required String turnId,
   required String itemId,
 }) {
   for (final cell in cells) {
-    if (cell.turnId != turnId) {
+    if (cell.turnId != turnId || cell.kind != TimelineCellKind.progressText) {
       continue;
     }
     final text = (cell.markdownText ?? '').trim();
@@ -2269,10 +2269,6 @@ bool _hasCommittedStreamTextForItem(
       continue;
     }
     final metadata = cell.metadata;
-    final streamCommitted = metadata['streamCommitted'] == true;
-    if (!streamCommitted) {
-      continue;
-    }
     final streamItemId =
         _asString(metadata['streamItemId']) ??
         _asString(metadata['stream_item_id']) ??

--- a/lib/src/features/session/application/session_timeline_reducer.dart
+++ b/lib/src/features/session/application/session_timeline_reducer.dart
@@ -438,7 +438,17 @@ SessionState _onLegacyItemCompleted(
       timestamp: timestamp,
     );
   }
-  return nextState;
+  final normalizedItem = _normalizeLegacyAssistantCompletionItem(
+    item,
+    phase: phase,
+  );
+  return _onAssistantItemCompleted(
+    nextState,
+    turnId: turnId,
+    itemId: itemId,
+    item: normalizedItem,
+    timestamp: timestamp,
+  );
 }
 
 SessionState _onLegacyTaskComplete(
@@ -457,7 +467,16 @@ SessionState _onLegacyTaskComplete(
   }
 
   final hasExplicitFinal = state.finalAnswerItemIdByTurn.containsKey(turnId);
-  if (hasExplicitFinal) {
+  final hasActiveStreamForTurn = state.activeAgentStreamTurnId == turnId;
+  final hasStreamingAssistantForTurn = state.timelineCells.any(
+    (cell) =>
+        cell.turnId == turnId &&
+        cell.kind == TimelineCellKind.assistantMessage &&
+        cell.isStreaming,
+  );
+  if (hasExplicitFinal &&
+      !hasActiveStreamForTurn &&
+      !hasStreamingAssistantForTurn) {
     return state;
   }
 
@@ -475,11 +494,6 @@ SessionState _onLegacyTaskComplete(
       existingAssistant = candidate;
       break;
     }
-  }
-
-  if (existingAssistant != null &&
-      (existingAssistant.markdownText ?? '').trim() == lastAgentMessage) {
-    return state;
   }
 
   final cellId = existingAssistant?.id ?? 'assistant-final-$turnId';
@@ -516,7 +530,18 @@ SessionState _onLegacyTaskComplete(
     );
   }
 
-  return state.copyWith(timelineCells: cells);
+  final shouldClearActiveStream = state.activeAgentStreamTurnId == turnId;
+  final shouldClearStreamingAssistant =
+      shouldClearActiveStream &&
+      (state.activeStreamingAssistantCellId ?? '').isNotEmpty;
+  return state.copyWith(
+    timelineCells: cells,
+    clearActiveStreamingAssistantCellId: shouldClearStreamingAssistant,
+    clearActiveAgentStreamItemId: shouldClearActiveStream,
+    clearActiveAgentStreamTurnId: shouldClearActiveStream,
+    clearActiveAgentStreamPhase: shouldClearActiveStream,
+    clearActiveAgentStreamLastDeltaAtMs: shouldClearActiveStream,
+  );
 }
 
 Map<String, dynamic> _withStreamCommitMetadata(
@@ -844,6 +869,7 @@ SessionState _onTurnStarted(
     clearActiveAgentStreamItemId: true,
     clearActiveAgentStreamTurnId: true,
     clearActiveAgentStreamPhase: true,
+    clearActiveAgentStreamLastDeltaAtMs: true,
     finalAnswerItemIdByTurn: nextFinalByTurn,
     turnHadWorkActivity: false,
     turnRuntimeMetrics: const <String, dynamic>{},
@@ -1029,6 +1055,8 @@ SessionState _onTurnCompleted(
     clearActiveAgentStreamItemId: nextState.activeAgentStreamTurnId == turnId,
     clearActiveAgentStreamTurnId: nextState.activeAgentStreamTurnId == turnId,
     clearActiveAgentStreamPhase: nextState.activeAgentStreamTurnId == turnId,
+    clearActiveAgentStreamLastDeltaAtMs:
+        nextState.activeAgentStreamTurnId == turnId,
     finalAnswerItemIdByTurn: nextFinalByTurn,
     turnHadWorkActivity: false,
     turnRuntimeMetrics: const <String, dynamic>{},
@@ -1093,6 +1121,7 @@ SessionState _onAssistantDelta(
     activeAgentStreamItemId: itemId,
     activeAgentStreamTurnId: turnId,
     activeAgentStreamPhase: phase,
+    activeAgentStreamLastDeltaAtMs: timestamp.millisecondsSinceEpoch,
     statusHeader: 'Working',
     pendingStatusRestore: false,
   );
@@ -2087,6 +2116,7 @@ SessionState _onAssistantItemCompleted(
       clearActiveAgentStreamItemId: shouldClearActiveStream,
       clearActiveAgentStreamTurnId: shouldClearActiveStream,
       clearActiveAgentStreamPhase: shouldClearActiveStream,
+      clearActiveAgentStreamLastDeltaAtMs: shouldClearActiveStream,
       clearActiveStreamingAssistantCellId:
           shouldClearActiveStream &&
           (nextState.activeStreamingAssistantCellId ?? '').isNotEmpty,
@@ -2104,6 +2134,7 @@ SessionState _onAssistantItemCompleted(
       clearActiveAgentStreamItemId: shouldClearActiveStream,
       clearActiveAgentStreamTurnId: shouldClearActiveStream,
       clearActiveAgentStreamPhase: shouldClearActiveStream,
+      clearActiveAgentStreamLastDeltaAtMs: shouldClearActiveStream,
     );
   }
 
@@ -2188,6 +2219,7 @@ SessionState _onAssistantItemCompleted(
     clearActiveAgentStreamItemId: shouldClearActiveStream,
     clearActiveAgentStreamTurnId: shouldClearActiveStream,
     clearActiveAgentStreamPhase: shouldClearActiveStream,
+    clearActiveAgentStreamLastDeltaAtMs: shouldClearActiveStream,
   );
 }
 
@@ -2755,7 +2787,7 @@ String _assistantFinalText(Map<String, dynamic> item) {
     for (final entry in content) {
       if (entry is Map) {
         final map = asMap(entry);
-        if (_asString(map['type']) == 'text') {
+        if ((_asString(map['type']) ?? '').toLowerCase() == 'text') {
           final text = _asString(map['text']);
           if (text != null) {
             if (buffer.isNotEmpty) {
@@ -2770,6 +2802,49 @@ String _assistantFinalText(Map<String, dynamic> item) {
   }
 
   return '';
+}
+
+Map<String, dynamic> _normalizeLegacyAssistantCompletionItem(
+  Map<String, dynamic> item, {
+  required String phase,
+}) {
+  final contentText = _legacyAssistantContentText(item);
+  final text = contentText.isNotEmpty
+      ? contentText
+      : _asString(item['text']) ?? _asString(item['message']) ?? '';
+  return <String, dynamic>{
+    ...item,
+    'type': 'agentMessage',
+    'phase': phase,
+    'status': _asString(item['status']) ?? 'completed',
+    'text': text,
+  };
+}
+
+String _legacyAssistantContentText(Map<String, dynamic> item) {
+  final content = item['content'];
+  if (content is! List) {
+    return '';
+  }
+  final buffer = StringBuffer();
+  for (final entry in content) {
+    if (entry is! Map) {
+      continue;
+    }
+    final map = asMap(entry);
+    if ((_asString(map['type']) ?? '').toLowerCase() != 'text') {
+      continue;
+    }
+    final text = _asString(map['text']);
+    if (text == null || text.isEmpty) {
+      continue;
+    }
+    if (buffer.isNotEmpty) {
+      buffer.writeln();
+    }
+    buffer.write(text);
+  }
+  return buffer.toString();
 }
 
 String _mergeFinalText(String current, String finalText) {

--- a/test/unit/session_controller_test.dart
+++ b/test/unit/session_controller_test.dart
@@ -2150,5 +2150,226 @@ void main() {
         isA<CodexReviewUncommittedChangesTarget>(),
       );
     });
+
+    test(
+      'logs stalled final_answer stream without clearing running turn count',
+      () async {
+        final fakeService = _FakeSessionService();
+        var now = DateTime.utc(2026, 3, 8, 12);
+        final controller = SessionController(
+          sessionService: fakeService,
+          projectService: _FakeProjectService(),
+          settingsService: _FakeSettingsService('gpt-5.3-codex', 'high', true),
+          now: () => now,
+          assistantStreamWarningGrace: const Duration(milliseconds: 20),
+        );
+        addTearDown(() async {
+          controller.dispose();
+          await fakeService.shutdown();
+        });
+
+        await controller.bootstrap();
+        await controller.selectWorkspaceFromPath('/repo');
+        await controller.sendInput('hello');
+
+        fakeService.emitNotification('turn/started', <String, dynamic>{
+          'turn': <String, dynamic>{
+            'id': 'turn-1',
+            'threadId': 'thread-1',
+            'status': 'inProgress',
+          },
+        });
+        fakeService.emitNotification(
+          'codex/event/item_started',
+          <String, dynamic>{
+            'msg': <String, dynamic>{
+              'type': 'item_started',
+              'turn_id': 'turn-1',
+              'item': <String, dynamic>{
+                'id': 'msg-final',
+                'type': 'AgentMessage',
+                'phase': 'final_answer',
+              },
+            },
+          },
+        );
+        fakeService
+            .emitNotification('item/agentMessage/delta', <String, dynamic>{
+              'threadId': 'thread-1',
+              'turnId': 'turn-1',
+              'itemId': 'msg-final',
+              'delta': 'partial without close',
+            });
+        await Future<void>.delayed(const Duration(milliseconds: 20));
+
+        now = now.add(const Duration(milliseconds: 40));
+        await Future<void>.delayed(const Duration(milliseconds: 140));
+
+        expect(
+          controller.state.activityLog.any(
+            (line) =>
+                line.contains('runtime/assistantStream stalled') &&
+                line.contains('turnId=turn-1') &&
+                line.contains('itemId=msg-final') &&
+                line.contains('signal=none'),
+          ),
+          isTrue,
+        );
+        expect(controller.state.runningTurnCount, 1);
+      },
+    );
+
+    test(
+      'ignores commentary-only legacy completion for terminal stream warnings',
+      () async {
+        final fakeService = _FakeSessionService();
+        var now = DateTime.utc(2026, 3, 8, 12);
+        final controller = SessionController(
+          sessionService: fakeService,
+          projectService: _FakeProjectService(),
+          settingsService: _FakeSettingsService('gpt-5.3-codex', 'high', true),
+          now: () => now,
+          assistantStreamWarningGrace: const Duration(milliseconds: 20),
+        );
+        addTearDown(() async {
+          controller.dispose();
+          await fakeService.shutdown();
+        });
+
+        await controller.bootstrap();
+        await controller.selectWorkspaceFromPath('/repo');
+        await controller.sendInput('hello');
+
+        fakeService.emitNotification('turn/started', <String, dynamic>{
+          'turn': <String, dynamic>{
+            'id': 'turn-1',
+            'threadId': 'thread-1',
+            'status': 'inProgress',
+          },
+        });
+        fakeService.emitNotification(
+          'codex/event/item_completed',
+          <String, dynamic>{
+            'msg': <String, dynamic>{
+              'type': 'item_completed',
+              'turn_id': 'turn-1',
+              'item': <String, dynamic>{
+                'id': 'msg-commentary',
+                'type': 'AgentMessage',
+                'phase': 'commentary',
+                'content': <Map<String, dynamic>>[
+                  <String, dynamic>{
+                    'type': 'Text',
+                    'text': 'legacy commentary',
+                  },
+                ],
+              },
+            },
+          },
+        );
+        await Future<void>.delayed(const Duration(milliseconds: 20));
+
+        now = now.add(const Duration(milliseconds: 40));
+        await Future<void>.delayed(const Duration(milliseconds: 140));
+
+        expect(
+          controller.state.activityLog.any(
+            (line) =>
+                line.contains(
+                  'runtime/assistantStream missingTurnCompletion',
+                ) &&
+                line.contains('turnId=turn-1'),
+          ),
+          isFalse,
+        );
+      },
+    );
+
+    test(
+      'logs missing turn completion after legacy assistant completion without clearing running turn count',
+      () async {
+        final fakeService = _FakeSessionService();
+        var now = DateTime.utc(2026, 3, 8, 12);
+        final controller = SessionController(
+          sessionService: fakeService,
+          projectService: _FakeProjectService(),
+          settingsService: _FakeSettingsService('gpt-5.3-codex', 'high', true),
+          now: () => now,
+          assistantStreamWarningGrace: const Duration(milliseconds: 20),
+        );
+        addTearDown(() async {
+          controller.dispose();
+          await fakeService.shutdown();
+        });
+
+        await controller.bootstrap();
+        await controller.selectWorkspaceFromPath('/repo');
+        await controller.sendInput('hello');
+
+        fakeService.emitNotification('turn/started', <String, dynamic>{
+          'turn': <String, dynamic>{
+            'id': 'turn-1',
+            'threadId': 'thread-1',
+            'status': 'inProgress',
+          },
+        });
+        fakeService.emitNotification(
+          'codex/event/item_started',
+          <String, dynamic>{
+            'msg': <String, dynamic>{
+              'type': 'item_started',
+              'turn_id': 'turn-1',
+              'item': <String, dynamic>{
+                'id': 'msg-final',
+                'type': 'AgentMessage',
+                'phase': 'final_answer',
+              },
+            },
+          },
+        );
+        fakeService
+            .emitNotification('item/agentMessage/delta', <String, dynamic>{
+              'threadId': 'thread-1',
+              'turnId': 'turn-1',
+              'itemId': 'msg-final',
+              'delta': 'legacy final\n',
+            });
+        fakeService.emitNotification(
+          'codex/event/item_completed',
+          <String, dynamic>{
+            'msg': <String, dynamic>{
+              'type': 'item_completed',
+              'turn_id': 'turn-1',
+              'item': <String, dynamic>{
+                'id': 'msg-final',
+                'type': 'AgentMessage',
+                'phase': 'final_answer',
+                'content': <Map<String, dynamic>>[
+                  <String, dynamic>{'type': 'text', 'text': 'legacy final'},
+                ],
+              },
+            },
+          },
+        );
+        await Future<void>.delayed(const Duration(milliseconds: 20));
+
+        now = now.add(const Duration(milliseconds: 40));
+        await Future<void>.delayed(const Duration(milliseconds: 140));
+
+        expect(
+          controller.state.activityLog.any(
+            (line) =>
+                line.contains(
+                  'runtime/assistantStream missingTurnCompletion',
+                ) &&
+                line.contains('turnId=turn-1') &&
+                line.contains('itemId=msg-final') &&
+                line.contains('signal=legacy_item_completed'),
+          ),
+          isTrue,
+        );
+        expect(controller.state.runningTurnCount, 1);
+      },
+    );
   });
 }

--- a/test/unit/session_controller_test.dart
+++ b/test/unit/session_controller_test.dart
@@ -2371,5 +2371,67 @@ void main() {
         expect(controller.state.runningTurnCount, 1);
       },
     );
+
+    test(
+      'logs missing turn completion after modern assistant completion without clearing running turn count',
+      () async {
+        final fakeService = _FakeSessionService();
+        var now = DateTime.utc(2026, 3, 8, 12);
+        final controller = SessionController(
+          sessionService: fakeService,
+          projectService: _FakeProjectService(),
+          settingsService: _FakeSettingsService('gpt-5.3-codex', 'high', true),
+          now: () => now,
+          assistantStreamWarningGrace: const Duration(milliseconds: 20),
+        );
+        addTearDown(() async {
+          controller.dispose();
+          await fakeService.shutdown();
+        });
+
+        await controller.bootstrap();
+        await controller.selectWorkspaceFromPath('/repo');
+        await controller.sendInput('hello');
+
+        fakeService.emitNotification('turn/started', <String, dynamic>{
+          'turn': <String, dynamic>{
+            'id': 'turn-1',
+            'threadId': 'thread-1',
+            'status': 'inProgress',
+          },
+        });
+        fakeService.emitNotification(
+          'item/completed',
+          <String, dynamic>{
+            'turnId': 'turn-1',
+            'item': <String, dynamic>{
+              'id': 'msg-final',
+              'type': 'agentMessage',
+              'phase': 'final_answer',
+              'status': 'completed',
+              'text': 'modern final',
+            },
+          },
+        );
+        await Future<void>.delayed(const Duration(milliseconds: 20));
+
+        now = now.add(const Duration(milliseconds: 40));
+        await Future<void>.delayed(const Duration(milliseconds: 140));
+
+        expect(
+          controller.state.activityLog.any(
+            (line) =>
+                line.contains(
+                  'runtime/assistantStream missingTurnCompletion',
+                ) &&
+                line.contains('turnId=turn-1') &&
+                line.contains('itemId=msg-final') &&
+                line.contains('signal=item_completed'),
+          ),
+          isTrue,
+        );
+        expect(controller.state.runningTurnCount, 1);
+      },
+    );
   });
 }

--- a/test/unit/session_timeline_reducer_test.dart
+++ b/test/unit/session_timeline_reducer_test.dart
@@ -394,41 +394,47 @@ void main() {
       expect(state.turnRuntimeMetrics['totalTokens'], 12000);
     });
 
-    test('thread token usage updated falls back to total tokens when last is 0', () {
-      var state = const SessionState();
-      state = reduceNotification(
-        state,
-        _event('thread/tokenUsage/updated', <String, dynamic>{
-          'threadId': 'thread-1',
-          'turnId': 'turn-1',
-          'tokenUsage': <String, dynamic>{
-            'total': <String, dynamic>{'totalTokens': 64000},
-            'last': <String, dynamic>{'totalTokens': 0},
-            'modelContextWindow': 128000,
-          },
-        }),
-      );
+    test(
+      'thread token usage updated falls back to total tokens when last is 0',
+      () {
+        var state = const SessionState();
+        state = reduceNotification(
+          state,
+          _event('thread/tokenUsage/updated', <String, dynamic>{
+            'threadId': 'thread-1',
+            'turnId': 'turn-1',
+            'tokenUsage': <String, dynamic>{
+              'total': <String, dynamic>{'totalTokens': 64000},
+              'last': <String, dynamic>{'totalTokens': 0},
+              'modelContextWindow': 128000,
+            },
+          }),
+        );
 
-      expect(state.contextUsage.tokensInContext, 64000);
-      expect(state.turnRuntimeMetrics['totalTokens'], 64000);
-    });
+        expect(state.contextUsage.tokensInContext, 64000);
+        expect(state.turnRuntimeMetrics['totalTokens'], 64000);
+      },
+    );
 
-    test('account rate limits updated stores rate limits without token usage event', () {
-      var state = const SessionState();
-      state = reduceNotification(
-        state,
-        _event('account/rateLimits/updated', <String, dynamic>{
-          'rateLimits': <String, dynamic>{
-            'primary': <String, dynamic>{'usedPercent': 30, 'resetsAt': 123},
-          },
-        }),
-      );
+    test(
+      'account rate limits updated stores rate limits without token usage event',
+      () {
+        var state = const SessionState();
+        state = reduceNotification(
+          state,
+          _event('account/rateLimits/updated', <String, dynamic>{
+            'rateLimits': <String, dynamic>{
+              'primary': <String, dynamic>{'usedPercent': 30, 'resetsAt': 123},
+            },
+          }),
+        );
 
-      expect(state.contextUsage.rateLimits, isNotNull);
-      expect(state.contextUsage.rateLimits!.primary, isNotNull);
-      expect(state.contextUsage.rateLimits!.primary!.usedPercent, 30);
-      expect(state.contextUsage.rateLimits!.primary!.resetsAt, 123);
-    });
+        expect(state.contextUsage.rateLimits, isNotNull);
+        expect(state.contextUsage.rateLimits!.primary, isNotNull);
+        expect(state.contextUsage.rateLimits!.primary!.usedPercent, 30);
+        expect(state.contextUsage.rateLimits!.primary!.resetsAt, 123);
+      },
+    );
 
     test('context compaction item toggles compacting state', () {
       var state = const SessionState();
@@ -867,6 +873,78 @@ void main() {
     );
 
     test(
+      'task_complete clears active assistant streaming state when rescuing',
+      () {
+        final now = DateTime.utc(2026, 2, 22);
+        var state = const SessionState();
+        state = reduceNotification(
+          state,
+          _event('turn/started', <String, dynamic>{
+            'turn': <String, dynamic>{'id': 'turn-1', 'threadId': 'thread-1'},
+          }),
+          now: now,
+        );
+        state = reduceNotification(
+          state,
+          _event('codex/event/item_started', <String, dynamic>{
+            'msg': <String, dynamic>{
+              'type': 'item_started',
+              'turn_id': 'turn-1',
+              'item': <String, dynamic>{
+                'id': 'msg-final',
+                'type': 'AgentMessage',
+                'phase': 'final_answer',
+              },
+            },
+          }),
+          now: now,
+        );
+        state = reduceNotification(
+          state,
+          _event('item/agentMessage/delta', <String, dynamic>{
+            'turnId': 'turn-1',
+            'itemId': 'msg-final',
+            'delta': 'Recovered final\n',
+          }),
+          now: now,
+        );
+
+        final assistantBefore = _cellsByKind(
+          state,
+          TimelineCellKind.assistantMessage,
+        );
+        expect(assistantBefore, hasLength(1));
+        expect(assistantBefore.first.isStreaming, isTrue);
+        expect(state.activeStreamingAssistantCellId, isNotNull);
+
+        state = reduceNotification(
+          state,
+          _event('codex/event/task_complete', <String, dynamic>{
+            'msg': <String, dynamic>{
+              'type': 'task_complete',
+              'turn_id': 'turn-1',
+              'last_agent_message': 'Recovered final',
+            },
+          }),
+          now: now.add(const Duration(seconds: 1)),
+        );
+
+        final assistantAfter = _cellsByKind(
+          state,
+          TimelineCellKind.assistantMessage,
+        );
+        expect(assistantAfter, hasLength(1));
+        expect(assistantAfter.first.markdownText, 'Recovered final');
+        expect(assistantAfter.first.isStreaming, isFalse);
+        expect(state.activeStreamingAssistantCellId, isNull);
+        expect(state.activeAgentStreamItemId, isNull);
+        expect(state.activeAgentStreamTurnId, isNull);
+        expect(state.activeAgentStreamPhase, isNull);
+        expect(state.activeAgentStreamLastDeltaAtMs, isNull);
+      },
+    );
+
+    test(
       'commandExecution classification uses commandActions then heuristic',
       () {
         var state = const SessionState();
@@ -1223,6 +1301,197 @@ void main() {
       expect(assistant, hasLength(1));
       expect(assistant.first.markdownText, 'partial without newline');
     });
+
+    test(
+      'legacy item_completed final_answer recovers payload text from capitalized Text content',
+      () {
+        var state = const SessionState();
+        state = reduceNotification(
+          state,
+          _event('turn/started', <String, dynamic>{
+            'turn': <String, dynamic>{'id': 'turn-1', 'threadId': 'thread-1'},
+          }),
+        );
+        state = reduceNotification(
+          state,
+          _event('codex/event/item_started', <String, dynamic>{
+            'msg': <String, dynamic>{
+              'type': 'item_started',
+              'turn_id': 'turn-1',
+              'item': <String, dynamic>{
+                'id': 'msg-final',
+                'type': 'AgentMessage',
+                'phase': 'final_answer',
+              },
+            },
+          }),
+        );
+
+        state = reduceNotification(
+          state,
+          _event('codex/event/item_completed', <String, dynamic>{
+            'msg': <String, dynamic>{
+              'type': 'item_completed',
+              'turn_id': 'turn-1',
+              'item': <String, dynamic>{
+                'id': 'msg-final',
+                'type': 'AgentMessage',
+                'phase': 'final_answer',
+                'content': <Map<String, dynamic>>[
+                  <String, dynamic>{'type': 'Text', 'text': 'legacy final'},
+                ],
+              },
+            },
+          }),
+        );
+
+        final assistant = _cellsByKind(
+          state,
+          TimelineCellKind.assistantMessage,
+        );
+        expect(assistant, hasLength(1));
+        expect(assistant.first.markdownText, 'legacy final');
+        expect(assistant.first.isStreaming, isFalse);
+      },
+    );
+
+    test(
+      'legacy item_completed final_answer closes assistant stream without modern item completion',
+      () {
+        var state = const SessionState();
+        state = reduceNotification(
+          state,
+          _event('turn/started', <String, dynamic>{
+            'turn': <String, dynamic>{'id': 'turn-1', 'threadId': 'thread-1'},
+          }),
+        );
+        state = reduceNotification(
+          state,
+          _event('codex/event/item_started', <String, dynamic>{
+            'msg': <String, dynamic>{
+              'type': 'item_started',
+              'turn_id': 'turn-1',
+              'item': <String, dynamic>{
+                'id': 'msg-final',
+                'type': 'AgentMessage',
+                'phase': 'final_answer',
+              },
+            },
+          }),
+        );
+        state = reduceNotification(
+          state,
+          _event('item/agentMessage/delta', <String, dynamic>{
+            'turnId': 'turn-1',
+            'itemId': 'msg-final',
+            'delta': 'legacy final\n',
+          }),
+        );
+
+        final streamingAssistant = _cellsByKind(
+          state,
+          TimelineCellKind.assistantMessage,
+        );
+        expect(streamingAssistant, hasLength(1));
+        expect(streamingAssistant.first.isStreaming, isTrue);
+
+        state = reduceNotification(
+          state,
+          _event('codex/event/item_completed', <String, dynamic>{
+            'msg': <String, dynamic>{
+              'type': 'item_completed',
+              'turn_id': 'turn-1',
+              'item': <String, dynamic>{
+                'id': 'msg-final',
+                'type': 'AgentMessage',
+                'phase': 'final_answer',
+                'content': <Map<String, dynamic>>[
+                  <String, dynamic>{'type': 'text', 'text': 'legacy final'},
+                ],
+              },
+            },
+          }),
+        );
+
+        final assistant = _cellsByKind(
+          state,
+          TimelineCellKind.assistantMessage,
+        );
+        expect(assistant, hasLength(1));
+        expect(assistant.first.markdownText, 'legacy final');
+        expect(assistant.first.isStreaming, isFalse);
+        expect(state.activeAgentStreamItemId, isNull);
+        expect(state.activeAgentStreamTurnId, isNull);
+        expect(state.activeAgentStreamPhase, isNull);
+        expect(state.activeAgentStreamLastDeltaAtMs, isNull);
+      },
+    );
+
+    test(
+      'legacy item_completed commentary flushes pending commentary without modern item completion',
+      () {
+        var state = const SessionState();
+        state = reduceNotification(
+          state,
+          _event('turn/started', <String, dynamic>{
+            'turn': <String, dynamic>{'id': 'turn-1', 'threadId': 'thread-1'},
+          }),
+        );
+        state = reduceNotification(
+          state,
+          _event('codex/event/item_started', <String, dynamic>{
+            'msg': <String, dynamic>{
+              'type': 'item_started',
+              'turn_id': 'turn-1',
+              'item': <String, dynamic>{
+                'id': 'msg-commentary',
+                'type': 'AgentMessage',
+                'phase': 'commentary',
+              },
+            },
+          }),
+        );
+        state = reduceNotification(
+          state,
+          _event('item/agentMessage/delta', <String, dynamic>{
+            'turnId': 'turn-1',
+            'itemId': 'msg-commentary',
+            'delta': 'legacy commentary',
+          }),
+        );
+
+        expect(_cellsByKind(state, TimelineCellKind.progressText), isEmpty);
+        expect(state.activeAgentStreamItemId, 'msg-commentary');
+
+        state = reduceNotification(
+          state,
+          _event('codex/event/item_completed', <String, dynamic>{
+            'msg': <String, dynamic>{
+              'type': 'item_completed',
+              'turn_id': 'turn-1',
+              'item': <String, dynamic>{
+                'id': 'msg-commentary',
+                'type': 'AgentMessage',
+                'phase': 'commentary',
+                'content': <Map<String, dynamic>>[
+                  <String, dynamic>{
+                    'type': 'text',
+                    'text': 'legacy commentary',
+                  },
+                ],
+              },
+            },
+          }),
+        );
+
+        final progress = _cellsByKind(state, TimelineCellKind.progressText);
+        expect(progress, hasLength(1));
+        expect(progress.first.markdownText, 'legacy commentary');
+        expect(_cellsByKind(state, TimelineCellKind.assistantMessage), isEmpty);
+        expect(state.activeAgentStreamItemId, isNull);
+        expect(state.activeAgentStreamLastDeltaAtMs, isNull);
+      },
+    );
 
     test(
       'final_answer long text without newline streams in soft chunks before completion',

--- a/test/unit/session_timeline_reducer_test.dart
+++ b/test/unit/session_timeline_reducer_test.dart
@@ -1497,6 +1497,72 @@ void main() {
     );
 
     test(
+      'legacy and modern commentary completions do not duplicate pending commentary',
+      () {
+        var state = const SessionState();
+        state = reduceNotification(
+          state,
+          _event('turn/started', <String, dynamic>{
+            'turn': <String, dynamic>{'id': 'turn-1', 'threadId': 'thread-1'},
+          }),
+        );
+        state = reduceNotification(
+          state,
+          _event('codex/event/item_started', <String, dynamic>{
+            'msg': <String, dynamic>{
+              'type': 'item_started',
+              'turn_id': 'turn-1',
+              'item': <String, dynamic>{
+                'id': 'msg-commentary',
+                'type': 'AgentMessage',
+                'phase': 'commentary',
+              },
+            },
+          }),
+        );
+        state = reduceNotification(
+          state,
+          _event('codex/event/item_completed', <String, dynamic>{
+            'msg': <String, dynamic>{
+              'type': 'item_completed',
+              'turn_id': 'turn-1',
+              'item': <String, dynamic>{
+                'id': 'msg-commentary',
+                'type': 'AgentMessage',
+                'phase': 'commentary',
+                'content': <Map<String, dynamic>>[
+                  <String, dynamic>{
+                    'type': 'text',
+                    'text': 'legacy commentary',
+                  },
+                ],
+              },
+            },
+          }),
+        );
+
+        state = reduceNotification(
+          state,
+          _event('item/completed', <String, dynamic>{
+            'turnId': 'turn-1',
+            'item': <String, dynamic>{
+              'id': 'msg-commentary',
+              'type': 'agentMessage',
+              'phase': 'commentary',
+              'status': 'completed',
+              'text': 'legacy commentary',
+            },
+          }),
+        );
+
+        final progress = _cellsByKind(state, TimelineCellKind.progressText);
+        expect(progress, hasLength(1));
+        expect(progress.first.itemId, 'msg-commentary');
+        expect(progress.first.markdownText, 'legacy commentary');
+      },
+    );
+
+    test(
       'final_answer long text without newline streams in soft chunks before completion',
       () {
         final t0 = DateTime.utc(2026, 2, 22, 4, 0, 0);

--- a/test/unit/session_timeline_reducer_test.dart
+++ b/test/unit/session_timeline_reducer_test.dart
@@ -598,7 +598,7 @@ void main() {
           TimelineCellKind.assistantMessage,
         );
         expect(assistant, hasLength(1));
-        expect(assistant.first.markdownText, 'stream line');
+        expect(assistant.first.markdownText, 'stream line\n\n');
         expect(
           assistant.first.metadata['dedupeMode'],
           'stream_commit_same_item_id',
@@ -1180,7 +1180,10 @@ void main() {
         expect(progress, hasLength(1));
         expect(progress.first.markdownText, 'Voy a revisar el README');
         expect(assistant, hasLength(1));
-        expect(assistant.first.markdownText, 'El readme.md está en español.');
+        expect(
+          assistant.first.markdownText,
+          'El readme.md está en español.\n\n',
+        );
       },
     );
 
@@ -1418,7 +1421,7 @@ void main() {
           TimelineCellKind.assistantMessage,
         );
         expect(assistant, hasLength(1));
-        expect(assistant.first.markdownText, 'legacy final');
+        expect(assistant.first.markdownText, 'legacy final\n\n');
         expect(assistant.first.isStreaming, isFalse);
         expect(state.activeAgentStreamItemId, isNull);
         expect(state.activeAgentStreamTurnId, isNull);


### PR DESCRIPTION
## Summary
- recover assistant completions from legacy `item_completed` events
- clear active stream state when `task_complete` rescues orphaned final answers
- add watchdog diagnostics for stalled final-answer streams and missing turn completion
- add reducer and controller tests for the new recovery paths

## Testing
- flutter test test/unit/session_timeline_reducer_test.dart test/unit/session_controller_test.dart