### PR TITLE
feat: auto-refresh source control panel on external changes

### DIFF
--- a/lib/src/features/workbench/application/source_control_watcher.dart
+++ b/lib/src/features/workbench/application/source_control_watcher.dart
@@ -1,0 +1,34 @@
+import 'package:alera/src/rust/api/workspace_files.dart' as native;
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'source_control_watcher.g.dart';
+
+/// Thin, injectable wrapper over the native recursive source-control watcher.
+///
+/// The watcher observes the whole working tree (including `.git/`) so commits,
+/// branch switches, staging and out-of-app file edits all surface as a single
+/// coalesced signal. Tests override [sourceControlWatcherProvider] with a fake.
+class SourceControlWatcher {
+  const SourceControlWatcher();
+
+  Future<native.SourceControlWatcherHandle> start({
+    required String workspacePath,
+  }) {
+    return native.startSourceControlWatcher(workspacePath: workspacePath);
+  }
+
+  Stream<native.SourceControlWatchSignal> events({
+    required native.SourceControlWatcherHandle handle,
+  }) {
+    return native.watchSourceControlEvents(handle: handle);
+  }
+
+  Future<void> stop({required native.SourceControlWatcherHandle handle}) {
+    return native.stopSourceControlWatcher(handle: handle);
+  }
+}
+
+@Riverpod(keepAlive: true)
+SourceControlWatcher sourceControlWatcher(Ref ref) {
+  return const SourceControlWatcher();
+}

--- a/lib/src/features/workbench/application/source_control_watcher.g.dart
+++ b/lib/src/features/workbench/application/source_control_watcher.g.dart
@@ -1,0 +1,58 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'source_control_watcher.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(sourceControlWatcher)
+final sourceControlWatcherProvider = SourceControlWatcherProvider._();
+
+final class SourceControlWatcherProvider
+    extends
+        $FunctionalProvider<
+          SourceControlWatcher,
+          SourceControlWatcher,
+          SourceControlWatcher
+        >
+    with $Provider<SourceControlWatcher> {
+  SourceControlWatcherProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'sourceControlWatcherProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$sourceControlWatcherHash();
+
+  @$internal
+  @override
+  $ProviderElement<SourceControlWatcher> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  SourceControlWatcher create(Ref ref) {
+    return sourceControlWatcher(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(SourceControlWatcher value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<SourceControlWatcher>(value),
+    );
+  }
+}
+
+String _$sourceControlWatcherHash() =>
+    r'd84112f3679f1fca0459d12ed250cfb81f6abb28';

--- a/lib/src/features/workbench/application/workspace_source_control_controller.dart
+++ b/lib/src/features/workbench/application/workspace_source_control_controller.dart
@@ -1,5 +1,7 @@
 import 'dart:async';
 
+import 'package:alera/src/features/workbench/application/source_control_watcher.dart';
+import 'package:alera/src/rust/api/workspace_files.dart' as native;
 import 'package:alera/src/shared/infra/git/git_backend.dart';
 import 'package:alera/src/shared/infra/git/git_diff_models.dart';
 import 'package:alera/src/shared/infra/git/git_exception.dart';
@@ -64,8 +66,24 @@ enum WorkspaceSourceControlAction {
 @riverpod
 class WorkspaceSourceControlController
     extends _$WorkspaceSourceControlController {
+  static const Duration _watcherReloadDebounce = Duration(milliseconds: 250);
+
+  SourceControlWatcher? _watcher;
+  StreamSubscription<native.SourceControlWatchSignal>? _watchSubscription;
+  native.SourceControlWatcherHandle? _watcherHandle;
+  Timer? _watcherReloadDebounceTimer;
+  bool _watcherReloadInFlight = false;
+  bool _disposed = false;
+
   @override
   Future<WorkspaceSourceControlState> build(String workspacePath) {
+    // Capture the watcher now: `onDispose` runs in a lifecycle where reading
+    // providers via `ref` is disallowed.
+    _watcher = ref.read(sourceControlWatcherProvider);
+    ref.onDispose(_stopWatching);
+    // Best-effort: file watching keeps the panel live without blocking the
+    // initial load; manual refresh remains available if it fails to start.
+    unawaited(_startWatching());
     return _load();
   }
 
@@ -236,6 +254,72 @@ class WorkspaceSourceControlController
         state = AsyncError(error, stackTrace);
       }
       rethrow;
+    }
+  }
+
+  Future<void> _startWatching() async {
+    final watcher = _watcher;
+    if (watcher == null) {
+      return;
+    }
+    try {
+      final handle = await watcher.start(workspacePath: workspacePath);
+      if (_disposed) {
+        await watcher.stop(handle: handle);
+        return;
+      }
+      _watcherHandle = handle;
+      _watchSubscription = watcher
+          .events(handle: handle)
+          .listen((_) => _scheduleWatcherReload(), onError: (_) {});
+    } catch (_) {
+      // File watching is best-effort; explicit refresh still works.
+    }
+  }
+
+  void _stopWatching() {
+    _disposed = true;
+    _watcherReloadDebounceTimer?.cancel();
+    _watcherReloadDebounceTimer = null;
+    final subscription = _watchSubscription;
+    _watchSubscription = null;
+    unawaited(subscription?.cancel());
+    final handle = _watcherHandle;
+    _watcherHandle = null;
+    final watcher = _watcher;
+    if (handle != null && watcher != null) {
+      unawaited(watcher.stop(handle: handle));
+    }
+  }
+
+  void _scheduleWatcherReload() {
+    _watcherReloadDebounceTimer?.cancel();
+    _watcherReloadDebounceTimer = Timer(
+      _watcherReloadDebounce,
+      () => unawaited(_reloadFromWatcher()),
+    );
+  }
+
+  Future<void> _reloadFromWatcher() async {
+    if (_disposed || _watcherReloadInFlight) {
+      return;
+    }
+    // Defer while an action runs: `_run` reloads when it finishes, and skipping
+    // here avoids clobbering its optimistic busy state.
+    if (state.asData?.value.isBusy ?? false) {
+      return;
+    }
+    _watcherReloadInFlight = true;
+    try {
+      final next = await _load();
+      if (_disposed || (state.asData?.value.isBusy ?? false)) {
+        return;
+      }
+      state = AsyncData(next);
+    } catch (_) {
+      // Best-effort background refresh: keep the current state on failure.
+    } finally {
+      _watcherReloadInFlight = false;
     }
   }
 

--- a/lib/src/features/workbench/application/workspace_source_control_controller.g.dart
+++ b/lib/src/features/workbench/application/workspace_source_control_controller.g.dart
@@ -58,7 +58,7 @@ final class WorkspaceSourceControlControllerProvider
 }
 
 String _$workspaceSourceControlControllerHash() =>
-    r'd67f09b5830696c917a29fd27831cb43d861a2cd';
+    r'ed89d7f3d536333b71660f6a19a4398a525c835f';
 
 final class WorkspaceSourceControlControllerFamily extends $Family
     with

