### PR TITLE
fix: update xterm shift enter handling

### DIFF
--- a/test/unit/xterm_regression_test.dart
+++ b/test/unit/xterm_regression_test.dart
@@ -2,6 +2,15 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:xterm/xterm.dart';
 
 void main() {
+  test('xterm preserves Shift+Enter as CSI-u input', () {
+    final output = <String>[];
+    final terminal = Terminal(onOutput: output.add);
+
+    terminal.keyInput(TerminalKey.enter, shift: true);
+
+    expect(output, <String>['\x1b[13;2u']);
+  });
+
   test('xterm handles resize while scrollback and margins are active', () {
     final terminal = Terminal(maxLines: 120, reflowEnabled: false);
 


### PR DESCRIPTION
## Summary
- update the vendored xterm submodule to emit CSI-u for Shift+Enter
- add an Alera regression that verifies Shift+Enter is preserved as CSI-u

## Validation
- flutter test test/src/core/input/handler_test.dart (in third_party/xterm)
- flutter test test/unit/xterm_regression_test.dart
- flutter test test/unit/terminal_runtime_native_test.dart
- flutter test test/widget/terminal_surface_test.dart

## Notes
- The xterm fix is published on leynier/xterm.dart branch fix/shift-enter-csi-u at eb4e231.