### PR TITLE
fix(session): normalize markdown newlines and fix text wrapping

### DIFF
--- a/lib/src/features/session/presentation/widgets/markdown_helpers.dart
+++ b/lib/src/features/session/presentation/widgets/markdown_helpers.dart
@@ -26,7 +26,7 @@ Widget buildMarkdownContent({
   }
   if (!useStreaming) {
     return GptMarkdown(
-      text,
+      normalizeMarkdownNewlines(text),
       style: markdownStyle ?? textStyle,
       textAlign: textAlign,
       textDirection: Directionality.of(context),
@@ -43,6 +43,70 @@ Widget buildMarkdownContent({
     selectable: false,
     textAlign: textAlign,
   );
+}
+
+final _blockLinePattern = RegExp(
+  r'^(?:[-*] |> |#{1,6} |\d+\. |\[[ x]\] |\([ x]\) |```|---+|\|)',
+);
+
+final _listItemStart = RegExp(
+  r'^(?:[-*] |\d+\. |\[[ x]\] |\([ x]\) )',
+);
+
+/// Converts single newlines within paragraphs to spaces so that text
+/// reflows to fill the available width.  Preserves paragraph breaks
+/// (\n\n), newlines adjacent to block-level markdown elements, and
+/// content inside fenced code blocks.
+@visibleForTesting
+String normalizeMarkdownNewlines(String text) {
+  final codeBlockRe = RegExp(r'```.*?```', dotAll: true);
+  final placeholders = <String>[];
+  var work = text.replaceAllMapped(codeBlockRe, (m) {
+    placeholders.add(m[0]!);
+    return '\x00CB${placeholders.length - 1}\x00';
+  });
+  final paragraphs = work.split('\n\n');
+  final processed = paragraphs.map((paragraph) {
+    final lines = paragraph.split('\n');
+    if (lines.length <= 1) return paragraph;
+    final buf = StringBuffer(lines[0]);
+    for (var i = 1; i < lines.length; i++) {
+      final cur = lines[i].trimLeft();
+      final prev = lines[i - 1].trimLeft();
+      final isBlockCur = _blockLinePattern.hasMatch(cur);
+      final isBlockPrev = _blockLinePattern.hasMatch(prev);
+      final isListPrev = _listItemStart.hasMatch(prev);
+      if (isBlockCur) {
+        buf.write('\n');
+      } else if (isBlockPrev && !isListPrev) {
+        buf.write('\n');
+      } else if (!lines[i - 1].endsWith(' ')) {
+        buf.write(' ');
+      }
+      buf.write(lines[i]);
+    }
+    return buf.toString();
+  }).toList();
+  final joined = StringBuffer();
+  for (var i = 0; i < processed.length; i++) {
+    if (i > 0) {
+      final prevLast = processed[i - 1].split('\n').last.trimLeft();
+      final curFirst = processed[i].split('\n').first.trimLeft();
+      if (_listItemStart.hasMatch(prevLast) &&
+          _listItemStart.hasMatch(curFirst)) {
+        joined.write('\n');
+      } else {
+        joined.write('\n\n');
+      }
+    }
+    joined.write(processed[i]);
+  }
+  final normalized = joined.toString();
+  var result = normalized;
+  for (var i = 0; i < placeholders.length; i++) {
+    result = result.replaceFirst('\x00CB$i\x00', placeholders[i]);
+  }
+  return result;
 }
 
 class MessageActionButtons extends StatelessWidget {

--- a/lib/src/features/session/presentation/widgets/timeline_cells.dart
+++ b/lib/src/features/session/presentation/widgets/timeline_cells.dart
@@ -285,36 +285,41 @@ class _AssistantMessageCellState extends State<AssistantMessageCell> {
         alignment: Alignment.centerLeft,
         child: ConstrainedBox(
           constraints: const BoxConstraints(maxWidth: 760),
-          child: Stack(
-            clipBehavior: Clip.none,
-            children: <Widget>[
-              Padding(
-                padding: const EdgeInsets.only(bottom: 18),
-                child: Container(
-                  key: ValueKey<String>('assistant-bubble-${widget.cell.id}'),
-                  child: AssistantBubbleMarkdown(
-                    markdownText: rawText,
-                    isStreaming: widget.cell.isStreaming,
+          child: SizedBox(
+            width: double.infinity,
+            child: Stack(
+              clipBehavior: Clip.none,
+              children: <Widget>[
+                Padding(
+                  padding: const EdgeInsets.only(bottom: 18),
+                  child: Container(
+                    key: ValueKey<String>('assistant-bubble-${widget.cell.id}'),
+                    child: AssistantBubbleMarkdown(
+                      markdownText: rawText,
+                      isStreaming: widget.cell.isStreaming,
+                      markdownEnabled: widget.markdownEnabled,
+                    ),
+                  ),
+                ),
+                Positioned(
+                  left: 0,
+                  bottom: 0,
+                  child: MessageActionButtons(
+                    alignLeft: true,
+                    copyKey: ValueKey<String>(
+                      'copy-assistant-${widget.cell.id}',
+                    ),
+                    copyText: rawText,
+                    copiedLabel: 'Message copied',
+                    toggleKey: ValueKey<String>(
+                      'toggle-markdown-assistant-${widget.cell.id}',
+                    ),
                     markdownEnabled: widget.markdownEnabled,
+                    onToggleMarkdown: widget.onMarkdownModeChanged,
                   ),
                 ),
-              ),
-              Positioned(
-                left: 0,
-                bottom: 0,
-                child: MessageActionButtons(
-                  alignLeft: true,
-                  copyKey: ValueKey<String>('copy-assistant-${widget.cell.id}'),
-                  copyText: rawText,
-                  copiedLabel: 'Message copied',
-                  toggleKey: ValueKey<String>(
-                    'toggle-markdown-assistant-${widget.cell.id}',
-                  ),
-                  markdownEnabled: widget.markdownEnabled,
-                  onToggleMarkdown: widget.onMarkdownModeChanged,
-                ),
-              ),
-            ],
+              ],
+            ),
           ),
         ),
       ),
@@ -340,12 +345,16 @@ class AssistantBubbleMarkdown extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: <Widget>[
-        buildMarkdownContent(
-          context: context,
-          text: markdownText,
-          markdownEnabled: markdownEnabled,
-          textStyle: messageStyle,
-          markdownStyle: messageStyle,
+        SizedBox(
+          width: double.infinity,
+          child: buildMarkdownContent(
+            context: context,
+            text: markdownText,
+            markdownEnabled: markdownEnabled,
+            textStyle: messageStyle,
+            markdownStyle: messageStyle,
+            useStreaming: isStreaming,
+          ),
         ),
         if (isStreaming)
           const Padding(
@@ -1169,7 +1178,9 @@ class _QuestionAnswerCellState extends State<QuestionAnswerCell> {
   @override
   Widget build(BuildContext context) {
     final questions = _getQuestions();
-    final title = widget.cell.title ?? 'Asked ${questions.length} question${questions.length == 1 ? '' : 's'}';
+    final title =
+        widget.cell.title ??
+        'Asked ${questions.length} question${questions.length == 1 ? '' : 's'}';
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: <Widget>[
@@ -1286,7 +1297,10 @@ class _QuestionAnswerCellState extends State<QuestionAnswerCell> {
     }).toList();
   }
 
-  List<Widget> _buildQuestionWidgets(BuildContext context, List<Map<String, String>> questions) {
+  List<Widget> _buildQuestionWidgets(
+    BuildContext context,
+    List<Map<String, String>> questions,
+  ) {
     final widgets = <Widget>[];
     for (var i = 0; i < questions.length; i++) {
       final qa = questions[i];
@@ -1306,9 +1320,9 @@ class _QuestionAnswerCellState extends State<QuestionAnswerCell> {
             const SizedBox(height: AleraTokens.space4),
             Text(
               answer,
-              style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                color: AleraTokens.foreground,
-              ),
+              style: Theme.of(
+                context,
+              ).textTheme.bodySmall?.copyWith(color: AleraTokens.foreground),
             ),
           ],
         ),
@@ -1317,10 +1331,7 @@ class _QuestionAnswerCellState extends State<QuestionAnswerCell> {
         widgets.add(
           Padding(
             padding: const EdgeInsets.symmetric(vertical: AleraTokens.space8),
-            child: Divider(
-              height: 1,
-              color: AleraTokens.borderSubtle,
-            ),
+            child: Divider(height: 1, color: AleraTokens.borderSubtle),
           ),
         );
       }

--- a/test/unit/markdown_helpers_test.dart
+++ b/test/unit/markdown_helpers_test.dart
@@ -1,0 +1,174 @@
+import 'package:alera/src/features/session/presentation/widgets/markdown_helpers.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('normalizeMarkdownNewlines', () {
+    test('joins single-newline sentences into one paragraph', () {
+      expect(
+        normalizeMarkdownNewlines('First sentence.\nSecond sentence.'),
+        'First sentence. Second sentence.',
+      );
+    });
+
+    test('preserves paragraph breaks', () {
+      expect(
+        normalizeMarkdownNewlines('Paragraph one.\n\nParagraph two.'),
+        'Paragraph one.\n\nParagraph two.',
+      );
+    });
+
+    test('preserves newlines before unordered list items', () {
+      expect(
+        normalizeMarkdownNewlines('Intro:\n- Item one\n- Item two'),
+        'Intro:\n- Item one\n- Item two',
+      );
+    });
+
+    test('preserves newlines before ordered list items', () {
+      expect(
+        normalizeMarkdownNewlines('Intro:\n1. First\n2. Second'),
+        'Intro:\n1. First\n2. Second',
+      );
+    });
+
+    test('preserves newlines before headings', () {
+      expect(
+        normalizeMarkdownNewlines('Some text.\n# Heading'),
+        'Some text.\n# Heading',
+      );
+    });
+
+    test('preserves newlines before blockquotes', () {
+      expect(
+        normalizeMarkdownNewlines('Some text.\n> Quote'),
+        'Some text.\n> Quote',
+      );
+    });
+
+    test('preserves content inside code blocks', () {
+      expect(
+        normalizeMarkdownNewlines(
+          'Before.\n```\nline1\nline2\n```\nAfter.',
+        ),
+        'Before. ```\nline1\nline2\n``` After.',
+      );
+    });
+
+    test('preserves newlines between table rows', () {
+      expect(
+        normalizeMarkdownNewlines('Header\n| A | B |\n| 1 | 2 |'),
+        'Header\n| A | B |\n| 1 | 2 |',
+      );
+    });
+
+    test('preserves horizontal rules', () {
+      expect(
+        normalizeMarkdownNewlines('Above\n---\nBelow'),
+        'Above\n---\nBelow',
+      );
+    });
+
+    test('normalizes real LLM output with mixed content', () {
+      final input = 'Aquí tienes un texto pequeño con listas:\n\n'
+          'Mi rutina de la mañana es simple y ordenada.\n'
+          'Primero preparo lo necesario para empezar bien el día:\n\n'
+          '- Agua\n- Café\n- Fruta\n\n'
+          'También quiero seguir este orden:\n\n'
+          '1. Trabajar en la mañana\n'
+          '2. Descansar después de comer\n\n'
+          'Si quieres, puedo escribir otro más formal,\n'
+          'más creativo o más largo.';
+      final expected = 'Aquí tienes un texto pequeño con listas:\n\n'
+          'Mi rutina de la mañana es simple y ordenada. '
+          'Primero preparo lo necesario para empezar bien el día:\n\n'
+          '- Agua\n- Café\n- Fruta\n\n'
+          'También quiero seguir este orden:\n\n'
+          '1. Trabajar en la mañana\n'
+          '2. Descansar después de comer\n\n'
+          'Si quieres, puedo escribir otro más formal, '
+          'más creativo o más largo.';
+      expect(normalizeMarkdownNewlines(input), expected);
+    });
+
+    test('handles empty text', () {
+      expect(normalizeMarkdownNewlines(''), '');
+    });
+
+    test('handles text without newlines', () {
+      expect(normalizeMarkdownNewlines('Hello world'), 'Hello world');
+    });
+
+    test('preserves star-prefixed unordered list items', () {
+      expect(
+        normalizeMarkdownNewlines('Intro:\n* Alpha\n* Beta'),
+        'Intro:\n* Alpha\n* Beta',
+      );
+    });
+
+    test('preserves checkboxes', () {
+      expect(
+        normalizeMarkdownNewlines('[x] Done\n[ ] Pending'),
+        '[x] Done\n[ ] Pending',
+      );
+    });
+
+    test('does not produce double spaces when line ends with trailing space', () {
+      expect(
+        normalizeMarkdownNewlines('conviene preparar varios \naspectos con anticipación.'),
+        'conviene preparar varios aspectos con anticipación.',
+      );
+    });
+
+    test('collapses paragraph breaks between consecutive ordered list items', () {
+      expect(
+        normalizeMarkdownNewlines('1. First\n\n2. Second\n\n3. Third'),
+        '1. First\n2. Second\n3. Third',
+      );
+    });
+
+    test('collapses paragraph breaks between consecutive unordered list items', () {
+      expect(
+        normalizeMarkdownNewlines('- Alpha\n\n- Beta\n\n- Gamma'),
+        '- Alpha\n- Beta\n- Gamma',
+      );
+    });
+
+    test('preserves paragraph break between list and non-list text', () {
+      expect(
+        normalizeMarkdownNewlines('1. First\n\n2. Second\n\nSome text.'),
+        '1. First\n2. Second\n\nSome text.',
+      );
+    });
+
+    test('joins list item continuation text with space', () {
+      expect(
+        normalizeMarkdownNewlines(
+          '4. Revisar el equipo.\n\n'
+          '5. Realizar una última verificación el día\n'
+          'anterior.',
+        ),
+        '4. Revisar el equipo.\n'
+        '5. Realizar una última verificación el día anterior.',
+      );
+    });
+
+    test('collapses loose list items from LLM output', () {
+      final input = 'Lista numerada de pasos a seguir:\n\n'
+          '1. Confirmar la disponibilidad del espacio.\n\n'
+          '2. Enviar las invitaciones.\n\n'
+          '3. Coordinar la comida y la bebida.\n\n'
+          '4. Revisar el equipo técnico necesario.\n\n'
+          '5. Realizar una última verificación el día\n'
+          'anterior.\n\n'
+          'Si quieres, también puedo generarlo.';
+      final expected = 'Lista numerada de pasos a seguir:\n\n'
+          '1. Confirmar la disponibilidad del espacio.\n'
+          '2. Enviar las invitaciones.\n'
+          '3. Coordinar la comida y la bebida.\n'
+          '4. Revisar el equipo técnico necesario.\n'
+          '5. Realizar una última verificación el día anterior.\n\n'
+          'Si quieres, también puedo generarlo.';
+      expect(normalizeMarkdownNewlines(input), expected);
+    });
+  });
+}

--- a/test/widget/session_workspace_view_test.dart
+++ b/test/widget/session_workspace_view_test.dart
@@ -11,6 +11,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_streaming_text_markdown/flutter_streaming_text_markdown.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:gpt_markdown/gpt_markdown.dart';
 
 TimelineCell _cell({
   required String id,
@@ -648,10 +649,110 @@ void main() {
 
     await _pumpWorkspace(tester, state: state);
 
-    expect(find.byType(StreamingText), findsOneWidget);
+    expect(find.byType(StreamingText), findsNothing);
+    expect(find.byType(GptMarkdown), findsOneWidget);
     expect(find.textContaining('**negrita**'), findsNothing);
     expect(find.textContaining('negrita'), findsOneWidget);
   });
+
+  testWidgets(
+    'assistant completed uses available timeline width for markdown layout',
+    (tester) async {
+      await tester.binding.setSurfaceSize(const Size(1600, 900));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      final state = SessionState(
+        timelineCells: <TimelineCell>[
+          _cell(
+            id: 'a-wide-markdown',
+            kind: TimelineCellKind.assistantMessage,
+            status: TimelineCellStatus.completed,
+            turnId: 't1',
+            markdownText:
+                '# Texto breve\n\nEste es un ejemplo de texto en Markdown con listas.\n\n- Markdown es simple\n- Las listas ayudan a organizar la información',
+          ),
+        ],
+      );
+
+      await _pumpWorkspace(tester, state: state);
+
+      final markdownRect = tester.getRect(find.byType(GptMarkdown));
+      expect(markdownRect.width, greaterThan(650));
+    },
+  );
+
+  testWidgets('completed turn assistant message uses full timeline width', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(1600, 900));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    final state = SessionState(
+      timelineCells: <TimelineCell>[
+        _cell(
+          id: 'user-1',
+          kind: TimelineCellKind.userMessage,
+          status: TimelineCellStatus.completed,
+          turnId: 't1',
+          markdownText: 'Escribe un texto pequeño que contenga listas',
+        ),
+        _cell(
+          id: 'reasoning-1',
+          kind: TimelineCellKind.reasoning,
+          status: TimelineCellStatus.completed,
+          turnId: 't1',
+          markdownText: 'Thinking about lists...',
+          isCollapsed: true,
+        ),
+        _cell(
+          id: 'assistant-1',
+          kind: TimelineCellKind.assistantMessage,
+          status: TimelineCellStatus.completed,
+          turnId: 't1',
+          markdownText:
+              'Aquí tienes un texto pequeño con listas:\n\nHoy quiero organizar mejor mi semana. Para empezar, tengo tres prioridades principales:\n\n- Terminar una tarea pendiente\n- Hacer ejercicio al menos dos días\n- Leer un poco cada noche\n\nTambién quiero seguir este orden:\n\n1. Trabajar en la mañana\n2. Descansar después de comer\n3. Dedicar tiempo a actividades personales por la noche\n\nSi quieres, puedo escribir otro más formal, más creativo o más largo.',
+        ),
+        _cell(
+          id: 'sep-1',
+          kind: TimelineCellKind.turnSeparator,
+          status: TimelineCellStatus.completed,
+          turnId: 't1',
+          title: 'Worked for 5s',
+        ),
+      ],
+    );
+    await _pumpWorkspace(tester, state: state);
+    final bubbleRect = tester.getRect(
+      find.byKey(const ValueKey<String>('assistant-bubble-assistant-1')),
+    );
+    expect(bubbleRect.width, greaterThan(650));
+  });
+
+  testWidgets(
+    'assistant streaming uses available timeline width for markdown layout',
+    (tester) async {
+      await tester.binding.setSurfaceSize(const Size(1600, 900));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      final state = SessionState(
+        timelineCells: <TimelineCell>[
+          _cell(
+            id: 'a-wide-streaming',
+            kind: TimelineCellKind.assistantMessage,
+            status: TimelineCellStatus.inProgress,
+            turnId: 't1',
+            isStreaming: true,
+            markdownText:
+                'Hoy quiero organizar una tarde tranquila y productiva en casa. Para que todo salga bien, preparé una pequeña lista de prioridades y otra de cosas opcionales.',
+          ),
+        ],
+      );
+
+      await _pumpWorkspace(tester, state: state);
+
+      final streamingRect = tester.getRect(find.byType(StreamingText));
+      expect(streamingRect.width, greaterThan(650));
+    },
+  );
 
   testWidgets(
     'assistant completed renders malformed markdown without fallback',
@@ -670,7 +771,8 @@ void main() {
 
       await _pumpWorkspace(tester, state: state);
 
-      expect(find.byType(StreamingText), findsOneWidget);
+      expect(find.byType(StreamingText), findsNothing);
+      expect(find.byType(GptMarkdown), findsOneWidget);
       expect(find.textContaining('backtick abierto'), findsOneWidget);
     },
   );


### PR DESCRIPTION
## Summary

- Add `normalizeMarkdownNewlines()` to join soft-wrapped lines within paragraphs while preserving paragraph breaks, block-level constructs, and code fences
- Wrap assistant bubble and markdown content in `SizedBox(width: double.infinity)` to fill available timeline width instead of shrink-wrapping
- Switch to `GptMarkdown` for completed messages; only use `StreamingText` while streaming

## Changes

- **markdown_helpers.dart**: New normalization function handles paragraph reflowing with context-aware block detection
- **timeline_cells.dart**: Width constraints fixed with SizedBox wrappers; streaming state properly passed to content builder
- **test/unit/markdown_helpers_test.dart**: 16 comprehensive tests for normalization edge cases
- **session_workspace_view_test.dart**: 3 new widget tests asserting layout widths and correct widget selection by state

Fixes the excessive line wrapping observed in multi-line LLM responses and improves markdown rendering stability for completed messages.