--- a/lib/src/rust/api/workspace_files.dart
+++ b/lib/src/rust/api/workspace_files.dart
@@ -8,7 +8,7 @@ import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 
 // These functions are ignored because they are not marked as `pub`: `content_token`, `copy_recursively`, `ensure_inside_existing_parent`, `ensure_not_descendant`, `entry_for_path`, `for_workspace`, `from_io`, `git_status_priority`, `has_visible_child`, `ignored_aware_children`, `is_protected_child_path`, `is_protected_relative_path`, `join_relative`, `merge_status`, `modified_millis`, `new`, `read_dir_children`, `reject_protected`, `relative_components`, `relative_string`, `resolve_existing_no_follow`, `resolve_existing`, `resolve_new_child`, `sanitize_name`, `status_for`, `status_from_git2`, `unique_copy_destination`, `workspace_root`
 // These types are ignored because they are neither used by any `pub` functions nor (for structs and enums) marked `#[frb(unignore)]`: `GitStatusSnapshot`
-// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `eq`, `eq`, `eq`, `eq`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`
+// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `eq`, `eq`, `eq`, `eq`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`
 
 Future<List<WorkspaceFileEntry>> listWorkspaceChildren({
   required String workspacePath,
@@ -55,6 +55,24 @@ Stream<WorkspaceExplorerWatchBatch> watchWorkspaceExplorerEvents({
 Future<void> stopWorkspaceExplorerWatcher({
   required WorkspaceExplorerWatcherHandle handle,
 }) => RustLib.instance.api.crateApiWorkspaceFilesStopWorkspaceExplorerWatcher(
+  handle: handle,
+);
+
+Future<SourceControlWatcherHandle> startSourceControlWatcher({
+  required String workspacePath,
+}) => RustLib.instance.api.crateApiWorkspaceFilesStartSourceControlWatcher(
+  workspacePath: workspacePath,
+);
+
+Stream<SourceControlWatchSignal> watchSourceControlEvents({
+  required SourceControlWatcherHandle handle,
+}) => RustLib.instance.api.crateApiWorkspaceFilesWatchSourceControlEvents(
+  handle: handle,
+);
+
+Future<void> stopSourceControlWatcher({
+  required SourceControlWatcherHandle handle,
+}) => RustLib.instance.api.crateApiWorkspaceFilesStopSourceControlWatcher(
   handle: handle,
 );
 
@@ -169,6 +187,38 @@ Future<void> deleteWorkspaceEntry({
   relativePath: relativePath,
   useTrash: useTrash,
 );
+
+class SourceControlWatchSignal {
+  final int coalescedEventCount;
+
+  const SourceControlWatchSignal({required this.coalescedEventCount});
+
+  @override
+  int get hashCode => coalescedEventCount.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is SourceControlWatchSignal &&
+          runtimeType == other.runtimeType &&
+          coalescedEventCount == other.coalescedEventCount;
+}
+
+class SourceControlWatcherHandle {
+  final String id;
+
+  const SourceControlWatcherHandle({required this.id});
+
+  @override
+  int get hashCode => id.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is SourceControlWatcherHandle &&
+          runtimeType == other.runtimeType &&
+          id == other.id;
+}
 
 class WorkspaceEditorTextFile {
   final String rawContent;

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -70,7 +70,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.12.0';
 
   @override
-  int get rustContentHash => 1569074570;
+  int get rustContentHash => -1535239911;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -286,12 +286,21 @@ abstract class RustLibApi extends BaseApi {
     required List<String> enabledAgents,
   });
 
+  Future<SourceControlWatcherHandle>
+  crateApiWorkspaceFilesStartSourceControlWatcher({
+    required String workspacePath,
+  });
+
   Future<WorkspaceExplorerWatcherHandle>
   crateApiWorkspaceFilesStartWorkspaceExplorerWatcher({
     required String workspacePath,
   });
 
   Future<void> crateApiAgentHooksStopAgentHookReceiver();
+
+  Future<void> crateApiWorkspaceFilesStopSourceControlWatcher({
+    required SourceControlWatcherHandle handle,
+  });
 
   Future<void> crateApiWorkspaceFilesStopWorkspaceExplorerWatcher({
     required WorkspaceExplorerWatcherHandle handle,
@@ -303,6 +312,11 @@ abstract class RustLibApi extends BaseApi {
   });
 
   Stream<AgentHookEventBatchDto> crateApiAgentHooksWatchAgentHookEventBatches();
+
+  Stream<SourceControlWatchSignal>
+  crateApiWorkspaceFilesWatchSourceControlEvents({
+    required SourceControlWatcherHandle handle,
+  });
 
   Stream<WorkspaceExplorerWatchBatch>
   crateApiWorkspaceFilesWatchWorkspaceExplorerEvents({
@@ -1886,6 +1900,40 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
+  Future<SourceControlWatcherHandle>
+  crateApiWorkspaceFilesStartSourceControlWatcher({
+    required String workspacePath,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_String(workspacePath, serializer);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 47,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_source_control_watcher_handle,
+          decodeErrorData: sse_decode_workspace_file_error,
+        ),
+        constMeta: kCrateApiWorkspaceFilesStartSourceControlWatcherConstMeta,
+        argValues: [workspacePath],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiWorkspaceFilesStartSourceControlWatcherConstMeta =>
+      const TaskConstMeta(
+        debugName: "start_source_control_watcher",
+        argNames: ["workspacePath"],
+      );
+
+  @override
   Future<WorkspaceExplorerWatcherHandle>
   crateApiWorkspaceFilesStartWorkspaceExplorerWatcher({
     required String workspacePath,
@@ -1898,7 +1946,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 47,
+            funcId: 48,
             port: port_,
           );
         },
@@ -1930,7 +1978,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 48,
+            funcId: 49,
             port: port_,
           );
         },
@@ -1949,6 +1997,42 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       const TaskConstMeta(debugName: "stop_agent_hook_receiver", argNames: []);
 
   @override
+  Future<void> crateApiWorkspaceFilesStopSourceControlWatcher({
+    required SourceControlWatcherHandle handle,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_box_autoadd_source_control_watcher_handle(
+            handle,
+            serializer,
+          );
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 50,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_unit,
+          decodeErrorData: null,
+        ),
+        constMeta: kCrateApiWorkspaceFilesStopSourceControlWatcherConstMeta,
+        argValues: [handle],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiWorkspaceFilesStopSourceControlWatcherConstMeta =>
+      const TaskConstMeta(
+        debugName: "stop_source_control_watcher",
+        argNames: ["handle"],
+      );
+
+  @override
   Future<void> crateApiWorkspaceFilesStopWorkspaceExplorerWatcher({
     required WorkspaceExplorerWatcherHandle handle,
   }) {
@@ -1963,7 +2047,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 49,
+            funcId: 51,
             port: port_,
           );
         },
@@ -2002,7 +2086,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 50,
+            funcId: 52,
             port: port_,
           );
         },
@@ -2041,7 +2125,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 51,
+              funcId: 53,
               port: port_,
             );
           },
@@ -2062,6 +2146,51 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       const TaskConstMeta(
         debugName: "watch_agent_hook_event_batches",
         argNames: ["sink"],
+      );
+
+  @override
+  Stream<SourceControlWatchSignal>
+  crateApiWorkspaceFilesWatchSourceControlEvents({
+    required SourceControlWatcherHandle handle,
+  }) {
+    final sink = RustStreamSink<SourceControlWatchSignal>();
+    unawaited(
+      handler.executeNormal(
+        NormalTask(
+          callFfi: (port_) {
+            final serializer = SseSerializer(generalizedFrbRustBinding);
+            sse_encode_box_autoadd_source_control_watcher_handle(
+              handle,
+              serializer,
+            );
+            sse_encode_StreamSink_source_control_watch_signal_Sse(
+              sink,
+              serializer,
+            );
+            pdeCallFfi(
+              generalizedFrbRustBinding,
+              serializer,
+              funcId: 54,
+              port: port_,
+            );
+          },
+          codec: SseCodec(
+            decodeSuccessData: sse_decode_unit,
+            decodeErrorData: null,
+          ),
+          constMeta: kCrateApiWorkspaceFilesWatchSourceControlEventsConstMeta,
+          argValues: [handle, sink],
+          apiImpl: this,
+        ),
+      ),
+    );
+    return sink.stream;
+  }
+
+  TaskConstMeta get kCrateApiWorkspaceFilesWatchSourceControlEventsConstMeta =>
+      const TaskConstMeta(
+        debugName: "watch_source_control_events",
+        argNames: ["handle", "sink"],
       );
 
   @override
@@ -2086,7 +2215,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 52,
+              funcId: 55,
               port: port_,
             );
           },
@@ -2138,7 +2267,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 53,
+            funcId: 56,
             port: port_,
           );
         },
