### PR TITLE
fix(session): place question-answer cells in timeline worked section

### DIFF
--- a/lib/src/features/session/application/session_controller.dart
+++ b/lib/src/features/session/application/session_controller.dart
@@ -601,6 +601,19 @@ class SessionController extends StateNotifier<SessionState> {
         );
         return;
       }
+      // Add question-answer cells to timeline for local plan fallback
+      final fallbackAnswer = decision.accepted
+          ? 'Yes, implement this plan'
+          : 'No, and tell Alera what to do differently';
+      _appendQuestionAnswerCells(
+        pending,
+        <String, dynamic>{
+          pending.questions.first.id: <String, dynamic>{
+            'answers': <String>[fallbackAnswer],
+          },
+        },
+        turnId: pendingTurnId,
+      );
       state = state.copyWith(clearPendingUserInput: true);
       if (pendingTurnId != null) {
         final reason = decision.accepted
@@ -648,6 +661,8 @@ class SessionController extends StateNotifier<SessionState> {
           'turnId=$pendingTurnId',
         );
       }
+      // Add question-answer cells to timeline
+      _appendQuestionAnswerCells(pending, answers, turnId: pendingTurnId);
       state = state.copyWith(clearPendingUserInput: true);
     } catch (e) {
       state = state.copyWith(error: e.toString());
@@ -694,6 +709,29 @@ class SessionController extends StateNotifier<SessionState> {
         const <String, dynamic>{},
       ),
     );
+  }
+
+  void _appendQuestionAnswerCells(PendingUserInput pending, Map<String, dynamic> answers, {String? turnId}) {
+    final effectiveTurnId = turnId ?? _normalizeOptionalId(state.activeTurnId);
+    final questionAnswers = <Map<String, String>>[];
+    for (final question in pending.questions) {
+      final answerData = answers[question.id] as Map<String, dynamic>?;
+      final answerList = answerData?['answers'] as List<dynamic>?;
+      if (answerList != null && answerList.isNotEmpty) {
+        final mainAnswer = answerList.first.toString();
+        questionAnswers.add({
+          'question': question.question,
+          'answer': mainAnswer,
+        });
+      }
+    }
+    if (questionAnswers.isNotEmpty) {
+      state = appendQuestionAnswerCell(
+        state,
+        questionAnswers: questionAnswers,
+        turnId: effectiveTurnId,
+      );
+    }
   }
 
   void removeFromQueue(String id) {

--- a/lib/src/features/session/application/session_controller.dart
+++ b/lib/src/features/session/application/session_controller.dart
@@ -730,6 +730,7 @@ class SessionController extends StateNotifier<SessionState> {
         state,
         questionAnswers: questionAnswers,
         turnId: effectiveTurnId,
+        now: _now(),
       );
     }
   }

--- a/lib/src/features/session/application/session_timeline_reducer.dart
+++ b/lib/src/features/session/application/session_timeline_reducer.dart
@@ -59,6 +59,30 @@ SessionState appendOptimisticUserMessage(
   );
 }
 
