### PR TITLE
chore: switch website references to alera.build

### DIFF
--- a/landing/AGENTS.md
+++ b/landing/AGENTS.md
@@ -11,7 +11,7 @@ This document defines governance only. It does not change runtime APIs, schemas,
 ## Project Shape
 
 - The site MUST remain an Astro static output project unless the user explicitly requests otherwise.
-- `astro.config.mjs` MUST keep `output: 'static'` and the canonical site URL `https://alera.dev`.
+- `astro.config.mjs` MUST keep `output: 'static'` and the canonical site URL `https://alera.build`.
 - Use the existing landing structure before adding new patterns:
   - `src/pages/index.astro` for page composition.
   - `src/layouts/Layout.astro` for document metadata, global imports, fonts, analytics, and page shell.

--- a/landing/astro.config.mjs
+++ b/landing/astro.config.mjs
@@ -1,6 +1,6 @@
 import { defineConfig } from 'astro/config';
 
 export default defineConfig({
-  site: 'https://alera.dev',
+  site: 'https://alera.build',
   output: 'static',
 });

--- a/landing/src/layouts/Layout.astro
+++ b/landing/src/layouts/Layout.astro
@@ -10,7 +10,7 @@ const { title } = Astro.props;
 
 const description = 'Run every CLI coding agent in parallel: Claude Code, Codex, Amp, Antigravity, OpenCode, Cursor, Copilot, Pi, or any other CLI agent. Native performance with Flutter + Rust + Ghostty. No Electron, no Chromium. Available for macOS, Windows, and Linux.';
 const shortDescription = 'Native, performance-first workbench for CLI coding agents. Built with Flutter + Rust + Ghostty. macOS, Windows, and Linux.';
-const siteUrl = 'https://alera.dev';
+const siteUrl = 'https://alera.build';
 const ogImage = `${siteUrl}/logo.png`;
 
 const jsonLd = {

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,5 @@
 <h1 align="center">
-  <a href="https://alera.dev"><img src="assets/logo/alera-logo.png" alt="Alera" width="64" valign="middle" /></a> Alera
+  <a href="https://alera.build"><img src="assets/logo/alera-logo.png" alt="Alera" width="64" valign="middle" /></a> Alera
 </h1>
 
 <p align="center">
@@ -17,7 +17,7 @@
 
 <p align="center">
   <a href="#install"><strong>Get Alera →</strong></a> &nbsp;·&nbsp;
-  <a href="https://alera.dev"><strong>alera.dev</strong></a> &nbsp;·&nbsp;
+  <a href="https://alera.build"><strong>alera.build</strong></a> &nbsp;·&nbsp;
   <a href="roadmap.md"><strong>Roadmap</strong></a>
 </p>
 
@@ -113,7 +113,7 @@ See the full [roadmap](roadmap.md) for the complete picture, including difficult
 
 ## Install
 
-> Public release artifacts and download links are being finalized. Track [releases on GitHub](https://github.com/leynier/alera/releases) or visit **[alera.dev](https://alera.dev)** for the latest.
+> Public release artifacts and download links are being finalized. Track [releases on GitHub](https://github.com/leynier/alera/releases) or visit **[alera.build](https://alera.build)** for the latest.
 
 ### Run from source
 
@@ -231,7 +231,7 @@ Public release cuts are maintainer-managed through GitHub Actions. Release artif
 
 - ⭐ **Star this repo** to follow along. Alera ships often
 - 🐛 **Found a bug or want a feature?** [Open an issue](https://github.com/leynier/alera/issues)
-- 🌐 **Website:** [alera.dev](https://alera.dev)
+- 🌐 **Website:** [alera.build](https://alera.build)
 - 📜 **License:** see [`LICENSE`](LICENSE)
 - 🛡️ **Security:** see [`SECURITY.md`](SECURITY.md)
 - 🤝 **Code of conduct:** see [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md)

--- a/tool/release/package_linux.sh
+++ b/tool/release/package_linux.sh
@@ -21,7 +21,7 @@ package_version="${artifact_version}"
 package_release="${build_number}"
 arch_deb="amd64"
 arch_rpm="x86_64"
-maintainer="${ALERA_LINUX_PACKAGE_MAINTAINER:-Alera Release Engineering <releases@alera.dev>}"
+maintainer="${ALERA_LINUX_PACKAGE_MAINTAINER:-Alera Release Engineering <dev@alera.build>}"
 description="Alera desktop agentic development environment."
 
 stage="$(mktemp -d)"


### PR DESCRIPTION
## Summary
- Updated landing and metadata configuration to use `https://alera.build` as the canonical site URL.
- Updated homepage link targets in landing layout and root README from `alera.dev` to `alera.build`.
- Updated Linux package maintainer default email/domain to `dev@alera.build`.
- Synchronized landing contributor guidance in `landing/AGENTS.md` with the new canonical URL policy.

## Scope of changes
- `landing/AGENTS.md`
- `landing/astro.config.mjs`
- `landing/src/layouts/Layout.astro`
- `readme.md`
- `tool/release/package_linux.sh`

Fix #51