### PR TITLE
ci: make platform code-signing optional in release-cut

### DIFF
--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -248,7 +248,20 @@ jobs:
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
         run: |
           set -euo pipefail
-          bash tool/release/sign_macos.sh "$BUNDLE_DIR" "$BUNDLE_DIR/Alera.app"
+          # macOS Developer ID signing/notarization is optional: when the Apple
+          # credentials are absent the bundle ships unsigned (users must allow it
+          # through Gatekeeper). The Ed25519 update manifest is still signed, so
+          # update integrity is unaffected. See docs/release-trust.md.
+          if [[ -n "${APPLE_DEVELOPER_ID_APPLICATION:-}" \
+            && -n "${APPLE_DEVELOPER_ID_TEAM_ID:-}" \
+            && -n "${APPLE_CERTIFICATE_P12_BASE64:-}" \
+            && -n "${APPLE_CERTIFICATE_PASSWORD:-}" \
+            && -n "${APPLE_ID:-}" \
+            && -n "${APPLE_APP_SPECIFIC_PASSWORD:-}" ]]; then
+            bash tool/release/sign_macos.sh "$BUNDLE_DIR" "$BUNDLE_DIR/Alera.app"
+          else
+            echo "::warning::Apple Developer ID credentials are not configured; packaging an unsigned macOS release."
+          fi
           tar -czf "release-assets/alera-${RELEASE_VERSION}-macos.tar.gz" -C "$BUNDLE_DIR" .
 
       - name: Sign and package Windows release
@@ -260,7 +273,15 @@ jobs:
           WINDOWS_CERTIFICATE_PASSWORD: ${{ secrets.WINDOWS_CERTIFICATE_PASSWORD }}
           WINDOWS_TIMESTAMP_URL: ${{ vars.WINDOWS_TIMESTAMP_URL }}
         run: |
-          pwsh -NoProfile -File tool/release/sign_windows.ps1 -BundleDir "$env:BUNDLE_DIR"
+          # Authenticode signing is optional: when the certificate is absent the
+          # bundle ships unsigned (SmartScreen shows an unknown publisher). The
+          # Ed25519 update manifest is still signed. See docs/release-trust.md.
+          if (-not [string]::IsNullOrWhiteSpace($env:WINDOWS_CERTIFICATE_PFX_BASE64) -and `
+              -not [string]::IsNullOrWhiteSpace($env:WINDOWS_CERTIFICATE_PASSWORD)) {
+            pwsh -NoProfile -File tool/release/sign_windows.ps1 -BundleDir "$env:BUNDLE_DIR"
+          } else {
+            Write-Output "::warning::Windows code-signing certificate is not configured; packaging an unsigned Windows release."
+          }
           tar -czf "release-assets/alera-$env:RELEASE_VERSION-windows.tar.gz" -C "$env:BUNDLE_DIR" .
 
       - name: Package stable Linux release

--- a/docs/release-trust.md
+++ b/docs/release-trust.md
@@ -2,13 +2,17 @@
 
 Alera release builds are expected to be trusted before they are published publicly. The release workflow builds the desktop bundle for each platform, signs or packages the platform artifact, emits a signed schema v2 update manifest, and uploads both GitHub Release assets and R2 update indexes.
 
+## Platform signing is conditional
+
+Platform code-signing (macOS Developer ID, Windows Authenticode) runs only when its credentials are configured as repository secrets. When they are absent the release job logs a warning and ships an unsigned platform artifact instead of failing. This is independent of update-manifest signing: the Ed25519 manifest below is always signed, so update integrity holds even for unsigned platform bundles. Configuring the relevant secrets re-enables signing automatically with no workflow change.
+
 ## macOS
 
-Production macOS artifacts must contain a Developer ID signed and notarized `Alera.app`. The release job signs the bundled Rust sidecar under `Contents/Resources/alera/`, signs the app bundle with hardened runtime, submits it to Apple notarization, staples the ticket, and verifies the result with `codesign`, `stapler`, and `spctl`.
+Production macOS artifacts should contain a Developer ID signed and notarized `Alera.app`. When the `APPLE_*` credentials are present, the release job signs the bundled Rust sidecar under `Contents/Resources/alera/`, signs the app bundle with hardened runtime, submits it to Apple notarization, staples the ticket, and verifies the result with `codesign`, `stapler`, and `spctl`. While Apple credentials are not configured, the macOS bundle ships unsigned and users must allow it through Gatekeeper (right-click → Open, or `xattr -dr com.apple.quarantine`).
 
 ## Windows
 
-Production Windows artifacts must be Authenticode signed. The release job signs every executable payload in the bundle, including the Rust sidecar under `resources/alera/`, and verifies each signed file with `signtool verify /pa /all`. Windows SmartScreen reputation can still take time to accrue for a new publisher or certificate even when Authenticode verification succeeds.
+Production Windows artifacts should be Authenticode signed. When the `WINDOWS_CERTIFICATE_*` credentials are present, the release job signs every executable payload in the bundle, including the Rust sidecar under `resources/alera/`, and verifies each signed file with `signtool verify /pa /all`. Windows SmartScreen reputation can still take time to accrue for a new publisher or certificate even when Authenticode verification succeeds. While the certificate is not configured, the Windows bundle ships unsigned and SmartScreen reports an unknown publisher; the planned trusted path is a free SignPath Foundation certificate for this MIT-licensed project.
 
 ## Linux
 


### PR DESCRIPTION
## Summary

The Cut Release workflow was failing on all three platforms at **Build release bundle**. Commit \`efbadc8\` (harden release signing) introduced a full signing pipeline that hard-requires secrets/variables which were never configured, so every build aborted at the first guard (\`ALERA_UPDATE_MANIFEST_PUBLIC_KEY is required\`, exit 64).

This change unblocks releases on a free-first path (Alera is MIT):

- **Platform code-signing is now conditional.** macOS Developer ID and Windows Authenticode run only when their credentials are present; otherwise the bundle ships unsigned with a \`::warning::\` instead of failing. Adding the secrets later re-enables signing with no further workflow change.
- **Update-manifest signing stays mandatory.** The Ed25519 manifest is always signed, so update integrity is unaffected by unsigned platform bundles. \`ALERA_SIGNED_RELEASE\` and the auto-install gate are unchanged.
- Docs updated in \`docs/release-trust.md\`.

The required free secrets have been configured on the repo: the Ed25519 manifest keypair (\`ALERA_UPDATE_MANIFEST_PUBLIC_KEY\`/\`_PRIVATE_KEY\`/\`_PUBLIC_KEY_ID\`) and the Linux APT/RPM GPG key (\`ALERA_LINUX_GPG_PRIVATE_KEY_BASE64\`/\`_KEY_ID\`).

## Follow-ups (not blocking)

- macOS: optionally add \`APPLE_*\` secrets (Apple Developer Program, \$99/yr) to enable Developer ID signing + notarization.
- Windows: apply to SignPath Foundation (free for OSS) and switch the Windows step to its cloud signing pipeline.
- Linux: publish the GPG public key + repo-add instructions for end users.

## Validation

- \`release-cut.yml\` parses as valid YAML.
- Ed25519 keypair verified to round-trip through the repo's \`signAleraManifest\` / \`verifyAleraManifestSignature\`.
- Pending: trigger Cut Release (rc) and confirm all jobs green.