### PR TITLE
fix(session): handle empty lines as paragraph breaks in streaming

### DIFF
--- a/lib/src/features/session/application/session_timeline_reducer.dart
+++ b/lib/src/features/session/application/session_timeline_reducer.dart
@@ -240,9 +240,6 @@ SessionState reduceCommitTick(
       final text = line.appendWithoutNewline
           ? line.text
           : line.text.trimRight();
-      if (text.isEmpty) {
-        continue;
-      }
       final streamPhase = _normalizeAgentPhase(line.streamPhase);
       if (streamPhase == 'final_answer') {
         final assistantCellId = line.itemId ?? 'assistant-final-${line.turnId}';
@@ -269,11 +266,17 @@ SessionState reduceCommitTick(
         } else {
           final existing = cells[assistantIndex];
           final currentText = existing.markdownText ?? '';
-          final nextText = currentText.isEmpty
-              ? text
-              : line.appendWithoutNewline
-              ? '$currentText$text'
-              : '$currentText\n$text';
+          final String nextText;
+          if (text.isEmpty) {
+            // Empty line = paragraph break
+            nextText = currentText.isEmpty ? '' : '$currentText\n\n';
+          } else {
+            nextText = currentText.isEmpty
+                ? text
+                : line.appendWithoutNewline
+                    ? '$currentText$text'
+                    : '$currentText\n$text';
+          }
           cells[assistantIndex] = existing.copyWith(
             turnId: line.turnId,
             itemId: line.itemId,
@@ -289,7 +292,7 @@ SessionState reduceCommitTick(
           );
         }
         activeStreamingAssistantCellId = assistantCellId;
-      } else {
+      } else if (text.isNotEmpty) {
         cells.add(
           TimelineCell(
             id: 'stream-${line.turnId}-${timestamp.microsecondsSinceEpoch}',

--- a/lib/src/features/session/application/streaming/markdown_stream_collector.dart
+++ b/lib/src/features/session/application/streaming/markdown_stream_collector.dart
@@ -75,7 +75,7 @@ MarkdownStreamPushResult pushMarkdownDelta(
 
   final completePart = merged.substring(0, lastNewline + 1);
   final pending = merged.substring(lastNewline + 1);
-  final lines = _nonEmptyLines(completePart.split('\n'));
+  final lines = _trimmedLines(completePart.split('\n'));
   return MarkdownStreamPushResult(
     state: state.copyWith(
       pendingBuffer: pending,
@@ -202,14 +202,5 @@ bool _hasOpenCodeFence(String text) {
   return count.isOdd;
 }
 
-List<String> _nonEmptyLines(List<String> lines) {
-  final out = <String>[];
-  for (final line in lines) {
-    final trimmed = line.trimRight();
-    if (trimmed.isEmpty) {
-      continue;
-    }
-    out.add(trimmed);
-  }
-  return out;
-}
+List<String> _trimmedLines(List<String> lines) =>
+    lines.map((line) => line.trimRight()).toList();


### PR DESCRIPTION
Convert empty lines to paragraph breaks (\n\n) instead of skipping them to preserve markdown formatting in assistant message bubbles. Simplify _trimmedLines to use idiomatic Dart map expression.