### PR TITLE
fix: hydrate ai command environment

### DIFF
--- a/lib/src/features/ai_text_generation/application/ai_text_generation_service.dart
+++ b/lib/src/features/ai_text_generation/application/ai_text_generation_service.dart
@@ -6,6 +6,7 @@ import 'package:alera/src/features/ai_text_generation/application/ai_text_genera
 import 'package:alera/src/features/ai_text_generation/domain/ai_text_generation_settings.dart';
 import 'package:alera/src/shared/infra/git/git_backend.dart';
 import 'package:alera/src/shared/infra/git/git_diff_models.dart';
+import 'package:alera/src/shared/infra/process/command_environment_resolver.dart';
 import 'package:alera/src/shared/infra/process/process_runner.dart';
 
 const int maxArgvPromptBytes = 24000;
@@ -52,10 +53,13 @@ class CliAiTextGenerationService implements AiTextGenerationService {
   CliAiTextGenerationService({
     required this.gitBackend,
     required this.processRunner,
-  });
+    CommandEnvironmentResolver? commandEnvironmentResolver,
+  }) : commandEnvironmentResolver =
+           commandEnvironmentResolver ?? UserCommandEnvironmentResolver();
 
   final GitBackend gitBackend;
   final ProcessRunner processRunner;
+  final CommandEnvironmentResolver commandEnvironmentResolver;
   final Map<String, StartedProcess> _running = <String, StartedProcess>{};
   final Set<String> _pending = <String>{};
   final Set<String> _canceled = <String>{};
@@ -80,12 +84,17 @@ class CliAiTextGenerationService implements AiTextGenerationService {
         throw const AiTextGenerationCanceledException();
       }
       final plan = _planCommand(request.settings, prompt);
