### PR TITLE
feat(agents): add experimental acp backend alongside codex app-server

### DIFF
--- a/lib/src/features/agents/acp/application/acp_agent_orchestrator.dart
+++ b/lib/src/features/agents/acp/application/acp_agent_orchestrator.dart
@@ -1,0 +1,217 @@
+import 'dart:async';
+
+import 'package:alera/src/features/agents/acp/infrastructure/codex_acp_client.dart';
+import 'package:alera/src/features/agents/application/agent_orchestrator_event.dart';
+import 'package:alera/src/shared/infra/json_rpc/json_rpc_client.dart';
+import 'package:uuid/uuid.dart';
+
+/// ACP-flavored counterpart of `AgentOrchestrator`. Mirrors its public surface
+/// (boot/ensureThread/runTurn/interrupt/approve/decline/close + events stream)
+/// and emits the same `AgentOrchestratorEvent` types so a future unification
+/// can swap implementations without touching consumers.
+///
+/// "Thread" terminology is preserved on the API for parity with the Codex
+/// path; internally a thread maps 1:1 to an ACP `sessionId`.
+class AcpAgentOrchestrator {
+  AcpAgentOrchestrator(this._client);
+
+  final CodexAcpClient _client;
+  final Uuid _uuid = const Uuid();
+
+  final StreamController<AgentOrchestratorEvent> _eventsController =
+      StreamController<AgentOrchestratorEvent>.broadcast();
+
+  StreamSubscription<Map<String, dynamic>>? _notificationSub;
+  StreamSubscription<JsonRpcServerRequest>? _requestSub;
+
+  Stream<AgentOrchestratorEvent> get events => _eventsController.stream;
+
+  Future<void> boot() async {
+    await _client.start();
+
+    _notificationSub = _client.events.listen(_handleNotification);
+    _requestSub = _client.requests.listen(_handleIncomingRequest);
+  }
+
+  /// ACP gives no native session resume in the current `codex-acp` build, so
+  /// `existingThreadId` is honored only as a best-effort `session/load` and
+  /// silently falls back to `session/new` when the agent rejects it.
+  Future<String> ensureThread({String? existingThreadId, String? cwd}) async {
+    final workspace = cwd ?? '.';
+    if (existingThreadId != null && existingThreadId.isNotEmpty) {
+      try {
+        return await _client.loadSession(
+          sessionId: existingThreadId,
+          cwd: workspace,
+        );
+      } catch (_) {
+        // Fall through to new session.
+      }
+    }
+    return _client.newSession(cwd: workspace);
+  }
+
+  /// Sends a user prompt as a `session/prompt` request, returning a synthetic
+  /// turn id immediately. Streaming agent output arrives on [events] as
+  /// `AgentNotificationEvent`s with `method == 'session/update'`. A final
+  /// `turn/completed` (or `turn/failed`) notification is emitted when the
+  /// underlying request settles.
+  Future<String> runTurn({
+    required String threadId,
+    required List<Map<String, dynamic>> input,
+    String? cwd,
+  }) async {
+    final turnId = _uuid.v4();
+
+    unawaited(
+      _client
+          .prompt(sessionId: threadId, content: input)
+          .then(
+            (stopReason) {
+              _eventsController.add(
+                AgentNotificationEvent(
+                  method: 'turn/completed',
+                  payload: <String, dynamic>{
+                    'method': 'turn/completed',
+                    'params': <String, dynamic>{
+                      'sessionId': threadId,
+                      'turnId': turnId,
+                      'stopReason': stopReason,
+                    },
+                  },
+                ),
+              );
+            },
+            onError: (Object error) {
+              _eventsController.add(
+                AgentNotificationEvent(
+                  method: 'turn/failed',
+                  payload: <String, dynamic>{
+                    'method': 'turn/failed',
+                    'params': <String, dynamic>{
+                      'sessionId': threadId,
+                      'turnId': turnId,
+                      'error': error.toString(),
+                    },
+                  },
+                ),
+              );
+            },
+          ),
+    );
+
+    return turnId;
+  }
+
+  Future<void> interrupt({required String threadId, String? turnId}) {
+    return _client.cancel(sessionId: threadId);
+  }
+
+  Future<void> approveRequest(Object requestId, {String optionId = 'allow'}) {
+    return _client.respondPermission(
+      requestId: requestId,
+      optionId: optionId,
+    );
+  }
+
+  Future<void> declineRequest(Object requestId) {
+    return _client.declinePermission(requestId: requestId);
+  }
+
+  Future<void> close() async {
+    await _notificationSub?.cancel();
+    await _requestSub?.cancel();
+    await _eventsController.close();
+    await _client.close();
+  }
+
+  // ACP gaps — preserved for surface parity with AgentOrchestrator. Calls land
+  // here as loud failures rather than silent no-ops.
+  Future<Never> startReview() {
+    throw UnsupportedError(
+      'review/start has no ACP equivalent. Use a "/review" prompt instead.',
+    );
+  }
+
+  Future<Never> compactThread() {
+    throw UnsupportedError(
+      'thread/compact/start has no ACP equivalent. Use a "/compact" prompt instead.',
+    );
+  }
+
+  Future<Never> setThreadName() {
+    throw UnsupportedError('thread/name/set is not part of ACP.');
+  }
+
+  Future<Never> steerTurn() {
+    throw UnsupportedError(
+      'turn/steer has no ACP equivalent. Cancel and send a new prompt.',
+    );
+  }
+
+  void _handleNotification(Map<String, dynamic> payload) {
+    final method = payload['method'];
+    if (method is! String) {
+      return;
+    }
+    _eventsController.add(
+      AgentNotificationEvent(method: method, payload: payload),
+    );
+  }
+
+  void _handleIncomingRequest(JsonRpcServerRequest request) {
+    if (request.method == 'session/request_permission') {
+      _eventsController.add(
+        AgentApprovalRequestEvent(
+          requestId: request.id,
+          method: request.method,
+          description: _describePermission(request.params),
+          threadId: _optionalString(request.params['sessionId']),
+        ),
+      );
+      return;
+    }
+
+    // fs/* and terminal/* are handled inside CodexAcpClient.
+    if (request.method.startsWith('fs/') ||
+        request.method.startsWith('terminal/')) {
+      return;
+    }
+
+    // Anything else surfaces as a generic notification so the UI can log it.
+    _eventsController.add(
+      AgentNotificationEvent(
+        method: request.method,
+        payload: <String, dynamic>{
+          'method': request.method,
+          'params': request.params,
+          'id': request.id,
+        },
+      ),
+    );
+  }
+
+  String _describePermission(Map<String, dynamic> params) {
+    final toolCall = params['toolCall'];
+    if (toolCall is Map) {
+      final cast = toolCall.cast<String, dynamic>();
+      final title = cast['title'] ?? cast['kind'] ?? cast['name'];
+      if (title is String && title.isNotEmpty) {
+        return title;
+      }
+    }
+    final options = params['options'];
+    if (options is List && options.isNotEmpty) {
+      return 'Approve action (${options.length} options)';
+    }
+    return 'Approve action';
+  }
+
+  String? _optionalString(Object? value) {
+    if (value is! String) {
+      return null;
+    }
+    final trimmed = value.trim();
+    return trimmed.isEmpty ? null : trimmed;
+  }
+}

