### PR TITLE
perf: cache search rows and fix replace line mapping

### DIFF
--- a/lib/src/features/workbench/application/workspace_search_controller.dart
+++ b/lib/src/features/workbench/application/workspace_search_controller.dart
@@ -4,12 +4,14 @@ import 'package:alera/src/features/workbench/application/workbench_providers.dar
 import 'package:alera/src/features/workbench/application/workspace_file_service.dart';
 import 'package:alera/src/features/workbench/application/workspace_search_service.dart';
 import 'package:alera/src/rust/api/workspace_search.dart' as native;
+import 'package:path/path.dart' as p;
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'workspace_search_controller.g.dart';
 
 const int _workspaceSearchMaxResults = 2000;
 const Duration _workspaceSearchDebounce = Duration(milliseconds: 250);
+final p.Context _workspaceSearchPathContext = p.Context(style: p.Style.posix);
 
 String workspaceSearchDirectoryNodeKey(String relativePath) {
   return 'dir:$relativePath';
@@ -41,8 +43,9 @@ Set<String> workspaceSearchCollapsibleNodeKeys(
 }
 
 List<String> workspaceSearchDirectoryPaths(String relativePath) {
-  final segments = relativePath
-      .split(RegExp(r'[/\\]'))
+  final normalized = relativePath.replaceAll('\\', '/');
+  final segments = _workspaceSearchPathContext
+      .split(normalized)
       .where((segment) => segment.isNotEmpty)
       .toList(growable: false);
   if (segments.length <= 1) {
@@ -52,7 +55,7 @@ List<String> workspaceSearchDirectoryPaths(String relativePath) {
   final current = <String>[];
   for (final segment in segments.take(segments.length - 1)) {
     current.add(segment);
-    paths.add(current.join('/'));
+    paths.add(_workspaceSearchPathContext.joinAll(current));
   }
   return paths;
 }

--- a/lib/src/features/workbench/presentation/workspace_search_panel.dart
+++ b/lib/src/features/workbench/presentation/workspace_search_panel.dart
@@ -155,7 +155,6 @@ class _WorkspaceSearchPanelState extends ConsumerState<WorkspaceSearchPanel> {
             ],
           ),
         ),
-        const Divider(height: 1, color: AleraTokens.borderSubtle),
         _SearchSummary(state: state),
         if (state.error case final error?)
           Padding(
@@ -172,6 +171,7 @@ class _WorkspaceSearchPanelState extends ConsumerState<WorkspaceSearchPanel> {
               ).textTheme.bodySmall?.copyWith(color: AleraTokens.error),
             ),
           ),
