### PR TITLE
fix: keep agent wrapper dir first in path after shell rc runs

### DIFF
--- a/lib/src/features/workbench/infra/terminal_shell_startup_templates.dart
+++ b/lib/src/features/workbench/infra/terminal_shell_startup_templates.dart
@@ -36,7 +36,7 @@ const String _fishRestoreManagedAgentEnvironment =
     'if set -q ALERA_OPENCODE_CONFIG_DIR; set -gx OPENCODE_CONFIG_DIR \$ALERA_OPENCODE_CONFIG_DIR; end\n'
     'if set -q ALERA_PI_CODING_AGENT_DIR; set -gx PI_CODING_AGENT_DIR \$ALERA_PI_CODING_AGENT_DIR; end\n'
     'if set -q ALERA_COPILOT_HOME; set -gx COPILOT_HOME \$ALERA_COPILOT_HOME; end\n'
-    'if set -q ALERA_AGENT_WRAPPER_PATH; if not contains -- \$ALERA_AGENT_WRAPPER_PATH \$PATH; set -gx PATH \$ALERA_AGENT_WRAPPER_PATH \$PATH; end; end\n';
+    'if set -q ALERA_AGENT_WRAPPER_PATH; set -gx PATH \$ALERA_AGENT_WRAPPER_PATH (string match --invert -- \$ALERA_AGENT_WRAPPER_PATH \$PATH); end\n';
 
 const String _cmdRestoreManagedAgentEnvironment =
     'if defined ALERA_CODEX_HOME set "CODEX_HOME=%ALERA_CODEX_HOME%"\n'
@@ -52,7 +52,7 @@ const String _shRestoreManagedAgentEnvironment =
     'if [ -n "\${ALERA_OPENCODE_CONFIG_DIR:-}" ]; then export OPENCODE_CONFIG_DIR="\$ALERA_OPENCODE_CONFIG_DIR"; fi\n'
     'if [ -n "\${ALERA_PI_CODING_AGENT_DIR:-}" ]; then export PI_CODING_AGENT_DIR="\$ALERA_PI_CODING_AGENT_DIR"; fi\n'
     'if [ -n "\${ALERA_COPILOT_HOME:-}" ]; then export COPILOT_HOME="\$ALERA_COPILOT_HOME"; fi\n'
-    'if [ -n "\${ALERA_AGENT_WRAPPER_PATH:-}" ]; then case ":\${PATH:-}:" in *":\${ALERA_AGENT_WRAPPER_PATH}:"*) ;; *) export PATH="\${ALERA_AGENT_WRAPPER_PATH}\${PATH:+:\${PATH}}" ;; esac; fi\n';
+    'if [ -n "\${ALERA_AGENT_WRAPPER_PATH:-}" ]; then __alera_new_path=""; __alera_old_ifs="\${IFS-}"; IFS=":"; for __alera_entry in \${PATH:-}; do [ "\${__alera_entry}" = "\${ALERA_AGENT_WRAPPER_PATH}" ] && continue; if [ -z "\${__alera_new_path}" ]; then __alera_new_path="\${__alera_entry}"; else __alera_new_path="\${__alera_new_path}:\${__alera_entry}"; fi; done; IFS="\${__alera_old_ifs}"; export PATH="\${ALERA_AGENT_WRAPPER_PATH}\${__alera_new_path:+:\${__alera_new_path}}"; unset __alera_new_path __alera_old_ifs __alera_entry; fi\n';
 
 const String _nushellRestoreManagedAgentEnvironment =
     r'if ("ALERA_CODEX_HOME" in $env) { $env.CODEX_HOME = $env.ALERA_CODEX_HOME }'
@@ -65,7 +65,7 @@ const String _nushellRestoreManagedAgentEnvironment =
     '\n'
     r'if ("ALERA_COPILOT_HOME" in $env) { $env.COPILOT_HOME = $env.ALERA_COPILOT_HOME }'
     '\n'