+SessionState appendQuestionAnswerCell(
+  SessionState state, {
+  required List<Map<String, String>> questionAnswers,
+  String? turnId,
+  DateTime? now,
+}) {
+  final timestamp = now ?? DateTime.now().toUtc();
+  final cell = TimelineCell(
+    id: 'qa-${timestamp.microsecondsSinceEpoch}',
+    turnId: turnId,
+    kind: TimelineCellKind.questionAnswer,
+    status: TimelineCellStatus.completed,
+    createdAt: timestamp,
+    updatedAt: timestamp,
+    title: 'Asked ${questionAnswers.length} question${questionAnswers.length == 1 ? '' : 's'}',
+    metadata: <String, dynamic>{
+      'questions': questionAnswers,
+    },
+  );
+  return state.copyWith(
+    timelineCells: <TimelineCell>[...state.timelineCells, cell],
+  );
+}
+
 SessionState reduceNotification(
   SessionState state,
   SessionNotificationEvent event, {
@@ -2483,7 +2507,8 @@ bool _isSecondaryKind(TimelineCellKind kind) {
       kind == TimelineCellKind.reasoning ||
       kind == TimelineCellKind.toolCall ||
       kind == TimelineCellKind.subAgent ||
-      kind == TimelineCellKind.systemNotice;
+      kind == TimelineCellKind.systemNotice ||
+      kind == TimelineCellKind.questionAnswer;
 }
 
 TimelineCellStatus? _statusFromString(String? status) {

--- a/lib/src/features/session/domain/chat_timeline.dart
+++ b/lib/src/features/session/domain/chat_timeline.dart
@@ -8,6 +8,7 @@ enum TimelineCellKind {
   plan,
   turnSeparator,
   systemNotice,
+  questionAnswer,
 }
 
 enum TimelineCellStatus { inProgress, completed, failed, declined, info }

--- a/lib/src/features/session/presentation/widgets/chat_timeline_list.dart
+++ b/lib/src/features/session/presentation/widgets/chat_timeline_list.dart
@@ -360,6 +360,8 @@ class CompletedTurnSection extends StatelessWidget {
             TimelineCellKind.toolCall ||
             TimelineCellKind.subAgent:
           secondary.add(cell);
+        case TimelineCellKind.questionAnswer:
+          secondary.add(cell);
         case TimelineCellKind.systemNotice:
           if (placement == TimelineCellMetadata.outsideWorked) {
             postTurnRows.add(cell);

--- a/lib/src/features/session/presentation/widgets/timeline_cells.dart
+++ b/lib/src/features/session/presentation/widgets/timeline_cells.dart
@@ -59,6 +59,10 @@ class TimelineCellView extends StatelessWidget {
       ),
       TimelineCellKind.turnSeparator => const SizedBox.shrink(),
       TimelineCellKind.systemNotice => SystemNoticeCell(cell: cell),
+      TimelineCellKind.questionAnswer => QuestionAnswerCell(
+        key: ValueKey(cell.id),
+        cell: cell,
+      ),
     };
   }
 }
@@ -1132,6 +1136,196 @@ class SystemNoticeCell extends StatelessWidget {
         ).textTheme.bodySmall?.copyWith(color: AleraTokens.foregroundFaint),
       ),
     );
