### PR TITLE
[codex] harden release signing workflow

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -16,6 +16,8 @@ This file applies to GitHub metadata and GitHub Actions workflows.
 - Update indexes must be deployed only after the corresponding GitHub Release is public.
 - Existing stable and release-candidate update indexes must be preserved when publishing the other channel; ignore only confirmed first-time 404 responses.
 - Stable release jobs must not enable automatic installation until signing and notarization or trust are configured for the relevant platform.
+- Release jobs must sign schema v2 update indexes before publication and verify the manifest signature before upload.
+- Linux release jobs must publish signed APT and RPM repository metadata when Linux packages are included.
 - Signing secrets must be scoped only to release jobs that need them.
 
 ## Issue And PR Policy

--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -26,6 +26,8 @@ on:
 
 permissions:
   contents: write
+  id-token: write
+  attestations: write
 
 concurrency:
   group: release-cut
@@ -158,7 +160,7 @@ jobs:
 
       - name: Install Linux Flutter dependencies
         if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y clang cmake ninja-build pkg-config libgtk-3-dev
+        run: sudo apt-get update && sudo apt-get install -y clang cmake ninja-build pkg-config libgtk-3-dev rpm
 
       - name: Install dependencies
         run: flutter pub get
@@ -179,13 +181,14 @@ jobs:
       - name: Apply release version locally
         run: dart tool/release/update_pubspec_version.dart "${{ needs.cut.outputs.artifact_version }}" "${{ needs.cut.outputs.build_number }}"
 
-      - name: Build updater archive
+      - name: Build release bundle
         shell: bash
         env:
           PLATFORM: ${{ matrix.platform }}
           CHANNEL: ${{ needs.cut.outputs.channel }}
           BASE_URL: ${{ env.ALERA_UPDATE_BASE_URL }}
           RELEASE_PAGE_URL: https://github.com/${{ github.repository }}/releases/tag/${{ needs.cut.outputs.tag }}
+          ALERA_UPDATE_MANIFEST_PUBLIC_KEY: ${{ secrets.ALERA_UPDATE_MANIFEST_PUBLIC_KEY }}
         run: |
           set -euo pipefail
           archive_file="app-archive.json"
@@ -199,34 +202,27 @@ jobs:
             --dart-define "ALERA_UPDATE_ARCHIVE_URL=$archive_url" \
             --dart-define "ALERA_RELEASE_PAGE_URL=$RELEASE_PAGE_URL" \
             --dart-define "ALERA_UPDATE_AUTO_INSTALL_ENABLED=false" \
-            --dart-define "ALERA_SIGNED_RELEASE=false"
-          dart run desktop_updater:archive "$PLATFORM"
+            --dart-define "ALERA_SIGNED_RELEASE=true" \
+            --dart-define "ALERA_UPDATE_MANIFEST_PUBLIC_KEY=$ALERA_UPDATE_MANIFEST_PUBLIC_KEY"
 
-      - name: Prepare release and updater artifacts
+      - name: Prepare release artifact directories
         shell: bash
         env:
           PLATFORM: ${{ matrix.platform }}
           CHANNEL: ${{ needs.cut.outputs.channel }}
-          RELEASE_VERSION: ${{ needs.cut.outputs.release_version }}
           ARTIFACT_VERSION: ${{ needs.cut.outputs.artifact_version }}
           BUILD_NUMBER: ${{ needs.cut.outputs.build_number }}
         run: |
           set -euo pipefail
           app_name="$(grep -E '^name:' pubspec.yaml | awk '{print $2}')"
-          updater_dir="dist/${BUILD_NUMBER}/${ARTIFACT_VERSION}+${BUILD_NUMBER}-${PLATFORM}"
           bundle_dir="dist/${BUILD_NUMBER}/${app_name}-${ARTIFACT_VERSION}+${BUILD_NUMBER}-${PLATFORM}"
-          if [[ ! -d "$updater_dir" ]]; then
-            echo "::error::Missing updater archive $updater_dir"
-            find dist -maxdepth 3 -type d -print || true
-            exit 1
-          fi
           if [[ ! -d "$bundle_dir" ]]; then
             echo "::error::Missing release bundle $bundle_dir"
             find dist -maxdepth 3 -type d -print || true
             exit 1
           fi
-          mkdir -p "pages/updates/${CHANNEL}/${ARTIFACT_VERSION}+${BUILD_NUMBER}-${PLATFORM}" release-assets
-          cp -R "$updater_dir/." "pages/updates/${CHANNEL}/${ARTIFACT_VERSION}+${BUILD_NUMBER}-${PLATFORM}/"
+          asset_dir="pages/updates/${CHANNEL}/${ARTIFACT_VERSION}+${BUILD_NUMBER}-${PLATFORM}"
+          mkdir -p "$asset_dir" release-assets
           if [[ "$PLATFORM" == "macos" && -d "$bundle_dir/alera.app" ]]; then
             # desktop_updater names the bundle after the lowercase pubspec
             # package name; the release display name is Alera (see
@@ -238,7 +234,62 @@ jobs:
             mv "$bundle_dir/alera.app" "$bundle_dir/.Alera.app.tmp"
             mv "$bundle_dir/.Alera.app.tmp" "$bundle_dir/Alera.app"
           fi