-    r'if ("ALERA_AGENT_WRAPPER_PATH" in $env) { let __alera_path_entries = if ("PATH" in $env) { $env.PATH } else { [] }; if not ($env.ALERA_AGENT_WRAPPER_PATH in $__alera_path_entries) { $env.PATH = ($__alera_path_entries | prepend $env.ALERA_AGENT_WRAPPER_PATH) } }'
+    r'if ("ALERA_AGENT_WRAPPER_PATH" in $env) { let __alera_path_entries = if ("PATH" in $env) { $env.PATH } else { [] }; $env.PATH = ($__alera_path_entries | where $it != $env.ALERA_AGENT_WRAPPER_PATH | prepend $env.ALERA_AGENT_WRAPPER_PATH) }'
     '\n';
 
 const String _nushellConfigFile = r'''
@@ -91,9 +91,7 @@ if ("ALERA_COPILOT_HOME" in $env) {
 }
 if ("ALERA_AGENT_WRAPPER_PATH" in $env) {
   let __alera_path_entries = if ("PATH" in $env) { $env.PATH } else { [] }
-  if not ($env.ALERA_AGENT_WRAPPER_PATH in $__alera_path_entries) {
-    $env.PATH = ($__alera_path_entries | prepend $env.ALERA_AGENT_WRAPPER_PATH)
-  }
+  $env.PATH = ($__alera_path_entries | where $it != $env.ALERA_AGENT_WRAPPER_PATH | prepend $env.ALERA_AGENT_WRAPPER_PATH)
 }
 let __alera_restore_managed_agent_environment = { ||
   if ("ALERA_CODEX_HOME" in $env) {
@@ -113,9 +111,7 @@ let __alera_restore_managed_agent_environment = { ||
   }
   if ("ALERA_AGENT_WRAPPER_PATH" in $env) {
     let __alera_path_entries = if ("PATH" in $env) { $env.PATH } else { [] }
-    if not ($env.ALERA_AGENT_WRAPPER_PATH in $__alera_path_entries) {
-      $env.PATH = ($__alera_path_entries | prepend $env.ALERA_AGENT_WRAPPER_PATH)
-    }
+    $env.PATH = ($__alera_path_entries | where $it != $env.ALERA_AGENT_WRAPPER_PATH | prepend $env.ALERA_AGENT_WRAPPER_PATH)
   }
 }
 if not ("config" in $env) {
@@ -144,9 +140,7 @@ if ($env:ALERA_COPILOT_HOME) {
 }
 if ($env:ALERA_AGENT_WRAPPER_PATH) {
   $separator = [IO.Path]::PathSeparator
-  $entries = @($env:PATH -split [Regex]::Escape([string]$separator))
-  if ($entries -notcontains $env:ALERA_AGENT_WRAPPER_PATH) {
-    $env:PATH = $env:ALERA_AGENT_WRAPPER_PATH + $separator + $env:PATH
-  }
+  $entries = @($env:PATH -split [Regex]::Escape([string]$separator)) | Where-Object { $_ -ne $env:ALERA_AGENT_WRAPPER_PATH }
+  $env:PATH = (@($env:ALERA_AGENT_WRAPPER_PATH) + $entries) -join $separator
 }
 ''';

--- a/lib/src/features/workbench/infra/terminal_shell_startup_templates.dart
+++ b/lib/src/features/workbench/infra/terminal_shell_startup_templates.dart
@@ -23,10 +23,26 @@ if [ -n "\${ALERA_COPILOT_HOME:-}" ]; then
   export COPILOT_HOME="\${ALERA_COPILOT_HOME}"
 fi
 if [ -n "\${ALERA_AGENT_WRAPPER_PATH:-}" ]; then
-  case ":\${PATH:-}:" in
-    *":\${ALERA_AGENT_WRAPPER_PATH}:"*) ;;
-    *) export PATH="\${ALERA_AGENT_WRAPPER_PATH}\${PATH:+:\${PATH}}" ;;
-  esac
+  __alera_new_path=""
+  __alera_appended=0
+  __alera_old_ifs="\${IFS-}"
+  IFS=":"
+  for __alera_entry in \${PATH:-}; do
+    [ "\${__alera_entry}" = "\${ALERA_AGENT_WRAPPER_PATH}" ] && continue
+    if [ "\${__alera_appended}" -eq 0 ]; then
+      __alera_new_path="\${__alera_entry}"
+      __alera_appended=1
+    else
+      __alera_new_path="\${__alera_new_path}:\${__alera_entry}"
+    fi
+  done
+  IFS="\${__alera_old_ifs}"
+  if [ "\${__alera_appended}" -eq 1 ]; then
+    export PATH="\${ALERA_AGENT_WRAPPER_PATH}:\${__alera_new_path}"
+  else
+    export PATH="\${ALERA_AGENT_WRAPPER_PATH}"
+  fi
+  unset __alera_new_path __alera_appended __alera_old_ifs __alera_entry
 fi
 ''';
 
@@ -52,7 +68,7 @@ const String _shRestoreManagedAgentEnvironment =
     'if [ -n "\${ALERA_OPENCODE_CONFIG_DIR:-}" ]; then export OPENCODE_CONFIG_DIR="\$ALERA_OPENCODE_CONFIG_DIR"; fi\n'
     'if [ -n "\${ALERA_PI_CODING_AGENT_DIR:-}" ]; then export PI_CODING_AGENT_DIR="\$ALERA_PI_CODING_AGENT_DIR"; fi\n'
     'if [ -n "\${ALERA_COPILOT_HOME:-}" ]; then export COPILOT_HOME="\$ALERA_COPILOT_HOME"; fi\n'
-    'if [ -n "\${ALERA_AGENT_WRAPPER_PATH:-}" ]; then __alera_new_path=""; __alera_old_ifs="\${IFS-}"; IFS=":"; for __alera_entry in \${PATH:-}; do [ "\${__alera_entry}" = "\${ALERA_AGENT_WRAPPER_PATH}" ] && continue; if [ -z "\${__alera_new_path}" ]; then __alera_new_path="\${__alera_entry}"; else __alera_new_path="\${__alera_new_path}:\${__alera_entry}"; fi; done; IFS="\${__alera_old_ifs}"; export PATH="\${ALERA_AGENT_WRAPPER_PATH}\${__alera_new_path:+:\${__alera_new_path}}"; unset __alera_new_path __alera_old_ifs __alera_entry; fi\n';
+    'if [ -n "\${ALERA_AGENT_WRAPPER_PATH:-}" ]; then __alera_new_path=""; __alera_appended=0; __alera_old_ifs="\${IFS-}"; IFS=":"; for __alera_entry in \${PATH:-}; do [ "\${__alera_entry}" = "\${ALERA_AGENT_WRAPPER_PATH}" ] && continue; if [ "\${__alera_appended}" -eq 0 ]; then __alera_new_path="\${__alera_entry}"; __alera_appended=1; else __alera_new_path="\${__alera_new_path}:\${__alera_entry}"; fi; done; IFS="\${__alera_old_ifs}"; if [ "\${__alera_appended}" -eq 1 ]; then export PATH="\${ALERA_AGENT_WRAPPER_PATH}:\${__alera_new_path}"; else export PATH="\${ALERA_AGENT_WRAPPER_PATH}"; fi; unset __alera_new_path __alera_appended __alera_old_ifs __alera_entry; fi\n';
 
 const String _nushellRestoreManagedAgentEnvironment =
     r'if ("ALERA_CODEX_HOME" in $env) { $env.CODEX_HOME = $env.ALERA_CODEX_HOME }'

--- a/lib/src/features/workbench/infra/terminal_shell_zsh_startup.dart
+++ b/lib/src/features/workbench/infra/terminal_shell_zsh_startup.dart
@@ -39,10 +39,10 @@ if [[ -n "\${ALERA_COPILOT_HOME:-}" ]]; then
   export COPILOT_HOME="\${ALERA_COPILOT_HOME}"
 fi
 if [[ -n "\${ALERA_AGENT_WRAPPER_PATH:-}" ]]; then
-  case ":\${PATH:-}:" in
-    *":\${ALERA_AGENT_WRAPPER_PATH}:"*) ;;
-    *) export PATH="\${ALERA_AGENT_WRAPPER_PATH}\${PATH:+:\${PATH}}" ;;
-  esac
+  # Move the managed wrapper dir to the front even if a sourced rc (e.g.
+  # ~/.zshenv prepending ~/.local/bin) already placed it later in PATH.
+  path=("\${ALERA_AGENT_WRAPPER_PATH}" "\${(@)path:#\${ALERA_AGENT_WRAPPER_PATH}}")
+  export PATH
 fi
 ''';
 }
