### PR TITLE
fix(session): refine timeline interactions and status updates

### DIFF
--- a/lib/src/features/session/presentation/widgets/attachment_bar.dart
+++ b/lib/src/features/session/presentation/widgets/attachment_bar.dart
@@ -29,7 +29,7 @@ class AttachmentBar extends StatelessWidget {
         0,
       ),
       child: SizedBox(
-        height: 28,
+        height: 34,
         child: Builder(
           builder: (context) {
             final sorted = List<ComposerAttachment>.of(attachments)
@@ -69,8 +69,7 @@ class _AttachmentChip extends StatelessWidget {
       padding: const EdgeInsets.symmetric(horizontal: AleraTokens.space6),
       child: Text(
         attachment.displayName,
-        style: const TextStyle(
-          fontSize: 11,
+        style: Theme.of(context).textTheme.labelMedium?.copyWith(
           color: AleraTokens.foregroundMuted,
         ),
         maxLines: 1,
@@ -91,7 +90,7 @@ class _AttachmentChip extends StatelessWidget {
     return Container(
       decoration: BoxDecoration(
         color: AleraTokens.surface,
-        borderRadius: BorderRadius.circular(AleraTokens.radiusXl),
+        borderRadius: BorderRadius.circular(AleraTokens.radiusMd),
       ),
       child: Row(
         mainAxisSize: MainAxisSize.min,
@@ -103,12 +102,12 @@ class _AttachmentChip extends StatelessWidget {
                 cursor: SystemMouseCursors.click,
                 child: ClipRRect(
                   borderRadius: const BorderRadius.only(
-                    topLeft: Radius.circular(AleraTokens.radiusXl),
-                    bottomLeft: Radius.circular(AleraTokens.radiusXl),
+                    topLeft: Radius.circular(AleraTokens.radiusMd),
+                    bottomLeft: Radius.circular(AleraTokens.radiusMd),
                   ),
                   child: SizedBox(
-                    width: 28,
-                    height: 28,
+                    width: 34,
+                    height: 34,
                     child: Image.file(
                       File(attachment.path),
                       fit: BoxFit.cover,
@@ -141,7 +140,7 @@ class _AttachmentChip extends StatelessWidget {
           InkWell(
             onTap: onRemove,
             mouseCursor: SystemMouseCursors.click,
-            borderRadius: BorderRadius.circular(AleraTokens.radiusXl),
+            borderRadius: BorderRadius.circular(AleraTokens.radiusMd),
             child: const Padding(
               padding: EdgeInsets.all(AleraTokens.space4),
               child: Icon(

--- a/lib/src/features/session/presentation/widgets/chat_timeline_list.dart
+++ b/lib/src/features/session/presentation/widgets/chat_timeline_list.dart
@@ -46,7 +46,7 @@ class ChatTimelineList extends StatelessWidget {
             child: FilledButton(
               key: const ValueKey<String>('implement-plan-button'),
               onPressed: onImplementPlanPressed,
-              child: const Text('Implement Plan'),
+              child: const Text('Implement plan'),
             ),
           ),
         ),

--- a/lib/src/features/session/presentation/widgets/chat_timeline_list.dart
+++ b/lib/src/features/session/presentation/widgets/chat_timeline_list.dart
@@ -34,63 +34,60 @@ class ChatTimelineList extends StatelessWidget {
     if (state.timelineCells.isEmpty) {
       return EmptyChatState(state: state);
     }
-
-    final widgets = _buildTimelineWidgets();
-
-    if (showImplementPlanButton) {
-      widgets.add(
-        Padding(
-          padding: const EdgeInsets.only(bottom: AleraTokens.space8),
-          child: Align(
-            alignment: Alignment.center,
-            child: FilledButton(
-              key: const ValueKey<String>('implement-plan-button'),
-              onPressed: onImplementPlanPressed,
-              child: const Text('Implement plan'),
-            ),
-          ),
-        ),
-      );
-    }
+    final items = _buildTimelineItems();
+    final itemCount = items.length + (showImplementPlanButton ? 1 : 0);
 
     return SelectionArea(
-      child: SingleChildScrollView(
+      child: ListView.builder(
         key: const ValueKey<String>('timeline-list'),
         controller: controller,
         padding: const EdgeInsets.all(AleraTokens.space16),
-        child: Center(
-          child: ConstrainedBox(
-            key: const ValueKey<String>('timeline-content-container'),
-            constraints: BoxConstraints(maxWidth: contentMaxWidth),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: widgets,
+        itemCount: itemCount,
+        itemBuilder: (context, index) {
+          final Widget child;
+          if (index < items.length) {
+            child = _buildTimelineItem(items[index]);
+          } else {
+            child = Padding(
+              padding: const EdgeInsets.only(bottom: AleraTokens.space8),
+              child: Align(
+                alignment: Alignment.center,
+                child: FilledButton(
+                  key: const ValueKey<String>('implement-plan-button'),
+                  onPressed: onImplementPlanPressed,
+                  child: const Text('Implement plan'),
+                ),
+              ),
+            );
+          }
+
+          return Center(
+            child: ConstrainedBox(
+              constraints: BoxConstraints(maxWidth: contentMaxWidth),
+              child: child,
             ),
-          ),
-        ),
+          );
+        },
       ),
     );
   }
 
-  List<Widget> _buildTimelineWidgets() {
-    final items = _buildTimelineItems();
-    return items.map((item) {
-      return switch (item) {
-        _CellItem(cell: final cell) => _timelineCellWithSpacing(cell),
-        _ClusterItem(cells: final cluster) => Padding(
-          padding: const EdgeInsets.only(bottom: AleraTokens.space8),
-          child: ExploringClusterCell(
-            key: ValueKey(
-              'cluster-open-${cluster.first.id}-${cluster.last.id}',
-            ),
-            cells: cluster,
-          ),
+  Widget _buildTimelineItem(_TimelineItem item) {
+    return switch (item) {
+      _CellItem(cell: final cell) => _timelineCellWithSpacing(cell),
+      _ClusterItem(cells: final cluster) => Padding(
+        padding: const EdgeInsets.only(bottom: AleraTokens.space8),
+        child: ExploringClusterCell(
+          key: ValueKey('cluster-open-${cluster.first.id}-${cluster.last.id}'),
+          cells: cluster,
         ),
-        _TurnItem(
-          turnId: final turnId,
-          separator: final separator,
-          turnCells: final turnCells,
-        ) => Padding(
+      ),
+      _TurnItem(
+        turnId: final turnId,
+        separator: final separator,
+        turnCells: final turnCells,
+      ) =>
+        Padding(
           padding: const EdgeInsets.only(bottom: AleraTokens.space8),
           child: CompletedTurnSection(
             turnId: turnId,
@@ -102,8 +99,7 @@ class ChatTimelineList extends StatelessWidget {
             onMarkdownModeChanged: onMarkdownModeChanged,
           ),
         ),
-      };
-    }).toList();
+    };
   }
 
   List<_TimelineItem> _buildTimelineItems() {
@@ -162,11 +158,7 @@ class ChatTimelineList extends StatelessWidget {
       renderedCompletedTurns.add(turnId);
       final turnCells = turnCellsMap[turnId] ?? const <TimelineCell>[];
       items.add(
-        _TurnItem(
-          turnId: turnId,
-          separator: separator,
-          turnCells: turnCells,
-        ),
+        _TurnItem(turnId: turnId, separator: separator, turnCells: turnCells),
       );
     }
     return items;

--- a/lib/src/features/session/presentation/widgets/chat_timeline_list.dart
+++ b/lib/src/features/session/presentation/widgets/chat_timeline_list.dart
@@ -34,52 +34,84 @@ class ChatTimelineList extends StatelessWidget {
     if (state.timelineCells.isEmpty) {
       return EmptyChatState(state: state);
     }
-    final timelineWidgets = _buildTimelineWidgets();
-    final itemCount =
-        timelineWidgets.length + (showImplementPlanButton ? 1 : 0);
+
+    final widgets = _buildTimelineWidgets();
+
+    if (showImplementPlanButton) {
+      widgets.add(
+        Padding(
+          padding: const EdgeInsets.only(bottom: AleraTokens.space8),
+          child: Align(
+            alignment: Alignment.center,
+            child: FilledButton(
+              key: const ValueKey<String>('implement-plan-button'),
+              onPressed: onImplementPlanPressed,
+              child: const Text('Implement Plan'),
+            ),
+          ),
+        ),
+      );
+    }
 
     return SelectionArea(
-      child: ListView.builder(
+      child: SingleChildScrollView(
         key: const ValueKey<String>('timeline-list'),
         controller: controller,
-        padding: const EdgeInsets.symmetric(
-          horizontal: AleraTokens.space16,
-          vertical: AleraTokens.space16,
-        ),
-        itemCount: itemCount,
-        itemBuilder: (context, index) {
-          Widget child;
-          if (index < timelineWidgets.length) {
-            child = timelineWidgets[index];
-          } else {
-            child = Padding(
-              padding: const EdgeInsets.only(bottom: AleraTokens.space8),
-              child: Align(
-                alignment: Alignment.center,
-                child: FilledButton(
-                  key: const ValueKey<String>('implement-plan-button'),
-                  onPressed: onImplementPlanPressed,
-                  child: const Text('Implement Plan'),
-                ),
-              ),
-            );
-          }
-
-          return Center(
-            child: ConstrainedBox(
-              constraints: BoxConstraints(maxWidth: contentMaxWidth),
-              child: child,
+        padding: const EdgeInsets.all(AleraTokens.space16),
+        child: Center(
+          child: ConstrainedBox(
+            key: const ValueKey<String>('timeline-content-container'),
+            constraints: BoxConstraints(maxWidth: contentMaxWidth),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: widgets,
             ),
-          );
-        },
+          ),
+        ),
       ),
     );
   }
 
   List<Widget> _buildTimelineWidgets() {
+    final items = _buildTimelineItems();
+    return items.map((item) {
+      return switch (item) {
+        _CellItem(cell: final cell) => _timelineCellWithSpacing(cell),
+        _ClusterItem(cells: final cluster) => Padding(
+          padding: const EdgeInsets.only(bottom: AleraTokens.space8),
+          child: ExploringClusterCell(
+            key: ValueKey(
+              'cluster-open-${cluster.first.id}-${cluster.last.id}',
+            ),
+            cells: cluster,
+          ),
+        ),
+        _TurnItem(
+          turnId: final turnId,
+          separator: final separator,
+          turnCells: final turnCells,
+        ) => Padding(
+          padding: const EdgeInsets.only(bottom: AleraTokens.space8),
+          child: CompletedTurnSection(
+            turnId: turnId,
+            separator: separator,
+            turnCells: turnCells,
+            workedExpanded: expandedWorkedTurns.contains(turnId),
+            onToggleWorked: () => onToggleWorkedTurn(turnId),
+            markdownEnabled: markdownEnabled,
+            onMarkdownModeChanged: onMarkdownModeChanged,
+          ),
+        ),
+      };
+    }).toList();
+  }
+
+  List<_TimelineItem> _buildTimelineItems() {
     final cells = state.timelineCells;
     final separatorsByTurn = <String, TimelineCell>{};
     final firstIndexByTurn = <String, int>{};
+    final turnCellsMap = <String, List<TimelineCell>>{};
+
     for (var i = 0; i < cells.length; i++) {
       final cell = cells[i];
       final turnId = cell.turnId;
@@ -87,11 +119,14 @@ class ChatTimelineList extends StatelessWidget {
         firstIndexByTurn.putIfAbsent(turnId, () => i);
         if (cell.kind == TimelineCellKind.turnSeparator) {
           separatorsByTurn[turnId] = cell;
+        } else {
+          turnCellsMap.putIfAbsent(turnId, () => []).add(cell);
         }
       }
     }
+
     final renderedCompletedTurns = <String>{};
-    final widgets = <Widget>[];
+    final items = <_TimelineItem>[];
     for (var i = 0; i < cells.length; i++) {
       final cell = cells[i];
       final turnId = cell.turnId;
@@ -99,7 +134,7 @@ class ChatTimelineList extends StatelessWidget {
         if (cell.kind == TimelineCellKind.turnSeparator) {
           continue;
         }
-        widgets.add(_timelineCellWithSpacing(cell));
+        items.add(_CellItem(cell));
         continue;
       }
       final separator = separatorsByTurn[turnId];
@@ -112,22 +147,12 @@ class ChatTimelineList extends StatelessWidget {
           final runLength = _exploratoryRunLength(cells, i);
           if (runLength >= 2) {
             final cluster = cells.sublist(i, i + runLength);
-            widgets.add(
-              Padding(
-                padding: const EdgeInsets.only(bottom: AleraTokens.space8),
-                child: ExploringClusterCell(
-                  key: ValueKey(
-                    'cluster-open-${cluster.first.id}-${cluster.last.id}',
-                  ),
-                  cells: cluster,
-                ),
-              ),
-            );
+            items.add(_ClusterItem(cluster));
             i += runLength - 1;
             continue;
           }
         }
-        widgets.add(_timelineCellWithSpacing(cell));
+        items.add(_CellItem(cell));
         continue;
       }
       final firstTurnIndex = firstIndexByTurn[turnId];
@@ -135,29 +160,16 @@ class ChatTimelineList extends StatelessWidget {
         continue;
       }
       renderedCompletedTurns.add(turnId);
-      final turnCells = cells
-          .where(
-            (candidate) =>
-                candidate.turnId == turnId &&
-                candidate.kind != TimelineCellKind.turnSeparator,
-          )
-          .toList(growable: false);
-      widgets.add(
-        Padding(
-          padding: const EdgeInsets.only(bottom: AleraTokens.space8),
-          child: CompletedTurnSection(
-            turnId: turnId,
-            separator: separator,
-            turnCells: turnCells,
-            workedExpanded: expandedWorkedTurns.contains(turnId),
-            onToggleWorked: () => onToggleWorkedTurn(turnId),
-            markdownEnabled: markdownEnabled,
-            onMarkdownModeChanged: onMarkdownModeChanged,
-          ),
+      final turnCells = turnCellsMap[turnId] ?? const <TimelineCell>[];
+      items.add(
+        _TurnItem(
+          turnId: turnId,
+          separator: separator,
+          turnCells: turnCells,
         ),
       );
     }
-    return widgets;
+    return items;
   }
 
   Widget _timelineCellWithSpacing(TimelineCell cell) {
@@ -490,6 +502,28 @@ class CompletedTurnSection extends StatelessWidget {
 String _uiPlacement(TimelineCell cell) {
   return (cell.metadata[TimelineCellMetadata.uiPlacementKey] ?? '')
       .toString()
-      .toLowerCase()
       .trim();
+}
+
+sealed class _TimelineItem {}
+
+class _CellItem extends _TimelineItem {
+  _CellItem(this.cell);
+  final TimelineCell cell;
+}
+
+class _ClusterItem extends _TimelineItem {
+  _ClusterItem(this.cells);
+  final List<TimelineCell> cells;
+}
+
+class _TurnItem extends _TimelineItem {
+  _TurnItem({
+    required this.turnId,
+    required this.separator,
+    required this.turnCells,
+  });
+  final String turnId;
+  final TimelineCell separator;
+  final List<TimelineCell> turnCells;
 }

--- a/lib/src/features/session/presentation/widgets/composer.dart
+++ b/lib/src/features/session/presentation/widgets/composer.dart
@@ -489,7 +489,7 @@ class ComposerState extends State<Composer> {
     }
 
     return IconButton(
-      key: const ValueKey<String>('composer-send-stop-button'),
+      key: const ValueKey<String>('composer-action-button'),
       onPressed: onPressed,
       mouseCursor: SystemMouseCursors.click,
       constraints: const BoxConstraints(minWidth: 32, minHeight: 32),

--- a/lib/src/features/session/presentation/widgets/markdown_helpers.dart
+++ b/lib/src/features/session/presentation/widgets/markdown_helpers.dart
@@ -227,7 +227,7 @@ class MessageMarkdownToggleButton extends StatelessWidget {
   Widget build(BuildContext context) {
     final bool effectivelyActive = !mouseIsConnected() || active;
     return Tooltip(
-      message: effectivelyActive ? (markdownEnabled ? 'Markdown ON' : 'Markdown OFF') : '',
+      message: effectivelyActive ? (markdownEnabled ? 'Markdown on' : 'Markdown off') : '',
       child: InkWell(
         onTap: effectivelyActive ? () => onChanged(!markdownEnabled) : null,
         mouseCursor: effectivelyActive ? SystemMouseCursors.click : SystemMouseCursors.basic,

--- a/lib/src/features/session/presentation/widgets/markdown_helpers.dart
+++ b/lib/src/features/session/presentation/widgets/markdown_helpers.dart
@@ -119,6 +119,7 @@ class MessageActionButtons extends StatelessWidget {
     required this.toggleKey,
     required this.markdownEnabled,
     required this.onToggleMarkdown,
+    this.active = true,
   });
 
   final bool alignLeft;
@@ -128,6 +129,7 @@ class MessageActionButtons extends StatelessWidget {
   final ValueKey<String> toggleKey;
   final bool markdownEnabled;
   final ValueChanged<bool> onToggleMarkdown;
+  final bool active;
 
   @override
   Widget build(BuildContext context) {
@@ -135,11 +137,13 @@ class MessageActionButtons extends StatelessWidget {
       key: copyKey,
       copyText: copyText,
       copiedLabel: copiedLabel,
+      active: active,
     );
     final markdownToggle = MessageMarkdownToggleButton(
       key: toggleKey,
       markdownEnabled: markdownEnabled,
       onChanged: onToggleMarkdown,
+      active: active,
     );
     return Row(
       mainAxisSize: MainAxisSize.min,
@@ -163,10 +167,12 @@ class MessageCopyButton extends StatelessWidget {
     super.key,
     required this.copyText,
     required this.copiedLabel,
+    this.active = true,
   });
 
   final String copyText;
   final String copiedLabel;
+  final bool active;
 
   Future<void> _copy(BuildContext context) async {
     if (copyText.isEmpty) {
@@ -185,19 +191,20 @@ class MessageCopyButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final bool effectivelyActive = !mouseIsConnected() || active;
     return InkWell(
-      onTap: () => _copy(context),
-      mouseCursor: SystemMouseCursors.click,
+      onTap: effectivelyActive ? () => _copy(context) : null,
+      mouseCursor: effectivelyActive ? SystemMouseCursors.click : SystemMouseCursors.basic,
       borderRadius: BorderRadius.circular(AleraTokens.radiusSm),
-      child: const Padding(
-        padding: EdgeInsets.symmetric(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(
           horizontal: AleraTokens.space4,
           vertical: AleraTokens.space2,
         ),
         child: Icon(
           Icons.content_copy,
           size: 12,
-          color: AleraTokens.foregroundFaint,
+          color: effectivelyActive ? AleraTokens.foregroundFaint : Colors.transparent,
         ),
       ),
     );
@@ -209,25 +216,32 @@ class MessageMarkdownToggleButton extends StatelessWidget {
     super.key,
     required this.markdownEnabled,
     required this.onChanged,
+    this.active = true,
   });
 
   final bool markdownEnabled;
   final ValueChanged<bool> onChanged;
+  final bool active;
 
   @override
   Widget build(BuildContext context) {
+    final bool effectivelyActive = !mouseIsConnected() || active;
     return Tooltip(
-      message: markdownEnabled ? 'Markdown ON' : 'Markdown OFF',
+      message: effectivelyActive ? (markdownEnabled ? 'Markdown ON' : 'Markdown OFF') : '',
       child: InkWell(
-        onTap: () => onChanged(!markdownEnabled),
-        mouseCursor: SystemMouseCursors.click,
+        onTap: effectivelyActive ? () => onChanged(!markdownEnabled) : null,
+        mouseCursor: effectivelyActive ? SystemMouseCursors.click : SystemMouseCursors.basic,
         borderRadius: BorderRadius.circular(AleraTokens.radiusSm),
-        child: const Padding(
-          padding: EdgeInsets.symmetric(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(
             horizontal: AleraTokens.space4,
             vertical: AleraTokens.space2,
           ),
-          child: Icon(Icons.code, size: 13, color: AleraTokens.foregroundFaint),
+          child: Icon(
+            Icons.code,
+            size: 13,
+            color: effectivelyActive ? AleraTokens.foregroundFaint : Colors.transparent,
+          ),
         ),
       ),
     );

--- a/lib/src/features/session/presentation/widgets/timeline_cells.dart
+++ b/lib/src/features/session/presentation/widgets/timeline_cells.dart
@@ -84,6 +84,8 @@ class UserMessageCell extends StatefulWidget {
 }
 
 class _UserMessageCellState extends State<UserMessageCell> {
+  bool _isHovered = false;
+
   List<Map<String, dynamic>> _parseAttachments() {
     final raw = widget.cell.metadata['attachments'];
     if (raw is! List) {
@@ -121,15 +123,18 @@ class _UserMessageCellState extends State<UserMessageCell> {
       alignment: Alignment.centerRight,
       child: ConstrainedBox(
         constraints: const BoxConstraints(maxWidth: 760),
-        child: Padding(
-          padding: const EdgeInsets.only(
-            top: AleraTokens.space6,
-            bottom: AleraTokens.space4,
-            left: 80,
-          ),
-          child: Stack(
-            clipBehavior: Clip.none,
-            children: <Widget>[
+        child: MouseRegion(
+          onEnter: (_) => setState(() => _isHovered = true),
+          onExit: (_) => setState(() => _isHovered = false),
+          child: Padding(
+            padding: const EdgeInsets.only(
+              top: AleraTokens.space6,
+              bottom: AleraTokens.space4,
+              left: 80,
+            ),
+            child: Stack(
+              clipBehavior: Clip.none,
+              children: <Widget>[
               Padding(
                 padding: const EdgeInsets.only(bottom: 18),
                 child: Column(
@@ -226,22 +231,25 @@ class _UserMessageCellState extends State<UserMessageCell> {
                   ],
                 ),
               ),
-              Positioned(
-                right: 0,
-                bottom: 0,
-                child: MessageActionButtons(
-                  alignLeft: false,
-                  copyKey: ValueKey<String>('copy-user-${widget.cell.id}'),
-                  copyText: messageText,
-                  copiedLabel: 'Message copied',
-                  toggleKey: ValueKey<String>(
-                    'toggle-markdown-user-${widget.cell.id}',
+                Positioned(
+                  right: 0,
+                  bottom: 0,
+                  child: MessageActionButtons(
+                    key: ValueKey<String>('copy-zone-user-${widget.cell.id}'),
+                    alignLeft: false,
+                    copyKey: ValueKey<String>('copy-user-${widget.cell.id}'),
+                    copyText: messageText,
+                    copiedLabel: 'Message copied',
+                    toggleKey: ValueKey<String>(
+                      'toggle-markdown-user-${widget.cell.id}',
+                    ),
+                    markdownEnabled: widget.markdownEnabled,
+                    onToggleMarkdown: widget.onMarkdownModeChanged,
+                    active: _isHovered,
                   ),
-                  markdownEnabled: widget.markdownEnabled,
-                  onToggleMarkdown: widget.onMarkdownModeChanged,
                 ),
-              ),
-            ],
+              ],
+            ),
           ),
         ),
       ),
@@ -270,6 +278,8 @@ class AssistantMessageCell extends StatefulWidget {
 }
 
 class _AssistantMessageCellState extends State<AssistantMessageCell> {
+  bool _isHovered = false;
+
   @override
   Widget build(BuildContext context) {
     final rawText = widget.cell.markdownText ?? '';
@@ -287,9 +297,12 @@ class _AssistantMessageCellState extends State<AssistantMessageCell> {
           constraints: const BoxConstraints(maxWidth: 760),
           child: SizedBox(
             width: double.infinity,
-            child: Stack(
-              clipBehavior: Clip.none,
-              children: <Widget>[
+            child: MouseRegion(
+              onEnter: (_) => setState(() => _isHovered = true),
+              onExit: (_) => setState(() => _isHovered = false),
+              child: Stack(
+                clipBehavior: Clip.none,
+                children: <Widget>[
                 Padding(
                   padding: const EdgeInsets.only(bottom: 18),
                   child: Container(
@@ -301,24 +314,29 @@ class _AssistantMessageCellState extends State<AssistantMessageCell> {
                     ),
                   ),
                 ),
-                Positioned(
-                  left: 0,
-                  bottom: 0,
-                  child: MessageActionButtons(
-                    alignLeft: true,
-                    copyKey: ValueKey<String>(
-                      'copy-assistant-${widget.cell.id}',
+                  Positioned(
+                    left: 0,
+                    bottom: 0,
+                    child: MessageActionButtons(
+                      key: ValueKey<String>(
+                        'copy-zone-assistant-${widget.cell.id}',
+                      ),
+                      alignLeft: true,
+                      copyKey: ValueKey<String>(
+                        'copy-assistant-${widget.cell.id}',
+                      ),
+                      copyText: rawText,
+                      copiedLabel: 'Message copied',
+                      toggleKey: ValueKey<String>(
+                        'toggle-markdown-assistant-${widget.cell.id}',
+                      ),
+                      markdownEnabled: widget.markdownEnabled,
+                      onToggleMarkdown: widget.onMarkdownModeChanged,
+                      active: _isHovered,
                     ),
-                    copyText: rawText,
-                    copiedLabel: 'Message copied',
-                    toggleKey: ValueKey<String>(
-                      'toggle-markdown-assistant-${widget.cell.id}',
-                    ),
-                    markdownEnabled: widget.markdownEnabled,
-                    onToggleMarkdown: widget.onMarkdownModeChanged,
                   ),
-                ),
-              ],
+                ],
+              ),
             ),
           ),
         ),

--- a/lib/src/features/shell/presentation/alera_shell_page.dart
+++ b/lib/src/features/shell/presentation/alera_shell_page.dart
@@ -38,38 +38,73 @@ class _AleraShellPageState extends ConsumerState<AleraShellPage> {
 
   @override
   Widget build(BuildContext context) {
-    final state = ref.watch(sessionControllerProvider);
     final controller = ref.read(sessionControllerProvider.notifier);
+    final error = ref.watch(sessionControllerProvider.select((s) => s.error));
 
-    if (state.error != null && state.error != _lastErrorMessage) {
-      _lastErrorMessage = state.error;
+    if (error != null && error != _lastErrorMessage) {
+      _lastErrorMessage = error;
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (!mounted) {
           return;
         }
-        _showError(state.error!);
+        _showError(error);
       });
     }
+
+    final workspacePath = ref.watch(
+      sessionControllerProvider.select((s) => s.selectedWorkspacePath),
+    );
+    final activeSessionTitle = ref.watch(
+      sessionControllerProvider.select((s) => s.activeSession?.title),
+    );
+    final isBusy = ref.watch(
+      sessionControllerProvider.select((s) => s.isBusy),
+    );
+    final activityLogEmpty = ref.watch(
+      sessionControllerProvider.select((s) => s.activityLog.isEmpty),
+    );
+
+    final connectionState = ref.watch(
+      sessionControllerProvider.select((s) => s.connectionState),
+    );
+    final runningTurnCount = ref.watch(
+      sessionControllerProvider.select((s) => s.runningTurnCount),
+    );
+    final statusHeader = ref.watch(
+      sessionControllerProvider.select((s) => s.statusHeader),
+    );
+    final lastTurnDiff = ref.watch(
+      sessionControllerProvider.select((s) => s.lastTurnDiff),
+    );
 
     return Scaffold(
       body: Column(
         children: <Widget>[
           AleraTopBar(
-            workspaceName: _workspaceName(state.selectedWorkspacePath),
-            sessionTitle: state.activeSession?.title,
-            isBusy: state.isBusy,
+            workspaceName: _workspaceName(workspacePath),
+            sessionTitle: activeSessionTitle,
+            isBusy: isBusy,
             onSelectWorkspace: () => _selectWorkspace(controller),
           ),
           Expanded(
-            child: _buildContent(state: state, controller: controller),
+            child: Consumer(
+              builder: (context, ref, child) {
+                final state = ref.watch(sessionControllerProvider);
+                return _buildContent(state: state, controller: controller);
+              },
+            ),
           ),
           AleraStatusBar(
-            state: state,
+            connectionState: connectionState,
+            runningTurnCount: runningTurnCount,
+            statusHeader: statusHeader,
+            lastTurnDiff: lastTurnDiff,
+            workspacePath: workspacePath,
             rawLogExpanded: _rawLogExpanded,
             onToggleRawLog: () =>
                 setState(() => _rawLogExpanded = !_rawLogExpanded),
-            onCopyRawLog: () => _copyRawLog(state),
-            canCopyRawLog: state.activityLog.isNotEmpty,
+            onCopyRawLog: () => _copyRawLog(ref.read(sessionControllerProvider)),
+            canCopyRawLog: !activityLogEmpty,
           ),
         ],
       ),
@@ -88,6 +123,7 @@ class _AleraShellPageState extends ConsumerState<AleraShellPage> {
         message: 'Choose a git repository folder to start working.',
         actionLabel: 'Select folder',
         onAction: () => _selectWorkspace(controller),
+        statusHeader: state.statusHeader,
       );
     }
     return SessionWorkspaceView(
@@ -287,6 +323,7 @@ class _EmptyState extends StatelessWidget {
     required this.message,
     this.actionLabel,
     this.onAction,
+    this.statusHeader,
   });
 
   final IconData icon;
@@ -294,6 +331,7 @@ class _EmptyState extends StatelessWidget {
   final String message;
   final String? actionLabel;
   final VoidCallback? onAction;
+  final String? statusHeader;
 
   @override
   Widget build(BuildContext context) {
@@ -326,7 +364,7 @@ class _EmptyState extends StatelessWidget {
                   color: AleraTokens.foregroundMuted,
                 ),
               ),
-              if (actionLabel != null && onAction != null) ...<Widget>[
+              if (actionLabel != null && actionLabel!.trim().isNotEmpty && onAction != null) ...<Widget>[
                 const SizedBox(height: AleraTokens.space24),
                 FilledButton.icon(
                   onPressed: onAction,

--- a/lib/src/features/shell/presentation/alera_shell_page.dart
+++ b/lib/src/features/shell/presentation/alera_shell_page.dart
@@ -54,12 +54,15 @@ class _AleraShellPageState extends ConsumerState<AleraShellPage> {
     final workspacePath = ref.watch(
       sessionControllerProvider.select((s) => s.selectedWorkspacePath),
     );
+    final statusBarWorkspacePath = ref.watch(
+      sessionControllerProvider.select(
+        (s) => s.activeSession?.workspacePath ?? s.selectedWorkspacePath,
+      ),
+    );
     final activeSessionTitle = ref.watch(
       sessionControllerProvider.select((s) => s.activeSession?.title),
     );
-    final isBusy = ref.watch(
-      sessionControllerProvider.select((s) => s.isBusy),
-    );
+    final isBusy = ref.watch(sessionControllerProvider.select((s) => s.isBusy));
     final activityLogEmpty = ref.watch(
       sessionControllerProvider.select((s) => s.activityLog.isEmpty),
     );
@@ -99,11 +102,12 @@ class _AleraShellPageState extends ConsumerState<AleraShellPage> {
             runningTurnCount: runningTurnCount,
             statusHeader: statusHeader,
             lastTurnDiff: lastTurnDiff,
-            workspacePath: workspacePath,
+            workspacePath: statusBarWorkspacePath,
             rawLogExpanded: _rawLogExpanded,
             onToggleRawLog: () =>
                 setState(() => _rawLogExpanded = !_rawLogExpanded),
-            onCopyRawLog: () => _copyRawLog(ref.read(sessionControllerProvider)),
+            onCopyRawLog: () =>
+                _copyRawLog(ref.read(sessionControllerProvider)),
             canCopyRawLog: !activityLogEmpty,
           ),
         ],
@@ -364,7 +368,9 @@ class _EmptyState extends StatelessWidget {
                   color: AleraTokens.foregroundMuted,
                 ),
               ),
-              if (actionLabel != null && actionLabel!.trim().isNotEmpty && onAction != null) ...<Widget>[
+              if (actionLabel != null &&
+                  actionLabel!.trim().isNotEmpty &&
+                  onAction != null) ...<Widget>[
                 const SizedBox(height: AleraTokens.space24),
                 FilledButton.icon(
                   onPressed: onAction,

--- a/lib/src/features/shell/presentation/alera_status_bar.dart
+++ b/lib/src/features/shell/presentation/alera_status_bar.dart
@@ -1,5 +1,4 @@
 import 'package:alera/src/app/theme/alera_tokens.dart';
-import 'package:alera/src/features/session/application/session_state.dart';
 import 'package:alera/src/features/session/presentation/widgets/diff_viewer.dart';
 import 'package:alera/src/shared/models/contracts.dart';
 import 'package:flutter/material.dart';
@@ -7,14 +6,22 @@ import 'package:flutter/material.dart';
 class AleraStatusBar extends StatelessWidget {
   const AleraStatusBar({
     super.key,
-    required this.state,
+    required this.connectionState,
+    required this.runningTurnCount,
+    this.statusHeader,
+    this.lastTurnDiff,
+    this.workspacePath,
     required this.rawLogExpanded,
     required this.onToggleRawLog,
     required this.onCopyRawLog,
     required this.canCopyRawLog,
   });
 
-  final SessionState state;
+  final AppServerConnectionState connectionState;
+  final int runningTurnCount;
+  final String? statusHeader;
+  final String? lastTurnDiff;
+  final String? workspacePath;
   final bool rawLogExpanded;
   final VoidCallback onToggleRawLog;
   final VoidCallback onCopyRawLog;
@@ -23,8 +30,9 @@ class AleraStatusBar extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final session = state.activeSession;
-    final workspacePath = session?.workspacePath ?? state.selectedWorkspacePath;
+    final header = statusHeader;
+    final diff = lastTurnDiff;
+
     return Container(
       height: AleraTokens.statusBarHeight,
       padding: const EdgeInsets.symmetric(horizontal: AleraTokens.space12),
@@ -34,29 +42,30 @@ class AleraStatusBar extends StatelessWidget {
       ),
       child: Row(
         children: <Widget>[
-          _StatusChip(label: _connectionLabel(), color: _connectionColor()),
-          if (state.runningTurnCount > 0) ...<Widget>[
+          _StatusChip(
+            label: _connectionLabel(connectionState),
+            color: _connectionColor(connectionState),
+          ),
+          if (runningTurnCount > 0) ...<Widget>[
             _separator(),
             _StatusChip(
-              label: 'Running: ${state.runningTurnCount}',
+              label: 'Running: $runningTurnCount',
               color: AleraTokens.accent,
             ),
           ],
-          if (state.statusHeader != null &&
-              state.statusHeader!.trim().isNotEmpty) ...<Widget>[
+          if (header != null && header.trim().isNotEmpty) ...<Widget>[
             _separator(),
             _StatusChip(
-              label: state.statusHeader!,
+              label: header,
               color: AleraTokens.foregroundMuted,
             ),
           ],
           const Spacer(),
-          if (state.lastTurnDiff != null) ...<Widget>[
+          if (diff != null) ...<Widget>[
             Tooltip(
               message: 'View file changes',
               child: InkWell(
-                onTap: () =>
-                    DiffViewerDialog.show(context, state.lastTurnDiff!),
+                onTap: () => DiffViewerDialog.show(context, diff),
                 mouseCursor: SystemMouseCursors.click,
                 borderRadius: BorderRadius.circular(AleraTokens.radiusLg),
                 child: const Padding(
@@ -141,8 +150,8 @@ class AleraStatusBar extends StatelessWidget {
     );
   }
 
-  String _connectionLabel() {
-    return switch (state.connectionState) {
+  String _connectionLabel(AppServerConnectionState state) {
+    return switch (state) {
       AppServerConnectionState.connected => 'Connected',
       AppServerConnectionState.starting => 'Starting',
       AppServerConnectionState.error => 'Error',
@@ -150,8 +159,8 @@ class AleraStatusBar extends StatelessWidget {
     };
   }
 
-  Color _connectionColor() {
-    return switch (state.connectionState) {
+  Color _connectionColor(AppServerConnectionState state) {
+    return switch (state) {
       AppServerConnectionState.connected => AleraTokens.success,
       AppServerConnectionState.starting => AleraTokens.accent,
       AppServerConnectionState.error => AleraTokens.error,

--- a/lib/src/shared/infra/process/io_process_runner.dart
+++ b/lib/src/shared/infra/process/io_process_runner.dart
@@ -53,7 +53,9 @@ class IoProcessRunner implements ProcessRunner {
       stderr: process.stderr,
       pid: process.pid,
       exitCode: process.exitCode,
-      kill: () => process.kill(),
+      kill: ([signal]) => process.kill(
+        signal is ProcessSignal ? signal : ProcessSignal.sigterm,
+      ),
     );
   }
 }

--- a/lib/src/shared/infra/process/process_runner.dart
+++ b/lib/src/shared/infra/process/process_runner.dart
@@ -27,7 +27,7 @@ class StartedProcess {
   final Stream<List<int>> stderr;
   final int pid;
   final Future<int> exitCode;
-  final bool Function() kill;
+  final bool Function([dynamic signal]) kill;
 }
 
 abstract interface class ProcessRunner {

--- a/test/widget/alera_shell_page_test.dart
+++ b/test/widget/alera_shell_page_test.dart
@@ -16,20 +16,32 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 class _ShellFakeSessionService implements SessionService {
+  _ShellFakeSessionService({
+    List<AleraSession> sessions = const <AleraSession>[],
+  }) : _sessions = List<AleraSession>.of(sessions);
+
   final StreamController<SessionRuntimeEvent> _eventsController =
       StreamController<SessionRuntimeEvent>.broadcast();
+  final List<AleraSession> _sessions;
 
   @override
   Stream<SessionRuntimeEvent> get events => _eventsController.stream;
 
   @override
-  List<AleraSession> get sessions => const <AleraSession>[];
+  List<AleraSession> get sessions => List<AleraSession>.unmodifiable(_sessions);
 
   @override
   Future<void> ensureConnected() async {}
 
   @override
-  AleraSession? findLatestSessionForWorkspace(String workspacePath) => null;
+  AleraSession? findLatestSessionForWorkspace(String workspacePath) {
+    for (final session in _sessions.reversed) {
+      if (session.workspacePath == workspacePath) {
+        return session;
+      }
+    }
+    return null;
+  }
 
   @override
   Future<AleraSession> createSession(SessionCreateRequest request) {
@@ -134,8 +146,8 @@ class _ShellFakeSessionService implements SessionService {
   }
 
   @override
-  Future<AleraSession> setActiveSession(String sessionId) {
-    throw UnimplementedError();
+  Future<AleraSession> setActiveSession(String sessionId) async {
+    return _sessions.firstWhere((session) => session.id == sessionId);
   }
 
   @override
@@ -196,9 +208,31 @@ class _ShellFakeSettingsService implements SettingsService {
 }
 
 void main() {
-  Future<(SessionController, _ShellFakeSessionService)>
-  buildController() async {
-    final fakeService = _ShellFakeSessionService();
+  AleraSession buildSession({
+    required String id,
+    required String workspacePath,
+    String title = 'session',
+  }) {
+    final now = DateTime.utc(2026, 3, 15);
+    return AleraSession(
+      id: id,
+      request: SessionCreateRequest(
+        projectPath: workspacePath,
+        firstPrompt: 'hello',
+        model: 'gpt-5.3-codex',
+      ),
+      workspacePath: workspacePath,
+      createdAt: now,
+      updatedAt: now,
+      title: title,
+      model: 'gpt-5.3-codex',
+    );
+  }
+
+  Future<(SessionController, _ShellFakeSessionService)> buildController({
+    List<AleraSession> sessions = const <AleraSession>[],
+  }) async {
+    final fakeService = _ShellFakeSessionService(sessions: sessions);
     final controller = SessionController(
       sessionService: fakeService,
       projectService: _ShellFakeProjectService(),
@@ -297,6 +331,47 @@ void main() {
 
     expect((topBarRect.width - scaffoldRect.width).abs(), lessThan(1.0));
     expect((statusBarRect.width - scaffoldRect.width).abs(), lessThan(1.0));
+  });
+
+  testWidgets('status bar shows active session workspace path fallback', (
+    tester,
+  ) async {
+    final session = buildSession(
+      id: 'session-1',
+      workspacePath: '/session-repo',
+      title: 'existing session',
+    );
+    final (controller, fakeService) = await buildController(
+      sessions: <AleraSession>[session],
+    );
+    addTearDown(() async {
+      await fakeService.shutdown();
+    });
+
+    controller.state = controller.state.copyWith(
+      selectedWorkspacePath: '/selected-repo',
+      sessions: <AleraSession>[session],
+      activeSessionId: session.id,
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          sessionControllerProvider.overrideWith((ref) => controller),
+        ],
+        child: const MaterialApp(home: AleraShellPage()),
+      ),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 300));
+
+    expect(
+      find.descendant(
+        of: find.byType(AleraStatusBar),
+        matching: find.text('/session-repo'),
+      ),
+      findsOneWidget,
+    );
   });
 
   testWidgets('empty state unchanged when no workspace is selected', (

--- a/test/widget/alera_status_bar_test.dart
+++ b/test/widget/alera_status_bar_test.dart
@@ -1,5 +1,5 @@
-import 'package:alera/src/features/session/application/session_state.dart';
 import 'package:alera/src/features/shell/presentation/alera_status_bar.dart';
+import 'package:alera/src/shared/models/contracts.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -14,7 +14,9 @@ Future<void> _pumpStatusBar(
     MaterialApp(
       home: Scaffold(
         body: AleraStatusBar(
-          state: const SessionState(selectedWorkspacePath: '/repo'),
+          connectionState: AppServerConnectionState.connected,
+          runningTurnCount: 0,
+          workspacePath: '/repo',
           rawLogExpanded: rawLogExpanded,
           onToggleRawLog: onToggleRawLog,
           onCopyRawLog: onCopyRawLog,
@@ -34,10 +36,9 @@ void main() {
       MaterialApp(
         home: Scaffold(
           body: AleraStatusBar(
-            state: const SessionState(
-              selectedWorkspacePath: '/repo',
-              turnRuntimeMetrics: <String, dynamic>{'totalTokens': 205000},
-            ),
+            connectionState: AppServerConnectionState.connected,
+            runningTurnCount: 0,
+            workspacePath: '/repo',
             rawLogExpanded: false,
             onToggleRawLog: () {},
             onCopyRawLog: () {},

--- a/test/widget/session_command_ux_test.dart
+++ b/test/widget/session_command_ux_test.dart
@@ -76,7 +76,7 @@ void main() {
 
     await tester.enterText(find.byType(TextField).first, '/status');
     await tester.tap(
-      find.byKey(const ValueKey<String>('composer-send-stop-button')),
+      find.byKey(const ValueKey<String>('composer-action-button')),
     );
     await tester.pumpAndSettle();
 
@@ -92,7 +92,7 @@ void main() {
 
     await tester.enterText(find.byType(TextField).first, '/status');
     await tester.tap(
-      find.byKey(const ValueKey<String>('composer-send-stop-button')),
+      find.byKey(const ValueKey<String>('composer-action-button')),
     );
     await tester.pumpAndSettle();
 
@@ -120,7 +120,7 @@ void main() {
 
     await tester.enterText(find.byType(TextField).first, '/review');
     await tester.tap(
-      find.byKey(const ValueKey<String>('composer-send-stop-button')),
+      find.byKey(const ValueKey<String>('composer-action-button')),
     );
     await tester.pumpAndSettle();
 
@@ -152,7 +152,7 @@ void main() {
 
     await tester.enterText(find.byType(TextField).first, '/review');
     await tester.tap(
-      find.byKey(const ValueKey<String>('composer-send-stop-button')),
+      find.byKey(const ValueKey<String>('composer-action-button')),
     );
     await tester.pumpAndSettle();
 
@@ -184,7 +184,7 @@ void main() {
 
     await tester.enterText(find.byType(TextField).first, '/review');
     await tester.tap(
-      find.byKey(const ValueKey<String>('composer-send-stop-button')),
+      find.byKey(const ValueKey<String>('composer-action-button')),
     );
     await tester.pumpAndSettle();
 
@@ -211,7 +211,7 @@ void main() {
 
     await tester.enterText(find.byType(TextField).first, '/review');
     await tester.tap(
-      find.byKey(const ValueKey<String>('composer-send-stop-button')),
+      find.byKey(const ValueKey<String>('composer-action-button')),
     );
     await tester.pumpAndSettle();
 
@@ -253,7 +253,7 @@ void main() {
 
     await tester.enterText(find.byType(TextField).first, '/skills');
     await tester.tap(
-      find.byKey(const ValueKey<String>('composer-send-stop-button')),
+      find.byKey(const ValueKey<String>('composer-action-button')),
     );
     await tester.pumpAndSettle();
 
@@ -288,7 +288,7 @@ void main() {
 
     await tester.enterText(find.byType(TextField).first, '/skills');
     await tester.tap(
-      find.byKey(const ValueKey<String>('composer-send-stop-button')),
+      find.byKey(const ValueKey<String>('composer-action-button')),
     );
     await tester.pumpAndSettle();
 
@@ -319,7 +319,7 @@ void main() {
 
     await tester.enterText(find.byType(TextField).first, '/skills');
     await tester.tap(
-      find.byKey(const ValueKey<String>('composer-send-stop-button')),
+      find.byKey(const ValueKey<String>('composer-action-button')),
     );
     await tester.pumpAndSettle();
 

--- a/test/widget/session_workspace_view_test.dart
+++ b/test/widget/session_workspace_view_test.dart
@@ -1,3 +1,4 @@
+import 'package:alera/src/app/theme/alera_tokens.dart';
 import 'package:alera/src/features/session/application/session_runtime_event.dart';
 import 'package:alera/src/features/session/application/session_state.dart';
 import 'package:alera/src/features/session/application/session_timeline_reducer.dart';
@@ -130,6 +131,21 @@ IconButton _scrollToBottomButton(WidgetTester tester) {
   );
 }
 
+const double _timelineRowMaxWidth =
+    720 - (AleraTokens.space12 * 2) - AleraTokens.space8;
+
+Finder _timelineContentRowFinder() {
+  return find.descendant(
+    of: find.byKey(const ValueKey<String>('timeline-list')),
+    matching: find.byWidgetPredicate(
+      (widget) =>
+          widget is ConstrainedBox &&
+          widget.constraints.maxWidth == _timelineRowMaxWidth,
+      description: 'timeline content row',
+    ),
+  );
+}
+
 void main() {
   SessionState stateWithActiveSession({
     List<TimelineCell> timeline = const [],
@@ -223,7 +239,7 @@ void main() {
     },
   );
 
-  testWidgets('implement plan button renders inside timeline container', (
+  testWidgets('implement plan button renders inside a timeline row', (
     tester,
   ) async {
     final state = stateWithActiveSession(
@@ -246,10 +262,7 @@ void main() {
     );
     expect(buttonFinder, findsOneWidget);
     expect(
-      find.descendant(
-        of: find.byKey(const ValueKey<String>('timeline-content-container')),
-        matching: buttonFinder,
-      ),
+      find.ancestor(of: buttonFinder, matching: _timelineContentRowFinder()),
       findsOneWidget,
     );
   });
@@ -1941,12 +1954,10 @@ void main() {
         find.byKey(const ValueKey<String>('timeline-list')),
       );
       final scaffoldRect = tester.getRect(find.byType(Scaffold));
-      final contentRect = tester.getRect(
-        find.byKey(const ValueKey<String>('timeline-content-container')),
-      );
+      final contentRect = tester.getRect(_timelineContentRowFinder().first);
 
       expect((listRect.width - scaffoldRect.width).abs(), lessThan(1.0));
-      expect(contentRect.width, lessThanOrEqualTo(720));
+      expect(contentRect.width, lessThanOrEqualTo(_timelineRowMaxWidth));
       final leftGap = contentRect.left - listRect.left;
       final rightGap = listRect.right - contentRect.right;
       expect((leftGap - rightGap).abs(), lessThan(2.0));


### PR DESCRIPTION
## summary
- refine session timeline rendering to group completed turns and exploratory clusters in a scrollable column layout
- improve message action visibility, attachment sizing, and shell/status bar state updates to better match the design tokens
- align process runner kill signatures with signal-aware shutdown handling and update the status bar widget test

## testing
- flutter test test/widget/alera_status_bar_test.dart
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/leynier/alera/pull/19" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
