### PR TITLE
feat: improve left side panel

### DIFF
--- a/lib/src/app/providers.dart
+++ b/lib/src/app/providers.dart
@@ -14,3 +14,8 @@ export 'package:alera/src/features/updater/application/update_controller.dart'
 export 'package:alera/src/features/workbench/application/workbench_controller.dart'
     show WorkbenchController, workbenchControllerProvider;
 export 'package:alera/src/features/workbench/application/workbench_providers.dart';
+export 'package:alera/src/features/workbench/application/workspace_activity_controller.dart'
+    show
+        WorkspaceActivityController,
+        workspaceActivityControllerProvider,
+        workspaceActivityCoordinatorProvider;

--- a/lib/src/design_system/forms/alera_dropdown_field.dart
+++ b/lib/src/design_system/forms/alera_dropdown_field.dart
@@ -28,6 +28,7 @@ class AleraDropdownField<T> extends StatelessWidget {
     required this.entries,
     required this.onChanged,
     this.hintText,
+    this.labelText,
     this.enabled = true,
   });
 
@@ -35,6 +36,7 @@ class AleraDropdownField<T> extends StatelessWidget {
   final List<AleraDropdownFieldEntry<T>> entries;
   final ValueChanged<T> onChanged;
   final String? hintText;
+  final String? labelText;
   final bool enabled;
 
   static const double _height = 34;
@@ -44,20 +46,52 @@ class AleraDropdownField<T> extends StatelessWidget {
     final overlay =
         Overlay.of(context).context.findRenderObject()! as RenderBox;
     final origin = box.localToGlobal(Offset.zero, ancestor: overlay);
+    final position = RelativeRect.fromLTRB(
+      origin.dx,
+      origin.dy + box.size.height + AleraTokens.space4,
+      overlay.size.width - origin.dx - box.size.width,
+      overlay.size.height - origin.dy,
+    );
+    final constraints = BoxConstraints(minWidth: box.size.width);
+    final shape = RoundedRectangleBorder(
+      borderRadius: BorderRadius.circular(AleraTokens.radiusMd),
+      side: const BorderSide(color: AleraTokens.border),
+    );
+    if (entries.any((entry) => entry.value == null)) {
+      // A null-valued entry (e.g. "No Parent") is indistinguishable from a
+      // dismissed menu when popped as a value, so resolve by entry index.
+      final selectedIndex = await showMenu<int>(
+        context: context,
+        position: position,
+        constraints: constraints,
+        color: AleraTokens.surface,
+        shape: shape,
+        items: <PopupMenuEntry<int>>[
+          for (final (index, entry) in entries.indexed)
+            AleraDropdownEntry<int>(
+              value: index,
+              label: entry.label,
+              leading: entry.leading,
+              selected: entry.value == value,
+              enabled: entry.enabled,
+            ),
+        ],
+      );
+      if (selectedIndex == null) {
+        return;
+      }
+      final selected = entries[selectedIndex].value;
+      if (selected != value) {
+        onChanged(selected);
+      }
+      return;
+    }
     final selected = await showMenu<T>(
       context: context,
-      position: RelativeRect.fromLTRB(
-        origin.dx,
-        origin.dy + box.size.height + AleraTokens.space4,
-        overlay.size.width - origin.dx - box.size.width,
-        overlay.size.height - origin.dy,
-      ),
-      constraints: BoxConstraints(minWidth: box.size.width),
+      position: position,
+      constraints: constraints,
       color: AleraTokens.surface,
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(AleraTokens.radiusMd),
-        side: const BorderSide(color: AleraTokens.border),
-      ),
+      shape: shape,
       items: <PopupMenuEntry<T>>[
         for (final entry in entries)
           AleraDropdownEntry<T>(
@@ -89,7 +123,7 @@ class AleraDropdownField<T> extends StatelessWidget {
         : current == null
         ? AleraTokens.foregroundMuted
         : AleraTokens.foreground;
-    return Semantics(
+    final field = Semantics(
       button: true,
       enabled: enabled,
       label: current?.label ?? hintText,
@@ -135,6 +169,24 @@ class AleraDropdownField<T> extends StatelessWidget {
           ),
         ),
       ),
+    );
+    final label = labelText;
+    if (label == null) {
+      return field;
+    }
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: <Widget>[
+        Text(
+          label,
+          style: theme.textTheme.labelSmall?.copyWith(
+            color: AleraTokens.foregroundMuted,
+          ),
+        ),
+        const SizedBox(height: AleraTokens.space4),
+        field,
+      ],
     );
   }
 }

--- a/lib/src/design_system/forms/alera_dropdown_field.preview.dart
+++ b/lib/src/design_system/forms/alera_dropdown_field.preview.dart
@@ -35,6 +35,20 @@ Widget aleraDropdownFieldPlaceholderPreview() => const SizedBox(
   ),
 );
 
+@AleraPreview(name: 'Labeled', group: 'Dropdown field', size: Size(280, 110))
+Widget aleraDropdownFieldLabeledPreview() => const SizedBox(
+  width: 220,
+  child: AleraDropdownField<String>(
+    value: 'agent',
+    labelText: 'Auth Method',
+    entries: <AleraDropdownFieldEntry<String>>[
+      AleraDropdownFieldEntry<String>(value: 'agent', label: 'SSH Agent'),
+      AleraDropdownFieldEntry<String>(value: 'key', label: 'Private Key'),
+    ],
+    onChanged: _ignoreValue,
+  ),
+);
+
 @AleraPreview(name: 'Disabled', group: 'Dropdown field', size: Size(280, 90))
 Widget aleraDropdownFieldDisabledPreview() => const SizedBox(
   width: 220,

--- a/lib/src/features/shell/presentation/alera_shell_page.dart
+++ b/lib/src/features/shell/presentation/alera_shell_page.dart
@@ -106,6 +106,8 @@ class _AleraShellPageBodyState extends ConsumerState<_AleraShellPageBody> {
     ref.watch(agentStatusNotificationCoordinatorProvider);
     ref.watch(agentAwakeCoordinatorProvider);
     ref.watch(terminalRuntimeExitCoordinatorProvider);
+    ref.watch(workspaceActivityCoordinatorProvider);
+    ref.watch(workspaceActivityPersistenceCoordinatorProvider);
     final state = ref.watch(workbenchControllerProvider);
     final error = state.error;
     if (error != null && error != _lastErrorMessage) {

--- a/lib/src/features/workbench/application/workbench_agent_activity_sort.dart
+++ b/lib/src/features/workbench/application/workbench_agent_activity_sort.dart
@@ -1,0 +1,136 @@
+import 'package:alera/src/features/agent_status/domain/agent_status.dart';
+import 'package:alera/src/features/workbench/application/workspace_agent_status_projection.dart';
+import 'package:alera/src/features/workbench/domain/workspace_tab_record.dart';
+
+/// Urgency buckets for the Agent Activity sort. Ordinal order is sort order:
+/// agents needing input outrank finished ones, which outrank running ones.
+enum AgentAttentionClass { needsYou, done, working, idle }
+
+/// Agent statuses older than this no longer influence the Agent Activity
+/// ordering; stale runs fall back to the workspace recency timestamp.
+const Duration agentActivityStaleness = Duration(minutes: 30);
+
+class WorkspaceAttention {
+  const WorkspaceAttention({required this.attentionClass, this.attentionAt});
+
+  static const WorkspaceAttention idle = WorkspaceAttention(
+    attentionClass: AgentAttentionClass.idle,
+  );
+
+  final AgentAttentionClass attentionClass;
+
+  /// When the most urgent run entered its current state. Null for idle.
+  final DateTime? attentionAt;
+}
+
+/// Classifies a workspace by its live agent runs for the Agent Activity sort.
+WorkspaceAttention workspaceAttention({
+  required Iterable<WorkspaceTabRecord> tabs,
+  required Map<String, AgentStatusEntry> agentStatuses,
+  required DateTime now,
+}) {
+  var best = WorkspaceAttention.idle;
+  final runs = visibleWorkspaceAgentRuns(
+    tabs: tabs,
+    agentStatuses: agentStatuses,
+  );
+  for (final run in runs) {
+    final status = run.status;
+    if (now.difference(status.updatedAt) > agentActivityStaleness) {
+      continue;
+    }
+    final candidate = WorkspaceAttention(
+      attentionClass: _classify(status),
+      attentionAt: status.stateStartedAt,
+    );
+    if (_moreUrgent(candidate, best)) {
+      best = candidate;
+    }
+  }
+  return best;
+}
+
+AgentAttentionClass _classify(AgentStatusEntry status) {
+  if (status.interrupted ?? false) {
+    return AgentAttentionClass.needsYou;
+  }
+  return switch (status.state) {
+    AgentStatusState.waiting ||
+    AgentStatusState.blocked => AgentAttentionClass.needsYou,
+    AgentStatusState.done => AgentAttentionClass.done,
+    AgentStatusState.working => AgentAttentionClass.working,
+  };
+}
+
+bool _moreUrgent(WorkspaceAttention a, WorkspaceAttention b) {
+  if (a.attentionClass != b.attentionClass) {
+    return a.attentionClass.index < b.attentionClass.index;
+  }
+  final aAt = a.attentionAt;
+  final bAt = b.attentionAt;
+  if (aAt == null || bAt == null) {
+    return bAt == null && aAt != null;
+  }
+  return aAt.isAfter(bAt);
+}
+
+/// Comparator for the Agent Activity sort: urgency class ascending, then the
+/// attention (or fallback recency) timestamp descending, then name.
+int compareByAgentActivity({
+  required WorkspaceAttention aAttention,
+  required DateTime aFallback,
+  required String aName,
+  required WorkspaceAttention bAttention,
+  required DateTime bFallback,
+  required String bName,
+}) {
+  final byClass = aAttention.attentionClass.index.compareTo(
+    bAttention.attentionClass.index,
+  );
+  if (byClass != 0) {
+    return byClass;
+  }
+  final aAt = aAttention.attentionAt ?? aFallback;
+  final bAt = bAttention.attentionAt ?? bFallback;
+  final byTime = bAt.compareTo(aAt);
+  if (byTime != 0) {
+    return byTime;
+  }
+  return aName.toLowerCase().compareTo(bName.toLowerCase());
+}
+
+/// Mutable holder for the workspace order of the last sidebar render. Owned by
+/// a keep-alive provider so [buildSidebarRows] can stay pure while the active
+/// row keeps its position across rebuilds.
+class SidebarOrderMemory {
+  List<String> order = const <String>[];
+}
+
+/// Re-inserts the active workspace at the index it occupied in the previously
+/// rendered order so live status changes never reorder the row the user is
+/// interacting with.
+List<T> stabilizeActiveEntry<T>({
+  required List<T> sorted,
+  required String Function(T) idOf,
+  required List<String> previousOrder,
+  required String? activeId,
+}) {
+  if (activeId == null) {
+    return sorted;
+  }
+  final currentIndex = sorted.indexWhere((entry) => idOf(entry) == activeId);
+  if (currentIndex < 0) {
+    return sorted;
+  }
+  final previousIndex = previousOrder.indexOf(activeId);
+  if (previousIndex < 0 || previousIndex == currentIndex) {
+    return sorted;
+  }
+  final result = List<T>.from(sorted);
+  final entry = result.removeAt(currentIndex);
+  result.insert(
+    previousIndex >= result.length ? result.length : previousIndex,
+    entry,
+  );
+  return result;
+}

--- a/lib/src/features/workbench/application/workbench_controller.dart
+++ b/lib/src/features/workbench/application/workbench_controller.dart
@@ -10,6 +10,7 @@ import 'package:alera/src/features/workbench/application/workbench_repository.da
 import 'package:alera/src/features/workbench/application/workbench_providers.dart';
 import 'package:alera/src/features/workbench/application/workbench_state.dart';
 import 'package:alera/src/features/workbench/application/workbench_view_prefs_repository.dart';
+import 'package:alera/src/features/workbench/application/workspace_activity_controller.dart';
 import 'package:alera/src/features/workbench/application/workspace_file_preview_kind.dart';
 import 'package:alera/src/features/workbench/application/workspace_graph_repository.dart';
 import 'package:alera/src/features/workbench/application/workspace_service.dart';

--- a/lib/src/features/workbench/application/workbench_controller_projects.dart
+++ b/lib/src/features/workbench/application/workbench_controller_projects.dart
@@ -127,6 +127,9 @@ mixin _WorkbenchControllerProjects
         workspace: workspace,
         deleteBranch: deleteBranch,
       );
+      ref
+          .read(workspaceActivityControllerProvider.notifier)
+          .removeWorkspace(workspace.id);
       state = state.copyWith(error: null);
     } catch (error) {
       state = state.copyWith(error: error.toString());
@@ -186,6 +189,16 @@ mixin _WorkbenchControllerProjects
       throw WorkspaceException('Tag Name Is Required');
     }
     try {
+      // Tag names are unique case-insensitively in the runtime store, so a
+      // duplicate name reuses the existing tag instead of minting a new id.
+      final lowered = trimmed.toLowerCase();
+      final existing = (await _workspaceGraphRepository.listTags())
+          .where((tag) => tag.name.toLowerCase() == lowered)
+          .firstOrNull;
+      if (existing != null) {
+        state = state.copyWith(error: null);
+        return existing;
+      }
       final tag = await _workspaceGraphRepository.upsertTag(
         WorkspaceTag.create(name: trimmed),
       );

--- a/lib/src/features/workbench/application/workbench_controller_tabs.dart
+++ b/lib/src/features/workbench/application/workbench_controller_tabs.dart
@@ -15,6 +15,9 @@ mixin _WorkbenchControllerTabs
       final groupId = targetGroupId ?? layout.activeGroupId;
       final nextLayout = layout.addTabToGroup(groupId: groupId, tabId: tab.id);
       await _applyLayout(nextLayout.sanitize(tabs), persist: true);
+      ref
+          .read(workspaceActivityControllerProvider.notifier)
+          .recordActivity(workspace.id, DateTime.now().toUtc());
       state = state.copyWith(error: null);
       return tab;
     } catch (error) {

--- a/lib/src/features/workbench/application/workbench_controller_view_prefs.dart
+++ b/lib/src/features/workbench/application/workbench_controller_view_prefs.dart
@@ -76,6 +76,55 @@ mixin _WorkbenchControllerViewPrefs
     );
   }
 
+  void toggleTagFilter(String tagId) {
+    final next = Set<String>.from(state.viewPrefs.selectedTagIds);
+    if (!next.add(tagId)) {
+      next.remove(tagId);
+    }
+    _updateViewPrefs(state.viewPrefs.copyWith(selectedTagIds: next));
+  }
+
+  void addTagFilter(String tagId) {
+    final current = state.viewPrefs.selectedTagIds;
+    if (current.contains(tagId)) {
+      return;
+    }
+    _updateViewPrefs(
+      state.viewPrefs.copyWith(selectedTagIds: <String>{...current, tagId}),
+    );
+  }
+
+  void removeTagFilter(String tagId) {
+    final current = state.viewPrefs.selectedTagIds;
+    if (!current.contains(tagId)) {
+      return;
+    }
+    _updateViewPrefs(
+      state.viewPrefs.copyWith(
+        selectedTagIds: current.where((id) => id != tagId).toSet(),
+      ),
+    );
+  }
+
+  void clearTagFilters() {
+    if (state.viewPrefs.selectedTagIds.isEmpty) {
+      return;
+    }
+    _updateViewPrefs(
+      state.viewPrefs.copyWith(selectedTagIds: const <String>{}),
+    );
+  }
+
+  void toggleParentWorkspaceCollapsed(String workspaceId) {
+    final next = Set<String>.from(state.viewPrefs.collapsedParentWorkspaceIds);
+    if (!next.add(workspaceId)) {
+      next.remove(workspaceId);
+    }
+    _updateViewPrefs(
+      state.viewPrefs.copyWith(collapsedParentWorkspaceIds: next),
+    );
+  }
+
   /// Collapses or expands the appropriate items depending on the active group
   /// mode. In [WorkbenchGroupBy.project] this toggles every visible project
   /// group; in [WorkbenchGroupBy.none] it toggles the sidebar-visible agent-run

--- a/lib/src/features/workbench/application/workbench_listing.dart
+++ b/lib/src/features/workbench/application/workbench_listing.dart
@@ -1,5 +1,7 @@
 import 'package:alera/src/features/agent_status/domain/agent_status.dart';
 import 'package:alera/src/features/projects/domain/project.dart';
+import 'package:alera/src/features/workbench/application/workbench_agent_activity_sort.dart';
+import 'package:alera/src/features/workbench/application/workbench_listing_tree.dart';
 import 'package:alera/src/features/workbench/application/workspace_agent_status_projection.dart';
 import 'package:alera/src/features/workbench/application/workbench_state.dart';
 import 'package:alera/src/features/workbench/domain/workspace_tab_record.dart';
@@ -32,12 +34,18 @@ class WorkbenchWorkspaceRow extends WorkbenchSidebarRow {
     required this.showProjectChip,
     required this.indent,
     required this.expanded,
+    this.hasVisibleChildren = false,
+    this.childrenCollapsed = false,
   });
 
   final Project project;
   final Workspace workspace;
   final bool showProjectChip;
   final bool expanded;
+
+  /// Whether child workspaces are nested (or collapsed) under this row.
+  final bool hasVisibleChildren;
+  final bool childrenCollapsed;
 
   /// How deeply the row should be indented from the left edge of the sidebar
   /// (in token-space units). `0` for top-level rows, `1` for workspaces inside
