### PR TITLE
feat: add ai-powered commit message generation

### DIFF
--- a/lib/src/features/ai_text_generation/application/ai_text_generation_prompt.dart
+++ b/lib/src/features/ai_text_generation/application/ai_text_generation_prompt.dart
@@ -1,0 +1,116 @@
+import 'package:alera/src/features/ai_text_generation/domain/ai_text_generation_settings.dart';
+
+const int stagedDiffPromptBudget = 200000;
+
+class AiTextCommitContext {
+  const AiTextCommitContext({
+    required this.branch,
+    required this.stagedSummary,
+    required this.stagedPatch,
+  });
+
+  final String? branch;
+  final String stagedSummary;
+  final String stagedPatch;
+}
+
+String buildCommitMessagePrompt({
+  required AiTextCommitContext context,
+  required String customInstructions,
+}) {
+  final base = <String>[
+    'You are generating a single git commit message.',
+    'Return only the commit message text. Do not include a preamble, quotes, or code fences.',
+    '',
+    'Rules:',
+    '- First line: imperative mood, <= 72 chars, no trailing period.',
+    '- Optional body: blank line, then short wrapped bullet points or prose explaining WHY.',
+    '- Capture the primary user-visible or developer-visible change.',
+    '- Use only the staged changes below as context.',
+    '- Do not include "Co-authored-by" or other git trailers.',
+    '',
+    'Branch: ${context.branch ?? '(detached)'}',
+    '',
+    'Staged files:',
+    limitPromptSection(context.stagedSummary, 6000),
+    '',
+    'Staged patch:',
+    '```diff',
+    truncateDiffForPrompt(context.stagedPatch),
+    '```',
+  ].join('\n');
+
+  final trimmed = customInstructions.trim();
+  if (trimmed.isEmpty) {
+    return base;
+  }
+  return <String>[
+    base,
+    '',
+    'Additional user instructions:',
+    limitPromptSection(trimmed, 4000),
+  ].join('\n');
+}
+
+String limitPromptSection(String value, int maxChars) {
+  if (value.length <= maxChars) {
+    return value;
+  }
+  final omitted = value.length - maxChars;
+  return '${value.substring(0, maxChars)}\n\n[truncated: $omitted characters omitted]';
+}
+
+String truncateDiffForPrompt(
+  String diff, {
+  int budget = stagedDiffPromptBudget,
+}) {
+  if (diff.length <= budget) {
+    return diff;
+  }
+  final omitted = diff.length - budget;
+  return '${diff.substring(0, budget)}\n...(diff truncated, $omitted characters omitted)';
+}
+
+String cleanGeneratedText(String raw) {
+  var text = raw.replaceAll('\r\n', '\n').trim();
+  final firstNewline = text.indexOf('\n');
+  if (firstNewline != -1) {
+    final firstLine = text.substring(0, firstNewline).trim();
+    if (RegExp(
+          r'^(generating|thinking)\b',
+          caseSensitive: false,
+        ).hasMatch(firstLine) ||
+        RegExp(r'^[.…]+$').hasMatch(firstLine)) {
+      text = text.substring(firstNewline + 1).trim();
+    }
+  }
+  final fenced = RegExp(
+    r'^```[a-zA-Z0-9_-]*\n([\s\S]*?)\n```$',
+  ).firstMatch(text);
+  if (fenced != null) {
+    text = fenced.group(1)!.trim();
+  }
+  return text.replaceFirst(RegExp(r'^\s*(?:[-*]\s+|\d+[.)]\s+)'), '').trim();
+}
+
+String cleanGeneratedCommitMessage(String raw) {
+  final normalized = cleanGeneratedText(raw);
+  final lines = normalized.split('\n');
+  final subject = (lines.isEmpty ? '' : lines.first).trim().replaceFirst(
+    RegExp(r'[.]+$'),
+    '',
+  );
+  final candidate = subject.isEmpty ? 'Update project files' : subject;
+  final safeSubject = candidate
+      .substring(0, candidate.length > 72 ? 72 : candidate.length)
+      .trimRight();
+  final body = lines.skip(1).join('\n').trim();
+  return body.isEmpty ? safeSubject : '$safeSubject\n\n$body';
+}
+
+String promptInstructionsFor(
+  AiTextGenerationSettings settings,
+  AiTextGenerationOperation operation,
+) {
+  return settings.instructionsFor(operation);
+}

--- a/lib/src/features/ai_text_generation/application/ai_text_generation_providers.dart
+++ b/lib/src/features/ai_text_generation/application/ai_text_generation_providers.dart
@@ -1,0 +1,22 @@
+import 'package:alera/src/features/ai_text_generation/application/ai_text_generation_service.dart';
+import 'package:alera/src/features/ai_text_generation/application/ai_text_model_discovery_service.dart';
+import 'package:alera/src/shared/infra/git/git_providers.dart';
+import 'package:alera/src/shared/infra/process/process_providers.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'ai_text_generation_providers.g.dart';
+
+@Riverpod(keepAlive: true)
+AiTextGenerationService aiTextGenerationService(Ref ref) {
+  return CliAiTextGenerationService(
+    gitBackend: ref.read(gitBackendProvider),
+    processRunner: ref.read(processRunnerProvider),
+  );
+}
+
+@Riverpod(keepAlive: true)
+AiTextModelDiscoveryService aiTextModelDiscoveryService(Ref ref) {
+  return CliAiTextModelDiscoveryService(
+    processRunner: ref.read(processRunnerProvider),
+  );
+}