+        const Divider(height: 1, color: AleraTokens.borderSubtle),
         Expanded(
           child: rows.items.isEmpty
               ? _SearchEmptyState(state: state)

--- a/lib/src/features/workbench/presentation/workspace_search_panel.dart
+++ b/lib/src/features/workbench/presentation/workspace_search_panel.dart
@@ -56,6 +56,13 @@ class _WorkspaceSearchPanelState extends ConsumerState<WorkspaceSearchPanel> {
   bool _replaceVisible = false;
   bool _detailsVisible = false;
   String? _initializedOptionalSectionsWorkspaceId;
+  native.WorkspaceSearchResult? _cachedCollapsibleResult;
+  bool? _cachedCollapsibleViewAsTree;
+  Set<String> _cachedCollapsibleNodeKeys = const <String>{};
+  native.WorkspaceSearchResult? _cachedRowsResult;
+  Set<String>? _cachedRowsCollapsedNodeKeys;
+  bool? _cachedRowsViewAsTree;
+  _SearchRows _cachedRows = const _SearchRows(<_SearchRow>[]);
 
   @override
   void initState() {
@@ -85,18 +92,11 @@ class _WorkspaceSearchPanelState extends ConsumerState<WorkspaceSearchPanel> {
     _syncController(_excludeController, state.excludePattern);
     _initializeOptionalSections(state);
     final controller = ref.read(provider.notifier);
-    final collapsibleNodeKeys = workspaceSearchCollapsibleNodeKeys(
-      state.result,
-      viewAsTree: state.viewAsTree,
-    );
+    final collapsibleNodeKeys = _collapsibleNodeKeysFor(state);
     final allResultsCollapsed =
         collapsibleNodeKeys.isNotEmpty &&
         collapsibleNodeKeys.every(state.collapsedResultNodeKeys.contains);
-    final rows = _SearchRows.from(
-      state.result,
-      collapsedResultNodeKeys: state.collapsedResultNodeKeys,
-      viewAsTree: state.viewAsTree,
-    );
+    final rows = _rowsFor(state);
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: <Widget>[
@@ -325,5 +325,39 @@ class _WorkspaceSearchPanelState extends ConsumerState<WorkspaceSearchPanel> {
 
   void _toggleDetails() {
     setState(() => _detailsVisible = !_detailsVisible);
+  }
+
+  Set<String> _collapsibleNodeKeysFor(WorkspaceSearchState state) {
+    if (identical(_cachedCollapsibleResult, state.result) &&
+        _cachedCollapsibleViewAsTree == state.viewAsTree) {
+      return _cachedCollapsibleNodeKeys;
+    }
+    _cachedCollapsibleResult = state.result;
+    _cachedCollapsibleViewAsTree = state.viewAsTree;
+    _cachedCollapsibleNodeKeys = workspaceSearchCollapsibleNodeKeys(
+      state.result,
+      viewAsTree: state.viewAsTree,
+    );
+    return _cachedCollapsibleNodeKeys;
+  }
+
+  _SearchRows _rowsFor(WorkspaceSearchState state) {
+    if (identical(_cachedRowsResult, state.result) &&
+        identical(
+          _cachedRowsCollapsedNodeKeys,
+          state.collapsedResultNodeKeys,
+        ) &&
+        _cachedRowsViewAsTree == state.viewAsTree) {
+      return _cachedRows;
+    }
+    _cachedRowsResult = state.result;
+    _cachedRowsCollapsedNodeKeys = state.collapsedResultNodeKeys;
+    _cachedRowsViewAsTree = state.viewAsTree;
+    _cachedRows = _SearchRows.from(
+      state.result,
+      collapsedResultNodeKeys: state.collapsedResultNodeKeys,
+      viewAsTree: state.viewAsTree,
+    );
+    return _cachedRows;
   }
 }

--- a/lib/src/features/workbench/presentation/workspace_search_panel_toolbar.dart
+++ b/lib/src/features/workbench/presentation/workspace_search_panel_toolbar.dart
@@ -45,12 +45,6 @@ class _SearchToolbar extends StatelessWidget {
             ),
             const Spacer(),
             AleraIconButton(
-              tooltip: 'Refresh',
-              icon: state.loading ? Icons.hourglass_empty : Icons.refresh,
-              onPressed: state.hasQuery && !state.loading ? onRefresh : null,
-            ),
-            const SizedBox(width: AleraTokens.space2),
-            AleraIconButton(
               tooltip: 'Clear search results',
               icon: Icons.close,
               onPressed: canClear ? onClear : null,
@@ -76,22 +70,21 @@ class _SearchToolbar extends StatelessWidget {
             AleraIconButton(
               tooltip: state.viewAsTree ? 'View as list' : 'View as tree',
               icon: state.viewAsTree
-                  ? Icons.account_tree
+                  ? Icons.format_list_bulleted
                   : Icons.account_tree_outlined,
               onPressed: onToggleViewAsTree,
-              iconColor: state.viewAsTree
-                  ? AleraTokens.foreground
-                  : AleraTokens.foregroundMuted,
-              backgroundColor: state.viewAsTree
-                  ? AleraTokens.surfaceElevated
-                  : null,
-              borderColor: state.viewAsTree ? AleraTokens.border : null,
             ),
             const SizedBox(width: AleraTokens.space2),
             AleraIconButton(
               tooltip: allResultsCollapsed ? 'Expand all' : 'Collapse all',
               icon: allResultsCollapsed ? Icons.unfold_more : Icons.unfold_less,
               onPressed: hasResults ? onToggleAllResultsCollapsed : null,
+            ),
+            const SizedBox(width: AleraTokens.space2),
+            AleraIconButton(
+              tooltip: 'Refresh',
+              icon: state.loading ? Icons.hourglass_empty : Icons.refresh,
+              onPressed: state.hasQuery && !state.loading ? onRefresh : null,
             ),
           ],
         ),

--- a/rust/src/api/workspace_search/engine.rs
+++ b/rust/src/api/workspace_search/engine.rs
@@ -9,16 +9,14 @@ use super::paths::{
     content_token, is_protected_relative_path, relative_string, safe_regular_file_metadata,
     should_walk_entry,
 };
-use super::preview::replacement_for_slice;
 use super::{
-    WorkspaceReplaceOptions, WorkspaceSearchError, WorkspaceSearchErrorKind,
-    WorkspaceSearchFileResult, WorkspaceSearchMatch, WorkspaceSearchResult,
-    MAX_LINE_CONTENT_LENGTH, MAX_MATCHES_PER_FILE, MAX_TEXT_FILE_BYTES,
+    WorkspaceSearchError, WorkspaceSearchErrorKind, WorkspaceSearchFileResult,
+    WorkspaceSearchMatch, WorkspaceSearchResult, MAX_LINE_CONTENT_LENGTH, MAX_MATCHES_PER_FILE,
+    MAX_TEXT_FILE_BYTES,
 };
 
 pub(super) fn run_search(
     compiled: &CompiledSearch,
-    replace: Option<&WorkspaceReplaceOptions>,
     full_lines: bool,
 ) -> Result<WorkspaceSearchResult, WorkspaceSearchError> {
     let mut files = Vec::<WorkspaceSearchFileResult>::new();
@@ -94,7 +92,6 @@ pub(super) fn run_search(
             &relative_path,
             &text,
             compiled,
-            replace,
             full_lines,
             &mut total_matches,
             &mut truncated,
@@ -119,7 +116,6 @@ fn matches_in_file(
     relative_path: &str,
     text: &str,
     compiled: &CompiledSearch,
-    replace: Option<&WorkspaceReplaceOptions>,
     full_lines: bool,
     total_matches: &mut u32,
     truncated: &mut bool,
@@ -154,9 +150,6 @@ fn matches_in_file(
                     clamp_line_context(line, start, end)
                 };
                 let id = format!("{relative_path}:{line_number}:{column}:{}", out.len());
-                let replacement_preview = replace.map(|options| {
-                    replacement_for_slice(&line[start..end], &compiled.replacement_regex, options)
-                });
                 out.push(WorkspaceSearchMatch {
                     id,
                     line: line_number,
@@ -165,7 +158,7 @@ fn matches_in_file(
                     line_content: clamped.line_content,
                     display_column: clamped.display_column,
                     display_match_length: clamped.display_match_length,
-                    replacement_preview,
+                    replacement_preview: None,
                 });
                 *total_matches += 1;
                 file_count += 1;

--- a/rust/src/api/workspace_search/line_ranges.rs
+++ b/rust/src/api/workspace_search/line_ranges.rs
@@ -1,0 +1,60 @@
+pub(super) struct LineRanges {
+    ranges: Vec<LineRange>,
+}
+
+impl LineRanges {
+    pub(super) fn new(content: &str) -> Self {
+        let mut ranges = Vec::new();
+        let mut start = 0;
+        for line in content.split_inclusive('\n') {
+            let mut end = start + line.len();
+            if line.ends_with('\n') {
+                end -= 1;
+            }
+            if end > start && content.as_bytes()[end - 1] == b'\r' {
+                end -= 1;
+            }
+            ranges.push(LineRange { start, end });
+            start += line.len();
+        }
+        Self { ranges }
+    }
+
+    pub(super) fn locate_match_range(
+        &self,
+        content: &str,
+        line_number: u32,
+        column: u32,
+        match_length: u32,
+    ) -> Option<(usize, usize)> {
+        let line = self.ranges.get(line_number.checked_sub(1)? as usize)?;
+        let clean_line = &content[line.start..line.end];
+        let start_col = column.saturating_sub(1) as usize;
+        let start_byte = byte_offset_for_char(clean_line, start_col);
+        let end_byte = byte_offset_for_char(clean_line, start_col + match_length as usize);
+        Some((line.start + start_byte, line.start + end_byte))
+    }
+
+    pub(super) fn match_slice<'a>(
+        &self,
+        content: &'a str,
+        line_number: u32,
+        column: u32,
+        match_length: u32,
+    ) -> Option<&'a str> {
+        let (start, end) = self.locate_match_range(content, line_number, column, match_length)?;
+        content.get(start..end)
+    }
+}
+
+struct LineRange {
+    start: usize,
+    end: usize,
+}
+
+fn byte_offset_for_char(text: &str, char_offset: usize) -> usize {
+    text.char_indices()
+        .nth(char_offset)
+        .map(|(byte, _)| byte)
+        .unwrap_or(text.len())
+}

--- a/rust/src/api/workspace_search/mod.rs
+++ b/rust/src/api/workspace_search/mod.rs
@@ -3,12 +3,15 @@ use std::io;
 mod compile;
 mod engine;
 mod globs;
+mod line_ranges;
 mod paths;
 mod preview;
 mod replace;
 
 #[cfg(test)]
 mod ignore_tests;
+#[cfg(test)]
+mod preview_tests;
 #[cfg(test)]
 mod replace_tests;
 #[cfg(test)]

--- a/rust/src/api/workspace_search/mod.rs
+++ b/rust/src/api/workspace_search/mod.rs
@@ -134,7 +134,7 @@ pub fn search_workspace(
     options: WorkspaceSearchOptions,
 ) -> Result<WorkspaceSearchResult, WorkspaceSearchError> {
     let compiled = compile::compile_search(&options)?;
-    engine::run_search(&compiled, None, false)
+    engine::run_search(&compiled, false)
 }
 
 pub fn preview_workspace_replace(

--- a/rust/src/api/workspace_search/preview.rs
+++ b/rust/src/api/workspace_search/preview.rs
@@ -10,7 +10,7 @@ pub(super) fn preview_workspace_replace_impl(
     options: WorkspaceReplaceOptions,
 ) -> Result<WorkspaceReplacePreview, WorkspaceSearchError> {
     let compiled = compile_search(&options.search)?;
-    let mut result = run_search(&compiled, Some(&options), false)?;
+    let mut result = run_search(&compiled, false)?;
     for file in &mut result.files {
         for m in &mut file.matches {
             m.replacement_preview = Some(preview_replacement(m, &compiled, &options));

--- a/rust/src/api/workspace_search/preview.rs
+++ b/rust/src/api/workspace_search/preview.rs
@@ -1,7 +1,11 @@
+use std::fs;
+
 use regex::Regex;
 
 use super::compile::{compile_search, CompiledSearch};
 use super::engine::run_search;
+use super::line_ranges::LineRanges;
+use super::paths::resolve_replace_file;
 use super::{
     WorkspaceReplaceOptions, WorkspaceReplacePreview, WorkspaceSearchError, WorkspaceSearchMatch,
 };
@@ -12,8 +16,18 @@ pub(super) fn preview_workspace_replace_impl(
     let compiled = compile_search(&options.search)?;
     let mut result = run_search(&compiled, false)?;
     for file in &mut result.files {
+        let (path, _) = resolve_replace_file(&compiled.root, &file.relative_path)?;
+        let content = fs::read_to_string(&path)
+            .map_err(|error| WorkspaceSearchError::from_io(error, file.relative_path.clone()))?;
+        let line_ranges = LineRanges::new(&content);
         for m in &mut file.matches {
-            m.replacement_preview = Some(preview_replacement(m, &compiled, &options));
+            m.replacement_preview = Some(preview_replacement(
+                m,
+                &content,
+                &line_ranges,
+                &compiled,
+                &options,
+            ));
         }
     }
     Ok(WorkspaceReplacePreview {
@@ -25,17 +39,15 @@ pub(super) fn preview_workspace_replace_impl(
 
 pub(super) fn preview_replacement(
     m: &WorkspaceSearchMatch,
+    content: &str,
+    line_ranges: &LineRanges,
     compiled: &CompiledSearch,
     options: &WorkspaceReplaceOptions,
 ) -> String {
-    let col = m.display_column.unwrap_or(m.column).saturating_sub(1) as usize;
-    let len = m.display_match_length.unwrap_or(m.match_length) as usize;
-    let chars = m.line_content.chars().collect::<Vec<_>>();
-    if col + len > chars.len() {
-        return options.replacement.clone();
-    }
-    let matched = chars[col..col + len].iter().collect::<String>();
-    replacement_for_slice(&matched, &compiled.replacement_regex, options)
+    line_ranges
+        .match_slice(content, m.line, m.column, m.match_length)
+        .map(|matched| replacement_for_slice(matched, &compiled.replacement_regex, options))
+        .unwrap_or_else(|| options.replacement.clone())
 }
 
 pub(super) fn replacement_for_slice(

--- a/rust/src/api/workspace_search/preview_tests.rs
+++ b/rust/src/api/workspace_search/preview_tests.rs
@@ -1,0 +1,32 @@
+use std::fs;
+
+use super::*;
+use tempfile::tempdir;
+
+#[test]
+fn replace_preview_uses_unclamped_match_slice() {
+    let dir = tempdir().unwrap();
+    let matched = "a".repeat(600);
+    fs::write(dir.path().join("note.txt"), format!("🙂{matched}\n")).unwrap();
+
+    let preview = preview_workspace_replace(WorkspaceReplaceOptions {
+        search: WorkspaceSearchOptions {
+            workspace_path: dir.path().to_string_lossy().to_string(),
+            query: "(a+)".to_string(),
+            case_sensitive: true,
+            whole_word: false,
+            use_regex: true,
+            include_pattern: None,
+            exclude_pattern: None,
+            include_ignored: false,
+            max_results: None,
+        },
+        replacement: "${1}z".to_string(),
+        preserve_case: false,
+    })
+    .unwrap();
+
+    let m = &preview.result.files[0].matches[0];
+    assert!(m.line_content.starts_with('…'));
+    assert_eq!(m.replacement_preview, Some(format!("{matched}z")));
+}

--- a/rust/src/api/workspace_search/replace.rs
+++ b/rust/src/api/workspace_search/replace.rs
@@ -3,6 +3,7 @@ use std::fs;
 
 use super::compile::compile_search;
 use super::engine::run_search;
+use super::line_ranges::LineRanges;
 use super::paths::resolve_replace_file;
 use super::preview::replacement_for_slice;
 use super::{
@@ -145,56 +146,6 @@ pub(super) fn replace_workspace_matches_impl(
         matches_replaced,
         conflicts,
     })
-}
-
-struct LineRanges {
-    ranges: Vec<LineRange>,
-}
-
-impl LineRanges {
-    fn new(content: &str) -> Self {
-        let mut ranges = Vec::new();
-        let mut start = 0;
-        for line in content.split_inclusive('\n') {
-            let mut end = start + line.len();
-            if line.ends_with('\n') {
-                end -= 1;
-            }
-            if end > start && content.as_bytes()[end - 1] == b'\r' {
-                end -= 1;
-            }
-            ranges.push(LineRange { start, end });
-            start += line.len();
-        }
-        Self { ranges }
-    }
-
-    fn locate_match_range(
-        &self,
-        content: &str,
-        line_number: u32,
-        column: u32,
-        match_length: u32,
-    ) -> Option<(usize, usize)> {
-        let line = self.ranges.get(line_number.checked_sub(1)? as usize)?;
-        let clean_line = &content[line.start..line.end];
-        let start_col = column.saturating_sub(1) as usize;
-        let start_byte = byte_offset_for_char(clean_line, start_col);
-        let end_byte = byte_offset_for_char(clean_line, start_col + match_length as usize);
-        Some((line.start + start_byte, line.start + end_byte))
-    }
-}
-
-struct LineRange {
-    start: usize,
-    end: usize,
-}
-
-fn byte_offset_for_char(text: &str, char_offset: usize) -> usize {
-    text.char_indices()
-        .nth(char_offset)
-        .map(|(byte, _)| byte)
-        .unwrap_or(text.len())
 }
 
 fn relative_path_from_match_id(id: &str) -> String {

--- a/rust/src/api/workspace_search/replace.rs
+++ b/rust/src/api/workspace_search/replace.rs
@@ -24,7 +24,7 @@ pub(super) fn replace_workspace_matches_impl(
     } else {
         Some(request.match_ids.into_iter().collect::<HashSet<_>>())
     };
-    let matches = run_search(&compiled, Some(&request.options), true)?;
+    let matches = run_search(&compiled, true)?;
     if selected.is_none() && matches.truncated {
         return Err(WorkspaceSearchError::new(
             WorkspaceSearchErrorKind::InvalidPattern,
@@ -98,9 +98,12 @@ pub(super) fn replace_workspace_matches_impl(
                 continue;
             }
         };
+        let line_ranges = LineRanges::new(&content);
         let mut ranges = Vec::new();
         for m in selected_matches {
-            if let Some(range) = locate_match_range(&content, m.line, m.column, m.match_length) {
+            if let Some(range) =
+                line_ranges.locate_match_range(&content, m.line, m.column, m.match_length)
+            {
                 let replacement = replacement_for_slice(
                     &content[range.0..range.1],
                     &compiled.replacement_regex,
@@ -144,33 +147,54 @@ pub(super) fn replace_workspace_matches_impl(
     })
 }
 
-fn locate_match_range(
-    content: &str,
-    line_number: u32,
-    column: u32,
-    match_length: u32,
-) -> Option<(usize, usize)> {
-    let mut byte_cursor = 0;
-    for (idx, line) in content.split_inclusive('\n').enumerate() {
-        if idx as u32 + 1 == line_number {
-            let clean_line = line.strip_suffix('\n').unwrap_or(line);
-            let start_col = column.saturating_sub(1) as usize;
-            let start_byte = clean_line
-                .char_indices()
-                .nth(start_col)
-                .map(|(byte, _)| byte)
-                .unwrap_or(clean_line.len());
-            let end_char = start_col + match_length as usize;
-            let end_byte = clean_line
-                .char_indices()
-                .nth(end_char)
-                .map(|(byte, _)| byte)
-                .unwrap_or(clean_line.len());
-            return Some((byte_cursor + start_byte, byte_cursor + end_byte));
+struct LineRanges {
+    ranges: Vec<LineRange>,
+}
+
+impl LineRanges {
+    fn new(content: &str) -> Self {
+        let mut ranges = Vec::new();
+        let mut start = 0;
+        for line in content.split_inclusive('\n') {
+            let mut end = start + line.len();
+            if line.ends_with('\n') {
+                end -= 1;
+            }
+            if end > start && content.as_bytes()[end - 1] == b'\r' {
+                end -= 1;
+            }
+            ranges.push(LineRange { start, end });
+            start += line.len();
         }
-        byte_cursor += line.len();
+        Self { ranges }
     }
-    None
+
+    fn locate_match_range(
+        &self,
+        content: &str,
+        line_number: u32,
+        column: u32,
+        match_length: u32,
+    ) -> Option<(usize, usize)> {
+        let line = self.ranges.get(line_number.checked_sub(1)? as usize)?;
+        let clean_line = &content[line.start..line.end];
+        let start_col = column.saturating_sub(1) as usize;
+        let start_byte = byte_offset_for_char(clean_line, start_col);
+        let end_byte = byte_offset_for_char(clean_line, start_col + match_length as usize);
+        Some((line.start + start_byte, line.start + end_byte))
+    }
+}
+
+struct LineRange {
+    start: usize,
+    end: usize,
+}
+
+fn byte_offset_for_char(text: &str, char_offset: usize) -> usize {
+    text.char_indices()
+        .nth(char_offset)
+        .map(|(byte, _)| byte)
+        .unwrap_or(text.len())
 }
 
 fn relative_path_from_match_id(id: &str) -> String {

--- a/rust/src/api/workspace_search/replace_tests.rs
+++ b/rust/src/api/workspace_search/replace_tests.rs
@@ -3,6 +3,56 @@ use std::fs;
 use super::*;
 use tempfile::tempdir;
 
+#[test]
+fn replace_selected_matches_uses_line_ranges_for_later_lines() {
+    let dir = tempdir().unwrap();
+    fs::write(
+        dir.path().join("note.txt"),
+        "skip needle\nemoji 🙂 needle\nlast needle\n",
+    )
+    .unwrap();
+    let search = WorkspaceSearchOptions {
+        workspace_path: dir.path().to_string_lossy().to_string(),
+        query: "needle".to_string(),
+        case_sensitive: true,
+        whole_word: false,
+        use_regex: false,
+        include_pattern: None,
+        exclude_pattern: None,
+        include_ignored: false,
+        max_results: None,
+    };
+    let preview = preview_workspace_replace(WorkspaceReplaceOptions {
+        search: search.clone(),
+        replacement: "pin".to_string(),
+        preserve_case: false,
+    })
+    .unwrap();
+    let file = &preview.result.files[0];
+    let selected = vec![file.matches[1].id.clone(), file.matches[2].id.clone()];
+
+    let replaced = replace_workspace_matches(WorkspaceReplaceRequest {
+        options: WorkspaceReplaceOptions {
+            search,
+            replacement: "pin".to_string(),
+            preserve_case: false,
+        },
+        match_ids: selected,
+        expected_files: vec![WorkspaceReplaceFileExpectation {
+            relative_path: file.relative_path.clone(),
+            content_token: file.content_token.clone(),
+        }],
+    })
+    .unwrap();
+
+    assert_eq!(replaced.files_changed, 1);
+    assert_eq!(replaced.matches_replaced, 2);
+    assert_eq!(
+        fs::read_to_string(dir.path().join("note.txt")).unwrap(),
+        "skip needle\nemoji 🙂 pin\nlast pin\n"
+    );
+}
+
 #[cfg(unix)]
 #[test]
 fn replace_reports_file_write_failures_as_conflicts() {

--- a/test/widget/workspace_search_panel_test.dart
+++ b/test/widget/workspace_search_panel_test.dart
@@ -6,6 +6,34 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  testWidgets('search toolbar keeps refresh rightmost and toggles view icon', (
+    tester,
+  ) async {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    await _pumpSearchPanel(
+      tester,
+      container: container,
+      workspace: _workspace(id: 'workspace-a', path: '/workspace-a'),
+    );
+
+    expect(find.byTooltip('View as tree'), findsOneWidget);
+    expect(find.byIcon(Icons.account_tree_outlined), findsOneWidget);
+    expect(find.byIcon(Icons.format_list_bulleted), findsNothing);
+    expect(
+      tester.getCenter(find.byTooltip('Refresh')).dx,
+      greaterThan(tester.getCenter(find.byTooltip('Collapse all')).dx),
+    );
+
+    await tester.tap(find.byTooltip('View as tree'));
+    await tester.pump();
+
+    expect(find.byTooltip('View as list'), findsOneWidget);
+    expect(find.byIcon(Icons.account_tree_outlined), findsNothing);
+    expect(find.byIcon(Icons.format_list_bulleted), findsOneWidget);
+  });
+
   testWidgets('toggles search ignored files action in toolbar', (tester) async {
     final container = ProviderContainer();
     addTearDown(container.dispose);


### PR DESCRIPTION
## summary

- cache workspace search panel row models to reduce repeated tree/list rebuild work
- avoid duplicate replacement preview computation in the Rust search engine
- reuse indexed line ranges during selected replacement mapping

## validation

- `cd rust && cargo test workspace_search`
- `flutter test test/unit/workspace_search_controller_test.dart test/unit/workspace_search_controller_ignore_test.dart test/unit/workspace_search_panel_test.dart test/widget/workspace_search_panel_test.dart`
- `flutter analyze`
- `make rust-test`
- `git diff --check`

## notes

- this PR is based on the already merged workspace search PR #39
- no flutter_rust_bridge regeneration was needed because the public Rust bridge API did not change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved path normalization and handling in workspace search for cross-platform compatibility.

* **Improvements**
  * Enhanced performance of search panel UI through optimized computation caching.
  * Refined replacement preview and application workflow.
  * Better accuracy in match location calculation for replacements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->