@@ -61,13 +69,22 @@ class SidebarAgentRunRow extends WorkbenchSidebarRow {
 
 /// Builds the flat list of rows the sidebar should render for the current
 /// [state]. Pure function — easy to unit test.
+///
+/// [lastActivityByWorkspaceId] supplies the persisted recency fallback for the
+/// Agent Activity sort; [previousWorkspaceOrder] is the workspace-id order of
+/// the previous render, used to keep the active workspace pinned in place
+/// while live statuses reshuffle its siblings.
 List<WorkbenchSidebarRow> buildSidebarRows(
   WorkbenchState state, {
   Map<String, AgentStatusEntry> agentStatuses =
       const <String, AgentStatusEntry>{},
+  Map<String, DateTime> lastActivityByWorkspaceId = const <String, DateTime>{},
+  List<String> previousWorkspaceOrder = const <String>[],
+  DateTime? now,
 }) {
   final prefs = state.viewPrefs;
   final query = state.searchQuery.trim().toLowerCase();
+  final clock = now ?? DateTime.now().toUtc();
 
   bool projectVisible(Project project) {
     // Positive selection: when no projects are selected we show everything;
@@ -78,7 +95,26 @@ List<WorkbenchSidebarRow> buildSidebarRows(
     return prefs.selectedProjectIds.contains(project.id);
   }
 
-  bool workspaceMatchesQuery(Project project, Workspace workspace) {
+  final attentionCache = <String, WorkspaceAttention>{};
+  WorkspaceAttention attentionOf(Workspace workspace) {
+    return attentionCache.putIfAbsent(
+      workspace.id,
+      () => workspaceAttention(
+        tabs: state.tabsFor(workspace.id),
+        agentStatuses: agentStatuses,
+        now: clock,
+      ),
+    );
+  }
+
+  DateTime fallbackActivityOf(Workspace workspace) {
+    return lastActivityByWorkspaceId[workspace.id] ?? workspace.updatedAt;
+  }
+
+  bool workspaceVisible(Project project, Workspace workspace) {
+    if (!workspaceMatchesTagFilter(prefs, workspace)) {
+      return false;
+    }
     if (query.isEmpty) {
       return true;
     }
@@ -98,20 +134,13 @@ List<WorkbenchSidebarRow> buildSidebarRows(
     return false;
   }
 
-  List<Project> sortProjects(List<Project> projects) {
-    final sorted = List<Project>.from(projects);
-    switch (prefs.projectSort) {
-      case WorkbenchSortBy.name:
-        sorted.sort(
-          (a, b) => a.name.toLowerCase().compareTo(b.name.toLowerCase()),
-        );
-      case WorkbenchSortBy.recent:
-        sorted.sort((a, b) => b.updatedAt.compareTo(a.updatedAt));
-    }
-    return sorted;
-  }
-
-  List<Workspace> sortWorkspaces(List<Workspace> workspaces) {
+  // The flat view mixes several projects, so pinning each project's main
+  // worktree only applies to the name sort there; grouped mode pins it for
+  // name and recent. Agent Activity never pins — urgency owns the order.
+  List<Workspace> sortWorkspaces(
+    List<Workspace> workspaces, {
+    required bool pinMainOnRecent,
+  }) {
     final sorted = List<Workspace>.from(workspaces);
     switch (prefs.workspaceSort) {
       case WorkbenchSortBy.name:
@@ -124,10 +153,81 @@ List<WorkbenchSidebarRow> buildSidebarRows(
         });
       case WorkbenchSortBy.recent:
         sorted.sort((a, b) {
-          if (a.isMain != b.isMain) {
+          if (pinMainOnRecent && a.isMain != b.isMain) {
             return a.isMain ? -1 : 1;
           }
           return b.updatedAt.compareTo(a.updatedAt);
+        });
+      case WorkbenchSortBy.activity:
+        // Urgency outranks the main-worktree pin in this mode.
+        sorted.sort(
+          (a, b) => compareByAgentActivity(
+            aAttention: attentionOf(a),
+            aFallback: fallbackActivityOf(a),
+            aName: a.name,
+            bAttention: attentionOf(b),
+            bFallback: fallbackActivityOf(b),
+            bName: b.name,
+          ),
+        );
+    }
+    return stabilizeActiveEntry(
+      sorted: sorted,
+      idOf: (workspace) => workspace.id,
+      previousOrder: previousWorkspaceOrder,
+      activeId: prefs.workspaceSort == WorkbenchSortBy.activity
+          ? state.activeWorkspaceId
+          : null,
+    );
+  }
+
+  List<Project> sortProjects(List<Project> projects) {
+    final sorted = List<Project>.from(projects);
+    switch (prefs.projectSort) {
+      case WorkbenchSortBy.name:
+        sorted.sort(
+          (a, b) => a.name.toLowerCase().compareTo(b.name.toLowerCase()),
+        );
+      case WorkbenchSortBy.recent:
+        sorted.sort((a, b) => b.updatedAt.compareTo(a.updatedAt));
+      case WorkbenchSortBy.activity:
+        // Rank each project by its most urgent / most recently active visible
+        // workspace.
+        final rank = <String, ({WorkspaceAttention attention, DateTime at})>{};
+        for (final project in sorted) {
+          var best = WorkspaceAttention.idle;
+          var bestAt = project.updatedAt;
+          for (final workspace in state.workspacesFor(project.id)) {
+            if (!workspaceVisible(project, workspace)) {
+              continue;
+            }
+            final attention = attentionOf(workspace);
+            final at = attention.attentionAt ?? fallbackActivityOf(workspace);
+            final better =
+                attention.attentionClass.index < best.attentionClass.index ||
+                (attention.attentionClass == best.attentionClass &&
+                    at.isAfter(bestAt));
+            if (better) {
+              best = attention;
+              bestAt = at;
+            }
+          }
+          rank[project.id] = (attention: best, at: bestAt);
+        }
+        sorted.sort((a, b) {
+          final ra = rank[a.id]!;
+          final rb = rank[b.id]!;
+          final byClass = ra.attention.attentionClass.index.compareTo(
+            rb.attention.attentionClass.index,
+          );
+          if (byClass != 0) {
+            return byClass;
+          }
+          final byTime = rb.at.compareTo(ra.at);
+          if (byTime != 0) {
+            return byTime;
+          }
+          return a.name.toLowerCase().compareTo(b.name.toLowerCase());
         });
     }
     return sorted;
@@ -157,8 +257,38 @@ List<WorkbenchSidebarRow> buildSidebarRows(
     }
   }
 
+  void appendWorkspaceTreeRows(
+    List<WorkbenchSidebarRow> rows, {
+    required List<Workspace> workspaces,
+    required Project Function(Workspace) projectOf,
+    required int baseIndent,
+    required bool showProjectChip,
+  }) {
+    final tree = buildWorkspaceTree(
+      entries: workspaces,
+      collapsedParentIds: prefs.collapsedParentWorkspaceIds,
+    );
+    for (final entry in tree) {
+      final indent = baseIndent + entry.depth;
+      rows.add(
+        WorkbenchWorkspaceRow(
+          project: projectOf(entry.workspace),
+          workspace: entry.workspace,
+          showProjectChip: showProjectChip,
+          indent: indent,
+          expanded: prefs.expandedWorkspaceIds.contains(entry.workspace.id),
+          hasVisibleChildren: entry.hasVisibleChildren,
+          childrenCollapsed: entry.childrenCollapsed,
+        ),
+      );
+      appendSidebarAgentRunRows(rows, entry.workspace, indent + 1);
+    }
+  }
+
   final rows = <WorkbenchSidebarRow>[];
   final visibleProjects = state.projects.where(projectVisible).toList();
+  final filtersHideEmptyProjects =
+      query.isNotEmpty || prefs.selectedTagIds.isNotEmpty;
 
   switch (prefs.groupBy) {
     case WorkbenchGroupBy.project:
@@ -167,10 +297,11 @@ List<WorkbenchSidebarRow> buildSidebarRows(
         final workspaces = sortWorkspaces(
           state
               .workspacesFor(project.id)
-              .where((w) => workspaceMatchesQuery(project, w))
+              .where((w) => workspaceVisible(project, w))
               .toList(),
+          pinMainOnRecent: true,
         );
-        if (query.isNotEmpty && workspaces.isEmpty) {
+        if (filtersHideEmptyProjects && workspaces.isEmpty) {
           continue;
         }
         final collapsed = prefs.collapsedProjectIds.contains(project.id);
@@ -184,59 +315,54 @@ List<WorkbenchSidebarRow> buildSidebarRows(
         if (collapsed) {
           continue;
         }
-        for (final workspace in workspaces) {
-          rows.add(
-            WorkbenchWorkspaceRow(
-              project: project,
-              workspace: workspace,
-              showProjectChip: false,
-              indent: 1,
-              expanded: prefs.expandedWorkspaceIds.contains(workspace.id),
-            ),
-          );
-          appendSidebarAgentRunRows(rows, workspace, 2);
-        }
+        appendWorkspaceTreeRows(
+          rows,
+          workspaces: workspaces,
+          projectOf: (_) => project,
+          baseIndent: 1,
+          showProjectChip: false,
+        );
       }
     case WorkbenchGroupBy.none:
-      final entries = <({Project project, Workspace workspace})>[];
+      final projectByWorkspaceId = <String, Project>{};
+      final workspaces = <Workspace>[];
       for (final project in visibleProjects) {
         for (final workspace in state.workspacesFor(project.id)) {
-          if (!workspaceMatchesQuery(project, workspace)) {
+          if (!workspaceVisible(project, workspace)) {
             continue;
           }
-          entries.add((project: project, workspace: workspace));
+          projectByWorkspaceId[workspace.id] = project;
+          workspaces.add(workspace);
         }
       }
-      switch (prefs.workspaceSort) {
-        case WorkbenchSortBy.name:
-          entries.sort((a, b) {
-            if (a.workspace.isMain != b.workspace.isMain) {
-              return a.workspace.isMain ? -1 : 1;
-            }
-            return a.workspace.name.toLowerCase().compareTo(
-              b.workspace.name.toLowerCase(),
-            );
-          });
-        case WorkbenchSortBy.recent:
-          entries.sort((a, b) {
-            return b.workspace.updatedAt.compareTo(a.workspace.updatedAt);
-          });
-      }
-      for (final entry in entries) {
-        rows.add(
-          WorkbenchWorkspaceRow(
-            project: entry.project,
-            workspace: entry.workspace,
-            showProjectChip: true,
-            indent: 0,
-            expanded: prefs.expandedWorkspaceIds.contains(entry.workspace.id),
-          ),
-        );
-        appendSidebarAgentRunRows(rows, entry.workspace, 1);
-      }
+      appendWorkspaceTreeRows(
+        rows,
+        workspaces: sortWorkspaces(workspaces, pinMainOnRecent: false),
+        projectOf: (workspace) => projectByWorkspaceId[workspace.id]!,
+        baseIndent: 0,
+        showProjectChip: true,
+      );
   }
 
   return rows;
+}
+
+/// OR semantics over the selected tag filter: an empty selection shows every
+/// workspace; otherwise a workspace must carry at least one selected tag.
+bool workspaceMatchesTagFilter(WorkbenchViewPrefs prefs, Workspace workspace) {
+  if (prefs.selectedTagIds.isEmpty) {
+    return true;
+  }
+  return workspace.tagIds.any(prefs.selectedTagIds.contains);
+}
+
+/// The workspace-id order of the rendered rows, used to remember the previous
+/// ordering for [buildSidebarRows]'s active-row stabilization.
+List<String> workspaceOrderOfRows(List<WorkbenchSidebarRow> rows) {
+  return <String>[
+    for (final row in rows)
+      if (row is WorkbenchWorkspaceRow) row.workspace.id,
+  ];
 }
 
 /// Counts the workspaces currently visible in the sidebar for the header label
@@ -251,6 +377,9 @@ int countVisibleWorkspaces(WorkbenchState state) {
       continue;
     }
     for (final workspace in state.workspacesFor(project.id)) {
+      if (!workspaceMatchesTagFilter(prefs, workspace)) {
+        continue;
+      }
       if (query.isEmpty) {
         count++;
         continue;

--- a/lib/src/features/workbench/application/workbench_listing_tree.dart
+++ b/lib/src/features/workbench/application/workbench_listing_tree.dart
@@ -1,0 +1,103 @@
+import 'package:alera/src/features/workbench/domain/workspace.dart';
+
+/// One workspace positioned in the sidebar tree.
+class WorkspaceTreeEntry {
+  const WorkspaceTreeEntry({
+    required this.workspace,
+    required this.depth,
+    required this.hasVisibleChildren,
+    required this.childrenCollapsed,
+  });
+
+  final Workspace workspace;
+
+  /// Nesting depth relative to the sibling group root (0 = root level).
+  final int depth;
+
+  /// Whether this workspace has children rendered (or collapsed) beneath it in
+  /// the current group.
+  final bool hasVisibleChildren;
+
+  /// Whether this workspace's children are currently hidden by the user.
+  final bool childrenCollapsed;
+}
+
+/// Deeper nesting reuses the max indent so rows stay readable in a narrow
+/// sidebar.
+const int maxWorkspaceTreeDepth = 4;
+
+/// Orders one sibling group's already-filtered, already-sorted workspaces into
+/// a depth-first tree. A workspace whose parent is not part of [entries]
+/// (filtered out, in another group, or absent) is promoted to the root level,
+/// so filters never hide a child.
+List<WorkspaceTreeEntry> buildWorkspaceTree({
+  required List<Workspace> entries,
+  required Set<String> collapsedParentIds,
+}) {
+  final ids = <String>{for (final workspace in entries) workspace.id};
+  final childrenOf = <String, List<Workspace>>{};
+  final roots = <Workspace>[];
+  for (final workspace in entries) {
+    final parentId = workspace.parentWorkspaceId;
+    if (parentId != null &&
+        parentId != workspace.id &&
+        ids.contains(parentId)) {
+      childrenOf.putIfAbsent(parentId, () => <Workspace>[]).add(workspace);
+    } else {
+      roots.add(workspace);
+    }
+  }
+
+  final out = <WorkspaceTreeEntry>[];
+  // Guards against stale relation cycles so the walk always terminates.
+  final visited = <String>{};
+
+  void markSubtreeVisited(Workspace workspace) {
+    if (!visited.add(workspace.id)) {
+      return;
+    }
+    for (final child in childrenOf[workspace.id] ?? const <Workspace>[]) {
+      markSubtreeVisited(child);
+    }
+  }
+
+  void visit(Workspace workspace, int depth) {
+    if (!visited.add(workspace.id)) {
+      return;
+    }
+    final children = childrenOf[workspace.id] ?? const <Workspace>[];
+    final collapsed = collapsedParentIds.contains(workspace.id);
+    out.add(
+      WorkspaceTreeEntry(
+        workspace: workspace,
+        depth: depth,
+        hasVisibleChildren: children.isNotEmpty,
+        childrenCollapsed: collapsed,
+      ),
+    );
+    if (collapsed) {
+      for (final child in children) {
+        markSubtreeVisited(child);
+      }
+      return;
+    }
+    final childDepth = depth >= maxWorkspaceTreeDepth
+        ? maxWorkspaceTreeDepth
+        : depth + 1;
+    for (final child in children) {
+      visit(child, childDepth);
+    }
+  }
+
+  for (final root in roots) {
+    visit(root, 0);
+  }
+  // A cycle among non-root workspaces leaves them unvisited; append them at
+  // the root level rather than dropping them.
+  for (final workspace in entries) {
+    if (!visited.contains(workspace.id)) {
+      visit(workspace, 0);
+    }
+  }
+  return out;
+}

--- a/lib/src/features/workbench/application/workbench_providers.dart
+++ b/lib/src/features/workbench/application/workbench_providers.dart
@@ -11,6 +11,9 @@ import 'package:alera/src/features/workbench/application/workbench_controller.da
 import 'package:alera/src/features/workbench/application/workbench_repository.dart';
 import 'package:alera/src/features/workbench/application/workbench_state.dart';
 import 'package:alera/src/features/workbench/application/workbench_view_prefs_repository.dart';
+import 'package:alera/src/features/workbench/application/workbench_agent_activity_sort.dart';
+import 'package:alera/src/features/workbench/application/workspace_activity_controller.dart';
+import 'package:alera/src/features/workbench/application/workspace_activity_repository.dart';
 import 'package:alera/src/features/workbench/application/workspace_file_service.dart';
 import 'package:alera/src/features/workbench/application/workspace_graph_repository.dart';
 import 'package:alera/src/features/workbench/application/workspace_search_service.dart';
@@ -20,6 +23,7 @@ import 'package:alera/src/features/workbench/application/worktree_setup_service.
 import 'package:alera/src/features/workbench/domain/workspace.dart';
 import 'package:alera/src/features/workbench/domain/workspace_tab_record.dart';
 import 'package:alera/src/features/workbench/infra/drift_workbench_view_prefs_repository.dart';
+import 'package:alera/src/features/workbench/infra/drift_workspace_activity_repository.dart';
 import 'package:alera/src/features/workbench/infra/alera_cli_terminal_shim.dart';
 import 'package:alera/src/features/workbench/infra/runtime_managed_workspace_client.dart';
 import 'package:alera/src/features/workbench/infra/runtime_workspace_graph_repository.dart';
@@ -61,6 +65,31 @@ WorkbenchViewPrefsRepository workbenchViewPrefsRepository(Ref ref) {
   final dbAsync = ref.watch(aleraDatabaseProvider);
   final db = dbAsync.requireValue;
   return DriftWorkbenchViewPrefsRepository(db);
+}
+
+@Riverpod(keepAlive: true)
+SidebarOrderMemory sidebarOrderMemory(Ref ref) {
+  return SidebarOrderMemory();
+}
+
+@Riverpod(keepAlive: true)
+WorkspaceActivityRepository workspaceActivityRepository(Ref ref) {
+  final dbAsync = ref.watch(aleraDatabaseProvider);
+  final db = dbAsync.requireValue;
+  return DriftWorkspaceActivityRepository(db);
+}
+
+/// Seeds [WorkspaceActivityController] from Drift once the database is ready
+/// so the Agent Activity sort keeps its recency ordering across restarts.
+@Riverpod(keepAlive: true)
+void workspaceActivityPersistenceCoordinator(Ref ref) {
+  final repository = ref.watch(workspaceActivityRepositoryProvider);
+  unawaited(
+    ref
+        .read(workspaceActivityControllerProvider.notifier)
+        .attachRepository(repository)
+        .catchError((_) {}),
+  );
 }
 
 @Riverpod(keepAlive: true)
@@ -269,6 +298,9 @@ void terminalRuntimeExitCoordinator(Ref ref) {
           tabId: event.tabId,
           exitCode: event.exitCode,
         );
+    ref
+        .read(workspaceActivityControllerProvider.notifier)
+        .recordActivity(event.workspaceId, DateTime.now().toUtc());
     unawaited(closeExitedTerminalTab(event));
   });
 

--- a/lib/src/features/workbench/application/workbench_providers.g.dart
+++ b/lib/src/features/workbench/application/workbench_providers.g.dart
@@ -154,6 +154,155 @@ final class WorkbenchViewPrefsRepositoryProvider
 String _$workbenchViewPrefsRepositoryHash() =>
     r'b7726a6ea38683368a484b1c0015eebc3e65bda8';
 
+@ProviderFor(sidebarOrderMemory)
+final sidebarOrderMemoryProvider = SidebarOrderMemoryProvider._();
+
+final class SidebarOrderMemoryProvider
+    extends
+        $FunctionalProvider<
+          SidebarOrderMemory,
+          SidebarOrderMemory,
+          SidebarOrderMemory
+        >
+    with $Provider<SidebarOrderMemory> {
+  SidebarOrderMemoryProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'sidebarOrderMemoryProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$sidebarOrderMemoryHash();
+
+  @$internal
+  @override
+  $ProviderElement<SidebarOrderMemory> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  SidebarOrderMemory create(Ref ref) {
+    return sidebarOrderMemory(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(SidebarOrderMemory value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<SidebarOrderMemory>(value),
+    );
+  }
+}
+
+String _$sidebarOrderMemoryHash() =>
+    r'63af5266267a090aad55563c87262c6ea27d6a5b';
+
+@ProviderFor(workspaceActivityRepository)
+final workspaceActivityRepositoryProvider =
+    WorkspaceActivityRepositoryProvider._();
+
+final class WorkspaceActivityRepositoryProvider
+    extends
+        $FunctionalProvider<
+          WorkspaceActivityRepository,
+          WorkspaceActivityRepository,
+          WorkspaceActivityRepository
+        >
+    with $Provider<WorkspaceActivityRepository> {
+  WorkspaceActivityRepositoryProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'workspaceActivityRepositoryProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$workspaceActivityRepositoryHash();
+
+  @$internal
+  @override
+  $ProviderElement<WorkspaceActivityRepository> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  WorkspaceActivityRepository create(Ref ref) {
+    return workspaceActivityRepository(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(WorkspaceActivityRepository value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<WorkspaceActivityRepository>(value),
+    );
+  }
+}
+
+String _$workspaceActivityRepositoryHash() =>
+    r'07afee80ccb3807edd70367eac0c5d2d0a7c5be0';
+
+/// Seeds [WorkspaceActivityController] from Drift once the database is ready
+/// so the Agent Activity sort keeps its recency ordering across restarts.
+
+@ProviderFor(workspaceActivityPersistenceCoordinator)
+final workspaceActivityPersistenceCoordinatorProvider =
+    WorkspaceActivityPersistenceCoordinatorProvider._();
+
+/// Seeds [WorkspaceActivityController] from Drift once the database is ready
+/// so the Agent Activity sort keeps its recency ordering across restarts.
+
+final class WorkspaceActivityPersistenceCoordinatorProvider
+    extends $FunctionalProvider<void, void, void>
+    with $Provider<void> {
+  /// Seeds [WorkspaceActivityController] from Drift once the database is ready
+  /// so the Agent Activity sort keeps its recency ordering across restarts.
+  WorkspaceActivityPersistenceCoordinatorProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'workspaceActivityPersistenceCoordinatorProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() =>
+      _$workspaceActivityPersistenceCoordinatorHash();
+
+  @$internal
+  @override
+  $ProviderElement<void> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  void create(Ref ref) {
+    return workspaceActivityPersistenceCoordinator(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(void value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<void>(value),
+    );
+  }
+}
+
+String _$workspaceActivityPersistenceCoordinatorHash() =>
+    r'7ae7aae0460472435ae00d4737f1f5ee19f4816c';
+
 @ProviderFor(workspaceTabService)
 final workspaceTabServiceProvider = WorkspaceTabServiceProvider._();
 
@@ -760,4 +909,4 @@ final class TerminalRuntimeExitCoordinatorProvider
 }
 
 String _$terminalRuntimeExitCoordinatorHash() =>
-    r'c29c3c8c7baf565c55dc510a840f3996cff0160b';
+    r'c06ba37819e3b0da9764d184a2ead782fb10e48e';

--- a/lib/src/features/workbench/application/workspace_activity_controller.dart
+++ b/lib/src/features/workbench/application/workspace_activity_controller.dart
@@ -1,0 +1,100 @@
+import 'dart:async';
+
+import 'package:alera/src/features/agent_status/application/agent_status_controller.dart';
+import 'package:alera/src/features/agent_status/domain/agent_status.dart';
+import 'package:alera/src/features/workbench/application/workspace_activity_repository.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'workspace_activity_controller.g.dart';
+
+/// Delay between an activity event and its batched write to Drift so bursts of
+/// agent transitions produce a single disk write.
+const Duration workspaceActivityFlushDelay = Duration(seconds: 2);
+
+/// Tracks the last discrete activity timestamp per workspace (agent state
+/// transitions, terminal lifecycle) and persists it with a debounce. State is
+/// the in-memory map used by the Agent Activity sort as its recency fallback.
+@Riverpod(keepAlive: true)
+class WorkspaceActivityController extends _$WorkspaceActivityController {
+  WorkspaceActivityRepository? _repository;
+  final Map<String, DateTime> _dirty = <String, DateTime>{};
+  Timer? _flushTimer;
+
+  @override
+  Map<String, DateTime> build() {
+    ref.onDispose(() {
+      _flushTimer?.cancel();
+    });
+    return const <String, DateTime>{};
+  }
+
+  /// Injects the persistence backend and seeds state from disk. Called by the
+  /// coordinator once the database is available.
+  Future<void> attachRepository(WorkspaceActivityRepository repository) async {
+    _repository = repository;
+    final persisted = await repository.loadAll();
+    // In-memory entries recorded before the seed win: they are newer.
+    state = <String, DateTime>{...persisted, ...state};
+  }
+
+  void recordActivity(String workspaceId, DateTime at) {
+    final current = state[workspaceId];
+    if (current != null && !at.isAfter(current)) {
+      return;
+    }
+    state = <String, DateTime>{...state, workspaceId: at};
+    _dirty[workspaceId] = at;
+    _scheduleFlush();
+  }
+
+  void removeWorkspace(String workspaceId) {
+    if (!state.containsKey(workspaceId)) {
+      return;
+    }
+    final next = Map<String, DateTime>.from(state)..remove(workspaceId);
+    state = next;
+    _dirty.remove(workspaceId);
+    final repository = _repository;
+    if (repository != null) {
+      unawaited(repository.remove(workspaceId).catchError((_) {}));
+    }
+  }
+
+  void _scheduleFlush() {
+    _flushTimer ??= Timer(workspaceActivityFlushDelay, () {
+      _flushTimer = null;
+      final repository = _repository;
+      if (repository == null || _dirty.isEmpty) {
+        return;
+      }
+      final batch = Map<String, DateTime>.from(_dirty);
+      _dirty.clear();
+      unawaited(repository.upsertAll(batch).catchError((_) {}));
+    });
+  }
+}
+
+/// Feeds [WorkspaceActivityController] from discrete agent status transitions.
+/// Tool-by-tool updates within one state do not count as activity — only a
+/// `state`/`stateStartedAt` change marks the workspace as active.
+@Riverpod(keepAlive: true)
+void workspaceActivityCoordinator(Ref ref) {
+  ref.listen<Map<String, AgentStatusEntry>>(agentStatusControllerProvider, (
+    previous,
+    next,
+  ) {
+    final controller = ref.read(workspaceActivityControllerProvider.notifier);
+    for (final entry in next.entries) {
+      final before = previous?[entry.key];
+      final after = entry.value;
+      final transitioned =
+          before == null ||
+          before.state != after.state ||
+          before.stateStartedAt != after.stateStartedAt ||
+          before.interrupted != after.interrupted;
+      if (transitioned) {
+        controller.recordActivity(after.workspaceId, after.stateStartedAt);
+      }
+    }
+  });
+}

--- a/lib/src/features/workbench/application/workspace_activity_controller.g.dart
+++ b/lib/src/features/workbench/application/workspace_activity_controller.g.dart
@@ -1,0 +1,133 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'workspace_activity_controller.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// Tracks the last discrete activity timestamp per workspace (agent state
+/// transitions, terminal lifecycle) and persists it with a debounce. State is
+/// the in-memory map used by the Agent Activity sort as its recency fallback.
+
+@ProviderFor(WorkspaceActivityController)
+final workspaceActivityControllerProvider =
+    WorkspaceActivityControllerProvider._();
+
+/// Tracks the last discrete activity timestamp per workspace (agent state
+/// transitions, terminal lifecycle) and persists it with a debounce. State is
+/// the in-memory map used by the Agent Activity sort as its recency fallback.
+final class WorkspaceActivityControllerProvider
+    extends
+        $NotifierProvider<WorkspaceActivityController, Map<String, DateTime>> {
+  /// Tracks the last discrete activity timestamp per workspace (agent state
+  /// transitions, terminal lifecycle) and persists it with a debounce. State is
+  /// the in-memory map used by the Agent Activity sort as its recency fallback.
+  WorkspaceActivityControllerProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'workspaceActivityControllerProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$workspaceActivityControllerHash();
+
+  @$internal
+  @override
+  WorkspaceActivityController create() => WorkspaceActivityController();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(Map<String, DateTime> value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<Map<String, DateTime>>(value),
+    );
+  }
+}
+
+String _$workspaceActivityControllerHash() =>
+    r'a0733e981dd5ae0a369cd370aa6c86db837ff4ef';
+
+/// Tracks the last discrete activity timestamp per workspace (agent state
+/// transitions, terminal lifecycle) and persists it with a debounce. State is
+/// the in-memory map used by the Agent Activity sort as its recency fallback.
+
+abstract class _$WorkspaceActivityController
+    extends $Notifier<Map<String, DateTime>> {
+  Map<String, DateTime> build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final ref = this.ref as $Ref<Map<String, DateTime>, Map<String, DateTime>>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<Map<String, DateTime>, Map<String, DateTime>>,
+              Map<String, DateTime>,
+              Object?,
+              Object?
+            >;
+    element.handleCreate(ref, build);
+  }
+}
+
+/// Feeds [WorkspaceActivityController] from discrete agent status transitions.
+/// Tool-by-tool updates within one state do not count as activity — only a
+/// `state`/`stateStartedAt` change marks the workspace as active.
+
+@ProviderFor(workspaceActivityCoordinator)
+final workspaceActivityCoordinatorProvider =
+    WorkspaceActivityCoordinatorProvider._();
+
+/// Feeds [WorkspaceActivityController] from discrete agent status transitions.
+/// Tool-by-tool updates within one state do not count as activity — only a
+/// `state`/`stateStartedAt` change marks the workspace as active.
+
+final class WorkspaceActivityCoordinatorProvider
+    extends $FunctionalProvider<void, void, void>
+    with $Provider<void> {
+  /// Feeds [WorkspaceActivityController] from discrete agent status transitions.
+  /// Tool-by-tool updates within one state do not count as activity — only a
+  /// `state`/`stateStartedAt` change marks the workspace as active.
+  WorkspaceActivityCoordinatorProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'workspaceActivityCoordinatorProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$workspaceActivityCoordinatorHash();
+
+  @$internal
+  @override
+  $ProviderElement<void> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  void create(Ref ref) {
+    return workspaceActivityCoordinator(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(void value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<void>(value),
+    );
+  }
+}
+
+String _$workspaceActivityCoordinatorHash() =>
+    r'dc943e73259eb13cd704e5e552c2fbb6b6a6f867';

--- a/lib/src/features/workbench/application/workspace_activity_repository.dart
+++ b/lib/src/features/workbench/application/workspace_activity_repository.dart
@@ -1,0 +1,7 @@
+/// Persists per-workspace last-activity timestamps used as the recency
+/// fallback for the Agent Activity sort across app restarts.
+abstract interface class WorkspaceActivityRepository {
+  Future<Map<String, DateTime>> loadAll();
+  Future<void> upsertAll(Map<String, DateTime> entries);
+  Future<void> remove(String workspaceId);
+}

--- a/lib/src/features/workbench/application/workspace_agent_run_groups.dart
+++ b/lib/src/features/workbench/application/workspace_agent_run_groups.dart
@@ -1,0 +1,43 @@
+import 'package:alera/src/features/agent_status/domain/agent_status.dart';
+import 'package:alera/src/features/workbench/application/workspace_agent_status_projection.dart';
+
+/// Display buckets for the compact agent summary. Enum order is display
+/// order: attention-needing states surface first.
+enum WorkspaceAgentGroupKind { waiting, blocked, interrupted, working, done }
+
+class WorkspaceAgentRunGroup {
+  const WorkspaceAgentRunGroup({required this.kind, required this.runs});
+
+  final WorkspaceAgentGroupKind kind;
+  final List<WorkspaceAgentRun> runs;
+}
+
+/// Groups a workspace's agent runs by visual state for the compact summary
+/// pill. Interruption wins over the reported state, mirroring the per-row
+/// indicator.
+List<WorkspaceAgentRunGroup> groupWorkspaceAgentRuns(
+  List<WorkspaceAgentRun> runs,
+) {
+  final byKind = <WorkspaceAgentGroupKind, List<WorkspaceAgentRun>>{};
+  for (final run in runs) {
+    final kind = _groupKindOf(run.status);
+    byKind.putIfAbsent(kind, () => <WorkspaceAgentRun>[]).add(run);
+  }
+  return <WorkspaceAgentRunGroup>[
+    for (final kind in WorkspaceAgentGroupKind.values)
+      if (byKind[kind] case final List<WorkspaceAgentRun> grouped)
+        WorkspaceAgentRunGroup(kind: kind, runs: grouped),
+  ];
+}
+
+WorkspaceAgentGroupKind _groupKindOf(AgentStatusEntry status) {
+  if (status.interrupted ?? false) {
+    return WorkspaceAgentGroupKind.interrupted;
+  }
+  return switch (status.state) {
+    AgentStatusState.waiting => WorkspaceAgentGroupKind.waiting,
+    AgentStatusState.blocked => WorkspaceAgentGroupKind.blocked,
+    AgentStatusState.working => WorkspaceAgentGroupKind.working,
+    AgentStatusState.done => WorkspaceAgentGroupKind.done,
+  };
+}

--- a/lib/src/features/workbench/domain/workbench_view_prefs.dart
+++ b/lib/src/features/workbench/domain/workbench_view_prefs.dart
@@ -6,7 +6,7 @@ part 'workbench_view_prefs.mapper.dart';
 enum WorkbenchGroupBy { none, project }
 
 @MappableEnum()
-enum WorkbenchSortBy { name, recent }
+enum WorkbenchSortBy { name, recent, activity }
 
 @MappableEnum()
 enum WorkbenchContextPanelTab { explorer, search, gitDiff }
@@ -26,6 +26,8 @@ class WorkbenchViewPrefs with WorkbenchViewPrefsMappable {
     required this.selectedProjectIds,
     required this.collapsedProjectIds,
     required this.expandedWorkspaceIds,
+    this.selectedTagIds = const <String>{},
+    this.collapsedParentWorkspaceIds = const <String>{},
     this.sourceControlRootByWorkspaceId = const <String, String>{},
     this.rightSidebarVisible = true,
     this.rightSidebarWidth = 280,
@@ -50,6 +52,15 @@ class WorkbenchViewPrefs with WorkbenchViewPrefsMappable {
   /// changing the active selection.
   final Set<String> expandedWorkspaceIds;
 
+  /// Tags the user has explicitly added to the visibility filter. Empty means
+  /// no tag filtering; non-empty shows workspaces carrying at least one of the
+  /// selected tags (OR semantics, mirroring [selectedProjectIds]).
+  final Set<String> selectedTagIds;
+
+  /// Parent workspaces whose nested children are currently hidden in the
+  /// sidebar tree.
+  final Set<String> collapsedParentWorkspaceIds;
+
   /// Folder-workspace ids mapped to the workspace-relative Git folder that
   /// should back the Source Control tab.
   final Map<String, String> sourceControlRootByWorkspaceId;
@@ -66,6 +77,8 @@ class WorkbenchViewPrefs with WorkbenchViewPrefsMappable {
     selectedProjectIds: <String>{},
     collapsedProjectIds: <String>{},
     expandedWorkspaceIds: <String>{},
+    selectedTagIds: <String>{},
+    collapsedParentWorkspaceIds: <String>{},
     sourceControlRootByWorkspaceId: <String, String>{},
     rightSidebarVisible: true,
     rightSidebarWidth: 280,

--- a/lib/src/features/workbench/domain/workbench_view_prefs.mapper.dart
+++ b/lib/src/features/workbench/domain/workbench_view_prefs.mapper.dart
@@ -77,6 +77,8 @@ class WorkbenchSortByMapper extends EnumMapper<WorkbenchSortBy> {
         return WorkbenchSortBy.name;
       case r'recent':
         return WorkbenchSortBy.recent;
+      case r'activity':
+        return WorkbenchSortBy.activity;
       default:
         throw MapperException.unknownEnumValue(value);
     }
@@ -89,6 +91,8 @@ class WorkbenchSortByMapper extends EnumMapper<WorkbenchSortBy> {
         return r'name';
       case WorkbenchSortBy.recent:
         return r'recent';
+      case WorkbenchSortBy.activity:
+        return r'activity';
     }
   }
 }
@@ -290,6 +294,22 @@ class WorkbenchViewPrefsMapper extends ClassMapperBase<WorkbenchViewPrefs> {
       v.expandedWorkspaceIds;
   static const Field<WorkbenchViewPrefs, Set<String>> _f$expandedWorkspaceIds =
       Field('expandedWorkspaceIds', _$expandedWorkspaceIds);
+  static Set<String> _$selectedTagIds(WorkbenchViewPrefs v) => v.selectedTagIds;
+  static const Field<WorkbenchViewPrefs, Set<String>> _f$selectedTagIds = Field(
+    'selectedTagIds',
+    _$selectedTagIds,
+    opt: true,
+    def: const <String>{},
+  );
+  static Set<String> _$collapsedParentWorkspaceIds(WorkbenchViewPrefs v) =>
+      v.collapsedParentWorkspaceIds;
+  static const Field<WorkbenchViewPrefs, Set<String>>
+  _f$collapsedParentWorkspaceIds = Field(
+    'collapsedParentWorkspaceIds',
+    _$collapsedParentWorkspaceIds,
+    opt: true,
+    def: const <String>{},
+  );
   static Map<String, String> _$sourceControlRootByWorkspaceId(
     WorkbenchViewPrefs v,
   ) => v.sourceControlRootByWorkspaceId;
@@ -353,6 +373,8 @@ class WorkbenchViewPrefsMapper extends ClassMapperBase<WorkbenchViewPrefs> {
     #selectedProjectIds: _f$selectedProjectIds,
     #collapsedProjectIds: _f$collapsedProjectIds,
     #expandedWorkspaceIds: _f$expandedWorkspaceIds,
+    #selectedTagIds: _f$selectedTagIds,
+    #collapsedParentWorkspaceIds: _f$collapsedParentWorkspaceIds,
     #sourceControlRootByWorkspaceId: _f$sourceControlRootByWorkspaceId,
     #rightSidebarVisible: _f$rightSidebarVisible,
     #rightSidebarWidth: _f$rightSidebarWidth,
@@ -369,6 +391,8 @@ class WorkbenchViewPrefsMapper extends ClassMapperBase<WorkbenchViewPrefs> {
       selectedProjectIds: data.dec(_f$selectedProjectIds),
       collapsedProjectIds: data.dec(_f$collapsedProjectIds),
       expandedWorkspaceIds: data.dec(_f$expandedWorkspaceIds),
+      selectedTagIds: data.dec(_f$selectedTagIds),
+      collapsedParentWorkspaceIds: data.dec(_f$collapsedParentWorkspaceIds),
       sourceControlRootByWorkspaceId: data.dec(
         _f$sourceControlRootByWorkspaceId,
       ),
@@ -460,6 +484,8 @@ abstract class WorkbenchViewPrefsCopyWith<
     Set<String>? selectedProjectIds,
     Set<String>? collapsedProjectIds,
     Set<String>? expandedWorkspaceIds,
+    Set<String>? selectedTagIds,
+    Set<String>? collapsedParentWorkspaceIds,
     Map<String, String>? sourceControlRootByWorkspaceId,
     bool? rightSidebarVisible,
     double? rightSidebarWidth,
@@ -495,6 +521,8 @@ class _WorkbenchViewPrefsCopyWithImpl<$R, $Out>
     Set<String>? selectedProjectIds,
     Set<String>? collapsedProjectIds,
     Set<String>? expandedWorkspaceIds,
+    Set<String>? selectedTagIds,
+    Set<String>? collapsedParentWorkspaceIds,
     Map<String, String>? sourceControlRootByWorkspaceId,
     bool? rightSidebarVisible,
     double? rightSidebarWidth,
@@ -511,6 +539,9 @@ class _WorkbenchViewPrefsCopyWithImpl<$R, $Out>
         #collapsedProjectIds: collapsedProjectIds,
       if (expandedWorkspaceIds != null)
         #expandedWorkspaceIds: expandedWorkspaceIds,
+      if (selectedTagIds != null) #selectedTagIds: selectedTagIds,
+      if (collapsedParentWorkspaceIds != null)
+        #collapsedParentWorkspaceIds: collapsedParentWorkspaceIds,
       if (sourceControlRootByWorkspaceId != null)
         #sourceControlRootByWorkspaceId: sourceControlRootByWorkspaceId,
       if (rightSidebarVisible != null)
@@ -538,6 +569,11 @@ class _WorkbenchViewPrefsCopyWithImpl<$R, $Out>
     expandedWorkspaceIds: data.get(
       #expandedWorkspaceIds,
       or: $value.expandedWorkspaceIds,
+    ),
+    selectedTagIds: data.get(#selectedTagIds, or: $value.selectedTagIds),
+    collapsedParentWorkspaceIds: data.get(
+      #collapsedParentWorkspaceIds,
+      or: $value.collapsedParentWorkspaceIds,
     ),
     sourceControlRootByWorkspaceId: data.get(
       #sourceControlRootByWorkspaceId,

--- a/lib/src/features/workbench/infra/drift_workspace_activity_repository.dart
+++ b/lib/src/features/workbench/infra/drift_workspace_activity_repository.dart
@@ -1,0 +1,45 @@
+import 'package:alera/src/features/workbench/application/workspace_activity_repository.dart';
+import 'package:alera/src/shared/infra/storage/drift_database.dart';
+import 'package:drift/drift.dart' show Value;
+
+class DriftWorkspaceActivityRepository implements WorkspaceActivityRepository {
+  DriftWorkspaceActivityRepository(this._db);
+
+  final AleraDatabase _db;
+
+  @override
+  Future<Map<String, DateTime>> loadAll() async {
+    final rows = await _db.select(_db.workspaceActivityTable).get();
+    // Drift round-trips DateTime in local time; normalize to UTC so loaded
+    // values compare cleanly against the UTC timestamps recorded in memory.
+    return <String, DateTime>{
+      for (final row in rows) row.workspaceId: row.lastActivityAt.toUtc(),
+    };
+  }
+
+  @override
+  Future<void> upsertAll(Map<String, DateTime> entries) async {
+    if (entries.isEmpty) {
+      return;
+    }
+    await _db.batch((batch) {
+      batch.insertAllOnConflictUpdate(
+        _db.workspaceActivityTable,
+        <WorkspaceActivityTableCompanion>[
+          for (final entry in entries.entries)
+            WorkspaceActivityTableCompanion(
+              workspaceId: Value(entry.key),
+              lastActivityAt: Value(entry.value),
+            ),
+        ],
+      );
+    });
+  }
+
+  @override
+  Future<void> remove(String workspaceId) async {
+    await (_db.delete(
+      _db.workspaceActivityTable,
+    )..where((table) => table.workspaceId.equals(workspaceId))).go();
+  }
+}

--- a/lib/src/features/workbench/infra/runtime_workspace_graph_repository.dart
+++ b/lib/src/features/workbench/infra/runtime_workspace_graph_repository.dart
@@ -105,7 +105,9 @@ List<Map<String, Object?>> _asList(Object? value) {
   if (value is List) {
     return <Map<String, Object?>>[for (final item in value) _asMap(item)];
   }
-  return const <Map<String, Object?>>[];
+  // A malformed payload must surface as an error instead of masquerading as
+  // an empty collection (e.g. "no tags exist").
+  throw const FormatException('Workspace graph payload must be a JSON array.');
 }
 
 Map<String, Object?> _asMap(Object? value) {

--- a/lib/src/features/workbench/presentation/create_workspace_dialog.dart
+++ b/lib/src/features/workbench/presentation/create_workspace_dialog.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:alera/src/app/theme/alera_tokens.dart';
 import 'package:alera/src/design_system/buttons/alera_segmented_button.dart';
 import 'package:alera/src/design_system/feedback/alera_empty_state.dart';
+import 'package:alera/src/design_system/forms/alera_dropdown_field.dart';
 import 'package:alera/src/design_system/forms/alera_search_field.dart';
 import 'package:alera/src/design_system/forms/alera_text_field.dart';
 import 'package:alera/src/design_system/icons/alera_icons.dart';
@@ -954,33 +955,26 @@ class _CreateWorkspaceDialogState extends State<CreateWorkspaceDialog> {
                                 ],
                               ),
                               const SizedBox(height: AleraTokens.space16),
-                              DropdownButtonFormField<String?>(
-                                initialValue: _selectedParentWorkspaceId,
-                                isExpanded: true,
-                                decoration: const InputDecoration(
-                                  labelText: 'Parent Workspace',
-                                ),
-                                items: <DropdownMenuItem<String?>>[
-                                  const DropdownMenuItem<String?>(
+                              AleraDropdownField<String?>(
+                                value: _selectedParentWorkspaceId,
+                                labelText: 'Parent Workspace',
+                                enabled: !_creating,
+                                entries: <AleraDropdownFieldEntry<String?>>[
+                                  const AleraDropdownFieldEntry<String?>(
                                     value: null,
-                                    child: Text('No Parent'),
+                                    label: 'No Parent',
                                   ),
                                   for (final candidate in _parentCandidates)
-                                    DropdownMenuItem<String?>(
+                                    AleraDropdownFieldEntry<String?>(
                                       value: candidate.workspace.id,
-                                      child: Text(
-                                        _parentLabel(candidate),
-                                        overflow: TextOverflow.ellipsis,
-                                      ),
+                                      label: _parentLabel(candidate),
                                     ),
                                 ],
-                                onChanged: _creating
-                                    ? null
-                                    : (value) {
-                                        setState(() {
-                                          _selectedParentWorkspaceId = value;
-                                        });
-                                      },
+                                onChanged: (value) {
+                                  setState(() {
+                                    _selectedParentWorkspaceId = value;
+                                  });
+                                },
                               ),
                               const SizedBox(height: AleraTokens.space16),
                               Text(

--- a/lib/src/features/workbench/presentation/project_workbench_agent_rows.dart
+++ b/lib/src/features/workbench/presentation/project_workbench_agent_rows.dart
@@ -58,7 +58,7 @@ class _AgentRunRowState extends State<_AgentRunRow> {
                 children: <Widget>[
                   Padding(
                     padding: const EdgeInsets.only(top: 1),
-                    child: _AgentRunStateIndicator(
+                    child: AgentRunStateIndicator(
                       status: widget.status,
                       size: 12,
                     ),
@@ -137,80 +137,12 @@ class _AgentRunRowState extends State<_AgentRunRow> {
   }
 }
 
-class _AgentRunStateIndicator extends StatelessWidget {
-  const _AgentRunStateIndicator({required this.status, this.size = 13});
-
-  final AgentStatusEntry status;
-  final double size;
-
-  @override
-  Widget build(BuildContext context) {
-    final label = _agentRunStateLabel(status);
-    final color = _agentRunStateColor(status);
-    return Tooltip(
-      message: label,
-      child: Semantics(
-        label: label,
-        child: SizedBox.square(
-          dimension: size,
-          child: Center(child: _buildIndicator(color)),
-        ),
-      ),
-    );
-  }
-
-  Widget _buildIndicator(Color color) {
-    if (status.state == AgentStatusState.working) {
-      return SizedBox.square(
-        dimension: size - 2,
-        child: CircularProgressIndicator(
-          strokeWidth: 1.7,
-          color: AleraTokens.warning,
-        ),
-      );
-    }
-    final icon = status.interrupted == true
-        ? AleraIcons.cancel
-        : switch (status.state) {
-            AgentStatusState.done => AleraIcons.success,
-            AgentStatusState.waiting ||
-            AgentStatusState.blocked => AleraIcons.notifications,
-            AgentStatusState.working => AleraIcons.sync, // coverage:ignore-line
-          };
-    return Icon(icon, size: size, color: color);
-  }
-}
-
-Color _agentRunStateColor(AgentStatusEntry status) {
-  if (status.interrupted == true) {
-    return AleraTokens.error;
-  }
-  return switch (status.state) {
-    AgentStatusState.working => AleraTokens.warning,
-    AgentStatusState.waiting => AleraTokens.warning,
-    AgentStatusState.blocked => AleraTokens.error,
-    AgentStatusState.done => AleraTokens.success,
-  };
-}
-
-String _agentRunStateLabel(AgentStatusEntry status) {
-  if (status.interrupted == true) {
-    return 'Interrupted';
-  }
-  return switch (status.state) {
-    AgentStatusState.working => 'Working',
-    AgentStatusState.waiting => 'Waiting for input',
-    AgentStatusState.blocked => 'Blocked',
-    AgentStatusState.done => 'Done',
-  };
-}
-
 String _agentRunPrimaryLabel(AgentStatusEntry status) {
   final prompt = status.prompt.trim();
   if (prompt.isNotEmpty) {
     return prompt;
   }
-  return _agentRunStateLabel(status);
+  return agentRunStateLabel(status);
 }
 
 String _agentRunSecondaryLabel(AgentStatusEntry status) {
@@ -228,5 +160,5 @@ String _agentRunSecondaryLabel(AgentStatusEntry status) {
   if (assistantMessage.isNotEmpty) {
     return assistantMessage;
   }
-  return '${agentDisplayName(status.agentType)} · ${_agentRunStateLabel(status)}';
+  return '${agentDisplayName(status.agentType)} · ${agentRunStateLabel(status)}';
 }

--- a/lib/src/features/workbench/presentation/project_workbench_sidebar.dart
+++ b/lib/src/features/workbench/presentation/project_workbench_sidebar.dart
@@ -17,11 +17,15 @@ import 'package:alera/src/features/agent_status/domain/agent_status.dart';
 import 'package:alera/src/features/agent_status/presentation/agent_identity_icon.dart';
 import 'package:alera/src/features/projects/presentation/widgets/sidebar_resize_handle.dart';
 import 'package:alera/src/features/projects/presentation/widgets/sidebar_search_bar.dart';
+import 'package:alera/src/features/workbench/application/workbench_agent_activity_sort.dart';
 import 'package:alera/src/features/workbench/application/workbench_listing.dart';
 import 'package:alera/src/features/workbench/application/workbench_state.dart';
+import 'package:alera/src/features/workbench/application/workspace_agent_run_groups.dart';
 import 'package:alera/src/features/workbench/application/workspace_agent_status_projection.dart';
 import 'package:alera/src/features/workbench/domain/workspace_tab_record.dart';
 import 'package:alera/src/features/workbench/domain/workspace.dart';
+import 'package:alera/src/features/workbench/presentation/widgets/agent_run_state_indicator.dart';
+import 'package:alera/src/features/workbench/presentation/widgets/workspace_agent_compact_summary.dart';
 import 'package:alera/src/features/workbench/presentation/workbench_dialog_launchers.dart';
 import 'package:alera/src/features/workbench/presentation/workspace_graph_dialogs.dart';
 import 'package:alera/src/features/workbench/presentation/workspace_graph_indicators.dart';
@@ -60,6 +64,8 @@ class _ProjectWorkbenchSidebarState
   Widget build(BuildContext context) {
     final state = ref.watch(workbenchControllerProvider);
     final agentStatuses = ref.watch(agentStatusControllerProvider);
+    final lastActivity = ref.watch(workspaceActivityControllerProvider);
+    final orderMemory = ref.read(sidebarOrderMemoryProvider);
     final controller = ref.read(workbenchControllerProvider.notifier);
     final workspaceFolderOpener = ref.read(workspaceFolderOpenerProvider);
     if (state.collapsed) {
@@ -107,6 +113,8 @@ class _ProjectWorkbenchSidebarState
                           state: state,
                           controller: controller,
                           agentStatuses: agentStatuses,
+                          lastActivityByWorkspaceId: lastActivity,
+                          orderMemory: orderMemory,
                           onOpenWorkspace: _openWorkspace,
                           onOpenWorkspaceFolder: _openWorkspaceFolder,
                           onCopyWorkspacePath: _copyWorkspacePath,

--- a/lib/src/features/workbench/presentation/project_workbench_sidebar_body.dart
+++ b/lib/src/features/workbench/presentation/project_workbench_sidebar_body.dart
@@ -5,6 +5,8 @@ class _SidebarBody extends StatelessWidget {
     required this.state,
     required this.controller,
     required this.agentStatuses,
+    required this.lastActivityByWorkspaceId,
+    required this.orderMemory,
     required this.onOpenWorkspace,
     required this.onOpenWorkspaceFolder,
     required this.onCopyWorkspacePath,
@@ -25,6 +27,8 @@ class _SidebarBody extends StatelessWidget {
   final WorkbenchState state;
   final WorkbenchController controller;
   final Map<String, AgentStatusEntry> agentStatuses;
+  final Map<String, DateTime> lastActivityByWorkspaceId;
+  final SidebarOrderMemory orderMemory;
   final Future<void> Function(Project project, Workspace workspace)
   onOpenWorkspace;
   final Future<void> Function(Workspace workspace) onOpenWorkspaceFolder;
@@ -45,7 +49,13 @@ class _SidebarBody extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final rows = buildSidebarRows(state, agentStatuses: agentStatuses);
+    final rows = buildSidebarRows(
+      state,
+      agentStatuses: agentStatuses,
+      lastActivityByWorkspaceId: lastActivityByWorkspaceId,
+      previousWorkspaceOrder: orderMemory.order,
+    );
+    orderMemory.order = workspaceOrderOfRows(rows);
     if (rows.isEmpty) {
       return _EmptyResultsView(query: state.searchQuery);
     }
@@ -83,9 +93,7 @@ class _SidebarBody extends StatelessWidget {
       );
     }
     if (row is WorkbenchWorkspaceRow) {
-      final leftPadding = row.indent == 0
-          ? AleraTokens.space8
-          : AleraTokens.space20;
+      final leftPadding = _indentPadding(row.indent);
       final tabs = state.tabsFor(row.workspace.id);
       final agentRuns = visibleWorkspaceAgentRuns(
         tabs: tabs,
@@ -99,12 +107,18 @@ class _SidebarBody extends StatelessWidget {
         child: _WorkspaceRow(
           project: row.project,
           workspace: row.workspace,
-          agentRunCount: agentRuns.length,
+          agentRunGroups: groupWorkspaceAgentRuns(agentRuns),
           status: agentRuns.isEmpty ? null : agentRuns.first.status,
           hasTerminalTabs: hasTerminalTabs,
           isActive: row.workspace.id == state.activeWorkspaceId,
           showProjectChip: row.showProjectChip,
           expanded: row.expanded,
+          hasVisibleChildren: row.hasVisibleChildren,
+          childrenCollapsed: row.childrenCollapsed,
+          onToggleChildren: row.hasVisibleChildren
+              ? () =>
+                    controller.toggleParentWorkspaceCollapsed(row.workspace.id)
+              : null,
           onTap: () => onOpenWorkspace(row.project, row.workspace),
           onOpenFolder: () => unawaited(onOpenWorkspaceFolder(row.workspace)),
           onCopyPath: () => unawaited(onCopyWorkspacePath(row.workspace)),
@@ -125,9 +139,7 @@ class _SidebarBody extends StatelessWidget {
       );
     }
     if (row is SidebarAgentRunRow) {
-      final leftPadding = row.indent <= 1
-          ? AleraTokens.space20
-          : AleraTokens.space32;
+      final leftPadding = _indentPadding(row.indent);
       return Padding(
         padding: EdgeInsets.only(left: leftPadding, right: AleraTokens.space8),
         child: _AgentRunRow(
@@ -145,6 +157,16 @@ class _SidebarBody extends StatelessWidget {
       );
     }
     return const SizedBox.shrink();
+  }
+
+  /// Base sidebar padding plus one step per nesting level, clamped so deep
+  /// trees keep usable row widths in a narrow sidebar.
+  double _indentPadding(int indent) {
+    const double base = AleraTokens.space8;
+    const double step = AleraTokens.space12;
+    const double max = base + 6 * step;
+    final padding = base + indent * step;
+    return padding > max ? max : padding;
   }
 }
 

--- a/lib/src/features/workbench/presentation/project_workbench_workspace_rows.dart
+++ b/lib/src/features/workbench/presentation/project_workbench_workspace_rows.dart
@@ -4,7 +4,7 @@ class _WorkspaceRow extends StatefulWidget {
   const _WorkspaceRow({
     required this.project,
     required this.workspace,
-    required this.agentRunCount,
+    required this.agentRunGroups,
     required this.status,
     required this.hasTerminalTabs,
     required this.isActive,
@@ -19,18 +19,24 @@ class _WorkspaceRow extends StatefulWidget {
     required this.onRename,
     required this.onManageTags,
     required this.onSetParent,
+    this.hasVisibleChildren = false,
+    this.childrenCollapsed = false,
+    this.onToggleChildren,
     this.onClearParent,
     this.onDelete,
   });
 
   final Project project;
   final Workspace workspace;
-  final int agentRunCount;
+  final List<WorkspaceAgentRunGroup> agentRunGroups;
   final AgentStatusEntry? status;
   final bool hasTerminalTabs;
   final bool isActive;
   final bool showProjectChip;
   final bool expanded;
+  final bool hasVisibleChildren;
+  final bool childrenCollapsed;
+  final VoidCallback? onToggleChildren;
   final VoidCallback onTap;
   final VoidCallback onOpenFolder;
   final VoidCallback onCopyPath;
@@ -173,13 +179,6 @@ class _WorkspaceRowState extends State<_WorkspaceRow> {
         source.isNotEmpty) {
       parts.add('Base: $source');
     }
-    if (widget.agentRunCount > 0) {
-      parts.add(
-        widget.agentRunCount == 1
-            ? '1 Agent Run'
-            : '${widget.agentRunCount} Agent Runs',
-      );
-    }
     return parts.join(' · ');
   }
 
@@ -216,13 +215,31 @@ class _WorkspaceRowState extends State<_WorkspaceRow> {
                 child: Row(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: <Widget>[
+                    if (widget.hasVisibleChildren &&
+                        widget.onToggleChildren != null) ...<Widget>[
+                      Padding(
+                        padding: const EdgeInsets.only(top: 2),
+                        child: AleraIconButton(
+                          tooltip: widget.childrenCollapsed
+                              ? 'Show Child Workspaces'
+                              : 'Hide Child Workspaces',
+                          onPressed: widget.onToggleChildren!,
+                          icon: widget.childrenCollapsed
+                              ? AleraIcons.chevronRight
+                              : AleraIcons.chevronDown,
+                          iconSize: 12,
+                          minSize: 20,
+                        ),
+                      ),
+                      const SizedBox(width: AleraTokens.space2),
+                    ],
                     Padding(
                       padding: const EdgeInsets.only(top: 6),
                       child: widget.status == null
                           ? AleraStatusDot(
                               active: isActive || widget.hasTerminalTabs,
                             )
-                          : _AgentRunStateIndicator(status: widget.status!),
+                          : AgentRunStateIndicator(status: widget.status!),
                     ),
                     const SizedBox(width: AleraTokens.space8),
                     Expanded(
@@ -272,6 +289,17 @@ class _WorkspaceRowState extends State<_WorkspaceRow> {
                               ),
                             ],
                           ),
+                          if (widget.agentRunGroups.isNotEmpty) ...<Widget>[
+                            const SizedBox(height: AleraTokens.space6),
+                            Align(
+                              alignment: Alignment.centerLeft,
+                              child: WorkspaceAgentCompactSummary(
+                                groups: widget.agentRunGroups,
+                                expanded: widget.expanded,
+                                onToggle: widget.onToggleExpanded,
+                              ),
+                            ),
+                          ],
                           if (WorkspaceGraphChips.hasContent(
                             widget.workspace,
                           )) ...<Widget>[
@@ -281,18 +309,6 @@ class _WorkspaceRowState extends State<_WorkspaceRow> {
                         ],
                       ),
                     ),
-                    if (widget.agentRunCount > 0)
-                      AleraIconButton(
-                        tooltip: widget.expanded
-                            ? 'Hide Agent Runs'
-                            : 'Show Agent Runs',
-                        onPressed: widget.onToggleExpanded,
-                        icon: widget.expanded
-                            ? AleraIcons.chevronUp
-                            : AleraIcons.chevronDown,
-                        iconSize: 14,
-                        minSize: 24,
-                      ),
                     if (widget.onDelete != null)
                       IgnorePointer(
                         ignoring: !actionsVisible,

--- a/lib/src/features/workbench/presentation/widgets/agent_run_state_indicator.dart
+++ b/lib/src/features/workbench/presentation/widgets/agent_run_state_indicator.dart
@@ -1,0 +1,78 @@
+import 'package:alera/src/app/theme/alera_tokens.dart';
+import 'package:alera/src/design_system/icons/alera_icons.dart';
+import 'package:alera/src/features/agent_status/domain/agent_status.dart';
+import 'package:flutter/material.dart';
+
+/// Visual state glyph for one agent run: spinner while working, state-colored
+/// icon otherwise. Shared by the sidebar agent rows and the compact summary.
+class AgentRunStateIndicator extends StatelessWidget {
+  const AgentRunStateIndicator({
+    super.key,
+    required this.status,
+    this.size = 13,
+  });
+
+  final AgentStatusEntry status;
+  final double size;
+
+  @override
+  Widget build(BuildContext context) {
+    final label = agentRunStateLabel(status);
+    final color = agentRunStateColor(status);
+    return Tooltip(
+      message: label,
+      child: Semantics(
+        label: label,
+        child: SizedBox.square(
+          dimension: size,
+          child: Center(child: _buildIndicator(color)),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildIndicator(Color color) {
+    if (status.state == AgentStatusState.working) {
+      return SizedBox.square(
+        dimension: size - 2,
+        child: CircularProgressIndicator(
+          strokeWidth: 1.7,
+          color: AleraTokens.warning,
+        ),
+      );
+    }
+    final icon = status.interrupted == true
+        ? AleraIcons.cancel
+        : switch (status.state) {
+            AgentStatusState.done => AleraIcons.success,
+            AgentStatusState.waiting ||
+            AgentStatusState.blocked => AleraIcons.notifications,
+            AgentStatusState.working => AleraIcons.sync, // coverage:ignore-line
+          };
+    return Icon(icon, size: size, color: color);
+  }
+}
+
+Color agentRunStateColor(AgentStatusEntry status) {
+  if (status.interrupted == true) {
+    return AleraTokens.error;
+  }
+  return switch (status.state) {
+    AgentStatusState.working => AleraTokens.warning,
+    AgentStatusState.waiting => AleraTokens.warning,
+    AgentStatusState.blocked => AleraTokens.error,
+    AgentStatusState.done => AleraTokens.success,
+  };
+}
+
+String agentRunStateLabel(AgentStatusEntry status) {
+  if (status.interrupted == true) {
+    return 'Interrupted';
+  }
+  return switch (status.state) {
+    AgentStatusState.working => 'Working',
+    AgentStatusState.waiting => 'Waiting for input',
+    AgentStatusState.blocked => 'Blocked',
+    AgentStatusState.done => 'Done',
+  };
+}

--- a/lib/src/features/workbench/presentation/widgets/workbench_view_options_controls.dart
+++ b/lib/src/features/workbench/presentation/widgets/workbench_view_options_controls.dart
@@ -95,6 +95,7 @@ class _SortRow extends StatelessWidget {
   static const Map<WorkbenchSortBy, String> _labels = <WorkbenchSortBy, String>{
     WorkbenchSortBy.name: 'Name',
     WorkbenchSortBy.recent: 'Recent',
+    WorkbenchSortBy.activity: 'Agent Activity',
   };
 
   @override

--- a/lib/src/features/workbench/presentation/widgets/workbench_view_options_menu.dart
+++ b/lib/src/features/workbench/presentation/widgets/workbench_view_options_menu.dart
@@ -11,11 +11,13 @@ import 'package:alera/src/design_system/layout/alera_dialog.dart';
 import 'package:alera/src/design_system/layout/alera_dialog_header.dart';
 import 'package:alera/src/design_system/menus/alera_dropdown_entry.dart';
 import 'package:alera/src/features/projects/domain/project.dart';
+import 'package:alera/src/features/workbench/application/workbench_state.dart';
 import 'package:alera/src/features/workbench/domain/workbench_view_prefs.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 part 'workbench_view_options_controls.dart';
+part 'workbench_view_options_tags.dart';
 
 /// Filter/sort/group icon button that opens the view-options modal centered on
 /// screen. Using a centered dialog (instead of an anchored popover) sidesteps
@@ -30,6 +32,7 @@ class WorkbenchViewOptionsButton extends ConsumerWidget {
     );
     final hasFilters =
         prefs.selectedProjectIds.isNotEmpty ||
+        prefs.selectedTagIds.isNotEmpty ||
         prefs.groupBy != WorkbenchViewPrefs.defaults.groupBy ||
         prefs.projectSort != WorkbenchViewPrefs.defaults.projectSort ||
         prefs.workspaceSort != WorkbenchViewPrefs.defaults.workspaceSort;
@@ -97,7 +100,14 @@ class _WorkbenchViewOptionsPanel extends ConsumerStatefulWidget {
 class _WorkbenchViewOptionsPanelState
     extends ConsumerState<_WorkbenchViewOptionsPanel> {
   final TextEditingController _searchController = TextEditingController();
+  final TextEditingController _tagSearchController = TextEditingController();
   String _projectQuery = '';
+  String _tagQuery = '';
+
+  /// Tags known to the runtime, loaded once when the panel opens. Until (or if
+  /// ever) the fetch fails, the tags carried by the loaded workspaces act as a
+  /// fallback so the filter stays usable offline.
+  List<_TagOption>? _runtimeTags;
 
   @override
   void initState() {
@@ -108,11 +118,37 @@ class _WorkbenchViewOptionsPanelState
         setState(() => _projectQuery = value);
       }
     });
+    _tagSearchController.addListener(() {
+      final value = _tagSearchController.text.trim().toLowerCase();
+      if (value != _tagQuery) {
+        setState(() => _tagQuery = value);
+      }
+    });
+    _loadRuntimeTags();
+  }
+
+  Future<void> _loadRuntimeTags() async {
+    try {
+      final tags = await ref
+          .read(workbenchControllerProvider.notifier)
+          .listWorkspaceTags();
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _runtimeTags = <_TagOption>[
+          for (final tag in tags) (id: tag.id, name: tag.name),
+        ];
+      });
+    } catch (_) {
+      // Keep the workspace-derived fallback.
+    }
   }
 
   @override
   void dispose() {
     _searchController.dispose();
+    _tagSearchController.dispose();
     super.dispose();
   }
 
@@ -124,6 +160,27 @@ class _WorkbenchViewOptionsPanelState
         .read(workbenchControllerProvider.notifier)
         .addProjectFilter(available.first.id);
     _searchController.clear();
+  }
+
+  List<_TagOption> _knownTags(WorkbenchState state) {
+    final runtime = _runtimeTags;
+    if (runtime != null) {
+      return runtime;
+    }
+    final byId = <String, String>{};
+    for (final workspaces in state.workspacesByProject.values) {
+      for (final workspace in workspaces) {
+        for (var i = 0; i < workspace.tagIds.length; i++) {
+          byId[workspace.tagIds[i]] = i < workspace.tagNames.length
+              ? workspace.tagNames[i]
+              : workspace.tagIds[i];
+        }
+      }
+    }
+    final options = <_TagOption>[
+      for (final entry in byId.entries) (id: entry.key, name: entry.value),
+    ]..sort((a, b) => a.name.toLowerCase().compareTo(b.name.toLowerCase()));
+    return options;
   }
 
   @override
@@ -143,6 +200,22 @@ class _WorkbenchViewOptionsPanelState
           (p) =>
               _projectQuery.isEmpty ||
               p.name.toLowerCase().contains(_projectQuery),
+        )
+        .toList(growable: false);
+
+    final knownTags = _knownTags(state);
+    final tagNameById = <String, String>{
+      for (final tag in knownTags) tag.id: tag.name,
+    };
+    final selectedTags = <_TagOption>[
+      for (final id in prefs.selectedTagIds)
+        (id: id, name: tagNameById[id] ?? id),
+    ];
+    final availableTags = knownTags
+        .where((tag) => !prefs.selectedTagIds.contains(tag.id))
+        .where(
+          (tag) =>
+              _tagQuery.isEmpty || tag.name.toLowerCase().contains(_tagQuery),
         )
         .toList(growable: false);
 
@@ -225,6 +298,24 @@ class _WorkbenchViewOptionsPanelState
               controller.addProjectFilter(project.id);
               _searchController.clear();
             },
+            theme: theme,
+          ),
+          const SizedBox(height: AleraTokens.space16),
+          const Divider(height: 1, color: AleraTokens.borderSubtle),
+          const SizedBox(height: AleraTokens.space12),
+          _TagsFilterSection(
+            selectedTags: selectedTags,
+            availableTags: availableTags,
+            query: _tagQuery,
+            searchController: _tagSearchController,
+            onAdd: (tagId) {
+              controller.addTagFilter(tagId);
+              _tagSearchController.clear();
+            },
+            onRemove: controller.removeTagFilter,
+            onClear: prefs.selectedTagIds.isEmpty
+                ? null
+                : controller.clearTagFilters,
             theme: theme,
           ),
         ],

--- a/lib/src/features/workbench/presentation/widgets/workbench_view_options_tags.dart
+++ b/lib/src/features/workbench/presentation/widgets/workbench_view_options_tags.dart
@@ -1,0 +1,201 @@
+part of 'workbench_view_options_menu.dart';
+
+/// One pickable tag for the filter section: id plus display name.
+typedef _TagOption = ({String id, String name});
+
+class _TagsFilterSection extends StatelessWidget {
+  const _TagsFilterSection({
+    required this.selectedTags,
+    required this.availableTags,
+    required this.query,
+    required this.searchController,
+    required this.onAdd,
+    required this.onRemove,
+    required this.onClear,
+    required this.theme,
+  });
+
+  final List<_TagOption> selectedTags;
+  final List<_TagOption> availableTags;
+  final String query;
+  final TextEditingController searchController;
+  final ValueChanged<String> onAdd;
+  final ValueChanged<String> onRemove;
+  final VoidCallback? onClear;
+  final ThemeData theme;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: <Widget>[
+        Row(
+          children: <Widget>[
+            _SectionLabel(text: 'Tags'),
+            const SizedBox(width: AleraTokens.space6),
+            if (selectedTags.isNotEmpty)
+              AleraBadge(label: selectedTags.length.toString()),
+            const Spacer(),
+            MouseRegion(
+              cursor: onClear == null
+                  ? SystemMouseCursors.basic
+                  : SystemMouseCursors.click,
+              child: TextButton(
+                onPressed: onClear,
+                style: TextButton.styleFrom(
+                  foregroundColor: AleraTokens.foregroundMuted,
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: AleraTokens.space8,
+                  ),
+                  minimumSize: const Size(0, 24),
+                  tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                ),
+                child: Text('Clear', style: theme.textTheme.labelSmall),
+              ),
+            ),
+          ],
+        ),
+        if (selectedTags.isNotEmpty) ...<Widget>[
+          const SizedBox(height: AleraTokens.space8),
+          Wrap(
+            spacing: AleraTokens.space6,
+            runSpacing: AleraTokens.space6,
+            children: <Widget>[
+              for (final tag in selectedTags)
+                AleraChip(label: tag.name, onRemove: () => onRemove(tag.id)),
+            ],
+          ),
+        ],
+        const SizedBox(height: AleraTokens.space8),
+        AleraTextField(
+          dense: true,
+          prefixIcon: AleraIcons.add,
+          hintText: 'Add Tag…',
+          controller: searchController,
+          onSubmitted: (_) {
+            if (availableTags.isNotEmpty) {
+              onAdd(availableTags.first.id);
+            }
+          },
+        ),
+        const SizedBox(height: AleraTokens.space8),
+        _AvailableTagsList(
+          tags: availableTags,
+          hasSelection: selectedTags.isNotEmpty,
+          query: query,
+          onPick: onAdd,
+          theme: theme,
+        ),
+      ],
+    );
+  }
+}
+
+class _AvailableTagsList extends StatelessWidget {
+  const _AvailableTagsList({
+    required this.tags,
+    required this.hasSelection,
+    required this.query,
+    required this.onPick,
+    required this.theme,
+  });
+
+  final List<_TagOption> tags;
+  final bool hasSelection;
+  final String query;
+  final ValueChanged<String> onPick;
+  final ThemeData theme;
+
+  @override
+  Widget build(BuildContext context) {
+    if (tags.isEmpty) {
+      final emptyMessage = query.isNotEmpty
+          ? 'No Tags Match "$query"'
+          : (hasSelection ? 'All Tags Selected' : 'No Tags Yet');
+      return Padding(
+        padding: const EdgeInsets.symmetric(vertical: AleraTokens.space8),
+        child: Center(
+          child: Text(
+            emptyMessage,
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: AleraTokens.foregroundFaint,
+            ),
+          ),
+        ),
+      );
+    }
+    return ConstrainedBox(
+      constraints: const BoxConstraints(maxHeight: 160),
+      child: SingleChildScrollView(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: <Widget>[
+            for (final tag in tags)
+              _AvailableTagRow(tag: tag, onPick: () => onPick(tag.id)),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _AvailableTagRow extends StatefulWidget {
+  const _AvailableTagRow({required this.tag, required this.onPick});
+
+  final _TagOption tag;
+  final VoidCallback onPick;
+
+  @override
+  State<_AvailableTagRow> createState() => _AvailableTagRowState();
+}
+
+class _AvailableTagRowState extends State<_AvailableTagRow> {
+  bool _hovered = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return MouseRegion(
+      onEnter: (_) => setState(() => _hovered = true),
+      onExit: (_) => setState(() => _hovered = false),
+      cursor: SystemMouseCursors.click,
+      child: InkWell(
+        onTap: widget.onPick,
+        mouseCursor: SystemMouseCursors.click,
+        borderRadius: BorderRadius.circular(AleraTokens.radiusSm),
+        child: AnimatedContainer(
+          duration: AleraTokens.durationFast,
+          decoration: BoxDecoration(
+            color: _hovered ? AleraTokens.surface : Colors.transparent,
+            borderRadius: BorderRadius.circular(AleraTokens.radiusSm),
+          ),
+          padding: const EdgeInsets.symmetric(
+            horizontal: AleraTokens.space8,
+            vertical: AleraTokens.space6,
+          ),
+          child: Row(
+            children: <Widget>[
+              const Icon(
+                AleraIcons.tag,
+                size: 12,
+                color: AleraTokens.foregroundFaint,
+              ),
+              const SizedBox(width: AleraTokens.space8),
+              Expanded(
+                child: Text(
+                  widget.tag.name,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: AleraTokens.foreground,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/features/workbench/presentation/widgets/workspace_agent_compact_summary.dart
+++ b/lib/src/features/workbench/presentation/widgets/workspace_agent_compact_summary.dart
@@ -1,0 +1,141 @@
+import 'package:alera/src/app/theme/alera_tokens.dart';
+import 'package:alera/src/design_system/icons/alera_icons.dart';
+import 'package:alera/src/features/agent_status/presentation/agent_identity_icon.dart';
+import 'package:alera/src/features/workbench/application/workspace_agent_run_groups.dart';
+import 'package:alera/src/features/workbench/presentation/widgets/agent_run_state_indicator.dart';
+import 'package:flutter/material.dart';
+
+/// Single-line summary of a workspace's agent runs: agents grouped by state,
+/// each group showing its state glyph plus up to three overlapping identity
+/// icons. Clicking toggles the expanded per-agent rows.
+class WorkspaceAgentCompactSummary extends StatelessWidget {
+  const WorkspaceAgentCompactSummary({
+    super.key,
+    required this.groups,
+    required this.expanded,
+    required this.onToggle,
+  });
+
+  final List<WorkspaceAgentRunGroup> groups;
+  final bool expanded;
+  final VoidCallback onToggle;
+
+  static const int _maxVisibleGroups = 3;
+  static const int _maxIconsPerGroup = 3;
+  static const double _iconSize = 16;
+  static const double _iconOverlap = 5;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final visibleGroups = groups.take(_maxVisibleGroups).toList();
+    final hiddenGroupRuns = groups
+        .skip(_maxVisibleGroups)
+        .fold<int>(0, (sum, group) => sum + group.runs.length);
+    return Tooltip(
+      message: expanded ? 'Hide Agent Runs' : 'Show Agent Runs',
+      child: InkWell(
+        onTap: onToggle,
+        mouseCursor: SystemMouseCursors.click,
+        borderRadius: BorderRadius.circular(AleraTokens.radiusMd),
+        child: Container(
+          padding: const EdgeInsets.symmetric(
+            horizontal: AleraTokens.space6,
+            vertical: AleraTokens.space2,
+          ),
+          decoration: BoxDecoration(
+            color: AleraTokens.surface,
+            borderRadius: BorderRadius.circular(AleraTokens.radiusMd),
+            border: Border.all(color: AleraTokens.borderSubtle),
+          ),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: <Widget>[
+              for (final (index, group) in visibleGroups.indexed) ...<Widget>[
+                if (index > 0) const SizedBox(width: AleraTokens.space8),
+                _GroupCluster(group: group),
+              ],
+              if (hiddenGroupRuns > 0) ...<Widget>[
+                const SizedBox(width: AleraTokens.space6),
+                Text(
+                  '+$hiddenGroupRuns',
+                  style: theme.textTheme.labelSmall?.copyWith(
+                    color: AleraTokens.foregroundFaint,
+                  ),
+                ),
+              ],
+              const SizedBox(width: AleraTokens.space6),
+              Icon(
+                expanded ? AleraIcons.chevronUp : AleraIcons.chevronDown,
+                size: 12,
+                color: AleraTokens.foregroundMuted,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _GroupCluster extends StatelessWidget {
+  const _GroupCluster({required this.group});
+
+  final WorkspaceAgentRunGroup group;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    const iconSize = WorkspaceAgentCompactSummary._iconSize;
+    const overlap = WorkspaceAgentCompactSummary._iconOverlap;
+    final iconRuns = group.runs
+        .take(WorkspaceAgentCompactSummary._maxIconsPerGroup)
+        .toList();
+    final hiddenCount = group.runs.length - iconRuns.length;
+    final width = iconSize + (iconRuns.length - 1) * (iconSize - overlap);
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: <Widget>[
+        AgentRunStateIndicator(status: group.runs.first.status, size: 11),
+        const SizedBox(width: AleraTokens.space4),
+        SizedBox(
+          width: width,
+          height: iconSize,
+          child: Stack(
+            children: <Widget>[
+              for (final (index, run) in iconRuns.indexed)
+                Positioned(
+                  left: index * (iconSize - overlap),
+                  child: Container(
+                    width: iconSize,
+                    height: iconSize,
+                    decoration: BoxDecoration(
+                      color: AleraTokens.surfaceVariant,
+                      shape: BoxShape.circle,
+                      border: Border.all(color: AleraTokens.borderSubtle),
+                    ),
+                    child: Center(
+                      child: AgentIdentityIcon(
+                        agentType: run.status.agentType,
+                        size: 10,
+                        color: AleraTokens.foregroundMuted,
+                      ),
+                    ),
+                  ),
+                ),
+            ],
+          ),
+        ),
+        if (hiddenCount > 0) ...<Widget>[
+          const SizedBox(width: AleraTokens.space2),
+          Text(
+            '+$hiddenCount',
+            style: theme.textTheme.labelSmall?.copyWith(
+              color: AleraTokens.foregroundFaint,
+            ),
+          ),
+        ],
+      ],
+    );
+  }
+}

--- a/lib/src/features/workbench/presentation/workspace_graph_dialogs.dart
+++ b/lib/src/features/workbench/presentation/workspace_graph_dialogs.dart
@@ -1,5 +1,6 @@
 import 'package:alera/src/app/theme/alera_tokens.dart';
 import 'package:alera/src/design_system/buttons/alera_icon_button.dart';
+import 'package:alera/src/design_system/forms/alera_dropdown_field.dart';
 import 'package:alera/src/design_system/forms/alera_text_field.dart';
 import 'package:alera/src/design_system/icons/alera_icons.dart';
 import 'package:alera/src/design_system/layout/alera_confirm_dialog.dart';
@@ -368,29 +369,20 @@ class _WorkspaceParentDialogState extends State<_WorkspaceParentDialog> {
               ],
             ),
             const SizedBox(height: AleraTokens.space16),
-            DropdownButtonFormField<String?>(
-              initialValue: _selectedParentId,
-              isExpanded: true,
-              decoration: const InputDecoration(labelText: 'Parent Workspace'),
-              items: <DropdownMenuItem<String?>>[
-                const DropdownMenuItem<String?>(
+            AleraDropdownField<String?>(
+              value: _selectedParentId,
+              labelText: 'Parent Workspace',
+              entries: <AleraDropdownFieldEntry<String?>>[
+                const AleraDropdownFieldEntry<String?>(
                   value: null,
-                  child: Text('No Parent'),
+                  label: 'No Parent',
                 ),
                 for (final option in widget.options)
                   if (option.workspace.id != widget.workspace.id)
-                    DropdownMenuItem<String?>(
+                    AleraDropdownFieldEntry<String?>(
                       value: option.workspace.id,
+                      label: option.label,
                       enabled: !descendants.contains(option.workspace.id),
-                      child: Text(
-                        option.label,
-                        overflow: TextOverflow.ellipsis,
-                        style: descendants.contains(option.workspace.id)
-                            ? theme.textTheme.bodyMedium?.copyWith(
-                                color: AleraTokens.foregroundFaint,
-                              )
-                            : null,
-                      ),
                     ),
               ],
               onChanged: (value) {

--- a/lib/src/shared/infra/storage/drift_database.dart
+++ b/lib/src/shared/infra/storage/drift_database.dart
@@ -7,7 +7,7 @@ import 'package:path_provider/path_provider.dart';
 
 part 'drift_database.g.dart';
 
-const int aleraSchemaVersion = 4;
+const int aleraSchemaVersion = 5;
 const String aleraDatabaseFileName = 'alera.sqlite';
 
 class ProjectsTable extends Table {
@@ -95,6 +95,14 @@ class AppWindowStateTable extends Table {
   Set<Column<Object>> get primaryKey => <Column<Object>>{id};
 }
 
+class WorkspaceActivityTable extends Table {
+  TextColumn get workspaceId => text()();
+  DateTimeColumn get lastActivityAt => dateTime()();
+
+  @override
+  Set<Column<Object>> get primaryKey => <Column<Object>>{workspaceId};
+}
+
 LazyDatabase _openConnection() {
   return LazyDatabase(() async {
     final dir = await getApplicationSupportDirectory();
@@ -122,6 +130,7 @@ LazyDatabase _openConnection() {
     AppSettingsTable,
     ProjectConfigsTable,
     AppWindowStateTable,
+    WorkspaceActivityTable,
   ],
 )
 class AleraDatabase extends _$AleraDatabase {
@@ -146,6 +155,9 @@ class AleraDatabase extends _$AleraDatabase {
       }
       if (from < 4 && to >= 4) {
         await m.createTable(appWindowStateTable);
+      }
+      if (from < 5 && to >= 5) {
+        await m.createTable(workspaceActivityTable);
       }
     },
   );

--- a/lib/src/shared/infra/storage/drift_database.g.dart
+++ b/lib/src/shared/infra/storage/drift_database.g.dart
@@ -2709,6 +2709,247 @@ class AppWindowStateTableCompanion
   }
 }
 
+class $WorkspaceActivityTableTable extends WorkspaceActivityTable
+    with TableInfo<$WorkspaceActivityTableTable, WorkspaceActivityTableData> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $WorkspaceActivityTableTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _workspaceIdMeta = const VerificationMeta(
+    'workspaceId',
+  );
+  @override
+  late final GeneratedColumn<String> workspaceId = GeneratedColumn<String>(
+    'workspace_id',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _lastActivityAtMeta = const VerificationMeta(
+    'lastActivityAt',
+  );
+  @override
+  late final GeneratedColumn<DateTime> lastActivityAt =
+      GeneratedColumn<DateTime>(
+        'last_activity_at',
+        aliasedName,
+        false,
+        type: DriftSqlType.dateTime,
+        requiredDuringInsert: true,
+      );
+  @override
+  List<GeneratedColumn> get $columns => [workspaceId, lastActivityAt];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'workspace_activity_table';
+  @override
+  VerificationContext validateIntegrity(
+    Insertable<WorkspaceActivityTableData> instance, {
+    bool isInserting = false,
+  }) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('workspace_id')) {
+      context.handle(
+        _workspaceIdMeta,
+        workspaceId.isAcceptableOrUnknown(
+          data['workspace_id']!,
+          _workspaceIdMeta,
+        ),
+      );
+    } else if (isInserting) {
+      context.missing(_workspaceIdMeta);
+    }
+    if (data.containsKey('last_activity_at')) {
+      context.handle(
+        _lastActivityAtMeta,
+        lastActivityAt.isAcceptableOrUnknown(
+          data['last_activity_at']!,
+          _lastActivityAtMeta,
+        ),
+      );
+    } else if (isInserting) {
+      context.missing(_lastActivityAtMeta);
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {workspaceId};
+  @override
+  WorkspaceActivityTableData map(
+    Map<String, dynamic> data, {
+    String? tablePrefix,
+  }) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return WorkspaceActivityTableData(
+      workspaceId: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}workspace_id'],
+      )!,
+      lastActivityAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}last_activity_at'],
+      )!,
+    );
+  }
+
+  @override
+  $WorkspaceActivityTableTable createAlias(String alias) {
+    return $WorkspaceActivityTableTable(attachedDatabase, alias);
+  }
+}
+
+class WorkspaceActivityTableData extends DataClass
+    implements Insertable<WorkspaceActivityTableData> {
+  final String workspaceId;
+  final DateTime lastActivityAt;
+  const WorkspaceActivityTableData({
+    required this.workspaceId,
+    required this.lastActivityAt,
+  });
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['workspace_id'] = Variable<String>(workspaceId);
+    map['last_activity_at'] = Variable<DateTime>(lastActivityAt);
+    return map;
+  }
+
+  WorkspaceActivityTableCompanion toCompanion(bool nullToAbsent) {
+    return WorkspaceActivityTableCompanion(
+      workspaceId: Value(workspaceId),
+      lastActivityAt: Value(lastActivityAt),
+    );
+  }
+
+  factory WorkspaceActivityTableData.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return WorkspaceActivityTableData(
+      workspaceId: serializer.fromJson<String>(json['workspaceId']),
+      lastActivityAt: serializer.fromJson<DateTime>(json['lastActivityAt']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'workspaceId': serializer.toJson<String>(workspaceId),
+      'lastActivityAt': serializer.toJson<DateTime>(lastActivityAt),
+    };
+  }
+
+  WorkspaceActivityTableData copyWith({
+    String? workspaceId,
+    DateTime? lastActivityAt,
+  }) => WorkspaceActivityTableData(
+    workspaceId: workspaceId ?? this.workspaceId,
+    lastActivityAt: lastActivityAt ?? this.lastActivityAt,
+  );
+  WorkspaceActivityTableData copyWithCompanion(
+    WorkspaceActivityTableCompanion data,
+  ) {
+    return WorkspaceActivityTableData(
+      workspaceId: data.workspaceId.present
+          ? data.workspaceId.value
+          : this.workspaceId,
+      lastActivityAt: data.lastActivityAt.present
+          ? data.lastActivityAt.value
+          : this.lastActivityAt,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('WorkspaceActivityTableData(')
+          ..write('workspaceId: $workspaceId, ')
+          ..write('lastActivityAt: $lastActivityAt')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(workspaceId, lastActivityAt);
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is WorkspaceActivityTableData &&
+          other.workspaceId == this.workspaceId &&
+          other.lastActivityAt == this.lastActivityAt);
+}
+
+class WorkspaceActivityTableCompanion
+    extends UpdateCompanion<WorkspaceActivityTableData> {
+  final Value<String> workspaceId;
+  final Value<DateTime> lastActivityAt;
+  final Value<int> rowid;
+  const WorkspaceActivityTableCompanion({
+    this.workspaceId = const Value.absent(),
+    this.lastActivityAt = const Value.absent(),
+    this.rowid = const Value.absent(),
+  });
+  WorkspaceActivityTableCompanion.insert({
+    required String workspaceId,
+    required DateTime lastActivityAt,
+    this.rowid = const Value.absent(),
+  }) : workspaceId = Value(workspaceId),
+       lastActivityAt = Value(lastActivityAt);
+  static Insertable<WorkspaceActivityTableData> custom({
+    Expression<String>? workspaceId,
+    Expression<DateTime>? lastActivityAt,
+    Expression<int>? rowid,
+  }) {
+    return RawValuesInsertable({
+      if (workspaceId != null) 'workspace_id': workspaceId,
+      if (lastActivityAt != null) 'last_activity_at': lastActivityAt,
+      if (rowid != null) 'rowid': rowid,
+    });
+  }
+
+  WorkspaceActivityTableCompanion copyWith({
+    Value<String>? workspaceId,
+    Value<DateTime>? lastActivityAt,
+    Value<int>? rowid,
+  }) {
+    return WorkspaceActivityTableCompanion(
+      workspaceId: workspaceId ?? this.workspaceId,
+      lastActivityAt: lastActivityAt ?? this.lastActivityAt,
+      rowid: rowid ?? this.rowid,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (workspaceId.present) {
+      map['workspace_id'] = Variable<String>(workspaceId.value);
+    }
+    if (lastActivityAt.present) {
+      map['last_activity_at'] = Variable<DateTime>(lastActivityAt.value);
+    }
+    if (rowid.present) {
+      map['rowid'] = Variable<int>(rowid.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('WorkspaceActivityTableCompanion(')
+          ..write('workspaceId: $workspaceId, ')
+          ..write('lastActivityAt: $lastActivityAt, ')
+          ..write('rowid: $rowid')
+          ..write(')'))
+        .toString();
+  }
+}
+
 abstract class _$AleraDatabase extends GeneratedDatabase {
   _$AleraDatabase(QueryExecutor e) : super(e);
   $AleraDatabaseManager get managers => $AleraDatabaseManager(this);
@@ -2729,6 +2970,8 @@ abstract class _$AleraDatabase extends GeneratedDatabase {
       $ProjectConfigsTableTable(this);
   late final $AppWindowStateTableTable appWindowStateTable =
       $AppWindowStateTableTable(this);
+  late final $WorkspaceActivityTableTable workspaceActivityTable =
+      $WorkspaceActivityTableTable(this);
   @override
   Iterable<TableInfo<Table, Object?>> get allTables =>
       allSchemaEntities.whereType<TableInfo<Table, Object?>>();
@@ -2742,6 +2985,7 @@ abstract class _$AleraDatabase extends GeneratedDatabase {
     appSettingsTable,
     projectConfigsTable,
     appWindowStateTable,
+    workspaceActivityTable,
   ];
 }
 
@@ -4360,6 +4604,172 @@ typedef $$AppWindowStateTableTableProcessedTableManager =
       AppWindowStateTableData,
       PrefetchHooks Function()
     >;
+typedef $$WorkspaceActivityTableTableCreateCompanionBuilder =
+    WorkspaceActivityTableCompanion Function({
+      required String workspaceId,
+      required DateTime lastActivityAt,
+      Value<int> rowid,
+    });
+typedef $$WorkspaceActivityTableTableUpdateCompanionBuilder =
+    WorkspaceActivityTableCompanion Function({
+      Value<String> workspaceId,
+      Value<DateTime> lastActivityAt,
+      Value<int> rowid,
+    });
+
+class $$WorkspaceActivityTableTableFilterComposer
+    extends Composer<_$AleraDatabase, $WorkspaceActivityTableTable> {
+  $$WorkspaceActivityTableTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<String> get workspaceId => $composableBuilder(
+    column: $table.workspaceId,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<DateTime> get lastActivityAt => $composableBuilder(
+    column: $table.lastActivityAt,
+    builder: (column) => ColumnFilters(column),
+  );
+}
+
+class $$WorkspaceActivityTableTableOrderingComposer
+    extends Composer<_$AleraDatabase, $WorkspaceActivityTableTable> {
+  $$WorkspaceActivityTableTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<String> get workspaceId => $composableBuilder(
+    column: $table.workspaceId,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<DateTime> get lastActivityAt => $composableBuilder(
+    column: $table.lastActivityAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+}
+
+class $$WorkspaceActivityTableTableAnnotationComposer
+    extends Composer<_$AleraDatabase, $WorkspaceActivityTableTable> {
+  $$WorkspaceActivityTableTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<String> get workspaceId => $composableBuilder(
+    column: $table.workspaceId,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<DateTime> get lastActivityAt => $composableBuilder(
+    column: $table.lastActivityAt,
+    builder: (column) => column,
+  );
+}
+
+class $$WorkspaceActivityTableTableTableManager
+    extends
+        RootTableManager<
+          _$AleraDatabase,
+          $WorkspaceActivityTableTable,
+          WorkspaceActivityTableData,
+          $$WorkspaceActivityTableTableFilterComposer,
+          $$WorkspaceActivityTableTableOrderingComposer,
+          $$WorkspaceActivityTableTableAnnotationComposer,
+          $$WorkspaceActivityTableTableCreateCompanionBuilder,
+          $$WorkspaceActivityTableTableUpdateCompanionBuilder,
+          (
+            WorkspaceActivityTableData,
+            BaseReferences<
+              _$AleraDatabase,
+              $WorkspaceActivityTableTable,
+              WorkspaceActivityTableData
+            >,
+          ),
+          WorkspaceActivityTableData,
+          PrefetchHooks Function()
+        > {
+  $$WorkspaceActivityTableTableTableManager(
+    _$AleraDatabase db,
+    $WorkspaceActivityTableTable table,
+  ) : super(
+        TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $$WorkspaceActivityTableTableFilterComposer(
+                $db: db,
+                $table: table,
+              ),
+          createOrderingComposer: () =>
+              $$WorkspaceActivityTableTableOrderingComposer(
+                $db: db,
+                $table: table,
+              ),
+          createComputedFieldComposer: () =>
+              $$WorkspaceActivityTableTableAnnotationComposer(
+                $db: db,
+                $table: table,
+              ),
+          updateCompanionCallback:
+              ({
+                Value<String> workspaceId = const Value.absent(),
+                Value<DateTime> lastActivityAt = const Value.absent(),
+                Value<int> rowid = const Value.absent(),
+              }) => WorkspaceActivityTableCompanion(
+                workspaceId: workspaceId,
+                lastActivityAt: lastActivityAt,
+                rowid: rowid,
+              ),
+          createCompanionCallback:
+              ({
+                required String workspaceId,
+                required DateTime lastActivityAt,
+                Value<int> rowid = const Value.absent(),
+              }) => WorkspaceActivityTableCompanion.insert(
+                workspaceId: workspaceId,
+                lastActivityAt: lastActivityAt,
+                rowid: rowid,
+              ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ),
+      );
+}
+
+typedef $$WorkspaceActivityTableTableProcessedTableManager =
+    ProcessedTableManager<
+      _$AleraDatabase,
+      $WorkspaceActivityTableTable,
+      WorkspaceActivityTableData,
+      $$WorkspaceActivityTableTableFilterComposer,
+      $$WorkspaceActivityTableTableOrderingComposer,
+      $$WorkspaceActivityTableTableAnnotationComposer,
+      $$WorkspaceActivityTableTableCreateCompanionBuilder,
+      $$WorkspaceActivityTableTableUpdateCompanionBuilder,
+      (
+        WorkspaceActivityTableData,
+        BaseReferences<
+          _$AleraDatabase,
+          $WorkspaceActivityTableTable,
+          WorkspaceActivityTableData
+        >,
+      ),
+      WorkspaceActivityTableData,
+      PrefetchHooks Function()
+    >;
 
 class $AleraDatabaseManager {
   final _$AleraDatabase _db;
@@ -4383,4 +4793,9 @@ class $AleraDatabaseManager {
       $$ProjectConfigsTableTableTableManager(_db, _db.projectConfigsTable);
   $$AppWindowStateTableTableTableManager get appWindowStateTable =>
       $$AppWindowStateTableTableTableManager(_db, _db.appWindowStateTable);
+  $$WorkspaceActivityTableTableTableManager get workspaceActivityTable =>
+      $$WorkspaceActivityTableTableTableManager(
+        _db,
+        _db.workspaceActivityTable,
+      );
 }

--- a/rust/alera-core/src/runtime/store.rs
+++ b/rust/alera-core/src/runtime/store.rs
@@ -519,6 +519,20 @@ impl RuntimeStore {
     }
 
     pub async fn upsert_tag(&self, tag: WorkspaceTag) -> Result<WorkspaceTag> {
+        // Tag names are unique (COLLATE NOCASE). Callers mint a fresh id per
+        // create, so a duplicate name must reuse the existing row instead of
+        // tripping the unique name index.
+        if let Some(row) = sqlx::query(
+            "SELECT id, name, color, createdAt, updatedAt FROM workspaceTags \
+             WHERE name = ? COLLATE NOCASE AND id != ?",
+        )
+        .bind(&tag.name)
+        .bind(&tag.id)
+        .fetch_optional(&self.pool)
+        .await?
+        {
+            return tag_from_row(row);
+        }
         sqlx::query(
             "INSERT INTO workspaceTags (id, name, color, createdAt, updatedAt) VALUES (?, ?, ?, ?, ?) \
              ON CONFLICT(id) DO UPDATE SET name = excluded.name, color = excluded.color, updatedAt = excluded.updatedAt",
@@ -1237,6 +1251,37 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(preview.workspace_ids, vec!["a", "b", "c"]);
+    }
+
+    #[tokio::test]
+    async fn upsert_tag_reuses_existing_row_for_duplicate_name() {
+        let (_dir, store) = store().await;
+        let now = Utc::now();
+        let original = store
+            .upsert_tag(WorkspaceTag {
+                id: "tag-1".to_string(),
+                name: "Review".to_string(),
+                color: None,
+                created_at: now,
+                updated_at: now,
+            })
+            .await
+            .unwrap();
+        let duplicate = store
+            .upsert_tag(WorkspaceTag {
+                id: "tag-2".to_string(),
+                name: "review".to_string(),
+                color: None,
+                created_at: now,
+                updated_at: now,
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(duplicate.id, original.id);
+        assert_eq!(duplicate.name, "Review");
+        let tags = store.list_tags().await.unwrap();
+        assert_eq!(tags.len(), 1);
     }
 
     #[tokio::test]

--- a/test/unit/drift_workspace_activity_repository_test.dart
+++ b/test/unit/drift_workspace_activity_repository_test.dart
@@ -1,0 +1,42 @@
+import 'package:alera/src/features/workbench/infra/drift_workspace_activity_repository.dart';
+import 'package:alera/src/shared/infra/storage/drift_database.dart';
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  late AleraDatabase db;
+  late DriftWorkspaceActivityRepository repository;
+
+  setUp(() async {
+    db = AleraDatabase(executor: NativeDatabase.memory());
+    repository = DriftWorkspaceActivityRepository(db);
+  });
+
+  tearDown(() async {
+    await db.close();
+  });
+
+  test('loadAll returns an empty map for a fresh database', () async {
+    expect(await repository.loadAll(), isEmpty);
+  });
+
+  test('upsertAll inserts and updates entries', () async {
+    final first = DateTime.utc(2026, 7, 4, 10);
+    final second = DateTime.utc(2026, 7, 4, 12);
+
+    await repository.upsertAll(<String, DateTime>{'w-1': first});
+    await repository.upsertAll(<String, DateTime>{'w-1': second, 'w-2': first});
+
+    final loaded = await repository.loadAll();
+    expect(loaded, <String, DateTime>{'w-1': second, 'w-2': first});
+  });
+
+  test('remove deletes only the targeted workspace', () async {
+    final at = DateTime.utc(2026, 7, 4, 10);
+    await repository.upsertAll(<String, DateTime>{'w-1': at, 'w-2': at});
+
+    await repository.remove('w-1');
+
+    expect(await repository.loadAll(), <String, DateTime>{'w-2': at});
+  });
+}

--- a/test/unit/workbench_agent_activity_sort_test.dart
+++ b/test/unit/workbench_agent_activity_sort_test.dart
@@ -1,0 +1,191 @@
+import 'package:alera/src/features/agent_status/domain/agent_status.dart';
+import 'package:alera/src/features/workbench/application/workbench_agent_activity_sort.dart';
+import 'package:alera/src/features/workbench/domain/workspace_tab_record.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+final DateTime _now = DateTime.utc(2026, 7, 4, 12);
+
+WorkspaceTabRecord _tab(String id, String workspaceId) {
+  return WorkspaceTabRecord(
+    id: id,
+    workspaceId: workspaceId,
+    kind: WorkspaceTabKind.terminal,
+    title: id,
+    createdAt: _now,
+    updatedAt: _now,
+  );
+}
+
+AgentStatusEntry _status(
+  WorkspaceTabRecord tab, {
+  required AgentStatusState state,
+  bool? interrupted,
+  Duration age = Duration.zero,
+}) {
+  return AgentStatusEntry(
+    terminalSessionId: tab.terminalSessionId,
+    workspaceId: tab.workspaceId,
+    tabId: tab.id,
+    agentType: AgentType.claude,
+    state: state,
+    prompt: 'Prompt',
+    updatedAt: _now.subtract(age),
+    stateStartedAt: _now.subtract(age),
+    interrupted: interrupted,
+  );
+}
+
+void main() {
+  group('workspaceAttention', () {
+    test('waiting and blocked classify as needsYou', () {
+      for (final state in <AgentStatusState>[
+        AgentStatusState.waiting,
+        AgentStatusState.blocked,
+      ]) {
+        final tab = _tab('t-1', 'w-1');
+        final attention = workspaceAttention(
+          tabs: <WorkspaceTabRecord>[tab],
+          agentStatuses: <String, AgentStatusEntry>{
+            tab.terminalSessionId: _status(tab, state: state),
+          },
+          now: _now,
+        );
+        expect(attention.attentionClass, AgentAttentionClass.needsYou);
+      }
+    });
+
+    test('interrupted done classifies as needsYou', () {
+      final tab = _tab('t-1', 'w-1');
+      final attention = workspaceAttention(
+        tabs: <WorkspaceTabRecord>[tab],
+        agentStatuses: <String, AgentStatusEntry>{
+          tab.terminalSessionId: _status(
+            tab,
+            state: AgentStatusState.done,
+            interrupted: true,
+          ),
+        },
+        now: _now,
+      );
+      expect(attention.attentionClass, AgentAttentionClass.needsYou);
+    });
+
+    test('stale statuses are ignored', () {
+      final tab = _tab('t-1', 'w-1');
+      final attention = workspaceAttention(
+        tabs: <WorkspaceTabRecord>[tab],
+        agentStatuses: <String, AgentStatusEntry>{
+          tab.terminalSessionId: _status(
+            tab,
+            state: AgentStatusState.waiting,
+            age: agentActivityStaleness + const Duration(minutes: 1),
+          ),
+        },
+        now: _now,
+      );
+      expect(attention.attentionClass, AgentAttentionClass.idle);
+    });
+
+    test('the most urgent run wins', () {
+      final working = _tab('t-1', 'w-1');
+      final waiting = _tab('t-2', 'w-1');
+      final attention = workspaceAttention(
+        tabs: <WorkspaceTabRecord>[working, waiting],
+        agentStatuses: <String, AgentStatusEntry>{
+          working.terminalSessionId: _status(
+            working,
+            state: AgentStatusState.working,
+          ),
+          waiting.terminalSessionId: _status(
+            waiting,
+            state: AgentStatusState.waiting,
+            age: const Duration(minutes: 5),
+          ),
+        },
+        now: _now,
+      );
+      expect(attention.attentionClass, AgentAttentionClass.needsYou);
+      expect(attention.attentionAt, _now.subtract(const Duration(minutes: 5)));
+    });
+  });
+
+  group('compareByAgentActivity', () {
+    test('lower class ranks first regardless of recency', () {
+      final result = compareByAgentActivity(
+        aAttention: const WorkspaceAttention(
+          attentionClass: AgentAttentionClass.working,
+        ),
+        aFallback: _now,
+        aName: 'a',
+        bAttention: const WorkspaceAttention(
+          attentionClass: AgentAttentionClass.needsYou,
+        ),
+        bFallback: _now.subtract(const Duration(days: 1)),
+        bName: 'b',
+      );
+      expect(result, greaterThan(0));
+    });
+
+    test('same class ranks by recency then name', () {
+      final result = compareByAgentActivity(
+        aAttention: WorkspaceAttention(
+          attentionClass: AgentAttentionClass.done,
+          attentionAt: _now,
+        ),
+        aFallback: _now,
+        aName: 'a',
+        bAttention: WorkspaceAttention(
+          attentionClass: AgentAttentionClass.done,
+          attentionAt: _now.subtract(const Duration(minutes: 1)),
+        ),
+        bFallback: _now,
+        bName: 'b',
+      );
+      expect(result, lessThan(0));
+    });
+
+    test('idle entries fall back to the provided timestamp', () {
+      final result = compareByAgentActivity(
+        aAttention: WorkspaceAttention.idle,
+        aFallback: _now.subtract(const Duration(days: 2)),
+        aName: 'a',
+        bAttention: WorkspaceAttention.idle,
+        bFallback: _now,
+        bName: 'b',
+      );
+      expect(result, greaterThan(0));
+    });
+  });
+
+  group('stabilizeActiveEntry', () {
+    test('re-inserts the active id at its previous index', () {
+      final stabilized = stabilizeActiveEntry<String>(
+        sorted: <String>['b', 'c', 'a'],
+        idOf: (id) => id,
+        previousOrder: <String>['a', 'b', 'c'],
+        activeId: 'a',
+      );
+      expect(stabilized, <String>['a', 'b', 'c']);
+    });
+
+    test('leaves the order untouched without an active id', () {
+      final stabilized = stabilizeActiveEntry<String>(
+        sorted: <String>['b', 'a'],
+        idOf: (id) => id,
+        previousOrder: <String>['a', 'b'],
+        activeId: null,
+      );
+      expect(stabilized, <String>['b', 'a']);
+    });
+
+    test('ignores an active id missing from the previous order', () {
+      final stabilized = stabilizeActiveEntry<String>(
+        sorted: <String>['b', 'a'],
+        idOf: (id) => id,
+        previousOrder: const <String>[],
+        activeId: 'a',
+      );
+      expect(stabilized, <String>['b', 'a']);
+    });
+  });
+}

--- a/test/unit/workbench_controller_workspace_graph_test_cases.dart
+++ b/test/unit/workbench_controller_workspace_graph_test_cases.dart
@@ -52,6 +52,19 @@ void _registerWorkbenchControllerWorkspaceGraphTests() {
     },
   );
 
+  test(
+    'createWorkspaceTag reuses an existing tag with the same name',
+    () async {
+      final existing = WorkspaceTag.create(name: 'Review');
+      _harness.workspaceGraphRepository.tags.add(existing);
+
+      final result = await _controller.createWorkspaceTag('review');
+
+      expect(result.id, existing.id);
+      expect(_harness.workspaceGraphRepository.tags, hasLength(1));
+    },
+  );
+
   test('updateWorkspaceTags applies only tag assignment diffs', () async {
     final workspace = Workspace(
       id: 'workspace-1',

--- a/test/unit/workbench_listing_test.dart
+++ b/test/unit/workbench_listing_test.dart
@@ -27,6 +27,8 @@ Workspace _workspace(
   WorkspaceKind kind = WorkspaceKind.linked,
   int recencyOffset = 0,
   String? sourceBranch,
+  List<String> tagIds = const <String>[],
+  String? parentWorkspaceId,
 }) {
   return Workspace(
     id: id,
@@ -39,6 +41,8 @@ Workspace _workspace(
     kind: kind,
     status: WorkspaceStatus.active,
     sourceBranch: sourceBranch,
+    tagIds: tagIds,
+    parentWorkspaceId: parentWorkspaceId,
   );
 }
 
@@ -393,6 +397,301 @@ void main() {
       final workspaces = rows.whereType<WorkbenchWorkspaceRow>().toList();
       expect(workspaces, hasLength(1));
       expect(workspaces.single.workspace.id, 'w-orca-main');
+    });
+  });
+
+  group('buildSidebarRows · tag filter', () {
+    WorkbenchState taggedState(WorkbenchViewPrefs prefs) {
+      final alera = _project('p-alera', 'alera');
+      final orca = _project('p-orca', 'orca');
+      final tagged = _workspace(
+        'w-tagged',
+        alera.id,
+        'tagged',
+        'feature/tagged',
+        tagIds: const <String>['tag-review'],
+      );
+      final untagged = _workspace('w-plain', alera.id, 'plain', 'feature/p');
+      final orcaTagged = _workspace(
+        'w-orca',
+        orca.id,
+        'orca-ws',
+        'main',
+        tagIds: const <String>['tag-mobile'],
+      );
+      return WorkbenchState(
+        projects: <Project>[alera, orca],
+        workspacesByProject: <String, List<Workspace>>{
+          alera.id: <Workspace>[tagged, untagged],
+          orca.id: <Workspace>[orcaTagged],
+        },
+        viewPrefs: prefs,
+        bootstrapped: true,
+      );
+    }
+
+    test('empty selection shows every workspace', () {
+      final rows = buildSidebarRows(taggedState(WorkbenchViewPrefs.defaults));
+      expect(rows.whereType<WorkbenchWorkspaceRow>(), hasLength(3));
+    });
+
+    test('OR semantics keep workspaces carrying any selected tag', () {
+      final prefs = WorkbenchViewPrefs.defaults.copyWith(
+        selectedTagIds: <String>{'tag-review', 'tag-mobile'},
+      );
+      final rows = buildSidebarRows(taggedState(prefs));
+      final ids = rows
+          .whereType<WorkbenchWorkspaceRow>()
+          .map((r) => r.workspace.id)
+          .toSet();
+      expect(ids, <String>{'w-tagged', 'w-orca'});
+    });
+
+    test('projects without matching workspaces hide their header', () {
+      final prefs = WorkbenchViewPrefs.defaults.copyWith(
+        selectedTagIds: <String>{'tag-mobile'},
+      );
+      final rows = buildSidebarRows(taggedState(prefs));
+      final headers = rows.whereType<WorkbenchProjectHeaderRow>().toList();
+      expect(headers, hasLength(1));
+      expect(headers.single.project.id, 'p-orca');
+    });
+
+    test('countVisibleWorkspaces honors the tag filter', () {
+      final prefs = WorkbenchViewPrefs.defaults.copyWith(
+        selectedTagIds: <String>{'tag-review'},
+      );
+      expect(countVisibleWorkspaces(taggedState(prefs)), 1);
+    });
+  });
+
+  group('buildSidebarRows · parent-child nesting', () {
+    WorkbenchState nestedState(WorkbenchViewPrefs prefs) {
+      final alera = _project('p-alera', 'alera');
+      final orca = _project('p-orca', 'orca');
+      final parent = _workspace('w-parent', alera.id, 'parent', 'main');
+      final child = _workspace(
+        'w-child',
+        alera.id,
+        'child',
+        'feature/child',
+        parentWorkspaceId: 'w-parent',
+      );
+      final crossProjectChild = _workspace(
+        'w-cross',
+        orca.id,
+        'cross',
+        'main',
+        parentWorkspaceId: 'w-parent',
+      );
+      return WorkbenchState(
+        projects: <Project>[alera, orca],
+        workspacesByProject: <String, List<Workspace>>{
+          alera.id: <Workspace>[parent, child],
+          orca.id: <Workspace>[crossProjectChild],
+        },
+        viewPrefs: prefs,
+        bootstrapped: true,
+      );
+    }
+
+    test('children indent under their parent in grouped mode', () {
+      final rows = buildSidebarRows(nestedState(WorkbenchViewPrefs.defaults));
+      final workspaceRows = rows.whereType<WorkbenchWorkspaceRow>().toList();
+      final parent = workspaceRows.firstWhere(
+        (r) => r.workspace.id == 'w-parent',
+      );
+      final child = workspaceRows.firstWhere(
+        (r) => r.workspace.id == 'w-child',
+      );
+      expect(parent.indent, 1);
+      expect(parent.hasVisibleChildren, isTrue);
+      expect(child.indent, 2);
+    });
+
+    test('cross-project children render at the root of their own group', () {
+      final rows = buildSidebarRows(nestedState(WorkbenchViewPrefs.defaults));
+      final cross = rows.whereType<WorkbenchWorkspaceRow>().firstWhere(
+        (r) => r.workspace.id == 'w-cross',
+      );
+      expect(cross.indent, 1);
+    });
+
+    test('collapsing the parent hides its children', () {
+      final prefs = WorkbenchViewPrefs.defaults.copyWith(
+        collapsedParentWorkspaceIds: <String>{'w-parent'},
+      );
+      final rows = buildSidebarRows(nestedState(prefs));
+      final ids = rows
+          .whereType<WorkbenchWorkspaceRow>()
+          .map((r) => r.workspace.id)
+          .toSet();
+      expect(ids, isNot(contains('w-child')));
+      final parent = rows.whereType<WorkbenchWorkspaceRow>().firstWhere(
+        (r) => r.workspace.id == 'w-parent',
+      );
+      expect(parent.childrenCollapsed, isTrue);
+    });
+
+    test('a child whose parent is filtered out is promoted to root', () {
+      final prefs = WorkbenchViewPrefs.defaults;
+      final state = nestedState(prefs);
+      final rows = buildSidebarRows(state.copyWith(searchQuery: 'child'));
+      final child = rows.whereType<WorkbenchWorkspaceRow>().firstWhere(
+        (r) => r.workspace.id == 'w-child',
+      );
+      expect(child.indent, 1);
+    });
+
+    test('children nest in flat mode too', () {
+      final prefs = WorkbenchViewPrefs.defaults.copyWith(
+        groupBy: WorkbenchGroupBy.none,
+      );
+      final rows = buildSidebarRows(nestedState(prefs));
+      final workspaceRows = rows.whereType<WorkbenchWorkspaceRow>().toList();
+      final parent = workspaceRows.firstWhere(
+        (r) => r.workspace.id == 'w-parent',
+      );
+      final child = workspaceRows.firstWhere(
+        (r) => r.workspace.id == 'w-child',
+      );
+      final cross = workspaceRows.firstWhere(
+        (r) => r.workspace.id == 'w-cross',
+      );
+      expect(parent.indent, 0);
+      expect(child.indent, 1);
+      // Flat mode is one sibling group, so cross-project children nest too.
+      expect(cross.indent, 1);
+    });
+  });
+
+  group('buildSidebarRows · agent activity sort', () {
+    WorkbenchState activityState(
+      WorkbenchViewPrefs prefs, {
+      String? activeWorkspaceId,
+    }) {
+      final alera = _project('p-alera', 'alera');
+      final orca = _project('p-orca', 'orca');
+      final waiting = _workspace('w-waiting', alera.id, 'aaa-waiting', 'w');
+      final working = _workspace('w-working', alera.id, 'bbb-working', 'x');
+      final idle = _workspace('w-idle', orca.id, 'ccc-idle', 'y');
+      return WorkbenchState(
+        projects: <Project>[alera, orca],
+        workspacesByProject: <String, List<Workspace>>{
+          alera.id: <Workspace>[working, waiting],
+          orca.id: <Workspace>[idle],
+        },
+        tabsByWorkspace: <String, List<WorkspaceTabRecord>>{
+          waiting.id: <WorkspaceTabRecord>[_tab('t-w', waiting.id, 'T')],
+          working.id: <WorkspaceTabRecord>[_tab('t-x', working.id, 'T')],
+        },
+        viewPrefs: prefs,
+        activeWorkspaceId: activeWorkspaceId,
+        bootstrapped: true,
+      );
+    }
+
+    Map<String, AgentStatusEntry> activityStatuses(WorkbenchState state) {
+      final statuses = <String, AgentStatusEntry>{};
+      for (final tabs in state.tabsByWorkspace.values) {
+        for (final tab in tabs) {
+          statuses[tab.terminalSessionId] = AgentStatusEntry(
+            terminalSessionId: tab.terminalSessionId,
+            workspaceId: tab.workspaceId,
+            tabId: tab.id,
+            agentType: AgentType.claude,
+            state: tab.workspaceId == 'w-waiting'
+                ? AgentStatusState.waiting
+                : AgentStatusState.working,
+            prompt: 'Prompt',
+            updatedAt: _t0,
+            stateStartedAt: _t0,
+          );
+        }
+      }
+      return statuses;
+    }
+
+    test('needs-you workspaces rank above working and idle in flat mode', () {
+      final prefs = WorkbenchViewPrefs.defaults.copyWith(
+        groupBy: WorkbenchGroupBy.none,
+        workspaceSort: WorkbenchSortBy.activity,
+      );
+      final state = activityState(prefs);
+      final rows = buildSidebarRows(
+        state,
+        agentStatuses: activityStatuses(state),
+        now: _t0,
+      );
+      final ids = rows
+          .whereType<WorkbenchWorkspaceRow>()
+          .map((r) => r.workspace.id)
+          .toList();
+      expect(ids, <String>['w-waiting', 'w-working', 'w-idle']);
+    });
+
+    test('project headers rank by their most urgent workspace', () {
+      final prefs = WorkbenchViewPrefs.defaults.copyWith(
+        projectSort: WorkbenchSortBy.activity,
+      );
+      final state = activityState(prefs);
+      final rows = buildSidebarRows(
+        state,
+        agentStatuses: activityStatuses(state),
+        now: _t0,
+      );
+      final headers = rows.whereType<WorkbenchProjectHeaderRow>().toList();
+      expect(headers.first.project.id, 'p-alera');
+    });
+
+    test('the active workspace keeps its previous position', () {
+      final prefs = WorkbenchViewPrefs.defaults.copyWith(
+        groupBy: WorkbenchGroupBy.none,
+        workspaceSort: WorkbenchSortBy.activity,
+      );
+      final state = activityState(prefs, activeWorkspaceId: 'w-working');
+      final rows = buildSidebarRows(
+        state,
+        agentStatuses: activityStatuses(state),
+        now: _t0,
+        // Previous render had the active workspace first.
+        previousWorkspaceOrder: <String>['w-working', 'w-waiting', 'w-idle'],
+      );
+      final ids = rows
+          .whereType<WorkbenchWorkspaceRow>()
+          .map((r) => r.workspace.id)
+          .toList();
+      expect(ids.first, 'w-working');
+    });
+
+    test('idle workspaces fall back to the persisted activity timestamp', () {
+      final prefs = WorkbenchViewPrefs.defaults.copyWith(
+        groupBy: WorkbenchGroupBy.none,
+        workspaceSort: WorkbenchSortBy.activity,
+      );
+      final alera = _project('p-alera', 'alera');
+      final a = _workspace('w-a', alera.id, 'aaa', 'a');
+      final b = _workspace('w-b', alera.id, 'bbb', 'b');
+      final state = WorkbenchState(
+        projects: <Project>[alera],
+        workspacesByProject: <String, List<Workspace>>{
+          alera.id: <Workspace>[a, b],
+        },
+        viewPrefs: prefs,
+        bootstrapped: true,
+      );
+      final rows = buildSidebarRows(
+        state,
+        lastActivityByWorkspaceId: <String, DateTime>{
+          'w-b': _t0.add(const Duration(days: 1)),
+        },
+        now: _t0,
+      );
+      final ids = rows
+          .whereType<WorkbenchWorkspaceRow>()
+          .map((r) => r.workspace.id)
+          .toList();
+      expect(ids, <String>['w-b', 'w-a']);
     });
   });
 

--- a/test/unit/workbench_listing_tree_test.dart
+++ b/test/unit/workbench_listing_tree_test.dart
@@ -1,0 +1,103 @@
+import 'package:alera/src/features/workbench/application/workbench_listing_tree.dart';
+import 'package:alera/src/features/workbench/domain/workspace.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+final DateTime _t0 = DateTime.utc(2026, 5, 1);
+
+Workspace _workspace(String id, {String? parentId}) {
+  return Workspace(
+    id: id,
+    projectId: 'p-1',
+    name: id,
+    branch: 'main',
+    path: '/repo/$id',
+    createdAt: _t0,
+    updatedAt: _t0,
+    kind: WorkspaceKind.linked,
+    status: WorkspaceStatus.active,
+    parentWorkspaceId: parentId,
+  );
+}
+
+void main() {
+  test('children nest under their parent preserving sibling order', () {
+    final entries = <Workspace>[
+      _workspace('a'),
+      _workspace('b', parentId: 'a'),
+      _workspace('c', parentId: 'a'),
+      _workspace('d'),
+    ];
+
+    final tree = buildWorkspaceTree(
+      entries: entries,
+      collapsedParentIds: const <String>{},
+    );
+
+    expect(tree.map((e) => e.workspace.id), <String>['a', 'b', 'c', 'd']);
+    expect(tree.map((e) => e.depth), <int>[0, 1, 1, 0]);
+    expect(tree.first.hasVisibleChildren, isTrue);
+    expect(tree.last.hasVisibleChildren, isFalse);
+  });
+
+  test('a child whose parent is absent is promoted to root', () {
+    final entries = <Workspace>[
+      _workspace('orphan', parentId: 'filtered-out'),
+      _workspace('root'),
+    ];
+
+    final tree = buildWorkspaceTree(
+      entries: entries,
+      collapsedParentIds: const <String>{},
+    );
+
+    expect(tree.map((e) => e.depth), everyElement(0));
+    expect(tree.map((e) => e.workspace.id), <String>['orphan', 'root']);
+  });
+
+  test('collapsed parents hide their whole subtree', () {
+    final entries = <Workspace>[
+      _workspace('a'),
+      _workspace('b', parentId: 'a'),
+      _workspace('c', parentId: 'b'),
+      _workspace('d'),
+    ];
+
+    final tree = buildWorkspaceTree(
+      entries: entries,
+      collapsedParentIds: const <String>{'a'},
+    );
+
+    expect(tree.map((e) => e.workspace.id), <String>['a', 'd']);
+    expect(tree.first.childrenCollapsed, isTrue);
+  });
+
+  test('nesting depth is capped for deep chains', () {
+    final entries = <Workspace>[
+      _workspace('w0'),
+      for (var i = 1; i <= 6; i++) _workspace('w$i', parentId: 'w${i - 1}'),
+    ];
+
+    final tree = buildWorkspaceTree(
+      entries: entries,
+      collapsedParentIds: const <String>{},
+    );
+
+    expect(tree.last.depth, maxWorkspaceTreeDepth);
+  });
+
+  test('a stale relation cycle terminates and keeps every workspace', () {
+    final entries = <Workspace>[
+      _workspace('a', parentId: 'b'),
+      _workspace('b', parentId: 'a'),
+      _workspace('root'),
+    ];
+
+    final tree = buildWorkspaceTree(
+      entries: entries,
+      collapsedParentIds: const <String>{},
+    );
+
+    expect(tree, hasLength(3));
+    expect(tree.map((e) => e.workspace.id).toSet(), <String>{'a', 'b', 'root'});
+  });
+}

--- a/test/unit/workbench_view_prefs_test.dart
+++ b/test/unit/workbench_view_prefs_test.dart
@@ -11,6 +11,8 @@ void main() {
       expect(WorkbenchViewPrefs.defaults.selectedProjectIds, isEmpty);
       expect(WorkbenchViewPrefs.defaults.collapsedProjectIds, isEmpty);
       expect(WorkbenchViewPrefs.defaults.expandedWorkspaceIds, isEmpty);
+      expect(WorkbenchViewPrefs.defaults.selectedTagIds, isEmpty);
+      expect(WorkbenchViewPrefs.defaults.collapsedParentWorkspaceIds, isEmpty);
       expect(
         WorkbenchViewPrefs.defaults.sourceControlRootByWorkspaceId,
         isEmpty,
@@ -35,6 +37,8 @@ void main() {
         selectedProjectIds: <String>{'p1', 'p2'},
         collapsedProjectIds: <String>{'p3'},
         expandedWorkspaceIds: <String>{'w1'},
+        selectedTagIds: <String>{'tag-1'},
+        collapsedParentWorkspaceIds: <String>{'w-parent'},
         sourceControlRootByWorkspaceId: <String, String>{
           'w-folder': 'packages/app',
         },
@@ -52,6 +56,8 @@ void main() {
       expect(restored.selectedProjectIds, <String>{'p1', 'p2'});
       expect(restored.collapsedProjectIds, <String>{'p3'});
       expect(restored.expandedWorkspaceIds, <String>{'w1'});
+      expect(restored.selectedTagIds, <String>{'tag-1'});
+      expect(restored.collapsedParentWorkspaceIds, <String>{'w-parent'});
       expect(restored.sourceControlRootByWorkspaceId, <String, String>{
         'w-folder': 'packages/app',
       });
@@ -80,6 +86,37 @@ void main() {
         }),
         throwsA(isA<MapperException>()),
       );
+    });
+
+    test('fromJson tolerates persisted prefs without the new fields', () {
+      // JSON persisted before selectedTagIds/collapsedParentWorkspaceIds and
+      // the activity sort existed must keep decoding.
+      final restored = WorkbenchViewPrefs.fromJson(<String, Object?>{
+        'groupBy': 'project',
+        'projectSort': 'name',
+        'workspaceSort': 'recent',
+        'selectedProjectIds': <String>['p1'],
+        'collapsedProjectIds': <String>[],
+        'expandedWorkspaceIds': <String>[],
+      });
+
+      expect(restored.selectedTagIds, isEmpty);
+      expect(restored.collapsedParentWorkspaceIds, isEmpty);
+      expect(restored.workspaceSort, WorkbenchSortBy.recent);
+    });
+
+    test('fromJson decodes the activity sort value', () {
+      final restored = WorkbenchViewPrefs.fromJson(<String, Object?>{
+        'groupBy': 'project',
+        'projectSort': 'activity',
+        'workspaceSort': 'activity',
+        'selectedProjectIds': <String>[],
+        'collapsedProjectIds': <String>[],
+        'expandedWorkspaceIds': <String>[],
+      });
+
+      expect(restored.projectSort, WorkbenchSortBy.activity);
+      expect(restored.workspaceSort, WorkbenchSortBy.activity);
     });
 
     test('fromJson applies mapper conversions inside id collections', () {

--- a/test/unit/workspace_activity_controller_test.dart
+++ b/test/unit/workspace_activity_controller_test.dart
@@ -1,0 +1,112 @@
+import 'package:alera/src/features/workbench/application/workspace_activity_controller.dart';
+import 'package:alera/src/features/workbench/application/workspace_activity_repository.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class _FakeWorkspaceActivityRepository implements WorkspaceActivityRepository {
+  final Map<String, DateTime> stored = <String, DateTime>{};
+  int upsertCalls = 0;
+
+  @override
+  Future<Map<String, DateTime>> loadAll() async =>
+      Map<String, DateTime>.from(stored);
+
+  @override
+  Future<void> upsertAll(Map<String, DateTime> entries) async {
+    upsertCalls++;
+    stored.addAll(entries);
+  }
+
+  @override
+  Future<void> remove(String workspaceId) async {
+    stored.remove(workspaceId);
+  }
+}
+
+void main() {
+  test('recordActivity updates in-memory state immediately', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final controller = container.read(
+      workspaceActivityControllerProvider.notifier,
+    );
+    final at = DateTime.utc(2026, 7, 4, 12);
+
+    controller.recordActivity('w-1', at);
+
+    expect(container.read(workspaceActivityControllerProvider), {'w-1': at});
+  });
+
+  test('older activity does not overwrite a newer timestamp', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final controller = container.read(
+      workspaceActivityControllerProvider.notifier,
+    );
+    final newer = DateTime.utc(2026, 7, 4, 12);
+    final older = DateTime.utc(2026, 7, 4, 11);
+
+    controller.recordActivity('w-1', newer);
+    controller.recordActivity('w-1', older);
+
+    expect(container.read(workspaceActivityControllerProvider), {'w-1': newer});
+  });
+
+  test(
+    'attachRepository seeds persisted entries under newer in-memory ones',
+    () async {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      final repository = _FakeWorkspaceActivityRepository()
+        ..stored['w-persisted'] = DateTime.utc(2026, 7, 1)
+        ..stored['w-live'] = DateTime.utc(2026, 7, 1);
+      final controller = container.read(
+        workspaceActivityControllerProvider.notifier,
+      );
+      final live = DateTime.utc(2026, 7, 4);
+      controller.recordActivity('w-live', live);
+
+      await controller.attachRepository(repository);
+
+      final state = container.read(workspaceActivityControllerProvider);
+      expect(state['w-persisted'], DateTime.utc(2026, 7, 1));
+      expect(state['w-live'], live);
+    },
+  );
+
+  test('recorded activity is flushed to the repository in one batch', () async {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final repository = _FakeWorkspaceActivityRepository();
+    final controller = container.read(
+      workspaceActivityControllerProvider.notifier,
+    );
+    await controller.attachRepository(repository);
+
+    controller.recordActivity('w-1', DateTime.utc(2026, 7, 4, 12));
+    controller.recordActivity('w-2', DateTime.utc(2026, 7, 4, 13));
+
+    await Future<void>.delayed(
+      workspaceActivityFlushDelay + const Duration(milliseconds: 100),
+    );
+    expect(repository.upsertCalls, 1);
+    expect(repository.stored.keys, containsAll(<String>['w-1', 'w-2']));
+  });
+
+  test('removeWorkspace drops the entry from state and persistence', () async {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final repository = _FakeWorkspaceActivityRepository()
+      ..stored['w-1'] = DateTime.utc(2026, 7, 1);
+    final controller = container.read(
+      workspaceActivityControllerProvider.notifier,
+    );
+    await controller.attachRepository(repository);
+
+    controller.removeWorkspace('w-1');
+    await Future<void>.delayed(Duration.zero);
+
+    expect(container.read(workspaceActivityControllerProvider), isEmpty);
+    expect(repository.stored, isEmpty);
+  });
+}

--- a/test/unit/workspace_agent_run_groups_test.dart
+++ b/test/unit/workspace_agent_run_groups_test.dart
@@ -1,0 +1,68 @@
+import 'package:alera/src/features/agent_status/domain/agent_status.dart';
+import 'package:alera/src/features/workbench/application/workspace_agent_run_groups.dart';
+import 'package:alera/src/features/workbench/application/workspace_agent_status_projection.dart';
+import 'package:alera/src/features/workbench/domain/workspace_tab_record.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+final DateTime _t0 = DateTime.utc(2026, 7, 4);
+
+WorkspaceAgentRun _run(String id, AgentStatusState state, {bool? interrupted}) {
+  final tab = WorkspaceTabRecord(
+    id: id,
+    workspaceId: 'w-1',
+    kind: WorkspaceTabKind.terminal,
+    title: id,
+    createdAt: _t0,
+    updatedAt: _t0,
+  );
+  return WorkspaceAgentRun(
+    tab: tab,
+    status: AgentStatusEntry(
+      terminalSessionId: tab.terminalSessionId,
+      workspaceId: tab.workspaceId,
+      tabId: tab.id,
+      agentType: AgentType.claude,
+      state: state,
+      prompt: 'Prompt',
+      updatedAt: _t0,
+      stateStartedAt: _t0,
+      interrupted: interrupted,
+    ),
+  );
+}
+
+void main() {
+  test('groups runs by state in display order', () {
+    final groups = groupWorkspaceAgentRuns(<WorkspaceAgentRun>[
+      _run('t-1', AgentStatusState.done),
+      _run('t-2', AgentStatusState.working),
+      _run('t-3', AgentStatusState.waiting),
+      _run('t-4', AgentStatusState.working),
+    ]);
+
+    expect(groups.map((g) => g.kind), <WorkspaceAgentGroupKind>[
+      WorkspaceAgentGroupKind.waiting,
+      WorkspaceAgentGroupKind.working,
+      WorkspaceAgentGroupKind.done,
+    ]);
+    expect(
+      groups
+          .firstWhere((g) => g.kind == WorkspaceAgentGroupKind.working)
+          .runs
+          .length,
+      2,
+    );
+  });
+
+  test('interruption overrides the reported state', () {
+    final groups = groupWorkspaceAgentRuns(<WorkspaceAgentRun>[
+      _run('t-1', AgentStatusState.done, interrupted: true),
+    ]);
+
+    expect(groups.single.kind, WorkspaceAgentGroupKind.interrupted);
+  });
+
+  test('an empty run list produces no groups', () {
+    expect(groupWorkspaceAgentRuns(const <WorkspaceAgentRun>[]), isEmpty);
+  });
+}

--- a/test/widget/alera_dropdown_field_test.dart
+++ b/test/widget/alera_dropdown_field_test.dart
@@ -83,6 +83,45 @@ void main() {
     expect(find.text('Select An Option'), findsOneWidget);
   });
 
+  testWidgets('shows the label above the field when provided', (tester) async {
+    await tester.pumpWidget(
+      _wrap(
+        AleraDropdownField<String>(
+          value: 'agent',
+          labelText: 'Auth Method',
+          entries: _entries,
+          onChanged: (_) {},
+        ),
+      ),
+    );
+
+    expect(find.text('Auth Method'), findsOneWidget);
+    expect(find.text('SSH Agent'), findsOneWidget);
+  });
+
+  testWidgets('a null-valued entry can be picked', (tester) async {
+    String? picked = 'unset';
+    await tester.pumpWidget(
+      _wrap(
+        AleraDropdownField<String?>(
+          value: 'child',
+          entries: const <AleraDropdownFieldEntry<String?>>[
+            AleraDropdownFieldEntry<String?>(value: null, label: 'No Parent'),
+            AleraDropdownFieldEntry<String?>(value: 'child', label: 'Child'),
+          ],
+          onChanged: (value) => picked = value,
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('Child'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('No Parent'));
+    await tester.pumpAndSettle();
+
+    expect(picked, isNull);
+  });
+
   testWidgets('disabled field does not open the menu', (tester) async {
     await tester.pumpWidget(
       _wrap(

--- a/test/widget/alera_shell_page_sidebar_actions_test_cases.dart
+++ b/test/widget/alera_shell_page_sidebar_actions_test_cases.dart
@@ -343,7 +343,9 @@ void _registerAleraShellSidebarActionTests() {
     );
   });
 
-  testWidgets('workspace rows show plural agent run counts', (tester) async {
+  testWidgets('workspace rows summarize agent runs in a compact pill', (
+    tester,
+  ) async {
     await _pumpShell(
       tester,
       state: _stackedWorkbenchState(),
@@ -363,7 +365,7 @@ void _registerAleraShellSidebarActionTests() {
       },
     );
 
-    expect(find.textContaining('2 Agent Runs'), findsOneWidget);
+    expect(find.byType(WorkspaceAgentCompactSummary), findsOneWidget);
   });
 
   testWidgets('closing a sidebar agent row closes the runtime tab', (

--- a/test/widget/alera_shell_page_test.dart
+++ b/test/widget/alera_shell_page_test.dart
@@ -18,6 +18,7 @@ import 'package:alera/src/features/workbench/domain/workbench_view_prefs.dart';
 import 'package:alera/src/features/workbench/domain/workspace.dart';
 import 'package:alera/src/features/workbench/presentation/terminal_runtime.dart';
 import 'package:alera/src/features/workbench/presentation/project_workbench_sidebar.dart';
+import 'package:alera/src/features/workbench/presentation/widgets/workspace_agent_compact_summary.dart';
 import 'package:alera/src/features/workbench/presentation/workspace_workbench_view.dart';
 import 'package:alera/src/shared/infra/process/process_runner.dart';
 import 'package:alera/src/shared/infra/storage/drift_database.dart';

--- a/test/widget/workbench_view_options_menu_test.dart
+++ b/test/widget/workbench_view_options_menu_test.dart
@@ -46,7 +46,7 @@ void main() {
 
       expect(controller.state.viewPrefs.workspaceSort, WorkbenchSortBy.recent);
 
-      await tester.enterText(find.byType(TextField).last, 'orca');
+      await tester.enterText(_projectSearchField(), 'orca');
       await tester.pumpAndSettle();
       await tester.tap(find.text('Orca').last);
       await tester.pumpAndSettle();
@@ -54,9 +54,9 @@ void main() {
       expect(controller.state.viewPrefs.selectedProjectIds, <String>{
         'project-2',
       });
-      expect(find.text('Clear'), findsOneWidget);
+      expect(find.text('Clear'), findsNWidgets(2));
 
-      await tester.tap(find.text('Clear'));
+      await tester.tap(find.text('Clear').first);
       await tester.pumpAndSettle();
 
       expect(controller.state.viewPrefs.selectedProjectIds, isEmpty);
@@ -79,7 +79,7 @@ void main() {
       await tester.tap(_viewOptionsButton());
       await tester.pumpAndSettle();
 
-      final field = find.byType(TextField).last;
+      final field = _projectSearchField();
       await tester.enterText(field, 'or');
       await tester.pumpAndSettle();
       await tester.testTextInput.receiveAction(TextInputAction.done);
@@ -107,6 +107,7 @@ void main() {
       await tester.tap(_viewOptionsButton());
       await tester.pumpAndSettle();
       expect(find.text('No Projects Yet'), findsOneWidget);
+      expect(find.text('No Tags Yet'), findsOneWidget);
 
       await tester.tap(find.byTooltip('Close'));
       await tester.pumpAndSettle();
@@ -120,7 +121,7 @@ void main() {
       await tester.tap(_viewOptionsButton());
       await tester.pumpAndSettle();
 
-      await tester.enterText(find.byType(TextField).last, 'missing');
+      await tester.enterText(_projectSearchField(), 'missing');
       await tester.pumpAndSettle();
       expect(find.text('No Projects Match "missing"'), findsOneWidget);
     });
@@ -180,6 +181,14 @@ Future<void> _pumpButton(
     ),
   );
   await tester.pump();
+}
+
+Finder _projectSearchField() {
+  return find.byWidgetPredicate(
+    (widget) =>
+        widget is TextField &&
+        widget.decoration?.hintText == 'Add Project\u2026',
+  );
 }
 
 Finder _viewOptionsButton() {


### PR DESCRIPTION
## summary

- improve the workbench left-side panel with richer workspace and agent activity organization.
- add persisted workspace activity plumbing and compact agent run summaries.
- add unit and widget coverage for listing, activity, grouping, dropdown, and view option behavior.

## validation

- `git diff --check --cached`
- `dart format --output=none --set-exit-if-changed` on changed dart files
- `flutter analyze`
- `flutter test -x golden`
- `make rust-test`

## notes

- documentation updates were considered; no docs change was needed because this is a focused UI/workbench behavior update with tests.