--- a/lib/src/features/ai_text_generation/application/ai_text_generation_providers.g.dart
+++ b/lib/src/features/ai_text_generation/application/ai_text_generation_providers.g.dart
@@ -1,0 +1,107 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'ai_text_generation_providers.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(aiTextGenerationService)
+final aiTextGenerationServiceProvider = AiTextGenerationServiceProvider._();
+
+final class AiTextGenerationServiceProvider
+    extends
+        $FunctionalProvider<
+          AiTextGenerationService,
+          AiTextGenerationService,
+          AiTextGenerationService
+        >
+    with $Provider<AiTextGenerationService> {
+  AiTextGenerationServiceProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'aiTextGenerationServiceProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$aiTextGenerationServiceHash();
+
+  @$internal
+  @override
+  $ProviderElement<AiTextGenerationService> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  AiTextGenerationService create(Ref ref) {
+    return aiTextGenerationService(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(AiTextGenerationService value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<AiTextGenerationService>(value),
+    );
+  }
+}
+
+String _$aiTextGenerationServiceHash() =>
+    r'da126de429e0e97a2bed76e1600e800b41054a48';
+
+@ProviderFor(aiTextModelDiscoveryService)
+final aiTextModelDiscoveryServiceProvider =
+    AiTextModelDiscoveryServiceProvider._();
+
+final class AiTextModelDiscoveryServiceProvider
+    extends
+        $FunctionalProvider<
+          AiTextModelDiscoveryService,
+          AiTextModelDiscoveryService,
+          AiTextModelDiscoveryService
+        >
+    with $Provider<AiTextModelDiscoveryService> {
+  AiTextModelDiscoveryServiceProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'aiTextModelDiscoveryServiceProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$aiTextModelDiscoveryServiceHash();
+
+  @$internal
+  @override
+  $ProviderElement<AiTextModelDiscoveryService> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  AiTextModelDiscoveryService create(Ref ref) {
+    return aiTextModelDiscoveryService(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(AiTextModelDiscoveryService value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<AiTextModelDiscoveryService>(value),
+    );
+  }
+}
+
+String _$aiTextModelDiscoveryServiceHash() =>
+    r'7c3bcd44c62867043bf9b5d188f5497492ffafd7';

--- a/lib/src/features/ai_text_generation/application/ai_text_generation_registry.dart
+++ b/lib/src/features/ai_text_generation/application/ai_text_generation_registry.dart
@@ -1,0 +1,562 @@
+import 'dart:convert';
+
+import 'package:alera/src/features/ai_text_generation/domain/ai_text_generation_settings.dart';
+
+enum AiPromptDelivery { argv, stdin }
+
+class AiThinkingLevel {
+  const AiThinkingLevel({required this.id, required this.label});
+
+  final String id;
+  final String label;
+}
+
+class AiTextModel {
+  const AiTextModel({
+    required this.id,
+    required this.label,
+    this.thinkingLevels = const <AiThinkingLevel>[],
+    this.defaultThinkingLevel,
+  });
+
+  final String id;
+  final String label;
+  final List<AiThinkingLevel> thinkingLevels;
+  final String? defaultThinkingLevel;
+
+  bool get supportsThinking => thinkingLevels.isNotEmpty;
+
+  AiTextDiscoveredModel toDiscovered() {
+    return AiTextDiscoveredModel(
+      id: id,
+      label: label,
+      thinkingLevels: <AiTextDiscoveredThinkingLevel>[
+        for (final level in thinkingLevels)
+          AiTextDiscoveredThinkingLevel(id: level.id, label: level.label),
+      ],
+      defaultThinkingLevel: defaultThinkingLevel,
+    );
+  }
+}
+
+AiTextModel modelFromDiscovered(AiTextDiscoveredModel model) {
+  return AiTextModel(
+    id: model.id,
+    label: model.label,
+    thinkingLevels: <AiThinkingLevel>[
+      for (final level in model.thinkingLevels)
+        AiThinkingLevel(id: level.id, label: level.label),
+    ],
+    defaultThinkingLevel: model.defaultThinkingLevel,
+  );
+}
+
+class AiTextAgentSpec {
+  const AiTextAgentSpec({
+    required this.agent,
+    required this.binary,
+    required this.promptDelivery,
+    required this.modelsCommand,
+    required this.parseModels,
+    required this.models,
+    required this.defaultModelId,
+    required this.buildArgs,
+  });
+
+  final AiTextGenerationAgent agent;
+  final String binary;
+  final AiPromptDelivery promptDelivery;
+  final List<String>? modelsCommand;
+  final List<AiTextModel> Function(String stdout) parseModels;
+  final List<AiTextModel> models;
+  final String defaultModelId;
+  final List<String> Function({
+    required String prompt,
+    required String model,
+    String? thinkingLevel,
+    required int timeoutSeconds,
+  })
+  buildArgs;
+
+  String get label => agent.label;
+}
+
+const List<AiThinkingLevel> basicThinkingLevels = <AiThinkingLevel>[
+  AiThinkingLevel(id: 'low', label: 'Low'),
+  AiThinkingLevel(id: 'medium', label: 'Medium'),
+  AiThinkingLevel(id: 'high', label: 'High'),
+];
+
+const List<AiThinkingLevel> openAiThinkingLevels = <AiThinkingLevel>[
+  AiThinkingLevel(id: 'low', label: 'Low'),
+  AiThinkingLevel(id: 'medium', label: 'Medium'),
+  AiThinkingLevel(id: 'high', label: 'High'),
+  AiThinkingLevel(id: 'xhigh', label: 'Extra high'),
+];
+
+const List<AiThinkingLevel> claudeThinkingLevels = <AiThinkingLevel>[
+  AiThinkingLevel(id: 'low', label: 'Low'),
+  AiThinkingLevel(id: 'medium', label: 'Medium'),
+  AiThinkingLevel(id: 'high', label: 'High'),
+  AiThinkingLevel(id: 'xhigh', label: 'Extra high'),
+  AiThinkingLevel(id: 'max', label: 'Max'),
+];
+
+const List<AiThinkingLevel> onOffThinkingLevels = <AiThinkingLevel>[
+  AiThinkingLevel(id: 'on', label: 'On'),
+  AiThinkingLevel(id: 'off', label: 'Off'),
+];
+
+final Map<AiTextGenerationAgent, AiTextAgentSpec>
+aiTextAgentSpecs = <AiTextGenerationAgent, AiTextAgentSpec>{
+  AiTextGenerationAgent.claude: AiTextAgentSpec(
+    agent: AiTextGenerationAgent.claude,
+    binary: 'claude',
+    promptDelivery: AiPromptDelivery.stdin,
+    modelsCommand: null,
+    parseModels: parseLineModels,
+    models: const <AiTextModel>[
+      AiTextModel(id: 'haiku', label: 'Haiku'),
+      AiTextModel(
+        id: 'sonnet',
+        label: 'Sonnet',
+        thinkingLevels: claudeThinkingLevels,
+        defaultThinkingLevel: 'low',
+      ),
+      AiTextModel(
+        id: 'opus',
+        label: 'Opus',
+        thinkingLevels: claudeThinkingLevels,
+        defaultThinkingLevel: 'low',
+      ),
+    ],
+    defaultModelId: 'sonnet',
+    buildArgs:
+        ({
+          required model,
+          thinkingLevel,
+          required prompt,
+          required timeoutSeconds,
+        }) => <String>[
+          '-p',
+          '--output-format',
+          'text',
+          '--model',
+          model,
+          '--permission-mode',
+          'plan',
+          if (thinkingLevel != null) ...<String>['--effort', thinkingLevel],
+        ],
+  ),
+  AiTextGenerationAgent.codex: AiTextAgentSpec(
+    agent: AiTextGenerationAgent.codex,
+    binary: 'codex',
+    promptDelivery: AiPromptDelivery.stdin,
+    modelsCommand: const <String>['debug', 'models'],
+    parseModels: parseCodexModels,
+    models: const <AiTextModel>[
+      AiTextModel(
+        id: 'gpt-5.5',
+        label: 'GPT-5.5',
+        thinkingLevels: openAiThinkingLevels,
+        defaultThinkingLevel: 'low',
+      ),
+      AiTextModel(
+        id: 'gpt-5.4',
+        label: 'GPT-5.4',
+        thinkingLevels: openAiThinkingLevels,
+        defaultThinkingLevel: 'low',
+      ),
+      AiTextModel(
+        id: 'gpt-5.4-mini',
+        label: 'GPT-5.4 Mini',
+        thinkingLevels: openAiThinkingLevels,
+        defaultThinkingLevel: 'low',
+      ),
+    ],
+    defaultModelId: 'gpt-5.5',
+    buildArgs:
+        ({
+          required model,
+          thinkingLevel,
+          required prompt,
+          required timeoutSeconds,
+        }) => <String>[
+          'exec',
+          '--ephemeral',
+          '--skip-git-repo-check',
+          '-s',
+          'read-only',
+          '--model',
+          model,
+          if (thinkingLevel != null) '-c' else '',
+          if (thinkingLevel != null) 'model_reasoning_effort=$thinkingLevel',
+        ].where((arg) => arg.isNotEmpty).toList(growable: false),
+  ),
+  AiTextGenerationAgent.copilot: AiTextAgentSpec(
+    agent: AiTextGenerationAgent.copilot,
+    binary: 'copilot',
+    promptDelivery: AiPromptDelivery.argv,
+    modelsCommand: null,
+    parseModels: parseLineModels,
+    models: const <AiTextModel>[
+      AiTextModel(id: 'auto', label: 'Auto'),
+      AiTextModel(
+        id: 'gpt-5.4',
+        label: 'GPT-5.4',
+        thinkingLevels: openAiThinkingLevels,
+        defaultThinkingLevel: 'low',
+      ),
+      AiTextModel(
+        id: 'gpt-5.4-mini',
+        label: 'GPT-5.4 Mini',
+        thinkingLevels: openAiThinkingLevels,
+        defaultThinkingLevel: 'low',
+      ),
+    ],
+    defaultModelId: 'gpt-5.4',
+    buildArgs:
+        ({
+          required prompt,
+          required model,
+          thinkingLevel,
+          required timeoutSeconds,
+        }) => <String>[
+          '--prompt',
+          prompt,
+          '--silent',
+          '--stream',
+          'off',
+          '--no-custom-instructions',
+          '--model',
+          model,
+          if (thinkingLevel != null) ...<String>['--effort', thinkingLevel],
+        ],
+  ),
+  AiTextGenerationAgent.cursor: AiTextAgentSpec(
+    agent: AiTextGenerationAgent.cursor,
+    binary: 'cursor-agent',
+    promptDelivery: AiPromptDelivery.argv,
+    modelsCommand: const <String>['--list-models'],
+    parseModels: parseCursorModels,
+    models: const <AiTextModel>[AiTextModel(id: 'auto', label: 'Auto')],
+    defaultModelId: 'auto',
+    buildArgs:
+        ({
+          required prompt,
+          required model,
+          thinkingLevel,
+          required timeoutSeconds,
+        }) => <String>[
+          '--print',
+          '--mode',
+          'ask',
+          '--trust',
+          '--output-format',
+          'text',
+          '--model',
+          model,
+          prompt,
+        ],
+  ),
+  AiTextGenerationAgent.agy: AiTextAgentSpec(
+    agent: AiTextGenerationAgent.agy,
+    binary: 'agy',
+    promptDelivery: AiPromptDelivery.stdin,
+    modelsCommand: const <String>['models'],
+    parseModels: parseLineModels,
+    models: const <AiTextModel>[
+      AiTextModel(
+        id: 'Gemini 3.5 Flash (Medium)',
+        label: 'Gemini 3.5 Flash (Medium)',
+      ),
+      AiTextModel(
+        id: 'Gemini 3.5 Flash (High)',
+        label: 'Gemini 3.5 Flash (High)',
+      ),
+      AiTextModel(
+        id: 'Gemini 3.5 Flash (Low)',
+        label: 'Gemini 3.5 Flash (Low)',
+      ),
+    ],
+    defaultModelId: 'Gemini 3.5 Flash (Medium)',
+    buildArgs:
+        ({
+          required model,
+          thinkingLevel,
+          required prompt,
+          required timeoutSeconds,
+        }) => <String>[
+          '--print',
+          '--sandbox',
+          '--print-timeout',
+          '${timeoutSeconds}s',
+          '--model',
+          model,
+        ],
+  ),
+  AiTextGenerationAgent.opencode: AiTextAgentSpec(
+    agent: AiTextGenerationAgent.opencode,
+    binary: 'opencode',
+    promptDelivery: AiPromptDelivery.stdin,
+    modelsCommand: const <String>['models'],
+    parseModels: parseLineModels,
+    models: const <AiTextModel>[
+      AiTextModel(
+        id: 'opencode/deepseek-v4-flash-free',
+        label: 'OpenCode DeepSeek V4 Flash Free',
+      ),
+    ],
+    defaultModelId: 'opencode/deepseek-v4-flash-free',
+    buildArgs:
+        ({
+          required prompt,
+          required model,
+          thinkingLevel,
+          required timeoutSeconds,
+        }) => <String>[
+          'run',
+          '--model',
+          model,
+          '--agent',
+          'build',
+          '--format',
+          'default',
+          if (thinkingLevel != null) ...<String>['--variant', thinkingLevel],
+        ],
+  ),
+  AiTextGenerationAgent.pi: AiTextAgentSpec(
+    agent: AiTextGenerationAgent.pi,
+    binary: 'pi',
+    promptDelivery: AiPromptDelivery.stdin,
+    modelsCommand: const <String>['--list-models'],
+    parseModels: parsePiModels,
+    models: const <AiTextModel>[
+      AiTextModel(
+        id: 'github-copilot/gpt-5.4-mini',
+        label: 'GitHub Copilot GPT-5.4 Mini',
+        thinkingLevels: openAiThinkingLevels,
+        defaultThinkingLevel: 'low',
+      ),
+    ],
+    defaultModelId: 'github-copilot/gpt-5.4-mini',
+    buildArgs:
+        ({
+          required model,
+          thinkingLevel,
+          required prompt,
+          required timeoutSeconds,
+        }) => <String>[
+          '--print',
+          '--no-session',
+          '--no-tools',
+          '--no-extensions',
+          '--no-skills',
+          '--no-context-files',
+          '--mode',
+          'text',
+          '--model',
+          model,
+          if (thinkingLevel != null) ...<String>['--thinking', thinkingLevel],
+        ],
+  ),
+  AiTextGenerationAgent.amp: AiTextAgentSpec(
+    agent: AiTextGenerationAgent.amp,
+    binary: 'amp',
+    promptDelivery: AiPromptDelivery.stdin,
+    modelsCommand: null,
+    parseModels: parseLineModels,
+    models: const <AiTextModel>[
+      AiTextModel(id: 'smart', label: 'Smart'),
+      AiTextModel(id: 'rush', label: 'Rush'),
+      AiTextModel(
+        id: 'large',
+        label: 'Large',
+        thinkingLevels: basicThinkingLevels,
+        defaultThinkingLevel: 'low',
+      ),
+      AiTextModel(
+        id: 'deep',
+        label: 'Deep',
+        thinkingLevels: basicThinkingLevels,
+        defaultThinkingLevel: 'low',
+      ),
+    ],
+    defaultModelId: 'smart',
+    buildArgs:
+        ({
+          required model,
+          thinkingLevel,
+          required prompt,
+          required timeoutSeconds,
+        }) => <String>[
+          '--execute',
+          '--no-notifications',
+          '--no-ide',
+          '--no-jetbrains',
+          '--mode',
+          model,
+          if (thinkingLevel != null) ...<String>['--effort', thinkingLevel],
+        ],
+  ),
+};
+
+List<AiTextModel> discoveredModelsForAgent(
+  AiTextGenerationSettings settings,
+  AiTextGenerationAgent agent,
+) {
+  return settings
+      .discoveredModelsFor(agent)
+      .map(modelFromDiscovered)
+      .toList(growable: false);
+}
+
+List<AiTextModel> modelsForAgent(
+  AiTextGenerationAgent agent,
+  AiTextGenerationSettings settings,
+) {
+  final spec = aiTextAgentSpecs[agent];
+  if (spec == null) {
+    return const <AiTextModel>[];
+  }
+  return _uniqueModels(<AiTextModel>[
+    ...discoveredModelsForAgent(settings, agent),
+    ...spec.models,
+  ]);
+}
+
+String defaultModelIdForAgent(
+  AiTextGenerationAgent agent,
+  AiTextGenerationSettings settings,
+) {
+  final spec = aiTextAgentSpecs[agent];
+  if (spec == null) {
+    return 'custom';
+  }
+  final discoveredDefault = settings.discoveredDefaultModelFor(agent);
+  if (discoveredDefault != null) {
+    return discoveredDefault;
+  }
+  return spec.defaultModelId;
+}
+
+AiTextModel modelForAgent(
+  AiTextGenerationAgent agent,
+  String? modelId, {
+  List<AiTextModel> extraModels = const <AiTextModel>[],
+}) {
+  final spec = aiTextAgentSpecs[agent];
+  if (spec == null) {
+    return const AiTextModel(id: 'custom', label: 'Custom');
+  }
+  final id = modelId?.trim().isNotEmpty == true
+      ? modelId!.trim()
+      : spec.defaultModelId;
+  return <AiTextModel>[...extraModels, ...spec.models].firstWhere(
+    (model) => model.id == id,
+    orElse: () => AiTextModel(id: id, label: labelFromModelId(id)),
+  );
+}
+
+List<AiTextModel> parseLineModels(String stdout) {
+  return _uniqueModels(
+    stdout
+        .split(RegExp(r'\r?\n'))
+        .map((line) => line.trim())
+        .where((line) => line.isNotEmpty)
+        .map((line) => AiTextModel(id: line, label: labelFromModelId(line)))
+        .toList(growable: false),
+  );
+}
+
+List<AiTextModel> parseCursorModels(String stdout) {
+  return _uniqueModels(
+    stdout
+        .split(RegExp(r'\r?\n'))
+        .map((line) => RegExp(r'^([^\s]+)\s+-\s+(.+)$').firstMatch(line.trim()))
+        .whereType<RegExpMatch>()
+        .map(
+          (match) => AiTextModel(
+            id: match.group(1)!,
+            label: match
+                .group(2)!
+                .replaceFirst(
+                  RegExp(r'\s+\((?:default|current)\)$', caseSensitive: false),
+                  '',
+                ),
+          ),
+        )
+        .toList(growable: false),
+  );
+}
+
+List<AiTextModel> parseCodexModels(String stdout) {
+  try {
+    final decoded = jsonDecode(stdout);
+    if (decoded is! Map) {
+      return const <AiTextModel>[];
+    }
+    final models = decoded['models'];
+    if (models is! List) {
+      return const <AiTextModel>[];
+    }
+    return _uniqueModels(
+      models
+          .whereType<Map>()
+          .map((item) {
+            final slug = item['slug'];
+            final label = item['display_name'];
+            return slug is String && label is String
+                ? AiTextModel(
+                    id: slug,
+                    label: label,
+                    thinkingLevels: openAiThinkingLevels,
+                    defaultThinkingLevel:
+                        item['default_reasoning_level'] is String
+                        ? item['default_reasoning_level'] as String
+                        : 'low',
+                  )
+                : null;
+          })
+          .whereType<AiTextModel>()
+          .toList(growable: false),
+    );
+  } catch (_) {
+    return const <AiTextModel>[];
+  }
+}
+
+List<AiTextModel> parsePiModels(String stdout) {
+  return _uniqueModels(
+    stdout
+        .split(RegExp(r'\r?\n'))
+        .map((line) => line.trim().split(RegExp(r'\s+')))
+        .where((parts) => parts.length >= 2 && parts.first != 'provider')
+        .map((parts) {
+          final id = '${parts[0]}/${parts[1]}';
+          return AiTextModel(id: id, label: labelFromModelId(id));
+        })
+        .toList(growable: false),
+  );
+}
+
+String labelFromModelId(String id) {
+  return id
+      .split(RegExp(r'[/-]'))
+      .where((part) => part.isNotEmpty)
+      .map((part) {
+        if (part.toLowerCase() == 'gpt') {
+          return 'GPT';
+        }
+        if (part.length <= 3 && RegExp(r'^\d').hasMatch(part)) {
+          return part.toUpperCase();
+        }
+        return '${part[0].toUpperCase()}${part.substring(1)}';
+      })
+      .join(' ');
+}
+
+List<AiTextModel> _uniqueModels(List<AiTextModel> models) {
+  final seen = <String>{};
+  return models.where((model) => seen.add(model.id)).toList(growable: false);
+}

--- a/lib/src/features/ai_text_generation/application/ai_text_generation_service.dart
+++ b/lib/src/features/ai_text_generation/application/ai_text_generation_service.dart
@@ -1,0 +1,350 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:alera/src/features/ai_text_generation/application/ai_text_generation_prompt.dart';
+import 'package:alera/src/features/ai_text_generation/application/ai_text_generation_registry.dart';
+import 'package:alera/src/features/ai_text_generation/domain/ai_text_generation_settings.dart';
+import 'package:alera/src/shared/infra/git/git_backend.dart';
+import 'package:alera/src/shared/infra/git/git_diff_models.dart';
+import 'package:alera/src/shared/infra/process/process_runner.dart';
+
+const int maxArgvPromptBytes = 24000;
+
+class AiTextGenerationException implements Exception {
+  const AiTextGenerationException(this.message);
+
+  final String message;
+
+  @override
+  String toString() => message;
+}
+
+class AiTextGenerationCanceledException extends AiTextGenerationException {
+  const AiTextGenerationCanceledException() : super('Generation canceled.');
+}
+
+class AiTextGenerationRequest {
+  const AiTextGenerationRequest({
+    required this.operation,
+    required this.workspacePath,
+    required this.settings,
+  });
+
+  final AiTextGenerationOperation operation;
+  final String workspacePath;
+  final AiTextGenerationSettings settings;
+}
+
+class AiTextGenerationResult {
+  const AiTextGenerationResult({required this.text, required this.agentLabel});
+
+  final String text;
+  final String agentLabel;
+}
+
+abstract interface class AiTextGenerationService {
+  Future<AiTextGenerationResult> generate(AiTextGenerationRequest request);
+
+  void cancel(String workspacePath, AiTextGenerationOperation operation);
+}
+
+class CliAiTextGenerationService implements AiTextGenerationService {
+  CliAiTextGenerationService({
+    required this.gitBackend,
+    required this.processRunner,
+  });
+
+  final GitBackend gitBackend;
+  final ProcessRunner processRunner;
+  final Map<String, StartedProcess> _running = <String, StartedProcess>{};
+  final Set<String> _pending = <String>{};
+  final Set<String> _canceled = <String>{};
+
+  @override
+  Future<AiTextGenerationResult> generate(
+    AiTextGenerationRequest request,
+  ) async {
+    if (!request.settings.enabled) {
+      throw const AiTextGenerationException('AI text generation is disabled.');
+    }
+    final key = _laneKey(request.workspacePath, request.operation);
+    if (_pending.contains(key) || _running.containsKey(key)) {
+      throw const AiTextGenerationException('Generation is already running.');
+    }
+    _canceled.remove(key);
+    _pending.add(key);
+
+    try {
+      final prompt = await _promptFor(request);
+      if (_canceled.contains(key)) {
+        throw const AiTextGenerationCanceledException();
+      }
+      final plan = _planCommand(request.settings, prompt);
+      final StartedProcess process;
+      try {
+        process = await processRunner.start(
+          plan.binary,
+          plan.args,
+          workingDirectory: request.workspacePath,
+        );
+      } catch (_) {
+        throw AiTextGenerationException(
+          '${plan.label} could not be started. Check that ${plan.binary} is installed and on PATH.',
+        );
+      }
+      if (_canceled.contains(key)) {
+        process.kill();
+        throw const AiTextGenerationCanceledException();
+      }
+      _pending.remove(key);
+      _running[key] = process;
+      if (plan.stdinPayload != null) {
+        process.stdinWrite(utf8.encode(plan.stdinPayload!));
+        process.stdinClose();
+      }
+      final output = await _collectProcess(process).timeout(
+        Duration(seconds: request.settings.timeoutSeconds),
+        onTimeout: () {
+          process.kill();
+          throw AiTextGenerationException(
+            'Generation timed out after ${request.settings.timeoutSeconds}s.',
+          );
+        },
+      );
+      if (_canceled.contains(key)) {
+        throw const AiTextGenerationCanceledException();
+      }
+      if (output.exitCode != 0) {
+        final detail = _failureDetail(output.stdout, output.stderr);
+        throw AiTextGenerationException(
+          detail == null
+              ? '${plan.label} failed. Check the agent CLI configuration and try again.'
+              : '${plan.label} failed: $detail',
+        );
+      }
+      final text = _cleanOutput(request.operation, output.stdout);
+      if (text.trim().isEmpty) {
+        throw AiTextGenerationException('${plan.label} returned no text.');
+      }
+      return AiTextGenerationResult(text: text, agentLabel: plan.label);
+    } finally {
+      _pending.remove(key);
+      _running.remove(key);
+      _canceled.remove(key);
+    }
+  }
+
+  @override
+  void cancel(String workspacePath, AiTextGenerationOperation operation) {
+    final key = _laneKey(workspacePath, operation);
+    final process = _running[key];
+    if (_pending.contains(key)) {
+      _canceled.add(key);
+      return;
+    }
+    if (process == null) {
+      return;
+    }
+    _canceled.add(key);
+    process.kill();
+  }
+
+  Future<String> _promptFor(AiTextGenerationRequest request) async {
+    return switch (request.operation) {
+      AiTextGenerationOperation.commitMessage => buildCommitMessagePrompt(
+        context: await _commitContext(request.workspacePath),
+        customInstructions: promptInstructionsFor(
+          request.settings,
+          AiTextGenerationOperation.commitMessage,
+        ),
+      ),
+      AiTextGenerationOperation.pullRequestDetails ||
+      AiTextGenerationOperation.branchName => throw AiTextGenerationException(
+        '${request.operation.label} generation is not wired yet.',
+      ),
+    };
+  }
+
+  Future<AiTextCommitContext> _commitContext(String workspacePath) async {
+    final status = await gitBackend.status(workspacePath);
+    final staged = status.entries
+        .where((entry) => entry.area == GitChangeArea.staged)
+        .toList(growable: false);
+    if (staged.isEmpty) {
+      throw const AiTextGenerationException('No staged changes to summarize.');
+    }
+    final repository = await gitBackend.repositoryState(workspacePath);
+    final summary = staged
+        .map((entry) {
+          final counts = <String>[
+            if (entry.added != null) '+${entry.added}',
+            if (entry.removed != null) '-${entry.removed}',
+          ].join(' ');
+          final prefix = entry.oldPath == null
+              ? entry.path
+              : '${entry.oldPath} -> ${entry.path}';
+          return counts.isEmpty ? '- $prefix' : '- $prefix ($counts)';
+        })
+        .join('\n');
+    final patches = <String>[];
+    for (final entry in staged) {
+      final diff = await gitBackend.diff(
+        path: workspacePath,
+        filePath: entry.path,
+        area: GitChangeArea.staged,
+      );
+      patches.add(_diffToPatch(diff));
+    }
+    return AiTextCommitContext(
+      branch: repository.branch == 'HEAD' ? null : repository.branch,
+      stagedSummary: summary,
+      stagedPatch: patches.join('\n'),
+    );
+  }
+
+  _AiTextCommandPlan _planCommand(
+    AiTextGenerationSettings settings,
+    String prompt,
+  ) {
+    if (settings.agent == AiTextGenerationAgent.custom) {
+      return _planCustomCommand(settings.customCommand, prompt);
+    }
+    final spec = aiTextAgentSpecs[settings.agent];
+    if (spec == null) {
+      throw AiTextGenerationException(
+        '${settings.agent.label} does not support AI text generation.',
+      );
+    }
+    final model = modelForAgent(
+      settings.agent,
+      settings.modelFor(settings.agent) ??
+          defaultModelIdForAgent(settings.agent, settings),
+      extraModels: discoveredModelsForAgent(settings, settings.agent),
+    );
+    final thinking =
+        settings.thinkingForModel(model.id) ?? model.defaultThinkingLevel;
+    if (spec.promptDelivery == AiPromptDelivery.argv &&
+        utf8.encode(prompt).length > maxArgvPromptBytes) {
+      throw AiTextGenerationException(
+        '${spec.label} cannot receive large prompts safely. Choose an agent that supports stdin prompts or reduce the staged diff.',
+      );
+    }
+    final argvPrompt = spec.promptDelivery == AiPromptDelivery.argv
+        ? prompt
+        : '';
+    return _AiTextCommandPlan(
+      binary: spec.binary,
+      args: spec.buildArgs(
+        prompt: argvPrompt,
+        model: model.id,
+        thinkingLevel: thinking,
+        timeoutSeconds: settings.timeoutSeconds,
+      ),
+      stdinPayload: spec.promptDelivery == AiPromptDelivery.stdin
+          ? prompt
+          : null,
+      label: spec.label,
+    );
+  }
+
+  _AiTextCommandPlan _planCustomCommand(String template, String prompt) {
+    final tokens = _tokenizeCommandTemplate(template);
+    if (tokens.isEmpty) {
+      throw const AiTextGenerationException('Custom command is empty.');
+    }
+    final usesPlaceholder = tokens.any((token) => token.contains('{prompt}'));
+    final substituted = tokens
+        .map((token) => token.replaceAll('{prompt}', prompt))
+        .toList(growable: false);
+    return _AiTextCommandPlan(
+      binary: substituted.first,
+      args: substituted.skip(1).toList(growable: false),
+      stdinPayload: usesPlaceholder ? null : prompt,
+      label: substituted.first,
+    );
+  }
+
+  List<String> _tokenizeCommandTemplate(String template) {
+    final matches = RegExp(
+      r'''"([^"]*)"|'([^']*)'|(\S+)''',
+    ).allMatches(template);
+    return matches
+        .map((match) => match.group(1) ?? match.group(2) ?? match.group(3)!)
+        .toList(growable: false);
+  }
+
+  Future<ProcessRunOutput> _collectProcess(StartedProcess process) async {
+    final stdout = StringBuffer();
+    final stderr = StringBuffer();
+    final stdoutDone = utf8.decoder.bind(process.stdout).forEach(stdout.write);
+    final stderrDone = utf8.decoder.bind(process.stderr).forEach(stderr.write);
+    final exitCode = await process.exitCode;
+    await Future.wait(<Future<void>>[stdoutDone, stderrDone]);
+    return ProcessRunOutput(
+      exitCode: exitCode,
+      stdout: stdout.toString(),
+      stderr: stderr.toString(),
+    );
+  }
+
+  String _diffToPatch(GitDiffResult diff) {
+    return diff.files
+        .map((file) {
+          final header = <String>[
+            'diff --git a/${file.oldPath ?? file.path} b/${file.path}',
+            if (file.isBinary) 'Binary file changed',
+            if (file.isLarge) 'Large file preview truncated',
+          ];
+          final lines = file.lines.map((line) => line.text);
+          return <String>[...header, ...lines].join('\n');
+        })
+        .join('\n');
+  }
+
+  String _cleanOutput(AiTextGenerationOperation operation, String stdout) {
+    return switch (operation) {
+      AiTextGenerationOperation.commitMessage => cleanGeneratedCommitMessage(
+        stdout,
+      ),
+      AiTextGenerationOperation.pullRequestDetails ||
+      AiTextGenerationOperation.branchName => cleanGeneratedText(stdout),
+    };
+  }
+
+  String? _failureDetail(String stdout, String stderr) {
+    final combined = '$stdout\n$stderr'
+        .replaceAll(RegExp(r'\x1B\[[0-?]*[ -/]*[@-~]'), '')
+        .trim();
+    if (combined.isEmpty) {
+      return null;
+    }
+    final lines = combined
+        .split(RegExp(r'\r?\n'))
+        .where((line) {
+          return line.trim().isNotEmpty;
+        })
+        .toList(growable: false);
+    final detail = lines.isEmpty ? combined : lines.last.trim();
+    return detail.length > 240
+        ? '${detail.substring(0, 240).trimRight()}...'
+        : detail;
+  }
+
+  String _laneKey(String workspacePath, AiTextGenerationOperation operation) {
+    return '$workspacePath::${operation.key}';
+  }
+}
+
+class _AiTextCommandPlan {
+  const _AiTextCommandPlan({
+    required this.binary,
+    required this.args,
+    required this.stdinPayload,
+    required this.label,
+  });
+
+  final String binary;
+  final List<String> args;
+  final String? stdinPayload;
+  final String label;
+}

--- a/lib/src/features/ai_text_generation/application/ai_text_model_discovery_service.dart
+++ b/lib/src/features/ai_text_generation/application/ai_text_model_discovery_service.dart
@@ -1,0 +1,200 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:alera/src/features/ai_text_generation/application/ai_text_generation_registry.dart';
+import 'package:alera/src/features/ai_text_generation/domain/ai_text_generation_settings.dart';
+import 'package:alera/src/shared/infra/process/process_runner.dart';
+
+const int aiTextModelDiscoveryTimeoutSeconds = 60;
+const int aiTextModelDiscoveryMaxOutputBytes = 4 * 1024 * 1024;
+
+class AiTextModelDiscoveryResult {
+  const AiTextModelDiscoveryResult({
+    required this.success,
+    required this.agent,
+    required this.models,
+    required this.defaultModelId,
+    this.error,
+  });
+
+  final bool success;
+  final AiTextGenerationAgent agent;
+  final List<AiTextModel> models;
+  final String defaultModelId;
+  final String? error;
+}
+
+abstract interface class AiTextModelDiscoveryService {
+  Future<AiTextModelDiscoveryResult> discover(AiTextGenerationAgent agent);
+}
+
+class CliAiTextModelDiscoveryService implements AiTextModelDiscoveryService {
+  const CliAiTextModelDiscoveryService({required this.processRunner});
+
+  final ProcessRunner processRunner;
+
+  @override
+  Future<AiTextModelDiscoveryResult> discover(
+    AiTextGenerationAgent agent,
+  ) async {
+    final spec = aiTextAgentSpecs[agent];
+    if (spec == null) {
+      return AiTextModelDiscoveryResult(
+        success: false,
+        agent: agent,
+        models: const <AiTextModel>[],
+        defaultModelId: 'custom',
+        error: '${agent.label} does not support AI text generation.',
+      );
+    }
+    if (spec.modelsCommand == null) {
+      return _staticResult(spec);
+    }
+
+    final StartedProcess process;
+    try {
+      process = await processRunner.start(spec.binary, spec.modelsCommand!);
+    } catch (_) {
+      return AiTextModelDiscoveryResult(
+        success: false,
+        agent: agent,
+        models: spec.models,
+        defaultModelId: spec.defaultModelId,
+        error:
+            '${spec.label} model discovery could not be started. Check that ${spec.binary} is installed and on PATH.',
+      );
+    }
+
+    try {
+      final output = await _collectProcess(process).timeout(
+        const Duration(seconds: aiTextModelDiscoveryTimeoutSeconds),
+        onTimeout: () {
+          process.kill();
+          throw TimeoutException(
+            '${spec.label} model discovery timed out after ${aiTextModelDiscoveryTimeoutSeconds}s.',
+          );
+        },
+      );
+      return _finalize(spec, output);
+    } on TimeoutException catch (error) {
+      return AiTextModelDiscoveryResult(
+        success: false,
+        agent: agent,
+        models: spec.models,
+        defaultModelId: spec.defaultModelId,
+        error: error.message,
+      );
+    } on _AiTextModelDiscoveryOutputLimitException {
+      process.kill();
+      return AiTextModelDiscoveryResult(
+        success: false,
+        agent: agent,
+        models: spec.models,
+        defaultModelId: spec.defaultModelId,
+        error: '${spec.label} returned too much model data.',
+      );
+    }
+  }
+
+  AiTextModelDiscoveryResult _staticResult(AiTextAgentSpec spec) {
+    return AiTextModelDiscoveryResult(
+      success: true,
+      agent: spec.agent,
+      models: spec.models,
+      defaultModelId: spec.defaultModelId,
+    );
+  }
+
+  AiTextModelDiscoveryResult _finalize(
+    AiTextAgentSpec spec,
+    ProcessRunOutput output,
+  ) {
+    if (output.exitCode != 0) {
+      final detail = _failureDetail(output.stdout, output.stderr);
+      return AiTextModelDiscoveryResult(
+        success: false,
+        agent: spec.agent,
+        models: spec.models,
+        defaultModelId: spec.defaultModelId,
+        error: detail == null
+            ? '${spec.label} model discovery failed. Check the agent CLI configuration and try again.'
+            : '${spec.label} model discovery failed: $detail',
+      );
+    }
+
+    var models = spec.parseModels(output.stdout);
+    if (models.isEmpty && output.stderr.trim().isNotEmpty) {
+      models = spec.parseModels(output.stderr);
+    }
+    if (models.isEmpty) {
+      if (spec.models.isNotEmpty) {
+        return _staticResult(spec);
+      }
+      return AiTextModelDiscoveryResult(
+        success: false,
+        agent: spec.agent,
+        models: const <AiTextModel>[],
+        defaultModelId: spec.defaultModelId,
+        error: '${spec.label} returned no available models.',
+      );
+    }
+    final defaultModelId =
+        models.any((model) => model.id == spec.defaultModelId)
+        ? spec.defaultModelId
+        : models.first.id;
+    return AiTextModelDiscoveryResult(
+      success: true,
+      agent: spec.agent,
+      models: models,
+      defaultModelId: defaultModelId,
+    );
+  }
+
+  Future<ProcessRunOutput> _collectProcess(StartedProcess process) async {
+    final stdout = StringBuffer();
+    final stderr = StringBuffer();
+    var totalBytes = 0;
+
+    Future<void> collect(Stream<List<int>> stream, StringBuffer buffer) async {
+      await for (final chunk in stream) {
+        totalBytes += chunk.length;
+        if (totalBytes > aiTextModelDiscoveryMaxOutputBytes) {
+          process.kill();
+          throw const _AiTextModelDiscoveryOutputLimitException();
+        }
+        buffer.write(utf8.decode(chunk));
+      }
+    }
+
+    final stdoutDone = collect(process.stdout, stdout);
+    final stderrDone = collect(process.stderr, stderr);
+    final exitCode = await process.exitCode;
+    await Future.wait(<Future<void>>[stdoutDone, stderrDone]);
+    return ProcessRunOutput(
+      exitCode: exitCode,
+      stdout: stdout.toString(),
+      stderr: stderr.toString(),
+    );
+  }
+
+  String? _failureDetail(String stdout, String stderr) {
+    final combined = '$stdout\n$stderr'
+        .replaceAll(RegExp(r'\x1B\[[0-?]*[ -/]*[@-~]'), '')
+        .trim();
+    if (combined.isEmpty) {
+      return null;
+    }
+    final lines = combined
+        .split(RegExp(r'\r?\n'))
+        .where((line) => line.trim().isNotEmpty)
+        .toList(growable: false);
+    final detail = lines.isEmpty ? combined : lines.last.trim();
+    return detail.length > 240
+        ? '${detail.substring(0, 240).trimRight()}...'
+        : detail;
+  }
+}
+
+class _AiTextModelDiscoveryOutputLimitException implements Exception {
+  const _AiTextModelDiscoveryOutputLimitException();
+}

--- a/lib/src/features/ai_text_generation/domain/ai_text_generation_settings.dart
+++ b/lib/src/features/ai_text_generation/domain/ai_text_generation_settings.dart
@@ -1,0 +1,144 @@
+import 'package:alera/src/features/agent_status/domain/agent_status.dart';
+import 'package:dart_mappable/dart_mappable.dart';
+
+part 'ai_text_generation_settings.mapper.dart';
+
+@MappableEnum()
+enum AiTextGenerationOperation {
+  commitMessage('commitMessage'),
+  pullRequestDetails('pullRequestDetails'),
+  branchName('branchName');
+
+  const AiTextGenerationOperation(this.key);
+
+  final String key;
+
+  String get label => switch (this) {
+    AiTextGenerationOperation.commitMessage => 'Commit messages',
+    AiTextGenerationOperation.pullRequestDetails => 'Pull request details',
+    AiTextGenerationOperation.branchName => 'Branch names',
+  };
+}
+
+@MappableEnum()
+enum AiTextGenerationAgent {
+  codex('codex'),
+  claude('claude'),
+  copilot('copilot'),
+  cursor('cursor'),
+  agy('agy'),
+  opencode('opencode'),
+  pi('pi'),
+  amp('amp'),
+  custom('custom');
+
+  const AiTextGenerationAgent(this.key);
+
+  final String key;
+
+  String get label => switch (this) {
+    AiTextGenerationAgent.codex => 'Codex',
+    AiTextGenerationAgent.claude => 'Claude Code',
+    AiTextGenerationAgent.copilot => 'GitHub Copilot',
+    AiTextGenerationAgent.cursor => 'Cursor',
+    AiTextGenerationAgent.agy => 'Antigravity',
+    AiTextGenerationAgent.opencode => 'OpenCode',
+    AiTextGenerationAgent.pi => 'Pi',
+    AiTextGenerationAgent.amp => 'Amp',
+    AiTextGenerationAgent.custom => 'Custom command',
+  };
+
+  AgentType? get agentType => switch (this) {
+    AiTextGenerationAgent.codex => AgentType.codex,
+    AiTextGenerationAgent.claude => AgentType.claude,
+    AiTextGenerationAgent.copilot => AgentType.copilot,
+    AiTextGenerationAgent.cursor => AgentType.cursor,
+    AiTextGenerationAgent.agy => AgentType.agy,
+    AiTextGenerationAgent.opencode => AgentType.opencode,
+    AiTextGenerationAgent.pi => AgentType.pi,
+    AiTextGenerationAgent.amp => AgentType.amp,
+    AiTextGenerationAgent.custom => null,
+  };
+}
+
+@MappableClass()
+class AiTextDiscoveredThinkingLevel with AiTextDiscoveredThinkingLevelMappable {
+  const AiTextDiscoveredThinkingLevel({required this.id, required this.label});
+
+  final String id;
+  final String label;
+}
+
+@MappableClass()
+class AiTextDiscoveredModel with AiTextDiscoveredModelMappable {
+  const AiTextDiscoveredModel({
+    required this.id,
+    required this.label,
+    this.thinkingLevels = const <AiTextDiscoveredThinkingLevel>[],
+    this.defaultThinkingLevel,
+  });
+
+  final String id;
+  final String label;
+  final List<AiTextDiscoveredThinkingLevel> thinkingLevels;
+  final String? defaultThinkingLevel;
+}
+
+@MappableClass()
+class AiTextGenerationSettings with AiTextGenerationSettingsMappable {
+  const AiTextGenerationSettings({
+    this.enabled = true,
+    this.agent = AiTextGenerationAgent.codex,
+    this.selectedModelByAgent = const <AiTextGenerationAgent, String>{},
+    this.selectedThinkingByModel = const <String, String>{},
+    this.discoveredModelsByAgent =
+        const <AiTextGenerationAgent, List<AiTextDiscoveredModel>>{},
+    this.discoveredDefaultModelByAgent =
+        const <AiTextGenerationAgent, String>{},
+    this.customCommand = '',
+    this.instructionsByOperation = const <AiTextGenerationOperation, String>{},
+    this.timeoutSeconds = 120,
+  });
+
+  final bool enabled;
+  final AiTextGenerationAgent agent;
+  final Map<AiTextGenerationAgent, String> selectedModelByAgent;
+  final Map<String, String> selectedThinkingByModel;
+  final Map<AiTextGenerationAgent, List<AiTextDiscoveredModel>>
+  discoveredModelsByAgent;
+  final Map<AiTextGenerationAgent, String> discoveredDefaultModelByAgent;
+  final String customCommand;
+  final Map<AiTextGenerationOperation, String> instructionsByOperation;
+  final int timeoutSeconds;
+
+  String? modelFor(AiTextGenerationAgent agent) {
+    final value = selectedModelByAgent[agent]?.trim();
+    return value == null || value.isEmpty ? null : value;
+  }
+
+  String? thinkingForModel(String? model) {
+    if (model == null || model.trim().isEmpty) {
+      return null;
+    }
+    final value = selectedThinkingByModel[model]?.trim();
+    return value == null || value.isEmpty ? null : value;
+  }
+
+  String instructionsFor(AiTextGenerationOperation operation) {
+    return instructionsByOperation[operation]?.trim() ?? '';
+  }
+
+  List<AiTextDiscoveredModel> discoveredModelsFor(AiTextGenerationAgent agent) {
+    return discoveredModelsByAgent[agent] ?? const <AiTextDiscoveredModel>[];
+  }
+
+  String? discoveredDefaultModelFor(AiTextGenerationAgent agent) {
+    final value = discoveredDefaultModelByAgent[agent]?.trim();
+    return value == null || value.isEmpty ? null : value;
+  }
+
+  static const AiTextGenerationSettings defaults = AiTextGenerationSettings();
+
+  factory AiTextGenerationSettings.fromJson(Map<String, Object?> json) =>
+      AiTextGenerationSettingsMapper.fromMap(Map<String, dynamic>.from(json));
+}

--- a/lib/src/features/ai_text_generation/domain/ai_text_generation_settings.mapper.dart
+++ b/lib/src/features/ai_text_generation/domain/ai_text_generation_settings.mapper.dart
@@ -1,0 +1,882 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// dart format off
+// ignore_for_file: type=lint
+// ignore_for_file: invalid_use_of_protected_member
+// ignore_for_file: unused_element, unnecessary_cast, override_on_non_overriding_member
+// ignore_for_file: strict_raw_type, inference_failure_on_untyped_parameter
+
+part of 'ai_text_generation_settings.dart';
+
+class AiTextGenerationOperationMapper
+    extends EnumMapper<AiTextGenerationOperation> {
+  AiTextGenerationOperationMapper._();
+
+  static AiTextGenerationOperationMapper? _instance;
+  static AiTextGenerationOperationMapper ensureInitialized() {
+    if (_instance == null) {
+      MapperContainer.globals.use(
+        _instance = AiTextGenerationOperationMapper._(),
+      );
+    }
+    return _instance!;
+  }
+
+  static AiTextGenerationOperation fromValue(dynamic value) {
+    ensureInitialized();
+    return MapperContainer.globals.fromValue(value);
+  }
+
+  @override
+  AiTextGenerationOperation decode(dynamic value) {
+    switch (value) {
+      case r'commitMessage':
+        return AiTextGenerationOperation.commitMessage;
+      case r'pullRequestDetails':
+        return AiTextGenerationOperation.pullRequestDetails;
+      case r'branchName':
+        return AiTextGenerationOperation.branchName;
+      default:
+        throw MapperException.unknownEnumValue(value);
+    }
+  }
+
+  @override
+  dynamic encode(AiTextGenerationOperation self) {
+    switch (self) {
+      case AiTextGenerationOperation.commitMessage:
+        return r'commitMessage';
+      case AiTextGenerationOperation.pullRequestDetails:
+        return r'pullRequestDetails';
+      case AiTextGenerationOperation.branchName:
+        return r'branchName';
+    }
+  }
+}
+
+extension AiTextGenerationOperationMapperExtension
+    on AiTextGenerationOperation {
+  String toValue() {
+    AiTextGenerationOperationMapper.ensureInitialized();
+    return MapperContainer.globals.toValue<AiTextGenerationOperation>(this)
+        as String;
+  }
+}
+
+class AiTextGenerationAgentMapper extends EnumMapper<AiTextGenerationAgent> {
+  AiTextGenerationAgentMapper._();
+
+  static AiTextGenerationAgentMapper? _instance;
+  static AiTextGenerationAgentMapper ensureInitialized() {
+    if (_instance == null) {
+      MapperContainer.globals.use(_instance = AiTextGenerationAgentMapper._());
+    }
+    return _instance!;
+  }
+
+  static AiTextGenerationAgent fromValue(dynamic value) {
+    ensureInitialized();
+    return MapperContainer.globals.fromValue(value);
+  }
+
+  @override
+  AiTextGenerationAgent decode(dynamic value) {
+    switch (value) {
+      case r'codex':
+        return AiTextGenerationAgent.codex;
+      case r'claude':
+        return AiTextGenerationAgent.claude;
+      case r'copilot':
+        return AiTextGenerationAgent.copilot;
+      case r'cursor':
+        return AiTextGenerationAgent.cursor;
+      case r'agy':
+        return AiTextGenerationAgent.agy;
+      case r'opencode':
+        return AiTextGenerationAgent.opencode;
+      case r'pi':
+        return AiTextGenerationAgent.pi;
+      case r'amp':
+        return AiTextGenerationAgent.amp;
+      case r'custom':
+        return AiTextGenerationAgent.custom;
+      default:
+        throw MapperException.unknownEnumValue(value);
+    }
+  }
+
+  @override
+  dynamic encode(AiTextGenerationAgent self) {
+    switch (self) {
+      case AiTextGenerationAgent.codex:
+        return r'codex';
+      case AiTextGenerationAgent.claude:
+        return r'claude';
+      case AiTextGenerationAgent.copilot:
+        return r'copilot';
+      case AiTextGenerationAgent.cursor:
+        return r'cursor';
+      case AiTextGenerationAgent.agy:
+        return r'agy';
+      case AiTextGenerationAgent.opencode:
+        return r'opencode';
+      case AiTextGenerationAgent.pi:
+        return r'pi';
+      case AiTextGenerationAgent.amp:
+        return r'amp';
+      case AiTextGenerationAgent.custom:
+        return r'custom';
+    }
+  }
+}
+
+extension AiTextGenerationAgentMapperExtension on AiTextGenerationAgent {
+  String toValue() {
+    AiTextGenerationAgentMapper.ensureInitialized();
+    return MapperContainer.globals.toValue<AiTextGenerationAgent>(this)
+        as String;
+  }
+}
+
+class AiTextDiscoveredThinkingLevelMapper
+    extends ClassMapperBase<AiTextDiscoveredThinkingLevel> {
+  AiTextDiscoveredThinkingLevelMapper._();
+
+  static AiTextDiscoveredThinkingLevelMapper? _instance;
+  static AiTextDiscoveredThinkingLevelMapper ensureInitialized() {
+    if (_instance == null) {
+      MapperContainer.globals.use(
+        _instance = AiTextDiscoveredThinkingLevelMapper._(),
+      );
+    }
+    return _instance!;
+  }
+
+  @override
+  final String id = 'AiTextDiscoveredThinkingLevel';
+
+  static String _$id(AiTextDiscoveredThinkingLevel v) => v.id;
+  static const Field<AiTextDiscoveredThinkingLevel, String> _f$id = Field(
+    'id',
+    _$id,
+  );
+  static String _$label(AiTextDiscoveredThinkingLevel v) => v.label;
+  static const Field<AiTextDiscoveredThinkingLevel, String> _f$label = Field(
+    'label',
+    _$label,
+  );
+
+  @override
+  final MappableFields<AiTextDiscoveredThinkingLevel> fields = const {
+    #id: _f$id,
+    #label: _f$label,
+  };
+
+  static AiTextDiscoveredThinkingLevel _instantiate(DecodingData data) {
+    return AiTextDiscoveredThinkingLevel(
+      id: data.dec(_f$id),
+      label: data.dec(_f$label),
+    );
+  }
+
+  @override
+  final Function instantiate = _instantiate;
+
+  static AiTextDiscoveredThinkingLevel fromMap(Map<String, dynamic> map) {
+    return ensureInitialized().decodeMap<AiTextDiscoveredThinkingLevel>(map);
+  }
+
+  static AiTextDiscoveredThinkingLevel fromJson(String json) {
+    return ensureInitialized().decodeJson<AiTextDiscoveredThinkingLevel>(json);
+  }
+}
+
+mixin AiTextDiscoveredThinkingLevelMappable {
+  String toJson() {
+    return AiTextDiscoveredThinkingLevelMapper.ensureInitialized()
+        .encodeJson<AiTextDiscoveredThinkingLevel>(
+          this as AiTextDiscoveredThinkingLevel,
+        );
+  }
+
+  Map<String, dynamic> toMap() {
+    return AiTextDiscoveredThinkingLevelMapper.ensureInitialized()
+        .encodeMap<AiTextDiscoveredThinkingLevel>(
+          this as AiTextDiscoveredThinkingLevel,
+        );
+  }
+
+  AiTextDiscoveredThinkingLevelCopyWith<
+    AiTextDiscoveredThinkingLevel,
+    AiTextDiscoveredThinkingLevel,
+    AiTextDiscoveredThinkingLevel
+  >
+  get copyWith =>
+      _AiTextDiscoveredThinkingLevelCopyWithImpl<
+        AiTextDiscoveredThinkingLevel,
+        AiTextDiscoveredThinkingLevel
+      >(this as AiTextDiscoveredThinkingLevel, $identity, $identity);
+  @override
+  String toString() {
+    return AiTextDiscoveredThinkingLevelMapper.ensureInitialized()
+        .stringifyValue(this as AiTextDiscoveredThinkingLevel);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return AiTextDiscoveredThinkingLevelMapper.ensureInitialized().equalsValue(
+      this as AiTextDiscoveredThinkingLevel,
+      other,
+    );
+  }
+
+  @override
+  int get hashCode {
+    return AiTextDiscoveredThinkingLevelMapper.ensureInitialized().hashValue(
+      this as AiTextDiscoveredThinkingLevel,
+    );
+  }
+}
+
+extension AiTextDiscoveredThinkingLevelValueCopy<$R, $Out>
+    on ObjectCopyWith<$R, AiTextDiscoveredThinkingLevel, $Out> {
+  AiTextDiscoveredThinkingLevelCopyWith<$R, AiTextDiscoveredThinkingLevel, $Out>
+  get $asAiTextDiscoveredThinkingLevel => $base.as(
+    (v, t, t2) =>
+        _AiTextDiscoveredThinkingLevelCopyWithImpl<$R, $Out>(v, t, t2),
+  );
+}
+
+abstract class AiTextDiscoveredThinkingLevelCopyWith<
+  $R,
+  $In extends AiTextDiscoveredThinkingLevel,
+  $Out
+>
+    implements ClassCopyWith<$R, $In, $Out> {
+  $R call({String? id, String? label});
+  AiTextDiscoveredThinkingLevelCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(
+    Then<$Out2, $R2> t,
+  );
+}
+
+class _AiTextDiscoveredThinkingLevelCopyWithImpl<$R, $Out>
+    extends ClassCopyWithBase<$R, AiTextDiscoveredThinkingLevel, $Out>
+    implements
+        AiTextDiscoveredThinkingLevelCopyWith<
+          $R,
+          AiTextDiscoveredThinkingLevel,
+          $Out
+        > {
+  _AiTextDiscoveredThinkingLevelCopyWithImpl(
+    super.value,
+    super.then,
+    super.then2,
+  );
+
+  @override
+  late final ClassMapperBase<AiTextDiscoveredThinkingLevel> $mapper =
+      AiTextDiscoveredThinkingLevelMapper.ensureInitialized();
+  @override
+  $R call({String? id, String? label}) => $apply(
+    FieldCopyWithData({
+      if (id != null) #id: id,
+      if (label != null) #label: label,
+    }),
+  );
+  @override
+  AiTextDiscoveredThinkingLevel $make(CopyWithData data) =>
+      AiTextDiscoveredThinkingLevel(
+        id: data.get(#id, or: $value.id),
+        label: data.get(#label, or: $value.label),
+      );
+
+  @override
+  AiTextDiscoveredThinkingLevelCopyWith<
+    $R2,
+    AiTextDiscoveredThinkingLevel,
+    $Out2
+  >
+  $chain<$R2, $Out2>(Then<$Out2, $R2> t) =>
+      _AiTextDiscoveredThinkingLevelCopyWithImpl<$R2, $Out2>($value, $cast, t);
+}
+
+class AiTextDiscoveredModelMapper
+    extends ClassMapperBase<AiTextDiscoveredModel> {
+  AiTextDiscoveredModelMapper._();
+
+  static AiTextDiscoveredModelMapper? _instance;
+  static AiTextDiscoveredModelMapper ensureInitialized() {
+    if (_instance == null) {
+      MapperContainer.globals.use(_instance = AiTextDiscoveredModelMapper._());
+      AiTextDiscoveredThinkingLevelMapper.ensureInitialized();
+    }
+    return _instance!;
+  }
+
+  @override
+  final String id = 'AiTextDiscoveredModel';
+
+  static String _$id(AiTextDiscoveredModel v) => v.id;
+  static const Field<AiTextDiscoveredModel, String> _f$id = Field('id', _$id);
+  static String _$label(AiTextDiscoveredModel v) => v.label;
+  static const Field<AiTextDiscoveredModel, String> _f$label = Field(
+    'label',
+    _$label,
+  );
+  static List<AiTextDiscoveredThinkingLevel> _$thinkingLevels(
+    AiTextDiscoveredModel v,
+  ) => v.thinkingLevels;
+  static const Field<AiTextDiscoveredModel, List<AiTextDiscoveredThinkingLevel>>
+  _f$thinkingLevels = Field(
+    'thinkingLevels',
+    _$thinkingLevels,
+    opt: true,
+    def: const <AiTextDiscoveredThinkingLevel>[],
+  );
+  static String? _$defaultThinkingLevel(AiTextDiscoveredModel v) =>
+      v.defaultThinkingLevel;
+  static const Field<AiTextDiscoveredModel, String> _f$defaultThinkingLevel =
+      Field('defaultThinkingLevel', _$defaultThinkingLevel, opt: true);
+
+  @override
+  final MappableFields<AiTextDiscoveredModel> fields = const {
+    #id: _f$id,
+    #label: _f$label,
+    #thinkingLevels: _f$thinkingLevels,
+    #defaultThinkingLevel: _f$defaultThinkingLevel,
+  };
+
+  static AiTextDiscoveredModel _instantiate(DecodingData data) {
+    return AiTextDiscoveredModel(
+      id: data.dec(_f$id),
+      label: data.dec(_f$label),
+      thinkingLevels: data.dec(_f$thinkingLevels),
+      defaultThinkingLevel: data.dec(_f$defaultThinkingLevel),
+    );
+  }
+
+  @override
+  final Function instantiate = _instantiate;
+
+  static AiTextDiscoveredModel fromMap(Map<String, dynamic> map) {
+    return ensureInitialized().decodeMap<AiTextDiscoveredModel>(map);
+  }
+
+  static AiTextDiscoveredModel fromJson(String json) {
+    return ensureInitialized().decodeJson<AiTextDiscoveredModel>(json);
+  }
+}
+
+mixin AiTextDiscoveredModelMappable {
+  String toJson() {
+    return AiTextDiscoveredModelMapper.ensureInitialized()
+        .encodeJson<AiTextDiscoveredModel>(this as AiTextDiscoveredModel);
+  }
+
+  Map<String, dynamic> toMap() {
+    return AiTextDiscoveredModelMapper.ensureInitialized()
+        .encodeMap<AiTextDiscoveredModel>(this as AiTextDiscoveredModel);
+  }
+
+  AiTextDiscoveredModelCopyWith<
+    AiTextDiscoveredModel,
+    AiTextDiscoveredModel,
+    AiTextDiscoveredModel
+  >
+  get copyWith =>
+      _AiTextDiscoveredModelCopyWithImpl<
+        AiTextDiscoveredModel,
+        AiTextDiscoveredModel
+      >(this as AiTextDiscoveredModel, $identity, $identity);
+  @override
+  String toString() {
+    return AiTextDiscoveredModelMapper.ensureInitialized().stringifyValue(
+      this as AiTextDiscoveredModel,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return AiTextDiscoveredModelMapper.ensureInitialized().equalsValue(
+      this as AiTextDiscoveredModel,
+      other,
+    );
+  }
+
+  @override
+  int get hashCode {
+    return AiTextDiscoveredModelMapper.ensureInitialized().hashValue(
+      this as AiTextDiscoveredModel,
+    );
+  }
+}
+
+extension AiTextDiscoveredModelValueCopy<$R, $Out>
+    on ObjectCopyWith<$R, AiTextDiscoveredModel, $Out> {
+  AiTextDiscoveredModelCopyWith<$R, AiTextDiscoveredModel, $Out>
+  get $asAiTextDiscoveredModel => $base.as(
+    (v, t, t2) => _AiTextDiscoveredModelCopyWithImpl<$R, $Out>(v, t, t2),
+  );
+}
+
+abstract class AiTextDiscoveredModelCopyWith<
+  $R,
+  $In extends AiTextDiscoveredModel,
+  $Out
+>
+    implements ClassCopyWith<$R, $In, $Out> {
+  ListCopyWith<
+    $R,
+    AiTextDiscoveredThinkingLevel,
+    AiTextDiscoveredThinkingLevelCopyWith<
+      $R,
+      AiTextDiscoveredThinkingLevel,
+      AiTextDiscoveredThinkingLevel
+    >
+  >
+  get thinkingLevels;
+  $R call({
+    String? id,
+    String? label,
+    List<AiTextDiscoveredThinkingLevel>? thinkingLevels,
+    String? defaultThinkingLevel,
+  });
+  AiTextDiscoveredModelCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(
+    Then<$Out2, $R2> t,
+  );
+}
+
+class _AiTextDiscoveredModelCopyWithImpl<$R, $Out>
+    extends ClassCopyWithBase<$R, AiTextDiscoveredModel, $Out>
+    implements AiTextDiscoveredModelCopyWith<$R, AiTextDiscoveredModel, $Out> {
+  _AiTextDiscoveredModelCopyWithImpl(super.value, super.then, super.then2);
+
+  @override
+  late final ClassMapperBase<AiTextDiscoveredModel> $mapper =
+      AiTextDiscoveredModelMapper.ensureInitialized();
+  @override
+  ListCopyWith<
+    $R,
+    AiTextDiscoveredThinkingLevel,
+    AiTextDiscoveredThinkingLevelCopyWith<
+      $R,
+      AiTextDiscoveredThinkingLevel,
+      AiTextDiscoveredThinkingLevel
+    >
+  >
+  get thinkingLevels => ListCopyWith(
+    $value.thinkingLevels,
+    (v, t) => v.copyWith.$chain(t),
+    (v) => call(thinkingLevels: v),
+  );
+  @override
+  $R call({
+    String? id,
+    String? label,
+    List<AiTextDiscoveredThinkingLevel>? thinkingLevels,
+    Object? defaultThinkingLevel = $none,
+  }) => $apply(
+    FieldCopyWithData({
+      if (id != null) #id: id,
+      if (label != null) #label: label,
+      if (thinkingLevels != null) #thinkingLevels: thinkingLevels,
+      if (defaultThinkingLevel != $none)
+        #defaultThinkingLevel: defaultThinkingLevel,
+    }),
+  );
+  @override
+  AiTextDiscoveredModel $make(CopyWithData data) => AiTextDiscoveredModel(
+    id: data.get(#id, or: $value.id),
+    label: data.get(#label, or: $value.label),
+    thinkingLevels: data.get(#thinkingLevels, or: $value.thinkingLevels),
+    defaultThinkingLevel: data.get(
+      #defaultThinkingLevel,
+      or: $value.defaultThinkingLevel,
+    ),
+  );
+
+  @override
+  AiTextDiscoveredModelCopyWith<$R2, AiTextDiscoveredModel, $Out2>
+  $chain<$R2, $Out2>(Then<$Out2, $R2> t) =>
+      _AiTextDiscoveredModelCopyWithImpl<$R2, $Out2>($value, $cast, t);
+}
+
+class AiTextGenerationSettingsMapper
+    extends ClassMapperBase<AiTextGenerationSettings> {
+  AiTextGenerationSettingsMapper._();
+
+  static AiTextGenerationSettingsMapper? _instance;
+  static AiTextGenerationSettingsMapper ensureInitialized() {
+    if (_instance == null) {
+      MapperContainer.globals.use(
+        _instance = AiTextGenerationSettingsMapper._(),
+      );
+      AiTextGenerationAgentMapper.ensureInitialized();
+      AiTextDiscoveredModelMapper.ensureInitialized();
+      AiTextGenerationOperationMapper.ensureInitialized();
+    }
+    return _instance!;
+  }
+
+  @override
+  final String id = 'AiTextGenerationSettings';
+
+  static bool _$enabled(AiTextGenerationSettings v) => v.enabled;
+  static const Field<AiTextGenerationSettings, bool> _f$enabled = Field(
+    'enabled',
+    _$enabled,
+    opt: true,
+    def: true,
+  );
+  static AiTextGenerationAgent _$agent(AiTextGenerationSettings v) => v.agent;
+  static const Field<AiTextGenerationSettings, AiTextGenerationAgent> _f$agent =
+      Field('agent', _$agent, opt: true, def: AiTextGenerationAgent.codex);
+  static Map<AiTextGenerationAgent, String> _$selectedModelByAgent(
+    AiTextGenerationSettings v,
+  ) => v.selectedModelByAgent;
+  static const Field<
+    AiTextGenerationSettings,
+    Map<AiTextGenerationAgent, String>
+  >
+  _f$selectedModelByAgent = Field(
+    'selectedModelByAgent',
+    _$selectedModelByAgent,
+    opt: true,
+    def: const <AiTextGenerationAgent, String>{},
+  );
+  static Map<String, String> _$selectedThinkingByModel(
+    AiTextGenerationSettings v,
+  ) => v.selectedThinkingByModel;
+  static const Field<AiTextGenerationSettings, Map<String, String>>
+  _f$selectedThinkingByModel = Field(
+    'selectedThinkingByModel',
+    _$selectedThinkingByModel,
+    opt: true,
+    def: const <String, String>{},
+  );
+  static Map<AiTextGenerationAgent, List<AiTextDiscoveredModel>>
+  _$discoveredModelsByAgent(AiTextGenerationSettings v) =>
+      v.discoveredModelsByAgent;
+  static const Field<
+    AiTextGenerationSettings,
+    Map<AiTextGenerationAgent, List<AiTextDiscoveredModel>>
+  >
+  _f$discoveredModelsByAgent = Field(
+    'discoveredModelsByAgent',
+    _$discoveredModelsByAgent,
+    opt: true,
+    def: const <AiTextGenerationAgent, List<AiTextDiscoveredModel>>{},
+  );
+  static Map<AiTextGenerationAgent, String> _$discoveredDefaultModelByAgent(
+    AiTextGenerationSettings v,
+  ) => v.discoveredDefaultModelByAgent;
+  static const Field<
+    AiTextGenerationSettings,
+    Map<AiTextGenerationAgent, String>
+  >
+  _f$discoveredDefaultModelByAgent = Field(
+    'discoveredDefaultModelByAgent',
+    _$discoveredDefaultModelByAgent,
+    opt: true,
+    def: const <AiTextGenerationAgent, String>{},
+  );
+  static String _$customCommand(AiTextGenerationSettings v) => v.customCommand;
+  static const Field<AiTextGenerationSettings, String> _f$customCommand = Field(
+    'customCommand',
+    _$customCommand,
+    opt: true,
+    def: '',
+  );
+  static Map<AiTextGenerationOperation, String> _$instructionsByOperation(
+    AiTextGenerationSettings v,
+  ) => v.instructionsByOperation;
+  static const Field<
+    AiTextGenerationSettings,
+    Map<AiTextGenerationOperation, String>
+  >
+  _f$instructionsByOperation = Field(
+    'instructionsByOperation',
+    _$instructionsByOperation,
+    opt: true,
+    def: const <AiTextGenerationOperation, String>{},
+  );
+  static int _$timeoutSeconds(AiTextGenerationSettings v) => v.timeoutSeconds;
+  static const Field<AiTextGenerationSettings, int> _f$timeoutSeconds = Field(
+    'timeoutSeconds',
+    _$timeoutSeconds,
+    opt: true,
+    def: 120,
+  );
+
+  @override
+  final MappableFields<AiTextGenerationSettings> fields = const {
+    #enabled: _f$enabled,
+    #agent: _f$agent,
+    #selectedModelByAgent: _f$selectedModelByAgent,
+    #selectedThinkingByModel: _f$selectedThinkingByModel,
+    #discoveredModelsByAgent: _f$discoveredModelsByAgent,
+    #discoveredDefaultModelByAgent: _f$discoveredDefaultModelByAgent,
+    #customCommand: _f$customCommand,
+    #instructionsByOperation: _f$instructionsByOperation,
+    #timeoutSeconds: _f$timeoutSeconds,
+  };
+
+  static AiTextGenerationSettings _instantiate(DecodingData data) {
+    return AiTextGenerationSettings(
+      enabled: data.dec(_f$enabled),
+      agent: data.dec(_f$agent),
+      selectedModelByAgent: data.dec(_f$selectedModelByAgent),
+      selectedThinkingByModel: data.dec(_f$selectedThinkingByModel),
+      discoveredModelsByAgent: data.dec(_f$discoveredModelsByAgent),
+      discoveredDefaultModelByAgent: data.dec(_f$discoveredDefaultModelByAgent),
+      customCommand: data.dec(_f$customCommand),
+      instructionsByOperation: data.dec(_f$instructionsByOperation),
+      timeoutSeconds: data.dec(_f$timeoutSeconds),
+    );
+  }
+
+  @override
+  final Function instantiate = _instantiate;
+
+  static AiTextGenerationSettings fromMap(Map<String, dynamic> map) {
+    return ensureInitialized().decodeMap<AiTextGenerationSettings>(map);
+  }
+
+  static AiTextGenerationSettings fromJson(String json) {
+    return ensureInitialized().decodeJson<AiTextGenerationSettings>(json);
+  }
+}
+
+mixin AiTextGenerationSettingsMappable {
+  String toJson() {
+    return AiTextGenerationSettingsMapper.ensureInitialized()
+        .encodeJson<AiTextGenerationSettings>(this as AiTextGenerationSettings);
+  }
+
+  Map<String, dynamic> toMap() {
+    return AiTextGenerationSettingsMapper.ensureInitialized()
+        .encodeMap<AiTextGenerationSettings>(this as AiTextGenerationSettings);
+  }
+
+  AiTextGenerationSettingsCopyWith<
+    AiTextGenerationSettings,
+    AiTextGenerationSettings,
+    AiTextGenerationSettings
+  >
+  get copyWith =>
+      _AiTextGenerationSettingsCopyWithImpl<
+        AiTextGenerationSettings,
+        AiTextGenerationSettings
+      >(this as AiTextGenerationSettings, $identity, $identity);
+  @override
+  String toString() {
+    return AiTextGenerationSettingsMapper.ensureInitialized().stringifyValue(
+      this as AiTextGenerationSettings,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return AiTextGenerationSettingsMapper.ensureInitialized().equalsValue(
+      this as AiTextGenerationSettings,
+      other,
+    );
+  }
+
+  @override
+  int get hashCode {
+    return AiTextGenerationSettingsMapper.ensureInitialized().hashValue(
+      this as AiTextGenerationSettings,
+    );
+  }
+}
+
+extension AiTextGenerationSettingsValueCopy<$R, $Out>
+    on ObjectCopyWith<$R, AiTextGenerationSettings, $Out> {
+  AiTextGenerationSettingsCopyWith<$R, AiTextGenerationSettings, $Out>
+  get $asAiTextGenerationSettings => $base.as(
+    (v, t, t2) => _AiTextGenerationSettingsCopyWithImpl<$R, $Out>(v, t, t2),
+  );
+}
+
+abstract class AiTextGenerationSettingsCopyWith<
+  $R,
+  $In extends AiTextGenerationSettings,
+  $Out
+>
+    implements ClassCopyWith<$R, $In, $Out> {
+  MapCopyWith<
+    $R,
+    AiTextGenerationAgent,
+    String,
+    ObjectCopyWith<$R, String, String>
+  >
+  get selectedModelByAgent;
+  MapCopyWith<$R, String, String, ObjectCopyWith<$R, String, String>>
+  get selectedThinkingByModel;
+  MapCopyWith<
+    $R,
+    AiTextGenerationAgent,
+    List<AiTextDiscoveredModel>,
+    ObjectCopyWith<$R, List<AiTextDiscoveredModel>, List<AiTextDiscoveredModel>>
+  >
+  get discoveredModelsByAgent;
+  MapCopyWith<
+    $R,
+    AiTextGenerationAgent,
+    String,
+    ObjectCopyWith<$R, String, String>
+  >
+  get discoveredDefaultModelByAgent;
+  MapCopyWith<
+    $R,
+    AiTextGenerationOperation,
+    String,
+    ObjectCopyWith<$R, String, String>
+  >
+  get instructionsByOperation;
+  $R call({
+    bool? enabled,
+    AiTextGenerationAgent? agent,
+    Map<AiTextGenerationAgent, String>? selectedModelByAgent,
+    Map<String, String>? selectedThinkingByModel,
+    Map<AiTextGenerationAgent, List<AiTextDiscoveredModel>>?
+    discoveredModelsByAgent,
+    Map<AiTextGenerationAgent, String>? discoveredDefaultModelByAgent,
+    String? customCommand,
+    Map<AiTextGenerationOperation, String>? instructionsByOperation,
+    int? timeoutSeconds,
+  });
+  AiTextGenerationSettingsCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(
+    Then<$Out2, $R2> t,
+  );
+}
+
+class _AiTextGenerationSettingsCopyWithImpl<$R, $Out>
+    extends ClassCopyWithBase<$R, AiTextGenerationSettings, $Out>
+    implements
+        AiTextGenerationSettingsCopyWith<$R, AiTextGenerationSettings, $Out> {
+  _AiTextGenerationSettingsCopyWithImpl(super.value, super.then, super.then2);
+
+  @override
+  late final ClassMapperBase<AiTextGenerationSettings> $mapper =
+      AiTextGenerationSettingsMapper.ensureInitialized();
+  @override
+  MapCopyWith<
+    $R,
+    AiTextGenerationAgent,
+    String,
+    ObjectCopyWith<$R, String, String>
+  >
+  get selectedModelByAgent => MapCopyWith(
+    $value.selectedModelByAgent,
+    (v, t) => ObjectCopyWith(v, $identity, t),
+    (v) => call(selectedModelByAgent: v),
+  );
+  @override
+  MapCopyWith<$R, String, String, ObjectCopyWith<$R, String, String>>
+  get selectedThinkingByModel => MapCopyWith(
+    $value.selectedThinkingByModel,
+    (v, t) => ObjectCopyWith(v, $identity, t),
+    (v) => call(selectedThinkingByModel: v),
+  );
+  @override
+  MapCopyWith<
+    $R,
+    AiTextGenerationAgent,
+    List<AiTextDiscoveredModel>,
+    ObjectCopyWith<$R, List<AiTextDiscoveredModel>, List<AiTextDiscoveredModel>>
+  >
+  get discoveredModelsByAgent => MapCopyWith(
+    $value.discoveredModelsByAgent,
+    (v, t) => ObjectCopyWith(v, $identity, t),
+    (v) => call(discoveredModelsByAgent: v),
+  );
+  @override
+  MapCopyWith<
+    $R,
+    AiTextGenerationAgent,
+    String,
+    ObjectCopyWith<$R, String, String>
+  >
+  get discoveredDefaultModelByAgent => MapCopyWith(
+    $value.discoveredDefaultModelByAgent,
+    (v, t) => ObjectCopyWith(v, $identity, t),
+    (v) => call(discoveredDefaultModelByAgent: v),
+  );
+  @override
+  MapCopyWith<
+    $R,
+    AiTextGenerationOperation,
+    String,
+    ObjectCopyWith<$R, String, String>
+  >
+  get instructionsByOperation => MapCopyWith(
+    $value.instructionsByOperation,
+    (v, t) => ObjectCopyWith(v, $identity, t),
+    (v) => call(instructionsByOperation: v),
+  );
+  @override
+  $R call({
+    bool? enabled,
+    AiTextGenerationAgent? agent,
+    Map<AiTextGenerationAgent, String>? selectedModelByAgent,
+    Map<String, String>? selectedThinkingByModel,
+    Map<AiTextGenerationAgent, List<AiTextDiscoveredModel>>?
+    discoveredModelsByAgent,
+    Map<AiTextGenerationAgent, String>? discoveredDefaultModelByAgent,
+    String? customCommand,
+    Map<AiTextGenerationOperation, String>? instructionsByOperation,
+    int? timeoutSeconds,
+  }) => $apply(
+    FieldCopyWithData({
+      if (enabled != null) #enabled: enabled,
+      if (agent != null) #agent: agent,
+      if (selectedModelByAgent != null)
+        #selectedModelByAgent: selectedModelByAgent,
+      if (selectedThinkingByModel != null)
+        #selectedThinkingByModel: selectedThinkingByModel,
+      if (discoveredModelsByAgent != null)
+        #discoveredModelsByAgent: discoveredModelsByAgent,
+      if (discoveredDefaultModelByAgent != null)
+        #discoveredDefaultModelByAgent: discoveredDefaultModelByAgent,
+      if (customCommand != null) #customCommand: customCommand,
+      if (instructionsByOperation != null)
+        #instructionsByOperation: instructionsByOperation,
+      if (timeoutSeconds != null) #timeoutSeconds: timeoutSeconds,
+    }),
+  );
+  @override
+  AiTextGenerationSettings $make(CopyWithData data) => AiTextGenerationSettings(
+    enabled: data.get(#enabled, or: $value.enabled),
+    agent: data.get(#agent, or: $value.agent),
+    selectedModelByAgent: data.get(
+      #selectedModelByAgent,
+      or: $value.selectedModelByAgent,
+    ),
+    selectedThinkingByModel: data.get(
+      #selectedThinkingByModel,
+      or: $value.selectedThinkingByModel,
+    ),
+    discoveredModelsByAgent: data.get(
+      #discoveredModelsByAgent,
+      or: $value.discoveredModelsByAgent,
+    ),
+    discoveredDefaultModelByAgent: data.get(
+      #discoveredDefaultModelByAgent,
+      or: $value.discoveredDefaultModelByAgent,
+    ),
+    customCommand: data.get(#customCommand, or: $value.customCommand),
+    instructionsByOperation: data.get(
+      #instructionsByOperation,
+      or: $value.instructionsByOperation,
+    ),
+    timeoutSeconds: data.get(#timeoutSeconds, or: $value.timeoutSeconds),
+  );
+
+  @override
+  AiTextGenerationSettingsCopyWith<$R2, AiTextGenerationSettings, $Out2>
+  $chain<$R2, $Out2>(Then<$Out2, $R2> t) =>
+      _AiTextGenerationSettingsCopyWithImpl<$R2, $Out2>($value, $cast, t);
+}
+

--- a/lib/src/features/settings/application/settings_controller.dart
+++ b/lib/src/features/settings/application/settings_controller.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:alera/src/features/ai_text_generation/domain/ai_text_generation_settings.dart';
 import 'package:alera/src/features/settings/application/settings_providers.dart';
 import 'package:alera/src/features/agent_status/domain/agent_status.dart';
 import 'package:alera/src/features/keyboard/domain/keyboard_action.dart';
@@ -34,6 +35,16 @@ class SettingsController extends _$SettingsController {
 
   Future<void> updateEditor(EditorSettings settings) async {
     await _save(state.copyWith(editor: settings));
+  }
+
+  Future<void> updateAiTextGeneration(AiTextGenerationSettings settings) async {
+    await _save(state.copyWith(aiTextGeneration: settings));
+  }
+
+  Future<void> resetAiTextGenerationSettings() async {
+    await _save(
+      state.copyWith(aiTextGeneration: AiTextGenerationSettings.defaults),
+    );
   }
 
   Future<void> resetEditorSettings() async {

--- a/lib/src/features/settings/application/settings_controller.g.dart
+++ b/lib/src/features/settings/application/settings_controller.g.dart
@@ -42,7 +42,7 @@ final class SettingsControllerProvider
 }
 
 String _$settingsControllerHash() =>
-    r'07cb59a9ede335d114b49627e1571d91116f6f41';
+    r'17fa8792cb3bb50ed46cba59528c06b4d082bfc1';
 
 abstract class _$SettingsController extends $Notifier<AleraSettings> {
   AleraSettings build();

--- a/lib/src/features/settings/domain/alera_settings.dart
+++ b/lib/src/features/settings/domain/alera_settings.dart
@@ -1,4 +1,5 @@
 import 'package:alera/src/app/theme/alera_tokens.dart';
+import 'package:alera/src/features/ai_text_generation/domain/ai_text_generation_settings.dart';
 import 'package:alera/src/features/keyboard/domain/keyboard_shortcut_settings.dart';
 import 'package:alera/src/features/settings/domain/editor_syntax_theme_catalog.dart';
 import 'package:alera/src/features/settings/domain/terminal_theme_catalog.dart';
@@ -209,18 +210,21 @@ class GeneralSettings with GeneralSettingsMappable {
 class AleraSettings with AleraSettingsMappable {
   const AleraSettings({
     required this.general,
+    this.aiTextGeneration = AiTextGenerationSettings.defaults,
     this.editor = EditorSettings.defaults,
     required this.terminal,
     required this.keyboard,
   });
 
   final GeneralSettings general;
+  final AiTextGenerationSettings aiTextGeneration;
   final EditorSettings editor;
   final TerminalSettings terminal;
   final KeyboardShortcutSettings keyboard;
 
   static const AleraSettings defaults = AleraSettings(
     general: GeneralSettings.defaults,
+    aiTextGeneration: AiTextGenerationSettings.defaults,
     editor: EditorSettings.defaults,
     terminal: TerminalSettings.defaults,
     keyboard: KeyboardShortcutSettings.defaults,

--- a/lib/src/features/settings/domain/alera_settings.mapper.dart
+++ b/lib/src/features/settings/domain/alera_settings.mapper.dart
@@ -1231,6 +1231,7 @@ class AleraSettingsMapper extends ClassMapperBase<AleraSettings> {
     if (_instance == null) {
       MapperContainer.globals.use(_instance = AleraSettingsMapper._());
       GeneralSettingsMapper.ensureInitialized();
+      AiTextGenerationSettingsMapper.ensureInitialized();
       EditorSettingsMapper.ensureInitialized();
       TerminalSettingsMapper.ensureInitialized();
       KeyboardShortcutSettingsMapper.ensureInitialized();
@@ -1245,6 +1246,15 @@ class AleraSettingsMapper extends ClassMapperBase<AleraSettings> {
   static const Field<AleraSettings, GeneralSettings> _f$general = Field(
     'general',
     _$general,
+  );
+  static AiTextGenerationSettings _$aiTextGeneration(AleraSettings v) =>
+      v.aiTextGeneration;
+  static const Field<AleraSettings, AiTextGenerationSettings>
+  _f$aiTextGeneration = Field(
+    'aiTextGeneration',
+    _$aiTextGeneration,
+    opt: true,
+    def: AiTextGenerationSettings.defaults,
   );
   static EditorSettings _$editor(AleraSettings v) => v.editor;
   static const Field<AleraSettings, EditorSettings> _f$editor = Field(
@@ -1265,6 +1275,7 @@ class AleraSettingsMapper extends ClassMapperBase<AleraSettings> {
   @override
   final MappableFields<AleraSettings> fields = const {
     #general: _f$general,
+    #aiTextGeneration: _f$aiTextGeneration,
     #editor: _f$editor,
     #terminal: _f$terminal,
     #keyboard: _f$keyboard,
@@ -1273,6 +1284,7 @@ class AleraSettingsMapper extends ClassMapperBase<AleraSettings> {
   static AleraSettings _instantiate(DecodingData data) {
     return AleraSettings(
       general: data.dec(_f$general),
+      aiTextGeneration: data.dec(_f$aiTextGeneration),
       editor: data.dec(_f$editor),
       terminal: data.dec(_f$terminal),
       keyboard: data.dec(_f$keyboard),
@@ -1342,6 +1354,12 @@ extension AleraSettingsValueCopy<$R, $Out>
 abstract class AleraSettingsCopyWith<$R, $In extends AleraSettings, $Out>
     implements ClassCopyWith<$R, $In, $Out> {
   GeneralSettingsCopyWith<$R, GeneralSettings, GeneralSettings> get general;
+  AiTextGenerationSettingsCopyWith<
+    $R,
+    AiTextGenerationSettings,
+    AiTextGenerationSettings
+  >
+  get aiTextGeneration;
   EditorSettingsCopyWith<$R, EditorSettings, EditorSettings> get editor;
   TerminalSettingsCopyWith<$R, TerminalSettings, TerminalSettings> get terminal;
   KeyboardShortcutSettingsCopyWith<
@@ -1352,6 +1370,7 @@ abstract class AleraSettingsCopyWith<$R, $In extends AleraSettings, $Out>
   get keyboard;
   $R call({
     GeneralSettings? general,
+    AiTextGenerationSettings? aiTextGeneration,
     EditorSettings? editor,
     TerminalSettings? terminal,
     KeyboardShortcutSettings? keyboard,
@@ -1371,6 +1390,14 @@ class _AleraSettingsCopyWithImpl<$R, $Out>
   GeneralSettingsCopyWith<$R, GeneralSettings, GeneralSettings> get general =>
       $value.general.copyWith.$chain((v) => call(general: v));
   @override
+  AiTextGenerationSettingsCopyWith<
+    $R,
+    AiTextGenerationSettings,
+    AiTextGenerationSettings
+  >
+  get aiTextGeneration =>
+      $value.aiTextGeneration.copyWith.$chain((v) => call(aiTextGeneration: v));
+  @override
   EditorSettingsCopyWith<$R, EditorSettings, EditorSettings> get editor =>
       $value.editor.copyWith.$chain((v) => call(editor: v));
   @override
@@ -1386,12 +1413,14 @@ class _AleraSettingsCopyWithImpl<$R, $Out>
   @override
   $R call({
     GeneralSettings? general,
+    AiTextGenerationSettings? aiTextGeneration,
     EditorSettings? editor,
     TerminalSettings? terminal,
     KeyboardShortcutSettings? keyboard,
   }) => $apply(
     FieldCopyWithData({
       if (general != null) #general: general,
+      if (aiTextGeneration != null) #aiTextGeneration: aiTextGeneration,
       if (editor != null) #editor: editor,
       if (terminal != null) #terminal: terminal,
       if (keyboard != null) #keyboard: keyboard,
@@ -1400,6 +1429,7 @@ class _AleraSettingsCopyWithImpl<$R, $Out>
   @override
   AleraSettings $make(CopyWithData data) => AleraSettings(
     general: data.get(#general, or: $value.general),
+    aiTextGeneration: data.get(#aiTextGeneration, or: $value.aiTextGeneration),
     editor: data.get(#editor, or: $value.editor),
     terminal: data.get(#terminal, or: $value.terminal),
     keyboard: data.get(#keyboard, or: $value.keyboard),

--- a/lib/src/features/settings/presentation/settings_dialog.dart
+++ b/lib/src/features/settings/presentation/settings_dialog.dart
@@ -1,5 +1,11 @@
+import 'dart:async';
+
 import 'package:alera/src/app/providers.dart';
 import 'package:alera/src/app/theme/alera_tokens.dart';
+import 'package:alera/src/features/ai_text_generation/application/ai_text_generation_providers.dart';
+import 'package:alera/src/features/ai_text_generation/application/ai_text_generation_registry.dart';
+import 'package:alera/src/features/ai_text_generation/application/ai_text_model_discovery_service.dart';
+import 'package:alera/src/features/ai_text_generation/domain/ai_text_generation_settings.dart';
 import 'package:alera/src/design_system/buttons/alera_icon_button.dart';
 import 'package:alera/src/design_system/buttons/alera_segmented_button.dart';
 import 'package:alera/src/design_system/feedback/alera_color_swatch.dart';
@@ -9,6 +15,7 @@ import 'package:alera/src/design_system/forms/alera_search_field.dart';
 import 'package:alera/src/design_system/forms/alera_setting_row.dart';
 import 'package:alera/src/design_system/forms/alera_text_field.dart';
 import 'package:alera/src/design_system/layout/alera_dialog.dart';
+import 'package:alera/src/design_system/menus/alera_dropdown_entry.dart';
 import 'package:alera/src/design_system/menus/alera_menu_item.dart';
 import 'package:alera/src/design_system/surfaces/alera_panel.dart';
 import 'package:alera/src/features/agent_status/domain/agent_status.dart';
@@ -25,6 +32,7 @@ import 'package:flutter/services.dart';
 
 part 'settings_dialog_navigation.dart';
 part 'settings_dialog_general_pane.dart';
+part 'settings_dialog_ai_text_pane.dart';
 part 'settings_dialog_editor_pane.dart';
 part 'settings_dialog_terminal_pane.dart';
 part 'settings_dialog_theme_picker.dart';
@@ -104,6 +112,18 @@ class _SettingsDialogState extends ConsumerState<SettingsDialog> {
         builder: (_) => _EditorSettingsPane(
           settings: settings.editor,
           onChanged: (editor) => controller.updateEditor(editor),
+        ),
+      ),
+      _SettingsSectionData(
+        id: 'aiText',
+        title: 'AI text',
+        description: 'AI-generated source control text.',
+        icon: Icons.auto_awesome,
+        entries: _aiTextSearchEntries,
+        onReset: controller.resetAiTextGenerationSettings,
+        builder: (_) => _AiTextSettingsPane(
+          settings: settings.aiTextGeneration,
+          onChanged: (aiText) => controller.updateAiTextGeneration(aiText),
         ),
       ),
       _SettingsSectionData(
@@ -356,6 +376,35 @@ const List<_SettingsSearchEntry> _editorSearchEntries = <_SettingsSearchEntry>[
     title: 'Tab size',
     description: 'Spaces inserted when pressing Tab in editor tabs.',
     keywords: <String>['indent', 'indentation', 'spaces', 'code'],
+  ),
+];
+
+const List<_SettingsSearchEntry> _aiTextSearchEntries = <_SettingsSearchEntry>[
+  _SettingsSearchEntry(
+    title: 'AI text generation',
+    description: 'Generate source control text with local agent CLIs.',
+    keywords: <String>['ai', 'commit', 'pull request', 'branch'],
+  ),
+  _SettingsSearchEntry(
+    title: 'AI text agent',
+    description: 'Choose the CLI used for generated text.',
+    keywords: <String>[
+      'codex',
+      'claude',
+      'copilot',
+      'cursor',
+      'antigravity',
+      'agy',
+      'opencode',
+      'pi',
+      'amp',
+      'custom',
+    ],
+  ),
+  _SettingsSearchEntry(
+    title: 'AI text instructions',
+    description: 'Commit message instructions for generated text.',
+    keywords: <String>['prompt', 'instructions', 'commit message'],
   ),
 ];
 

--- a/lib/src/features/settings/presentation/settings_dialog_ai_text_pane.dart
+++ b/lib/src/features/settings/presentation/settings_dialog_ai_text_pane.dart
@@ -1,0 +1,506 @@
+part of 'settings_dialog.dart';
+
+class _AiTextSettingsPane extends ConsumerStatefulWidget {
+  const _AiTextSettingsPane({required this.settings, required this.onChanged});
+
+  final AiTextGenerationSettings settings;
+  final ValueChanged<AiTextGenerationSettings> onChanged;
+
+  @override
+  ConsumerState<_AiTextSettingsPane> createState() =>
+      _AiTextSettingsPaneState();
+}
+
+class _AiTextSettingsPaneState extends ConsumerState<_AiTextSettingsPane> {
+  final Map<AiTextGenerationAgent, _AiTextModelDiscoveryState> _discovery =
+      <AiTextGenerationAgent, _AiTextModelDiscoveryState>{};
+  final Set<AiTextGenerationAgent> _autoDiscovered = <AiTextGenerationAgent>{};
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _autoDiscoverActiveAgent();
+    });
+  }
+
+  @override
+  void didUpdateWidget(covariant _AiTextSettingsPane oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.settings.agent != widget.settings.agent ||
+        oldWidget.settings.enabled != widget.settings.enabled) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        _autoDiscoverActiveAgent();
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final settings = widget.settings;
+    final agent = settings.agent;
+    final spec = aiTextAgentSpecs[agent];
+    final models = modelsForAgent(agent, settings);
+    final model = modelForAgent(
+      agent,
+      settings.modelFor(agent) ?? defaultModelIdForAgent(agent, settings),
+      extraModels: discoveredModelsForAgent(settings, agent),
+    );
+    final thinkingLevels = model.thinkingLevels;
+    final discovery = _discovery[agent] ?? const _AiTextModelDiscoveryState();
+    final canDiscoverModels = spec?.modelsCommand != null;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: <Widget>[
+        _SettingsGroup(
+          title: 'Generation',
+          description:
+              'Local agent CLIs generate text from source control context.',
+          children: <Widget>[
+            _SwitchSettingRow(
+              title: 'Enable AI text',
+              description: 'Show generation actions in source control.',
+              value: widget.settings.enabled,
+              onChanged: (value) =>
+                  widget.onChanged(settings.copyWith(enabled: value)),
+            ),
+            _AiTextAgentRow(
+              value: agent,
+              onChanged: (value) =>
+                  widget.onChanged(settings.copyWith(agent: value)),
+            ),
+            if (agent == AiTextGenerationAgent.custom)
+              _TextSettingRow(
+                title: 'Custom command',
+                description:
+                    'Use {prompt} to pass the prompt as an argument; otherwise Alera sends it on stdin.',
+                value: settings.customCommand,
+                hintText: 'llm --system commit-message',
+                onChanged: (value) =>
+                    widget.onChanged(settings.copyWith(customCommand: value)),
+              )
+            else if (spec != null)
+              _AiTextModelRow(
+                agent: agent,
+                models: models,
+                value: model.id,
+                canDiscoverModels: canDiscoverModels,
+                discovering: discovery.loading,
+                discoveryError: discovery.error,
+                onRefreshModels: canDiscoverModels
+                    ? () => unawaited(_discoverModels(agent))
+                    : null,
+                onChanged: (value) => widget.onChanged(
+                  settings.copyWith(
+                    selectedModelByAgent: <AiTextGenerationAgent, String>{
+                      ...settings.selectedModelByAgent,
+                      agent: value,
+                    },
+                  ),
+                ),
+              ),
+            if (thinkingLevels.isNotEmpty)
+              _AiTextThinkingRow(
+                levels: thinkingLevels,
+                value:
+                    settings.thinkingForModel(model.id) ??
+                    model.defaultThinkingLevel ??
+                    thinkingLevels.first.id,
+                onChanged: (value) => widget.onChanged(
+                  settings.copyWith(
+                    selectedThinkingByModel: <String, String>{
+                      ...settings.selectedThinkingByModel,
+                      model.id: value,
+                    },
+                  ),
+                ),
+              ),
+          ],
+        ),
+        const SizedBox(height: AleraTokens.space16),
+        _SettingsGroup(
+          title: 'Instructions',
+          description: 'Extra guidance appended to commit-message prompts.',
+          children: <Widget>[
+            _InstructionSettingRow(
+              title: AiTextGenerationOperation.commitMessage.label,
+              value: settings.instructionsFor(
+                AiTextGenerationOperation.commitMessage,
+              ),
+              onChanged: (value) => widget.onChanged(
+                settings.copyWith(
+                  instructionsByOperation: <AiTextGenerationOperation, String>{
+                    ...settings.instructionsByOperation,
+                    AiTextGenerationOperation.commitMessage: value,
+                  },
+                ),
+              ),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+
+  void _autoDiscoverActiveAgent() {
+    if (!mounted || !widget.settings.enabled) {
+      return;
+    }
+    final agent = widget.settings.agent;
+    final spec = aiTextAgentSpecs[agent];
+    if (spec?.modelsCommand == null ||
+        _autoDiscovered.contains(agent) ||
+        (_discovery[agent]?.loading ?? false)) {
+      return;
+    }
+    _autoDiscovered.add(agent);
+    unawaited(_discoverModels(agent));
+  }
+
+  Future<void> _discoverModels(AiTextGenerationAgent agent) async {
+    final spec = aiTextAgentSpecs[agent];
+    if (spec?.modelsCommand == null) {
+      return;
+    }
+    setState(() {
+      _discovery[agent] = const _AiTextModelDiscoveryState(loading: true);
+    });
+    final AiTextModelDiscoveryResult result;
+    try {
+      result = await ref
+          .read(aiTextModelDiscoveryServiceProvider)
+          .discover(agent);
+    } catch (error) {
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _discovery[agent] = _AiTextModelDiscoveryState(error: error.toString());
+      });
+      return;
+    }
+    if (!mounted) {
+      return;
+    }
+    if (!result.success) {
+      setState(() {
+        _discovery[agent] = _AiTextModelDiscoveryState(error: result.error);
+      });
+      return;
+    }
+    final latest = widget.settings;
+    widget.onChanged(
+      latest.copyWith(
+        discoveredModelsByAgent:
+            <AiTextGenerationAgent, List<AiTextDiscoveredModel>>{
+              ...latest.discoveredModelsByAgent,
+              agent: <AiTextDiscoveredModel>[
+                for (final model in result.models) model.toDiscovered(),
+              ],
+            },
+        discoveredDefaultModelByAgent: <AiTextGenerationAgent, String>{
+          ...latest.discoveredDefaultModelByAgent,
+          agent: result.defaultModelId,
+        },
+      ),
+    );
+    setState(() {
+      _discovery[agent] = const _AiTextModelDiscoveryState();
+    });
+  }
+}
+
+class _AiTextModelDiscoveryState {
+  const _AiTextModelDiscoveryState({this.loading = false, this.error});
+
+  final bool loading;
+  final String? error;
+}
+
+class _AiTextAgentRow extends StatelessWidget {
+  const _AiTextAgentRow({required this.value, required this.onChanged});
+
+  final AiTextGenerationAgent value;
+  final ValueChanged<AiTextGenerationAgent> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return AleraSettingRow(
+      title: 'Agent',
+      description: 'CLI used for generated source control text.',
+      child: _AiTextSelectField<AiTextGenerationAgent>(
+        key: ValueKey<String>('ai-text-agent-${value.key}'),
+        value: value,
+        label: value.label,
+        entries: <_AiTextSelectEntry<AiTextGenerationAgent>>[
+          for (final agent in AiTextGenerationAgent.values)
+            _AiTextSelectEntry<AiTextGenerationAgent>(
+              value: agent,
+              label: agent.label,
+            ),
+        ],
+        onChanged: (next) {
+          onChanged(next);
+        },
+      ),
+    );
+  }
+}
+
+class _AiTextModelRow extends StatelessWidget {
+  const _AiTextModelRow({
+    required this.agent,
+    required this.models,
+    required this.value,
+    required this.canDiscoverModels,
+    required this.discovering,
+    required this.discoveryError,
+    required this.onRefreshModels,
+    required this.onChanged,
+  });
+
+  final AiTextGenerationAgent agent;
+  final List<AiTextModel> models;
+  final String value;
+  final bool canDiscoverModels;
+  final bool discovering;
+  final String? discoveryError;
+  final VoidCallback? onRefreshModels;
+  final ValueChanged<String> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final known = models.any((model) => model.id == value);
+    if (!known) {
+      return _TextSettingRow(
+        title: 'Model',
+        description: 'Model passed to ${agent.label}.',
+        value: value,
+        onChanged: onChanged,
+      );
+    }
+    return AleraSettingRow(
+      title: 'Model',
+      description: discoveryError == null
+          ? 'Model passed to ${agent.label}.'
+          : discoveryError!,
+      child: Row(
+        children: <Widget>[
+          Expanded(
+            child: _AiTextSelectField<String>(
+              key: ValueKey<String>('ai-text-model-${agent.key}-$value'),
+              value: value,
+              label: models.firstWhere((model) => model.id == value).label,
+              entries: <_AiTextSelectEntry<String>>[
+                for (final model in models)
+                  _AiTextSelectEntry<String>(
+                    value: model.id,
+                    label: model.label,
+                  ),
+              ],
+              onChanged: (next) {
+                onChanged(next);
+              },
+            ),
+          ),
+          if (canDiscoverModels) ...<Widget>[
+            const SizedBox(width: AleraTokens.space8),
+            AleraIconButton(
+              tooltip: 'Refresh models',
+              icon: discovering ? Icons.sync : Icons.refresh,
+              onPressed: discovering ? null : onRefreshModels,
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _AiTextThinkingRow extends StatelessWidget {
+  const _AiTextThinkingRow({
+    required this.levels,
+    required this.value,
+    required this.onChanged,
+  });
+
+  final List<AiThinkingLevel> levels;
+  final String value;
+  final ValueChanged<String> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final selected = levels.any((level) => level.id == value)
+        ? value
+        : levels.first.id;
+    return AleraSettingRow(
+      title: 'Thinking',
+      description: 'Reasoning effort for models that support it.',
+      child: _AiTextSelectField<String>(
+        key: ValueKey<String>('ai-text-thinking-$value'),
+        value: selected,
+        label: levels.firstWhere((level) => level.id == selected).label,
+        entries: <_AiTextSelectEntry<String>>[
+          for (final level in levels)
+            _AiTextSelectEntry<String>(value: level.id, label: level.label),
+        ],
+        onChanged: (next) {
+          onChanged(next);
+        },
+      ),
+    );
+  }
+}
+
+class _AiTextSelectEntry<T> {
+  const _AiTextSelectEntry({required this.value, required this.label});
+
+  final T value;
+  final String label;
+}
+
+class _AiTextSelectField<T> extends StatelessWidget {
+  const _AiTextSelectField({
+    super.key,
+    required this.value,
+    required this.label,
+    required this.entries,
+    required this.onChanged,
+  });
+
+  final T value;
+  final String label;
+  final List<_AiTextSelectEntry<T>> entries;
+  final ValueChanged<T> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return Builder(
+      builder: (buttonContext) {
+        return MouseRegion(
+          cursor: SystemMouseCursors.click,
+          child: InkWell(
+            mouseCursor: SystemMouseCursors.click,
+            borderRadius: BorderRadius.circular(AleraTokens.radiusMd),
+            onTap: () => unawaited(_openMenu(buttonContext)),
+            child: InputDecorator(
+              isEmpty: false,
+              isFocused: false,
+              decoration: const InputDecoration(
+                isDense: true,
+                suffixIcon: Icon(Icons.expand_more, size: 18),
+              ),
+              child: Text(label, maxLines: 1, overflow: TextOverflow.ellipsis),
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  Future<void> _openMenu(BuildContext context) async {
+    final renderBox = context.findRenderObject() as RenderBox?;
+    final overlay = Navigator.of(context).overlay?.context.findRenderObject();
+    if (renderBox == null || overlay is! RenderBox) {
+      return;
+    }
+    final topLeft = renderBox.localToGlobal(Offset.zero, ancestor: overlay);
+    final bottomRight = renderBox.localToGlobal(
+      renderBox.size.bottomRight(Offset.zero),
+      ancestor: overlay,
+    );
+    final selected = await showMenu<T>(
+      context: context,
+      position: RelativeRect.fromRect(
+        Rect.fromPoints(topLeft, bottomRight),
+        Offset.zero & overlay.size,
+      ),
+      items: <PopupMenuEntry<T>>[
+        for (final entry in entries)
+          AleraDropdownEntry<T>(
+            value: entry.value,
+            label: entry.label,
+            selected: entry.value == value,
+          ),
+      ],
+    );
+    if (selected != null && selected != value) {
+      onChanged(selected);
+    }
+  }
+}
+
+class _InstructionSettingRow extends StatefulWidget {
+  const _InstructionSettingRow({
+    required this.title,
+    required this.value,
+    required this.onChanged,
+  });
+
+  final String title;
+  final String value;
+  final ValueChanged<String> onChanged;
+
+  @override
+  State<_InstructionSettingRow> createState() => _InstructionSettingRowState();
+}
+
+class _InstructionSettingRowState extends State<_InstructionSettingRow> {
+  late final TextEditingController _controller;
+  late final FocusNode _focusNode;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = TextEditingController(text: widget.value);
+    _focusNode = FocusNode();
+    _focusNode.addListener(_handleFocusChanged);
+  }
+
+  @override
+  void didUpdateWidget(_InstructionSettingRow oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.value != oldWidget.value && widget.value != _controller.text) {
+      _controller.text = widget.value;
+    }
+  }
+
+  @override
+  void dispose() {
+    _focusNode.removeListener(_handleFocusChanged);
+    _focusNode.dispose();
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void _handleFocusChanged() {
+    if (!_focusNode.hasFocus) {
+      _commit();
+    }
+  }
+
+  void _commit() {
+    final value = _controller.text.trim();
+    if (value != widget.value) {
+      widget.onChanged(value);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AleraSettingRow(
+      title: widget.title,
+      description: 'Optional prompt guidance.',
+      controlWidth: 360,
+      child: TextField(
+        controller: _controller,
+        focusNode: _focusNode,
+        minLines: 2,
+        maxLines: 4,
+        onEditingComplete: _commit,
+        onSubmitted: (_) => _commit(),
+        decoration: const InputDecoration(hintText: 'Optional instructions'),
+      ),
+    );
+  }
+}

--- a/lib/src/features/settings/presentation/settings_dialog_navigation.dart
+++ b/lib/src/features/settings/presentation/settings_dialog_navigation.dart
@@ -92,7 +92,10 @@ class _SettingsNavItem extends StatelessWidget {
     return Material(
       color: Colors.transparent,
       child: InkWell(
-        onTap: onTap,
+        onTap: () {
+          FocusManager.instance.primaryFocus?.unfocus();
+          onTap();
+        },
         borderRadius: BorderRadius.circular(AleraTokens.radiusMd),
         mouseCursor: SystemMouseCursors.click,
         child: Container(
@@ -161,7 +164,11 @@ class _SettingsContent extends StatelessWidget {
                 if (section.onReset != null) ...<Widget>[
                   const SizedBox(width: AleraTokens.space8),
                   TextButton(
-                    onPressed: () => section.onReset!(),
+                    onPressed: () async {
+                      FocusManager.instance.primaryFocus?.unfocus();
+                      await Future<void>.delayed(Duration.zero);
+                      await section.onReset!();
+                    },
                     child: Text('Reset ${section.title.toLowerCase()}'),
                   ),
                 ],

--- a/lib/src/features/workbench/application/workspace_source_control_controller.g.dart
+++ b/lib/src/features/workbench/application/workspace_source_control_controller.g.dart
@@ -58,7 +58,7 @@ final class WorkspaceSourceControlControllerProvider
 }
 
 String _$workspaceSourceControlControllerHash() =>
-    r'ece2d7d03d2074b325319bbd1662144c5a409956';
+    r'd67f09b5830696c917a29fd27831cb43d861a2cd';
 
 final class WorkspaceSourceControlControllerFamily extends $Family
     with

--- a/lib/src/features/workbench/presentation/workspace_git_diff_panel.dart
+++ b/lib/src/features/workbench/presentation/workspace_git_diff_panel.dart
@@ -8,6 +8,10 @@ import 'package:alera/src/design_system/icons/alera_file_icon.dart';
 import 'package:alera/src/design_system/layout/alera_confirm_dialog.dart';
 import 'package:alera/src/design_system/layout/alera_dialog.dart';
 import 'package:alera/src/design_system/menus/alera_dropdown_entry.dart';
+import 'package:alera/src/features/ai_text_generation/application/ai_text_generation_providers.dart';
+import 'package:alera/src/features/ai_text_generation/application/ai_text_generation_service.dart';
+import 'package:alera/src/features/ai_text_generation/domain/ai_text_generation_settings.dart';
+import 'package:alera/src/features/settings/application/settings_controller.dart';
 import 'package:alera/src/features/workbench/application/workspace_source_control_controller.dart';
 import 'package:alera/src/features/workbench/domain/workbench_view_prefs.dart';
 import 'package:alera/src/features/workbench/domain/workspace.dart';
@@ -54,22 +58,42 @@ class _WorkspaceGitDiffPanelState extends ConsumerState<WorkspaceGitDiffPanel> {
   final TextEditingController _filterController = TextEditingController();
   final Set<String> _collapsedSections = <String>{};
   final Set<String> _collapsedTreeNodes = <String>{};
+  late final AiTextGenerationService _aiTextGenerationService;
   bool _filterVisible = false;
+  bool _generatingCommitMessage = false;
+  int _commitMessageGenerationId = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _aiTextGenerationService = ref.read(aiTextGenerationServiceProvider);
+  }
 
   @override
   void didUpdateWidget(covariant WorkspaceGitDiffPanel oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.workspace.path != widget.workspace.path) {
+      _aiTextGenerationService.cancel(
+        oldWidget.workspace.path,
+        AiTextGenerationOperation.commitMessage,
+      );
+      _commitMessageGenerationId += 1;
       _messageController.clear();
       _filterController.clear();
       _collapsedSections.clear();
       _collapsedTreeNodes.clear();
       _filterVisible = false;
+      _generatingCommitMessage = false;
     }
   }
 
   @override
   void dispose() {
+    _aiTextGenerationService.cancel(
+      widget.workspace.path,
+      AiTextGenerationOperation.commitMessage,
+    );
+    _commitMessageGenerationId += 1;
     _messageController.dispose();
     _filterController.dispose();
     super.dispose();
@@ -80,6 +104,11 @@ class _WorkspaceGitDiffPanelState extends ConsumerState<WorkspaceGitDiffPanel> {
     final state = ref.watch(
       workspaceSourceControlControllerProvider(widget.workspace.path),
     );
+    final aiTextSettings = ref.watch(
+      settingsControllerProvider.select(
+        (settings) => settings.aiTextGeneration,
+      ),
+    );
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: <Widget>[
@@ -88,9 +117,13 @@ class _WorkspaceGitDiffPanelState extends ConsumerState<WorkspaceGitDiffPanel> {
           filterController: _filterController,
           viewMode: widget.viewMode,
           state: state,
+          aiTextSettings: aiTextSettings,
+          generatingCommitMessage: _generatingCommitMessage,
           allCollapsed: _allVisibleNodesCollapsed(state.asData?.value),
           filterVisible: _isFilterVisible,
           onMessageChanged: () => setState(() {}),
+          onGenerateCommitMessage: () => unawaited(_generateCommitMessage()),
+          onCancelGenerateCommitMessage: _cancelGenerateCommitMessage,
           onFilterChanged: () => setState(() {}),
           onToggleFilter: _toggleFilterVisibility,
           onRefresh: () => unawaited(_refresh()),
@@ -316,6 +349,104 @@ class _WorkspaceGitDiffPanelState extends ConsumerState<WorkspaceGitDiffPanel> {
     }
   }
 
+  Future<void> _generateCommitMessage() async {
+    final state = ref
+        .read(workspaceSourceControlControllerProvider(widget.workspace.path))
+        .asData
+        ?.value;
+    final settings = ref.read(settingsControllerProvider).aiTextGeneration;
+    if (_generatingCommitMessage ||
+        state == null ||
+        !settings.enabled ||
+        !state.hasStagedChanges ||
+        state.repositoryState.hasConflicts ||
+        state.isBusy) {
+      return;
+    }
+    final requestWorkspacePath = widget.workspace.path;
+    final generationId = _commitMessageGenerationId + 1;
+    final initialText = _messageController.text;
+    setState(() {
+      _commitMessageGenerationId = generationId;
+      _generatingCommitMessage = true;
+    });
+    try {
+      final result = await ref
+          .read(aiTextGenerationServiceProvider)
+          .generate(
+            AiTextGenerationRequest(
+              operation: AiTextGenerationOperation.commitMessage,
+              workspacePath: requestWorkspacePath,
+              settings: settings,
+            ),
+          );
+      if (!mounted) {
+        return;
+      }
+      if (!_isCurrentCommitMessageGeneration(
+        workspacePath: requestWorkspacePath,
+        generationId: generationId,
+      )) {
+        return;
+      }
+      if (_messageController.text == initialText) {
+        _messageController.text = result.text;
+        _messageController.selection = TextSelection.collapsed(
+          offset: _messageController.text.length,
+        );
+        setState(() {});
+        AleraToast.show(
+          context,
+          message: 'Commit message generated with ${result.agentLabel}',
+          tone: AleraToastTone.success,
+        );
+      } else {
+        AleraToast.show(
+          context,
+          message:
+              'Generated message was not applied because the field changed.',
+          tone: AleraToastTone.info,
+        );
+      }
+    } on AiTextGenerationCanceledException {
+      return;
+    } catch (error) {
+      if (_isCurrentCommitMessageGeneration(
+        workspacePath: requestWorkspacePath,
+        generationId: generationId,
+      )) {
+        AleraToast.show(
+          context,
+          message: _messageFor(error),
+          tone: AleraToastTone.error,
+        );
+      }
+    } finally {
+      if (_isCurrentCommitMessageGeneration(
+        workspacePath: requestWorkspacePath,
+        generationId: generationId,
+      )) {
+        setState(() => _generatingCommitMessage = false);
+      }
+    }
+  }
+
+  bool _isCurrentCommitMessageGeneration({
+    required String workspacePath,
+    required int generationId,
+  }) {
+    return mounted &&
+        widget.workspace.path == workspacePath &&
+        _commitMessageGenerationId == generationId;
+  }
+
+  void _cancelGenerateCommitMessage() {
+    _aiTextGenerationService.cancel(
+      widget.workspace.path,
+      AiTextGenerationOperation.commitMessage,
+    );
+  }
+
   Future<void> _amendAction() async {
     final state = ref
         .read(workspaceSourceControlControllerProvider(widget.workspace.path))
@@ -517,6 +648,9 @@ class _WorkspaceGitDiffPanelState extends ConsumerState<WorkspaceGitDiffPanel> {
     }
     if (error is GitConflictException) {
       return 'Resolve conflicts before continuing.';
+    }
+    if (error is AiTextGenerationException) {
+      return error.message;
     }
     if (error is GitException && error.context.trim().isNotEmpty) {
       return error.context;

--- a/lib/src/features/workbench/presentation/workspace_git_diff_panel_toolbar.dart
+++ b/lib/src/features/workbench/presentation/workspace_git_diff_panel_toolbar.dart
@@ -6,9 +6,13 @@ class _SourceControlToolbar extends StatelessWidget {
     required this.filterController,
     required this.viewMode,
     required this.state,
+    required this.aiTextSettings,
+    required this.generatingCommitMessage,
     required this.allCollapsed,
     required this.filterVisible,
     required this.onMessageChanged,
+    required this.onGenerateCommitMessage,
+    required this.onCancelGenerateCommitMessage,
     required this.onFilterChanged,
     required this.onToggleFilter,
     required this.onRefresh,
@@ -23,9 +27,13 @@ class _SourceControlToolbar extends StatelessWidget {
   final TextEditingController filterController;
   final GitDiffViewMode viewMode;
   final AsyncValue<WorkspaceSourceControlState> state;
+  final AiTextGenerationSettings aiTextSettings;
+  final bool generatingCommitMessage;
   final bool allCollapsed;
   final bool filterVisible;
   final VoidCallback onMessageChanged;
+  final VoidCallback onGenerateCommitMessage;
+  final VoidCallback onCancelGenerateCommitMessage;
   final VoidCallback onFilterChanged;
   final VoidCallback onToggleFilter;
   final VoidCallback onRefresh;
@@ -41,6 +49,8 @@ class _SourceControlToolbar extends StatelessWidget {
     final busy = state.isLoading || (data?.isBusy ?? false);
     final hasStagedChanges = data?.hasStagedChanges ?? false;
     final hasConflicts = data?.repositoryState.hasConflicts ?? false;
+    final canGenerateCommitMessage =
+        aiTextSettings.enabled && !busy && !hasConflicts && hasStagedChanges;
     final canCommit =
         !busy &&
         !hasConflicts &&
@@ -64,6 +74,16 @@ class _SourceControlToolbar extends StatelessWidget {
                   style: Theme.of(context).textTheme.titleSmall,
                 ),
               ),
+              if (aiTextSettings.enabled ||
+                  generatingCommitMessage) ...<Widget>[
+                _AiCommitMessageButton(
+                  generating: generatingCommitMessage,
+                  canGenerate: canGenerateCommitMessage,
+                  onGenerate: onGenerateCommitMessage,
+                  onCancel: onCancelGenerateCommitMessage,
+                ),
+                const SizedBox(width: AleraTokens.space2),
+              ],
               AleraIconButton(
                 tooltip: 'All changes',
                 icon: Icons.difference_outlined,
@@ -111,6 +131,7 @@ class _SourceControlToolbar extends StatelessWidget {
           _CommitMessageField(
             controller: messageController,
             enabled: !busy,
+            generating: generatingCommitMessage,
             onChanged: (_) => onMessageChanged(),
             onSubmitted: (_) {
               if (canCommit) {
@@ -252,25 +273,114 @@ enum _SourceControlMenuAction {
   stashPop,
 }
 
+class _AiCommitMessageButton extends StatefulWidget {
+  const _AiCommitMessageButton({
+    required this.generating,
+    required this.canGenerate,
+    required this.onGenerate,
+    required this.onCancel,
+  });
+
+  final bool generating;
+  final bool canGenerate;
+  final VoidCallback onGenerate;
+  final VoidCallback onCancel;
+
+  @override
+  State<_AiCommitMessageButton> createState() => _AiCommitMessageButtonState();
+}
+
+class _AiCommitMessageButtonState extends State<_AiCommitMessageButton> {
+  bool _hovered = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final showingStop = widget.generating && _hovered;
+    final onPressed = widget.generating
+        ? widget.onCancel
+        : widget.canGenerate
+        ? widget.onGenerate
+        : null;
+    return MouseRegion(
+      cursor: onPressed == null
+          ? SystemMouseCursors.basic
+          : SystemMouseCursors.click,
+      onEnter: (_) => setState(() => _hovered = true),
+      onExit: (_) => setState(() => _hovered = false),
+      child: Tooltip(
+        message: widget.generating
+            ? 'Stop generating commit message'
+            : 'Generate commit message with AI',
+        child: IconButton(
+          onPressed: onPressed,
+          visualDensity: VisualDensity.compact,
+          padding: EdgeInsets.zero,
+          constraints: const BoxConstraints(
+            minWidth: 30,
+            minHeight: 30,
+            maxWidth: 30,
+            maxHeight: 30,
+          ),
+          style: IconButton.styleFrom(
+            minimumSize: const Size(30, 30),
+            maximumSize: const Size(30, 30),
+            tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(AleraTokens.radiusMd),
+            ),
+          ),
+          icon: AnimatedSwitcher(
+            duration: AleraTokens.durationFast,
+            child: widget.generating && !showingStop
+                ? const SizedBox(
+                    key: ValueKey<String>('ai-commit-loading'),
+                    width: 16,
+                    height: 16,
+                    child: CircularProgressIndicator(
+                      strokeWidth: 2,
+                      color: AleraTokens.foregroundMuted,
+                    ),
+                  )
+                : Icon(
+                    showingStop
+                        ? Icons.stop_circle_outlined
+                        : Icons.auto_awesome,
+                    key: ValueKey<String>(
+                      showingStop ? 'ai-commit-stop' : 'ai-commit-generate',
+                    ),
+                    size: 16,
+                    color: showingStop
+                        ? AleraTokens.error
+                        : AleraTokens.foregroundMuted,
+                  ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
 class _CommitMessageField extends StatelessWidget {
   const _CommitMessageField({
     required this.controller,
     required this.enabled,
+    required this.generating,
     required this.onChanged,
     required this.onSubmitted,
   });
 
   final TextEditingController controller;
   final bool enabled;
+  final bool generating;
   final ValueChanged<String> onChanged;
   final ValueChanged<String> onSubmitted;
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    return TextField(
+    final field = TextField(
       controller: controller,
-      enabled: enabled,
+      enabled: enabled && !generating,
       minLines: 3,
       maxLines: 6,
       onChanged: onChanged,
@@ -295,6 +405,60 @@ class _CommitMessageField extends StatelessWidget {
         enabledBorder: _messageBorder(AleraTokens.borderSubtle),
         focusedBorder: _messageBorder(AleraTokens.border),
       ),
+    );
+    if (!generating) {
+      return field;
+    }
+    return Stack(
+      children: <Widget>[
+        field,
+        Positioned.fill(
+          child: AbsorbPointer(
+            child: DecoratedBox(
+              decoration: BoxDecoration(
+                color: AleraTokens.barrierDark,
+                borderRadius: BorderRadius.circular(AleraTokens.radiusLg),
+                border: Border.all(color: AleraTokens.borderSubtle),
+              ),
+              child: Center(
+                child: DecoratedBox(
+                  decoration: BoxDecoration(
+                    color: AleraTokens.surfaceElevated,
+                    borderRadius: BorderRadius.circular(AleraTokens.radiusMd),
+                    border: Border.all(color: AleraTokens.border),
+                  ),
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: AleraTokens.space12,
+                      vertical: AleraTokens.space8,
+                    ),
+                    child: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: <Widget>[
+                        const SizedBox(
+                          width: 14,
+                          height: 14,
+                          child: CircularProgressIndicator(
+                            strokeWidth: 2,
+                            color: AleraTokens.foregroundMuted,
+                          ),
+                        ),
+                        const SizedBox(width: AleraTokens.space8),
+                        Text(
+                          'Generating with AI',
+                          style: theme.textTheme.labelMedium?.copyWith(
+                            color: AleraTokens.foregroundMuted,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ],
     );
   }
 

--- a/lib/src/shared/infra/process/io_process_runner.dart
+++ b/lib/src/shared/infra/process/io_process_runner.dart
@@ -44,6 +44,7 @@ class IoProcessRunner implements ProcessRunner {
 
     return StartedProcess(
       stdinWrite: (data) => process.stdin.add(data),
+      stdinClose: process.stdin.close,
       stdout: process.stdout,
       stderr: process.stderr,
       pid: process.pid,

--- a/lib/src/shared/infra/process/process_runner.dart
+++ b/lib/src/shared/infra/process/process_runner.dart
@@ -15,6 +15,7 @@ class ProcessRunOutput {
 class StartedProcess {
   StartedProcess({
     required this.stdinWrite,
+    this.stdinClose = _noopStdinClose,
     required this.stdout,
     required this.stderr,
     required this.pid,
@@ -23,12 +24,15 @@ class StartedProcess {
   });
 
   final void Function(List<int> data) stdinWrite;
+  final void Function() stdinClose;
   final Stream<List<int>> stdout;
   final Stream<List<int>> stderr;
   final int pid;
   final Future<int> exitCode;
   final bool Function([dynamic signal]) kill;
 }
+
+void _noopStdinClose() {}
 
 abstract interface class ProcessRunner {
   Future<ProcessRunOutput> run(

--- a/test/unit/ai_text_generation_service_test.dart
+++ b/test/unit/ai_text_generation_service_test.dart
@@ -1,0 +1,648 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:alera/src/features/ai_text_generation/application/ai_text_generation_prompt.dart';
+import 'package:alera/src/features/ai_text_generation/application/ai_text_generation_registry.dart';
+import 'package:alera/src/features/ai_text_generation/application/ai_text_generation_service.dart';
+import 'package:alera/src/features/ai_text_generation/application/ai_text_model_discovery_service.dart';
+import 'package:alera/src/features/ai_text_generation/domain/ai_text_generation_settings.dart';
+import 'package:alera/src/shared/infra/git/git_diff_models.dart';
+import 'package:alera/src/shared/infra/process/process_runner.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'fake_git_backend.dart';
+
+void main() {
+  group('AI text generation', () {
+    test('builds commit prompts with staged context and instructions', () {
+      final prompt = buildCommitMessagePrompt(
+        context: const AiTextCommitContext(
+          branch: 'feature/ai-text',
+          stagedSummary: '- lib/foo.dart (+2 -1)',
+          stagedPatch: '+new line',
+        ),
+        customInstructions: 'Use conventional commits.',
+      );
+
+      expect(prompt, contains('Branch: feature/ai-text'));
+      expect(prompt, contains('Staged files:'));
+      expect(prompt, contains('+new line'));
+      expect(prompt, contains('Use conventional commits.'));
+    });
+
+    test('cleans fenced commit output and caps subject length', () {
+      final message = cleanGeneratedCommitMessage('''
+Generating...
+```text
+${List<String>.filled(90, 'a').join()}.
+
+Body line.
+```
+''');
+
+      expect(message.split('\n').first.length, 72);
+      expect(message, contains('Body line.'));
+    });
+
+    test('parses agy model output as verbatim model ids', () {
+      final models = parseLineModels('''
+Gemini 3.5 Flash (Medium)
+Claude Sonnet 4.6 (Thinking)
+''');
+
+      expect(models.map((model) => model.id), <String>[
+        'Gemini 3.5 Flash (Medium)',
+        'Claude Sonnet 4.6 (Thinking)',
+      ]);
+    });
+
+    test('generates commit message with agy using stdin print mode', () async {
+      final git = FakeGitBackend()
+        ..gitRepositoryStateResult = const GitRepositoryState(
+          branch: 'feature/ai-text',
+        )
+        ..gitStatusResult = const GitStatusResult(
+          entries: <GitChangeEntry>[
+            GitChangeEntry(
+              path: 'lib/foo.dart',
+              area: GitChangeArea.staged,
+              status: GitChangeStatus.modified,
+              added: 2,
+              removed: 1,
+            ),
+          ],
+        )
+        ..gitDiffResult = const GitDiffResult(
+          files: <GitDiffFile>[
+            GitDiffFile(
+              path: 'lib/foo.dart',
+              area: GitChangeArea.staged,
+              status: GitChangeStatus.modified,
+              lines: <GitDiffLine>[GitDiffLine.addition('+new line')],
+            ),
+          ],
+        );
+      final runner = _FakeProcessRunner(stdout: 'feat: add ai text\n');
+      final service = CliAiTextGenerationService(
+        gitBackend: git,
+        processRunner: runner,
+      );
+
+      final result = await service.generate(
+        const AiTextGenerationRequest(
+          operation: AiTextGenerationOperation.commitMessage,
+          workspacePath: '/repo',
+          settings: AiTextGenerationSettings(agent: AiTextGenerationAgent.agy),
+        ),
+      );
+
+      expect(result.text, 'feat: add ai text');
+      expect(runner.executable, 'agy');
+      expect(runner.arguments, containsAll(<String>['--print', '--sandbox']));
+      expect(runner.arguments, contains('Gemini 3.5 Flash (Medium)'));
+      expect(runner.stdinText, contains('feature/ai-text'));
+      expect(runner.stdinClosed, isTrue);
+    });
+
+    test('generates commit message with amp without archived flag', () async {
+      final git = FakeGitBackend()
+        ..gitRepositoryStateResult = const GitRepositoryState(
+          branch: 'feature/ai-text',
+        )
+        ..gitStatusResult = const GitStatusResult(
+          entries: <GitChangeEntry>[
+            GitChangeEntry(
+              path: 'lib/foo.dart',
+              area: GitChangeArea.staged,
+              status: GitChangeStatus.modified,
+            ),
+          ],
+        );
+      final runner = _FakeProcessRunner(stdout: 'fix: update source control\n');
+      final service = CliAiTextGenerationService(
+        gitBackend: git,
+        processRunner: runner,
+      );
+
+      await service.generate(
+        const AiTextGenerationRequest(
+          operation: AiTextGenerationOperation.commitMessage,
+          workspacePath: '/repo',
+          settings: AiTextGenerationSettings(agent: AiTextGenerationAgent.amp),
+        ),
+      );
+
+      expect(runner.executable, 'amp');
+      expect(runner.arguments, contains('--execute'));
+      expect(runner.arguments, isNot(contains('--archive')));
+    });
+
+    test('generates commit message with opencode using stdin', () async {
+      final git = FakeGitBackend()
+        ..gitRepositoryStateResult = const GitRepositoryState(
+          branch: 'feature/ai-text',
+        )
+        ..gitStatusResult = const GitStatusResult(
+          entries: <GitChangeEntry>[
+            GitChangeEntry(
+              path: 'lib/large.dart',
+              area: GitChangeArea.staged,
+              status: GitChangeStatus.modified,
+            ),
+          ],
+        )
+        ..gitDiffResult = GitDiffResult(
+          files: <GitDiffFile>[
+            GitDiffFile(
+              path: 'lib/large.dart',
+              area: GitChangeArea.staged,
+              status: GitChangeStatus.modified,
+              lines: <GitDiffLine>[
+                GitDiffLine.addition(
+                  '+${List<String>.filled(30000, 'x').join()}',
+                ),
+              ],
+            ),
+          ],
+        );
+      final runner = _FakeProcessRunner(stdout: 'feat: handle large diff\n');
+      final service = CliAiTextGenerationService(
+        gitBackend: git,
+        processRunner: runner,
+      );
+
+      final result = await service.generate(
+        const AiTextGenerationRequest(
+          operation: AiTextGenerationOperation.commitMessage,
+          workspacePath: '/repo',
+          settings: AiTextGenerationSettings(
+            agent: AiTextGenerationAgent.opencode,
+          ),
+        ),
+      );
+
+      expect(result.text, 'feat: handle large diff');
+      expect(runner.executable, 'opencode');
+      expect(
+        runner.arguments,
+        containsAll(<String>['run', '--agent', 'build']),
+      );
+      expect(runner.arguments, isNot(contains(runner.stdinText)));
+      expect(runner.stdinText, contains('lib/large.dart'));
+      expect(runner.stdinClosed, isTrue);
+    });
+
+    test('discovers dynamic models through the agent CLI', () async {
+      final runner = _FakeProcessRunner(
+        stdout: '''
+Gemini 3.5 Flash (Medium)
+Claude Sonnet 4.6 (Thinking)
+''',
+      );
+      final service = CliAiTextModelDiscoveryService(processRunner: runner);
+
+      final result = await service.discover(AiTextGenerationAgent.agy);
+
+      expect(result.success, isTrue);
+      expect(result.defaultModelId, 'Gemini 3.5 Flash (Medium)');
+      expect(result.models.map((model) => model.id), <String>[
+        'Gemini 3.5 Flash (Medium)',
+        'Claude Sonnet 4.6 (Thinking)',
+      ]);
+      expect(runner.executable, 'agy');
+      expect(runner.arguments, <String>['models']);
+    });
+
+    test('discovers pi models from stderr on successful exit', () async {
+      final runner = _FakeProcessRunner(
+        stdout: '',
+        stderr: '''
+provider        model                   context  max-out  thinking  images
+github-copilot  gpt-5.4-mini            400K     128K     yes       yes
+openai-codex    gpt-5.5                 272K     128K     yes       yes
+''',
+      );
+      final service = CliAiTextModelDiscoveryService(processRunner: runner);
+
+      final result = await service.discover(AiTextGenerationAgent.pi);
+
+      expect(result.success, isTrue);
+      expect(result.models.map((model) => model.id), <String>[
+        'github-copilot/gpt-5.4-mini',
+        'openai-codex/gpt-5.5',
+      ]);
+    });
+
+    test('returns static models without spawning for static agents', () async {
+      final runner = _FakeProcessRunner(stdout: 'unused');
+      final service = CliAiTextModelDiscoveryService(processRunner: runner);
+
+      final result = await service.discover(AiTextGenerationAgent.amp);
+
+      expect(result.success, isTrue);
+      expect(result.defaultModelId, 'smart');
+      expect(runner.started, isFalse);
+    });
+
+    test(
+      'falls back to static models when discovery returns no models',
+      () async {
+        final runner = _FakeProcessRunner(stdout: 'unparseable output');
+        final service = CliAiTextModelDiscoveryService(processRunner: runner);
+
+        final result = await service.discover(AiTextGenerationAgent.cursor);
+
+        expect(result.success, isTrue);
+        expect(result.defaultModelId, 'auto');
+        expect(result.models.map((model) => model.id), <String>['auto']);
+      },
+    );
+
+    test('surfaces model discovery failures with safe detail', () async {
+      final runner = _FakeProcessRunner(
+        stdout: '',
+        stderr: 'auth expired',
+        exitCode: 1,
+      );
+      final service = CliAiTextModelDiscoveryService(processRunner: runner);
+
+      final result = await service.discover(AiTextGenerationAgent.agy);
+
+      expect(result.success, isFalse);
+      expect(result.error, 'Antigravity model discovery failed: auth expired');
+    });
+
+    test('reports no staged changes before starting an agent', () async {
+      final runner = _FakeProcessRunner(stdout: 'unused');
+      final service = CliAiTextGenerationService(
+        gitBackend: FakeGitBackend(),
+        processRunner: runner,
+      );
+
+      await expectLater(
+        service.generate(
+          const AiTextGenerationRequest(
+            operation: AiTextGenerationOperation.commitMessage,
+            workspacePath: '/repo',
+            settings: AiTextGenerationSettings(),
+          ),
+        ),
+        throwsA(
+          isA<AiTextGenerationException>().having(
+            (error) => error.message,
+            'message',
+            'No staged changes to summarize.',
+          ),
+        ),
+      );
+      expect(runner.started, isFalse);
+    });
+
+    test('surfaces agent stderr on failure', () async {
+      final git = FakeGitBackend()
+        ..gitRepositoryStateResult = const GitRepositoryState(
+          branch: 'feature/ai-text',
+        )
+        ..gitStatusResult = const GitStatusResult(
+          entries: <GitChangeEntry>[
+            GitChangeEntry(
+              path: 'lib/foo.dart',
+              area: GitChangeArea.staged,
+              status: GitChangeStatus.modified,
+            ),
+          ],
+        );
+      final runner = _FakeProcessRunner(
+        stdout: '',
+        stderr: 'model is not available',
+        exitCode: 1,
+      );
+      final service = CliAiTextGenerationService(
+        gitBackend: git,
+        processRunner: runner,
+      );
+
+      await expectLater(
+        service.generate(
+          const AiTextGenerationRequest(
+            operation: AiTextGenerationOperation.commitMessage,
+            workspacePath: '/repo',
+            settings: AiTextGenerationSettings(
+              agent: AiTextGenerationAgent.agy,
+            ),
+          ),
+        ),
+        throwsA(
+          isA<AiTextGenerationException>().having(
+            (error) => error.message,
+            'message',
+            'Antigravity failed: model is not available',
+          ),
+        ),
+      );
+    });
+
+    test(
+      'throws a cancellation exception when a running lane is canceled',
+      () async {
+        final git = FakeGitBackend()
+          ..gitRepositoryStateResult = const GitRepositoryState(
+            branch: 'feature/ai-text',
+          )
+          ..gitStatusResult = const GitStatusResult(
+            entries: <GitChangeEntry>[
+              GitChangeEntry(
+                path: 'lib/foo.dart',
+                area: GitChangeArea.staged,
+                status: GitChangeStatus.modified,
+              ),
+            ],
+          );
+        final exitCode = Completer<int>();
+        final runner = _FakeProcessRunner(
+          stdout: '',
+          exitCodeCompleter: exitCode,
+        );
+        final service = CliAiTextGenerationService(
+          gitBackend: git,
+          processRunner: runner,
+        );
+
+        final generation = service.generate(
+          const AiTextGenerationRequest(
+            operation: AiTextGenerationOperation.commitMessage,
+            workspacePath: '/repo',
+            settings: AiTextGenerationSettings(
+              agent: AiTextGenerationAgent.agy,
+            ),
+          ),
+        );
+        await untilCalled(() => runner.started);
+
+        service.cancel('/repo', AiTextGenerationOperation.commitMessage);
+
+        await expectLater(
+          generation,
+          throwsA(isA<AiTextGenerationCanceledException>()),
+        );
+        expect(runner.killed, isTrue);
+      },
+    );
+
+    test('keeps a canceled running lane reserved until process exit', () async {
+      final git = FakeGitBackend()
+        ..gitRepositoryStateResult = const GitRepositoryState(
+          branch: 'feature/ai-text',
+        )
+        ..gitStatusResult = const GitStatusResult(
+          entries: <GitChangeEntry>[
+            GitChangeEntry(
+              path: 'lib/foo.dart',
+              area: GitChangeArea.staged,
+              status: GitChangeStatus.modified,
+            ),
+          ],
+        );
+      final exitCode = Completer<int>();
+      final runner = _FakeProcessRunner(
+        stdout: '',
+        exitCodeCompleter: exitCode,
+        completeExitOnKill: false,
+      );
+      final service = CliAiTextGenerationService(
+        gitBackend: git,
+        processRunner: runner,
+      );
+
+      final generation = service.generate(
+        const AiTextGenerationRequest(
+          operation: AiTextGenerationOperation.commitMessage,
+          workspacePath: '/repo',
+          settings: AiTextGenerationSettings(agent: AiTextGenerationAgent.agy),
+        ),
+      );
+      await untilCalled(() => runner.started);
+
+      service.cancel('/repo', AiTextGenerationOperation.commitMessage);
+
+      await expectLater(
+        service.generate(
+          const AiTextGenerationRequest(
+            operation: AiTextGenerationOperation.commitMessage,
+            workspacePath: '/repo',
+            settings: AiTextGenerationSettings(
+              agent: AiTextGenerationAgent.agy,
+            ),
+          ),
+        ),
+        throwsA(
+          isA<AiTextGenerationException>().having(
+            (error) => error.message,
+            'message',
+            'Generation is already running.',
+          ),
+        ),
+      );
+      expect(runner.startCount, 1);
+
+      exitCode.complete(143);
+      await expectLater(
+        generation,
+        throwsA(isA<AiTextGenerationCanceledException>()),
+      );
+    });
+
+    test('honors cancellation before the agent process starts', () async {
+      final git = _DelayedDiffGitBackend()
+        ..gitRepositoryStateResult = const GitRepositoryState(
+          branch: 'feature/ai-text',
+        )
+        ..gitStatusResult = const GitStatusResult(
+          entries: <GitChangeEntry>[
+            GitChangeEntry(
+              path: 'lib/foo.dart',
+              area: GitChangeArea.staged,
+              status: GitChangeStatus.modified,
+            ),
+          ],
+        );
+      final runner = _FakeProcessRunner(stdout: 'unused');
+      final service = CliAiTextGenerationService(
+        gitBackend: git,
+        processRunner: runner,
+      );
+
+      final generation = service.generate(
+        const AiTextGenerationRequest(
+          operation: AiTextGenerationOperation.commitMessage,
+          workspacePath: '/repo',
+          settings: AiTextGenerationSettings(agent: AiTextGenerationAgent.agy),
+        ),
+      );
+      await untilCalled(() => git.diffStarted);
+
+      service.cancel('/repo', AiTextGenerationOperation.commitMessage);
+      git.completeDiff();
+
+      await expectLater(
+        generation,
+        throwsA(isA<AiTextGenerationCanceledException>()),
+      );
+      expect(runner.started, isFalse);
+    });
+
+    test('rejects oversized prompts for argv agents before starting', () async {
+      final git = FakeGitBackend()
+        ..gitRepositoryStateResult = const GitRepositoryState(
+          branch: 'feature/ai-text',
+        )
+        ..gitStatusResult = const GitStatusResult(
+          entries: <GitChangeEntry>[
+            GitChangeEntry(
+              path: 'lib/foo.dart',
+              area: GitChangeArea.staged,
+              status: GitChangeStatus.modified,
+            ),
+          ],
+        )
+        ..gitDiffResult = GitDiffResult(
+          files: <GitDiffFile>[
+            GitDiffFile(
+              path: 'lib/foo.dart',
+              area: GitChangeArea.staged,
+              status: GitChangeStatus.modified,
+              lines: <GitDiffLine>[
+                GitDiffLine.addition(
+                  '+${List<String>.filled(30000, 'x').join()}',
+                ),
+              ],
+            ),
+          ],
+        );
+      final runner = _FakeProcessRunner(stdout: 'unused');
+      final service = CliAiTextGenerationService(
+        gitBackend: git,
+        processRunner: runner,
+      );
+
+      await expectLater(
+        service.generate(
+          const AiTextGenerationRequest(
+            operation: AiTextGenerationOperation.commitMessage,
+            workspacePath: '/repo',
+            settings: AiTextGenerationSettings(
+              agent: AiTextGenerationAgent.copilot,
+            ),
+          ),
+        ),
+        throwsA(
+          isA<AiTextGenerationException>().having(
+            (error) => error.message,
+            'message',
+            contains('cannot receive large prompts safely'),
+          ),
+        ),
+      );
+      expect(runner.started, isFalse);
+    });
+  });
+}
+
+class _FakeProcessRunner implements ProcessRunner {
+  _FakeProcessRunner({
+    required this.stdout,
+    this.stderr = '',
+    this.exitCode = 0,
+    this.exitCodeCompleter,
+    this.completeExitOnKill = true,
+  });
+
+  final String stdout;
+  final String stderr;
+  final int exitCode;
+  final Completer<int>? exitCodeCompleter;
+  final bool completeExitOnKill;
+  bool started = false;
+  int startCount = 0;
+  bool stdinClosed = false;
+  bool killed = false;
+  String? executable;
+  List<String> arguments = const <String>[];
+  final StringBuffer _stdin = StringBuffer();
+
+  String get stdinText => _stdin.toString();
+
+  @override
+  Future<ProcessRunOutput> run(
+    String executable,
+    List<String> arguments, {
+    String? workingDirectory,
+    Map<String, String>? environment,
+  }) async {
+    return ProcessRunOutput(exitCode: exitCode, stdout: stdout, stderr: stderr);
+  }
+
+  @override
+  Future<StartedProcess> start(
+    String executable,
+    List<String> arguments, {
+    String? workingDirectory,
+    Map<String, String>? environment,
+  }) async {
+    started = true;
+    startCount += 1;
+    this.executable = executable;
+    this.arguments = List<String>.from(arguments);
+    return StartedProcess(
+      stdinWrite: (data) => _stdin.write(utf8.decode(data)),
+      stdinClose: () => stdinClosed = true,
+      stdout: Stream<List<int>>.value(utf8.encode(stdout)),
+      stderr: Stream<List<int>>.value(utf8.encode(stderr)),
+      pid: 1,
+      exitCode: exitCodeCompleter?.future ?? Future<int>.value(exitCode),
+      kill: ([dynamic signal]) {
+        killed = true;
+        if (completeExitOnKill) {
+          if (exitCodeCompleter case final completer?) {
+            if (!completer.isCompleted) {
+              completer.complete(143);
+            }
+          }
+        }
+        return true;
+      },
+    );
+  }
+}
+
+class _DelayedDiffGitBackend extends FakeGitBackend {
+  final Completer<void> _diffGate = Completer<void>();
+  bool diffStarted = false;
+
+  @override
+  Future<GitDiffResult> diff({
+    required String path,
+    required String filePath,
+    required GitChangeArea area,
+  }) async {
+    diffStarted = true;
+    await _diffGate.future;
+    return super.diff(path: path, filePath: filePath, area: area);
+  }
+
+  void completeDiff() {
+    if (!_diffGate.isCompleted) {
+      _diffGate.complete();
+    }
+  }
+}
+
+Future<void> untilCalled(bool Function() predicate) async {
+  final deadline = DateTime.now().add(const Duration(seconds: 1));
+  while (!predicate()) {
+    if (DateTime.now().isAfter(deadline)) {
+      fail('Timed out waiting for call');
+    }
+    await Future<void>.delayed(const Duration(milliseconds: 5));
+  }
+}

--- a/test/unit/alera_settings_test.dart
+++ b/test/unit/alera_settings_test.dart
@@ -1,4 +1,5 @@
 import 'package:alera/src/features/keyboard/domain/keyboard_action.dart';
+import 'package:alera/src/features/ai_text_generation/domain/ai_text_generation_settings.dart';
 import 'package:alera/src/features/keyboard/domain/keyboard_shortcut_settings.dart';
 import 'package:alera/src/features/settings/domain/alera_settings.dart';
 import 'package:alera/src/features/settings/domain/editor_syntax_theme_catalog.dart';
@@ -54,6 +55,24 @@ void main() {
 
       expect(editor.tabSize, 4);
       expect(editor.themeName, EditorSyntaxThemeNames.alera);
+    });
+
+    test('ai text generation defaults cover Alera agents conservatively', () {
+      const ai = AiTextGenerationSettings.defaults;
+
+      expect(ai.enabled, isTrue);
+      expect(ai.agent, AiTextGenerationAgent.codex);
+      expect(ai.timeoutSeconds, 120);
+      expect(ai.customCommand, isEmpty);
+      expect(ai.modelFor(AiTextGenerationAgent.codex), isNull);
+      expect(
+        AiTextGenerationAgent.values
+            .where((agent) => agent != AiTextGenerationAgent.custom)
+            .map((agent) => agent.agentType)
+            .whereType<Object>()
+            .length,
+        8,
+      );
     });
 
     test('small settings fragments round-trip through json', () {
@@ -121,6 +140,16 @@ void main() {
           tabSize: 2,
           themeName: EditorSyntaxThemeNames.nord,
         ),
+        aiTextGeneration: AiTextGenerationSettings(
+          agent: AiTextGenerationAgent.agy,
+          selectedModelByAgent: <AiTextGenerationAgent, String>{
+            AiTextGenerationAgent.agy: 'Gemini 3.5 Flash (Medium)',
+          },
+          instructionsByOperation: <AiTextGenerationOperation, String>{
+            AiTextGenerationOperation.commitMessage:
+                'Use conventional commits.',
+          },
+        ),
         terminal: TerminalSettings(
           fontFamily: 'SF Mono',
           fontSize: 15,
@@ -170,6 +199,17 @@ void main() {
       expect(restored.general.keepComputerAwakeWhileAgentsWork, isTrue);
       expect(restored.editor.tabSize, 2);
       expect(restored.editor.themeName, EditorSyntaxThemeNames.nord);
+      expect(restored.aiTextGeneration.agent, AiTextGenerationAgent.agy);
+      expect(
+        restored.aiTextGeneration.modelFor(AiTextGenerationAgent.agy),
+        'Gemini 3.5 Flash (Medium)',
+      );
+      expect(
+        restored.aiTextGeneration.instructionsFor(
+          AiTextGenerationOperation.commitMessage,
+        ),
+        'Use conventional commits.',
+      );
       expect(restored.terminal.fontFamily, 'SF Mono');
       expect(restored.terminal.fontSize, 15);
       expect(restored.terminal.fontWeight, 500);

--- a/test/widget/settings_dialog_core_test_cases.dart
+++ b/test/widget/settings_dialog_core_test_cases.dart
@@ -7,6 +7,7 @@ void _registerSettingsDialogCoreTests() {
     AleraSettings initialSettings = AleraSettings.defaults,
     Size surfaceSize = const Size(1200, 900),
     SystemFontService? fontService,
+    AiTextModelDiscoveryService? modelDiscoveryService,
   }) async {
     await tester.binding.setSurfaceSize(surfaceSize);
     addTearDown(() => tester.binding.setSurfaceSize(null));
@@ -23,6 +24,9 @@ void _registerSettingsDialogCoreTests() {
               ]),
         ),
         aleraUpdateServiceProvider.overrideWithValue(_FakeUpdateService()),
+        aiTextModelDiscoveryServiceProvider.overrideWithValue(
+          modelDiscoveryService ?? const _FakeAiTextModelDiscoveryService(),
+        ),
         if (starController != null)
           gitHubStarControllerProvider.overrideWith(() => starController),
       ],
@@ -54,6 +58,11 @@ void _registerSettingsDialogCoreTests() {
 
   Future<void> selectEditorSectionLocal(WidgetTester tester) async {
     await tester.tap(find.text('Editor').first);
+    await tester.pump();
+  }
+
+  Future<void> selectAiTextSectionLocal(WidgetTester tester) async {
+    await tester.tap(find.text('AI text').first);
     await tester.pump();
   }
 
@@ -129,6 +138,144 @@ void _registerSettingsDialogCoreTests() {
     expect(
       container.read(settingsControllerProvider).editor.themeName,
       EditorSettings.defaults.themeName,
+    );
+  });
+
+  testWidgets('edits and resets AI text settings', (tester) async {
+    final container = await pumpSettingsDialogLocal(tester);
+    await selectAiTextSectionLocal(tester);
+
+    expect(find.text('AI text'), findsWidgets);
+    expect(find.text('Agent'), findsOneWidget);
+    expect(find.text('Model'), findsOneWidget);
+    expect(
+      tester
+          .widgetList<MouseRegion>(
+            find.descendant(
+              of: find.byKey(const ValueKey<String>('ai-text-agent-codex')),
+              matching: find.byType(MouseRegion),
+            ),
+          )
+          .first
+          .cursor,
+      SystemMouseCursors.click,
+    );
+    expect(
+      tester
+          .widgetList<MouseRegion>(
+            find.descendant(
+              of: find.byKey(
+                const ValueKey<String>('ai-text-model-codex-gpt-5.5'),
+              ),
+              matching: find.byType(MouseRegion),
+            ),
+          )
+          .first
+          .cursor,
+      SystemMouseCursors.click,
+    );
+    expect(
+      tester
+          .widgetList<MouseRegion>(
+            find.descendant(
+              of: find.byKey(const ValueKey<String>('ai-text-thinking-low')),
+              matching: find.byType(MouseRegion),
+            ),
+          )
+          .first
+          .cursor,
+      SystemMouseCursors.click,
+    );
+
+    await tester.tap(find.byKey(const ValueKey<String>('ai-text-agent-codex')));
+    await tester.pumpAndSettle();
+    expect(
+      find.byType(AleraDropdownEntry<AiTextGenerationAgent>),
+      findsWidgets,
+    );
+    expect(
+      tester
+          .widgetList<AleraDropdownEntry<AiTextGenerationAgent>>(
+            find.byType(AleraDropdownEntry<AiTextGenerationAgent>),
+          )
+          .first
+          .enabled,
+      isTrue,
+    );
+    await tester.tap(find.text('Antigravity').last);
+    await tester.pump(const Duration(milliseconds: 50));
+
+    expect(
+      container.read(settingsControllerProvider).aiTextGeneration.agent,
+      AiTextGenerationAgent.agy,
+    );
+    await tester.pump(const Duration(milliseconds: 50));
+    expect(
+      container
+          .read(settingsControllerProvider)
+          .aiTextGeneration
+          .discoveredModelsFor(AiTextGenerationAgent.agy)
+          .map((model) => model.id),
+      contains('gpt-5.5'),
+    );
+
+    await tester.tap(find.text('Reset ai text'));
+    await tester.pump(const Duration(milliseconds: 50));
+
+    expect(
+      container.read(settingsControllerProvider).aiTextGeneration.agent,
+      AiTextGenerationSettings.defaults.agent,
+    );
+    expect(find.text('Codex').last, findsOneWidget);
+
+    await tester.ensureVisible(find.text('Commit messages'));
+    expect(find.text('Pull request details'), findsNothing);
+    expect(find.text('Branch names'), findsNothing);
+    await tester.pump();
+    await tester.enterText(
+      find.widgetWithText(TextField, 'Optional instructions').first,
+      'Use conventional commits.',
+    );
+    await selectTerminalSectionLocal(tester);
+    await tester.pump(const Duration(milliseconds: 50));
+
+    expect(
+      container
+          .read(settingsControllerProvider)
+          .aiTextGeneration
+          .instructionsFor(AiTextGenerationOperation.commitMessage),
+      'Use conventional commits.',
+    );
+
+    await container
+        .read(settingsControllerProvider.notifier)
+        .resetAiTextGenerationSettings();
+    await tester.pump(const Duration(milliseconds: 50));
+
+    expect(
+      container.read(settingsControllerProvider).aiTextGeneration.agent,
+      AiTextGenerationSettings.defaults.agent,
+    );
+
+    await selectAiTextSectionLocal(tester);
+    await tester.pump();
+    await tester.enterText(
+      find.widgetWithText(TextField, 'Optional instructions').first,
+      'Draft that should not survive reset.',
+    );
+    await tester.ensureVisible(find.text('Reset ai text', skipOffstage: false));
+    await tester.pump();
+    await tester.tap(find.text('Reset ai text'));
+    await tester.pump(const Duration(milliseconds: 50));
+    await selectTerminalSectionLocal(tester);
+    await tester.pump(const Duration(milliseconds: 50));
+
+    expect(
+      container
+          .read(settingsControllerProvider)
+          .aiTextGeneration
+          .instructionsFor(AiTextGenerationOperation.commitMessage),
+      isEmpty,
     );
   });
 

--- a/test/widget/settings_dialog_test.dart
+++ b/test/widget/settings_dialog_test.dart
@@ -2,6 +2,10 @@ import 'dart:async';
 
 import 'package:alera/src/app/providers.dart';
 import 'package:alera/src/app/theme/alera_dark_theme.dart';
+import 'package:alera/src/features/ai_text_generation/application/ai_text_generation_providers.dart';
+import 'package:alera/src/features/ai_text_generation/application/ai_text_generation_registry.dart';
+import 'package:alera/src/features/ai_text_generation/application/ai_text_model_discovery_service.dart';
+import 'package:alera/src/features/ai_text_generation/domain/ai_text_generation_settings.dart';
 import 'package:alera/src/features/settings/application/settings_repository.dart';
 import 'package:alera/src/features/settings/domain/alera_settings.dart';
 import 'package:alera/src/features/settings/domain/editor_syntax_theme_catalog.dart';
@@ -12,6 +16,7 @@ import 'package:alera/src/features/updater/application/update_service.dart';
 import 'package:alera/src/features/updater/domain/alera_update.dart';
 import 'package:alera/src/design_system/feedback/alera_color_swatch.dart';
 import 'package:alera/src/design_system/forms/alera_text_field.dart';
+import 'package:alera/src/design_system/menus/alera_dropdown_entry.dart';
 import 'package:file_selector_platform_interface/file_selector_platform_interface.dart';
 import 'package:flutter_colorpicker/flutter_colorpicker.dart';
 import 'package:flutter/gestures.dart';
@@ -31,6 +36,7 @@ Future<ProviderContainer> _pumpSettingsDialog(
   AleraSettings initialSettings = AleraSettings.defaults,
   Size surfaceSize = const Size(1200, 900),
   SystemFontService? fontService,
+  AiTextModelDiscoveryService? modelDiscoveryService,
 }) async {
   await tester.binding.setSurfaceSize(surfaceSize);
   addTearDown(() => tester.binding.setSurfaceSize(null));
@@ -47,6 +53,9 @@ Future<ProviderContainer> _pumpSettingsDialog(
             ]),
       ),
       aleraUpdateServiceProvider.overrideWithValue(_FakeUpdateService()),
+      aiTextModelDiscoveryServiceProvider.overrideWithValue(
+        modelDiscoveryService ?? const _FakeAiTextModelDiscoveryService(),
+      ),
       if (starController != null)
         gitHubStarControllerProvider.overrideWith(() => starController),
     ],

--- a/test/widget/settings_dialog_test_harness.dart
+++ b/test/widget/settings_dialog_test_harness.dart
@@ -56,46 +56,32 @@ class _FakeSystemFontService implements SystemFontService {
 }
 
 class _FakeAiTextModelDiscoveryService implements AiTextModelDiscoveryService {
-  const _FakeAiTextModelDiscoveryService({
-    this.models = const <AiTextModel>[
-      AiTextModel(
-        id: 'gpt-5.5',
-        label: 'GPT-5.5',
-        thinkingLevels: openAiThinkingLevels,
-        defaultThinkingLevel: 'low',
-      ),
-      AiTextModel(
-        id: 'gpt-5.4-mini',
-        label: 'GPT-5.4 Mini',
-        thinkingLevels: openAiThinkingLevels,
-        defaultThinkingLevel: 'low',
-      ),
-    ],
-    this.error,
-  });
+  const _FakeAiTextModelDiscoveryService();
 
-  final List<AiTextModel> models;
-  final String? error;
+  static const List<AiTextModel> _models = <AiTextModel>[
+    AiTextModel(
+      id: 'gpt-5.5',
+      label: 'GPT-5.5',
+      thinkingLevels: openAiThinkingLevels,
+      defaultThinkingLevel: 'low',
+    ),
+    AiTextModel(
+      id: 'gpt-5.4-mini',
+      label: 'GPT-5.4 Mini',
+      thinkingLevels: openAiThinkingLevels,
+      defaultThinkingLevel: 'low',
+    ),
+  ];
 
   @override
   Future<AiTextModelDiscoveryResult> discover(
     AiTextGenerationAgent agent,
   ) async {
-    if (error case final error?) {
-      final spec = aiTextAgentSpecs[agent];
-      return AiTextModelDiscoveryResult(
-        success: false,
-        agent: agent,
-        models: spec?.models ?? const <AiTextModel>[],
-        defaultModelId: spec?.defaultModelId ?? 'custom',
-        error: error,
-      );
-    }
     return AiTextModelDiscoveryResult(
       success: true,
       agent: agent,
-      models: models,
-      defaultModelId: models.first.id,
+      models: _models,
+      defaultModelId: _models.first.id,
     );
   }
 }

--- a/test/widget/settings_dialog_test_harness.dart
+++ b/test/widget/settings_dialog_test_harness.dart
@@ -55,6 +55,51 @@ class _FakeSystemFontService implements SystemFontService {
   Future<List<String>> listFontFamilies() async => fonts;
 }
 
+class _FakeAiTextModelDiscoveryService implements AiTextModelDiscoveryService {
+  const _FakeAiTextModelDiscoveryService({
+    this.models = const <AiTextModel>[
+      AiTextModel(
+        id: 'gpt-5.5',
+        label: 'GPT-5.5',
+        thinkingLevels: openAiThinkingLevels,
+        defaultThinkingLevel: 'low',
+      ),
+      AiTextModel(
+        id: 'gpt-5.4-mini',
+        label: 'GPT-5.4 Mini',
+        thinkingLevels: openAiThinkingLevels,
+        defaultThinkingLevel: 'low',
+      ),
+    ],
+    this.error,
+  });
+
+  final List<AiTextModel> models;
+  final String? error;
+
+  @override
+  Future<AiTextModelDiscoveryResult> discover(
+    AiTextGenerationAgent agent,
+  ) async {
+    if (error case final error?) {
+      final spec = aiTextAgentSpecs[agent];
+      return AiTextModelDiscoveryResult(
+        success: false,
+        agent: agent,
+        models: spec?.models ?? const <AiTextModel>[],
+        defaultModelId: spec?.defaultModelId ?? 'custom',
+        error: error,
+      );
+    }
+    return AiTextModelDiscoveryResult(
+      success: true,
+      agent: agent,
+      models: models,
+      defaultModelId: models.first.id,
+    );
+  }
+}
+
 class _DelayedSystemFontService implements SystemFontService {
   _DelayedSystemFontService(this.futureFonts);
 

--- a/test/widget/workspace_git_diff_panel_test.dart
+++ b/test/widget/workspace_git_diff_panel_test.dart
@@ -1,4 +1,11 @@
+import 'dart:async';
+
 import 'package:alera/src/app/theme/alera_tokens.dart';
+import 'package:alera/src/features/ai_text_generation/application/ai_text_generation_providers.dart';
+import 'package:alera/src/features/ai_text_generation/application/ai_text_generation_service.dart';
+import 'package:alera/src/features/ai_text_generation/domain/ai_text_generation_settings.dart';
+import 'package:alera/src/features/settings/application/settings_controller.dart';
+import 'package:alera/src/features/settings/domain/alera_settings.dart';
 import 'package:alera/src/features/workbench/application/workspace_source_control_controller.dart';
 import 'package:alera/src/features/workbench/domain/workbench_view_prefs.dart';
 import 'package:alera/src/features/workbench/domain/workspace.dart';
@@ -6,6 +13,7 @@ import 'package:alera/src/features/workbench/presentation/workspace_git_diff_pan
 import 'package:alera/src/shared/infra/git/git_diff_models.dart';
 import 'package:alera/src/shared/infra/git/git_exception.dart';
 import 'package:alera/src/shared/infra/git/git_providers.dart';
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -29,7 +37,12 @@ void main() {
 
     await tester.pumpWidget(
       ProviderScope(
-        overrides: [gitBackendProvider.overrideWithValue(backend)],
+        overrides: [
+          gitBackendProvider.overrideWithValue(backend),
+          settingsControllerProvider.overrideWith(
+            () => _PanelSettingsController(AleraSettings.defaults),
+          ),
+        ],
         child: MaterialApp(
           home: Scaffold(
             body: SizedBox(
@@ -73,7 +86,12 @@ void main() {
 
     await tester.pumpWidget(
       ProviderScope(
-        overrides: [gitBackendProvider.overrideWithValue(backend)],
+        overrides: [
+          gitBackendProvider.overrideWithValue(backend),
+          settingsControllerProvider.overrideWith(
+            () => _PanelSettingsController(AleraSettings.defaults),
+          ),
+        ],
         child: MaterialApp(
           home: Scaffold(
             body: SizedBox(
@@ -563,6 +581,137 @@ void main() {
     expect(editableText.controller.text, isEmpty);
   });
 
+  testWidgets('generated commit message is ignored after workspace changes', (
+    tester,
+  ) async {
+    final backend = FakeGitBackend()
+      ..gitStatusResult = const GitStatusResult(
+        entries: <GitChangeEntry>[
+          GitChangeEntry(
+            path: 'lib/staged.dart',
+            area: GitChangeArea.staged,
+            status: GitChangeStatus.modified,
+          ),
+        ],
+      );
+    final service = _FakeAiTextGenerationService();
+
+    await _pumpPanel(
+      tester,
+      backend: backend,
+      service: service,
+      workspace: _workspace(id: 'workspace-a', path: '/tmp/project-a'),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byTooltip('Generate commit message with AI'));
+    await tester.pump();
+    expect(service.requests.single.workspacePath, '/tmp/project-a');
+
+    await _pumpPanel(
+      tester,
+      backend: backend,
+      service: service,
+      workspace: _workspace(id: 'workspace-b', path: '/tmp/project-b'),
+    );
+    await tester.pump();
+    await tester.tap(find.byTooltip('Generate commit message with AI'));
+    await tester.pump();
+    expect(service.requests.last.workspacePath, '/tmp/project-b');
+
+    service.completeAt(0, 'feat: stale message');
+    await tester.pump();
+
+    expect(find.text('Generating with AI'), findsOneWidget);
+    expect(find.byTooltip('Stop generating commit message'), findsOneWidget);
+    expect(find.byIcon(Icons.stop_circle_outlined), findsNothing);
+    expect(tester.widget<TextField>(_messageField()).enabled, isFalse);
+    expect(_messageEditable(tester).controller.text, isEmpty);
+
+    final gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    await gesture.addPointer();
+    await gesture.moveTo(
+      tester.getCenter(find.byTooltip('Stop generating commit message')),
+    );
+    await tester.pump(const Duration(milliseconds: 150));
+
+    expect(find.byIcon(Icons.stop_circle_outlined), findsOneWidget);
+    await gesture.removePointer();
+
+    service.completeAt(1, 'feat: workspace b message');
+    await tester.pumpAndSettle();
+
+    expect(
+      _messageEditable(tester).controller.text,
+      'feat: workspace b message',
+    );
+    expect(service.canceled, <String>[
+      '/tmp/project-a::${AiTextGenerationOperation.commitMessage.key}',
+    ]);
+  });
+
+  testWidgets('running commit message generation is canceled on dispose', (
+    tester,
+  ) async {
+    final backend = FakeGitBackend()
+      ..gitStatusResult = const GitStatusResult(
+        entries: <GitChangeEntry>[
+          GitChangeEntry(
+            path: 'lib/staged.dart',
+            area: GitChangeArea.staged,
+            status: GitChangeStatus.modified,
+          ),
+        ],
+      );
+    final service = _FakeAiTextGenerationService();
+
+    await _pumpPanel(
+      tester,
+      backend: backend,
+      service: service,
+      workspace: _workspace(path: '/tmp/project-a'),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byTooltip('Generate commit message with AI'));
+    await tester.pump();
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pump();
+
+    expect(service.canceled, <String>[
+      '/tmp/project-a::${AiTextGenerationOperation.commitMessage.key}',
+    ]);
+  });
+
+  testWidgets('AI commit message action is hidden when AI text is disabled', (
+    tester,
+  ) async {
+    final backend = FakeGitBackend()
+      ..gitStatusResult = const GitStatusResult(
+        entries: <GitChangeEntry>[
+          GitChangeEntry(
+            path: 'lib/staged.dart',
+            area: GitChangeArea.staged,
+            status: GitChangeStatus.modified,
+          ),
+        ],
+      );
+
+    await _pumpPanel(
+      tester,
+      backend: backend,
+      settings: AleraSettings.defaults.copyWith(
+        aiTextGeneration: AiTextGenerationSettings.defaults.copyWith(
+          enabled: false,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byTooltip('Generate commit message with AI'), findsNothing);
+  });
+
   test('sync without upstream fails before pull or push', () async {
     final backend = FakeGitBackend()
       ..gitRepositoryStateResult = const GitRepositoryState(branch: 'feature');
@@ -731,6 +880,7 @@ void main() {
     await tester.pumpAndSettle();
 
     final messageField = tester.widget<TextField>(_messageField());
+    expect(messageField.decoration?.suffixIcon, isNull);
     expect(
       messageField.decoration?.contentPadding,
       const EdgeInsets.fromLTRB(
@@ -831,10 +981,19 @@ Future<void> _pumpPanel(
   required FakeGitBackend backend,
   Workspace? workspace,
   GitDiffViewMode viewMode = GitDiffViewMode.flat,
+  AiTextGenerationService? service,
+  AleraSettings settings = AleraSettings.defaults,
 }) {
   return tester.pumpWidget(
     ProviderScope(
-      overrides: [gitBackendProvider.overrideWithValue(backend)],
+      overrides: [
+        gitBackendProvider.overrideWithValue(backend),
+        settingsControllerProvider.overrideWith(
+          () => _PanelSettingsController(settings),
+        ),
+        if (service != null)
+          aiTextGenerationServiceProvider.overrideWithValue(service),
+      ],
       child: MaterialApp(
         home: Scaffold(
           body: SizedBox(
@@ -851,6 +1010,41 @@ Future<void> _pumpPanel(
       ),
     ),
   );
+}
+
+class _PanelSettingsController extends SettingsController {
+  _PanelSettingsController(this._settings);
+
+  final AleraSettings _settings;
+
+  @override
+  AleraSettings build() => _settings;
+}
+
+class _FakeAiTextGenerationService implements AiTextGenerationService {
+  final List<AiTextGenerationRequest> requests = <AiTextGenerationRequest>[];
+  final List<String> canceled = <String>[];
+  final List<Completer<AiTextGenerationResult>> _results =
+      <Completer<AiTextGenerationResult>>[];
+
+  @override
+  Future<AiTextGenerationResult> generate(AiTextGenerationRequest request) {
+    requests.add(request);
+    final result = Completer<AiTextGenerationResult>();
+    _results.add(result);
+    return result.future;
+  }
+
+  @override
+  void cancel(String workspacePath, AiTextGenerationOperation operation) {
+    canceled.add('$workspacePath::${operation.key}');
+  }
+
+  void completeAt(int index, String text) {
+    _results[index].complete(
+      AiTextGenerationResult(text: text, agentLabel: 'Codex'),
+    );
+  }
 }
 
 Finder _messageField() {


### PR DESCRIPTION
## Summary

- add foundational AI text generation support for source-control commit messages
- support local agent CLIs with model/thinking settings and model discovery
- wire the source-control AI action with generation, cancelation, loading state, and blocked commit-message editing while generation runs

## Validation

- `flutter test test/unit/ai_text_generation_service_test.dart test/widget/settings_dialog_test.dart test/widget/workspace_git_diff_panel_test.dart`
- `dart analyze lib/src/features/ai_text_generation lib/src/features/settings lib/src/features/workbench/presentation/workspace_git_diff_panel.dart test/unit/ai_text_generation_service_test.dart test/widget/settings_dialog_test.dart test/widget/workspace_git_diff_panel_test.dart`
