### PR TITLE
docs: add platform compatibility analysis

### DIFF
--- a/chats/platform-compat-analysis.md
+++ b/chats/platform-compat-analysis.md
@@ -1,0 +1,52 @@
+# Platform Compatibility Analysis — Alera
+
+**Date:** 2026-03-16
+**Branch:** analyze-platform-compat
+
+## Context
+
+Analysis of project dependencies to determine on which platforms Alera could currently run, and evaluation of migrating `pasteboard` to `super_clipboard` for Web support.
+
+## Pasteboard vs Super Clipboard
+
+### pasteboard (current dependency)
+
+- **Latest version:** 0.5.0
+- **Platforms:** macOS, Windows, Linux, Android, iOS (no Web)
+- **Usage in project:** only `Pasteboard.image` to read image bytes from clipboard
+- **Used in:**
+  - `lib/src/features/session/presentation/widgets/composer.dart:428`
+  - `lib/src/features/session/presentation/widgets/queue_message_edit_dialog.dart:214`
+
+### super_clipboard 0.9.1
+
+- **Platforms:** macOS, Windows, Linux, Android, iOS, **Web**
+- **Heavy dependency chain:** `super_native_extensions` + `irondash_engine_context` + `irondash_message_channel` + `device_info_plus` + `ffi`
+- **Does support Web** via `flutter_web_plugins` and `SuperNativeExtensionsWeb` class
+
+### Migration effort
+
+- **Mechanically simple:** only 2 files, 1 call each
+- **Code change:**
+  ```dart
+  // Before
+  final bytes = await Pasteboard.image;
+
+  // After
+  final clipboard = SystemClipboard.instance;
+  final reader = clipboard.reader;
+  final image = reader.readImage();
+  final bytes = image?.bytes;
+  ```
+- **Downside:** `super_clipboard` pulls in a heavy dependency chain (FFI, device_info_plus, etc.) just to read clipboard images
+
+### Flutter Clipboard alternative
+
+- `Clipboard.getData()` (from `flutter/services.dart`, already imported) supports Web but **does not support reading images** — text only
+- Not viable as a replacement for the current use case
+
+## Conclusion
+
+- Migrating to `super_clipboard` is mechanically trivial (2 lines) but adds significant dependency weight
+- If Web support is a near-term goal, the migration is worth it
+- If Web is not needed soon, `pasteboard` remains the lighter option for the current use case


### PR DESCRIPTION
Adds a platform compatibility analysis document comparing `pasteboard` (current) and `super_clipboard` as clipboard dependencies, evaluating migration effort and Web support implications.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/leynier/alera/pull/24" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