@@ -74,10 +74,10 @@ if [[ -n "\${ALERA_COPILOT_HOME:-}" ]]; then
   export COPILOT_HOME="\${ALERA_COPILOT_HOME}"
 fi
 if [[ -n "\${ALERA_AGENT_WRAPPER_PATH:-}" ]]; then
-  case ":\${PATH:-}:" in
-    *":\${ALERA_AGENT_WRAPPER_PATH}:"*) ;;
-    *) export PATH="\${ALERA_AGENT_WRAPPER_PATH}\${PATH:+:\${PATH}}" ;;
-  esac
+  # Move the managed wrapper dir to the front even if a sourced rc (e.g.
+  # ~/.zshenv prepending ~/.local/bin) already placed it later in PATH.
+  path=("\${ALERA_AGENT_WRAPPER_PATH}" "\${(@)path:#\${ALERA_AGENT_WRAPPER_PATH}}")
+  export PATH
 fi
 export ZDOTDIR=$quotedManagedZdotdir
 unset _alera_orig_zdotdir

--- a/test/golden/welcome_dashboard_golden_test.dart
+++ b/test/golden/welcome_dashboard_golden_test.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:alchemist/alchemist.dart';
 import 'package:alera/src/app/providers.dart';
 import 'package:alera/src/features/projects/domain/project.dart';
@@ -5,6 +7,7 @@ import 'package:alera/src/features/settings/domain/alera_settings.dart';
 import 'package:alera/src/features/workbench/application/workbench_state.dart';
 import 'package:alera/src/features/workbench/domain/workspace.dart';
 import 'package:alera/src/features/workbench/presentation/welcome_dashboard.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -42,13 +45,33 @@ class _GoldenDashboardFrame extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return ProviderScope(
-      overrides: [
-        workbenchControllerProvider.overrideWithValue(state),
-        settingsControllerProvider.overrideWithValue(AleraSettings.defaults),
-      ],
-      child: const WelcomeDashboard(),
+    return DefaultAssetBundle(
+      bundle: _GoldenLogoAssetBundle(),
+      child: ProviderScope(
+        overrides: [
+          workbenchControllerProvider.overrideWithValue(state),
+          settingsControllerProvider.overrideWithValue(AleraSettings.defaults),
+        ],
+        child: const WelcomeDashboard(),
+      ),
     );
+  }
+}
+
+class _GoldenLogoAssetBundle extends CachingAssetBundle {
+  static const String _logoPath = 'assets/logo/alera-logo-white.png';
+  static final ByteData _logoBytes = ByteData.sublistView(
+    base64Decode(
+      'iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAALklEQVR42u3OQQEAAAQEMPQPeU2I4bMlWCfZejT1TEBAQEBAQEBAQEBAQEBA4ABySAPfxFCIhQAAAABJRU5ErkJggg==',
+    ),
+  );
+
+  @override
+  Future<ByteData> load(String key) async {
+    if (key == _logoPath) {
+      return _logoBytes;
+    }
+    return rootBundle.load(key);
   }
 }
 