--- a/lib/src/features/agents/acp/infrastructure/codex_acp_client.dart
+++ b/lib/src/features/agents/acp/infrastructure/codex_acp_client.dart
@@ -1,0 +1,293 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:alera/src/shared/infra/json_rpc/json_rpc_client.dart';
+import 'package:alera/src/shared/infra/json_rpc/json_rpc_error_codes.dart';
+import 'package:alera/src/shared/infra/process/process_runner.dart';
+
+/// Thin client over the Agent Client Protocol (ACP) — speaks newline-delimited
+/// JSON-RPC 2.0 over the spawned agent's stdio. Built on top of the shared
+/// [JsonRpcClient] so all framing, request/response correlation, and stderr
+/// forwarding behave the same as the existing Codex app-server transport.
+///
+/// Mirrors the public surface of `CodexAppServerClient` where ACP has a direct
+/// equivalent (initialize, session/new, session/load, session/prompt,
+/// session/cancel) and stubs the rest as `UnsupportedError` so callers fail
+/// loudly when a Codex-only feature is requested through the ACP path.
+class CodexAcpClient {
+  CodexAcpClient({
+    required ProcessRunner processRunner,
+    String executable = 'codex-acp',
+    List<String> arguments = const <String>[],
+    String? workingDirectory,
+    Map<String, String>? environment,
+    int protocolVersion = 1,
+  }) : _rpc = JsonRpcClient(
+         processRunner: processRunner,
+         executable: executable,
+         arguments: arguments,
+         workingDirectory: workingDirectory,
+         environment: environment,
+       ),
+       _protocolVersion = protocolVersion;
+
+  final JsonRpcClient _rpc;
+  final int _protocolVersion;
+
+  StreamSubscription<JsonRpcServerRequest>? _fsSub;
+  Map<String, dynamic>? _agentCapabilities;
+
+  /// All notifications coming from the agent (mostly `session/update` plus the
+  /// synthetic `alera.stderr` log entries forwarded by [JsonRpcClient]).
+  Stream<Map<String, dynamic>> get events => _rpc.notifications;
+
+  /// Server-initiated requests not handled internally (i.e. everything except
+  /// the `fs/*` requests, which the client services directly).
+  Stream<JsonRpcServerRequest> get requests => _rpc.incomingRequests;
+
+  /// Capabilities returned by the agent during [initialize]. `null` until the
+  /// handshake completes.
+  Map<String, dynamic>? get agentCapabilities => _agentCapabilities;
+
+  Future<void> start() async {
+    await _rpc.start();
+    _fsSub = _rpc.incomingRequests.listen(_maybeHandleFs);
+    await initialize();
+  }
+
+  Future<Map<String, dynamic>> initialize() async {
+    final response = await _rpc.request(
+      'initialize',
+      params: <String, dynamic>{
+        'protocolVersion': _protocolVersion,
+        'clientCapabilities': <String, dynamic>{
+          'fs': <String, dynamic>{
+            'readTextFile': true,
+            'writeTextFile': true,
+          },
+          'terminal': false,
+        },
+      },
+    );
+    final result = (response['result'] as Map?)?.cast<String, dynamic>();
+    _agentCapabilities = (result?['agentCapabilities'] as Map?)
+        ?.cast<String, dynamic>();
+    return response;
+  }
+
+  /// Starts a new ACP session and returns its `sessionId`.
+  Future<String> newSession({required String cwd}) async {
+    final response = await _rpc.request(
+      'session/new',
+      params: <String, dynamic>{
+        'cwd': cwd,
+        'mcpServers': const <Map<String, dynamic>>[],
+      },
+    );
+    final result = (response['result'] as Map?)?.cast<String, dynamic>();
+    final sessionId = result?['sessionId'] as String?;
+    if (sessionId == null || sessionId.isEmpty) {
+      throw StateError('session/new returned no sessionId');
+    }
+    return sessionId;
+  }
+
+  /// Resumes a previously created ACP session. Many agents (including current
+  /// `codex-acp` builds) do not implement this; callers should fall back to
+  /// [newSession] on failure.
+  Future<String> loadSession({
+    required String sessionId,
+    required String cwd,
+  }) async {
+    final response = await _rpc.request(
+      'session/load',
+      params: <String, dynamic>{
+        'sessionId': sessionId,
+        'cwd': cwd,
+        'mcpServers': const <Map<String, dynamic>>[],
+      },
+    );
+    final result = (response['result'] as Map?)?.cast<String, dynamic>();
+    return (result?['sessionId'] as String?) ?? sessionId;
+  }
+
+  /// Sends a user prompt. Resolves with the agent's `stopReason` once the turn
+  /// terminates. Streaming output arrives as `session/update` notifications on
+  /// [events] while the future is pending.
+  Future<String> prompt({
+    required String sessionId,
+    required List<Map<String, dynamic>> content,
+  }) async {
+    final response = await _rpc.request(
+      'session/prompt',
+      params: <String, dynamic>{
+        'sessionId': sessionId,
+        'prompt': content,
+      },
+    );
+    final result = (response['result'] as Map?)?.cast<String, dynamic>();
+    return (result?['stopReason'] as String?) ?? 'end_turn';
+  }
+
+  /// ACP `session/cancel` is a notification (no response expected).
+  Future<void> cancel({required String sessionId}) {
+    return _rpc.notify(
+      'session/cancel',
+      params: <String, dynamic>{'sessionId': sessionId},
+    );
+  }
+
+  /// Responds to a `session/request_permission` request. ACP expects an
+  /// `outcome` discriminated union: `{outcome: "selected", optionId: ...}` or
+  /// `{outcome: "cancelled"}`.
+  Future<void> respondPermission({
+    required Object requestId,
+    required String optionId,
+  }) {
+    return _rpc.respondSuccess(
+      requestId,
+      result: <String, dynamic>{
+        'outcome': <String, dynamic>{
+          'outcome': 'selected',
+          'optionId': optionId,
+        },
+      },
+    );
+  }
+
+  Future<void> declinePermission({required Object requestId}) {
+    return _rpc.respondSuccess(
+      requestId,
+      result: <String, dynamic>{
+        'outcome': <String, dynamic>{'outcome': 'cancelled'},
+      },
+    );
+  }
+
+  Future<void> respondError({
+    required Object requestId,
+    required int code,
+    required String message,
+  }) {
+    return _rpc.respondError(id: requestId, code: code, message: message);
+  }
+
+  Future<void> close() async {
+    await _fsSub?.cancel();
+    await _rpc.close();
+  }
+
+  /// Handles the `fs/*` server-initiated requests directly via `dart:io` so
+  /// the agent can read/write files when its capability negotiation allows it.
+  /// Returns silently for any other method (orchestrator handles those).
+  void _maybeHandleFs(JsonRpcServerRequest request) {
+    switch (request.method) {
+      case 'fs/read_text_file':
+        unawaited(_handleFsRead(request));
+        return;
+      case 'fs/write_text_file':
+        unawaited(_handleFsWrite(request));
+        return;
+      case 'terminal/create':
+      case 'terminal/output':
+      case 'terminal/wait_for_exit':
+      case 'terminal/kill':
+      case 'terminal/release':
+        unawaited(
+          respondError(
+            requestId: request.id,
+            code: jsonRpcMethodNotFound,
+            message: 'Terminal capability not enabled in this client',
+          ),
+        );
+        return;
+    }
+  }
+
+  Future<void> _handleFsRead(JsonRpcServerRequest request) async {
+    try {
+      final path = request.params['path'];
+      if (path is! String || path.isEmpty) {
+        await respondError(
+          requestId: request.id,
+          code: jsonRpcInvalidParams,
+          message: 'fs/read_text_file requires a non-empty "path"',
+        );
+        return;
+      }
+      final content = await File(path).readAsString();
+      final sliced = _sliceByLines(
+        content,
+        request.params['line'],
+        request.params['limit'],
+      );
+      await _rpc.respondSuccess(
+        request.id,
+        result: <String, dynamic>{'content': sliced},
+      );
+    } catch (error) {
+      await respondError(
+        requestId: request.id,
+        code: jsonRpcInternalError,
+        message: 'fs/read_text_file failed: $error',
+      );
+    }
+  }
+
+  Future<void> _handleFsWrite(JsonRpcServerRequest request) async {
+    try {
+      final path = request.params['path'];
+      final content = request.params['content'];
+      if (path is! String || path.isEmpty) {
+        await respondError(
+          requestId: request.id,
+          code: jsonRpcInvalidParams,
+          message: 'fs/write_text_file requires a non-empty "path"',
+        );
+        return;
+      }
+      if (content is! String) {
+        await respondError(
+          requestId: request.id,
+          code: jsonRpcInvalidParams,
+          message: 'fs/write_text_file requires a string "content"',
+        );
+        return;
+      }
+      final file = File(path);
+      await file.parent.create(recursive: true);
+      await file.writeAsString(content);
+      await _rpc.respondSuccess(request.id);
+    } catch (error) {
+      await respondError(
+        requestId: request.id,
+        code: jsonRpcInternalError,
+        message: 'fs/write_text_file failed: $error',
+      );
+    }
+  }
+
+  String _sliceByLines(String content, Object? lineParam, Object? limitParam) {
+    if (lineParam is! int && limitParam is! int) {
+      return content;
+    }
+    final lines = content.split('\n');
+    final lineCount = lines.length;
+    var start = 0;
+    if (lineParam is int) {
+      if (lineParam < 0) {
+        start = 0;
+      } else if (lineParam > lineCount) {
+        start = lineCount;
+      } else {
+        start = lineParam;
+      }
+    }
+    var end = lineCount;
+    if (limitParam is int && limitParam >= 0) {
+      final upper = start + limitParam;
+      end = upper > lineCount ? lineCount : upper;
+    }
+    return lines.sublist(start, end).join('\n');
+  }
+}