-          tar -czf "release-assets/alera-${RELEASE_VERSION}-${PLATFORM}.tar.gz" -C "$bundle_dir" .
+          echo "BUNDLE_DIR=$bundle_dir" >>"$GITHUB_ENV"
+          echo "ASSET_DIR=$asset_dir" >>"$GITHUB_ENV"
+
+      - name: Sign and package macOS release
+        if: matrix.platform == 'macos'
+        shell: bash
+        env:
+          RELEASE_VERSION: ${{ needs.cut.outputs.release_version }}
+          APPLE_DEVELOPER_ID_APPLICATION: ${{ secrets.APPLE_DEVELOPER_ID_APPLICATION }}
+          APPLE_DEVELOPER_ID_TEAM_ID: ${{ secrets.APPLE_DEVELOPER_ID_TEAM_ID }}
+          APPLE_CERTIFICATE_P12_BASE64: ${{ secrets.APPLE_CERTIFICATE_P12_BASE64 }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+        run: |
+          set -euo pipefail
+          bash tool/release/sign_macos.sh "$BUNDLE_DIR" "$BUNDLE_DIR/Alera.app"
+          tar -czf "release-assets/alera-${RELEASE_VERSION}-macos.tar.gz" -C "$BUNDLE_DIR" .
+
+      - name: Sign and package Windows release
+        if: matrix.platform == 'windows'
+        shell: pwsh
+        env:
+          RELEASE_VERSION: ${{ needs.cut.outputs.release_version }}
+          WINDOWS_CERTIFICATE_PFX_BASE64: ${{ secrets.WINDOWS_CERTIFICATE_PFX_BASE64 }}
+          WINDOWS_CERTIFICATE_PASSWORD: ${{ secrets.WINDOWS_CERTIFICATE_PASSWORD }}
+          WINDOWS_TIMESTAMP_URL: ${{ vars.WINDOWS_TIMESTAMP_URL }}
+        run: |
+          pwsh -NoProfile -File tool/release/sign_windows.ps1 -BundleDir "$env:BUNDLE_DIR"
+          tar -czf "release-assets/alera-$env:RELEASE_VERSION-windows.tar.gz" -C "$env:BUNDLE_DIR" .
+
+      - name: Package stable Linux release
+        if: matrix.platform == 'linux' && needs.cut.outputs.channel == 'stable'
+        shell: bash
+        env:
+          RELEASE_VERSION: ${{ needs.cut.outputs.release_version }}
+          ARTIFACT_VERSION: ${{ needs.cut.outputs.artifact_version }}
+          BUILD_NUMBER: ${{ needs.cut.outputs.build_number }}
+        run: |
+          set -euo pipefail
+          bash tool/release/package_linux.sh "$BUNDLE_DIR" release-assets "$RELEASE_VERSION" "$ARTIFACT_VERSION" "$BUILD_NUMBER"
+
+      - name: Package RC Linux release
+        if: matrix.platform == 'linux' && needs.cut.outputs.channel == 'rc'
+        shell: bash
+        env:
+          RELEASE_VERSION: ${{ needs.cut.outputs.release_version }}
+        run: |
+          set -euo pipefail
+          tar -czf "release-assets/alera-${RELEASE_VERSION}-linux.tar.gz" -C "$BUNDLE_DIR" .
+
+      - name: Stage release assets for updater
+        shell: bash
+        run: |
+          set -euo pipefail
+          cp -R release-assets/. "$ASSET_DIR/"
 
       - name: Upload updater artifact
         uses: actions/upload-artifact@v4
@@ -274,6 +325,15 @@ jobs:
       - name: Setup Dart
         uses: dart-lang/setup-dart@v1
 
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+
+      - name: Install dependencies
+        run: flutter pub get
+
       - name: Configure git author
         run: |
           git config user.name "github-actions[bot]"
@@ -292,6 +352,10 @@ jobs:
           pattern: release-*
           path: release-assets
           merge-multiple: true
+
+      - name: Install Linux repository tools
+        if: needs.cut.outputs.channel == 'stable'
+        run: sudo apt-get update && sudo apt-get install -y apt-utils createrepo-c
 
       - name: Preserve existing update indexes
         run: |
@@ -324,14 +388,25 @@ jobs:
           ALERA_RELEASE_BUILD_NUMBER: ${{ needs.cut.outputs.build_number }}
           ALERA_UPDATE_BASE_URL: ${{ env.ALERA_UPDATE_BASE_URL }}
           ALERA_UPDATE_PATH_PREFIX: updates/${{ needs.cut.outputs.channel }}
+          ALERA_UPDATE_MANIFEST_PRIVATE_KEY: ${{ secrets.ALERA_UPDATE_MANIFEST_PRIVATE_KEY }}
+          ALERA_UPDATE_MANIFEST_PUBLIC_KEY: ${{ secrets.ALERA_UPDATE_MANIFEST_PUBLIC_KEY }}
+          ALERA_UPDATE_MANIFEST_PUBLIC_KEY_ID: ${{ vars.ALERA_UPDATE_MANIFEST_PUBLIC_KEY_ID }}
         run: |
           archive_file="app-archive.json"
           if [[ "$CHANNEL" == "rc" ]]; then
             archive_file="app-archive-rc.json"
           fi
           dart tool/release/build_app_archive.dart "public/$archive_file"
+          dart tool/release/sign_app_archive.dart "public/$archive_file"
           dart tool/release/verify_app_archive.dart "public/$archive_file"
           echo "ALERA_ARCHIVE_FILE=$archive_file" >>"$GITHUB_ENV"
+
+      - name: Build signed Linux package repositories
+        if: needs.cut.outputs.channel == 'stable'
+        env:
+          ALERA_LINUX_GPG_PRIVATE_KEY_BASE64: ${{ secrets.ALERA_LINUX_GPG_PRIVATE_KEY_BASE64 }}
+          ALERA_LINUX_GPG_KEY_ID: ${{ secrets.ALERA_LINUX_GPG_KEY_ID }}
+        run: bash tool/release/build_linux_repositories.sh public
 
       - name: Ensure AWS CLI
         run: |
@@ -444,6 +519,13 @@ jobs:
           TAG: ${{ needs.cut.outputs.tag }}
         run: gh release upload "$TAG" release-assets/* "public/$ALERA_ARCHIVE_FILE" --repo "$GITHUB_REPOSITORY" --clobber
 
+      - name: Attest release assets
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: |
+            release-assets/*
+            public/${{ env.ALERA_ARCHIVE_FILE }}
+
       - name: Publish release
         id: publish_release
         env:
@@ -466,11 +548,17 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: auto
           R2_ENDPOINT: https://${{ secrets.CLOUDFLARE_ACCOUNT_ID }}.r2.cloudflarestorage.com
+          CHANNEL: ${{ needs.cut.outputs.channel }}
         run: |
           set -euo pipefail
           aws s3 sync public/updates "s3://${ALERA_R2_BUCKET}/updates" \
             --endpoint-url "$R2_ENDPOINT" \
             --cache-control "public, max-age=31536000, immutable"
+          if [[ "$CHANNEL" == "stable" ]]; then
+            aws s3 sync public/linux "s3://${ALERA_R2_BUCKET}/linux" \
+              --endpoint-url "$R2_ENDPOINT" \
+              --cache-control "public, max-age=300"
+          fi
           for archive_file in app-archive.json app-archive-rc.json; do
             if [[ -f "public/$archive_file" ]]; then
               aws s3 cp "public/$archive_file" "s3://${ALERA_R2_BUCKET}/$archive_file" \

--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -26,8 +26,6 @@ on:
 
 permissions:
   contents: write
-  id-token: write
-  attestations: write
 
 concurrency:
   group: release-cut
@@ -54,14 +52,14 @@ jobs:
       release_base_ref: ${{ steps.version.outputs.release_base_ref }}
     steps:
       - name: Checkout ref
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           ref: ${{ inputs.ref }}
           fetch-depth: 0
           submodules: recursive
 
       - name: Setup Dart
-        uses: dart-lang/setup-dart@v1
+        uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
 
       - name: Compute next version
         id: version
@@ -147,13 +145,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout release ref
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           ref: ${{ needs.cut.outputs.release_base_ref }}
           submodules: recursive
 
       - name: Setup Flutter
-        uses: subosito/flutter-action@v2
+        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
         with:
           channel: stable
           cache: true
@@ -168,13 +166,13 @@ jobs:
       # The native build hooks compile both the Rust terminal-host sidecar
       # (alera-cli) and the flutter_rust_bridge git library (alera_native).
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
         with:
           toolchain: "1.96"
           components: rustfmt, clippy
 
       - name: Cache Rust build
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32
         with:
           workspaces: rust
 
@@ -194,6 +192,10 @@ jobs:
           archive_file="app-archive.json"
           if [[ "$CHANNEL" == "rc" ]]; then
             archive_file="app-archive-rc.json"
+          fi
+          if [[ -z "${ALERA_UPDATE_MANIFEST_PUBLIC_KEY:-}" ]]; then
+            echo "::error::ALERA_UPDATE_MANIFEST_PUBLIC_KEY is required for signed release builds." >&2
+            exit 64
           fi
           archive_url="${BASE_URL}/${archive_file}"
           dart run desktop_updater:release "$PLATFORM" \
@@ -292,7 +294,7 @@ jobs:
           cp -R release-assets/. "$ASSET_DIR/"
 
       - name: Upload updater artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: updater-${{ matrix.platform }}
           path: pages/
@@ -300,7 +302,7 @@ jobs:
           if-no-files-found: error
 
       - name: Upload release asset artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: release-${{ matrix.platform }}
           path: release-assets/
@@ -312,21 +314,25 @@ jobs:
       - cut
       - build
     if: needs.cut.outputs.should_release == 'true'
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           ref: ${{ needs.cut.outputs.release_base_ref }}
           fetch-depth: 0
           submodules: recursive
 
       - name: Setup Dart
-        uses: dart-lang/setup-dart@v1
+        uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
 
       - name: Setup Flutter
-        uses: subosito/flutter-action@v2
+        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
         with:
           channel: stable
           cache: true
@@ -340,14 +346,14 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: Download updater artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
           pattern: updater-*
           path: public
           merge-multiple: true
 
       - name: Download release assets
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
           pattern: release-*
           path: release-assets
@@ -520,7 +526,7 @@ jobs:
         run: gh release upload "$TAG" release-assets/* "public/$ALERA_ARCHIVE_FILE" --repo "$GITHUB_REPOSITORY" --clobber
 
       - name: Attest release assets
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be
         with:
           subject-path: |
             release-assets/*

--- a/docs/release-trust.md
+++ b/docs/release-trust.md
@@ -1,0 +1,21 @@
+# Release trust
+
+Alera release builds are expected to be trusted before they are published publicly. The release workflow builds the desktop bundle for each platform, signs or packages the platform artifact, emits a signed schema v2 update manifest, and uploads both GitHub Release assets and R2 update indexes.
+
+## macOS
+
+Production macOS artifacts must contain a Developer ID signed and notarized `Alera.app`. The release job signs the bundled Rust sidecar under `Contents/Resources/alera/`, signs the app bundle with hardened runtime, submits it to Apple notarization, staples the ticket, and verifies the result with `codesign`, `stapler`, and `spctl`.
+
+## Windows
+
+Production Windows artifacts must be Authenticode signed. The release job signs every executable payload in the bundle, including the Rust sidecar under `resources/alera/`, and verifies each signed file with `signtool verify /pa /all`. Windows SmartScreen reputation can still take time to accrue for a new publisher or certificate even when Authenticode verification succeeds.
+
+## Linux
+
+Linux stable distribution uses signed package repositories rather than app self-replacement. Stable release jobs build both `.deb` and `.rpm` packages from the Linux bundle, publish an APT repository with signed `InRelease` / `Release.gpg` metadata, and publish an RPM repository with signed repository metadata. Release candidates use manual Linux tarballs and must not publish to the stable package repositories. Alera may detect a newer Linux package, but updates should be installed through the user's package manager.
+
+## Update manifest
+
+The public update indexes use `schemaVersion: 2` and include SHA-256 and size for each platform artifact. The manifest is signed with Ed25519 and the release build embeds the public key through `ALERA_UPDATE_MANIFEST_PUBLIC_KEY`. Stable update checks reject unsigned or tampered manifests when `ALERA_SIGNED_RELEASE=true`. GitHub artifact attestations are published through GitHub's attestation service; they are not advertised as R2 sidecar URLs unless matching sidecar files are generated and uploaded.
+
+Stable automatic installation remains disabled unless the build is signed, the manifest public key is embedded, and the platform apply path explicitly allows the artifact type.

--- a/lib/src/features/updater/domain/alera_update.dart
+++ b/lib/src/features/updater/domain/alera_update.dart
@@ -47,6 +47,7 @@ class AleraUpdateConfig with AleraUpdateConfigMappable {
     required this.channel,
     required this.autoInstallEnabled,
     required this.signedRelease,
+    this.manifestPublicKey = '',
   });
 
   static final Uri defaultArchiveUrl = Uri.parse(
@@ -63,6 +64,7 @@ class AleraUpdateConfig with AleraUpdateConfigMappable {
   final AleraUpdateChannel channel;
   final bool autoInstallEnabled;
   final bool signedRelease;
+  final String manifestPublicKey;
 
   static AleraUpdateConfig _resolvedEnvironmentConfig({
     required Uri? archiveUrl,
@@ -70,6 +72,7 @@ class AleraUpdateConfig with AleraUpdateConfigMappable {
     required AleraUpdateChannel channel,
     required bool autoInstallEnabled,
     required bool signedRelease,
+    required String manifestPublicKey,
   }) {
     return AleraUpdateConfig(
       archiveUrl: resolveUpdateConfigUriForTesting(
@@ -83,12 +86,14 @@ class AleraUpdateConfig with AleraUpdateConfigMappable {
       channel: channel,
       autoInstallEnabled: autoInstallEnabled,
       signedRelease: signedRelease,
+      manifestPublicKey: manifestPublicKey,
     );
   }
 
   bool get canAutoInstall {
     return autoInstallEnabled &&
-        (signedRelease || channel == AleraUpdateChannel.rc);
+        ((signedRelease && manifestPublicKey.trim().isNotEmpty) ||
+            channel == AleraUpdateChannel.rc);
   }
 
   factory AleraUpdateConfig.fromEnvironment() {
@@ -117,6 +122,9 @@ class AleraUpdateConfig with AleraUpdateConfigMappable {
         const bool.fromEnvironment('ALERA_UPDATE_AUTO_INSTALL_ENABLED'),
       ),
       signedRelease: const bool.fromEnvironment('ALERA_SIGNED_RELEASE'),
+      manifestPublicKey: const String.fromEnvironment(
+        'ALERA_UPDATE_MANIFEST_PUBLIC_KEY',
+      ),
     );
   }
 
@@ -150,6 +158,11 @@ class AleraUpdateInfo with AleraUpdateInfoMappable {
     required this.url,
     required this.platform,
     required this.changes,
+    this.installerKind = 'directory',
+    this.sha256,
+    this.size,
+    this.signatureBundleUrl,
+    this.provenanceUrl,
   });
 
   final String version;
@@ -160,6 +173,13 @@ class AleraUpdateInfo with AleraUpdateInfoMappable {
   final Uri url;
   final String platform;
   final List<String> changes;
+  final String installerKind;
+  final String? sha256;
+  final int? size;
+  @MappableField(hook: _UriStringHook())
+  final Uri? signatureBundleUrl;
+  @MappableField(hook: _UriStringHook())
+  final Uri? provenanceUrl;
 
   bool get isPrerelease => version.contains('-');
 

--- a/lib/src/features/updater/domain/alera_update.mapper.dart
+++ b/lib/src/features/updater/domain/alera_update.mapper.dart
@@ -166,6 +166,13 @@ class AleraUpdateConfigMapper extends ClassMapperBase<AleraUpdateConfig> {
     'signedRelease',
     _$signedRelease,
   );
+  static String _$manifestPublicKey(AleraUpdateConfig v) => v.manifestPublicKey;
+  static const Field<AleraUpdateConfig, String> _f$manifestPublicKey = Field(
+    'manifestPublicKey',
+    _$manifestPublicKey,
+    opt: true,
+    def: '',
+  );
 
   @override
   final MappableFields<AleraUpdateConfig> fields = const {
@@ -174,6 +181,7 @@ class AleraUpdateConfigMapper extends ClassMapperBase<AleraUpdateConfig> {
     #channel: _f$channel,
     #autoInstallEnabled: _f$autoInstallEnabled,
     #signedRelease: _f$signedRelease,
+    #manifestPublicKey: _f$manifestPublicKey,
   };
 
   static AleraUpdateConfig _instantiate(DecodingData data) {
@@ -183,6 +191,7 @@ class AleraUpdateConfigMapper extends ClassMapperBase<AleraUpdateConfig> {
       channel: data.dec(_f$channel),
       autoInstallEnabled: data.dec(_f$autoInstallEnabled),
       signedRelease: data.dec(_f$signedRelease),
+      manifestPublicKey: data.dec(_f$manifestPublicKey),
     );
   }
 
@@ -263,6 +272,7 @@ abstract class AleraUpdateConfigCopyWith<
     AleraUpdateChannel? channel,
     bool? autoInstallEnabled,
     bool? signedRelease,
+    String? manifestPublicKey,
   });
   AleraUpdateConfigCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(
     Then<$Out2, $R2> t,
@@ -284,6 +294,7 @@ class _AleraUpdateConfigCopyWithImpl<$R, $Out>
     AleraUpdateChannel? channel,
     bool? autoInstallEnabled,
     bool? signedRelease,
+    String? manifestPublicKey,
   }) => $apply(
     FieldCopyWithData({
       if (archiveUrl != null) #archiveUrl: archiveUrl,
@@ -291,6 +302,7 @@ class _AleraUpdateConfigCopyWithImpl<$R, $Out>
       if (channel != null) #channel: channel,
       if (autoInstallEnabled != null) #autoInstallEnabled: autoInstallEnabled,
       if (signedRelease != null) #signedRelease: signedRelease,
+      if (manifestPublicKey != null) #manifestPublicKey: manifestPublicKey,
     }),
   );
   @override
@@ -303,6 +315,10 @@ class _AleraUpdateConfigCopyWithImpl<$R, $Out>
       or: $value.autoInstallEnabled,
     ),
     signedRelease: data.get(#signedRelease, or: $value.signedRelease),
+    manifestPublicKey: data.get(
+      #manifestPublicKey,
+      or: $value.manifestPublicKey,
+    ),
   );
 
   @override
@@ -358,6 +374,39 @@ class AleraUpdateInfoMapper extends ClassMapperBase<AleraUpdateInfo> {
     'changes',
     _$changes,
   );
+  static String _$installerKind(AleraUpdateInfo v) => v.installerKind;
+  static const Field<AleraUpdateInfo, String> _f$installerKind = Field(
+    'installerKind',
+    _$installerKind,
+    opt: true,
+    def: 'directory',
+  );
+  static String? _$sha256(AleraUpdateInfo v) => v.sha256;
+  static const Field<AleraUpdateInfo, String> _f$sha256 = Field(
+    'sha256',
+    _$sha256,
+    opt: true,
+  );
+  static int? _$size(AleraUpdateInfo v) => v.size;
+  static const Field<AleraUpdateInfo, int> _f$size = Field(
+    'size',
+    _$size,
+    opt: true,
+  );
+  static Uri? _$signatureBundleUrl(AleraUpdateInfo v) => v.signatureBundleUrl;
+  static const Field<AleraUpdateInfo, Uri> _f$signatureBundleUrl = Field(
+    'signatureBundleUrl',
+    _$signatureBundleUrl,
+    opt: true,
+    hook: _UriStringHook(),
+  );
+  static Uri? _$provenanceUrl(AleraUpdateInfo v) => v.provenanceUrl;
+  static const Field<AleraUpdateInfo, Uri> _f$provenanceUrl = Field(
+    'provenanceUrl',
+    _$provenanceUrl,
+    opt: true,
+    hook: _UriStringHook(),
+  );
 
   @override
   final MappableFields<AleraUpdateInfo> fields = const {
@@ -368,6 +417,11 @@ class AleraUpdateInfoMapper extends ClassMapperBase<AleraUpdateInfo> {
     #url: _f$url,
     #platform: _f$platform,
     #changes: _f$changes,
+    #installerKind: _f$installerKind,
+    #sha256: _f$sha256,
+    #size: _f$size,
+    #signatureBundleUrl: _f$signatureBundleUrl,
+    #provenanceUrl: _f$provenanceUrl,
   };
 
   static AleraUpdateInfo _instantiate(DecodingData data) {
@@ -379,6 +433,11 @@ class AleraUpdateInfoMapper extends ClassMapperBase<AleraUpdateInfo> {
       url: data.dec(_f$url),
       platform: data.dec(_f$platform),
       changes: data.dec(_f$changes),
+      installerKind: data.dec(_f$installerKind),
+      sha256: data.dec(_f$sha256),
+      size: data.dec(_f$size),
+      signatureBundleUrl: data.dec(_f$signatureBundleUrl),
+      provenanceUrl: data.dec(_f$provenanceUrl),
     );
   }
 
@@ -453,6 +512,11 @@ abstract class AleraUpdateInfoCopyWith<$R, $In extends AleraUpdateInfo, $Out>
     Uri? url,
     String? platform,
     List<String>? changes,
+    String? installerKind,
+    String? sha256,
+    int? size,
+    Uri? signatureBundleUrl,
+    Uri? provenanceUrl,
   });
   AleraUpdateInfoCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(
     Then<$Out2, $R2> t,
@@ -483,6 +547,11 @@ class _AleraUpdateInfoCopyWithImpl<$R, $Out>
     Uri? url,
     String? platform,
     List<String>? changes,
+    String? installerKind,
+    Object? sha256 = $none,
+    Object? size = $none,
+    Object? signatureBundleUrl = $none,
+    Object? provenanceUrl = $none,
   }) => $apply(
     FieldCopyWithData({
       if (version != null) #version: version,
@@ -492,6 +561,11 @@ class _AleraUpdateInfoCopyWithImpl<$R, $Out>
       if (url != null) #url: url,
       if (platform != null) #platform: platform,
       if (changes != null) #changes: changes,
+      if (installerKind != null) #installerKind: installerKind,
+      if (sha256 != $none) #sha256: sha256,
+      if (size != $none) #size: size,
+      if (signatureBundleUrl != $none) #signatureBundleUrl: signatureBundleUrl,
+      if (provenanceUrl != $none) #provenanceUrl: provenanceUrl,
     }),
   );
   @override
@@ -503,6 +577,14 @@ class _AleraUpdateInfoCopyWithImpl<$R, $Out>
     url: data.get(#url, or: $value.url),
     platform: data.get(#platform, or: $value.platform),
     changes: data.get(#changes, or: $value.changes),
+    installerKind: data.get(#installerKind, or: $value.installerKind),
+    sha256: data.get(#sha256, or: $value.sha256),
+    size: data.get(#size, or: $value.size),
+    signatureBundleUrl: data.get(
+      #signatureBundleUrl,
+      or: $value.signatureBundleUrl,
+    ),
+    provenanceUrl: data.get(#provenanceUrl, or: $value.provenanceUrl),
   );
 
   @override

--- a/lib/src/features/updater/infra/desktop_update_service.dart
+++ b/lib/src/features/updater/infra/desktop_update_service.dart
@@ -179,7 +179,7 @@ String _linuxUpdateMessage(AleraUpdateChannel channel, AleraUpdateInfo update) {
 
 String _manualInstallBlockedMessage(AleraUpdateArchive archive) {
   if (archive.schemaVersion >= 2) {
-    return 'Update manifest is signed; automatic installer apply is pending for this artifact type.';
+    return 'Update manifest is signed; automatic installation is pending for this artifact type.';
   }
   return 'Automatic installation is blocked until stable releases are signed.';
 }

--- a/lib/src/features/updater/infra/desktop_update_service.dart
+++ b/lib/src/features/updater/infra/desktop_update_service.dart
@@ -50,7 +50,9 @@ class DesktopAleraUpdateService implements AleraUpdateService {
         message: 'Desktop updates are not available on $_platform.',
       );
     }
-    if (config.canAutoInstall) {
+    if (config.canAutoInstall &&
+        config.channel == AleraUpdateChannel.rc &&
+        !config.signedRelease) {
       return _checkWithDesktopUpdater();
     }
     return _checkManually();
@@ -87,7 +89,12 @@ class DesktopAleraUpdateService implements AleraUpdateService {
 
     final packageInfo = await _loadPackageInfo();
     final currentBuild = int.tryParse(packageInfo.buildNumber) ?? 0;
-    final archive = AleraUpdateArchive.fromJsonString(response.body);
+    final archive = config.signedRelease
+        ? await AleraUpdateArchive.fromSignedJsonString(
+            response.body,
+            publicKeyBase64: config.manifestPublicKey,
+          )
+        : AleraUpdateArchive.fromJsonString(response.body);
     final latest = archive.latestFor(
       platform: _platform,
       currentBuildNumber: currentBuild,
@@ -98,10 +105,18 @@ class DesktopAleraUpdateService implements AleraUpdateService {
       return const AleraUpdateCheckResult(message: 'Alera is up to date.');
     }
 
+    if (_platform == 'linux') {
+      return AleraUpdateCheckResult(
+        latest: latest,
+        message: _linuxUpdateMessage(config.channel, latest),
+      );
+    }
+
     return AleraUpdateCheckResult(
       latest: latest,
+      autoInstallAllowed: config.canAutoInstall && archive.schemaVersion == 1,
       message: config.autoInstallEnabled
-          ? 'Automatic installation is blocked until stable releases are signed.'
+          ? _manualInstallBlockedMessage(archive)
           : 'Update ${latest.version} is available for manual download.',
     );
   }
@@ -152,6 +167,21 @@ class DesktopAleraUpdateService implements AleraUpdateService {
       _client.close();
     }
   }
+}
+
+String _linuxUpdateMessage(AleraUpdateChannel channel, AleraUpdateInfo update) {
+  if (channel == AleraUpdateChannel.stable &&
+      (update.installerKind == 'deb' || update.installerKind == 'rpm')) {
+    return 'Update ${update.version} is available through the Linux package repository.';
+  }
+  return 'Update ${update.version} is available for manual download.';
+}
+
+String _manualInstallBlockedMessage(AleraUpdateArchive archive) {
+  if (archive.schemaVersion >= 2) {
+    return 'Update manifest is signed; automatic installer apply is pending for this artifact type.';
+  }
+  return 'Automatic installation is blocked until stable releases are signed.';
 }
 
 AleraUpdateInfo _fromItemModel(ItemModel item) {

--- a/lib/src/features/updater/infra/update_archive.dart
+++ b/lib/src/features/updater/infra/update_archive.dart
@@ -43,11 +43,14 @@ class AleraUpdateArchive {
       schemaVersion: schemaVersion,
       items: [
         for (final item in items)
-          if (item is Map)
-            ..._itemsFromJson(
-              Map<String, Object?>.from(item),
+          ..._itemsFromJson(
+            _archiveEntryAsMap(
+              item,
+              collectionName: 'items',
               schemaVersion: schemaVersion,
             ),
+            schemaVersion: schemaVersion,
+          ),
       ],
     );
   }
@@ -87,24 +90,57 @@ List<AleraUpdateInfo> _itemsFromJson(
   required int schemaVersion,
 }) {
   final artifacts = json['artifacts'];
-  if (schemaVersion >= 2 && artifacts is List && artifacts.isNotEmpty) {
+  if (schemaVersion >= 2 && artifacts != null) {
+    if (artifacts is! List) {
+      throw FormatException(
+        'artifacts must be a JSON array for schemaVersion $schemaVersion.',
+      );
+    }
+    if (artifacts.isEmpty) {
+      return [_itemFromJson(json, schemaVersion: schemaVersion)];
+    }
     return [
       for (final artifact in artifacts)
-        if (artifact is Map)
-          _itemFromJson(json, artifact: Map<String, Object?>.from(artifact)),
+        _itemFromJson(
+          json,
+          schemaVersion: schemaVersion,
+          artifact: _archiveEntryAsMap(
+            artifact,
+            collectionName: 'artifacts',
+            schemaVersion: schemaVersion,
+          ),
+        ),
     ];
   }
-  return [_itemFromJson(json)];
+  return [_itemFromJson(json, schemaVersion: schemaVersion)];
 }
 
 AleraUpdateInfo _itemFromJson(
   Map<String, Object?> json, {
+  required int schemaVersion,
   Map<String, Object?>? artifact,
 }) {
   final source = artifact ?? json;
   final url = _requiredString(source, 'url');
+  final sha256 = _optionalString(source['sha256']);
   final size = _optionalInt(source['size']);
-  if (size != null && size <= 0) {
+  if (schemaVersion >= 2) {
+    if (sha256 == null) {
+      throw const FormatException(
+        'sha256 is required for schema v2 artifacts.',
+      );
+    }
+    if (!_sha256Pattern.hasMatch(sha256)) {
+      throw const FormatException(
+        'sha256 must be a lowercase hex SHA-256 for schema v2 artifacts.',
+      );
+    }
+    if (size == null || size <= 0) {
+      throw const FormatException(
+        'size must be a positive integer for schema v2 artifacts.',
+      );
+    }
+  } else if (size != null && size <= 0) {
     throw const FormatException('size must be a positive integer.');
   }
   return AleraUpdateInfo(
@@ -116,10 +152,26 @@ AleraUpdateInfo _itemFromJson(
     platform: _requiredString(source, 'platform'),
     changes: _changesFromJson(json['changes']),
     installerKind: _optionalString(source['installerKind']) ?? 'directory',
-    sha256: _optionalString(source['sha256']),
+    sha256: sha256,
     size: size,
     signatureBundleUrl: _optionalUri(source['signatureBundleUrl']),
     provenanceUrl: _optionalUri(source['provenanceUrl']),
+  );
+}
+
+final RegExp _sha256Pattern = RegExp(r'^[0-9a-f]{64}$');
+
+Map<String, Object?> _archiveEntryAsMap(
+  Object? value, {
+  required String collectionName,
+  required int schemaVersion,
+}) {
+  if (value is Map) {
+    return Map<String, Object?>.from(value);
+  }
+  throw FormatException(
+    'Each $collectionName entry must be a JSON object for '
+    'schemaVersion $schemaVersion: $value.',
   );
 }
 

--- a/lib/src/features/updater/infra/update_archive.dart
+++ b/lib/src/features/updater/infra/update_archive.dart
@@ -1,9 +1,14 @@
 import 'dart:convert';
 
 import 'package:alera/src/features/updater/domain/alera_update.dart';
+import 'package:alera/src/features/updater/infra/update_manifest_signature.dart';
 
 class AleraUpdateArchive {
-  const AleraUpdateArchive({required this.appName, required this.items});
+  const AleraUpdateArchive({
+    required this.appName,
+    required this.items,
+    this.schemaVersion = 1,
+  });
 
   factory AleraUpdateArchive.fromJsonString(String source) {
     final decoded = jsonDecode(source);
@@ -13,21 +18,42 @@ class AleraUpdateArchive {
     return AleraUpdateArchive.fromJson(Map<String, Object?>.from(decoded));
   }
 
+  static Future<AleraUpdateArchive> fromSignedJsonString(
+    String source, {
+    required String publicKeyBase64,
+  }) async {
+    final verified = await verifyAleraManifestSignature(
+      manifestJson: source,
+      publicKeyBase64: publicKeyBase64,
+    );
+    if (!verified) {
+      throw const FormatException('Update manifest signature is invalid.');
+    }
+    return AleraUpdateArchive.fromJsonString(source);
+  }
+
   factory AleraUpdateArchive.fromJson(Map<String, Object?> json) {
+    final schemaVersion = _optionalInt(json['schemaVersion']) ?? 1;
     final items = json['items'];
     if (items is! List) {
       throw const FormatException('Update archive must contain items.');
     }
     return AleraUpdateArchive(
       appName: _optionalString(json['appName']) ?? 'Alera',
+      schemaVersion: schemaVersion,
       items: [
         for (final item in items)
-          if (item is Map) _itemFromJson(Map<String, Object?>.from(item)),
+          if (item is Map)
+            ..._itemsFromJson(
+              Map<String, Object?>.from(item),
+              schemaVersion: schemaVersion,
+            ),
       ],
     );
   }
 
   final String appName;
+  final int schemaVersion;
   final List<AleraUpdateInfo> items;
 
   AleraUpdateInfo? latestFor({
@@ -56,15 +82,44 @@ class AleraUpdateArchive {
   }
 }
 
-AleraUpdateInfo _itemFromJson(Map<String, Object?> json) {
+List<AleraUpdateInfo> _itemsFromJson(
+  Map<String, Object?> json, {
+  required int schemaVersion,
+}) {
+  final artifacts = json['artifacts'];
+  if (schemaVersion >= 2 && artifacts is List && artifacts.isNotEmpty) {
+    return [
+      for (final artifact in artifacts)
+        if (artifact is Map)
+          _itemFromJson(json, artifact: Map<String, Object?>.from(artifact)),
+    ];
+  }
+  return [_itemFromJson(json)];
+}
+
+AleraUpdateInfo _itemFromJson(
+  Map<String, Object?> json, {
+  Map<String, Object?>? artifact,
+}) {
+  final source = artifact ?? json;
+  final url = _requiredString(source, 'url');
+  final size = _optionalInt(source['size']);
+  if (size != null && size <= 0) {
+    throw const FormatException('size must be a positive integer.');
+  }
   return AleraUpdateInfo(
     version: _requiredString(json, 'version'),
     shortVersion: _requiredInt(json, 'shortVersion'),
     date: _requiredString(json, 'date'),
     mandatory: _requiredBool(json, 'mandatory'),
-    url: Uri.parse(_requiredString(json, 'url')),
-    platform: _requiredString(json, 'platform'),
+    url: Uri.parse(url),
+    platform: _requiredString(source, 'platform'),
     changes: _changesFromJson(json['changes']),
+    installerKind: _optionalString(source['installerKind']) ?? 'directory',
+    sha256: _optionalString(source['sha256']),
+    size: size,
+    signatureBundleUrl: _optionalUri(source['signatureBundleUrl']),
+    provenanceUrl: _optionalUri(source['provenanceUrl']),
   );
 }
 
@@ -97,6 +152,14 @@ String? _optionalString(Object? value) {
 
 int _requiredInt(Map<String, Object?> json, String key) {
   final value = json[key];
+  final parsed = _optionalInt(value);
+  if (parsed != null) {
+    return parsed;
+  }
+  throw FormatException('$key must be an integer.');
+}
+
+int? _optionalInt(Object? value) {
   if (value is int) {
     return value;
   }
@@ -106,7 +169,7 @@ int _requiredInt(Map<String, Object?> json, String key) {
       return parsed;
     }
   }
-  throw FormatException('$key must be an integer.');
+  return null;
 }
 
 bool _requiredBool(Map<String, Object?> json, String key) {
@@ -115,4 +178,12 @@ bool _requiredBool(Map<String, Object?> json, String key) {
     return value;
   }
   throw FormatException('$key must be a boolean.');
+}
+
+Uri? _optionalUri(Object? value) {
+  final raw = _optionalString(value);
+  if (raw == null) {
+    return null;
+  }
+  return Uri.parse(raw);
 }

--- a/lib/src/features/updater/infra/update_manifest_signature.dart
+++ b/lib/src/features/updater/infra/update_manifest_signature.dart
@@ -1,0 +1,135 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:cryptography/cryptography.dart';
+
+const String aleraManifestSignatureKey = 'signature';
+const String aleraManifestSignatureAlgorithm = 'ed25519';
+
+class AleraManifestSignature {
+  const AleraManifestSignature({
+    required this.algorithm,
+    required this.publicKeyId,
+    required this.signature,
+  });
+
+  factory AleraManifestSignature.fromJson(Object? value) {
+    if (value is! Map) {
+      throw const FormatException('Manifest signature must be an object.');
+    }
+    final json = Map<String, Object?>.from(value);
+    final algorithm = _requiredString(json, 'algorithm');
+    if (algorithm != aleraManifestSignatureAlgorithm) {
+      throw FormatException(
+        'Unsupported manifest signature algorithm: $algorithm.',
+      );
+    }
+    return AleraManifestSignature(
+      algorithm: algorithm,
+      publicKeyId: _requiredString(json, 'publicKeyId'),
+      signature: _requiredString(json, 'signature'),
+    );
+  }
+
+  final String algorithm;
+  final String publicKeyId;
+  final String signature;
+
+  Map<String, Object?> toJson() {
+    return <String, Object?>{
+      'algorithm': algorithm,
+      'publicKeyId': publicKeyId,
+      'signature': signature,
+    };
+  }
+}
+
+Future<bool> verifyAleraManifestSignature({
+  required String manifestJson,
+  required String publicKeyBase64,
+}) async {
+  if (publicKeyBase64.trim().isEmpty) {
+    throw const FormatException('A manifest public key is required.');
+  }
+
+  final decoded = jsonDecode(manifestJson);
+  if (decoded is! Map) {
+    throw const FormatException('Update manifest must be a JSON object.');
+  }
+  final manifest = Map<String, Object?>.from(decoded);
+  final signature = AleraManifestSignature.fromJson(
+    manifest[aleraManifestSignatureKey],
+  );
+  final signatureBytes = base64Decode(signature.signature);
+  final publicKeyBytes = base64Decode(publicKeyBase64);
+  final payload = canonicalAleraManifestPayload(manifest);
+  final algorithm = Ed25519();
+  return algorithm.verify(
+    utf8.encode(payload),
+    signature: Signature(
+      signatureBytes,
+      publicKey: SimplePublicKey(publicKeyBytes, type: KeyPairType.ed25519),
+    ),
+  );
+}
+
+Future<Map<String, Object?>> signAleraManifest({
+  required Map<String, Object?> manifest,
+  required String privateKeyBase64,
+  required String publicKeyBase64,
+  required String publicKeyId,
+}) async {
+  final unsigned = Map<String, Object?>.from(manifest)
+    ..remove(aleraManifestSignatureKey);
+  final privateKeyBytes = base64Decode(privateKeyBase64);
+  final publicKeyBytes = base64Decode(publicKeyBase64);
+  final keyPair = SimpleKeyPairData(
+    privateKeyBytes,
+    publicKey: SimplePublicKey(publicKeyBytes, type: KeyPairType.ed25519),
+    type: KeyPairType.ed25519,
+  );
+  final signature = await Ed25519().sign(
+    utf8.encode(canonicalAleraManifestPayload(unsigned)),
+    keyPair: keyPair,
+  );
+  return <String, Object?>{
+    ...unsigned,
+    aleraManifestSignatureKey: AleraManifestSignature(
+      algorithm: aleraManifestSignatureAlgorithm,
+      publicKeyId: publicKeyId,
+      signature: base64Encode(signature.bytes),
+    ).toJson(),
+  };
+}
+
+String canonicalAleraManifestPayload(Map<String, Object?> manifest) {
+  final unsigned = Map<String, Object?>.from(manifest)
+    ..remove(aleraManifestSignatureKey);
+  return jsonEncode(_canonicalValue(unsigned));
+}
+
+Object? _canonicalValue(Object? value) {
+  if (value is Map) {
+    final sorted = <String, Object?>{};
+    final keys = value.keys.map((key) => key.toString()).toList()..sort();
+    for (final key in keys) {
+      sorted[key] = _canonicalValue(value[key]);
+    }
+    return sorted;
+  }
+  if (value is List) {
+    return <Object?>[for (final item in value) _canonicalValue(item)];
+  }
+  if (value is Uint8List) {
+    return base64Encode(value);
+  }
+  return value;
+}
+
+String _requiredString(Map<String, Object?> json, String key) {
+  final value = json[key];
+  if (value is String && value.trim().isNotEmpty) {
+    return value;
+  }
+  throw FormatException('$key must be a non-empty string.');
+}

--- a/lib/src/features/updater/infra/update_manifest_signature.dart
+++ b/lib/src/features/updater/infra/update_manifest_signature.dart
@@ -79,6 +79,10 @@ Future<Map<String, Object?>> signAleraManifest({
   required String publicKeyBase64,
   required String publicKeyId,
 }) async {
+  final normalizedPublicKeyId = publicKeyId.trim();
+  if (normalizedPublicKeyId.isEmpty) {
+    throw const FormatException('publicKeyId must be a non-empty string.');
+  }
   final unsigned = Map<String, Object?>.from(manifest)
     ..remove(aleraManifestSignatureKey);
   final privateKeyBytes = base64Decode(privateKeyBase64);
@@ -96,7 +100,7 @@ Future<Map<String, Object?>> signAleraManifest({
     ...unsigned,
     aleraManifestSignatureKey: AleraManifestSignature(
       algorithm: aleraManifestSignatureAlgorithm,
-      publicKeyId: publicKeyId,
+      publicKeyId: normalizedPublicKeyId,
       signature: base64Encode(signature.bytes),
     ).toJson(),
   };

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -264,6 +264,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.7"
+  cryptography:
+    dependency: "direct main"
+    description:
+      name: cryptography
+      sha256: "3eda3029d34ec9095a27a198ac9785630fe525c0eb6a49f3d575272f8e792ef0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.9.0"
   cryptography_flutter_plus:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,6 +37,7 @@ dependencies:
   flutter_local_notifications: ^21.0.0
   window_manager: ^0.5.1
   crypto: ^3.0.6
+  cryptography: ^2.7.0
   alera_native:
     path: rust_builder
   flutter_rust_bridge: 2.12.0

--- a/readme.md
+++ b/readme.md
@@ -177,6 +177,7 @@ Want to contribute or hack on Alera locally? Start with:
 
 - [`AGENTS.md`](AGENTS.md): contributor and agent governance rules
 - [`docs/architecture.md`](docs/architecture.md): architecture glossary and naming rules
+- [`docs/release-trust.md`](docs/release-trust.md): release signing, Linux package trust, and update manifest verification
 - [`docs/testing.md`](docs/testing.md): unit, widget, golden, E2E, and coverage workflow
 - [`docs/ui-styleguide.md`](docs/ui-styleguide.md): design tokens and UI rules
 
@@ -216,11 +217,12 @@ See [`lib/src/core/build_flavor.dart`](lib/src/core/build_flavor.dart) for the c
 
 ## Releases and updates
 
-Public release cuts are maintainer-managed through GitHub Actions. Stable builds can detect new releases and open the manual download page; automatic stable installation stays disabled until release builds are signed and trusted for the target platform. Release-candidate builds may opt into automatic installation through explicit build flags.
+Public release cuts are maintainer-managed through GitHub Actions. Release artifacts are signed or packaged for platform trust, and the public update indexes are Ed25519-signed schema v2 manifests with SHA-256 metadata for each artifact. Stable automatic installation stays disabled unless the release build embeds the manifest public key and the platform apply path explicitly allows the artifact type. Stable Linux updates are installed through signed package repositories; release-candidate Linux builds remain manual downloads.
 
 - Stable manifest: `https://updates.alera.build/app-archive.json`
 - Release-candidate manifest: `https://updates.alera.build/app-archive-rc.json`
 - Updater payloads are hosted in Cloudflare R2 under `updates/stable/` and `updates/rc/`
+- Stable Linux repositories are hosted in Cloudflare R2 under `linux/apt/` and `linux/rpm/`
 - [GitHub Releases](https://github.com/leynier/alera/releases) remain the manual download surface
 
 ---

--- a/test/unit/desktop_update_service_test.dart
+++ b/test/unit/desktop_update_service_test.dart
@@ -1,7 +1,10 @@
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:alera/src/features/updater/domain/alera_update.dart';
 import 'package:alera/src/features/updater/infra/desktop_update_service.dart';
+import 'package:alera/src/features/updater/infra/update_manifest_signature.dart';
+import 'package:cryptography/cryptography.dart';
 import 'package:desktop_updater/desktop_updater.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
@@ -124,6 +127,71 @@ void main() {
 
         expect(notPublishedResult.message, 'No update index is published yet.');
         expect(upToDateResult.message, 'Alera is up to date.');
+      },
+    );
+
+    test(
+      'verifies signed manifests and routes Linux updates through packages',
+      () async {
+        final signed = await _signedArchiveV2Json();
+        final service = DesktopAleraUpdateService(
+          config: AleraUpdateConfig(
+            archiveUrl: Uri.parse('https://example.com/archive.json'),
+            releasePageUrl: Uri.parse('https://example.com/releases'),
+            channel: AleraUpdateChannel.stable,
+            autoInstallEnabled: true,
+            signedRelease: true,
+            manifestPublicKey: signed.publicKey,
+          ),
+          client: MockClient((_) async => http.Response(signed.manifest, 200)),
+          loadPackageInfo: () async => _packageInfo(buildNumber: '1'),
+          platform: 'linux',
+        );
+
+        final result = await service.checkForUpdates();
+
+        expect(result.latest?.version, '1.0.0');
+        expect(result.latest?.installerKind, 'deb');
+        expect(result.autoInstallAllowed, isFalse);
+        expect(
+          result.message,
+          'Update 1.0.0 is available through the Linux package repository.',
+        );
+      },
+    );
+
+    test(
+      'routes Linux release-candidate tarballs to manual download',
+      () async {
+        final signed = await _signedArchiveV2Json(
+          channel: 'rc',
+          version: '1.0.0-rc.0',
+          installerKind: 'tar.gz',
+          artifactUrl: 'https://example.com/alera-linux.tar.gz',
+        );
+        final service = DesktopAleraUpdateService(
+          config: AleraUpdateConfig(
+            archiveUrl: Uri.parse('https://example.com/archive-rc.json'),
+            releasePageUrl: Uri.parse('https://example.com/releases'),
+            channel: AleraUpdateChannel.rc,
+            autoInstallEnabled: true,
+            signedRelease: true,
+            manifestPublicKey: signed.publicKey,
+          ),
+          client: MockClient((_) async => http.Response(signed.manifest, 200)),
+          loadPackageInfo: () async => _packageInfo(buildNumber: '1'),
+          platform: 'linux',
+        );
+
+        final result = await service.checkForUpdates();
+
+        expect(result.latest?.version, '1.0.0-rc.0');
+        expect(result.latest?.installerKind, 'tar.gz');
+        expect(result.autoInstallAllowed, isFalse);
+        expect(
+          result.message,
+          'Update 1.0.0-rc.0 is available for manual download.',
+        );
       },
     );
 
@@ -347,6 +415,32 @@ PackageInfo _packageInfo({required String buildNumber}) {
   );
 }
 
+Future<({String manifest, String publicKey})> _signedArchiveV2Json({
+  String channel = 'stable',
+  String version = '1.0.0',
+  String installerKind = 'deb',
+  String artifactUrl = 'https://example.com/alera.deb',
+}) async {
+  final keyPair = await Ed25519().newKeyPairFromSeed(List.filled(32, 2));
+  final keyData = await keyPair.extract();
+  final publicKeyData = await keyPair.extractPublicKey();
+  final privateKey = base64Encode(keyData.bytes);
+  final publicKey = base64Encode(publicKeyData.bytes);
+  final decoded = _archiveV2Json(
+    channel: channel,
+    version: version,
+    installerKind: installerKind,
+    artifactUrl: artifactUrl,
+  );
+  final signed = await signAleraManifest(
+    manifest: decoded,
+    privateKeyBase64: privateKey,
+    publicKeyBase64: publicKey,
+    publicKeyId: 'test-key',
+  );
+  return (manifest: jsonEncode(signed), publicKey: publicKey);
+}
+
 ItemModel _item({
   required String version,
   required int shortVersion,
@@ -450,3 +544,37 @@ const String _archiveJson = '''
   ]
 }
 ''';
+
+Map<String, Object?> _archiveV2Json({
+  required String channel,
+  required String version,
+  required String installerKind,
+  required String artifactUrl,
+}) {
+  return <String, Object?>{
+    'schemaVersion': 2,
+    'appName': 'Alera',
+    'description': 'Alera desktop agentic development environment.',
+    'channel': channel,
+    'version': version,
+    'buildNumber': 10,
+    'publishedAt': '2026-06-06T00:00:00Z',
+    'items': <Object?>[
+      <String, Object?>{
+        'version': version,
+        'shortVersion': 10,
+        'changes': <Object?>[
+          <String, Object?>{'type': 'fix', 'message': 'Fix release.'},
+        ],
+        'date': '2026-06-06',
+        'mandatory': false,
+        'platform': 'linux',
+        'installerKind': installerKind,
+        'url': artifactUrl,
+        'sha256':
+            'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        'size': 42,
+      },
+    ],
+  };
+}

--- a/test/unit/release_app_archive_scripts_test.dart
+++ b/test/unit/release_app_archive_scripts_test.dart
@@ -1,0 +1,214 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:cryptography/cryptography.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+
+void main() {
+  group('release archive scripts', () {
+    test(
+      'builds and verifies a stable manifest without sidecar URLs',
+      () async {
+        final temp = await Directory.systemTemp.createTemp('alera-release-');
+        addTearDown(() => temp.deleteSync(recursive: true));
+        _writeArtifact(
+          temp,
+          'stable',
+          '1.2.3+99-macos',
+          'alera-1.2.3-macos.tar.gz',
+        );
+        _writeArtifact(
+          temp,
+          'stable',
+          '1.2.3+99-windows',
+          'alera-1.2.3-windows.tar.gz',
+        );
+        _writeArtifact(
+          temp,
+          'stable',
+          '1.2.3+99-linux',
+          'alera-1.2.3-linux.deb',
+        );
+        _writeArtifact(
+          temp,
+          'stable',
+          '1.2.3+99-linux',
+          'alera-1.2.3-linux.rpm',
+        );
+        final output = p.join(temp.path, 'public', 'app-archive.json');
+        final keys = await _signingKeys(seed: 4);
+
+        await _runDartScript(
+          'tool/release/build_app_archive.dart',
+          <String>[output],
+          environment: _archiveEnvironment(temp, channel: 'stable'),
+        );
+        await _runDartScript('tool/release/sign_app_archive.dart', <String>[
+          output,
+        ], environment: keys.toEnvironment());
+        await _runDartScript(
+          'tool/release/verify_app_archive.dart',
+          <String>[output],
+          environment: <String, String>{
+            'ALERA_UPDATE_MANIFEST_PUBLIC_KEY': keys.publicKey,
+          },
+        );
+
+        final manifest = jsonDecode(File(output).readAsStringSync()) as Map;
+        final items = manifest['items'] as List;
+        expect(items, hasLength(4));
+        for (final item in items.cast<Map>()) {
+          expect(item, contains('url'));
+          expect(item, contains('platform'));
+          expect(item, contains('installerKind'));
+          expect(item, contains('sha256'));
+          expect(item, contains('size'));
+          expect(item, isNot(contains('artifacts')));
+          expect(item, isNot(contains('signatureBundleUrl')));
+          expect(item, isNot(contains('provenanceUrl')));
+        }
+        _expectLegacyArchiveShape(manifest);
+      },
+    );
+
+    test('verifies rc manifests without Linux packages', () async {
+      final temp = await Directory.systemTemp.createTemp('alera-release-');
+      addTearDown(() => temp.deleteSync(recursive: true));
+      _writeArtifact(
+        temp,
+        'rc',
+        '1.2.3+99-macos',
+        'alera-1.2.3-rc.0-macos.tar.gz',
+      );
+      _writeArtifact(
+        temp,
+        'rc',
+        '1.2.3+99-windows',
+        'alera-1.2.3-rc.0-windows.tar.gz',
+      );
+      _writeArtifact(
+        temp,
+        'rc',
+        '1.2.3+99-linux',
+        'alera-1.2.3-rc.0-linux.tar.gz',
+      );
+      final output = p.join(temp.path, 'public', 'app-archive-rc.json');
+      final keys = await _signingKeys(seed: 5);
+
+      await _runDartScript(
+        'tool/release/build_app_archive.dart',
+        <String>[output],
+        environment: _archiveEnvironment(
+          temp,
+          channel: 'rc',
+          releaseVersion: '1.2.3-rc.0',
+        ),
+      );
+      await _runDartScript('tool/release/sign_app_archive.dart', <String>[
+        output,
+      ], environment: keys.toEnvironment());
+      await _runDartScript(
+        'tool/release/verify_app_archive.dart',
+        <String>[output],
+        environment: <String, String>{
+          'ALERA_UPDATE_MANIFEST_PUBLIC_KEY': keys.publicKey,
+        },
+      );
+
+      final manifest = jsonDecode(File(output).readAsStringSync()) as Map;
+      expect(manifest['channel'], 'rc');
+      final items = manifest['items'] as List;
+      expect(
+        items.cast<Map>().where((item) => item['platform'] == 'linux'),
+        contains(predicate<Map>((item) => item['installerKind'] == 'tar.gz')),
+      );
+      _expectLegacyArchiveShape(manifest);
+    });
+  });
+}
+
+void _expectLegacyArchiveShape(Map<Object?, Object?> manifest) {
+  final items = manifest['items'];
+  expect(items, isA<List>());
+  for (final item in (items! as List).cast<Map>()) {
+    expect(item['version'], isA<String>());
+    expect(item['shortVersion'], isA<int>());
+    expect(item['changes'], isA<List>());
+    expect(item['date'], isA<String>());
+    expect(item['mandatory'], isA<bool>());
+    expect(item['url'], isA<String>());
+    expect(item['platform'], isA<String>());
+  }
+}
+
+Map<String, String> _archiveEnvironment(
+  Directory temp, {
+  required String channel,
+  String releaseVersion = '1.2.3',
+}) {
+  return <String, String>{
+    'ALERA_RELEASE_VERSION': releaseVersion,
+    'ALERA_ARTIFACT_VERSION': '1.2.3',
+    'ALERA_RELEASE_BUILD_NUMBER': '99',
+    'ALERA_UPDATE_BASE_URL': 'https://updates.example.test',
+    'ALERA_UPDATE_PATH_PREFIX': 'updates/$channel',
+    'ALERA_RELEASE_PUBLIC_DIR': p.join(temp.path, 'public'),
+  };
+}
+
+void _writeArtifact(
+  Directory temp,
+  String channel,
+  String folder,
+  String name,
+) {
+  final file = File(
+    p.join(temp.path, 'public', 'updates', channel, folder, name),
+  );
+  file.parent.createSync(recursive: true);
+  file.writeAsStringSync(name);
+}
+
+Future<void> _runDartScript(
+  String script,
+  List<String> args, {
+  Map<String, String>? environment,
+}) async {
+  final result = await Process.run(
+    'dart',
+    <String>[script, ...args],
+    workingDirectory: Directory.current.path,
+    environment: environment,
+  );
+  if (result.exitCode != 0) {
+    fail(
+      '$script failed with ${result.exitCode}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}',
+    );
+  }
+}
+
+Future<_SigningKeys> _signingKeys({required int seed}) async {
+  final keyPair = await Ed25519().newKeyPairFromSeed(List.filled(32, seed));
+  final keyData = await keyPair.extract();
+  final publicKeyData = await keyPair.extractPublicKey();
+  return _SigningKeys(
+    privateKey: base64Encode(keyData.bytes),
+    publicKey: base64Encode(publicKeyData.bytes),
+  );
+}
+
+class _SigningKeys {
+  const _SigningKeys({required this.privateKey, required this.publicKey});
+
+  final String privateKey;
+  final String publicKey;
+
+  Map<String, String> toEnvironment() {
+    return <String, String>{
+      'ALERA_UPDATE_MANIFEST_PRIVATE_KEY': privateKey,
+      'ALERA_UPDATE_MANIFEST_PUBLIC_KEY': publicKey,
+      'ALERA_UPDATE_MANIFEST_PUBLIC_KEY_ID': 'test-key',
+    };
+  }
+}

--- a/test/unit/update_archive_test.dart
+++ b/test/unit/update_archive_test.dart
@@ -1,5 +1,9 @@
+import 'dart:convert';
+
 import 'package:alera/src/features/updater/domain/alera_update.dart';
 import 'package:alera/src/features/updater/infra/update_archive.dart';
+import 'package:alera/src/features/updater/infra/update_manifest_signature.dart';
+import 'package:cryptography/cryptography.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -119,6 +123,55 @@ void main() {
         throwsFormatException,
       );
     });
+
+    test('parses schema v2 items with integrity metadata', () {
+      final archive = AleraUpdateArchive.fromJsonString(_archiveV2Json);
+
+      final linux = archive.latestFor(
+        platform: 'linux',
+        currentBuildNumber: 1,
+        channel: AleraUpdateChannel.stable,
+      );
+
+      expect(archive.schemaVersion, 2);
+      expect(archive.items, hasLength(3));
+      expect(linux?.installerKind, 'deb');
+      expect(linux?.sha256, startsWith('aaaaaaaa'));
+      expect(linux?.size, 42);
+      expect(linux?.signatureBundleUrl, isNull);
+      expect(linux?.provenanceUrl, isNull);
+    });
+
+    test('verifies signed schema v2 manifests', () async {
+      final keyPair = await Ed25519().newKeyPairFromSeed(List.filled(32, 1));
+      final keyData = await keyPair.extract();
+      final publicKeyData = await keyPair.extractPublicKey();
+      final privateKey = base64Encode(keyData.bytes);
+      final publicKey = base64Encode(publicKeyData.bytes);
+      final decoded = Map<String, Object?>.from(jsonDecode(_archiveV2Json));
+      final signed = await signAleraManifest(
+        manifest: decoded,
+        privateKeyBase64: privateKey,
+        publicKeyBase64: publicKey,
+        publicKeyId: 'test-key',
+      );
+
+      final archive = await AleraUpdateArchive.fromSignedJsonString(
+        jsonEncode(signed),
+        publicKeyBase64: publicKey,
+      );
+
+      expect(archive.schemaVersion, 2);
+
+      final tampered = Map<String, Object?>.from(signed)..['version'] = '9.9.9';
+      await expectLater(
+        AleraUpdateArchive.fromSignedJsonString(
+          jsonEncode(tampered),
+          publicKeyBase64: publicKey,
+        ),
+        throwsFormatException,
+      );
+    });
   });
 }
 
@@ -162,6 +215,56 @@ const String _archiveJson = '''
       "mandatory": false,
       "url": "https://example.com/updates/0.1.1+2-linux",
       "platform": "linux"
+    }
+  ]
+}
+''';
+
+const String _archiveV2Json = '''
+{
+  "schemaVersion": 2,
+  "appName": "Alera",
+  "description": "Alera desktop agentic development environment.",
+  "channel": "stable",
+  "version": "1.0.0",
+  "buildNumber": 10,
+  "publishedAt": "2026-06-06T00:00:00Z",
+  "items": [
+    {
+      "version": "1.0.0",
+      "shortVersion": 10,
+      "changes": [{"type": "fix", "message": "Fix release."}],
+      "date": "2026-06-06",
+      "mandatory": false,
+      "platform": "macos",
+      "installerKind": "tar.gz",
+      "url": "https://example.com/alera-macos.tar.gz",
+      "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "size": 40
+    },
+    {
+      "version": "1.0.0",
+      "shortVersion": 10,
+      "changes": [{"type": "fix", "message": "Fix release."}],
+      "date": "2026-06-06",
+      "mandatory": false,
+      "platform": "linux",
+      "installerKind": "deb",
+      "url": "https://example.com/alera.deb",
+      "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "size": 42
+    },
+    {
+      "version": "1.0.0",
+      "shortVersion": 10,
+      "changes": [{"type": "fix", "message": "Fix release."}],
+      "date": "2026-06-06",
+      "mandatory": false,
+      "platform": "linux",
+      "installerKind": "rpm",
+      "url": "https://example.com/alera.rpm",
+      "sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "size": 43
     }
   ]
 }

--- a/test/unit/update_archive_test.dart
+++ b/test/unit/update_archive_test.dart
@@ -142,6 +142,74 @@ void main() {
       expect(linux?.provenanceUrl, isNull);
     });
 
+    test('rejects malformed schema entries instead of dropping them', () {
+      expect(
+        () => AleraUpdateArchive.fromJson(<String, Object?>{
+          'schemaVersion': 2,
+          'items': <Object?>['not-an-object'],
+        }),
+        throwsFormatException,
+      );
+
+      expect(
+        () => AleraUpdateArchive.fromJson(<String, Object?>{
+          'schemaVersion': 2,
+          'items': <Object?>[
+            <String, Object?>{
+              'version': '1.0.0',
+              'shortVersion': 10,
+              'changes': <Object?>[],
+              'date': '2026-06-06',
+              'mandatory': false,
+              'artifacts': <Object?>['not-an-object'],
+            },
+          ],
+        }),
+        throwsFormatException,
+      );
+    });
+
+    test('requires schema v2 integrity metadata', () {
+      final missingSha = Map<String, Object?>.from(jsonDecode(_archiveV2Json));
+      final missingShaItems = List<Object?>.from(missingSha['items'] as List);
+      final missingShaItem = Map<String, Object?>.from(
+        missingShaItems.first as Map,
+      )..remove('sha256');
+      missingShaItems[0] = missingShaItem;
+      missingSha['items'] = missingShaItems;
+
+      expect(
+        () => AleraUpdateArchive.fromJson(missingSha),
+        throwsFormatException,
+      );
+
+      final invalidSize = Map<String, Object?>.from(jsonDecode(_archiveV2Json));
+      final invalidSizeItems = List<Object?>.from(invalidSize['items'] as List);
+      final invalidSizeItem = Map<String, Object?>.from(
+        invalidSizeItems.first as Map,
+      )..['size'] = 0;
+      invalidSizeItems[0] = invalidSizeItem;
+      invalidSize['items'] = invalidSizeItems;
+
+      expect(
+        () => AleraUpdateArchive.fromJson(invalidSize),
+        throwsFormatException,
+      );
+
+      final invalidSha = Map<String, Object?>.from(jsonDecode(_archiveV2Json));
+      final invalidShaItems = List<Object?>.from(invalidSha['items'] as List);
+      final invalidShaItem = Map<String, Object?>.from(
+        invalidShaItems.first as Map,
+      )..['sha256'] = 'not-a-sha';
+      invalidShaItems[0] = invalidShaItem;
+      invalidSha['items'] = invalidShaItems;
+
+      expect(
+        () => AleraUpdateArchive.fromJson(invalidSha),
+        throwsFormatException,
+      );
+    });
+
     test('verifies signed schema v2 manifests', () async {
       final keyPair = await Ed25519().newKeyPairFromSeed(List.filled(32, 1));
       final keyData = await keyPair.extract();
@@ -168,6 +236,25 @@ void main() {
         AleraUpdateArchive.fromSignedJsonString(
           jsonEncode(tampered),
           publicKeyBase64: publicKey,
+        ),
+        throwsFormatException,
+      );
+    });
+
+    test('rejects empty manifest public key ids when signing', () async {
+      final keyPair = await Ed25519().newKeyPairFromSeed(List.filled(32, 1));
+      final keyData = await keyPair.extract();
+      final publicKeyData = await keyPair.extractPublicKey();
+      final privateKey = base64Encode(keyData.bytes);
+      final publicKey = base64Encode(publicKeyData.bytes);
+      final decoded = Map<String, Object?>.from(jsonDecode(_archiveV2Json));
+
+      await expectLater(
+        signAleraManifest(
+          manifest: decoded,
+          privateKeyBase64: privateKey,
+          publicKeyBase64: publicKey,
+          publicKeyId: '   ',
         ),
         throwsFormatException,
       );

--- a/tool/release/AGENTS.md
+++ b/tool/release/AGENTS.md
@@ -18,6 +18,8 @@ This file applies to release scripts, packaging helpers, updater manifest genera
 - UI and controllers must depend on Alera updater abstractions, not directly on `desktop_updater`.
 - The stable public update index is `app-archive.json`.
 - The release-candidate public update index is `app-archive-rc.json`.
+- Public update indexes use schema v2 and MUST be Ed25519-signed before publication.
+- Schema v2 artifacts MUST include SHA-256 and size metadata. Signature bundle and provenance URLs are optional and must only be present when the referenced files are actually published.
 - Stable auto-install is disabled until trusted signing/notarization is available for the release build.
 - Unsigned stable builds may show that an update exists and open the manual download page.
 - RC or preview auto-install may be enabled only by explicit build flags.
@@ -26,5 +28,5 @@ This file applies to release scripts, packaging helpers, updater manifest genera
 
 - macOS production auto-update requires Apple Developer ID signing and notarization.
 - Windows production auto-update requires Authenticode signing.
-- Linux artifacts must document package/dependency expectations.
+- Linux stable production distribution requires signed `.deb` and `.rpm` package repositories. Release candidates must not publish to the stable Linux package repositories.
 - Signing secrets must never be required by local manifest-generation scripts.

--- a/tool/release/AGENTS.md
+++ b/tool/release/AGENTS.md
@@ -28,5 +28,5 @@ This file applies to release scripts, packaging helpers, updater manifest genera
 
 - macOS production auto-update requires Apple Developer ID signing and notarization.
 - Windows production auto-update requires Authenticode signing.
-- Linux stable production distribution requires signed `.deb` and `.rpm` package repositories. Release candidates must not publish to the stable Linux package repositories.
+- Linux stable production distribution requires `.deb` and `.rpm` package repositories to be signed. Release candidates must not publish to the stable Linux package repositories.
 - Signing secrets must never be required by local manifest-generation scripts.

--- a/tool/release/build_app_archive.dart
+++ b/tool/release/build_app_archive.dart
@@ -1,7 +1,16 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:crypto/crypto.dart';
+import 'package:path/path.dart' as p;
+
 const _platforms = <String>['macos', 'windows', 'linux'];
+const _ignoredSuffixes = <String>[
+  '.intoto.jsonl',
+  '.sha256',
+  '.sig',
+  '.sigstore',
+];
 
 void main(List<String> args) {
   final outputPath = args.isEmpty ? 'public/app-archive.json' : args.first;
@@ -22,29 +31,102 @@ void main(List<String> args) {
       DateTime.now().toUtc().toIso8601String().split('T').first;
   final mandatory =
       (Platform.environment['ALERA_RELEASE_MANDATORY'] ?? 'false') == 'true';
+  final publicDir = Directory(
+    Platform.environment['ALERA_RELEASE_PUBLIC_DIR'] ?? 'public',
+  );
+  final channelPath = pathPrefix.split('/').last;
   final changes = _changesFromEnvironment(releaseVersion);
 
+  final items = <Map<String, Object?>>[];
+  for (final platform in _platforms) {
+    final artifactDir = Directory(
+      p.join(
+        publicDir.path,
+        'updates',
+        channelPath,
+        '$artifactVersion+$buildNumber-$platform',
+      ),
+    );
+    if (!artifactDir.existsSync()) {
+      stderr.writeln('Missing update artifact directory: ${artifactDir.path}');
+      exit(1);
+    }
+    final files =
+        artifactDir
+            .listSync()
+            .whereType<File>()
+            .where((file) => !_isSidecarFile(file.path))
+            .toList()
+          ..sort((left, right) => left.path.compareTo(right.path));
+    if (files.isEmpty) {
+      stderr.writeln('No release artifacts found in ${artifactDir.path}');
+      exit(1);
+    }
+    for (final file in files) {
+      final name = p.basename(file.path);
+      final relativePath = [
+        pathPrefix,
+        '$artifactVersion+$buildNumber-$platform',
+        name,
+      ].join('/');
+      final url = '$baseUrl/$relativePath';
+      items.add(<String, Object?>{
+        'version': releaseVersion,
+        'shortVersion': buildNumber,
+        'changes': changes,
+        'date': releaseDate,
+        'mandatory': mandatory,
+        'platform': platform,
+        'installerKind': _installerKindFor(name),
+        'url': url,
+        'sha256': sha256.convert(file.readAsBytesSync()).toString(),
+        'size': file.lengthSync(),
+      });
+    }
+  }
+
   final archive = <String, Object?>{
+    'schemaVersion': 2,
     'appName': 'Alera',
     'description': 'Alera desktop agentic development environment.',
-    'items': [
-      for (final platform in _platforms)
-        <String, Object?>{
-          'version': releaseVersion,
-          'shortVersion': buildNumber,
-          'changes': changes,
-          'date': releaseDate,
-          'mandatory': mandatory,
-          'url': '$baseUrl/$pathPrefix/$artifactVersion+$buildNumber-$platform',
-          'platform': platform,
-        },
-    ],
+    'channel': channelPath,
+    'version': releaseVersion,
+    'buildNumber': buildNumber,
+    'publishedAt': '${releaseDate}T00:00:00Z',
+    'items': items,
   };
 
   final output = File(outputPath);
   output.parent.createSync(recursive: true);
   output.writeAsStringSync(const JsonEncoder.withIndent('  ').convert(archive));
   stdout.writeln('Wrote ${output.path}');
+}
+
+bool _isSidecarFile(String path) {
+  return _ignoredSuffixes.any(path.endsWith);
+}
+
+String _installerKindFor(String fileName) {
+  if (fileName.endsWith('.deb')) {
+    return 'deb';
+  }
+  if (fileName.endsWith('.rpm')) {
+    return 'rpm';
+  }
+  if (fileName.endsWith('.msi')) {
+    return 'msi';
+  }
+  if (fileName.endsWith('.dmg')) {
+    return 'dmg';
+  }
+  if (fileName.endsWith('.zip')) {
+    return 'zip';
+  }
+  if (fileName.endsWith('.tar.gz')) {
+    return 'tar.gz';
+  }
+  stderr.writeln('Unsupported release artifact type: $fileName');
+  exit(1);
 }
 
 String _requiredEnv(String name) {

--- a/tool/release/build_linux_repositories.sh
+++ b/tool/release/build_linux_repositories.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+public_dir="${1:-public}"
+
+require_env() {
+  local name="$1"
+  if [[ -z "${!name:-}" ]]; then
+    echo "::error::$name is required for Linux repository signing." >&2
+    exit 64
+  fi
+}
+
+require_env ALERA_LINUX_GPG_PRIVATE_KEY_BASE64
+require_env ALERA_LINUX_GPG_KEY_ID
+
+gpg_home="$RUNNER_TEMP/alera-linux-gpg"
+mkdir -p "$gpg_home"
+chmod 700 "$gpg_home"
+printf '%s' "$ALERA_LINUX_GPG_PRIVATE_KEY_BASE64" | base64 --decode | gpg --homedir "$gpg_home" --batch --import
+
+apt_root="$public_dir/linux/apt"
+rpm_root="$public_dir/linux/rpm"
+apt_pool="$apt_root/pool/main/a/alera"
+apt_dist="$apt_root/dists/stable"
+rpm_arch="$rpm_root/x86_64"
+mkdir -p "$apt_pool" "$apt_dist/main/binary-amd64" "$rpm_arch"
+
+find "$public_dir/updates/stable" -type f -name '*.deb' -exec cp {} "$apt_pool/" \;
+find "$public_dir/updates/stable" -type f -name '*.rpm' -exec cp {} "$rpm_arch/" \;
+
+if ! command -v apt-ftparchive >/dev/null 2>&1; then
+  echo "::error::apt-ftparchive is required to build the APT repository." >&2
+  exit 1
+fi
+if ! command -v createrepo_c >/dev/null 2>&1; then
+  echo "::error::createrepo_c is required to build the RPM repository." >&2
+  exit 1
+fi
+
+(
+  cd "$apt_root"
+  apt-ftparchive packages pool/main/a/alera >dists/stable/main/binary-amd64/Packages
+  gzip -fk dists/stable/main/binary-amd64/Packages
+  apt-ftparchive \
+    -o APT::FTPArchive::Release::Origin=Alera \
+    -o APT::FTPArchive::Release::Label=Alera \
+    -o APT::FTPArchive::Release::Suite=stable \
+    -o APT::FTPArchive::Release::Codename=stable \
+    -o APT::FTPArchive::Release::Architectures=amd64 \
+    -o APT::FTPArchive::Release::Components=main \
+    release dists/stable >dists/stable/Release
+)
+gpg --homedir "$gpg_home" --batch --yes --local-user "$ALERA_LINUX_GPG_KEY_ID" \
+  --clearsign --digest-algo SHA256 --output "$apt_dist/InRelease" "$apt_dist/Release"
+gpg --homedir "$gpg_home" --batch --yes --local-user "$ALERA_LINUX_GPG_KEY_ID" \
+  --detach-sign --armor --digest-algo SHA256 --output "$apt_dist/Release.gpg" "$apt_dist/Release"
+
+createrepo_c "$rpm_arch"
+gpg --homedir "$gpg_home" --batch --yes --local-user "$ALERA_LINUX_GPG_KEY_ID" \
+  --detach-sign --armor --output "$rpm_arch/repodata/repomd.xml.asc" "$rpm_arch/repodata/repomd.xml"

--- a/tool/release/build_linux_repositories.sh
+++ b/tool/release/build_linux_repositories.sh
@@ -14,8 +14,9 @@ require_env() {
 require_env ALERA_LINUX_GPG_PRIVATE_KEY_BASE64
 require_env ALERA_LINUX_GPG_KEY_ID
 
-gpg_home="$RUNNER_TEMP/alera-linux-gpg"
-mkdir -p "$gpg_home"
+tmp_root="${RUNNER_TEMP:-${TMPDIR:-/tmp}}"
+mkdir -p "$tmp_root"
+gpg_home="$(mktemp -d "${tmp_root%/}/alera-linux-gpg.XXXXXX")"
 chmod 700 "$gpg_home"
 printf '%s' "$ALERA_LINUX_GPG_PRIVATE_KEY_BASE64" | base64 --decode | gpg --homedir "$gpg_home" --batch --import
 

--- a/tool/release/package_linux.sh
+++ b/tool/release/package_linux.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+bundle_dir="${1:?bundle directory is required}"
+output_dir="${2:?output directory is required}"
+release_version="${3:?release version is required}"
+artifact_version="${4:?artifact version is required}"
+build_number="${5:?build number is required}"
+
+if [[ ! -d "$bundle_dir" ]]; then
+  echo "::error::Missing Linux bundle directory: $bundle_dir" >&2
+  exit 1
+fi
+if [[ "$release_version" == *"-rc."* ]]; then
+  echo "::error::Linux packages are only published for stable releases." >&2
+  exit 64
+fi
+
+mkdir -p "$output_dir"
+package_version="${artifact_version}"
+package_release="${build_number}"
+arch_deb="amd64"
+arch_rpm="x86_64"
+maintainer="${ALERA_LINUX_PACKAGE_MAINTAINER:-Alera Release Engineering <releases@alera.dev>}"
+description="Alera desktop agentic development environment."
+
+stage="$(mktemp -d)"
+trap 'rm -rf "$stage"' EXIT
+
+install_payload() {
+  local root="$1"
+  mkdir -p "$root/opt/alera" "$root/usr/bin" "$root/usr/share/applications" "$root/usr/share/icons/hicolor/256x256/apps"
+  cp -R "$bundle_dir/." "$root/opt/alera/"
+  ln -s /opt/alera/alera "$root/usr/bin/alera"
+  if [[ -f assets/logo/alera-logo.png ]]; then
+    cp assets/logo/alera-logo.png "$root/usr/share/icons/hicolor/256x256/apps/alera.png"
+  fi
+  cat >"$root/usr/share/applications/dev.leynier.alera.desktop" <<'DESKTOP'
+[Desktop Entry]
+Type=Application
+Name=Alera
+Comment=Alera desktop agentic development environment
+Exec=/opt/alera/alera
+Icon=alera
+Terminal=false
+Categories=Development;
+DESKTOP
+}
+
+deb_root="$stage/deb"
+install_payload "$deb_root"
+mkdir -p "$deb_root/DEBIAN"
+installed_size="$(du -sk "$deb_root/opt/alera" | awk '{print $1}')"
+cat >"$deb_root/DEBIAN/control" <<DEB
+Package: alera
+Version: ${package_version}-${package_release}
+Section: devel
+Priority: optional
+Architecture: ${arch_deb}
+Maintainer: ${maintainer}
+Installed-Size: ${installed_size}
+Depends: libgtk-3-0, libayatana-appindicator3-1 | libappindicator3-1
+Description: ${description}
+DEB
+dpkg-deb --build "$deb_root" "$output_dir/alera-${release_version}-linux.deb"
+
+if ! command -v rpmbuild >/dev/null 2>&1; then
+  echo "::error::rpmbuild is required to produce the Linux RPM package." >&2
+  exit 1
+fi
+
+rpm_top="$stage/rpmbuild"
+mkdir -p "$rpm_top/BUILD" "$rpm_top/BUILDROOT" "$rpm_top/RPMS" "$rpm_top/SOURCES" "$rpm_top/SPECS" "$rpm_top/SRPMS"
+tar_root="$stage/alera-${package_version}"
+install_payload "$tar_root"
+tar -C "$stage" -czf "$rpm_top/SOURCES/alera-${package_version}.tar.gz" "alera-${package_version}"
+cat >"$rpm_top/SPECS/alera.spec" <<RPM
+Name: alera
+Version: ${package_version}
+Release: ${package_release}%{?dist}
+Summary: ${description}
+License: Proprietary
+BuildArch: ${arch_rpm}
+
+Source0: %{name}-%{version}.tar.gz
+Requires: gtk3
+
+%description
+${description}
+
+%prep
+%setup -q
+
+%build
+
+%install
+mkdir -p %{buildroot}
+cp -a . %{buildroot}/
+
+%files
+/opt/alera
+/usr/bin/alera
+/usr/share/applications/dev.leynier.alera.desktop
+/usr/share/icons/hicolor/256x256/apps/alera.png
+RPM
+rpmbuild --define "_topdir $rpm_top" -bb "$rpm_top/SPECS/alera.spec"
+cp "$rpm_top/RPMS/$arch_rpm/"*.rpm "$output_dir/alera-${release_version}-linux.rpm"

--- a/tool/release/sign_app_archive.dart
+++ b/tool/release/sign_app_archive.dart
@@ -1,0 +1,45 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:alera/src/features/updater/infra/update_manifest_signature.dart';
+
+Future<void> main(List<String> args) async {
+  final path = args.isEmpty ? 'public/app-archive.json' : args.first;
+  final file = File(path);
+  if (!file.existsSync()) {
+    stderr.writeln('$path does not exist.');
+    exit(1);
+  }
+
+  final privateKey = _requiredEnv('ALERA_UPDATE_MANIFEST_PRIVATE_KEY');
+  final publicKey = _requiredEnv('ALERA_UPDATE_MANIFEST_PUBLIC_KEY');
+  final publicKeyId = Platform
+      .environment['ALERA_UPDATE_MANIFEST_PUBLIC_KEY_ID']
+      ?.trim();
+
+  final decoded = jsonDecode(file.readAsStringSync());
+  if (decoded is! Map) {
+    stderr.writeln('$path must contain a JSON object.');
+    exit(1);
+  }
+
+  final signed = await signAleraManifest(
+    manifest: Map<String, Object?>.from(decoded),
+    privateKeyBase64: privateKey,
+    publicKeyBase64: publicKey,
+    publicKeyId: publicKeyId == null || publicKeyId.isEmpty
+        ? 'alera-release-v1'
+        : publicKeyId,
+  );
+  file.writeAsStringSync(const JsonEncoder.withIndent('  ').convert(signed));
+  stdout.writeln('Signed $path');
+}
+
+String _requiredEnv(String name) {
+  final value = Platform.environment[name]?.trim();
+  if (value == null || value.isEmpty) {
+    stderr.writeln('$name must be set.');
+    exit(64);
+  }
+  return value;
+}

--- a/tool/release/sign_macos.sh
+++ b/tool/release/sign_macos.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+bundle_dir="${1:?bundle directory is required}"
+app_path="${2:-$bundle_dir/Alera.app}"
+
+require_env() {
+  local name="$1"
+  if [[ -z "${!name:-}" ]]; then
+    echo "::error::$name is required for macOS release signing." >&2
+    exit 64
+  fi
+}
+
+require_env APPLE_DEVELOPER_ID_APPLICATION
+require_env APPLE_DEVELOPER_ID_TEAM_ID
+require_env APPLE_CERTIFICATE_P12_BASE64
+require_env APPLE_CERTIFICATE_PASSWORD
+require_env APPLE_ID
+require_env APPLE_APP_SPECIFIC_PASSWORD
+
+base64_decode() {
+  if base64 --decode >/dev/null 2>&1 <<<""; then
+    base64 --decode
+  else
+    base64 -D
+  fi
+}
+
+if [[ ! -d "$app_path" ]]; then
+  echo "::error::Missing macOS app bundle: $app_path" >&2
+  exit 1
+fi
+
+keychain="$RUNNER_TEMP/alera-release-signing.keychain-db"
+security create-keychain -p "$APPLE_CERTIFICATE_PASSWORD" "$keychain"
+security set-keychain-settings -lut 21600 "$keychain"
+security unlock-keychain -p "$APPLE_CERTIFICATE_PASSWORD" "$keychain"
+security list-keychains -d user -s "$keychain" $(security list-keychains -d user | tr -d '"')
+
+cert_path="$RUNNER_TEMP/alera-developer-id.p12"
+printf '%s' "$APPLE_CERTIFICATE_P12_BASE64" | base64_decode >"$cert_path"
+security import "$cert_path" -k "$keychain" -P "$APPLE_CERTIFICATE_PASSWORD" -T /usr/bin/codesign
+security set-key-partition-list -S apple-tool:,apple: -s -k "$APPLE_CERTIFICATE_PASSWORD" "$keychain"
+
+identity="$APPLE_DEVELOPER_ID_APPLICATION"
+entitlements="macos/Runner/Release.entitlements"
+
+while IFS= read -r binary; do
+  codesign --force --options runtime --timestamp --sign "$identity" "$binary"
+done < <(find "$app_path/Contents/Resources/alera" -type f -perm -111 2>/dev/null || true)
+
+codesign --force --deep --options runtime --timestamp \
+  --entitlements "$entitlements" \
+  --sign "$identity" \
+  "$app_path"
+
+codesign --verify --strict --deep --verbose=2 "$app_path"
+
+zip_path="$RUNNER_TEMP/Alera-notarization.zip"
+ditto -c -k --keepParent "$app_path" "$zip_path"
+xcrun notarytool submit "$zip_path" \
+  --apple-id "$APPLE_ID" \
+  --password "$APPLE_APP_SPECIFIC_PASSWORD" \
+  --team-id "$APPLE_DEVELOPER_ID_TEAM_ID" \
+  --wait
+xcrun stapler staple "$app_path"
+xcrun stapler validate "$app_path"
+spctl -a -t exec -vv "$app_path"

--- a/tool/release/sign_macos.sh
+++ b/tool/release/sign_macos.sh
@@ -32,13 +32,21 @@ if [[ ! -d "$app_path" ]]; then
   exit 1
 fi
 
-keychain="$RUNNER_TEMP/alera-release-signing.keychain-db"
+tmp_root="${RUNNER_TEMP:-${TMPDIR:-/tmp}}"
+mkdir -p "$tmp_root"
+keychain="$tmp_root/alera-release-signing.keychain-db"
 security create-keychain -p "$APPLE_CERTIFICATE_PASSWORD" "$keychain"
 security set-keychain-settings -lut 21600 "$keychain"
 security unlock-keychain -p "$APPLE_CERTIFICATE_PASSWORD" "$keychain"
-security list-keychains -d user -s "$keychain" $(security list-keychains -d user | tr -d '"')
+existing_keychains=()
+while IFS= read -r existing_keychain; do
+  if [[ -n "$existing_keychain" ]]; then
+    existing_keychains+=("$existing_keychain")
+  fi
+done < <(security list-keychains -d user | tr -d '"')
+security list-keychains -d user -s "$keychain" "${existing_keychains[@]}"
 
-cert_path="$RUNNER_TEMP/alera-developer-id.p12"
+cert_path="$tmp_root/alera-developer-id.p12"
 printf '%s' "$APPLE_CERTIFICATE_P12_BASE64" | base64_decode >"$cert_path"
 security import "$cert_path" -k "$keychain" -P "$APPLE_CERTIFICATE_PASSWORD" -T /usr/bin/codesign
 security set-key-partition-list -S apple-tool:,apple: -s -k "$APPLE_CERTIFICATE_PASSWORD" "$keychain"
@@ -57,7 +65,7 @@ codesign --force --deep --options runtime --timestamp \
 
 codesign --verify --strict --deep --verbose=2 "$app_path"
 
-zip_path="$RUNNER_TEMP/Alera-notarization.zip"
+zip_path="$tmp_root/Alera-notarization.zip"
 ditto -c -k --keepParent "$app_path" "$zip_path"
 xcrun notarytool submit "$zip_path" \
   --apple-id "$APPLE_ID" \

--- a/tool/release/sign_windows.ps1
+++ b/tool/release/sign_windows.ps1
@@ -34,7 +34,12 @@ if ($null -eq $signtool) {
   exit 1
 }
 
-$pfxPath = Join-Path $env:RUNNER_TEMP "alera-signing.pfx"
+$tempRoot = if ([string]::IsNullOrWhiteSpace($env:RUNNER_TEMP)) {
+  [IO.Path]::GetTempPath()
+} else {
+  $env:RUNNER_TEMP
+}
+$pfxPath = Join-Path $tempRoot "alera-signing.pfx"
 [IO.File]::WriteAllBytes($pfxPath, [Convert]::FromBase64String($certificateBase64))
 
 $targets = Get-ChildItem $BundleDir -Recurse -File |

--- a/tool/release/sign_windows.ps1
+++ b/tool/release/sign_windows.ps1
@@ -1,0 +1,50 @@
+param(
+  [Parameter(Mandatory = $true)]
+  [string] $BundleDir
+)
+
+$ErrorActionPreference = "Stop"
+
+function Require-Env([string] $Name) {
+  $value = [Environment]::GetEnvironmentVariable($Name)
+  if ([string]::IsNullOrWhiteSpace($value)) {
+    Write-Error "$Name is required for Windows release signing."
+    exit 64
+  }
+  return $value
+}
+
+$certificateBase64 = Require-Env "WINDOWS_CERTIFICATE_PFX_BASE64"
+$certificatePassword = Require-Env "WINDOWS_CERTIFICATE_PASSWORD"
+$timestampUrl = [Environment]::GetEnvironmentVariable("WINDOWS_TIMESTAMP_URL")
+if ([string]::IsNullOrWhiteSpace($timestampUrl)) {
+  $timestampUrl = "http://timestamp.digicert.com"
+}
+
+if (-not (Test-Path $BundleDir)) {
+  Write-Error "Missing Windows bundle directory: $BundleDir"
+  exit 1
+}
+
+$signtool = Get-ChildItem "${env:ProgramFiles(x86)}\Windows Kits\10\bin" -Recurse -Filter signtool.exe |
+  Sort-Object FullName -Descending |
+  Select-Object -First 1
+if ($null -eq $signtool) {
+  Write-Error "signtool.exe was not found."
+  exit 1
+}
+
+$pfxPath = Join-Path $env:RUNNER_TEMP "alera-signing.pfx"
+[IO.File]::WriteAllBytes($pfxPath, [Convert]::FromBase64String($certificateBase64))
+
+$targets = Get-ChildItem $BundleDir -Recurse -File |
+  Where-Object { $_.Extension -in ".exe", ".dll", ".msi" }
+if ($targets.Count -eq 0) {
+  Write-Error "No Windows binaries found to sign in $BundleDir"
+  exit 1
+}
+
+foreach ($target in $targets) {
+  & $signtool.FullName sign /fd SHA256 /tr $timestampUrl /td SHA256 /f $pfxPath /p $certificatePassword $target.FullName
+  & $signtool.FullName verify /pa /all $target.FullName
+}

--- a/tool/release/verify_app_archive.dart
+++ b/tool/release/verify_app_archive.dart
@@ -1,9 +1,12 @@
 import 'dart:convert';
 import 'dart:io';
 
-const _requiredPlatforms = <String>{'macos', 'windows', 'linux'};
+import 'package:alera/src/features/updater/infra/update_manifest_signature.dart';
 
-void main(List<String> args) {
+const _requiredPlatforms = <String>{'macos', 'windows', 'linux'};
+const _linuxInstallers = <String>{'deb', 'rpm'};
+
+Future<void> main(List<String> args) async {
   final path = args.isEmpty ? 'public/app-archive.json' : args.first;
   final file = File(path);
   if (!file.existsSync()) {
@@ -11,9 +14,39 @@ void main(List<String> args) {
     exit(1);
   }
 
-  final decoded = jsonDecode(file.readAsStringSync());
+  final source = file.readAsStringSync();
+  final publicKey = Platform.environment['ALERA_UPDATE_MANIFEST_PUBLIC_KEY'];
+  if (publicKey != null && publicKey.trim().isNotEmpty) {
+    final verified = await verifyAleraManifestSignature(
+      manifestJson: source,
+      publicKeyBase64: publicKey,
+    );
+    if (!verified) {
+      stderr.writeln('$path has an invalid manifest signature.');
+      exit(1);
+    }
+  }
+
+  final decoded = jsonDecode(source);
   if (decoded is! Map<String, Object?>) {
     stderr.writeln('$path must contain a JSON object.');
+    exit(1);
+  }
+
+  final schemaVersion = decoded['schemaVersion'];
+  if (schemaVersion != 2) {
+    stderr.writeln('schemaVersion must be 2.');
+    exit(1);
+  }
+  final channel = _requireString(decoded, 'channel');
+  _requireString(decoded, 'version');
+  _requireString(decoded, 'publishedAt');
+  if (decoded['buildNumber'] is! int) {
+    stderr.writeln('buildNumber must be an integer.');
+    exit(1);
+  }
+  if (decoded[aleraManifestSignatureKey] is! Map) {
+    stderr.writeln('A signed schema v2 manifest requires signature metadata.');
     exit(1);
   }
 
@@ -24,6 +57,7 @@ void main(List<String> args) {
   }
 
   final platforms = <String>{};
+  final linuxInstallers = <String>{};
   for (final item in items) {
     if (item is! Map<String, Object?>) {
       stderr.writeln('Every item must be a JSON object.');
@@ -31,21 +65,42 @@ void main(List<String> args) {
     }
     _requireString(item, 'version');
     _requireString(item, 'date');
-    _requireString(item, 'url');
-    final platform = _requireString(item, 'platform');
-    platforms.add(platform);
     if (item['shortVersion'] is! int) {
-      stderr.writeln('shortVersion must be an integer for $platform.');
+      stderr.writeln('shortVersion must be an integer.');
       exit(1);
     }
     if (item['mandatory'] is! bool) {
-      stderr.writeln('mandatory must be a boolean for $platform.');
+      stderr.writeln('mandatory must be a boolean.');
       exit(1);
     }
     if (item['changes'] is! List || (item['changes'] as List).isEmpty) {
-      stderr.writeln('changes must be a non-empty array for $platform.');
+      stderr.writeln('changes must be a non-empty array.');
       exit(1);
     }
+    if (item['artifacts'] != null) {
+      stderr.writeln(
+        'schema v2 items must use top-level url/platform fields, not artifacts.',
+      );
+      exit(1);
+    }
+    final platform = _requireString(item, 'platform');
+    final installerKind = _requireString(item, 'installerKind');
+    platforms.add(platform);
+    if (platform == 'linux') {
+      linuxInstallers.add(installerKind);
+    }
+    _requireString(item, 'url');
+    final sha = _requireString(item, 'sha256');
+    if (!RegExp(r'^[0-9a-f]{64}$').hasMatch(sha)) {
+      stderr.writeln('sha256 must be a lowercase hex SHA-256 for $platform.');
+      exit(1);
+    }
+    if (item['size'] is! int || (item['size'] as int) <= 0) {
+      stderr.writeln('size must be a positive integer for $platform.');
+      exit(1);
+    }
+    _requireOptionalString(item, 'signatureBundleUrl');
+    _requireOptionalString(item, 'provenanceUrl');
   }
 
   final missing = _requiredPlatforms.difference(platforms);
@@ -53,15 +108,34 @@ void main(List<String> args) {
     stderr.writeln('Missing platforms: ${missing.join(', ')}');
     exit(1);
   }
+  if (channel == 'stable') {
+    final missingLinux = _linuxInstallers.difference(linuxInstallers);
+    if (missingLinux.isNotEmpty) {
+      stderr.writeln('Missing Linux installers: ${missingLinux.join(', ')}');
+      exit(1);
+    }
+  }
 
-  stdout.writeln('Verified $path for ${platforms.length} platforms.');
+  stdout.writeln('Verified signed schema v2 archive at $path.');
+}
+
+void _requireOptionalString(Map<String, Object?> item, String key) {
+  if (!item.containsKey(key)) {
+    return;
+  }
+  final value = item[key];
+  if (value is String && value.trim().isNotEmpty) {
+    return;
+  }
+  stderr.writeln('$key must be omitted or a non-empty string.');
+  exit(1);
 }
 
 String _requireString(Map<String, Object?> item, String key) {
   final value = item[key];
-  if (value is! String || value.trim().isEmpty) {
-    stderr.writeln('$key must be a non-empty string.');
-    exit(1);
+  if (value is String && value.trim().isNotEmpty) {
+    return value;
   }
-  return value;
+  stderr.writeln('$key must be a non-empty string.');
+  exit(1);
 }

--- a/tool/release/verify_app_archive.dart
+++ b/tool/release/verify_app_archive.dart
@@ -16,10 +16,11 @@ Future<void> main(List<String> args) async {
 
   final source = file.readAsStringSync();
   final publicKey = Platform.environment['ALERA_UPDATE_MANIFEST_PUBLIC_KEY'];
-  if (publicKey != null && publicKey.trim().isNotEmpty) {
+  final normalizedPublicKey = publicKey?.trim();
+  if (normalizedPublicKey != null && normalizedPublicKey.isNotEmpty) {
     final verified = await verifyAleraManifestSignature(
       manifestJson: source,
-      publicKeyBase64: publicKey,
+      publicKeyBase64: normalizedPublicKey,
     );
     if (!verified) {
       stderr.writeln('$path has an invalid manifest signature.');


### PR DESCRIPTION
## Summary

- add signed schema v2 update manifests while preserving legacy `items[].url` / `items[].platform` compatibility
- add platform-scoped signing and packaging steps for macOS, Windows, and Linux stable repositories
- keep Linux RC releases as manual tarballs and document release trust expectations

## Validation

- `dart analyze tool/release/build_app_archive.dart tool/release/sign_app_archive.dart tool/release/verify_app_archive.dart`
- `flutter test test/unit/release_app_archive_scripts_test.dart`
- `bash -n tool/release/sign_macos.sh tool/release/package_linux.sh tool/release/build_linux_repositories.sh`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-cut.yml")'`
- `git diff --check HEAD~1..HEAD`
- `flutter test test/unit/update_archive_test.dart test/unit/desktop_update_service_test.dart test/unit/alera_update_test.dart test/unit/update_controller_test.dart`
- `flutter analyze`

## Notes

The Linux repository builder still requires `apt-ftparchive` and `createrepo_c` in CI, so local validation covered syntax and manifest behavior rather than a full repository publish.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added signed releases with Ed25519-based manifest verification for enhanced security.
  * Extended update manifests to schema v2 with SHA256 checksums, file sizes, and installer type metadata.
  * Added Linux APT/RPM repository signing for stable releases.
  * Enhanced platform-specific release signing (macOS notarization, Windows code signing).

* **Documentation**
  * Added release trust documentation covering signing and verification processes.
  * Updated README with signed release details and stable Linux repository locations.

* **Chores**
  * Updated release pipeline with new cryptographic signing and verification steps.
  * Added cryptography dependency for manifest signing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->