--- a/test/golden/welcome_dashboard_golden_test.dart
+++ b/test/golden/welcome_dashboard_golden_test.dart
@@ -18,6 +18,7 @@ void main() {
         'renders populated desktop dashboard',
         fileName: 'welcome_dashboard_populated_desktop',
         constraints: const BoxConstraints.tightFor(width: 980, height: 720),
+        pumpBeforeTest: precacheImages,
         builder: () => _GoldenDashboardFrame(state: _populatedState()),
       );
 
@@ -25,6 +26,7 @@ void main() {
         'renders empty compact dashboard',
         fileName: 'welcome_dashboard_empty_compact',
         constraints: const BoxConstraints.tightFor(width: 390, height: 760),
+        pumpBeforeTest: precacheImages,
         builder: () => const _GoldenDashboardFrame(
           state: WorkbenchState(bootstrapped: true),
         ),

--- a/test/unit/agent_hook_event_normalizer_test.dart
+++ b/test/unit/agent_hook_event_normalizer_test.dart
@@ -561,6 +561,18 @@ void main() {
         isTrue,
       );
     });
+
+    test('detects Amp new turn and prompt on agent.start', () {
+      final normalized = normalizeAgentHookEvent(
+        _event(
+          agentType: AgentType.amp,
+          hookEventName: 'agent.start',
+          payload: const <String, Object?>{'message': 'Ship the feature'},
+        ),
+      );
+      expect(normalized?.state, AgentStatusState.working);
+      expect(normalized?.prompt, 'Ship the feature');
+    });
   });
 }
 

--- a/test/unit/terminal_shell_startup_preparer_advanced_test_cases.dart
+++ b/test/unit/terminal_shell_startup_preparer_advanced_test_cases.dart
@@ -151,42 +151,56 @@ void _registerTerminalShellStartupPreparerAdvancedTests() {
       );
 
       expect(launch.arguments, const <String>['-l']);
-      expect(
-        launch.setupCommand,
-        'if [ -n "\${ALERA_CODEX_HOME:-}" ]; then export CODEX_HOME="\$ALERA_CODEX_HOME"; fi\n'
-        'if [ -n "\${ALERA_CLAUDE_CONFIG_DIR:-}" ]; then export CLAUDE_CONFIG_DIR="\$ALERA_CLAUDE_CONFIG_DIR"; fi\n'
-        'if [ -n "\${ALERA_OPENCODE_CONFIG_DIR:-}" ]; then export OPENCODE_CONFIG_DIR="\$ALERA_OPENCODE_CONFIG_DIR"; fi\n'
-        'if [ -n "\${ALERA_PI_CODING_AGENT_DIR:-}" ]; then export PI_CODING_AGENT_DIR="\$ALERA_PI_CODING_AGENT_DIR"; fi\n'
-        'if [ -n "\${ALERA_COPILOT_HOME:-}" ]; then export COPILOT_HOME="\$ALERA_COPILOT_HOME"; fi\n'
-        'if [ -n "\${ALERA_AGENT_WRAPPER_PATH:-}" ]; then __alera_new_path=""; __alera_old_ifs="\${IFS-}"; IFS=":"; for __alera_entry in \${PATH:-}; do [ "\${__alera_entry}" = "\${ALERA_AGENT_WRAPPER_PATH}" ] && continue; if [ -z "\${__alera_new_path}" ]; then __alera_new_path="\${__alera_entry}"; else __alera_new_path="\${__alera_new_path}:\${__alera_entry}"; fi; done; IFS="\${__alera_old_ifs}"; export PATH="\${ALERA_AGENT_WRAPPER_PATH}\${__alera_new_path:+:\${__alera_new_path}}"; unset __alera_new_path __alera_old_ifs __alera_entry; fi\n',
-      );
+      expect(launch.setupCommand, _expectedPosixRestoreManagedAgentEnvironment);
     }
   });
 
