### PR TITLE
fix: remove vertical gutter divider in editor

### DIFF
--- a/lib/src/features/workbench/presentation/workspace_editor_surface.dart
+++ b/lib/src/features/workbench/presentation/workspace_editor_surface.dart
@@ -162,7 +162,7 @@ class _WorkspaceEditorSurfaceState
             enableLocalSuggestions: false,
             enableGuideLines: true,
             enableGutter: true,
-            enableGutterDivider: true,
+            enableGutterDivider: false,
             editorTheme: editorTheme,
             language: _languageForPath(filePath),
             tabSize: effectiveTabSize,


### PR DESCRIPTION
## Summary

Removes the vertical line divider that CodeForge drew between the line-number gutter and the code content in the workspace editor.

The change flips `enableGutterDivider` from `true` to `false` on the `CodeForge` widget in `workspace_editor_surface.dart`. The horizontal divider between the file bar and the editor, and the indentation guide lines, are unchanged.

## Validation

- `flutter analyze` could not run in this worktree because the `third_party/` git submodules (`xterm`, `dart_terminal`) are not checked out; the change is a single boolean flip.
- Visual check pending: open a file in the editor and confirm the vertical line between line numbers and code is gone.