### PR TITLE
refresh workspace explorer on ignored-files mode changes

### DIFF
--- a/lib/src/features/workbench/presentation/workspace_explorer.dart
+++ b/lib/src/features/workbench/presentation/workspace_explorer.dart
@@ -86,8 +86,7 @@ class _WorkspaceExplorerState extends ConsumerState<WorkspaceExplorer> {
   @override
   void didUpdateWidget(covariant WorkspaceExplorer oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (oldWidget.workspace.id != widget.workspace.id ||
-        oldWidget.mode != widget.mode) {
+    if (oldWidget.workspace.id != widget.workspace.id) {
       _resetExplorerProjection();
       _controller.dispose();
       _controller = tree.DirectoryTreeController(
@@ -95,6 +94,8 @@ class _WorkspaceExplorerState extends ConsumerState<WorkspaceExplorer> {
         flattenStrategy: const _AleraFlattenStrategy(),
       );
       unawaited(_restartExplorer());
+    } else if (oldWidget.mode != widget.mode) {
+      unawaited(_reloadForModeChange());
     }
   }
 
@@ -219,6 +220,45 @@ class _WorkspaceExplorerState extends ConsumerState<WorkspaceExplorer> {
       }
       _rebuildTree();
     } catch (error) {
+      if (mounted) {
+        _rebuildTree(tryPreserveState: false);
+      }
+      _showError(error);
+    } finally {
+      if (mounted) {
+        setState(() => _loading = false);
+      }
+    }
+  }
+
+  Future<void> _reloadForModeChange() async {
+    final loadedDirectories =
+        _childrenByDirectory.keys
+            .where((relativePath) => relativePath.isNotEmpty)
+            .toList(growable: false)
+          ..sort(_compareDirectoryDepth);
+    setState(() => _loading = true);
+    try {
+      _resetExplorerProjection();
+      await _syncWatchedDirectories();
+      await _loadDirectory('');
+      for (final relativePath in loadedDirectories) {
+        if (!mounted) {
+          return;
+        }
+        if (!_isDirectoryEntry(_entryByPath[relativePath])) {
+          continue;
+        }
+        await _loadDirectory(relativePath);
+      }
+      if (!mounted) {
+        return;
+      }
+      _rebuildTree();
+    } catch (error) {
+      if (mounted) {
+        _rebuildTree(tryPreserveState: false);
+      }
       _showError(error);
     } finally {
       if (mounted) {
@@ -239,12 +279,29 @@ class _WorkspaceExplorerState extends ConsumerState<WorkspaceExplorer> {
     await _replaceDirectoryChildren(relativePath, children);
   }
 
-  void _rebuildTree() {
+  void _rebuildTree({bool tryPreserveState = true}) {
     if (!mounted) {
       return;
     }
     final next = _buildTreeData();
-    _controller.rebuild(next);
+    _controller.rebuild(next, tryPreserveState: tryPreserveState);
+  }
+
+  int _compareDirectoryDepth(String left, String right) {
+    final depthComparison = _directoryDepth(
+      left,
+    ).compareTo(_directoryDepth(right));
+    if (depthComparison != 0) {
+      return depthComparison;
+    }
+    return left.compareTo(right);
+  }
+
+  int _directoryDepth(String relativePath) {
+    if (relativePath.isEmpty) {
+      return 0;
+    }
+    return relativePath.split('/').length;
   }
 
   tree.TreeData _buildTreeData() {

--- a/test/widget/workspace_explorer_test.dart
+++ b/test/widget/workspace_explorer_test.dart
@@ -108,6 +108,189 @@ void main() {
     expect(service.watchedPathUpdates.last, contains(''));
   });
 
+  testWidgets(
+    'ignored files toggle refreshes the listing without manual refresh',
+    (tester) async {
+      final service = _FakeWorkspaceFileService()
+        ..childrenByDirectory[''] = <native.WorkspaceFileEntry>[
+          _file('tracked.dart'),
+        ]
+        ..showAllChildrenByDirectory[''] = <native.WorkspaceFileEntry>[
+          _file('ignored.dart'),
+          _file('tracked.dart'),
+        ];
+
+      await tester.pumpWidget(
+        _withWorkspaceFiles(
+          service,
+          child: MaterialApp(
+            home: Scaffold(
+              body: SizedBox(
+                width: 320,
+                height: 480,
+                child: const _WorkspaceExplorerModeHarness(),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('tracked.dart'), findsOneWidget);
+      expect(find.text('ignored.dart'), findsNothing);
+      expect(service.listChildrenCalls.last.hideIgnored, isTrue);
+
+      await tester.tap(find.byTooltip('Show ignored files'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('tracked.dart'), findsOneWidget);
+      expect(find.text('ignored.dart'), findsOneWidget);
+      expect(
+        service.listChildrenCalls.map((call) => call.hideIgnored),
+        containsAllInOrder(<bool>[true, false]),
+      );
+    },
+  );
+
+  testWidgets(
+    'ignored files toggle reloads expanded directories with the new filter',
+    (tester) async {
+      final service = _FakeWorkspaceFileService()
+        ..childrenByDirectory[''] = <native.WorkspaceFileEntry>[
+          _directory('src', hasChildrenHint: true),
+        ]
+        ..childrenByDirectory['src'] = <native.WorkspaceFileEntry>[
+          _file('src/main.dart'),
+        ]
+        ..showAllChildrenByDirectory[''] = <native.WorkspaceFileEntry>[
+          _directory('src', hasChildrenHint: true),
+        ]
+        ..showAllChildrenByDirectory['src'] = <native.WorkspaceFileEntry>[
+          _file('src/generated.dart'),
+          _file('src/main.dart'),
+        ];
+
+      await tester.pumpWidget(
+        _withWorkspaceFiles(
+          service,
+          child: MaterialApp(
+            home: Scaffold(
+              body: SizedBox(
+                width: 320,
+                height: 480,
+                child: const _WorkspaceExplorerModeHarness(),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('src'));
+      await tester.pumpAndSettle();
+      expect(find.text('main.dart'), findsOneWidget);
+      expect(find.text('generated.dart'), findsNothing);
+
+      await tester.tap(find.byTooltip('Show ignored files'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('main.dart'), findsOneWidget);
+      expect(find.text('generated.dart'), findsOneWidget);
+      expect(
+        service.listChildrenCalls,
+        contains(
+          const _ListChildrenCall(relativePath: 'src', hideIgnored: false),
+        ),
+      );
+    },
+  );
+
+  testWidgets('ignored files toggle clears stale rows when root reload fails', (
+    tester,
+  ) async {
+    final service = _FakeWorkspaceFileService()
+      ..childrenByDirectory[''] = <native.WorkspaceFileEntry>[
+        _file('tracked.dart'),
+      ]
+      ..failingListChildrenCalls.add(
+        const _ListChildrenCall(relativePath: '', hideIgnored: false),
+      );
+
+    await tester.pumpWidget(
+      _withWorkspaceFiles(
+        service,
+        child: MaterialApp(
+          home: Scaffold(
+            body: SizedBox(
+              width: 320,
+              height: 480,
+              child: const _WorkspaceExplorerModeHarness(),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(find.text('tracked.dart'), findsOneWidget);
+
+    await tester.tap(find.byTooltip('Show ignored files'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('tracked.dart'), findsNothing);
+  });
+
+  testWidgets(
+    'ignored files toggle clears stale children when expanded directory reload fails',
+    (tester) async {
+      final service = _FakeWorkspaceFileService()
+        ..childrenByDirectory[''] = <native.WorkspaceFileEntry>[
+          _directory('src', hasChildrenHint: true),
+        ]
+        ..childrenByDirectory['src'] = <native.WorkspaceFileEntry>[
+          _file('src/main.dart'),
+        ]
+        ..showAllChildrenByDirectory[''] = <native.WorkspaceFileEntry>[
+          _directory('src', hasChildrenHint: true),
+        ]
+        ..failingListChildrenCalls.add(
+          const _ListChildrenCall(relativePath: 'src', hideIgnored: false),
+        );
+
+      await tester.pumpWidget(
+        _withWorkspaceFiles(
+          service,
+          child: MaterialApp(
+            home: Scaffold(
+              body: SizedBox(
+                width: 320,
+                height: 480,
+                child: const _WorkspaceExplorerModeHarness(),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('src'));
+      await tester.pumpAndSettle();
+      expect(find.text('src'), findsOneWidget);
+      expect(find.text('main.dart'), findsOneWidget);
+
+      await tester.tap(find.byTooltip('Show ignored files'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('src'), findsOneWidget);
+      expect(find.text('main.dart'), findsNothing);
+      expect(
+        service.listChildrenCalls,
+        contains(
+          const _ListChildrenCall(relativePath: 'src', hideIgnored: false),
+        ),
+      );
+    },
+  );
+
   testWidgets('save all writes dirty editor documents that are not mounted', (
     tester,
   ) async {
@@ -339,6 +522,30 @@ Future<void> _pumpExplorer(
   await tester.pumpAndSettle();
 }
 
+class _WorkspaceExplorerModeHarness extends StatefulWidget {
+  const _WorkspaceExplorerModeHarness();
+
+  @override
+  State<_WorkspaceExplorerModeHarness> createState() =>
+      _WorkspaceExplorerModeHarnessState();
+}
+
+class _WorkspaceExplorerModeHarnessState
+    extends State<_WorkspaceExplorerModeHarness> {
+  WorkspaceExplorerMode _mode = WorkspaceExplorerMode.hideIgnored;
+
+  @override
+  Widget build(BuildContext context) {
+    return WorkspaceExplorer(
+      workspace: _workspace(),
+      mode: _mode,
+      onModeChanged: (mode) => setState(() => _mode = mode),
+      onOpenFile: (_) {},
+      onPathMoved: (_, _) async {},
+    );
+  }
+}
+
 Widget _withWorkspaceFiles(
   _FakeWorkspaceFileService service, {
   required Widget child,
@@ -365,8 +572,12 @@ class _FakeWorkspaceFileService extends WorkspaceFileService {
       StreamController<native.WorkspaceExplorerWatchBatch>.broadcast();
   final Map<String, List<native.WorkspaceFileEntry>> childrenByDirectory =
       <String, List<native.WorkspaceFileEntry>>{};
+  final Map<String, List<native.WorkspaceFileEntry>>
+  showAllChildrenByDirectory = <String, List<native.WorkspaceFileEntry>>{};
+  final Set<_ListChildrenCall> failingListChildrenCalls = <_ListChildrenCall>{};
   final List<String> createdFiles = <String>[];
   final List<String> copiedFiles = <String>[];
+  final List<_ListChildrenCall> listChildrenCalls = <_ListChildrenCall>[];
   final List<List<String>> watchedPathUpdates = <List<String>>[];
   final Map<String, String> writtenFiles = <String, String>{};
 
@@ -386,7 +597,18 @@ class _FakeWorkspaceFileService extends WorkspaceFileService {
     required String relativePath,
     required bool hideIgnored,
   }) async {
-    return childrenByDirectory[relativePath] ??
+    final call = _ListChildrenCall(
+      relativePath: relativePath,
+      hideIgnored: hideIgnored,
+    );
+    listChildrenCalls.add(call);
+    if (failingListChildrenCalls.contains(call)) {
+      throw StateError('Failed to list $relativePath');
+    }
+    return (hideIgnored
+            ? childrenByDirectory[relativePath]
+            : showAllChildrenByDirectory[relativePath]) ??
+        childrenByDirectory[relativePath] ??
         const <native.WorkspaceFileEntry>[];
   }
 
@@ -490,6 +712,26 @@ class _FakeWorkspaceFileService extends WorkspaceFileService {
     ];
     return entry;
   }
+}
+
+class _ListChildrenCall {
+  const _ListChildrenCall({
+    required this.relativePath,
+    required this.hideIgnored,
+  });
+
+  final String relativePath;
+  final bool hideIgnored;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is _ListChildrenCall &&
+          other.relativePath == relativePath &&
+          other.hideIgnored == hideIgnored;
+
+  @override
+  int get hashCode => Object.hash(relativePath, hideIgnored);
 }
 
 native.WorkspaceExplorerTreeProjection _projectExplorerTree({


### PR DESCRIPTION
## Summary
- Fixes workspace explorer lifecycle so mode changes no longer trigger a full controller rebuild, only a targeted reload path.
- Adds a dedicated mode-change reload flow that preserves expanded-directory state order, refreshes current root and previously loaded directories with the new `hideIgnored` filter, and rebuilds tree data.
- Updates tree rebuild logic to support non-preserved state when a mode reload fails, preventing stale rows from persisting.
- Improves error handling in mode-switch reload to clear stale entries and surface errors consistently.

## Validation
- Added widget tests in `test/widget/workspace_explorer_test.dart` verifying:
  - toggling ignored-files mode updates listing automatically,
  - expanded directories reload with new filter,
  - stale rows are cleared when root reload fails,
  - stale children are cleared when expanded directory reload fails.