-  test('POSIX fallback shells prepend restore before existing setup commands', () async {
-    for (final shell in _posixFallbackShells) {
-      final launch = await preparer.prepare(
-        _launch(
-          shell: shell,
-          environment: const <String, String>{
-            'CODEX_HOME': '/runtime/codex',
-            'ALERA_CODEX_HOME': '/runtime/codex',
-          },
-          setupCommand: 'printf setup\n',
-        ),
-      );
+  test(
+    'POSIX fallback shells prepend restore before existing setup commands',
+    () async {
+      for (final shell in _posixFallbackShells) {
+        final launch = await preparer.prepare(
+          _launch(
+            shell: shell,
+            environment: const <String, String>{
+              'CODEX_HOME': '/runtime/codex',
+              'ALERA_CODEX_HOME': '/runtime/codex',
+            },
+            setupCommand: 'printf setup\n',
+          ),
+        );
 
-      expect(
-        launch.setupCommand,
-        'if [ -n "\${ALERA_CODEX_HOME:-}" ]; then export CODEX_HOME="\$ALERA_CODEX_HOME"; fi\n'
-        'if [ -n "\${ALERA_CLAUDE_CONFIG_DIR:-}" ]; then export CLAUDE_CONFIG_DIR="\$ALERA_CLAUDE_CONFIG_DIR"; fi\n'
-        'if [ -n "\${ALERA_OPENCODE_CONFIG_DIR:-}" ]; then export OPENCODE_CONFIG_DIR="\$ALERA_OPENCODE_CONFIG_DIR"; fi\n'
-        'if [ -n "\${ALERA_PI_CODING_AGENT_DIR:-}" ]; then export PI_CODING_AGENT_DIR="\$ALERA_PI_CODING_AGENT_DIR"; fi\n'
-        'if [ -n "\${ALERA_COPILOT_HOME:-}" ]; then export COPILOT_HOME="\$ALERA_COPILOT_HOME"; fi\n'
-        'if [ -n "\${ALERA_AGENT_WRAPPER_PATH:-}" ]; then __alera_new_path=""; __alera_old_ifs="\${IFS-}"; IFS=":"; for __alera_entry in \${PATH:-}; do [ "\${__alera_entry}" = "\${ALERA_AGENT_WRAPPER_PATH}" ] && continue; if [ -z "\${__alera_new_path}" ]; then __alera_new_path="\${__alera_entry}"; else __alera_new_path="\${__alera_new_path}:\${__alera_entry}"; fi; done; IFS="\${__alera_old_ifs}"; export PATH="\${ALERA_AGENT_WRAPPER_PATH}\${__alera_new_path:+:\${__alera_new_path}}"; unset __alera_new_path __alera_old_ifs __alera_entry; fi\n'
-        'printf setup\n',
-      );
-    }
+        expect(
+          launch.setupCommand,
+          '${_expectedPosixRestoreManagedAgentEnvironment}printf setup\n',
+        );
+      }
+    },
+  );
+
+  test('POSIX fallback shells preserve leading empty PATH entries', () async {
+    final launch = await preparer.prepare(
+      _launch(
+        shell: '/bin/sh',
+        environment: const <String, String>{
+          'ALERA_AGENT_WRAPPER_PATH': '/wrapper/bin',
+        },
+        setupCommand: 'printf "%s" "\$PATH"\n',
+      ),
+    );
+
+    final result = await Process.run(
+      '/bin/sh',
+      <String>['-c', launch.setupCommand!],
+      includeParentEnvironment: false,
+      environment: const <String, String>{
+        'ALERA_AGENT_WRAPPER_PATH': '/wrapper/bin',
+        'PATH': ':/usr/bin:/wrapper/bin',
+      },
+    );
+
+    expect(result.exitCode, 0, reason: result.stderr.toString());
+    expect(result.stdout, '/wrapper/bin::/usr/bin');
   });
 
   test('Claude runtime env alone triggers shell restore preparation', () async {

--- a/test/unit/terminal_shell_startup_preparer_advanced_test_cases.dart
+++ b/test/unit/terminal_shell_startup_preparer_advanced_test_cases.dart
@@ -82,7 +82,7 @@ void _registerTerminalShellStartupPreparerAdvancedTests() {
         '\n'
         r'if ("ALERA_COPILOT_HOME" in $env) { $env.COPILOT_HOME = $env.ALERA_COPILOT_HOME }'
         '\n'
-        r'if ("ALERA_AGENT_WRAPPER_PATH" in $env) { let __alera_path_entries = if ("PATH" in $env) { $env.PATH } else { [] }; if not ($env.ALERA_AGENT_WRAPPER_PATH in $__alera_path_entries) { $env.PATH = ($__alera_path_entries | prepend $env.ALERA_AGENT_WRAPPER_PATH) } }'
+        r'if ("ALERA_AGENT_WRAPPER_PATH" in $env) { let __alera_path_entries = if ("PATH" in $env) { $env.PATH } else { [] }; $env.PATH = ($__alera_path_entries | where $it != $env.ALERA_AGENT_WRAPPER_PATH | prepend $env.ALERA_AGENT_WRAPPER_PATH) }'
         '\n',
       ),
     );
@@ -158,7 +158,7 @@ void _registerTerminalShellStartupPreparerAdvancedTests() {
         'if [ -n "\${ALERA_OPENCODE_CONFIG_DIR:-}" ]; then export OPENCODE_CONFIG_DIR="\$ALERA_OPENCODE_CONFIG_DIR"; fi\n'
         'if [ -n "\${ALERA_PI_CODING_AGENT_DIR:-}" ]; then export PI_CODING_AGENT_DIR="\$ALERA_PI_CODING_AGENT_DIR"; fi\n'
         'if [ -n "\${ALERA_COPILOT_HOME:-}" ]; then export COPILOT_HOME="\$ALERA_COPILOT_HOME"; fi\n'
-        'if [ -n "\${ALERA_AGENT_WRAPPER_PATH:-}" ]; then case ":\${PATH:-}:" in *":\${ALERA_AGENT_WRAPPER_PATH}:"*) ;; *) export PATH="\${ALERA_AGENT_WRAPPER_PATH}\${PATH:+:\${PATH}}" ;; esac; fi\n',
+        'if [ -n "\${ALERA_AGENT_WRAPPER_PATH:-}" ]; then __alera_new_path=""; __alera_old_ifs="\${IFS-}"; IFS=":"; for __alera_entry in \${PATH:-}; do [ "\${__alera_entry}" = "\${ALERA_AGENT_WRAPPER_PATH}" ] && continue; if [ -z "\${__alera_new_path}" ]; then __alera_new_path="\${__alera_entry}"; else __alera_new_path="\${__alera_new_path}:\${__alera_entry}"; fi; done; IFS="\${__alera_old_ifs}"; export PATH="\${ALERA_AGENT_WRAPPER_PATH}\${__alera_new_path:+:\${__alera_new_path}}"; unset __alera_new_path __alera_old_ifs __alera_entry; fi\n',
       );
     }
   });