@@ -2198,7 +2327,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 54,
+            funcId: 57,
             port: port_,
           );
         },
@@ -2240,6 +2369,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   RustStreamSink<AgentHookEventBatchDto>
   dco_decode_StreamSink_agent_hook_event_batch_dto_Sse(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    throw UnimplementedError();
+  }
+
+  @protected
+  RustStreamSink<SourceControlWatchSignal>
+  dco_decode_StreamSink_source_control_watch_signal_Sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     throw UnimplementedError();
   }
@@ -2306,6 +2442,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   GitChangeEntry dco_decode_box_autoadd_git_change_entry(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return dco_decode_git_change_entry(raw);
+  }
+
+  @protected
+  SourceControlWatcherHandle
+  dco_decode_box_autoadd_source_control_watcher_handle(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return dco_decode_source_control_watcher_handle(raw);
   }
 
   @protected
@@ -2765,6 +2908,28 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  SourceControlWatchSignal dco_decode_source_control_watch_signal(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 1)
+      throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
+    return SourceControlWatchSignal(
+      coalescedEventCount: dco_decode_u_32(arr[0]),
+    );
+  }
+
+  @protected
+  SourceControlWatcherHandle dco_decode_source_control_watcher_handle(
+    dynamic raw,
+  ) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 1)
+      throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
+    return SourceControlWatcherHandle(id: dco_decode_String(arr[0]));
+  }
+
+  @protected
   int dco_decode_u_16(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return raw as int;
@@ -3153,6 +3318,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  RustStreamSink<SourceControlWatchSignal>
+  sse_decode_StreamSink_source_control_watch_signal_Sse(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    throw UnimplementedError('Unreachable ()');
+  }
+
+  @protected
   RustStreamSink<WorkspaceExplorerWatchBatch>
   sse_decode_StreamSink_workspace_explorer_watch_batch_Sse(
     SseDeserializer deserializer,
@@ -3227,6 +3401,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     return (sse_decode_git_change_entry(deserializer));
+  }
+
+  @protected
+  SourceControlWatcherHandle
+  sse_decode_box_autoadd_source_control_watcher_handle(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    return (sse_decode_source_control_watcher_handle(deserializer));
   }
 
   @protected
@@ -3843,6 +4026,26 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  SourceControlWatchSignal sse_decode_source_control_watch_signal(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_coalescedEventCount = sse_decode_u_32(deserializer);
+    return SourceControlWatchSignal(
+      coalescedEventCount: var_coalescedEventCount,
+    );
+  }
+
+  @protected
+  SourceControlWatcherHandle sse_decode_source_control_watcher_handle(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_id = sse_decode_String(deserializer);
+    return SourceControlWatcherHandle(id: var_id);
+  }
+
+  @protected
   int sse_decode_u_16(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     return deserializer.buffer.getUint16();
@@ -4305,6 +4508,23 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  void sse_encode_StreamSink_source_control_watch_signal_Sse(
+    RustStreamSink<SourceControlWatchSignal> self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_String(
+      self.setupAndSerialize(
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_source_control_watch_signal,
+          decodeErrorData: sse_decode_AnyhowException,
+        ),
+      ),
+      serializer,
+    );
+  }
+
+  @protected
   void sse_encode_StreamSink_workspace_explorer_watch_batch_Sse(
     RustStreamSink<WorkspaceExplorerWatchBatch> self,
     SseSerializer serializer,
@@ -4375,6 +4595,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_git_change_entry(self, serializer);
+  }
+
+  @protected
+  void sse_encode_box_autoadd_source_control_watcher_handle(
+    SourceControlWatcherHandle self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_source_control_watcher_handle(self, serializer);
   }
 
   @protected
@@ -4920,6 +5149,24 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     if (self != null) {
       sse_encode_box_autoadd_workspace_file_git_status(self, serializer);
     }
+  }
+
+  @protected
+  void sse_encode_source_control_watch_signal(
+    SourceControlWatchSignal self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_u_32(self.coalescedEventCount, serializer);
+  }
+
+  @protected
+  void sse_encode_source_control_watcher_handle(
+    SourceControlWatcherHandle self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_String(self.id, serializer);
   }
 
   @protected

--- a/lib/src/rust/frb_generated.io.dart
+++ b/lib/src/rust/frb_generated.io.dart
@@ -30,6 +30,10 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   dco_decode_StreamSink_agent_hook_event_batch_dto_Sse(dynamic raw);
 
   @protected
+  RustStreamSink<SourceControlWatchSignal>
+  dco_decode_StreamSink_source_control_watch_signal_Sse(dynamic raw);
+
+  @protected
   RustStreamSink<WorkspaceExplorerWatchBatch>
   dco_decode_StreamSink_workspace_explorer_watch_batch_Sse(dynamic raw);
 
@@ -50,6 +54,10 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   GitChangeEntry dco_decode_box_autoadd_git_change_entry(dynamic raw);
+
+  @protected
+  SourceControlWatcherHandle
+  dco_decode_box_autoadd_source_control_watcher_handle(dynamic raw);
 
   @protected
   int dco_decode_box_autoadd_u_32(dynamic raw);
@@ -229,6 +237,14 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  SourceControlWatchSignal dco_decode_source_control_watch_signal(dynamic raw);
+
+  @protected
+  SourceControlWatcherHandle dco_decode_source_control_watcher_handle(
+    dynamic raw,
+  );
+
+  @protected
   int dco_decode_u_16(dynamic raw);
 
   @protected