+      final environment = await commandEnvironmentResolver.environment();
+      if (_canceled.contains(key)) {
+        throw const AiTextGenerationCanceledException();
+      }
       final StartedProcess process;
       try {
         process = await processRunner.start(
           plan.binary,
           plan.args,
           workingDirectory: request.workspacePath,
+          environment: environment,
         );
       } catch (_) {
         throw AiTextGenerationException(

--- a/lib/src/features/ai_text_generation/application/ai_text_model_discovery_service.dart
+++ b/lib/src/features/ai_text_generation/application/ai_text_model_discovery_service.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 
 import 'package:alera/src/features/ai_text_generation/application/ai_text_generation_registry.dart';
 import 'package:alera/src/features/ai_text_generation/domain/ai_text_generation_settings.dart';
+import 'package:alera/src/shared/infra/process/command_environment_resolver.dart';
 import 'package:alera/src/shared/infra/process/process_runner.dart';
 
 const int aiTextModelDiscoveryTimeoutSeconds = 60;
@@ -29,9 +30,14 @@ abstract interface class AiTextModelDiscoveryService {
 }
 
 class CliAiTextModelDiscoveryService implements AiTextModelDiscoveryService {
-  const CliAiTextModelDiscoveryService({required this.processRunner});
+  CliAiTextModelDiscoveryService({
+    required this.processRunner,
+    CommandEnvironmentResolver? commandEnvironmentResolver,
+  }) : commandEnvironmentResolver =
+           commandEnvironmentResolver ?? UserCommandEnvironmentResolver();
 
   final ProcessRunner processRunner;
+  final CommandEnvironmentResolver commandEnvironmentResolver;
 
   @override
   Future<AiTextModelDiscoveryResult> discover(
@@ -53,7 +59,11 @@ class CliAiTextModelDiscoveryService implements AiTextModelDiscoveryService {
 
     final StartedProcess process;
     try {
-      process = await processRunner.start(spec.binary, spec.modelsCommand!);
+      process = await processRunner.start(
+        spec.binary,
+        spec.modelsCommand!,
+        environment: await commandEnvironmentResolver.environment(),
+      );
     } catch (_) {
       return AiTextModelDiscoveryResult(
         success: false,

--- a/lib/src/shared/infra/process/command_environment_resolver.dart
+++ b/lib/src/shared/infra/process/command_environment_resolver.dart
@@ -1,0 +1,221 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+const String shellPathHydrationDelimiter = '__ALERA_SHELL_PATH__';
+const Duration shellPathHydrationTimeout = Duration(seconds: 5);
+
+typedef ShellPathHydrator =
+    Future<CommandEnvironmentHydrationResult> Function(String shell);
+
+enum CommandEnvironmentHydrationFailureReason {
+  none,
+  noShell,
+  spawnError,
+  timeout,
+  emptyPath,
+}
+
+class CommandEnvironmentHydrationResult {
+  const CommandEnvironmentHydrationResult._({
+    required this.ok,
+    required this.segments,
+    required this.failureReason,
+  });
+
+  const CommandEnvironmentHydrationResult.success(List<String> segments)
+    : this._(
+        ok: true,
+        segments: segments,
+        failureReason: CommandEnvironmentHydrationFailureReason.none,
+      );
+
+  const CommandEnvironmentHydrationResult.failure(
+    CommandEnvironmentHydrationFailureReason failureReason,
+  ) : this._(
+        ok: false,
+        segments: const <String>[],
+        failureReason: failureReason,
+      );
+
+  final bool ok;
+  final List<String> segments;
+  final CommandEnvironmentHydrationFailureReason failureReason;
+}
+
+abstract interface class CommandEnvironmentResolver {
+  Future<Map<String, String>> environment();
+}
+
+class UserCommandEnvironmentResolver implements CommandEnvironmentResolver {
+  UserCommandEnvironmentResolver({
+    this.platformEnvironment,
+    this.isWindows,
+    this.isMacOS,
+    this.hydrator,
+  });
+
+  final Map<String, String>? platformEnvironment;
+  final bool? isWindows;
+  final bool? isMacOS;
+  final ShellPathHydrator? hydrator;
+  Future<CommandEnvironmentHydrationResult>? _hydration;
+
+  @override
+  Future<Map<String, String>> environment() async {
+    final base = <String, String>{
+      ...(platformEnvironment ?? Platform.environment),
+    };
+    final result = await _hydrate();
+    if (!result.ok) {
+      return base;
+    }
+    _mergePathSegments(base, result.segments);
+    return base;
+  }
+
+  Future<CommandEnvironmentHydrationResult> _hydrate() {
+    final cached = _hydration;
+    if (cached != null) {
+      return cached;
+    }
+    final shell = _pickShell();
+    if (shell == null) {
+      return _hydration = Future<CommandEnvironmentHydrationResult>.value(
+        const CommandEnvironmentHydrationResult.failure(
+          CommandEnvironmentHydrationFailureReason.noShell,
+        ),
+      );
+    }
+    return _hydration = (hydrator ?? hydrateShellPath)(shell);
+  }
+
+  String? _pickShell() {
+    if (isWindows ?? Platform.isWindows) {
+      return null;
+    }
+    final environment = platformEnvironment ?? Platform.environment;
+    final shell = environment['SHELL']?.trim();
+    if (shell != null && shell.isNotEmpty) {
+      return shell;
+    }
+    return (isMacOS ?? Platform.isMacOS) ? '/bin/zsh' : '/bin/bash';
+  }
+}
+
+Future<CommandEnvironmentHydrationResult> hydrateShellPath(String shell) async {
+  final command =
+      "printf '%s' '$shellPathHydrationDelimiter'; "
+      'printf \'%s\' "\$PATH"; '
+      "printf '%s' '$shellPathHydrationDelimiter'";
+  Process process;
+  try {
+    process = await Process.start(shell, <String>[
+      '-ilc',
+      command,
+    ], mode: ProcessStartMode.normal);
+  } catch (_) {
+    return const CommandEnvironmentHydrationResult.failure(
+      CommandEnvironmentHydrationFailureReason.spawnError,
+    );
+  }
+
+  final stdout = StringBuffer();
+  final stdoutDone = utf8.decoder.bind(process.stdout).forEach(stdout.write);
+  final stderrDone = process.stderr.drain<void>();
+
+  try {
+    await process.exitCode.timeout(
+      shellPathHydrationTimeout,
+      onTimeout: () {
+        process.kill(ProcessSignal.sigkill);
+        throw TimeoutException('Shell PATH hydration timed out.');
+      },
+    );
+    await Future.wait(<Future<void>>[stdoutDone, stderrDone]);
+  } on TimeoutException {
+    return const CommandEnvironmentHydrationResult.failure(
+      CommandEnvironmentHydrationFailureReason.timeout,
+    );
+  }
+
+  final segments = parseHydratedShellPath(stdout.toString());
+  if (segments.isEmpty) {
+    return const CommandEnvironmentHydrationResult.failure(
+      CommandEnvironmentHydrationFailureReason.emptyPath,
+    );
+  }
+  return CommandEnvironmentHydrationResult.success(segments);
+}
+
+List<String> parseHydratedShellPath(String stdout) {
+  final cleaned = stdout.replaceAll(RegExp(r'\x1B\[[0-?]*[ -/]*[@-~]'), '');
+  final first = cleaned.indexOf(shellPathHydrationDelimiter);
+  if (first < 0) {
+    return const <String>[];
+  }
+  final second = cleaned.indexOf(
+    shellPathHydrationDelimiter,
+    first + shellPathHydrationDelimiter.length,
+  );
+  if (second < 0) {
+    return const <String>[];
+  }
+  final value = cleaned
+      .substring(first + shellPathHydrationDelimiter.length, second)
+      .trim();
+  if (value.isEmpty) {
+    return const <String>[];
+  }
+
+  final seen = <String>{};
+  return value
+      .split(_pathListSeparator)
+      .map((segment) => segment.trim())
+      .where((segment) => segment.isNotEmpty && seen.add(segment))
+      .toList(growable: false);
+}
+
+List<String> mergePathSegmentsForTesting(
+  Map<String, String> environment,
+  List<String> segments,
+) {
+  return _mergePathSegments(environment, segments);
+}
+
+List<String> _mergePathSegments(
+  Map<String, String> environment,
+  List<String> segments,
+) {
+  if (segments.isEmpty) {
+    return const <String>[];
+  }
+  final key = _pathEnvironmentKey(environment);
+  final current = environment[key] ?? '';
+  final existing = current
+      .split(_pathListSeparator)
+      .where((segment) => segment.isNotEmpty)
+      .toSet();
+  final seenIncoming = <String>{};
+  final added = segments
+      .where((segment) => segment.isNotEmpty && seenIncoming.add(segment))
+      .where((segment) => !existing.contains(segment))
+      .toList(growable: false);
+  if (added.isEmpty) {
+    return const <String>[];
+  }
+  environment[key] = <String>[
+    ...added,
+    ...current.split(_pathListSeparator).where((segment) => segment.isNotEmpty),
+  ].join(_pathListSeparator);
+  return added;
+}
+
+String _pathEnvironmentKey(Map<String, String> environment) {
+  if (Platform.isWindows && environment.containsKey('Path')) {
+    return 'Path';
+  }
+  return 'PATH';
+}
+
+String get _pathListSeparator => Platform.isWindows ? ';' : ':';

--- a/test/unit/ai_text_generation_service_test.dart
+++ b/test/unit/ai_text_generation_service_test.dart
@@ -7,6 +7,7 @@ import 'package:alera/src/features/ai_text_generation/application/ai_text_genera
 import 'package:alera/src/features/ai_text_generation/application/ai_text_model_discovery_service.dart';
 import 'package:alera/src/features/ai_text_generation/domain/ai_text_generation_settings.dart';
 import 'package:alera/src/shared/infra/git/git_diff_models.dart';
+import 'package:alera/src/shared/infra/process/command_environment_resolver.dart';
 import 'package:alera/src/shared/infra/process/process_runner.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -103,6 +104,45 @@ Claude Sonnet 4.6 (Thinking)
       expect(runner.stdinText, contains('feature/ai-text'));
       expect(runner.stdinClosed, isTrue);
     });
+
+    test(
+      'starts commit message agents with resolved command environment',
+      () async {
+        final git = FakeGitBackend()
+          ..gitRepositoryStateResult = const GitRepositoryState(
+            branch: 'feature/ai-text',
+          )
+          ..gitStatusResult = const GitStatusResult(
+            entries: <GitChangeEntry>[
+              GitChangeEntry(
+                path: 'lib/foo.dart',
+                area: GitChangeArea.staged,
+                status: GitChangeStatus.modified,
+              ),
+            ],
+          );
+        final runner = _FakeProcessRunner(stdout: 'feat: add ai text\n');
+        final service = CliAiTextGenerationService(
+          gitBackend: git,
+          processRunner: runner,
+          commandEnvironmentResolver: const _FakeCommandEnvironmentResolver(
+            value: <String, String>{'PATH': '/shell/bin:/usr/bin'},
+          ),
+        );
+
+        await service.generate(
+          const AiTextGenerationRequest(
+            operation: AiTextGenerationOperation.commitMessage,
+            workspacePath: '/repo',
+            settings: AiTextGenerationSettings(
+              agent: AiTextGenerationAgent.agy,
+            ),
+          ),
+        );
+
+        expect(runner.environment, containsPair('PATH', '/shell/bin:/usr/bin'));
+      },
+    );
 
     test('generates commit message with amp without archived flag', () async {
       final git = FakeGitBackend()
@@ -212,6 +252,25 @@ Claude Sonnet 4.6 (Thinking)
       expect(runner.executable, 'agy');
       expect(runner.arguments, <String>['models']);
     });
+
+    test(
+      'discovers dynamic models with resolved command environment',
+      () async {
+        final runner = _FakeProcessRunner(
+          stdout: 'Gemini 3.5 Flash (Medium)\n',
+        );
+        final service = CliAiTextModelDiscoveryService(
+          processRunner: runner,
+          commandEnvironmentResolver: const _FakeCommandEnvironmentResolver(
+            value: <String, String>{'PATH': '/shell/bin:/usr/bin'},
+          ),
+        );
+
+        await service.discover(AiTextGenerationAgent.agy);
+
+        expect(runner.environment, containsPair('PATH', '/shell/bin:/usr/bin'));
+      },
+    );
 
     test('discovers pi models from stderr on successful exit', () async {
       final runner = _FakeProcessRunner(
@@ -568,6 +627,7 @@ class _FakeProcessRunner implements ProcessRunner {
   bool killed = false;
   String? executable;
   List<String> arguments = const <String>[];
+  Map<String, String>? environment;
   final StringBuffer _stdin = StringBuffer();
 
   String get stdinText => _stdin.toString();
@@ -593,6 +653,9 @@ class _FakeProcessRunner implements ProcessRunner {
     startCount += 1;
     this.executable = executable;
     this.arguments = List<String>.from(arguments);
+    this.environment = environment == null
+        ? null
+        : Map<String, String>.from(environment);
     return StartedProcess(
       stdinWrite: (data) => _stdin.write(utf8.decode(data)),
       stdinClose: () => stdinClosed = true,
@@ -612,6 +675,19 @@ class _FakeProcessRunner implements ProcessRunner {
         return true;
       },
     );
+  }
+}
+
+class _FakeCommandEnvironmentResolver implements CommandEnvironmentResolver {
+  const _FakeCommandEnvironmentResolver({
+    this.value = const <String, String>{'PATH': '/usr/bin'},
+  });
+
+  final Map<String, String> value;
+
+  @override
+  Future<Map<String, String>> environment() async {
+    return Map<String, String>.from(value);
   }
 }
 

--- a/test/unit/command_environment_resolver_test.dart
+++ b/test/unit/command_environment_resolver_test.dart
@@ -1,0 +1,124 @@
+import 'package:alera/src/shared/infra/process/command_environment_resolver.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('UserCommandEnvironmentResolver', () {
+    test('parses shell PATH between delimiters and strips ANSI output', () {
+      final segments = parseHydratedShellPath(
+        '\x1B[32mbanner\x1B[0m\n'
+        '$shellPathHydrationDelimiter'
+        '/Users/test/.opencode/bin:/Users/test/.cargo/bin:/usr/bin:/Users/test/.cargo/bin'
+        '$shellPathHydrationDelimiter\nprompt',
+      );
+
+      expect(segments, <String>[
+        '/Users/test/.opencode/bin',
+        '/Users/test/.cargo/bin',
+        '/usr/bin',
+      ]);
+    });
+
+    test('returns no parsed PATH when delimiters are missing', () {
+      expect(parseHydratedShellPath('/usr/bin:/bin'), isEmpty);
+      expect(
+        parseHydratedShellPath('$shellPathHydrationDelimiter/usr/bin'),
+        isEmpty,
+      );
+    });
+
+    test(
+      'prepends shell PATH segments without duplicating existing entries',
+      () {
+        final environment = <String, String>{'PATH': '/usr/bin:/bin'};
+
+        final added = mergePathSegmentsForTesting(environment, <String>[
+          '/Users/test/.opencode/bin',
+          '/usr/bin',
+          '/Users/test/.cargo/bin',
+        ]);
+
+        expect(added, <String>[
+          '/Users/test/.opencode/bin',
+          '/Users/test/.cargo/bin',
+        ]);
+        expect(
+          environment['PATH'],
+          '/Users/test/.opencode/bin:/Users/test/.cargo/bin:/usr/bin:/bin',
+        );
+      },
+    );
+
+    test(
+      'hydrates POSIX shell PATH once and merges it into command environment',
+      () async {
+        var hydrateCount = 0;
+        final resolver = UserCommandEnvironmentResolver(
+          platformEnvironment: const <String, String>{
+            'SHELL': '/bin/zsh',
+            'PATH': '/usr/bin',
+          },
+          isWindows: false,
+          isMacOS: true,
+          hydrator: (shell) async {
+            hydrateCount += 1;
+            expect(shell, '/bin/zsh');
+            return const CommandEnvironmentHydrationResult.success(<String>[
+              '/Users/test/.opencode/bin',
+              '/usr/bin',
+            ]);
+          },
+        );
+
+        final first = await resolver.environment();
+        final second = await resolver.environment();
+
+        expect(hydrateCount, 1);
+        expect(first['PATH'], '/Users/test/.opencode/bin:/usr/bin');
+        expect(second['PATH'], '/Users/test/.opencode/bin:/usr/bin');
+      },
+    );
+
+    test(
+      'falls back to platform environment when shell hydration is unavailable',
+      () async {
+        final resolver = UserCommandEnvironmentResolver(
+          platformEnvironment: const <String, String>{'PATH': r'C:\Windows'},
+          isWindows: true,
+          hydrator: (_) async {
+            throw StateError('hydrator must not run on Windows');
+          },
+        );
+
+        final environment = await resolver.environment();
+
+        expect(environment, <String, String>{'PATH': r'C:\Windows'});
+      },
+    );
+
+    test(
+      'falls back to platform environment when shell hydration fails',
+      () async {
+        final resolver = UserCommandEnvironmentResolver(
+          platformEnvironment: const <String, String>{
+            'SHELL': '/bin/zsh',
+            'PATH': '/usr/bin',
+          },
+          isWindows: false,
+          isMacOS: true,
+          hydrator: (_) async {
+            return const CommandEnvironmentHydrationResult.failure(
+              CommandEnvironmentHydrationFailureReason.timeout,
+            );
+          },
+        );
+
+        final environment = await resolver.environment();
+
+        expect(environment, <String, String>{
+          'SHELL': '/bin/zsh',
+          'PATH': '/usr/bin',
+        });
+      },
+    );
+  });
+}


### PR DESCRIPTION
## summary

- Hydrate background AI command environments from the user login shell PATH on macOS/Linux.
- Pass the resolved environment to AI commit-message generation and dynamic model discovery.
- Add focused tests for PATH parsing/merging, fallback behavior, and AI command environment wiring.

## root cause

Alera terminals prepare a shell-like environment, but background AI text commands inherited the app process environment. GUI-launched desktop apps can miss PATH entries from shell startup files, so commands like opencode or codex were unavailable in commit-message generation even though they worked in Alera terminals.

## validation

- `flutter analyze lib/src/shared/infra/process/command_environment_resolver.dart lib/src/features/ai_text_generation/application/ai_text_generation_service.dart lib/src/features/ai_text_generation/application/ai_text_model_discovery_service.dart test/unit/command_environment_resolver_test.dart test/unit/ai_text_generation_service_test.dart`
- `flutter test test/unit/command_environment_resolver_test.dart test/unit/ai_text_generation_service_test.dart`
- `git diff --check`