@@ -183,7 +183,7 @@ void _registerTerminalShellStartupPreparerAdvancedTests() {
         'if [ -n "\${ALERA_OPENCODE_CONFIG_DIR:-}" ]; then export OPENCODE_CONFIG_DIR="\$ALERA_OPENCODE_CONFIG_DIR"; fi\n'
         'if [ -n "\${ALERA_PI_CODING_AGENT_DIR:-}" ]; then export PI_CODING_AGENT_DIR="\$ALERA_PI_CODING_AGENT_DIR"; fi\n'
         'if [ -n "\${ALERA_COPILOT_HOME:-}" ]; then export COPILOT_HOME="\$ALERA_COPILOT_HOME"; fi\n'
-        'if [ -n "\${ALERA_AGENT_WRAPPER_PATH:-}" ]; then case ":\${PATH:-}:" in *":\${ALERA_AGENT_WRAPPER_PATH}:"*) ;; *) export PATH="\${ALERA_AGENT_WRAPPER_PATH}\${PATH:+:\${PATH}}" ;; esac; fi\n'
+        'if [ -n "\${ALERA_AGENT_WRAPPER_PATH:-}" ]; then __alera_new_path=""; __alera_old_ifs="\${IFS-}"; IFS=":"; for __alera_entry in \${PATH:-}; do [ "\${__alera_entry}" = "\${ALERA_AGENT_WRAPPER_PATH}" ] && continue; if [ -z "\${__alera_new_path}" ]; then __alera_new_path="\${__alera_entry}"; else __alera_new_path="\${__alera_new_path}:\${__alera_entry}"; fi; done; IFS="\${__alera_old_ifs}"; export PATH="\${ALERA_AGENT_WRAPPER_PATH}\${__alera_new_path:+:\${__alera_new_path}}"; unset __alera_new_path __alera_old_ifs __alera_entry; fi\n'
         'printf setup\n',
       );
     }
@@ -283,4 +283,82 @@ void _registerTerminalShellStartupPreparerAdvancedTests() {
       }
     },
   );
+
+  test('generated zsh startup moves wrapper dir to front, not skip', () async {
+    final prepared = await preparer.prepare(
+      _launch(
+        shell: '/bin/zsh',
+        environment: const <String, String>{
+          'HOME': '/Users/leynier',
+          'ALERA_AGENT_WRAPPER_PATH': '/wrapper/bin',
+        },
+      ),
+    );
+    final zdotdir = prepared.environment!['ZDOTDIR']!;
+    for (final fileName in const <String>['.zshenv', '.zshrc']) {
+      final contents = File(p.join(zdotdir, fileName)).readAsStringSync();
+      expect(
+        contents,
+        contains(r'path=("${ALERA_AGENT_WRAPPER_PATH}"'),
+        reason: '$fileName must rebuild PATH with the wrapper dir first',
+      );
+      expect(
+        contents,
+        isNot(contains(r'*":${ALERA_AGENT_WRAPPER_PATH}:"*) ;;')),
+        reason: '$fileName must not skip when the wrapper dir is present',
+      );
+    }
+  });
+
+  test('zsh startup puts wrapper dir first even after rc prepends', () async {
+    final zshExecutable = <String>[
+      '/bin/zsh',
+      '/usr/bin/zsh',
+      '/usr/local/bin/zsh',
+      '/opt/homebrew/bin/zsh',
+    ].firstWhere((path) => File(path).existsSync(), orElse: () => '');
+    if (zshExecutable.isEmpty) {
+      markTestSkipped('zsh is not available on this platform');
+      return;
+    }
+
+    // A user ZDOTDIR whose .zshenv prepends a decoy dir, the exact shape that
+    // defeated the previous skip-if-present logic.
+    final userZdotdir = Directory(p.join(tempDir.path, 'user-zdotdir'))
+      ..createSync(recursive: true);
+    File(
+      p.join(userZdotdir.path, '.zshenv'),
+    ).writeAsStringSync('export PATH="/decoy/bin:\$PATH"\n');
+
+    final prepared = await preparer.prepare(
+      _launch(
+        shell: zshExecutable,
+        environment: <String, String>{
+          'HOME': userZdotdir.path,
+          'ZDOTDIR': userZdotdir.path,
+          'ALERA_AGENT_WRAPPER_PATH': '/wrapper/bin',
+        },
+      ),
+    );
+    final managedZdotdir = prepared.environment!['ZDOTDIR']!;
+    final originalZdotdir = prepared.environment!['ALERA_ORIG_ZDOTDIR']!;
+
+    // Wrapper dir starts in the middle of PATH; the rc prepend then pushes a
+    // decoy in front of it, so only "move to front" yields the right result.
+    final result = await Process.run(
+      zshExecutable,
+      const <String>['-c', r'print -rn -- ${path[1]}'],
+      includeParentEnvironment: false,
+      environment: <String, String>{
+        'ZDOTDIR': managedZdotdir,
+        'ALERA_ORIG_ZDOTDIR': originalZdotdir,
+        'ALERA_AGENT_WRAPPER_PATH': '/wrapper/bin',
+        'HOME': userZdotdir.path,
+        'PATH': '/usr/bin:/wrapper/bin:/bin',
+      },
+    );
+
+    expect(result.exitCode, 0, reason: result.stderr.toString());
+    expect((result.stdout as String).trim(), '/wrapper/bin');
+  });
 }