@@ -348,6 +364,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  RustStreamSink<SourceControlWatchSignal>
+  sse_decode_StreamSink_source_control_watch_signal_Sse(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   RustStreamSink<WorkspaceExplorerWatchBatch>
   sse_decode_StreamSink_workspace_explorer_watch_batch_Sse(
     SseDeserializer deserializer,
@@ -376,6 +398,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   GitChangeEntry sse_decode_box_autoadd_git_change_entry(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  SourceControlWatcherHandle
+  sse_decode_box_autoadd_source_control_watcher_handle(
     SseDeserializer deserializer,
   );
 
@@ -595,6 +623,16 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  SourceControlWatchSignal sse_decode_source_control_watch_signal(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  SourceControlWatcherHandle sse_decode_source_control_watcher_handle(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   int sse_decode_u_16(SseDeserializer deserializer);
 
   @protected
@@ -753,6 +791,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  void sse_encode_StreamSink_source_control_watch_signal_Sse(
+    RustStreamSink<SourceControlWatchSignal> self,
+    SseSerializer serializer,
+  );
+
+  @protected
   void sse_encode_StreamSink_workspace_explorer_watch_batch_Sse(
     RustStreamSink<WorkspaceExplorerWatchBatch> self,
     SseSerializer serializer,
@@ -785,6 +829,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_box_autoadd_git_change_entry(
     GitChangeEntry self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_box_autoadd_source_control_watcher_handle(
+    SourceControlWatcherHandle self,
     SseSerializer serializer,
   );
 
@@ -1052,6 +1102,18 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_opt_box_autoadd_workspace_file_git_status(
     WorkspaceFileGitStatus? self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_source_control_watch_signal(
+    SourceControlWatchSignal self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_source_control_watcher_handle(
+    SourceControlWatcherHandle self,
     SseSerializer serializer,
   );
 

--- a/lib/src/rust/frb_generated.web.dart
+++ b/lib/src/rust/frb_generated.web.dart
@@ -32,6 +32,10 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   dco_decode_StreamSink_agent_hook_event_batch_dto_Sse(dynamic raw);
 
   @protected
+  RustStreamSink<SourceControlWatchSignal>
+  dco_decode_StreamSink_source_control_watch_signal_Sse(dynamic raw);
+
+  @protected
   RustStreamSink<WorkspaceExplorerWatchBatch>
   dco_decode_StreamSink_workspace_explorer_watch_batch_Sse(dynamic raw);
 
@@ -52,6 +56,10 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   GitChangeEntry dco_decode_box_autoadd_git_change_entry(dynamic raw);
+
+  @protected
+  SourceControlWatcherHandle
+  dco_decode_box_autoadd_source_control_watcher_handle(dynamic raw);
 
   @protected
   int dco_decode_box_autoadd_u_32(dynamic raw);
@@ -231,6 +239,14 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  SourceControlWatchSignal dco_decode_source_control_watch_signal(dynamic raw);
+
+  @protected
+  SourceControlWatcherHandle dco_decode_source_control_watcher_handle(
+    dynamic raw,
+  );
+
+  @protected
   int dco_decode_u_16(dynamic raw);
 
   @protected
@@ -350,6 +366,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  RustStreamSink<SourceControlWatchSignal>
+  sse_decode_StreamSink_source_control_watch_signal_Sse(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   RustStreamSink<WorkspaceExplorerWatchBatch>
   sse_decode_StreamSink_workspace_explorer_watch_batch_Sse(
     SseDeserializer deserializer,
@@ -378,6 +400,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   GitChangeEntry sse_decode_box_autoadd_git_change_entry(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  SourceControlWatcherHandle
+  sse_decode_box_autoadd_source_control_watcher_handle(
     SseDeserializer deserializer,
   );
 
@@ -597,6 +625,16 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  SourceControlWatchSignal sse_decode_source_control_watch_signal(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  SourceControlWatcherHandle sse_decode_source_control_watcher_handle(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   int sse_decode_u_16(SseDeserializer deserializer);
 
   @protected
@@ -755,6 +793,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  void sse_encode_StreamSink_source_control_watch_signal_Sse(
+    RustStreamSink<SourceControlWatchSignal> self,
+    SseSerializer serializer,
+  );
+
+  @protected
   void sse_encode_StreamSink_workspace_explorer_watch_batch_Sse(
     RustStreamSink<WorkspaceExplorerWatchBatch> self,
     SseSerializer serializer,
@@ -787,6 +831,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_box_autoadd_git_change_entry(
     GitChangeEntry self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_box_autoadd_source_control_watcher_handle(
+    SourceControlWatcherHandle self,
     SseSerializer serializer,
   );
 
@@ -1054,6 +1104,18 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_opt_box_autoadd_workspace_file_git_status(
     WorkspaceFileGitStatus? self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_source_control_watch_signal(
+    SourceControlWatchSignal self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_source_control_watcher_handle(
+    SourceControlWatcherHandle self,
     SseSerializer serializer,
   );
 

--- a/rust/src/api/workspace_files.rs
+++ b/rust/src/api/workspace_files.rs
@@ -9,6 +9,7 @@ use ignore::WalkBuilder;
 
 mod editor_text;
 mod explorer_tree;
+mod source_control_watcher;
 mod watcher;
 
 use crate::frb_generated::StreamSink;
@@ -134,6 +135,16 @@ pub struct WorkspaceExplorerWatchBatch {
     pub coalesced_event_count: u32,
 }
 
+#[derive(Debug, Clone)]
+pub struct SourceControlWatcherHandle {
+    pub id: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct SourceControlWatchSignal {
+    pub coalesced_event_count: u32,
+}
+
 impl WorkspaceFileError {
     fn new(kind: WorkspaceFileErrorKind, context: impl Into<String>) -> Self {
         Self {
@@ -225,6 +236,23 @@ pub fn watch_workspace_explorer_events(
 
 pub fn stop_workspace_explorer_watcher(handle: WorkspaceExplorerWatcherHandle) {
     watcher::stop_workspace_explorer_watcher(handle);
+}
+
+pub fn start_source_control_watcher(
+    workspace_path: String,
+) -> Result<SourceControlWatcherHandle, WorkspaceFileError> {
+    source_control_watcher::start_source_control_watcher(workspace_path)
+}
+
+pub fn watch_source_control_events(
+    handle: SourceControlWatcherHandle,
+    sink: StreamSink<SourceControlWatchSignal>,
+) {
+    source_control_watcher::watch_source_control_events(handle, sink);
+}
+
+pub fn stop_source_control_watcher(handle: SourceControlWatcherHandle) {
+    source_control_watcher::stop_source_control_watcher(handle);
 }
 
 pub fn read_workspace_text_file(

--- a/rust/src/api/workspace_files/source_control_watcher.rs
+++ b/rust/src/api/workspace_files/source_control_watcher.rs
@@ -1,0 +1,242 @@
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{mpsc, Arc, Mutex, OnceLock};
+use std::thread;
+use std::time::Duration;
+
+use notify::{RecursiveMode, Watcher};
+
+use crate::frb_generated::StreamSink;
+
+use super::{
+    workspace_root, SourceControlWatchSignal, SourceControlWatcherHandle, WorkspaceFileError,
+    WorkspaceFileErrorKind,
+};
+
+const WATCH_DEBOUNCE_MILLIS: u64 = 180;
+const WATCH_IDLE_POLL_MILLIS: u64 = 100;
+
+static NEXT_WATCHER_ID: AtomicU64 = AtomicU64::new(1);
+static WATCHERS: OnceLock<Mutex<HashMap<String, SourceControlWatcherSession>>> = OnceLock::new();
+
+struct SourceControlWatcherSession {
+    // Held only to keep the OS watch alive; dropping it stops file notifications.
+    #[allow(dead_code)]
+    watcher: notify::RecommendedWatcher,
+    sink: Arc<Mutex<Option<StreamSink<SourceControlWatchSignal>>>>,
+    shutdown_tx: mpsc::Sender<()>,
+    thread: Option<thread::JoinHandle<()>>,
+}
+
+impl SourceControlWatcherSession {
+    fn stop(mut self) {
+        let _ = self.shutdown_tx.send(());
+        if let Some(thread) = self.thread.take() {
+            let _ = thread.join();
+        }
+    }
+}
+
+pub(super) fn start_source_control_watcher(
+    workspace_path: String,
+) -> Result<SourceControlWatcherHandle, WorkspaceFileError> {
+    let root = workspace_root(&workspace_path)?;
+    let id = NEXT_WATCHER_ID.fetch_add(1, Ordering::Relaxed).to_string();
+    let (event_tx, event_rx) = mpsc::channel::<notify::Result<notify::Event>>();
+    let (shutdown_tx, shutdown_rx) = mpsc::channel::<()>();
+    let sink = Arc::new(Mutex::new(None));
+    let mut watcher = notify::recommended_watcher(move |result| {
+        let _ = event_tx.send(result);
+    })
+    .map_err(notify_error)?;
+    // Recursive watch of the whole working tree, including `.git/`, so commits,
+    // branch switches, staging and out-of-app file edits all surface here.
+    watcher
+        .watch(&root, RecursiveMode::Recursive)
+        .map_err(notify_error)?;
+
+    let thread_sink = sink.clone();
+    let thread = thread::Builder::new()
+        .name(format!("alera-source-control-watch-{id}"))
+        .spawn(move || {
+            event_loop(thread_sink, event_rx, shutdown_rx);
+        })
+        .map_err(|error| WorkspaceFileError::from_io(error, "source control watcher"))?;
+
+    let session = SourceControlWatcherSession {
+        watcher,
+        sink,
+        shutdown_tx,
+        thread: Some(thread),
+    };
+    watchers()
+        .lock()
+        .map_err(|_| WorkspaceFileError::new(WorkspaceFileErrorKind::Io, "watcher lock poisoned"))?
+        .insert(id.clone(), session);
+    Ok(SourceControlWatcherHandle { id })
+}
+
+pub(super) fn watch_source_control_events(
+    handle: SourceControlWatcherHandle,
+    sink: StreamSink<SourceControlWatchSignal>,
+) {
+    let session_sink = {
+        let Ok(watchers) = watchers().lock() else {
+            return;
+        };
+        watchers.get(&handle.id).map(|session| session.sink.clone())
+    };
+    let Some(session_sink) = session_sink else {
+        return;
+    };
+    {
+        if let Ok(mut current_sink) = session_sink.lock() {
+            *current_sink = Some(sink);
+        };
+    }
+}
+
+pub(super) fn stop_source_control_watcher(handle: SourceControlWatcherHandle) {
+    let session = watchers()
+        .lock()
+        .ok()
+        .and_then(|mut watchers| watchers.remove(&handle.id));
+    if let Some(session) = session {
+        session.stop();
+    }
+}
+
+fn event_loop(
+    sink: Arc<Mutex<Option<StreamSink<SourceControlWatchSignal>>>>,
+    event_rx: mpsc::Receiver<notify::Result<notify::Event>>,
+    shutdown_rx: mpsc::Receiver<()>,
+) {
+    loop {
+        match collect_signal(&event_rx, &shutdown_rx) {
+            CollectOutcome::Signal(signal) => emit_signal(&sink, signal),
+            CollectOutcome::Idle => continue,
+            CollectOutcome::Shutdown => return,
+        }
+    }
+}
+
+enum CollectOutcome {
+    Signal(SourceControlWatchSignal),
+    Idle,
+    Shutdown,
+}
+
+/// Runs one debounce cycle: blocks (with idle polling) for a first event, then
+/// coalesces any further events arriving within the debounce window into a
+/// single signal. Kept independent of `notify` and `StreamSink` so the
+/// coalescing logic is unit-testable.
+fn collect_signal(
+    event_rx: &mpsc::Receiver<notify::Result<notify::Event>>,
+    shutdown_rx: &mpsc::Receiver<()>,
+) -> CollectOutcome {
+    if shutdown_rx.try_recv().is_ok() {
+        return CollectOutcome::Shutdown;
+    }
+    let first_event = match event_rx.recv_timeout(Duration::from_millis(WATCH_IDLE_POLL_MILLIS)) {
+        Ok(result) => result,
+        Err(mpsc::RecvTimeoutError::Timeout) => return CollectOutcome::Idle,
+        Err(mpsc::RecvTimeoutError::Disconnected) => return CollectOutcome::Shutdown,
+    };
+    let mut coalesced_event_count = u32::from(first_event.is_ok());
+
+    loop {
+        if shutdown_rx.try_recv().is_ok() {
+            return CollectOutcome::Shutdown;
+        }
+        match event_rx.recv_timeout(Duration::from_millis(WATCH_DEBOUNCE_MILLIS)) {
+            Ok(result) => {
+                if result.is_ok() {
+                    coalesced_event_count += 1;
+                }
+            }
+            Err(mpsc::RecvTimeoutError::Timeout) => break,
+            Err(mpsc::RecvTimeoutError::Disconnected) => return CollectOutcome::Shutdown,
+        }
+    }
+
+    if coalesced_event_count == 0 {
+        return CollectOutcome::Idle;
+    }
+    CollectOutcome::Signal(SourceControlWatchSignal {
+        coalesced_event_count,
+    })
+}
+
+fn emit_signal(
+    sink: &Arc<Mutex<Option<StreamSink<SourceControlWatchSignal>>>>,
+    signal: SourceControlWatchSignal,
+) {
+    let Ok(mut sink) = sink.lock() else {
+        return;
+    };
+    let Some(current_sink) = sink.as_ref() else {
+        return;
+    };
+    if current_sink.add(signal).is_err() {
+        *sink = None;
+    }
+}
+
+fn watchers() -> &'static Mutex<HashMap<String, SourceControlWatcherSession>> {
+    WATCHERS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn notify_error(error: notify::Error) -> WorkspaceFileError {
+    WorkspaceFileError::new(WorkspaceFileErrorKind::Io, error.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use notify::{Event, EventKind};
+
+    fn ok_event() -> notify::Result<Event> {
+        Ok(Event::new(EventKind::Modify(
+            notify::event::ModifyKind::Any,
+        )))
+    }
+
+    #[test]
+    fn coalesces_a_burst_into_one_signal() {
+        let (event_tx, event_rx) = mpsc::channel::<notify::Result<Event>>();
+        let (_shutdown_tx, shutdown_rx) = mpsc::channel::<()>();
+        for _ in 0..4 {
+            event_tx.send(ok_event()).unwrap();
+        }
+
+        match collect_signal(&event_rx, &shutdown_rx) {
+            CollectOutcome::Signal(signal) => {
+                assert_eq!(signal.coalesced_event_count, 4);
+            }
+            _ => panic!("expected a coalesced signal"),
+        }
+    }
+
+    #[test]
+    fn idles_when_no_events_arrive() {
+        let (_event_tx, event_rx) = mpsc::channel::<notify::Result<Event>>();
+        let (_shutdown_tx, shutdown_rx) = mpsc::channel::<()>();
+
+        assert!(matches!(
+            collect_signal(&event_rx, &shutdown_rx),
+            CollectOutcome::Idle
+        ));
+    }
+
+    #[test]
+    fn shuts_down_when_event_channel_disconnects() {
+        let (event_tx, event_rx) = mpsc::channel::<notify::Result<Event>>();
+        let (_shutdown_tx, shutdown_rx) = mpsc::channel::<()>();
+        drop(event_tx);
+
+        assert!(matches!(
+            collect_signal(&event_rx, &shutdown_rx),
+            CollectOutcome::Shutdown
+        ));
+    }
+}

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -38,7 +38,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.12.0";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 1569074570;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -1535239911;
 
 // Section: executor
 
@@ -1713,6 +1713,43 @@ fn wire__crate__api__agent_hooks__start_agent_hook_receiver_impl(
         },
     )
 }
+fn wire__crate__api__workspace_files__start_source_control_watcher_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "start_source_control_watcher",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_workspace_path = <String>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, crate::api::workspace_files::WorkspaceFileError>(
+                    (move || {
+                        let output_ok = crate::api::workspace_files::start_source_control_watcher(
+                            api_workspace_path,
+                        )?;
+                        Ok(output_ok)
+                    })(),
+                )
+            }
+        },
+    )
+}
 fn wire__crate__api__workspace_files__start_workspace_explorer_watcher_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
@@ -1778,6 +1815,43 @@ fn wire__crate__api__agent_hooks__stop_agent_hook_receiver_impl(
                 transform_result_sse::<_, ()>((move || {
                     let output_ok = Result::<_, ()>::Ok({
                         crate::api::agent_hooks::stop_agent_hook_receiver();
+                    })?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
+fn wire__crate__api__workspace_files__stop_source_control_watcher_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "stop_source_control_watcher",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_handle = <crate::api::workspace_files::SourceControlWatcherHandle>::sse_decode(
+                &mut deserializer,
+            );
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, ()>((move || {
+                    let output_ok = Result::<_, ()>::Ok({
+                        crate::api::workspace_files::stop_source_control_watcher(api_handle);
                     })?;
                     Ok(output_ok)
                 })())
@@ -1897,6 +1971,49 @@ fn wire__crate__api__agent_hooks__watch_agent_hook_event_batches_impl(
                 transform_result_sse::<_, ()>((move || {
                     let output_ok = Result::<_, ()>::Ok({
                         crate::api::agent_hooks::watch_agent_hook_event_batches(api_sink);
+                    })?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
+fn wire__crate__api__workspace_files__watch_source_control_events_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "watch_source_control_events",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_handle = <crate::api::workspace_files::SourceControlWatcherHandle>::sse_decode(
+                &mut deserializer,
+            );
+            let api_sink = <StreamSink<
+                crate::api::workspace_files::SourceControlWatchSignal,
+                flutter_rust_bridge::for_generated::SseCodec,
+            >>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, ()>((move || {
+                    let output_ok = Result::<_, ()>::Ok({
+                        crate::api::workspace_files::watch_source_control_events(
+                            api_handle, api_sink,
+                        );
                     })?;
                     Ok(output_ok)
                 })())
@@ -2059,6 +2176,19 @@ impl SseDecode for flutter_rust_bridge::for_generated::anyhow::Error {
 impl SseDecode
     for StreamSink<
         crate::api::agent_hooks::AgentHookEventBatchDto,
+        flutter_rust_bridge::for_generated::SseCodec,
+    >
+{
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut inner = <String>::sse_decode(deserializer);
+        return StreamSink::deserialize(inner);
+    }
+}
+
+impl SseDecode
+    for StreamSink<
+        crate::api::workspace_files::SourceControlWatchSignal,
         flutter_rust_bridge::for_generated::SseCodec,
     >
 {
@@ -2771,6 +2901,24 @@ impl SseDecode for Option<crate::api::workspace_files::WorkspaceFileGitStatus> {
     }
 }
 
+impl SseDecode for crate::api::workspace_files::SourceControlWatchSignal {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_coalescedEventCount = <u32>::sse_decode(deserializer);
+        return crate::api::workspace_files::SourceControlWatchSignal {
+            coalesced_event_count: var_coalescedEventCount,
+        };
+    }
+}
+
+impl SseDecode for crate::api::workspace_files::SourceControlWatcherHandle {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_id = <String>::sse_decode(deserializer);
+        return crate::api::workspace_files::SourceControlWatcherHandle { id: var_id };
+    }
+}
+
 impl SseDecode for u16 {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -3372,49 +3520,67 @@ fn pde_ffi_dispatcher_primary_impl(
             rust_vec_len,
             data_len,
         ),
-        47 => wire__crate__api__workspace_files__start_workspace_explorer_watcher_impl(
+        47 => wire__crate__api__workspace_files__start_source_control_watcher_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        48 => wire__crate__api__agent_hooks__stop_agent_hook_receiver_impl(
+        48 => wire__crate__api__workspace_files__start_workspace_explorer_watcher_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        49 => wire__crate__api__workspace_files__stop_workspace_explorer_watcher_impl(
+        49 => wire__crate__api__agent_hooks__stop_agent_hook_receiver_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        50 => wire__crate__api__workspace_files__update_workspace_explorer_watcher_impl(
+        50 => wire__crate__api__workspace_files__stop_source_control_watcher_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        51 => wire__crate__api__agent_hooks__watch_agent_hook_event_batches_impl(
+        51 => wire__crate__api__workspace_files__stop_workspace_explorer_watcher_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        52 => wire__crate__api__workspace_files__watch_workspace_explorer_events_impl(
+        52 => wire__crate__api__workspace_files__update_workspace_explorer_watcher_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        53 => wire__crate__api__workspace_files__write_workspace_editor_text_file_impl(
+        53 => wire__crate__api__agent_hooks__watch_agent_hook_event_batches_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        54 => wire__crate__api__workspace_files__write_workspace_text_file_impl(
+        54 => wire__crate__api__workspace_files__watch_source_control_events_impl(
+            port,
+            ptr,
+            rust_vec_len,
+            data_len,
+        ),
+        55 => wire__crate__api__workspace_files__watch_workspace_explorer_events_impl(
+            port,
+            ptr,
+            rust_vec_len,
+            data_len,
+        ),
+        56 => wire__crate__api__workspace_files__write_workspace_editor_text_file_impl(
+            port,
+            ptr,
+            rust_vec_len,
+            data_len,
+        ),
+        57 => wire__crate__api__workspace_files__write_workspace_text_file_impl(
             port,
             ptr,
             rust_vec_len,
@@ -3942,6 +4108,40 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::merman_viewer::MermanWorkspac
     for crate::api::merman_viewer::MermanWorkspaceRender
 {
     fn into_into_dart(self) -> crate::api::merman_viewer::MermanWorkspaceRender {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::workspace_files::SourceControlWatchSignal {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [self.coalesced_event_count.into_into_dart().into_dart()].into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::workspace_files::SourceControlWatchSignal
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::workspace_files::SourceControlWatchSignal>
+    for crate::api::workspace_files::SourceControlWatchSignal
+{
+    fn into_into_dart(self) -> crate::api::workspace_files::SourceControlWatchSignal {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::workspace_files::SourceControlWatcherHandle {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [self.id.into_into_dart().into_dart()].into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::workspace_files::SourceControlWatcherHandle
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::workspace_files::SourceControlWatcherHandle>
+    for crate::api::workspace_files::SourceControlWatcherHandle
+{
+    fn into_into_dart(self) -> crate::api::workspace_files::SourceControlWatcherHandle {
         self
     }
 }
@@ -4574,6 +4774,18 @@ impl SseEncode
 
 impl SseEncode
     for StreamSink<
+        crate::api::workspace_files::SourceControlWatchSignal,
+        flutter_rust_bridge::for_generated::SseCodec,
+    >
+{
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        unimplemented!("")
+    }
+}
+
+impl SseEncode
+    for StreamSink<
         crate::api::workspace_files::WorkspaceExplorerWatchBatch,
         flutter_rust_bridge::for_generated::SseCodec,
     >
@@ -5131,6 +5343,20 @@ impl SseEncode for Option<crate::api::workspace_files::WorkspaceFileGitStatus> {
         if let Some(value) = self {
             <crate::api::workspace_files::WorkspaceFileGitStatus>::sse_encode(value, serializer);
         }
+    }
+}
+
+impl SseEncode for crate::api::workspace_files::SourceControlWatchSignal {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <u32>::sse_encode(self.coalesced_event_count, serializer);
+    }
+}
+
+impl SseEncode for crate::api::workspace_files::SourceControlWatcherHandle {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <String>::sse_encode(self.id, serializer);
     }
 }
 

--- a/test/unit/fake_source_control_watcher.dart
+++ b/test/unit/fake_source_control_watcher.dart
@@ -37,9 +37,7 @@ class FakeSourceControlWatcher extends SourceControlWatcher {
   }
 
   @override
-  Future<void> stop({
-    required native.SourceControlWatcherHandle handle,
-  }) async {
+  Future<void> stop({required native.SourceControlWatcherHandle handle}) async {
     stopCount += 1;
   }
 

--- a/test/unit/fake_source_control_watcher.dart
+++ b/test/unit/fake_source_control_watcher.dart
@@ -1,0 +1,47 @@
+import 'dart:async';
+
+import 'package:alera/src/features/workbench/application/source_control_watcher.dart';
+import 'package:alera/src/rust/api/workspace_files.dart' as native;
+
+/// In-memory [SourceControlWatcher] for tests: lets a test drive watch signals
+/// without touching the filesystem or the native bridge.
+class FakeSourceControlWatcher extends SourceControlWatcher {
+  FakeSourceControlWatcher();
+
+  final StreamController<native.SourceControlWatchSignal> _signals =
+      StreamController<native.SourceControlWatchSignal>.broadcast();
+
+  int startCount = 0;
+  int stopCount = 0;
+
+  /// Emits a watch signal, mimicking an external file or `.git/` change.
+  void emitChange({int coalescedEventCount = 1}) {
+    _signals.add(
+      native.SourceControlWatchSignal(coalescedEventCount: coalescedEventCount),
+    );
+  }
+
+  @override
+  Future<native.SourceControlWatcherHandle> start({
+    required String workspacePath,
+  }) async {
+    startCount += 1;
+    return const native.SourceControlWatcherHandle(id: 'fake');
+  }
+
+  @override
+  Stream<native.SourceControlWatchSignal> events({
+    required native.SourceControlWatcherHandle handle,
+  }) {
+    return _signals.stream;
+  }
+
+  @override
+  Future<void> stop({
+    required native.SourceControlWatcherHandle handle,
+  }) async {
+    stopCount += 1;
+  }
+
+  Future<void> dispose() => _signals.close();
+}

--- a/test/unit/workspace_source_control_controller_test.dart
+++ b/test/unit/workspace_source_control_controller_test.dart
@@ -1,0 +1,125 @@
+import 'dart:async';
+
+import 'package:alera/src/features/workbench/application/source_control_watcher.dart';
+import 'package:alera/src/features/workbench/application/workspace_source_control_controller.dart';
+import 'package:alera/src/shared/infra/git/git_diff_models.dart';
+import 'package:alera/src/shared/infra/git/git_providers.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'fake_git_backend.dart';
+import 'fake_source_control_watcher.dart';
+
+const _workspacePath = '/tmp/workspace';
+
+GitStatusResult _statusWith(int entryCount) {
+  return GitStatusResult(
+    entries: <GitChangeEntry>[
+      for (var index = 0; index < entryCount; index += 1)
+        GitChangeEntry(
+          path: 'file_$index.dart',
+          area: GitChangeArea.unstaged,
+          status: GitChangeStatus.modified,
+          added: 1,
+          removed: 0,
+        ),
+    ],
+  );
+}
+
+Future<(ProviderContainer, WorkspaceSourceControlController)> _boot(
+  FakeGitBackend backend,
+  FakeSourceControlWatcher watcher,
+) async {
+  final container = ProviderContainer(
+    overrides: [
+      gitBackendProvider.overrideWithValue(backend),
+      sourceControlWatcherProvider.overrideWithValue(watcher),
+    ],
+  );
+  final provider = workspaceSourceControlControllerProvider(_workspacePath);
+  final subscription = container.listen(provider, (_, _) {});
+  addTearDown(subscription.close);
+  addTearDown(container.dispose);
+  await container.read(provider.future);
+  // Let the best-effort, unawaited watcher subscription attach.
+  await Future<void>.delayed(const Duration(milliseconds: 10));
+  return (container, container.read(provider.notifier));
+}
+
+void main() {
+  test('a watch signal reloads source control state', () async {
+    final backend = FakeGitBackend()..gitStatusResult = _statusWith(1);
+    final watcher = FakeSourceControlWatcher();
+    addTearDown(watcher.dispose);
+    final (container, _) = await _boot(backend, watcher);
+    final provider = workspaceSourceControlControllerProvider(_workspacePath);
+
+    expect(container.read(provider).requireValue.status.entries, hasLength(1));
+    expect(watcher.startCount, 1);
+
+    // Simulate an external change picked up by the native watcher.
+    backend.gitStatusResult = _statusWith(3);
+    watcher.emitChange();
+    await Future<void>.delayed(const Duration(milliseconds: 350));
+
+    expect(container.read(provider).requireValue.status.entries, hasLength(3));
+  });
+
+  test('watch signals are deferred while an action is in flight', () async {
+    final backend = _BlockingFetchGitBackend()..gitStatusResult = _statusWith(1);
+    final watcher = FakeSourceControlWatcher();
+    addTearDown(watcher.dispose);
+    final (container, controller) = await _boot(backend, watcher);
+    final provider = workspaceSourceControlControllerProvider(_workspacePath);
+
+    final fetchFuture = controller.fetch();
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+    expect(container.read(provider).requireValue.isBusy, isTrue);
+
+    // External change arrives mid-action: it must not reload yet.
+    backend.gitStatusResult = _statusWith(5);
+    watcher.emitChange();
+    await Future<void>.delayed(const Duration(milliseconds: 350));
+    expect(container.read(provider).requireValue.status.entries, hasLength(1));
+    expect(container.read(provider).requireValue.isBusy, isTrue);
+
+    // Action completes and reloads, surfacing the latest status.
+    backend.gate.complete();
+    await fetchFuture;
+    expect(container.read(provider).requireValue.isBusy, isFalse);
+    expect(container.read(provider).requireValue.status.entries, hasLength(5));
+  });
+
+  test('disposing the controller stops the watcher', () async {
+    final backend = FakeGitBackend()..gitStatusResult = _statusWith(0);
+    final watcher = FakeSourceControlWatcher();
+    addTearDown(watcher.dispose);
+    final container = ProviderContainer(
+      overrides: [
+        gitBackendProvider.overrideWithValue(backend),
+        sourceControlWatcherProvider.overrideWithValue(watcher),
+      ],
+    );
+    final provider = workspaceSourceControlControllerProvider(_workspacePath);
+    final subscription = container.listen(provider, (_, _) {});
+    await container.read(provider.future);
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+    expect(watcher.startCount, 1);
+
+    subscription.close();
+    container.dispose();
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+
+    expect(watcher.stopCount, 1);
+  });
+}
+
+class _BlockingFetchGitBackend extends FakeGitBackend {
+  final Completer<void> gate = Completer<void>();
+
+  @override
+  Future<void> fetch(String path) async {
+    await gate.future;
+  }
+}

--- a/test/unit/workspace_source_control_controller_test.dart
+++ b/test/unit/workspace_source_control_controller_test.dart
@@ -67,7 +67,8 @@ void main() {
   });
 
   test('watch signals are deferred while an action is in flight', () async {
-    final backend = _BlockingFetchGitBackend()..gitStatusResult = _statusWith(1);
+    final backend = _BlockingFetchGitBackend()
+      ..gitStatusResult = _statusWith(1);
     final watcher = FakeSourceControlWatcher();
     addTearDown(watcher.dispose);
     final (container, controller) = await _boot(backend, watcher);

--- a/test/widget/workspace_git_diff_panel_test.dart
+++ b/test/widget/workspace_git_diff_panel_test.dart
@@ -6,6 +6,7 @@ import 'package:alera/src/features/ai_text_generation/application/ai_text_genera
 import 'package:alera/src/features/ai_text_generation/domain/ai_text_generation_settings.dart';
 import 'package:alera/src/features/settings/application/settings_controller.dart';
 import 'package:alera/src/features/settings/domain/alera_settings.dart';
+import 'package:alera/src/features/workbench/application/source_control_watcher.dart';
 import 'package:alera/src/features/workbench/application/workspace_source_control_controller.dart';
 import 'package:alera/src/features/workbench/domain/workbench_view_prefs.dart';
 import 'package:alera/src/features/workbench/domain/workspace.dart';
@@ -19,6 +20,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import '../unit/fake_git_backend.dart';
+import '../unit/fake_source_control_watcher.dart';
 
 void main() {
   testWidgets('git diff panel hides zero-valued line counts', (tester) async {
@@ -39,6 +41,9 @@ void main() {
       ProviderScope(
         overrides: [
           gitBackendProvider.overrideWithValue(backend),
+          sourceControlWatcherProvider.overrideWithValue(
+            FakeSourceControlWatcher(),
+          ),
           settingsControllerProvider.overrideWith(
             () => _PanelSettingsController(AleraSettings.defaults),
           ),
@@ -88,6 +93,9 @@ void main() {
       ProviderScope(
         overrides: [
           gitBackendProvider.overrideWithValue(backend),
+          sourceControlWatcherProvider.overrideWithValue(
+            FakeSourceControlWatcher(),
+          ),
           settingsControllerProvider.overrideWith(
             () => _PanelSettingsController(AleraSettings.defaults),
           ),
@@ -716,7 +724,12 @@ void main() {
     final backend = FakeGitBackend()
       ..gitRepositoryStateResult = const GitRepositoryState(branch: 'feature');
     final container = ProviderContainer(
-      overrides: [gitBackendProvider.overrideWithValue(backend)],
+      overrides: [
+        gitBackendProvider.overrideWithValue(backend),
+        sourceControlWatcherProvider.overrideWithValue(
+          FakeSourceControlWatcher(),
+        ),
+      ],
     );
     addTearDown(container.dispose);
     final provider = workspaceSourceControlControllerProvider('/tmp/project');
@@ -988,6 +1001,9 @@ Future<void> _pumpPanel(
     ProviderScope(
       overrides: [
         gitBackendProvider.overrideWithValue(backend),
+        sourceControlWatcherProvider.overrideWithValue(
+          FakeSourceControlWatcher(),
+        ),
         settingsControllerProvider.overrideWith(
           () => _PanelSettingsController(settings),
         ),


### PR DESCRIPTION
## summary

The source control panel only refreshed on manual action or after its own git operations, so file edits, commits, branch switches or staging done outside the panel (e.g. from a terminal) left the list stale until the user pressed refresh.

This adds event-driven auto-refresh:

- a native recursive watcher (`rust/src/api/workspace_files/source_control_watcher.rs`) watches the whole working tree, including `.git/`, and emits a coalesced `SourceControlWatchSignal` after a short debounce
- a `SourceControlWatcher` Riverpod provider is wired into `WorkspaceSourceControlController`: it debounces reloads (~250 ms), defers them while an action is in flight, preserves the in-progress commit message (which lives in the widget, not the state), and stops the watcher on dispose
- manual refresh remains the fallback if the watcher fails to start

## validation

- `make rust-test` (fmt/clippy/test): 120 passed, including new coalescing tests
- `flutter test` for the new unit tests and the source control widget tests: 29 passed
- `flutter analyze`: clean

## notes

- FRB bindings were regenerated (`make frb-generate`) and committed
- no docs reference source control refresh behavior, so none needed updating