--- a/lib/src/features/agents/acp/presentation/acp_playground_page.dart
+++ b/lib/src/features/agents/acp/presentation/acp_playground_page.dart
@@ -97,7 +97,10 @@ class _AcpPlaygroundPageState extends ConsumerState<AcpPlaygroundPage> {
       _logLocal('Failed to start session: $error');
     } finally {
       if (mounted) {
-        setState(() => _starting = false);
+        setState(() {
+          _starting = false;
+          _booting = false;
+        });
       }
     }
   }
@@ -224,9 +227,7 @@ class _AcpPlaygroundPageState extends ConsumerState<AcpPlaygroundPage> {
   }
 
   void _logEvent(String method, Map<String, dynamic> payload) {
-    setState(
-      () => _entries.add(_AcpEntry(method: method, payload: payload)),
-    );
+    setState(() => _entries.add(_AcpEntry(method: method, payload: payload)));
     _scrollToEnd();
   }
 
@@ -349,7 +350,7 @@ class _AcpPlaygroundPageState extends ConsumerState<AcpPlaygroundPage> {
               for (final option in approval.options)
                 FilledButton(
                   onPressed: () => _approve(approval, option),
-                  child: Text(option),
+                  child: Text(_approvalOptionLabel(option)),
                 ),
               FilledButton(
                 onPressed: () => _decline(approval),
@@ -386,7 +387,7 @@ class _AcpPlaygroundPageState extends ConsumerState<AcpPlaygroundPage> {
           : ListView.separated(
               controller: _scrollController,
               itemCount: _entries.length,
-              separatorBuilder: (_, __) =>
+              separatorBuilder: (context, index) =>
                   const SizedBox(height: AleraTokens.space4),
               itemBuilder: (context, index) {
                 final entry = _entries[index];
@@ -479,6 +480,14 @@ class _AcpPlaygroundPageState extends ConsumerState<AcpPlaygroundPage> {
       return id;
     }
     return '${id.substring(0, 8)}…';
+  }
+
+  String _approvalOptionLabel(String optionId) {
+    final words = optionId.replaceAll('_', ' ').trim();
+    if (words.isEmpty) {
+      return optionId;
+    }
+    return words[0].toUpperCase() + words.substring(1);
   }
 }
 

--- a/lib/src/features/agents/acp/presentation/acp_playground_page.dart
+++ b/lib/src/features/agents/acp/presentation/acp_playground_page.dart
@@ -1,0 +1,502 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:alera/src/app/providers.dart';
+import 'package:alera/src/app/theme/alera_tokens.dart';
+import 'package:alera/src/features/agents/acp/application/acp_agent_orchestrator.dart';
+import 'package:alera/src/features/agents/acp/infrastructure/codex_acp_client.dart';
+import 'package:alera/src/features/agents/application/agent_orchestrator_event.dart';
+import 'package:file_selector/file_selector.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Experimental playground for the ACP backend. Independent from the regular
+/// Codex session flow — owns its own `CodexAcpClient` + `AcpAgentOrchestrator`
+/// and tears them down on dispose. Lets the user start a session against
+/// `codex-acp`, send prompts, watch streamed events, and approve/reject
+/// permission requests.
+class AcpPlaygroundPage extends ConsumerStatefulWidget {
+  const AcpPlaygroundPage({super.key});
+
+  @override
+  ConsumerState<AcpPlaygroundPage> createState() => _AcpPlaygroundPageState();
+}
+
+class _AcpPlaygroundPageState extends ConsumerState<AcpPlaygroundPage> {
+  final TextEditingController _promptController = TextEditingController();
+  final ScrollController _scrollController = ScrollController();
+  final List<_AcpEntry> _entries = <_AcpEntry>[];
+  final List<_PendingApproval> _approvals = <_PendingApproval>[];
+
+  StreamSubscription<AgentOrchestratorEvent>? _sub;
+  AcpAgentOrchestrator? _orchestrator;
+  String? _workspacePath;
+  String? _sessionId;
+  bool _booting = false;
+  bool _starting = false;
+  bool _sending = false;
+
+  @override
+  void dispose() {
+    unawaited(_sub?.cancel());
+    unawaited(_orchestrator?.close());
+    _promptController.dispose();
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _pickWorkspace() async {
+    try {
+      final selected = await getDirectoryPath(
+        confirmButtonText: 'Select workspace',
+      );
+      if (!mounted || selected == null || selected.trim().isEmpty) {
+        return;
+      }
+      setState(() => _workspacePath = selected.trim());
+    } catch (error) {
+      if (!mounted) {
+        return;
+      }
+      _logLocal('Folder picker unavailable: $error');
+    }
+  }
+
+  Future<void> _startSession() async {
+    final cwd = _workspacePath;
+    if (cwd == null || cwd.isEmpty) {
+      _logLocal('Pick a workspace first.');
+      return;
+    }
+    setState(() => _starting = true);
+    try {
+      var orchestrator = _orchestrator;
+      if (orchestrator == null) {
+        setState(() => _booting = true);
+        final processRunner = ref.read(processRunnerProvider);
+        final client = CodexAcpClient(processRunner: processRunner);
+        orchestrator = AcpAgentOrchestrator(client);
+        await orchestrator.boot();
+        if (!mounted) {
+          await orchestrator.close();
+          return;
+        }
+        _sub = orchestrator.events.listen(_onEvent);
+        setState(() {
+          _orchestrator = orchestrator;
+          _booting = false;
+        });
+      }
+      final sessionId = await orchestrator.ensureThread(cwd: cwd);
+      if (!mounted) {
+        return;
+      }
+      setState(() => _sessionId = sessionId);
+      _logLocal('Session ready: $sessionId');
+    } catch (error) {
+      _logLocal('Failed to start session: $error');
+    } finally {
+      if (mounted) {
+        setState(() => _starting = false);
+      }
+    }
+  }
+
+  Future<void> _sendPrompt() async {
+    final orchestrator = _orchestrator;
+    final sessionId = _sessionId;
+    final text = _promptController.text.trim();
+    if (orchestrator == null || sessionId == null || text.isEmpty) {
+      return;
+    }
+    setState(() => _sending = true);
+    try {
+      _logLocal('You: $text');
+      await orchestrator.runTurn(
+        threadId: sessionId,
+        input: <Map<String, dynamic>>[
+          <String, dynamic>{'type': 'text', 'text': text},
+        ],
+        cwd: _workspacePath,
+      );
+      _promptController.clear();
+    } catch (error) {
+      _logLocal('Prompt failed: $error');
+    } finally {
+      if (mounted) {
+        setState(() => _sending = false);
+      }
+    }
+  }
+
+  Future<void> _cancel() async {
+    final orchestrator = _orchestrator;
+    final sessionId = _sessionId;
+    if (orchestrator == null || sessionId == null) {
+      return;
+    }
+    try {
+      await orchestrator.interrupt(threadId: sessionId);
+      _logLocal('Cancel requested.');
+    } catch (error) {
+      _logLocal('Cancel failed: $error');
+    }
+  }
+
+  Future<void> _approve(_PendingApproval approval, String optionId) async {
+    final orchestrator = _orchestrator;
+    if (orchestrator == null) {
+      return;
+    }
+    try {
+      await orchestrator.approveRequest(approval.requestId, optionId: optionId);
+      _logLocal('Approved $optionId for: ${approval.description}');
+    } catch (error) {
+      _logLocal('Approve failed: $error');
+    } finally {
+      if (mounted) {
+        setState(() => _approvals.remove(approval));
+      }
+    }
+  }
+
+  Future<void> _decline(_PendingApproval approval) async {
+    final orchestrator = _orchestrator;
+    if (orchestrator == null) {
+      return;
+    }
+    try {
+      await orchestrator.declineRequest(approval.requestId);
+      _logLocal('Declined: ${approval.description}');
+    } catch (error) {
+      _logLocal('Decline failed: $error');
+    } finally {
+      if (mounted) {
+        setState(() => _approvals.remove(approval));
+      }
+    }
+  }
+
+  void _onEvent(AgentOrchestratorEvent event) {
+    if (!mounted) {
+      return;
+    }
+    switch (event) {
+      case AgentNotificationEvent():
+        _logEvent(event.method, event.payload);
+      case AgentApprovalRequestEvent():
+        // ACP options come embedded in the request params, which we lose by
+        // the time we hit AgentApprovalRequestEvent (it carries only the
+        // description). MVP shows two canonical choices; real wiring can pass
+        // them through when we extract a richer event type.
+        setState(() {
+          _approvals.add(
+            _PendingApproval(
+              requestId: event.requestId,
+              description: event.description,
+              options: const <String>['allow', 'allow_always'],
+            ),
+          );
+        });
+        _logEvent(event.method, <String, dynamic>{
+          'description': event.description,
+          'requestId': event.requestId.toString(),
+        });
+      case AgentToolCallRequestEvent():
+        _logEvent('tool_call', <String, dynamic>{'tool': event.tool});
+      case AgentUserInputRequestEvent():
+        _logEvent('user_input_request', <String, dynamic>{
+          'questions': event.questions,
+        });
+    }
+  }
+
+  void _logLocal(String message) {
+    setState(
+      () => _entries.add(
+        _AcpEntry(
+          method: 'local',
+          payload: <String, dynamic>{'message': message},
+        ),
+      ),
+    );
+    _scrollToEnd();
+  }
+
+  void _logEvent(String method, Map<String, dynamic> payload) {
+    setState(
+      () => _entries.add(_AcpEntry(method: method, payload: payload)),
+    );
+    _scrollToEnd();
+  }
+
+  void _scrollToEnd() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (_scrollController.hasClients) {
+        _scrollController.jumpTo(_scrollController.position.maxScrollExtent);
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Scaffold(
+      appBar: AppBar(title: const Text('ACP playground (experimental)')),
+      body: Padding(
+        padding: const EdgeInsets.all(AleraTokens.space16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: <Widget>[
+            _buildHeader(theme),
+            const SizedBox(height: AleraTokens.space12),
+            if (_approvals.isNotEmpty) ...<Widget>[
+              ..._approvals.map(_buildApprovalCard),
+              const SizedBox(height: AleraTokens.space12),
+            ],
+            Expanded(child: _buildTimeline(theme)),
+            const SizedBox(height: AleraTokens.space12),
+            _buildComposer(),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildHeader(ThemeData theme) {
+    final workspace = _workspacePath ?? 'No workspace selected';
+    final sessionLabel = _sessionId == null
+        ? 'No session'
+        : 'Session ${_shorten(_sessionId!)}';
+    return Container(
+      padding: const EdgeInsets.all(AleraTokens.space12),
+      decoration: BoxDecoration(
+        color: AleraTokens.surface,
+        borderRadius: BorderRadius.circular(AleraTokens.radiusLg),
+        border: Border.all(color: AleraTokens.border),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Row(
+            children: <Widget>[
+              Expanded(
+                child: Text(
+                  workspace,
+                  style: theme.textTheme.bodyMedium,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+              const SizedBox(width: AleraTokens.space8),
+              TextButton(
+                onPressed: _starting ? null : _pickWorkspace,
+                child: const Text('Choose folder'),
+              ),
+            ],
+          ),
+          const SizedBox(height: AleraTokens.space8),
+          Row(
+            children: <Widget>[
+              Expanded(
+                child: Text(
+                  sessionLabel,
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: AleraTokens.foregroundMuted,
+                  ),
+                ),
+              ),
+              const SizedBox(width: AleraTokens.space8),
+              FilledButton.icon(
+                onPressed: (_starting || _booting) ? null : _startSession,
+                icon: const Icon(Icons.play_arrow, size: 16),
+                label: Text(
+                  _sessionId == null ? 'Start session' : 'New session',
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildApprovalCard(_PendingApproval approval) {
+    return Container(
+      margin: const EdgeInsets.only(bottom: AleraTokens.space8),
+      padding: const EdgeInsets.all(AleraTokens.space12),
+      decoration: BoxDecoration(
+        color: AleraTokens.surfaceVariant,
+        borderRadius: BorderRadius.circular(AleraTokens.radiusLg),
+        border: Border.all(color: AleraTokens.warning),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Text(
+            'Permission requested',
+            style: TextStyle(
+              color: AleraTokens.warning,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+          const SizedBox(height: AleraTokens.space4),
+          Text(approval.description),
+          const SizedBox(height: AleraTokens.space8),
+          Wrap(
+            spacing: AleraTokens.space8,
+            children: <Widget>[
+              for (final option in approval.options)
+                FilledButton(
+                  onPressed: () => _approve(approval, option),
+                  child: Text(option),
+                ),
+              FilledButton(
+                onPressed: () => _decline(approval),
+                style: FilledButton.styleFrom(
+                  backgroundColor: AleraTokens.error,
+                  foregroundColor: AleraTokens.onError,
+                ),
+                child: const Text('Deny'),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildTimeline(ThemeData theme) {
+    return Container(
+      decoration: BoxDecoration(
+        color: AleraTokens.bg,
+        borderRadius: BorderRadius.circular(AleraTokens.radiusLg),
+        border: Border.all(color: AleraTokens.borderSubtle),
+      ),
+      padding: const EdgeInsets.all(AleraTokens.space8),
+      child: _entries.isEmpty
+          ? Center(
+              child: Text(
+                'No events yet. Start a session and send a prompt.',
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: AleraTokens.foregroundFaint,
+                ),
+              ),
+            )
+          : ListView.separated(
+              controller: _scrollController,
+              itemCount: _entries.length,
+              separatorBuilder: (_, __) =>
+                  const SizedBox(height: AleraTokens.space4),
+              itemBuilder: (context, index) {
+                final entry = _entries[index];
+                return _buildEntry(entry);
+              },
+            ),
+    );
+  }
+
+  Widget _buildEntry(_AcpEntry entry) {
+    final isLocal = entry.method == 'local';
+    final color = isLocal
+        ? AleraTokens.foregroundMuted
+        : AleraTokens.foreground;
+    final body = isLocal
+        ? entry.payload['message']?.toString() ?? ''
+        : _formatPayload(entry.payload);
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: AleraTokens.space2),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Text(
+            entry.method,
+            style: AleraTokens.monoStyle.copyWith(
+              color: AleraTokens.foregroundFaint,
+            ),
+          ),
+          Text(body, style: AleraTokens.monoStyle.copyWith(color: color)),
+        ],
+      ),
+    );
+  }
+
+  String _formatPayload(Map<String, dynamic> payload) {
+    try {
+      return const JsonEncoder.withIndent('  ').convert(payload);
+    } catch (_) {
+      return payload.toString();
+    }
+  }
+
+  Widget _buildComposer() {
+    final canSend = _sessionId != null && !_sending;
+    return Container(
+      padding: const EdgeInsets.all(AleraTokens.space8),
+      decoration: BoxDecoration(
+        color: AleraTokens.surface,
+        borderRadius: BorderRadius.circular(AleraTokens.radiusLg),
+        border: Border.all(color: AleraTokens.border),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: <Widget>[
+          TextField(
+            controller: _promptController,
+            minLines: 1,
+            maxLines: 4,
+            enabled: canSend,
+            decoration: const InputDecoration(
+              hintText: 'Type a prompt for the agent',
+              border: InputBorder.none,
+            ),
+            onSubmitted: (_) => canSend ? _sendPrompt() : null,
+          ),
+          const SizedBox(height: AleraTokens.space8),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.end,
+            children: <Widget>[
+              TextButton.icon(
+                onPressed: _sessionId == null ? null : _cancel,
+                icon: const Icon(Icons.stop, size: 16),
+                label: const Text('Cancel turn'),
+              ),
+              const SizedBox(width: AleraTokens.space8),
+              FilledButton.icon(
+                onPressed: canSend ? _sendPrompt : null,
+                icon: const Icon(Icons.send, size: 16),
+                label: const Text('Send'),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  String _shorten(String id) {
+    if (id.length <= 12) {
+      return id;
+    }
+    return '${id.substring(0, 8)}…';
+  }
+}
+
+class _AcpEntry {
+  _AcpEntry({required this.method, required this.payload});
+
+  final String method;
+  final Map<String, dynamic> payload;
+}
+
+class _PendingApproval {
+  _PendingApproval({
+    required this.requestId,
+    required this.description,
+    required this.options,
+  });
+
+  final Object requestId;
+  final String description;
+  final List<String> options;
+}

--- a/lib/src/features/shell/presentation/alera_shell_page.dart
+++ b/lib/src/features/shell/presentation/alera_shell_page.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:alera/src/app/providers.dart';
 import 'package:alera/src/app/theme/alera_tokens.dart';
+import 'package:alera/src/features/agents/acp/presentation/acp_playground_page.dart';
 import 'package:alera/src/features/projects/presentation/add_project_dialog.dart';
 import 'package:alera/src/features/projects/presentation/project_sidebar.dart';
 import 'package:alera/src/features/session/application/session_controller.dart';
@@ -160,6 +161,7 @@ class _AleraShellPageBodyState extends ConsumerState<_AleraShellPageBody> {
                   workspaceName: _workspaceName(workspacePath),
                   sessionTitle: activeSessionTitle,
                   isBusy: isBusy,
+                  onOpenAcpPlayground: () => _openAcpPlayground(context),
                 ),
                 Expanded(
                   child: Consumer(
@@ -337,6 +339,12 @@ class _AleraShellPageBodyState extends ConsumerState<_AleraShellPageBody> {
       }
       _showError(error.toString());
     }
+  }
+
+  void _openAcpPlayground(BuildContext context) {
+    Navigator.of(context).push(
+      MaterialPageRoute<void>(builder: (_) => const AcpPlaygroundPage()),
+    );
   }
 
   String? _workspaceName(String? workspacePath) {

--- a/lib/src/features/shell/presentation/alera_top_bar.dart
+++ b/lib/src/features/shell/presentation/alera_top_bar.dart
@@ -7,11 +7,13 @@ class AleraTopBar extends StatelessWidget {
     required this.workspaceName,
     required this.sessionTitle,
     required this.isBusy,
+    this.onOpenAcpPlayground,
   });
 
   final String? workspaceName;
   final String? sessionTitle;
   final bool isBusy;
+  final VoidCallback? onOpenAcpPlayground;
 
   @override
   Widget build(BuildContext context) {
@@ -42,6 +44,20 @@ class AleraTopBar extends StatelessWidget {
               ),
             ),
           ),
+          if (onOpenAcpPlayground != null) ...<Widget>[
+            const SizedBox(width: AleraTokens.space8),
+            IconButton(
+              onPressed: onOpenAcpPlayground,
+              tooltip: 'ACP playground (experimental)',
+              iconSize: 16,
+              padding: EdgeInsets.zero,
+              constraints: const BoxConstraints(minWidth: 28, minHeight: 28),
+              icon: const Icon(
+                Icons.science_outlined,
+                color: AleraTokens.foregroundMuted,
+              ),
+            ),
+          ],
           const SizedBox(width: AleraTokens.space8),
         ],
       ),


### PR DESCRIPTION
introduce a parallel agent backend that speaks the agent client protocol (acp)
over stdio via the published codex-acp wrapper. lives next to the existing
codex app-server stack without touching its wiring:

- codex_acp_client wraps the shared JsonRpcClient and handles initialize,
  session/new, session/load, session/prompt, session/cancel, permission
  responses, and fs/read|write_text_file server requests
- acp_agent_orchestrator mirrors the public surface of agent_orchestrator and
  emits the same AgentOrchestratorEvent types so future unification is a swap
- acp_playground_page is an experimental shell-level entry (science icon in
  the top bar) that owns its own client/orchestrator lifecycle and lets you
  start a session, send prompts, watch streamed events, and approve/reject
  permission requests

scope: the existing codex flow is untouched. nothing in session_service /
session_controller / providers consumes the new stack. running the playground
requires codex-acp on PATH (npm i -g @zed-industries/codex-acp).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/leynier/alera/pull/28" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Experimental ACP playground page for testing and interacting with agents
  * ACP playground button added to the top bar for easy access
  * Start/load sessions, send text prompts, and cancel in-progress turns from the UI
  * Live event timeline showing agent notifications, tool-call requests, and user requests
  * Approval cards for permission requests with quick allow/allow_always and decline actions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/leynier/alera/pull/28?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->