--- a/test/unit/terminal_shell_startup_preparer_core_test_cases.dart
+++ b/test/unit/terminal_shell_startup_preparer_core_test_cases.dart
@@ -194,7 +194,9 @@ void _registerTerminalShellStartupPreparerCoreTests() {
         contains('export PI_CODING_AGENT_DIR="\${ALERA_PI_CODING_AGENT_DIR}"'),
       );
       expect(rcFile, contains('export COPILOT_HOME="\${ALERA_COPILOT_HOME}"'));
-      expect(rcFile, contains('ALERA_AGENT_WRAPPER_PATH'));
+      expect(rcFile, contains('__alera_appended=0'));
+      expect(rcFile, contains('export PATH="\${ALERA_AGENT_WRAPPER_PATH}:'));
+      expect(rcFile, isNot(contains('*":\${ALERA_AGENT_WRAPPER_PATH}:"*) ;;')));
     },
   );
 

--- a/test/unit/terminal_shell_startup_preparer_core_test_cases.dart
+++ b/test/unit/terminal_shell_startup_preparer_core_test_cases.dart
@@ -316,7 +316,7 @@ void _registerTerminalShellStartupPreparerCoreTests() {
       'if set -q ALERA_OPENCODE_CONFIG_DIR; set -gx OPENCODE_CONFIG_DIR \$ALERA_OPENCODE_CONFIG_DIR; end\n'
       'if set -q ALERA_PI_CODING_AGENT_DIR; set -gx PI_CODING_AGENT_DIR \$ALERA_PI_CODING_AGENT_DIR; end\n'
       'if set -q ALERA_COPILOT_HOME; set -gx COPILOT_HOME \$ALERA_COPILOT_HOME; end\n'
-      'if set -q ALERA_AGENT_WRAPPER_PATH; if not contains -- \$ALERA_AGENT_WRAPPER_PATH \$PATH; set -gx PATH \$ALERA_AGENT_WRAPPER_PATH \$PATH; end; end',
+      'if set -q ALERA_AGENT_WRAPPER_PATH; set -gx PATH \$ALERA_AGENT_WRAPPER_PATH (string match --invert -- \$ALERA_AGENT_WRAPPER_PATH \$PATH); end',
     );
     expect(launch.setupCommand, isNull);
   });
@@ -343,7 +343,7 @@ void _registerTerminalShellStartupPreparerCoreTests() {
         'if set -q ALERA_OPENCODE_CONFIG_DIR; set -gx OPENCODE_CONFIG_DIR \$ALERA_OPENCODE_CONFIG_DIR; end\n'
         'if set -q ALERA_PI_CODING_AGENT_DIR; set -gx PI_CODING_AGENT_DIR \$ALERA_PI_CODING_AGENT_DIR; end\n'
         'if set -q ALERA_COPILOT_HOME; set -gx COPILOT_HOME \$ALERA_COPILOT_HOME; end\n'
-        'if set -q ALERA_AGENT_WRAPPER_PATH; if not contains -- \$ALERA_AGENT_WRAPPER_PATH \$PATH; set -gx PATH \$ALERA_AGENT_WRAPPER_PATH \$PATH; end; end\n',
+        'if set -q ALERA_AGENT_WRAPPER_PATH; set -gx PATH \$ALERA_AGENT_WRAPPER_PATH (string match --invert -- \$ALERA_AGENT_WRAPPER_PATH \$PATH); end\n',
       ),
     );
     expect(launch.setupCommand, contains('printf setup\n'));

--- a/test/unit/terminal_shell_startup_preparer_test.dart
+++ b/test/unit/terminal_shell_startup_preparer_test.dart
@@ -44,3 +44,11 @@ const List<String> _posixFallbackShells = <String>[
   '/bin/oksh',
   '/bin/sh',
 ];
