### PR TITLE
feat: enable new folder in native folder pickers

### DIFF
--- a/lib/src/features/projects/presentation/add_project_dialog.dart
+++ b/lib/src/features/projects/presentation/add_project_dialog.dart
@@ -75,6 +75,7 @@ class _AddProjectDialogState extends State<AddProjectDialog> {
     try {
       final selected = await getDirectoryPath(
         confirmButtonText: 'Select folder',
+        canCreateDirectories: true,
       );
       if (!mounted || selected == null || selected.trim().isEmpty) {
         return;
@@ -94,6 +95,7 @@ class _AddProjectDialogState extends State<AddProjectDialog> {
     try {
       final selected = await getDirectoryPath(
         confirmButtonText: 'Select parent folder',
+        canCreateDirectories: true,
       );
       if (!mounted || selected == null || selected.trim().isEmpty) {
         return;

--- a/lib/src/features/settings/presentation/settings_dialog_general_pane.dart
+++ b/lib/src/features/settings/presentation/settings_dialog_general_pane.dart
@@ -402,6 +402,7 @@ class _WorkspaceDirectoryRowState extends State<_WorkspaceDirectoryRow> {
           ? _controller.text
           : widget.value,
       confirmButtonText: 'Use as workspace directory',
+      canCreateDirectories: true,
     );
     if (picked == null) {
       return;

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -24,10 +24,10 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/screen_retriever_macos/macos
 
 SPEC CHECKSUMS:
-  alera_native: 84fbb2a99bbe531726d9fa7ed491470d40dadb91
-  cryptography_flutter_plus: b790cf76f050be15566d4ae320574b35cff72d1e
+  alera_native: e59b0a70ab4beed3b64bb122fba926baabfcca91
+  cryptography_flutter_plus: 7c6e0d0f08664499a2c5402aa7cbcca07f2a7130
   FlutterMacOS: d0db08ddef1a9af05a5ec4b724367152bb0500b1
-  screen_retriever_macos: 776e0fa5d42c6163d2bf772d22478df4b302b161
+  screen_retriever_macos: 452e51764a9e1cdb74b3c541238795849f21557f
 
 PODFILE CHECKSUM: 54d867c82ac51cbd61b565781b9fada492027009
 

--- a/test/widget/add_project_dialog_clone_test_cases.dart
+++ b/test/widget/add_project_dialog_clone_test_cases.dart
@@ -37,6 +37,7 @@ void _registerAddProjectDialogCloneTests() {
       fakePlatform.requests.single.confirmButtonText,
       'Select parent folder',
     );
+    expect(fakePlatform.requests.single.canCreateDirectories, isTrue);
   });
 
   testWidgets('clone parent browse shows picker errors', (tester) async {

--- a/test/widget/add_project_dialog_local_test_cases.dart
+++ b/test/widget/add_project_dialog_local_test_cases.dart
@@ -249,5 +249,6 @@ void _registerAddProjectDialogLocalTests() {
       'from-picker',
     );
     expect(fakePlatform.requests.first.confirmButtonText, 'Select folder');
+    expect(fakePlatform.requests.first.canCreateDirectories, isTrue);
   });
 }

--- a/test/widget/add_project_dialog_test_harness.dart
+++ b/test/widget/add_project_dialog_test_harness.dart
@@ -37,9 +37,7 @@ class _FakeFileSelectorPlatform extends FileSelectorPlatform
   final List<_DirectoryRequest> requests = <_DirectoryRequest>[];
 
   @override
-  Future<String?> getDirectoryPathWithOptions(
-    FileDialogOptions options,
-  ) async {
+  Future<String?> getDirectoryPathWithOptions(FileDialogOptions options) async {
     requests.add(
       _DirectoryRequest(
         initialDirectory: options.initialDirectory,

--- a/test/widget/add_project_dialog_test_harness.dart
+++ b/test/widget/add_project_dialog_test_harness.dart
@@ -37,14 +37,14 @@ class _FakeFileSelectorPlatform extends FileSelectorPlatform
   final List<_DirectoryRequest> requests = <_DirectoryRequest>[];
 
   @override
-  Future<String?> getDirectoryPath({
-    String? initialDirectory,
-    String? confirmButtonText,
-  }) async {
+  Future<String?> getDirectoryPathWithOptions(
+    FileDialogOptions options,
+  ) async {
     requests.add(
       _DirectoryRequest(
-        initialDirectory: initialDirectory,
-        confirmButtonText: confirmButtonText,
+        initialDirectory: options.initialDirectory,
+        confirmButtonText: options.confirmButtonText,
+        canCreateDirectories: options.canCreateDirectories,
       ),
     );
     if (responses.isEmpty) {
@@ -62,8 +62,10 @@ class _DirectoryRequest {
   const _DirectoryRequest({
     required this.initialDirectory,
     required this.confirmButtonText,
+    required this.canCreateDirectories,
   });
 
   final String? initialDirectory;
   final String? confirmButtonText;
+  final bool? canCreateDirectories;
 }

--- a/test/widget/settings_dialog_interaction_test_cases.dart
+++ b/test/widget/settings_dialog_interaction_test_cases.dart
@@ -124,6 +124,7 @@ void _registerSettingsDialogAdvancedTests() {
       fakePlatform.requests.single.confirmButtonText,
       'Use as workspace directory',
     );
+    expect(fakePlatform.requests.single.canCreateDirectories, isTrue);
   });
 
   testWidgets('font autocomplete supports arrow-up and numpad enter', (

--- a/test/widget/settings_dialog_test_harness.dart
+++ b/test/widget/settings_dialog_test_harness.dart
@@ -94,9 +94,7 @@ class _FakeFileSelectorPlatform extends FileSelectorPlatform
   final List<_DirectoryRequest> requests = <_DirectoryRequest>[];
 
   @override
-  Future<String?> getDirectoryPathWithOptions(
-    FileDialogOptions options,
-  ) async {
+  Future<String?> getDirectoryPathWithOptions(FileDialogOptions options) async {
     requests.add(
       _DirectoryRequest(
         initialDirectory: options.initialDirectory,

--- a/test/widget/settings_dialog_test_harness.dart
+++ b/test/widget/settings_dialog_test_harness.dart
@@ -94,14 +94,14 @@ class _FakeFileSelectorPlatform extends FileSelectorPlatform
   final List<_DirectoryRequest> requests = <_DirectoryRequest>[];
 
   @override
-  Future<String?> getDirectoryPath({
-    String? initialDirectory,
-    String? confirmButtonText,
-  }) async {
+  Future<String?> getDirectoryPathWithOptions(
+    FileDialogOptions options,
+  ) async {
     requests.add(
       _DirectoryRequest(
-        initialDirectory: initialDirectory,
-        confirmButtonText: confirmButtonText,
+        initialDirectory: options.initialDirectory,
+        confirmButtonText: options.confirmButtonText,
+        canCreateDirectories: options.canCreateDirectories,
       ),
     );
     if (responses.isEmpty) {
@@ -119,8 +119,10 @@ class _DirectoryRequest {
   const _DirectoryRequest({
     required this.initialDirectory,
     required this.confirmButtonText,
+    required this.canCreateDirectories,
   });
 
   final String? initialDirectory;
   final String? confirmButtonText;
+  final bool? canCreateDirectories;
 }


### PR DESCRIPTION
## Summary

Enables the native **New Folder** button in all folder selection dialogs by passing `canCreateDirectories: true` to `getDirectoryPath` from the existing `file_selector` package.

Affected flows:
- Add project → local folder browse
- Add project → clone destination parent folder browse
- Settings → General → workspace directory browse

On macOS this maps to `NSOpenPanel.canCreateDirectories`. Linux (`file_selector_linux`) also honors the flag. Windows currently ignores it in the pinned plugin, but the option is harmless and future-proof.

## Screenshots

No visual changes.

## Testing

- [x] `dart format --set-exit-if-changed lib test integration_test tool`
- [x] `flutter analyze`
- [x] `flutter test --exclude-tags golden` (targeted: `test/widget/add_project_dialog_test.dart`, `test/widget/settings_dialog_test.dart`; 36 tests passed)
- [ ] `dart run tool/quality/coverage_report.dart --input coverage/lcov.info --min-lines 65 --worst 25` (not run; narrow UI flag change)
- [ ] Golden tests, if UI changed: `flutter test --tags golden` (not applicable — change is native dialog configuration only)
- [ ] Desktop E2E, if app-shell flow changed: `flutter test integration_test -d macos` (not run; recommend manual picker check on macOS)
- [ ] Relevant desktop build: `flutter build macos`, `flutter build windows`, or `flutter build linux` (not run)
- [ ] Landing build, if applicable: `cd landing && bun run build` (not applicable)
- [x] Added or updated tests that would catch regressions, or explained why tests were not needed

Widget test fakes now assert `canCreateDirectories: true` is passed for browse actions.

## AI Review Report

Reviewed `file_selector` API and platform behavior: `canCreateDirectories` is supported on macOS and Linux directory pickers; default without the flag hides **New Folder** on macOS choose-directory panels.

Cross-platform: no shortcut, shell, terminal, release, or updater behavior changed. Windows does not wire this flag today; macOS and Linux are the platforms that benefit.

## Security Audit

No new input surfaces, command execution, auth, secrets, dependencies, or updater changes. Only passes an existing boolean to the OS folder picker API.

## Notes

- `macos/Podfile.lock` checksum drift is from a local pod resolve; drop that file from the PR if CI should not see unrelated lockfile churn.
- Manual verification on macOS: `make app-debug` → open each browse action and confirm **New Folder** appears and a created folder can be selected.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Directory creation is now available in folder selection dialogs. Users can create new directories directly when adding projects (local and clone operations) and when configuring workspace directory settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->