+  }
+}
+
+class QuestionAnswerCell extends StatefulWidget {
+  const QuestionAnswerCell({super.key, required this.cell});
+
+  final TimelineCell cell;
+
+  @override
+  State<QuestionAnswerCell> createState() => _QuestionAnswerCellState();
+}
+
+class _QuestionAnswerCellState extends State<QuestionAnswerCell> {
+  late bool _collapsed;
+  bool _isHovered = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _collapsed = widget.cell.isCollapsed;
+  }
+
+  @override
+  void didUpdateWidget(covariant QuestionAnswerCell oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.cell.isCollapsed != oldWidget.cell.isCollapsed) {
+      _collapsed = widget.cell.isCollapsed;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final questions = _getQuestions();
+    final title = widget.cell.title ?? 'Asked ${questions.length} question${questions.length == 1 ? '' : 's'}';
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        MouseRegion(
+          onEnter: (_) => setState(() => _isHovered = true),
+          onExit: (_) => setState(() => _isHovered = false),
+          child: AnimatedContainer(
+            duration: AleraTokens.durationFast,
+            curve: Curves.easeOut,
+            decoration: BoxDecoration(
+              color: _isHovered
+                  ? AleraTokens.surfaceVariant
+                  : Colors.transparent,
+              borderRadius: BorderRadius.circular(AleraTokens.radiusLg),
+            ),
+            child: InkWell(
+              onTap: () => setState(() => _collapsed = !_collapsed),
+              mouseCursor: SystemMouseCursors.click,
+              borderRadius: BorderRadius.circular(AleraTokens.radiusLg),
+              splashFactory: NoSplash.splashFactory,
+              hoverColor: Colors.transparent,
+              splashColor: Colors.transparent,
+              highlightColor: Colors.transparent,
+              child: Padding(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: AleraTokens.space6,
+                  vertical: AleraTokens.space4,
+                ),
+                child: Row(
+                  children: <Widget>[
+                    SizedBox(
+                      width: 10,
+                      child: Center(
+                        child: Container(
+                          width: 7,
+                          height: 7,
+                          decoration: const BoxDecoration(
+                            shape: BoxShape.circle,
+                            color: AleraTokens.success,
+                          ),
+                        ),
+                      ),
+                    ),
+                    const SizedBox(width: AleraTokens.space6),
+                    Flexible(
+                      child: Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: <Widget>[
+                          Flexible(
+                            child: Text(
+                              title,
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                              style: Theme.of(context).textTheme.bodySmall
+                                  ?.copyWith(
+                                    color: AleraTokens.foregroundMuted,
+                                  ),
+                            ),
+                          ),
+                          const SizedBox(width: AleraTokens.space4),
+                          AnimatedOpacity(
+                            duration: AleraTokens.durationFast,
+                            opacity: _isHovered ? 1 : 0,
+                            child: SizedBox(
+                              width: 14,
+                              child: Icon(
+                                _collapsed
+                                    ? Icons.keyboard_arrow_right
+                                    : Icons.keyboard_arrow_down,
+                                size: 14,
+                                color: AleraTokens.foregroundFaint,
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+        if (!_collapsed && questions.isNotEmpty)
+          Container(
+            margin: const EdgeInsets.only(
+              left: AleraTokens.space8,
+              top: AleraTokens.space4,
+            ),
+            padding: const EdgeInsets.all(AleraTokens.space8),
+            decoration: BoxDecoration(
+              color: AleraTokens.surface,
+              borderRadius: BorderRadius.circular(AleraTokens.radiusLg),
+              border: Border.all(color: AleraTokens.borderSubtle),
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: _buildQuestionWidgets(context, questions),
+            ),
+          ),
+      ],
+    );
+  }
+
+  List<Map<String, String>> _getQuestions() {
+    final questions = widget.cell.metadata['questions'] as List<dynamic>?;
+    if (questions == null) return <Map<String, String>>[];
+    return questions.map((q) {
+      final map = q as Map<String, dynamic>;
+      return <String, String>{
+        'question': map['question']?.toString() ?? '',
+        'answer': map['answer']?.toString() ?? '',
+      };
+    }).toList();
+  }
+
+  List<Widget> _buildQuestionWidgets(BuildContext context, List<Map<String, String>> questions) {
+    final widgets = <Widget>[];
+    for (var i = 0; i < questions.length; i++) {
+      final qa = questions[i];
+      final question = qa['question'] ?? '';
+      final answer = qa['answer'] ?? '';
+      widgets.add(
+        Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Text(
+              question,
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                color: AleraTokens.foregroundMuted,
+                fontWeight: FontWeight.w500,
+              ),
+            ),
+            const SizedBox(height: AleraTokens.space4),
+            Text(
+              answer,
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                color: AleraTokens.foreground,
+              ),
+            ),
+          ],
+        ),
+      );
+      if (i < questions.length - 1) {
+        widgets.add(
+          Padding(
+            padding: const EdgeInsets.symmetric(vertical: AleraTokens.space8),
+            child: Divider(
+              height: 1,
+              color: AleraTokens.borderSubtle,
+            ),
+          ),
+        );
+      }
+    }
+    return widgets;
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes the bug where question-answer timeline cells appeared outside the "Worked" section after a turn completed. Questions now render in the correct position during streaming and remain properly grouped after turn completion.

## Changes

- Add `questionAnswer` to `TimelineCellKind` enum and create dedicated `QuestionAnswerCell` widget
- Create `appendQuestionAnswerCell` reducer to group Q&A pairs by turn
- Add fallback to `state.activeTurnId` when turnId is null (handles backend edge cases)
- Include `questionAnswer` in `_isSecondaryKind` for consistent collapse behavior on turn completion
- Add `ValueKey` to `QuestionAnswerCell` for proper widget identity during streaming-to-completed transition