+
+const String _expectedPosixRestoreManagedAgentEnvironment =
+    'if [ -n "\${ALERA_CODEX_HOME:-}" ]; then export CODEX_HOME="\$ALERA_CODEX_HOME"; fi\n'
+    'if [ -n "\${ALERA_CLAUDE_CONFIG_DIR:-}" ]; then export CLAUDE_CONFIG_DIR="\$ALERA_CLAUDE_CONFIG_DIR"; fi\n'
+    'if [ -n "\${ALERA_OPENCODE_CONFIG_DIR:-}" ]; then export OPENCODE_CONFIG_DIR="\$ALERA_OPENCODE_CONFIG_DIR"; fi\n'
+    'if [ -n "\${ALERA_PI_CODING_AGENT_DIR:-}" ]; then export PI_CODING_AGENT_DIR="\$ALERA_PI_CODING_AGENT_DIR"; fi\n'
+    'if [ -n "\${ALERA_COPILOT_HOME:-}" ]; then export COPILOT_HOME="\$ALERA_COPILOT_HOME"; fi\n'
+    'if [ -n "\${ALERA_AGENT_WRAPPER_PATH:-}" ]; then __alera_new_path=""; __alera_appended=0; __alera_old_ifs="\${IFS-}"; IFS=":"; for __alera_entry in \${PATH:-}; do [ "\${__alera_entry}" = "\${ALERA_AGENT_WRAPPER_PATH}" ] && continue; if [ "\${__alera_appended}" -eq 0 ]; then __alera_new_path="\${__alera_entry}"; __alera_appended=1; else __alera_new_path="\${__alera_new_path}:\${__alera_entry}"; fi; done; IFS="\${__alera_old_ifs}"; if [ "\${__alera_appended}" -eq 1 ]; then export PATH="\${ALERA_AGENT_WRAPPER_PATH}:\${__alera_new_path}"; else export PATH="\${ALERA_AGENT_WRAPPER_PATH}"; fi; unset __alera_new_path __alera_appended __alera_old_ifs __alera_entry; fi\n';


### PR DESCRIPTION
## Summary

Amp (and other wrapper-based agents like Cursor) report terminal status through a managed wrapper directory that must stay first in `PATH` after shell startup files run.

This PR changes generated shell startup from "skip if already present" to "move the managed wrapper directory to the front" across supported shells. It also keeps POSIX empty `PATH` components intact while rebuilding the path and stabilizes the `WelcomeDashboard` goldens with deterministic logo loading in the golden harness.

## Screenshots

No visual change.

## Changes

- `terminal_shell_zsh_startup.dart`: zsh `.zshenv` and `.zshrc` rebuild `path` with the wrapper dir first.
- `terminal_shell_startup_templates.dart`: bash rc, POSIX fallback, fish, nushell, and PowerShell use move-to-front restore behavior.
- Tests cover zsh rc prepends, bash rc generation, POSIX leading empty `PATH` entries, and Amp `agent.start` normalization.
- Welcome dashboard goldens now precache images and replace the raster logo asset with a deterministic 32x32 test asset, matching the committed CI snapshot without depending on PNG decode/resampling timing.

## Testing

- [x] `dart format --set-exit-if-changed lib test integration_test tool`
- [x] `flutter analyze`
- [x] `flutter test --coverage --exclude-tags golden`
- [x] `dart run tool/quality/coverage_report.dart --input coverage/lcov.info --min-lines 65 --worst 25`
- [x] Golden tests, if UI changed: `docker run --rm -v "$PWD":/workspace -w /workspace ghcr.io/cirruslabs/flutter:stable bash -lc 'flutter pub get >/tmp/pub-get.log && CI=true flutter test --tags golden'`
- [ ] Desktop E2E, if app-shell flow changed: `flutter test integration_test -d macos`
- [ ] Relevant desktop build: `flutter build macos`, `flutter build windows`, or `flutter build linux`
- [ ] Landing build, if applicable: `cd landing && bun run build`
- [x] Added or updated tests that would catch regressions, or explained why tests were not needed

Golden note: the committed CI goldens are Linux/Ubuntu snapshots. Local macOS golden comparison is not the acceptance signal because it can report platform rasterization diffs. The full golden suite passes in Linux Docker with Flutter 3.44.0, matching the GitHub Actions runner version.

## AI Review Report

CodeRabbit flagged two shell-path issues. Both were valid: bash still had the old skip-if-present branch, and the POSIX fallback rebuild used the output string as its first-entry sentinel, which dropped a leading empty `PATH` component. This update fixes both and adds tests for the reviewed behaviors.

Cross-platform shell behavior checked: zsh, bash, POSIX fallback, fish, nushell, cmd, and PowerShell generation remain covered by unit tests. The new executable regression test covers POSIX `PATH=:/usr/bin:/wrapper/bin` and expects `/wrapper/bin::/usr/bin`.

## Security Audit

Reviewed path handling and shell startup behavior. The change does not add new process execution surfaces or secrets handling. The restore snippets continue to operate only on Alera-managed environment variables, keep variable references quoted in comparisons, and remove duplicate managed wrapper entries before prepending the managed directory. No runtime API, schema, auth, dependency, release signing, or updater behavior changes.

## Notes

End-to-end app verification is still a useful manual pass: launch Alera, enable Amp, confirm `command -v amp` resolves to the Alera wrapper directory, and confirm status changes to working when Amp starts.
