### PR TITLE
feat: add source control commit graph

### DIFF
--- a/integration_test/alera_smoke_flow_test.dart
+++ b/integration_test/alera_smoke_flow_test.dart
@@ -200,6 +200,45 @@ class _E2eGitBackend implements GitBackend {
   }) async => const GitDiffResult(files: <GitDiffFile>[]);
 
   @override
+  Future<GitHistoryResult> history(
+    String path, {
+    int? limit,
+    String? baseRef,
+  }) async => GitHistoryResult(
+    items: const <GitHistoryItem>[],
+    hasIncomingChanges: false,
+    hasOutgoingChanges: false,
+    hasMore: false,
+    limit: limit ?? 50,
+  );
+
+  @override
+  Future<GitCommitCompareResult> commitCompare({
+    required String path,
+    required String commitId,
+  }) async => GitCommitCompareResult(
+    summary: GitCommitCompareSummary(
+      commitOid: commitId,
+      parentOid: null,
+      compareRef: commitId,
+      baseRef: 'Parent',
+      changedFiles: 0,
+      status: GitCommitCompareStatus.invalidCommit,
+      errorMessage: 'Commit Not Available',
+    ),
+    entries: const <GitCommitChangeEntry>[],
+  );
+
+  @override
+  Future<GitDiffResult> commitDiff({
+    required String path,
+    required String commitOid,
+    String? parentOid,
+    String? filePath,
+    String? oldPath,
+  }) async => const GitDiffResult(files: <GitDiffFile>[]);
+
+  @override
   Future<GitRepositoryState> repositoryState(String path) async =>
       const GitRepositoryState(branch: 'HEAD');
 

--- a/lib/src/features/shell/presentation/alera_shell_page.dart
+++ b/lib/src/features/shell/presentation/alera_shell_page.dart
@@ -201,6 +201,31 @@ class _AleraShellPageBodyState extends ConsumerState<_AleraShellPageBody> {
                             gitDiffRoot: gitDiffRoot,
                           );
                         },
+                    onOpenGitCommitDiff:
+                        ({
+                          relativePath,
+                          oldPath,
+                          required scope,
+                          gitDiffRoot,
+                          required commitOid,
+                          parentOid,
+                          required compareRef,
+                          subject,
+                          message,
+                        }) {
+                          return controller.openGitCommitDiffTab(
+                            workspace: workspace,
+                            relativePath: relativePath,
+                            oldPath: oldPath,
+                            scope: scope,
+                            gitDiffRoot: gitDiffRoot,
+                            commitOid: commitOid,
+                            parentOid: parentOid,
+                            compareRef: compareRef,
+                            subject: subject,
+                            message: message,
+                          );
+                        },
                     onOpenSearchMatch: (target) {
                       unawaited(() async {
                         final tab = await controller.openEditorTab(

--- a/lib/src/features/workbench/application/workbench_controller_tabs.dart
+++ b/lib/src/features/workbench/application/workbench_controller_tabs.dart
@@ -208,6 +208,57 @@ mixin _WorkbenchControllerTabs
     }
   }
 
+  Future<WorkspaceTabRecord> openGitCommitDiffTab({
+    required Workspace workspace,
+    String? relativePath,
+    String? oldPath,
+    required WorkspaceGitDiffScope scope,
+    String? gitDiffRoot,
+    required String commitOid,
+    String? parentOid,
+    required String compareRef,
+    String? subject,
+    String? message,
+    String? targetGroupId,
+  }) async {
+    try {
+      final previousTabs = state.tabsFor(workspace.id);
+      final layout = _layoutForMutation(workspace.id, previousTabs);
+      final tab = await _workspaceTabService.openOrCreateGitCommitDiffTab(
+        workspaceId: workspace.id,
+        relativePath: relativePath,
+        oldPath: oldPath,
+        scope: scope,
+        gitDiffRoot: gitDiffRoot,
+        commitOid: commitOid,
+        parentOid: parentOid,
+        compareRef: compareRef,
+        subject: subject,
+        message: message,
+      );
+      final alreadyOpen = previousTabs.any(
+        (candidate) => candidate.id == tab.id,
+      );
+      final tabs = alreadyOpen
+          ? previousTabs
+          : <WorkspaceTabRecord>[...previousTabs, tab];
+      _setTabsForWorkspace(workspace.id, tabs);
+      final groupId = targetGroupId ?? layout.activeGroupId;
+      final nextLayout = alreadyOpen
+          ? layout.setActiveTab(
+              groupId: layout.groupIdForTab(tab.id) ?? groupId,
+              tabId: tab.id,
+            )
+          : layout.addTabToGroup(groupId: groupId, tabId: tab.id);
+      await _applyLayout(nextLayout.sanitize(tabs), persist: true);
+      state = state.copyWith(error: null);
+      return tab;
+    } catch (error) {
+      state = state.copyWith(error: error.toString());
+      rethrow;
+    }
+  }
+
   Future<void> closeWorkspaceTab({
     required Workspace workspace,
     required String tabId,

--- a/lib/src/features/workbench/application/workspace_tab_service.dart
+++ b/lib/src/features/workbench/application/workspace_tab_service.dart
@@ -159,7 +159,8 @@ class WorkspaceTabService {
       if (tab.kind != WorkspaceTabKind.gitDiff) {
         continue;
       }
-      if (tab.gitDiffScope == scope &&
+      if (tab.gitDiffSource == WorkspaceGitDiffSource.workingTree &&
+          tab.gitDiffScope == scope &&
           tab.filePath == normalizedPath &&
           tab.gitDiffRoot == normalizedRoot &&
           tab.gitDiffArea == area) {
@@ -188,6 +189,83 @@ class WorkspaceTabService {
         path: normalizedPath,
         area: area,
         root: normalizedRoot,
+      ),
+      createdAt: _now(),
+      updatedAt: _now(),
+      payload: payload,
+    );
+    await _repository.upsertWorkspaceTab(tab);
+    return tab;
+  }
+
+  Future<WorkspaceTabRecord> openOrCreateGitCommitDiffTab({
+    required String workspaceId,
+    String? relativePath,
+    String? oldPath,
+    required WorkspaceGitDiffScope scope,
+    String? gitDiffRoot,
+    required String commitOid,
+    String? parentOid,
+    required String compareRef,
+    String? subject,
+    String? message,
+  }) async {
+    final normalizedPath = relativePath == null
+        ? null
+        : _normalizeRelativePath(relativePath);
+    final normalizedOldPath = oldPath == null
+        ? null
+        : _normalizeRelativePath(oldPath);
+    final normalizedRoot = normalizeSourceControlRootRelativePath(gitDiffRoot);
+    if (scope != WorkspaceGitDiffScope.all && normalizedPath == null) {
+      throw StateError('Commit diff file tabs require a file path.');
+    }
+    final existing = await _repository.listWorkspaceTabs(workspaceId);
+    for (final tab in existing) {
+      if (tab.kind != WorkspaceTabKind.gitDiff ||
+          tab.gitDiffSource != WorkspaceGitDiffSource.commit) {
+        continue;
+      }
+      if (tab.gitDiffScope == scope &&
+          tab.filePath == normalizedPath &&
+          tab.gitDiffOldPath == normalizedOldPath &&
+          tab.gitDiffRoot == normalizedRoot &&
+          tab.gitDiffCommitOid == commitOid) {
+        return tab;
+      }
+    }
+    final payload = <String, Object?>{
+      workspaceTabGitDiffSourcePayloadKey: WorkspaceGitDiffSource.commit.key,
+      workspaceTabGitDiffScopePayloadKey: scope.key,
+      workspaceTabGitDiffCommitOidPayloadKey: commitOid,
+      workspaceTabGitDiffCompareRefPayloadKey: compareRef,
+    };
+    if (parentOid != null) {
+      payload[workspaceTabGitDiffParentOidPayloadKey] = parentOid;
+    }
+    if (subject != null) {
+      payload[workspaceTabGitDiffCommitSubjectPayloadKey] = subject;
+    }
+    if (message != null) {
+      payload[workspaceTabGitDiffCommitMessagePayloadKey] = message;
+    }
+    if (normalizedRoot != null) {
+      payload[workspaceTabGitDiffRootPayloadKey] = normalizedRoot;
+    }
+    if (normalizedPath != null) {
+      payload[workspaceTabFilePathPayloadKey] = normalizedPath;
+    }
+    if (normalizedOldPath != null) {
+      payload[workspaceTabGitDiffOldPathPayloadKey] = normalizedOldPath;
+    }
+    final tab = WorkspaceTabRecord(
+      id: _uuid.v4(),
+      workspaceId: workspaceId,
+      kind: WorkspaceTabKind.gitDiff,
+      title: _titleForGitCommitDiff(
+        scope: scope,
+        path: normalizedPath,
+        compareRef: compareRef,
       ),
       createdAt: _now(),
       updatedAt: _now(),
@@ -244,6 +322,9 @@ class WorkspaceTabService {
       if (tab.kind != WorkspaceTabKind.gitDiff || tab.gitDiffRoot == null) {
         continue;
       }
+      if (tab.gitDiffSource == WorkspaceGitDiffSource.commit) {
+        continue;
+      }
       final root = tab.gitDiffRoot!;
       final nextRoot = _replacePathPrefix(
         path: root,
@@ -287,6 +368,10 @@ class WorkspaceTabService {
     for (final originalTab in tabs) {
       final rootWasRetargeted = updatedById.containsKey(originalTab.id);
       final tab = updatedById[originalTab.id] ?? originalTab;
+      if (tab.kind == WorkspaceTabKind.gitDiff &&
+          tab.gitDiffSource == WorkspaceGitDiffSource.commit) {
+        continue;
+      }
       if (!_isFileTabKind(tab.kind)) {
         continue;
       }
@@ -520,6 +605,18 @@ class WorkspaceTabService {
       WorkspaceGitDiffScope.fileAll => '${_titleForPath(path!)} changes',
       WorkspaceGitDiffScope.file =>
         '${_titleForPath(path!)} ${area!.label.toLowerCase()}',
+    };
+  }
+
+  String _titleForGitCommitDiff({
+    required WorkspaceGitDiffScope scope,
+    required String? path,
+    required String compareRef,
+  }) {
+    return switch (scope) {
+      WorkspaceGitDiffScope.all => 'Commit $compareRef',
+      WorkspaceGitDiffScope.file ||
+      WorkspaceGitDiffScope.fileAll => '${_titleForPath(path!)} $compareRef',
     };
   }
 

--- a/lib/src/features/workbench/domain/workspace_tab_record.dart
+++ b/lib/src/features/workbench/domain/workspace_tab_record.dart
@@ -40,6 +40,36 @@ const String workspaceTabFileRoleMermanPreview = 'mermanPreview';
 const String workspaceTabGitDiffScopePayloadKey = 'gitDiffScope';
 const String workspaceTabGitDiffAreaPayloadKey = 'gitDiffArea';
 const String workspaceTabGitDiffRootPayloadKey = 'gitDiffRoot';
+const String workspaceTabGitDiffSourcePayloadKey = 'gitDiffSource';
+const String workspaceTabGitDiffCommitOidPayloadKey = 'gitDiffCommitOid';
+const String workspaceTabGitDiffParentOidPayloadKey = 'gitDiffParentOid';
+const String workspaceTabGitDiffCompareRefPayloadKey = 'gitDiffCompareRef';
+const String workspaceTabGitDiffCommitSubjectPayloadKey =
+    'gitDiffCommitSubject';
+const String workspaceTabGitDiffCommitMessagePayloadKey =
+    'gitDiffCommitMessage';
+const String workspaceTabGitDiffOldPathPayloadKey = 'gitDiffOldPath';
+
+enum WorkspaceGitDiffSource {
+  workingTree('workingTree'),
+  commit('commit');
+
+  const WorkspaceGitDiffSource(this.key);
+
+  final String key;
+
+  static WorkspaceGitDiffSource fromJson(Object? value) {
+    if (value is! String) {
+      return WorkspaceGitDiffSource.workingTree;
+    }
+    for (final source in WorkspaceGitDiffSource.values) {
+      if (source.key == value) {
+        return source;
+      }
+    }
+    return WorkspaceGitDiffSource.workingTree;
+  }
+}
 
 enum WorkspaceGitDiffScope {
   file('file'),
@@ -107,6 +137,10 @@ class WorkspaceTabRecord with WorkspaceTabRecordMappable {
     payload[workspaceTabGitDiffScopePayloadKey],
   );
 
+  WorkspaceGitDiffSource get gitDiffSource => WorkspaceGitDiffSource.fromJson(
+    payload[workspaceTabGitDiffSourcePayloadKey],
+  );
+
   String? get gitDiffRoot {
     final value = payload[workspaceTabGitDiffRootPayloadKey];
     return value is String && value.trim().isNotEmpty ? value : null;
@@ -123,6 +157,29 @@ class WorkspaceTabRecord with WorkspaceTabRecordMappable {
       }
     }
     return null;
+  }
+
+  String? get gitDiffCommitOid =>
+      _nonEmptyPayloadString(workspaceTabGitDiffCommitOidPayloadKey);
+
+  String? get gitDiffParentOid =>
+      _nonEmptyPayloadString(workspaceTabGitDiffParentOidPayloadKey);
+
+  String? get gitDiffCompareRef =>
+      _nonEmptyPayloadString(workspaceTabGitDiffCompareRefPayloadKey);
+
+  String? get gitDiffCommitSubject =>
+      _nonEmptyPayloadString(workspaceTabGitDiffCommitSubjectPayloadKey);
+
+  String? get gitDiffCommitMessage =>
+      _nonEmptyPayloadString(workspaceTabGitDiffCommitMessagePayloadKey);
+
+  String? get gitDiffOldPath =>
+      _nonEmptyPayloadString(workspaceTabGitDiffOldPathPayloadKey);
+
+  String? _nonEmptyPayloadString(String key) {
+    final value = payload[key];
+    return value is String && value.trim().isNotEmpty ? value : null;
   }
 
   factory WorkspaceTabRecord.fromJson(Map<String, Object?> json) =>

--- a/lib/src/features/workbench/presentation/workspace_context_sidebar.dart
+++ b/lib/src/features/workbench/presentation/workspace_context_sidebar.dart
@@ -26,6 +26,7 @@ class WorkspaceContextSidebar extends StatelessWidget {
     this.onClearSourceControlRoot,
     required this.onOpenFile,
     required this.onOpenGitDiff,
+    required this.onOpenGitCommitDiff,
     required this.onOpenSearchMatch,
     required this.onPathMoved,
   });
@@ -44,6 +45,7 @@ class WorkspaceContextSidebar extends StatelessWidget {
   final VoidCallback? onClearSourceControlRoot;
   final ValueChanged<String> onOpenFile;
   final OpenGitDiffTabCallback onOpenGitDiff;
+  final OpenGitCommitDiffTabCallback onOpenGitCommitDiff;
   final ValueChanged<WorkspaceSearchMatchTarget> onOpenSearchMatch;
   final Future<void> Function(String oldRelativePath, String newRelativePath)
   onPathMoved;
@@ -103,6 +105,7 @@ class WorkspaceContextSidebar extends StatelessWidget {
                               viewMode: prefs.gitDiffViewMode,
                               onViewModeChanged: onSetGitDiffViewMode,
                               onOpenGitDiff: onOpenGitDiff,
+                              onOpenGitCommitDiff: onOpenGitCommitDiff,
                               onClearSourceControlRoot:
                                   sourceControlScope.isWorkspaceRoot
                                   ? null

--- a/lib/src/features/workbench/presentation/workspace_git_diff_panel.dart
+++ b/lib/src/features/workbench/presentation/workspace_git_diff_panel.dart
@@ -20,14 +20,18 @@ import 'package:alera/src/features/workbench/domain/workspace_source_control_sco
 import 'package:alera/src/features/workbench/domain/workspace_tab_record.dart';
 import 'package:alera/src/shared/infra/git/git_diff_models.dart';
 import 'package:alera/src/shared/infra/git/git_exception.dart';
+import 'package:alera/src/shared/infra/git/git_history_graph.dart';
+import 'package:alera/src/shared/infra/git/git_providers.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter/services.dart';
 
 part 'workspace_git_diff_panel_groups.dart';
 part 'workspace_git_diff_panel_amend_dialog.dart';
 part 'workspace_git_diff_panel_stash_dialog.dart';
 part 'workspace_git_diff_panel_toolbar.dart';
 part 'workspace_git_diff_panel_tree.dart';
+part 'workspace_git_history_panel.dart';
 
 typedef OpenGitDiffTabCallback =
     Future<void> Function({
@@ -35,6 +39,19 @@ typedef OpenGitDiffTabCallback =
       GitChangeArea? area,
       String? gitDiffRoot,
       required WorkspaceGitDiffScope scope,
+    });
+
+typedef OpenGitCommitDiffTabCallback =
+    Future<void> Function({
+      String? relativePath,
+      String? oldPath,
+      required WorkspaceGitDiffScope scope,
+      String? gitDiffRoot,
+      required String commitOid,
+      String? parentOid,
+      required String compareRef,
+      String? subject,
+      String? message,
     });
 
 class WorkspaceGitDiffPanel extends ConsumerStatefulWidget {
@@ -45,6 +62,7 @@ class WorkspaceGitDiffPanel extends ConsumerStatefulWidget {
     required this.viewMode,
     required this.onViewModeChanged,
     required this.onOpenGitDiff,
+    required this.onOpenGitCommitDiff,
     this.onClearSourceControlRoot,
   });
 
@@ -53,6 +71,7 @@ class WorkspaceGitDiffPanel extends ConsumerStatefulWidget {
   final GitDiffViewMode viewMode;
   final ValueChanged<GitDiffViewMode> onViewModeChanged;
   final OpenGitDiffTabCallback onOpenGitDiff;
+  final OpenGitCommitDiffTabCallback onOpenGitCommitDiff;
   final VoidCallback? onClearSourceControlRoot;
 
   @override
@@ -68,6 +87,14 @@ class _WorkspaceGitDiffPanelState extends ConsumerState<WorkspaceGitDiffPanel> {
   late final AiTextGenerationService _aiTextGenerationService;
   bool _filterVisible = false;
   bool _generatingCommitMessage = false;
+  bool _historyCollapsed = true;
+  bool _historyDirty = false;
+  bool _historyRefreshing = false;
+  Future<GitHistoryResult>? _historyFuture;
+  GitHistoryResult? _historyResult;
+  String? _historyError;
+  final Map<String, GitCommitCompareResult> _commitCompareCache =
+      <String, GitCommitCompareResult>{};
   int _commitMessageGenerationId = 0;
 
   @override
@@ -91,6 +118,13 @@ class _WorkspaceGitDiffPanelState extends ConsumerState<WorkspaceGitDiffPanel> {
       _collapsedTreeNodes.clear();
       _filterVisible = false;
       _generatingCommitMessage = false;
+      _historyCollapsed = true;
+      _historyDirty = false;
+      _historyFuture = null;
+      _historyResult = null;
+      _historyError = null;
+      _historyRefreshing = false;
+      _commitCompareCache.clear();
     }
   }
 
@@ -108,9 +142,21 @@ class _WorkspaceGitDiffPanelState extends ConsumerState<WorkspaceGitDiffPanel> {
 
   @override
   Widget build(BuildContext context) {
-    final state = ref.watch(
-      workspaceSourceControlControllerProvider(widget.sourceControlScope.path),
+    final sourceControlProvider = workspaceSourceControlControllerProvider(
+      widget.sourceControlScope.path,
     );
+    ref.listen<AsyncValue<WorkspaceSourceControlState>>(sourceControlProvider, (
+      previous,
+      next,
+    ) {
+      final previousData = previous?.asData?.value;
+      final nextData = next.asData?.value;
+      if (previousData == null || nextData == null || nextData.isBusy) {
+        return;
+      }
+      _invalidateGitHistoryAfterRepositoryChange();
+    });
+    final state = ref.watch(sourceControlProvider);
     final aiTextSettings = ref.watch(
       settingsControllerProvider.select(
         (settings) => settings.aiTextGeneration,
@@ -150,36 +196,55 @@ class _WorkspaceGitDiffPanelState extends ConsumerState<WorkspaceGitDiffPanel> {
         ),
         const Divider(height: 1, color: AleraTokens.borderSubtle),
         Expanded(
-          child: state.when(
-            loading: () => const Center(child: CircularProgressIndicator()),
-            error: (error, _) => _GitDiffMessage(message: _messageFor(error)),
-            data: (data) {
-              final status = _filteredStatus(data.status);
-              final entries = status.entries;
-              if (entries.isEmpty) {
-                return _GitDiffMessage(
-                  message: _filterController.text.trim().isEmpty
-                      ? 'No changes'
-                      : 'No files match the current filter',
-                );
-              }
-              return _GitDiffGroups(
-                groups: status.effectiveGroups,
-                viewMode: widget.viewMode,
-                busy: data.isBusy,
-                collapsedSections: _collapsedSections,
-                collapsedTreeNodes: _collapsedTreeNodes,
-                onToggleSection: _toggleSectionCollapsed,
-                onToggleTreeNode: _toggleTreeNodeCollapsed,
-                onOpenGitDiff: _openGitDiff,
-                onStage: _stageEntry,
-                onUnstage: _unstageEntry,
-                onDiscard: _discardEntry,
-                onStageArea: _stageArea,
-                onUnstageArea: _unstageArea,
-                onDiscardArea: _discardAreaWithConfirmation,
-              );
-            },
+          child: Column(
+            children: <Widget>[
+              Expanded(
+                child: state.when(
+                  loading: () =>
+                      const Center(child: CircularProgressIndicator()),
+                  error: (error, _) =>
+                      _GitDiffMessage(message: _messageFor(error)),
+                  data: (data) {
+                    final status = _filteredStatus(data.status);
+                    final entries = status.entries;
+                    if (entries.isEmpty) {
+                      return _GitDiffMessage(
+                        message: _filterController.text.trim().isEmpty
+                            ? 'No changes'
+                            : 'No files match the current filter',
+                      );
+                    }
+                    return _GitDiffGroups(
+                      groups: status.effectiveGroups,
+                      viewMode: widget.viewMode,
+                      busy: data.isBusy,
+                      collapsedSections: _collapsedSections,
+                      collapsedTreeNodes: _collapsedTreeNodes,
+                      onToggleSection: _toggleSectionCollapsed,
+                      onToggleTreeNode: _toggleTreeNodeCollapsed,
+                      onOpenGitDiff: _openGitDiff,
+                      onStage: _stageEntry,
+                      onUnstage: _unstageEntry,
+                      onDiscard: _discardEntry,
+                      onStageArea: _stageArea,
+                      onUnstageArea: _unstageArea,
+                      onDiscardArea: _discardAreaWithConfirmation,
+                    );
+                  },
+                ),
+              ),
+              const Divider(height: 1, color: AleraTokens.borderSubtle),
+              _GitHistoryPanel(
+                state: _historyPanelState,
+                collapsed: _historyCollapsed,
+                onToggle: _toggleGitHistory,
+                onRefresh: _refreshGitHistory,
+                onLoadCommitFiles: _loadCommitFiles,
+                onOpenCommit: _openCommitDiff,
+                onOpenCommitFile: _openCommitFile,
+                onCopyCommitText: _copyCommitText,
+              ),
+            ],
           ),
         ),
       ],
@@ -620,6 +685,7 @@ class _WorkspaceGitDiffPanelState extends ConsumerState<WorkspaceGitDiffPanel> {
           message: successMessage,
           tone: AleraToastTone.success,
         );
+        _invalidateGitHistoryAfterMutation();
       }
       return true;
     } catch (error) {
@@ -678,6 +744,212 @@ class _WorkspaceGitDiffPanelState extends ConsumerState<WorkspaceGitDiffPanel> {
       gitDiffRoot: widget.sourceControlScope.relativeRoot,
       scope: scope,
     );
+  }
+
+  _GitHistoryPanelLoadState get _historyPanelState {
+    final future = _historyFuture;
+    final result = _historyResult;
+    if (_historyError case final error?) {
+      return _GitHistoryPanelLoadState.error(
+        error: error,
+        result: result,
+        loading: _historyRefreshing,
+      );
+    }
+    if (future != null && result == null) {
+      return const _GitHistoryPanelLoadState.loading();
+    }
+    if (result != null) {
+      return _GitHistoryPanelLoadState.ready(
+        result: result,
+        loading: _historyRefreshing,
+      );
+    }
+    return const _GitHistoryPanelLoadState.idle();
+  }
+
+  void _toggleGitHistory() {
+    final opening = _historyCollapsed;
+    setState(() => _historyCollapsed = !_historyCollapsed);
+    if (opening &&
+        (_historyDirty || (_historyResult == null && _historyFuture == null))) {
+      unawaited(_loadGitHistory());
+    }
+  }
+
+  void _invalidateGitHistoryAfterMutation() {
+    _commitCompareCache.clear();
+    if (_historyCollapsed) {
+      _markCollapsedHistoryDirty();
+      return;
+    }
+    unawaited(_loadGitHistory());
+  }
+
+  void _invalidateGitHistoryAfterRepositoryChange() {
+    if (_historyResult == null && _historyFuture == null) {
+      return;
+    }
+    _commitCompareCache.clear();
+    if (_historyCollapsed) {
+      setState(_markCollapsedHistoryDirty);
+      return;
+    }
+    unawaited(_loadGitHistory());
+  }
+
+  void _markCollapsedHistoryDirty() {
+    _historyDirty = true;
+    _historyFuture = null;
+    _historyRefreshing = false;
+  }
+
+  Future<void> _refreshGitHistory() async {
+    if (_historyCollapsed) {
+      setState(() => _historyCollapsed = false);
+    }
+    await _loadGitHistory();
+  }
+
+  Future<void> _loadGitHistory() async {
+    final future = ref
+        .read(gitBackendProvider)
+        .history(widget.sourceControlScope.path, limit: 50);
+    setState(() {
+      _historyFuture = future;
+      _historyError = null;
+      _historyRefreshing = _historyResult != null;
+    });
+    try {
+      final result = await future;
+      if (!mounted || _historyFuture != future) {
+        return;
+      }
+      setState(() {
+        _historyResult = result;
+        _historyDirty = false;
+        _historyFuture = null;
+        _historyRefreshing = false;
+        _commitCompareCache.clear();
+      });
+    } catch (error) {
+      if (!mounted || _historyFuture != future) {
+        return;
+      }
+      setState(() {
+        _historyError = _messageFor(error);
+        _historyFuture = null;
+        _historyRefreshing = false;
+      });
+    }
+  }
+
+  Future<List<GitCommitChangeEntry>> _loadCommitFiles(
+    GitHistoryItem item,
+  ) async {
+    final compare = await _commitCompareFor(item);
+    return compare.entries;
+  }
+
+  Future<void> _openCommitDiff(GitHistoryItem item) async {
+    try {
+      final compare = await _commitCompareFor(item);
+      if (!mounted) {
+        return;
+      }
+      await widget.onOpenGitCommitDiff(
+        scope: WorkspaceGitDiffScope.all,
+        gitDiffRoot: widget.sourceControlScope.relativeRoot,
+        commitOid: compare.summary.commitOid,
+        parentOid: compare.summary.parentOid,
+        compareRef: compare.summary.compareRef,
+        subject: item.subject,
+        message: item.message,
+      );
+    } catch (error) {
+      if (mounted) {
+        AleraToast.show(
+          context,
+          message: _messageFor(error),
+          tone: AleraToastTone.error,
+        );
+      }
+    }
+  }
+
+  Future<void> _openCommitFile(
+    GitHistoryItem item,
+    GitCommitChangeEntry entry,
+  ) async {
+    try {
+      final compare = await _commitCompareFor(item);
+      if (!mounted) {
+        return;
+      }
+      await widget.onOpenGitCommitDiff(
+        relativePath: widget.sourceControlScope.toWorkspaceRelativePath(
+          entry.path,
+        ),
+        oldPath: widget.sourceControlScope.toWorkspaceRelativePath(
+          entry.oldPath,
+        ),
+        scope: WorkspaceGitDiffScope.file,
+        gitDiffRoot: widget.sourceControlScope.relativeRoot,
+        commitOid: compare.summary.commitOid,
+        parentOid: compare.summary.parentOid,
+        compareRef: compare.summary.compareRef,
+        subject: item.subject,
+        message: item.message,
+      );
+    } catch (error) {
+      if (mounted) {
+        AleraToast.show(
+          context,
+          message: _messageFor(error),
+          tone: AleraToastTone.error,
+        );
+      }
+    }
+  }
+
+  Future<GitCommitCompareResult> _commitCompareFor(GitHistoryItem item) async {
+    final cached = _commitCompareCache[item.id];
+    if (cached != null) {
+      return cached;
+    }
+    final result = await ref
+        .read(gitBackendProvider)
+        .commitCompare(path: widget.sourceControlScope.path, commitId: item.id);
+    if (result.summary.status != GitCommitCompareStatus.ready) {
+      throw GitInternalException(
+        result.summary.errorMessage ?? 'Failed to load commit diff.',
+      );
+    }
+    _commitCompareCache[item.id] = result;
+    return result;
+  }
+
+  Future<void> _copyCommitText(String text, String label) async {
+    try {
+      await Clipboard.setData(ClipboardData(text: text));
+      if (!mounted) {
+        return;
+      }
+      AleraToast.show(
+        context,
+        message: '$label Copied',
+        tone: AleraToastTone.success,
+      );
+    } catch (_) {
+      if (!mounted) {
+        return;
+      }
+      AleraToast.show(
+        context,
+        message: 'Could Not Copy $label',
+        tone: AleraToastTone.error,
+      );
+    }
   }
 
   String _messageFor(Object? error) {

--- a/lib/src/features/workbench/presentation/workspace_git_diff_surface.dart
+++ b/lib/src/features/workbench/presentation/workspace_git_diff_surface.dart
@@ -8,6 +8,7 @@ import 'package:alera/src/design_system/icons/alera_icons.dart';
 import 'package:alera/src/features/workbench/domain/workspace.dart';
 import 'package:alera/src/features/workbench/domain/workspace_source_control_scope.dart';
 import 'package:alera/src/features/workbench/domain/workspace_tab_record.dart';
+import 'package:alera/src/shared/infra/git/git_backend.dart';
 import 'package:alera/src/shared/infra/git/git_diff_models.dart';
 import 'package:alera/src/shared/infra/git/git_providers.dart';
 import 'package:flutter/material.dart';
@@ -88,6 +89,9 @@ class _WorkspaceGitDiffSurfaceState
   }
 
   bool get _canOpenFile {
+    if (widget.tab.gitDiffSource == WorkspaceGitDiffSource.commit) {
+      return false;
+    }
     return _openableDiffFile != null;
   }
 
@@ -124,28 +128,38 @@ class _WorkspaceGitDiffSurfaceState
     final filePath = widget.tab.filePath;
     final sourceControlScope = _sourceControlScope;
     final sourceFilePath = sourceControlScope.toSourceRelativePath(filePath);
+    final sourceOldPath = sourceControlScope.toSourceRelativePath(
+      widget.tab.gitDiffOldPath,
+    );
     final area = widget.tab.gitDiffArea;
-    final nextFuture = switch (scope) {
-      WorkspaceGitDiffScope.all => backend.diffAll(
-        path: sourceControlScope.path,
-      ),
-      WorkspaceGitDiffScope.fileAll =>
-        sourceFilePath == null
-            ? Future<GitDiffResult>.value(const GitDiffResult(files: []))
-            : backend.diffAll(
-                path: sourceControlScope.path,
-                filePath: sourceFilePath,
-              ),
-      WorkspaceGitDiffScope.file =>
-        sourceFilePath == null || area == null
-            ? Future<GitDiffResult>.value(const GitDiffResult(files: []))
-            : backend.diff(
-                path: sourceControlScope.path,
-                filePath: sourceFilePath,
-                area: area,
-              ),
-      null => Future<GitDiffResult>.value(const GitDiffResult(files: [])),
-    };
+    final nextFuture = widget.tab.gitDiffSource == WorkspaceGitDiffSource.commit
+        ? _loadCommitDiff(
+            backend: backend,
+            sourceControlScope: sourceControlScope,
+            sourceFilePath: sourceFilePath,
+            sourceOldPath: sourceOldPath,
+          )
+        : switch (scope) {
+            WorkspaceGitDiffScope.all => backend.diffAll(
+              path: sourceControlScope.path,
+            ),
+            WorkspaceGitDiffScope.fileAll =>
+              sourceFilePath == null
+                  ? Future<GitDiffResult>.value(const GitDiffResult(files: []))
+                  : backend.diffAll(
+                      path: sourceControlScope.path,
+                      filePath: sourceFilePath,
+                    ),
+            WorkspaceGitDiffScope.file =>
+              sourceFilePath == null || area == null
+                  ? Future<GitDiffResult>.value(const GitDiffResult(files: []))
+                  : backend.diff(
+                      path: sourceControlScope.path,
+                      filePath: sourceFilePath,
+                      area: area,
+                    ),
+            null => Future<GitDiffResult>.value(const GitDiffResult(files: [])),
+          };
     setState(() {
       _loadedResult = null;
       _future = nextFuture;
@@ -183,6 +197,25 @@ class _WorkspaceGitDiffSurfaceState
           workspace: widget.workspace,
           relativePath: _sourceControlScope.toWorkspaceRelativePath(file.path)!,
         );
+  }
+
+  Future<GitDiffResult> _loadCommitDiff({
+    required GitBackend backend,
+    required WorkspaceSourceControlScope sourceControlScope,
+    required String? sourceFilePath,
+    required String? sourceOldPath,
+  }) {
+    final commitOid = widget.tab.gitDiffCommitOid;
+    if (commitOid == null) {
+      return Future<GitDiffResult>.value(const GitDiffResult(files: []));
+    }
+    return backend.commitDiff(
+      path: sourceControlScope.path,
+      commitOid: commitOid,
+      parentOid: widget.tab.gitDiffParentOid,
+      filePath: sourceFilePath,
+      oldPath: sourceOldPath,
+    );
   }
 
   WorkspaceSourceControlScope get _sourceControlScope {
@@ -346,7 +379,7 @@ class _FileHeaderRow extends _DiffRow {
             const SizedBox(width: AleraTokens.space8),
             Expanded(
               child: Text(
-                '${file.area.label} · ${file.path}',
+                '${file.sourceLabel ?? file.area.label} · ${file.path}',
                 maxLines: 1,
                 overflow: TextOverflow.ellipsis,
                 style: Theme.of(context).textTheme.bodySmall?.copyWith(

--- a/lib/src/features/workbench/presentation/workspace_git_history_panel.dart
+++ b/lib/src/features/workbench/presentation/workspace_git_history_panel.dart
@@ -1,0 +1,859 @@
+part of 'workspace_git_diff_panel.dart';
+
+enum _GitHistoryPanelStatus { idle, loading, ready, error }
+
+class _GitHistoryPanelLoadState {
+  const _GitHistoryPanelLoadState._({
+    required this.status,
+    this.result,
+    this.error,
+    this.loading = false,
+  });
+
+  const _GitHistoryPanelLoadState.idle()
+    : this._(status: _GitHistoryPanelStatus.idle);
+
+  const _GitHistoryPanelLoadState.loading()
+    : this._(status: _GitHistoryPanelStatus.loading, loading: true);
+
+  const _GitHistoryPanelLoadState.ready({
+    required GitHistoryResult result,
+    bool loading = false,
+  }) : this._(
+         status: _GitHistoryPanelStatus.ready,
+         result: result,
+         loading: loading,
+       );
+
+  const _GitHistoryPanelLoadState.error({
+    required String error,
+    GitHistoryResult? result,
+    bool loading = false,
+  }) : this._(
+         status: _GitHistoryPanelStatus.error,
+         result: result,
+         error: error,
+         loading: loading,
+       );
+
+  final _GitHistoryPanelStatus status;
+  final GitHistoryResult? result;
+  final String? error;
+  final bool loading;
+}
+
+class _GitHistoryPanel extends StatefulWidget {
+  const _GitHistoryPanel({
+    required this.state,
+    required this.collapsed,
+    required this.onToggle,
+    required this.onRefresh,
+    required this.onLoadCommitFiles,
+    required this.onOpenCommit,
+    required this.onOpenCommitFile,
+    required this.onCopyCommitText,
+  });
+
+  final _GitHistoryPanelLoadState state;
+  final bool collapsed;
+  final VoidCallback onToggle;
+  final Future<void> Function() onRefresh;
+  final Future<List<GitCommitChangeEntry>> Function(GitHistoryItem item)
+  onLoadCommitFiles;
+  final Future<void> Function(GitHistoryItem item) onOpenCommit;
+  final Future<void> Function(GitHistoryItem item, GitCommitChangeEntry entry)
+  onOpenCommitFile;
+  final Future<void> Function(String text, String label) onCopyCommitText;
+
+  @override
+  State<_GitHistoryPanel> createState() => _GitHistoryPanelState();
+}
+
+class _GitHistoryPanelState extends State<_GitHistoryPanel> {
+  static const double _defaultHeight = 256;
+  static const double _minHeight = 96;
+  static const double _maxHeight = 520;
+
+  final Set<String> _expandedCommitIds = <String>{};
+  final Map<String, _CommitFilesState> _filesByCommit =
+      <String, _CommitFilesState>{};
+  double _height = _defaultHeight;
+
+  @override
+  void didUpdateWidget(covariant _GitHistoryPanel oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.state.result != widget.state.result) {
+      _expandedCommitIds.clear();
+      _filesByCommit.clear();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final result = widget.state.result;
+    final count = result?.items.length ?? 0;
+    return DecoratedBox(
+      decoration: const BoxDecoration(color: AleraTokens.surfaceVariant),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: <Widget>[
+          if (!widget.collapsed) _ResizeHandle(onResize: _resize),
+          SizedBox(
+            height: 30,
+            child: Padding(
+              padding: const EdgeInsets.symmetric(
+                horizontal: AleraTokens.space8,
+              ),
+              child: Row(
+                children: <Widget>[
+                  Expanded(
+                    child: InkWell(
+                      onTap: widget.onToggle,
+                      child: Row(
+                        children: <Widget>[
+                          Icon(
+                            widget.collapsed
+                                ? AleraIcons.chevronRight
+                                : AleraIcons.chevronDown,
+                            size: 15,
+                            color: AleraTokens.foregroundMuted,
+                          ),
+                          const SizedBox(width: AleraTokens.space4),
+                          Text(
+                            'Commits',
+                            style: Theme.of(context).textTheme.labelSmall
+                                ?.copyWith(
+                                  color: AleraTokens.foregroundMuted,
+                                  fontWeight: FontWeight.w700,
+                                ),
+                          ),
+                          if (result != null) ...<Widget>[
+                            const SizedBox(width: AleraTokens.space6),
+                            Text(
+                              result.hasMore ? '$count+' : '$count',
+                              style: Theme.of(context).textTheme.labelSmall
+                                  ?.copyWith(
+                                    color: AleraTokens.foregroundFaint,
+                                  ),
+                            ),
+                          ],
+                        ],
+                      ),
+                    ),
+                  ),
+                  AleraIconButton(
+                    tooltip: 'Refresh Commits',
+                    icon: AleraIcons.refresh,
+                    onPressed: widget.state.loading
+                        ? null
+                        : () => unawaited(widget.onRefresh()),
+                  ),
+                ],
+              ),
+            ),
+          ),
+          if (!widget.collapsed)
+            SizedBox(height: _height, child: _buildBody(context)),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildBody(BuildContext context) {
+    final state = widget.state;
+    final result = state.result;
+    if (state.status == _GitHistoryPanelStatus.error && result == null) {
+      return _HistoryMessage(message: state.error ?? 'Could Not Load Commits');
+    }
+    if (result == null) {
+      return const _HistoryLoadingMessage();
+    }
+    final viewModels = buildGitHistoryViewModels(result);
+    if (viewModels.isEmpty) {
+      return const _HistoryMessage(message: 'No Commits Yet');
+    }
+    return Stack(
+      children: <Widget>[
+        ListView.builder(
+          padding: const EdgeInsets.only(bottom: AleraTokens.space8),
+          itemCount: viewModels.length,
+          itemBuilder: (context, index) {
+            final viewModel = viewModels[index];
+            final item = viewModel.historyItem;
+            final boundary =
+                viewModel.kind == GitHistoryItemViewModelKind.incomingChanges ||
+                viewModel.kind == GitHistoryItemViewModelKind.outgoingChanges;
+            final expanded = _expandedCommitIds.contains(item.id);
+            return Column(
+              mainAxisSize: MainAxisSize.min,
+              children: <Widget>[
+                _GitHistoryCommitRow(
+                  viewModel: viewModel,
+                  expanded: expanded,
+                  onTap: boundary ? null : () => _toggleCommit(item),
+                  onOpenActions: boundary
+                      ? null
+                      : (context) => _openActions(context, item),
+                ),
+                if (expanded)
+                  _CommitFiles(
+                    state:
+                        _filesByCommit[item.id] ??
+                        const _CommitFilesState.loading(),
+                    author: item.author,
+                    timestamp: item.timestamp,
+                    onOpenAll: () => unawaited(widget.onOpenCommit(item)),
+                    onOpenFile: (entry) =>
+                        unawaited(widget.onOpenCommitFile(item, entry)),
+                  ),
+              ],
+            );
+          },
+        ),
+        if (state.loading)
+          const Positioned(
+            top: AleraTokens.space8,
+            right: AleraTokens.space8,
+            child: SizedBox(
+              width: 12,
+              height: 12,
+              child: CircularProgressIndicator(strokeWidth: 2),
+            ),
+          ),
+      ],
+    );
+  }
+
+  void _resize(double delta) {
+    setState(() {
+      _height = (_height - delta).clamp(_minHeight, _maxHeight);
+    });
+  }
+
+  void _toggleCommit(GitHistoryItem item) {
+    final expanding = !_expandedCommitIds.contains(item.id);
+    setState(() {
+      if (expanding) {
+        _expandedCommitIds.add(item.id);
+        _filesByCommit[item.id] = const _CommitFilesState.loading();
+      } else {
+        _expandedCommitIds.remove(item.id);
+      }
+    });
+    if (!expanding) {
+      return;
+    }
+    widget
+        .onLoadCommitFiles(item)
+        .then(
+          (entries) {
+            if (!mounted || !_expandedCommitIds.contains(item.id)) {
+              return;
+            }
+            setState(() {
+              _filesByCommit[item.id] = _CommitFilesState.ready(
+                entries: entries,
+              );
+            });
+          },
+          onError: (Object error) {
+            if (!mounted || !_expandedCommitIds.contains(item.id)) {
+              return;
+            }
+            setState(() {
+              _filesByCommit[item.id] = _CommitFilesState.error(
+                error: error.toString(),
+              );
+            });
+          },
+        );
+  }
+
+  Future<void> _openActions(BuildContext context, GitHistoryItem item) async {
+    final renderBox = context.findRenderObject() as RenderBox?;
+    final overlay = Navigator.of(context).overlay?.context.findRenderObject();
+    if (renderBox == null || overlay is! RenderBox) {
+      return;
+    }
+    final topLeft = renderBox.localToGlobal(Offset.zero, ancestor: overlay);
+    final bottomRight = renderBox.localToGlobal(
+      renderBox.size.bottomRight(Offset.zero),
+      ancestor: overlay,
+    );
+    final action = await showMenu<_CommitAction>(
+      context: context,
+      position: RelativeRect.fromRect(
+        Rect.fromPoints(topLeft, bottomRight),
+        Offset.zero & overlay.size,
+      ),
+      items: const <PopupMenuEntry<_CommitAction>>[
+        AleraDropdownEntry<_CommitAction>(
+          value: _CommitAction.copyHash,
+          label: 'Copy Commit Hash',
+          leading: Icon(AleraIcons.gitBranch, size: 16),
+        ),
+        AleraDropdownEntry<_CommitAction>(
+          value: _CommitAction.copyMessage,
+          label: 'Copy Commit Message',
+          leading: Icon(AleraIcons.copy, size: 16),
+        ),
+      ],
+    );
+    if (action == null) {
+      return;
+    }
+    switch (action) {
+      case _CommitAction.copyHash:
+        await widget.onCopyCommitText(item.id, 'Commit Hash');
+      case _CommitAction.copyMessage:
+        await widget.onCopyCommitText(
+          item.message.trim().isEmpty ? item.subject : item.message,
+          'Commit Message',
+        );
+    }
+  }
+}
+
+enum _CommitAction { copyHash, copyMessage }
+
+class _ResizeHandle extends StatelessWidget {
+  const _ResizeHandle({required this.onResize});
+
+  final ValueChanged<double> onResize;
+
+  @override
+  Widget build(BuildContext context) {
+    return MouseRegion(
+      cursor: SystemMouseCursors.resizeUpDown,
+      child: GestureDetector(
+        behavior: HitTestBehavior.translucent,
+        onVerticalDragUpdate: (details) => onResize(details.delta.dy),
+        child: const SizedBox(height: AleraTokens.space4),
+      ),
+    );
+  }
+}
+
+class _GitHistoryCommitRow extends StatelessWidget {
+  const _GitHistoryCommitRow({
+    required this.viewModel,
+    required this.expanded,
+    required this.onTap,
+    required this.onOpenActions,
+  });
+
+  final GitHistoryItemViewModel viewModel;
+  final bool expanded;
+  final VoidCallback? onTap;
+  final void Function(BuildContext context)? onOpenActions;
+
+  @override
+  Widget build(BuildContext context) {
+    final item = viewModel.historyItem;
+    final boundary =
+        viewModel.kind == GitHistoryItemViewModelKind.incomingChanges ||
+        viewModel.kind == GitHistoryItemViewModelKind.outgoingChanges;
+    return InkWell(
+      onTap: onTap,
+      child: SizedBox(
+        height: 28,
+        child: Padding(
+          padding: const EdgeInsets.only(
+            left: AleraTokens.space8,
+            right: AleraTokens.space6,
+          ),
+          child: Row(
+            children: <Widget>[
+              _GitHistoryGraph(viewModel: viewModel),
+              const SizedBox(width: AleraTokens.space4),
+              if (!boundary)
+                Icon(
+                  expanded ? AleraIcons.chevronDown : AleraIcons.chevronRight,
+                  size: 14,
+                  color: AleraTokens.foregroundFaint,
+                )
+              else
+                const SizedBox(width: 14),
+              const SizedBox(width: AleraTokens.space4),
+              Expanded(
+                child: Text(
+                  item.subject,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: boundary
+                        ? AleraTokens.foregroundMuted
+                        : AleraTokens.foreground,
+                  ),
+                ),
+              ),
+              for (final itemRef in item.references.take(2)) ...<Widget>[
+                const SizedBox(width: AleraTokens.space4),
+                _GitRefBadge(itemRef: itemRef),
+              ],
+              if (item.references.length > 2) ...<Widget>[
+                const SizedBox(width: AleraTokens.space4),
+                Text(
+                  '+${item.references.length - 2}',
+                  style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                    color: AleraTokens.foregroundFaint,
+                  ),
+                ),
+              ],
+              if (onOpenActions != null)
+                Builder(
+                  builder: (context) => AleraIconButton(
+                    tooltip: 'Commit Actions',
+                    icon: AleraIcons.more,
+                    onPressed: () => onOpenActions!(context),
+                  ),
+                ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _GitRefBadge extends StatelessWidget {
+  const _GitRefBadge({required this.itemRef});
+
+  final GitHistoryItemRef itemRef;
+
+  @override
+  Widget build(BuildContext context) {
+    final color = _graphColor(itemRef.color);
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(AleraTokens.radiusPill),
+        border: Border.all(color: color ?? AleraTokens.borderSubtle),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(
+          horizontal: AleraTokens.space6,
+          vertical: AleraTokens.space2,
+        ),
+        child: Text(
+          itemRef.name,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          style: Theme.of(context).textTheme.labelSmall?.copyWith(
+            color: color ?? AleraTokens.foregroundMuted,
+            fontSize: 10,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _GitHistoryGraph extends StatelessWidget {
+  const _GitHistoryGraph({required this.viewModel});
+
+  final GitHistoryItemViewModel viewModel;
+
+  @override
+  Widget build(BuildContext context) {
+    final width =
+        11.0 *
+        ([
+              viewModel.inputSwimlanes.length,
+              viewModel.outputSwimlanes.length,
+              1,
+            ].reduce((a, b) => a > b ? a : b) +
+            1);
+    return SizedBox(
+      width: width,
+      height: 24,
+      child: CustomPaint(painter: _GitHistoryGraphPainter(viewModel)),
+    );
+  }
+}
+
+class _GitHistoryGraphPainter extends CustomPainter {
+  const _GitHistoryGraphPainter(this.viewModel);
+
+  static const double laneHeight = 24;
+  static const double laneWidth = 11;
+  static const double nodeY = laneHeight / 2;
+  static const double circleRadius = 3.5;
+
+  final GitHistoryItemViewModel viewModel;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final item = viewModel.historyItem;
+    final input = viewModel.inputSwimlanes;
+    final output = viewModel.outputSwimlanes;
+    final inputIndex = input.indexWhere((node) => node.id == item.id);
+    final circleIndex = gitHistoryItemLaneIndex(viewModel);
+    final circleColor = circleIndex < output.length
+        ? output[circleIndex].color
+        : circleIndex < input.length
+        ? input[circleIndex].color
+        : gitHistoryRefColor;
+    var outputIndex = 0;
+
+    for (var index = 0; index < input.length; index += 1) {
+      final color = input[index].color;
+      if (input[index].id == item.id) {
+        if (index != circleIndex) {
+          _drawPath(
+            canvas,
+            color,
+            Path()
+              ..moveTo(laneWidth * (index + 1), 0)
+              ..quadraticBezierTo(
+                laneWidth * index,
+                nodeY,
+                laneWidth * (circleIndex + 1),
+                nodeY,
+              ),
+          );
+        } else {
+          outputIndex += 1;
+        }
+        continue;
+      }
+      if (outputIndex < output.length &&
+          input[index].id == output[outputIndex].id) {
+        final path = Path()..moveTo(laneWidth * (index + 1), 0);
+        if (index == outputIndex) {
+          path.lineTo(laneWidth * (index + 1), laneHeight);
+        } else {
+          path
+            ..lineTo(laneWidth * (index + 1), 6)
+            ..quadraticBezierTo(
+              laneWidth * (index + 1),
+              nodeY,
+              laneWidth * (outputIndex + 1),
+              nodeY,
+            )
+            ..lineTo(laneWidth * (outputIndex + 1), laneHeight);
+        }
+        _drawPath(canvas, color, path);
+        outputIndex += 1;
+      }
+    }
+
+    for (var index = 1; index < item.parentIds.length; index += 1) {
+      final parentIndex = gitHistoryMergeParentLaneIndex(
+        viewModel,
+        item.parentIds[index],
+      );
+      if (parentIndex == -1) {
+        continue;
+      }
+      _drawPath(
+        canvas,
+        output[parentIndex].color,
+        Path()
+          ..moveTo(laneWidth * (parentIndex + 1), nodeY)
+          ..lineTo(laneWidth * (circleIndex + 1), nodeY)
+          ..moveTo(laneWidth * (parentIndex + 1), nodeY)
+          ..quadraticBezierTo(
+            laneWidth * (parentIndex + 1),
+            laneHeight,
+            laneWidth * (parentIndex + 1),
+            laneHeight,
+          ),
+      );
+    }
+
+    if (inputIndex != -1) {
+      _drawPath(
+        canvas,
+        input[inputIndex].color,
+        Path()
+          ..moveTo(laneWidth * (circleIndex + 1), 0)
+          ..lineTo(laneWidth * (circleIndex + 1), nodeY),
+      );
+    }
+    if (item.parentIds.isNotEmpty) {
+      _drawPath(
+        canvas,
+        circleColor,
+        Path()
+          ..moveTo(laneWidth * (circleIndex + 1), nodeY)
+          ..lineTo(laneWidth * (circleIndex + 1), laneHeight),
+      );
+    }
+
+    _drawNode(canvas, circleIndex, circleColor);
+  }
+
+  void _drawPath(Canvas canvas, GitHistoryGraphColorId color, Path path) {
+    canvas.drawPath(
+      path,
+      Paint()
+        ..color = _graphColor(color) ?? AleraTokens.foregroundMuted
+        ..strokeWidth = 1
+        ..strokeCap = StrokeCap.round
+        ..style = PaintingStyle.stroke,
+    );
+  }
+
+  void _drawNode(Canvas canvas, int circleIndex, GitHistoryGraphColorId color) {
+    final center = Offset(laneWidth * (circleIndex + 1), nodeY);
+    final paint = Paint()..color = _graphColor(color) ?? AleraTokens.foreground;
+    final boundary =
+        viewModel.kind == GitHistoryItemViewModelKind.incomingChanges ||
+        viewModel.kind == GitHistoryItemViewModelKind.outgoingChanges;
+    if (viewModel.kind == GitHistoryItemViewModelKind.head || boundary) {
+      canvas.drawCircle(center, circleRadius + 3, paint);
+      canvas.drawCircle(center, circleRadius, Paint()..color = AleraTokens.bg);
+      if (boundary) {
+        canvas.drawCircle(
+          center,
+          circleRadius + 1,
+          Paint()
+            ..color = paint.color
+            ..style = PaintingStyle.stroke
+            ..strokeWidth = 1,
+        );
+      }
+      return;
+    }
+    if (viewModel.historyItem.parentIds.length > 1) {
+      canvas.drawCircle(center, circleRadius + 1, paint);
+      canvas.drawCircle(
+        center,
+        circleRadius - 1.5,
+        Paint()..color = AleraTokens.bg,
+      );
+      return;
+    }
+    canvas.drawCircle(center, circleRadius, paint);
+  }
+
+  @override
+  bool shouldRepaint(covariant _GitHistoryGraphPainter oldDelegate) {
+    return oldDelegate.viewModel != viewModel;
+  }
+}
+
+Color? _graphColor(GitHistoryGraphColorId? color) {
+  return switch (color) {
+    GitHistoryGraphColorId.ref => AleraTokens.success,
+    GitHistoryGraphColorId.remoteRef => AleraTokens.info,
+    GitHistoryGraphColorId.baseRef => AleraTokens.warning,
+    GitHistoryGraphColorId.lane1 => AleraTokens.syntaxFunction,
+    GitHistoryGraphColorId.lane2 => AleraTokens.syntaxKeyword,
+    GitHistoryGraphColorId.lane3 => AleraTokens.syntaxLiteral,
+    GitHistoryGraphColorId.lane4 => AleraTokens.syntaxOperator,
+    GitHistoryGraphColorId.lane5 => AleraTokens.foregroundMuted,
+    null => null,
+  };
+}
+
+class _CommitFilesState {
+  const _CommitFilesState.loading()
+    : entries = const <GitCommitChangeEntry>[],
+      error = null,
+      loading = true;
+
+  const _CommitFilesState.ready({required this.entries})
+    : error = null,
+      loading = false;
+
+  const _CommitFilesState.error({required this.error})
+    : entries = const <GitCommitChangeEntry>[],
+      loading = false;
+
+  final List<GitCommitChangeEntry> entries;
+  final String? error;
+  final bool loading;
+}
+
+class _CommitFiles extends StatelessWidget {
+  const _CommitFiles({
+    required this.state,
+    required this.author,
+    required this.timestamp,
+    required this.onOpenAll,
+    required this.onOpenFile,
+  });
+
+  final _CommitFilesState state;
+  final String? author;
+  final DateTime? timestamp;
+  final VoidCallback onOpenAll;
+  final ValueChanged<GitCommitChangeEntry> onOpenFile;
+
+  @override
+  Widget build(BuildContext context) {
+    final meta = <String>[
+      if (author != null && author!.trim().isNotEmpty) author!,
+      if (timestamp != null) _formatTimestamp(timestamp!),
+    ].join(' · ');
+    return DecoratedBox(
+      decoration: const BoxDecoration(color: AleraTokens.surface),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: <Widget>[
+          if (meta.isNotEmpty)
+            Padding(
+              padding: const EdgeInsets.only(
+                left: 40,
+                right: AleraTokens.space8,
+                top: AleraTokens.space4,
+                bottom: AleraTokens.space2,
+              ),
+              child: Text(
+                meta,
+                style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                  color: AleraTokens.foregroundFaint,
+                ),
+              ),
+            ),
+          if (state.loading)
+            const Padding(
+              padding: EdgeInsets.fromLTRB(40, 4, 8, 6),
+              child: Text('Loading Files...'),
+            )
+          else if (state.error != null)
+            Padding(
+              padding: const EdgeInsets.fromLTRB(40, 4, 8, 6),
+              child: Text(
+                state.error!,
+                style: Theme.of(
+                  context,
+                ).textTheme.bodySmall?.copyWith(color: AleraTokens.error),
+              ),
+            )
+          else if (state.entries.isEmpty)
+            const Padding(
+              padding: EdgeInsets.fromLTRB(40, 4, 8, 6),
+              child: Text('No File Changes'),
+            )
+          else ...<Widget>[
+            for (final entry in state.entries)
+              _CommitFileRow(entry: entry, onOpen: () => onOpenFile(entry)),
+            InkWell(
+              onTap: onOpenAll,
+              child: Padding(
+                padding: const EdgeInsets.fromLTRB(40, 5, 8, 7),
+                child: Row(
+                  children: <Widget>[
+                    const Icon(
+                      AleraIcons.external,
+                      size: 13,
+                      color: AleraTokens.foregroundMuted,
+                    ),
+                    const SizedBox(width: AleraTokens.space6),
+                    Text(
+                      'Open All Changes',
+                      style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                        color: AleraTokens.foregroundMuted,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  String _formatTimestamp(DateTime timestamp) {
+    final local = timestamp.toLocal();
+    String two(int value) => value.toString().padLeft(2, '0');
+    return '${local.year}-${two(local.month)}-${two(local.day)} ${two(local.hour)}:${two(local.minute)}';
+  }
+}
+
+class _CommitFileRow extends StatelessWidget {
+  const _CommitFileRow({required this.entry, required this.onOpen});
+
+  final GitCommitChangeEntry entry;
+  final VoidCallback onOpen;
+
+  @override
+  Widget build(BuildContext context) {
+    final label = entry.oldPath == null
+        ? entry.path
+        : '${entry.oldPath} -> ${entry.path}';
+    return InkWell(
+      onTap: onOpen,
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(40, 4, 8, 4),
+        child: Row(
+          children: <Widget>[
+            AleraFileIcon(
+              pathOrName: entry.path,
+              kind: AleraFileIconKind.file,
+              size: 14,
+            ),
+            const SizedBox(width: AleraTokens.space6),
+            Expanded(
+              child: Text(
+                label,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: AleraTokens.monoStyle.copyWith(
+                  color: AleraTokens.foregroundMuted,
+                  fontSize: 11,
+                ),
+              ),
+            ),
+            _CommitStats(entry: entry),
+            const SizedBox(width: AleraTokens.space6),
+            _GitStatusLabel(status: entry.status),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _CommitStats extends StatelessWidget {
+  const _CommitStats({required this.entry});
+
+  final GitCommitChangeEntry entry;
+
+  @override
+  Widget build(BuildContext context) {
+    final style = Theme.of(context).textTheme.labelSmall;
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: <Widget>[
+        if (entry.added case final added? when added > 0)
+          Text('+$added', style: style?.copyWith(color: AleraTokens.success)),
+        if (entry.removed case final removed? when removed > 0) ...<Widget>[
+          const SizedBox(width: AleraTokens.space4),
+          Text('-$removed', style: style?.copyWith(color: AleraTokens.error)),
+        ],
+      ],
+    );
+  }
+}
+
+class _HistoryLoadingMessage extends StatelessWidget {
+  const _HistoryLoadingMessage();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Center(child: CircularProgressIndicator());
+  }
+}
+
+class _HistoryMessage extends StatelessWidget {
+  const _HistoryMessage({required this.message});
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Text(
+        message,
+        style: Theme.of(
+          context,
+        ).textTheme.bodySmall?.copyWith(color: AleraTokens.foregroundMuted),
+      ),
+    );
+  }
+}

--- a/lib/src/rust/api/git.dart
+++ b/lib/src/rust/api/git.dart
@@ -6,8 +6,8 @@
 import '../frb_generated.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 
-// These functions are ignored because they are not marked as `pub`: `canonical`, `checkout_path_for_branch`, `commit_parent_commits`, `configured_remote_for_tracking_branch`, `current_head_commit`, `delete_workspace_relative_path`, `discard_status_entries`, `entries_for_area_and_scope`, `existing_worktree_admin_names`, `fast_forward_local_branch`, `find_remote_tracking_branch_name`, `from_git2`, `from_io`, `git_cli_in_path`, `git_fetch_remote`, `git_signature`, `has_configured_remote_for_tracking_branch`, `head_branch_name`, `is_path_occupied`, `merge_head_oids`, `new`, `open_repo`, `pathspec_string`, `reject_out_of_scope_staged_entries`, `reject_out_of_scope_stash_pop`, `reject_out_of_scope_tracked_changes`, `reject_tree_diff_out_of_scope`, `relative_path`, `remote_tracking_upstream_name`, `remove_index_path_if_present`, `repo_path_is_in_scope`, `repo_relative_path_from_workspace`, `repo_relative_path`, `repo_workdir_path_exists`, `repository_has_conflicts`, `scoped_pathspecs`, `split_clone_destination`, `stage_selected_path`, `stage_status_entries`, `stash_oid`, `unborn_branch_name`, `unique_worktree_admin_name`, `unstage_selected_path`, `unstage_status_entries`, `workspace_path_is_in_scope`, `workspace_repo_relative_path`, `worktree_admin_name`
-// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`
+// These functions are ignored because they are not marked as `pub`: `commit_parent_commits`, `current_head_commit`, `delete_workspace_relative_path`, `discard_status_entries`, `entries_for_area_and_scope`, `from_git2`, `from_io`, `git_cli_in_path`, `git_signature`, `head_branch_name`, `merge_head_oids`, `new`, `open_repo`, `pathspec_string`, `reject_out_of_scope_staged_entries`, `reject_out_of_scope_stash_pop`, `reject_out_of_scope_tracked_changes`, `reject_tree_diff_out_of_scope`, `relative_path`, `remove_index_path_if_present`, `repo_path_is_in_scope`, `repo_relative_path_from_workspace`, `repo_relative_path`, `repo_workdir_path_exists`, `repository_has_conflicts`, `scoped_pathspecs`, `split_clone_destination`, `stage_selected_path`, `stage_status_entries`, `stash_oid`, `unborn_branch_name`, `unstage_selected_path`, `unstage_status_entries`, `workspace_path_is_in_scope`, `workspace_repo_relative_path`
+// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `from`
 
 Future<bool> isGitRepository({required String path}) =>
     RustLib.instance.api.crateApiGitIsGitRepository(path: path);
@@ -50,6 +50,38 @@ Future<GitDiffResult> gitDiff({
 
 Future<GitDiffResult> gitDiffAll({required String path, String? filePath}) =>
     RustLib.instance.api.crateApiGitGitDiffAll(path: path, filePath: filePath);
+
+Future<GitHistoryResult> gitHistory({
+  required String path,
+  int? limit,
+  String? baseRef,
+}) => RustLib.instance.api.crateApiGitGitHistory(
+  path: path,
+  limit: limit,
+  baseRef: baseRef,
+);
+
+Future<GitCommitCompareResult> gitCommitCompare({
+  required String path,
+  required String commitId,
+}) => RustLib.instance.api.crateApiGitGitCommitCompare(
+  path: path,
+  commitId: commitId,
+);
+
+Future<GitDiffResult> gitCommitDiff({
+  required String path,
+  required String commitOid,
+  String? parentOid,
+  String? filePath,
+  String? oldPath,
+}) => RustLib.instance.api.crateApiGitGitCommitDiff(
+  path: path,
+  commitOid: commitOid,
+  parentOid: parentOid,
+  filePath: filePath,
+  oldPath: oldPath,
+);
 
 Future<GitRepositoryState> gitRepositoryState({required String path}) =>
     RustLib.instance.api.crateApiGitGitRepositoryState(path: path);
@@ -306,6 +338,104 @@ class GitChangeTreeRow {
 
 enum GitChangeTreeRowKind { directory, file }
 
+class GitCommitChangeEntry {
+  final String path;
+  final String? oldPath;
+  final GitChangeStatus status;
+  final int? added;
+  final int? removed;
+
+  const GitCommitChangeEntry({
+    required this.path,
+    this.oldPath,
+    required this.status,
+    this.added,
+    this.removed,
+  });
+
+  @override
+  int get hashCode =>
+      path.hashCode ^
+      oldPath.hashCode ^
+      status.hashCode ^
+      added.hashCode ^
+      removed.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is GitCommitChangeEntry &&
+          runtimeType == other.runtimeType &&
+          path == other.path &&
+          oldPath == other.oldPath &&
+          status == other.status &&
+          added == other.added &&
+          removed == other.removed;
+}
+
+class GitCommitCompareResult {
+  final GitCommitCompareSummary summary;
+  final List<GitCommitChangeEntry> entries;
+
+  const GitCommitCompareResult({required this.summary, required this.entries});
+
+  @override
+  int get hashCode => summary.hashCode ^ entries.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is GitCommitCompareResult &&
+          runtimeType == other.runtimeType &&
+          summary == other.summary &&
+          entries == other.entries;
+}
+
+enum GitCommitCompareStatus { ready, invalidCommit, error }
+
+class GitCommitCompareSummary {
+  final String commitOid;
+  final String? parentOid;
+  final String compareRef;
+  final String baseRef;
+  final int changedFiles;
+  final GitCommitCompareStatus status;
+  final String? errorMessage;
+
+  const GitCommitCompareSummary({
+    required this.commitOid,
+    this.parentOid,
+    required this.compareRef,
+    required this.baseRef,
+    required this.changedFiles,
+    required this.status,
+    this.errorMessage,
+  });
+
+  @override
+  int get hashCode =>
+      commitOid.hashCode ^
+      parentOid.hashCode ^
+      compareRef.hashCode ^
+      baseRef.hashCode ^
+      changedFiles.hashCode ^
+      status.hashCode ^
+      errorMessage.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is GitCommitCompareSummary &&
+          runtimeType == other.runtimeType &&
+          commitOid == other.commitOid &&
+          parentOid == other.parentOid &&
+          compareRef == other.compareRef &&
+          baseRef == other.baseRef &&
+          changedFiles == other.changedFiles &&
+          status == other.status &&
+          errorMessage == other.errorMessage;
+}
+
 class GitDiffFile {
   final String path;
   final String? oldPath;
@@ -439,6 +569,138 @@ enum GitErrorKind {
   workspaceScope,
   missingIdentity,
   internal,
+}
+
+class GitHistoryItem {
+  final String id;
+  final List<String> parentIds;
+  final String subject;
+  final String message;
+  final String? displayId;
+  final String? author;
+  final String? authorEmail;
+  final PlatformInt64? timestamp;
+  final List<GitHistoryItemRef> references;
+
+  const GitHistoryItem({
+    required this.id,
+    required this.parentIds,
+    required this.subject,
+    required this.message,
+    this.displayId,
+    this.author,
+    this.authorEmail,
+    this.timestamp,
+    required this.references,
+  });
+
+  @override
+  int get hashCode =>
+      id.hashCode ^
+      parentIds.hashCode ^
+      subject.hashCode ^
+      message.hashCode ^
+      displayId.hashCode ^
+      author.hashCode ^
+      authorEmail.hashCode ^
+      timestamp.hashCode ^
+      references.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is GitHistoryItem &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          parentIds == other.parentIds &&
+          subject == other.subject &&
+          message == other.message &&
+          displayId == other.displayId &&
+          author == other.author &&
+          authorEmail == other.authorEmail &&
+          timestamp == other.timestamp &&
+          references == other.references;
+}
+
+class GitHistoryItemRef {
+  final String id;
+  final String name;
+  final String? revision;
+  final GitHistoryRefCategory? category;
+
+  const GitHistoryItemRef({
+    required this.id,
+    required this.name,
+    this.revision,
+    this.category,
+  });
+
+  @override
+  int get hashCode =>
+      id.hashCode ^ name.hashCode ^ revision.hashCode ^ category.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is GitHistoryItemRef &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          name == other.name &&
+          revision == other.revision &&
+          category == other.category;
+}
+
+enum GitHistoryRefCategory { branches, remoteBranches, tags, commits }
+
+class GitHistoryResult {
+  final List<GitHistoryItem> items;
+  final GitHistoryItemRef? currentRef;
+  final GitHistoryItemRef? remoteRef;
+  final GitHistoryItemRef? baseRef;
+  final String? mergeBase;
+  final bool hasIncomingChanges;
+  final bool hasOutgoingChanges;
+  final bool hasMore;
+  final int limit;
+
+  const GitHistoryResult({
+    required this.items,
+    this.currentRef,
+    this.remoteRef,
+    this.baseRef,
+    this.mergeBase,
+    required this.hasIncomingChanges,
+    required this.hasOutgoingChanges,
+    required this.hasMore,
+    required this.limit,
+  });
+
+  @override
+  int get hashCode =>
+      items.hashCode ^
+      currentRef.hashCode ^
+      remoteRef.hashCode ^
+      baseRef.hashCode ^
+      mergeBase.hashCode ^
+      hasIncomingChanges.hashCode ^
+      hasOutgoingChanges.hashCode ^
+      hasMore.hashCode ^
+      limit.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is GitHistoryResult &&
+          runtimeType == other.runtimeType &&
+          items == other.items &&
+          currentRef == other.currentRef &&
+          remoteRef == other.remoteRef &&
+          baseRef == other.baseRef &&
+          mergeBase == other.mergeBase &&
+          hasIncomingChanges == other.hasIncomingChanges &&
+          hasOutgoingChanges == other.hasOutgoingChanges &&
+          hasMore == other.hasMore &&
+          limit == other.limit;
 }
 
 class GitRepositoryState {

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -70,7 +70,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.12.0';
 
   @override
-  int get rustContentHash => -1983816553;
+  int get rustContentHash => -1007517553;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -142,6 +142,19 @@ abstract class RustLibApi extends BaseApi {
     required String message,
   });
 
+  Future<GitCommitCompareResult> crateApiGitGitCommitCompare({
+    required String path,
+    required String commitId,
+  });
+
+  Future<GitDiffResult> crateApiGitGitCommitDiff({
+    required String path,
+    required String commitOid,
+    String? parentOid,
+    String? filePath,
+    String? oldPath,
+  });
+
   Future<GitDiffResult> crateApiGitGitDiff({
     required String path,
     required String filePath,
@@ -162,6 +175,12 @@ abstract class RustLibApi extends BaseApi {
   });
 
   Future<void> crateApiGitGitFetch({required String path});
+
+  Future<GitHistoryResult> crateApiGitGitHistory({
+    required String path,
+    int? limit,
+    String? baseRef,
+  });
 
   Future<List<GitStashEntry>> crateApiGitGitListStashes({required String path});
 
@@ -759,6 +778,81 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   );
 
   @override
+  Future<GitCommitCompareResult> crateApiGitGitCommitCompare({
+    required String path,
+    required String commitId,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_String(path, serializer);
+          sse_encode_String(commitId, serializer);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 12,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_git_commit_compare_result,
+          decodeErrorData: sse_decode_git_error,
+        ),
+        constMeta: kCrateApiGitGitCommitCompareConstMeta,
+        argValues: [path, commitId],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiGitGitCommitCompareConstMeta =>
+      const TaskConstMeta(
+        debugName: "git_commit_compare",
+        argNames: ["path", "commitId"],
+      );
+
+  @override
+  Future<GitDiffResult> crateApiGitGitCommitDiff({
+    required String path,
+    required String commitOid,
+    String? parentOid,
+    String? filePath,
+    String? oldPath,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_String(path, serializer);
+          sse_encode_String(commitOid, serializer);
+          sse_encode_opt_String(parentOid, serializer);
+          sse_encode_opt_String(filePath, serializer);
+          sse_encode_opt_String(oldPath, serializer);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 13,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_git_diff_result,
+          decodeErrorData: sse_decode_git_error,
+        ),
+        constMeta: kCrateApiGitGitCommitDiffConstMeta,
+        argValues: [path, commitOid, parentOid, filePath, oldPath],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiGitGitCommitDiffConstMeta => const TaskConstMeta(
+    debugName: "git_commit_diff",
+    argNames: ["path", "commitOid", "parentOid", "filePath", "oldPath"],
+  );
+
+  @override
   Future<GitDiffResult> crateApiGitGitDiff({
     required String path,
     required String filePath,
@@ -774,7 +868,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 12,
+            funcId: 14,
             port: port_,
           );
         },
@@ -808,7 +902,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 13,
+            funcId: 15,
             port: port_,
           );
         },
@@ -839,7 +933,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 14,
+            funcId: 16,
             port: port_,
           );
         },
@@ -875,7 +969,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 15,
+            funcId: 17,
             port: port_,
           );
         },
@@ -905,7 +999,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 16,
+            funcId: 18,
             port: port_,
           );
         },
@@ -924,6 +1018,42 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       const TaskConstMeta(debugName: "git_fetch", argNames: ["path"]);
 
   @override
+  Future<GitHistoryResult> crateApiGitGitHistory({
+    required String path,
+    int? limit,
+    String? baseRef,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_String(path, serializer);
+          sse_encode_opt_box_autoadd_u_32(limit, serializer);
+          sse_encode_opt_String(baseRef, serializer);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 19,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_git_history_result,
+          decodeErrorData: sse_decode_git_error,
+        ),
+        constMeta: kCrateApiGitGitHistoryConstMeta,
+        argValues: [path, limit, baseRef],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiGitGitHistoryConstMeta => const TaskConstMeta(
+    debugName: "git_history",
+    argNames: ["path", "limit", "baseRef"],
+  );
+
+  @override
   Future<List<GitStashEntry>> crateApiGitGitListStashes({
     required String path,
   }) {
@@ -935,7 +1065,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 17,
+            funcId: 20,
             port: port_,
           );
         },
@@ -963,7 +1093,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 18,
+            funcId: 21,
             port: port_,
           );
         },
@@ -991,7 +1121,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 19,
+            funcId: 22,
             port: port_,
           );
         },
@@ -1021,7 +1151,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 20,
+            funcId: 23,
             port: port_,
           );
         },
@@ -1053,7 +1183,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 21,
+            funcId: 24,
             port: port_,
           );
         },
@@ -1089,7 +1219,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 22,
+            funcId: 25,
             port: port_,
           );
         },
@@ -1119,7 +1249,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 23,
+            funcId: 26,
             port: port_,
           );
         },
@@ -1151,7 +1281,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 24,
+            funcId: 27,
             port: port_,
           );
         },
@@ -1181,7 +1311,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 25,
+            funcId: 28,
             port: port_,
           );
         },
@@ -1213,7 +1343,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 26,
+            funcId: 29,
             port: port_,
           );
         },
@@ -1245,7 +1375,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 27,
+            funcId: 30,
             port: port_,
           );
         },
@@ -1281,7 +1411,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 28,
+            funcId: 31,
             port: port_,
           );
         },
@@ -1310,7 +1440,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 29,
+            funcId: 32,
             port: port_,
           );
         },
@@ -1338,7 +1468,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 30,
+            funcId: 33,
             port: port_,
           );
         },
@@ -1366,7 +1496,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 31,
+            funcId: 34,
             port: port_,
           );
         },
@@ -1397,7 +1527,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 32,
+            funcId: 35,
             port: port_,
           );
         },
@@ -1431,7 +1561,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 33,
+            funcId: 36,
             port: port_,
           );
         },
@@ -1464,7 +1594,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 34,
+            funcId: 37,
             port: port_,
           );
         },
@@ -1498,7 +1628,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 35,
+            funcId: 38,
             port: port_,
           );
         },
@@ -1532,7 +1662,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 36,
+            funcId: 39,
             port: port_,
           );
         },
@@ -1578,7 +1708,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 37,
+            funcId: 40,
             port: port_,
           );
         },
@@ -1622,7 +1752,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 38,
+            funcId: 41,
             port: port_,
           );
         },
@@ -1658,7 +1788,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 39,
+            funcId: 42,
             port: port_,
           );
         },
@@ -1693,7 +1823,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 40,
+            funcId: 43,
             port: port_,
           );
         },
@@ -1730,7 +1860,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 41,
+            funcId: 44,
             port: port_,
           );
         },
@@ -1766,7 +1896,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 42,
+            funcId: 45,
             port: port_,
           );
         },
@@ -1801,7 +1931,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 43,
+            funcId: 46,
             port: port_,
           );
         },
@@ -1835,7 +1965,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 44,
+            funcId: 47,
             port: port_,
           );
         },
@@ -1868,7 +1998,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 45,
+            funcId: 48,
             port: port_,
           );
         },
@@ -1898,7 +2028,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 46,
+            funcId: 49,
             port: port_,
           );
         },
@@ -1933,7 +2063,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 47,
+            funcId: 50,
             port: port_,
           );
         },
@@ -1967,7 +2097,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 48,
+            funcId: 51,
             port: port_,
           );
         },
@@ -2001,7 +2131,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 49,
+            funcId: 52,
             port: port_,
           );
         },
@@ -2033,7 +2163,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 50,
+            funcId: 53,
             port: port_,
           );
         },
@@ -2066,7 +2196,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 51,
+            funcId: 54,
             port: port_,
           );
         },
@@ -2102,7 +2232,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 52,
+            funcId: 55,
             port: port_,
           );
         },
@@ -2141,7 +2271,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 53,
+            funcId: 56,
             port: port_,
           );
         },
@@ -2180,7 +2310,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 54,
+              funcId: 57,
               port: port_,
             );
           },
@@ -2225,7 +2355,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 55,
+              funcId: 58,
               port: port_,
             );
           },
@@ -2270,7 +2400,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 56,
+              funcId: 59,
               port: port_,
             );
           },
@@ -2322,7 +2452,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 57,
+            funcId: 60,
             port: port_,
           );
         },
@@ -2382,7 +2512,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 58,
+            funcId: 61,
             port: port_,
           );
         },
@@ -2497,6 +2627,26 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   GitChangeEntry dco_decode_box_autoadd_git_change_entry(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return dco_decode_git_change_entry(raw);
+  }
+
+  @protected
+  GitHistoryItemRef dco_decode_box_autoadd_git_history_item_ref(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return dco_decode_git_history_item_ref(raw);
+  }
+
+  @protected
+  GitHistoryRefCategory dco_decode_box_autoadd_git_history_ref_category(
+    dynamic raw,
+  ) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return dco_decode_git_history_ref_category(raw);
+  }
+
+  @protected
+  PlatformInt64 dco_decode_box_autoadd_i_64(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return dco_decode_i_64(raw);
   }
 
   @protected
@@ -2624,6 +2774,56 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  GitCommitChangeEntry dco_decode_git_commit_change_entry(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 5)
+      throw Exception('unexpected arr length: expect 5 but see ${arr.length}');
+    return GitCommitChangeEntry(
+      path: dco_decode_String(arr[0]),
+      oldPath: dco_decode_opt_String(arr[1]),
+      status: dco_decode_git_change_status(arr[2]),
+      added: dco_decode_opt_box_autoadd_u_32(arr[3]),
+      removed: dco_decode_opt_box_autoadd_u_32(arr[4]),
+    );
+  }
+
+  @protected
+  GitCommitCompareResult dco_decode_git_commit_compare_result(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 2)
+      throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
+    return GitCommitCompareResult(
+      summary: dco_decode_git_commit_compare_summary(arr[0]),
+      entries: dco_decode_list_git_commit_change_entry(arr[1]),
+    );
+  }
+
+  @protected
+  GitCommitCompareStatus dco_decode_git_commit_compare_status(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return GitCommitCompareStatus.values[raw as int];
+  }
+
+  @protected
+  GitCommitCompareSummary dco_decode_git_commit_compare_summary(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 7)
+      throw Exception('unexpected arr length: expect 7 but see ${arr.length}');
+    return GitCommitCompareSummary(
+      commitOid: dco_decode_String(arr[0]),
+      parentOid: dco_decode_opt_String(arr[1]),
+      compareRef: dco_decode_String(arr[2]),
+      baseRef: dco_decode_String(arr[3]),
+      changedFiles: dco_decode_u_32(arr[4]),
+      status: dco_decode_git_commit_compare_status(arr[5]),
+      errorMessage: dco_decode_opt_String(arr[6]),
+    );
+  }
+
+  @protected
   GitDiffFile dco_decode_git_diff_file(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
@@ -2690,6 +2890,64 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   GitErrorKind dco_decode_git_error_kind(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return GitErrorKind.values[raw as int];
+  }
+
+  @protected
+  GitHistoryItem dco_decode_git_history_item(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 9)
+      throw Exception('unexpected arr length: expect 9 but see ${arr.length}');
+    return GitHistoryItem(
+      id: dco_decode_String(arr[0]),
+      parentIds: dco_decode_list_String(arr[1]),
+      subject: dco_decode_String(arr[2]),
+      message: dco_decode_String(arr[3]),
+      displayId: dco_decode_opt_String(arr[4]),
+      author: dco_decode_opt_String(arr[5]),
+      authorEmail: dco_decode_opt_String(arr[6]),
+      timestamp: dco_decode_opt_box_autoadd_i_64(arr[7]),
+      references: dco_decode_list_git_history_item_ref(arr[8]),
+    );
+  }
+
+  @protected
+  GitHistoryItemRef dco_decode_git_history_item_ref(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 4)
+      throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
+    return GitHistoryItemRef(
+      id: dco_decode_String(arr[0]),
+      name: dco_decode_String(arr[1]),
+      revision: dco_decode_opt_String(arr[2]),
+      category: dco_decode_opt_box_autoadd_git_history_ref_category(arr[3]),
+    );
+  }
+
+  @protected
+  GitHistoryRefCategory dco_decode_git_history_ref_category(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return GitHistoryRefCategory.values[raw as int];
+  }
+
+  @protected
+  GitHistoryResult dco_decode_git_history_result(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 9)
+      throw Exception('unexpected arr length: expect 9 but see ${arr.length}');
+    return GitHistoryResult(
+      items: dco_decode_list_git_history_item(arr[0]),
+      currentRef: dco_decode_opt_box_autoadd_git_history_item_ref(arr[1]),
+      remoteRef: dco_decode_opt_box_autoadd_git_history_item_ref(arr[2]),
+      baseRef: dco_decode_opt_box_autoadd_git_history_item_ref(arr[3]),
+      mergeBase: dco_decode_opt_String(arr[4]),
+      hasIncomingChanges: dco_decode_bool(arr[5]),
+      hasOutgoingChanges: dco_decode_bool(arr[6]),
+      hasMore: dco_decode_bool(arr[7]),
+      limit: dco_decode_u_32(arr[8]),
+    );
   }
 
   @protected
@@ -2789,6 +3047,16 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  List<GitCommitChangeEntry> dco_decode_list_git_commit_change_entry(
+    dynamic raw,
+  ) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return (raw as List<dynamic>)
+        .map(dco_decode_git_commit_change_entry)
+        .toList();
+  }
+
+  @protected
   List<GitDiffFile> dco_decode_list_git_diff_file(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return (raw as List<dynamic>).map(dco_decode_git_diff_file).toList();
@@ -2798,6 +3066,18 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<GitDiffLine> dco_decode_list_git_diff_line(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return (raw as List<dynamic>).map(dco_decode_git_diff_line).toList();
+  }
+
+  @protected
+  List<GitHistoryItem> dco_decode_list_git_history_item(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return (raw as List<dynamic>).map(dco_decode_git_history_item).toList();
+  }
+
+  @protected
+  List<GitHistoryItemRef> dco_decode_list_git_history_item_ref(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return (raw as List<dynamic>).map(dco_decode_git_history_item_ref).toList();
   }
 
   @protected
@@ -2933,6 +3213,32 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   GitChangeEntry? dco_decode_opt_box_autoadd_git_change_entry(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return raw == null ? null : dco_decode_box_autoadd_git_change_entry(raw);
+  }
+
+  @protected
+  GitHistoryItemRef? dco_decode_opt_box_autoadd_git_history_item_ref(
+    dynamic raw,
+  ) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return raw == null
+        ? null
+        : dco_decode_box_autoadd_git_history_item_ref(raw);
+  }
+
+  @protected
+  GitHistoryRefCategory? dco_decode_opt_box_autoadd_git_history_ref_category(
+    dynamic raw,
+  ) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return raw == null
+        ? null
+        : dco_decode_box_autoadd_git_history_ref_category(raw);
+  }
+
+  @protected
+  PlatformInt64? dco_decode_opt_box_autoadd_i_64(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return raw == null ? null : dco_decode_box_autoadd_i_64(raw);
   }
 
   @protected
@@ -3459,6 +3765,28 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  GitHistoryItemRef sse_decode_box_autoadd_git_history_item_ref(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    return (sse_decode_git_history_item_ref(deserializer));
+  }
+
+  @protected
+  GitHistoryRefCategory sse_decode_box_autoadd_git_history_ref_category(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    return (sse_decode_git_history_ref_category(deserializer));
+  }
+
+  @protected
+  PlatformInt64 sse_decode_box_autoadd_i_64(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    return (sse_decode_i_64(deserializer));
+  }
+
+  @protected
   SourceControlWatcherHandle
   sse_decode_box_autoadd_source_control_watcher_handle(
     SseDeserializer deserializer,
@@ -3604,6 +3932,67 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  GitCommitChangeEntry sse_decode_git_commit_change_entry(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_path = sse_decode_String(deserializer);
+    var var_oldPath = sse_decode_opt_String(deserializer);
+    var var_status = sse_decode_git_change_status(deserializer);
+    var var_added = sse_decode_opt_box_autoadd_u_32(deserializer);
+    var var_removed = sse_decode_opt_box_autoadd_u_32(deserializer);
+    return GitCommitChangeEntry(
+      path: var_path,
+      oldPath: var_oldPath,
+      status: var_status,
+      added: var_added,
+      removed: var_removed,
+    );
+  }
+
+  @protected
+  GitCommitCompareResult sse_decode_git_commit_compare_result(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_summary = sse_decode_git_commit_compare_summary(deserializer);
+    var var_entries = sse_decode_list_git_commit_change_entry(deserializer);
+    return GitCommitCompareResult(summary: var_summary, entries: var_entries);
+  }
+
+  @protected
+  GitCommitCompareStatus sse_decode_git_commit_compare_status(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var inner = sse_decode_i_32(deserializer);
+    return GitCommitCompareStatus.values[inner];
+  }
+
+  @protected
+  GitCommitCompareSummary sse_decode_git_commit_compare_summary(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_commitOid = sse_decode_String(deserializer);
+    var var_parentOid = sse_decode_opt_String(deserializer);
+    var var_compareRef = sse_decode_String(deserializer);
+    var var_baseRef = sse_decode_String(deserializer);
+    var var_changedFiles = sse_decode_u_32(deserializer);
+    var var_status = sse_decode_git_commit_compare_status(deserializer);
+    var var_errorMessage = sse_decode_opt_String(deserializer);
+    return GitCommitCompareSummary(
+      commitOid: var_commitOid,
+      parentOid: var_parentOid,
+      compareRef: var_compareRef,
+      baseRef: var_baseRef,
+      changedFiles: var_changedFiles,
+      status: var_status,
+      errorMessage: var_errorMessage,
+    );
+  }
+
+  @protected
   GitDiffFile sse_decode_git_diff_file(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     var var_path = sse_decode_String(deserializer);
@@ -3668,6 +4057,90 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     // Codec=Sse (Serialization based), see doc to use other codecs
     var inner = sse_decode_i_32(deserializer);
     return GitErrorKind.values[inner];
+  }
+
+  @protected
+  GitHistoryItem sse_decode_git_history_item(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_id = sse_decode_String(deserializer);
+    var var_parentIds = sse_decode_list_String(deserializer);
+    var var_subject = sse_decode_String(deserializer);
+    var var_message = sse_decode_String(deserializer);
+    var var_displayId = sse_decode_opt_String(deserializer);
+    var var_author = sse_decode_opt_String(deserializer);
+    var var_authorEmail = sse_decode_opt_String(deserializer);
+    var var_timestamp = sse_decode_opt_box_autoadd_i_64(deserializer);
+    var var_references = sse_decode_list_git_history_item_ref(deserializer);
+    return GitHistoryItem(
+      id: var_id,
+      parentIds: var_parentIds,
+      subject: var_subject,
+      message: var_message,
+      displayId: var_displayId,
+      author: var_author,
+      authorEmail: var_authorEmail,
+      timestamp: var_timestamp,
+      references: var_references,
+    );
+  }
+
+  @protected
+  GitHistoryItemRef sse_decode_git_history_item_ref(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_id = sse_decode_String(deserializer);
+    var var_name = sse_decode_String(deserializer);
+    var var_revision = sse_decode_opt_String(deserializer);
+    var var_category = sse_decode_opt_box_autoadd_git_history_ref_category(
+      deserializer,
+    );
+    return GitHistoryItemRef(
+      id: var_id,
+      name: var_name,
+      revision: var_revision,
+      category: var_category,
+    );
+  }
+
+  @protected
+  GitHistoryRefCategory sse_decode_git_history_ref_category(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var inner = sse_decode_i_32(deserializer);
+    return GitHistoryRefCategory.values[inner];
+  }
+
+  @protected
+  GitHistoryResult sse_decode_git_history_result(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_items = sse_decode_list_git_history_item(deserializer);
+    var var_currentRef = sse_decode_opt_box_autoadd_git_history_item_ref(
+      deserializer,
+    );
+    var var_remoteRef = sse_decode_opt_box_autoadd_git_history_item_ref(
+      deserializer,
+    );
+    var var_baseRef = sse_decode_opt_box_autoadd_git_history_item_ref(
+      deserializer,
+    );
+    var var_mergeBase = sse_decode_opt_String(deserializer);
+    var var_hasIncomingChanges = sse_decode_bool(deserializer);
+    var var_hasOutgoingChanges = sse_decode_bool(deserializer);
+    var var_hasMore = sse_decode_bool(deserializer);
+    var var_limit = sse_decode_u_32(deserializer);
+    return GitHistoryResult(
+      items: var_items,
+      currentRef: var_currentRef,
+      remoteRef: var_remoteRef,
+      baseRef: var_baseRef,
+      mergeBase: var_mergeBase,
+      hasIncomingChanges: var_hasIncomingChanges,
+      hasOutgoingChanges: var_hasOutgoingChanges,
+      hasMore: var_hasMore,
+      limit: var_limit,
+    );
   }
 
   @protected
@@ -3803,6 +4276,20 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  List<GitCommitChangeEntry> sse_decode_list_git_commit_change_entry(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    var len_ = sse_decode_i_32(deserializer);
+    var ans_ = <GitCommitChangeEntry>[];
+    for (var idx_ = 0; idx_ < len_; ++idx_) {
+      ans_.add(sse_decode_git_commit_change_entry(deserializer));
+    }
+    return ans_;
+  }
+
+  @protected
   List<GitDiffFile> sse_decode_list_git_diff_file(
     SseDeserializer deserializer,
   ) {
@@ -3826,6 +4313,34 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     var ans_ = <GitDiffLine>[];
     for (var idx_ = 0; idx_ < len_; ++idx_) {
       ans_.add(sse_decode_git_diff_line(deserializer));
+    }
+    return ans_;
+  }
+
+  @protected
+  List<GitHistoryItem> sse_decode_list_git_history_item(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    var len_ = sse_decode_i_32(deserializer);
+    var ans_ = <GitHistoryItem>[];
+    for (var idx_ = 0; idx_ < len_; ++idx_) {
+      ans_.add(sse_decode_git_history_item(deserializer));
+    }
+    return ans_;
+  }
+
+  @protected
+  List<GitHistoryItemRef> sse_decode_list_git_history_item_ref(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    var len_ = sse_decode_i_32(deserializer);
+    var ans_ = <GitHistoryItemRef>[];
+    for (var idx_ = 0; idx_ < len_; ++idx_) {
+      ans_.add(sse_decode_git_history_item_ref(deserializer));
     }
     return ans_;
   }
@@ -4035,6 +4550,43 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
     if (sse_decode_bool(deserializer)) {
       return (sse_decode_box_autoadd_git_change_entry(deserializer));
+    } else {
+      return null;
+    }
+  }
+
+  @protected
+  GitHistoryItemRef? sse_decode_opt_box_autoadd_git_history_item_ref(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    if (sse_decode_bool(deserializer)) {
+      return (sse_decode_box_autoadd_git_history_item_ref(deserializer));
+    } else {
+      return null;
+    }
+  }
+
+  @protected
+  GitHistoryRefCategory? sse_decode_opt_box_autoadd_git_history_ref_category(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    if (sse_decode_bool(deserializer)) {
+      return (sse_decode_box_autoadd_git_history_ref_category(deserializer));
+    } else {
+      return null;
+    }
+  }
+
+  @protected
+  PlatformInt64? sse_decode_opt_box_autoadd_i_64(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    if (sse_decode_bool(deserializer)) {
+      return (sse_decode_box_autoadd_i_64(deserializer));
     } else {
       return null;
     }
@@ -4653,6 +5205,33 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  void sse_encode_box_autoadd_git_history_item_ref(
+    GitHistoryItemRef self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_git_history_item_ref(self, serializer);
+  }
+
+  @protected
+  void sse_encode_box_autoadd_git_history_ref_category(
+    GitHistoryRefCategory self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_git_history_ref_category(self, serializer);
+  }
+
+  @protected
+  void sse_encode_box_autoadd_i_64(
+    PlatformInt64 self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_i_64(self, serializer);
+  }
+
+  @protected
   void sse_encode_box_autoadd_source_control_watcher_handle(
     SourceControlWatcherHandle self,
     SseSerializer serializer,
@@ -4790,6 +5369,53 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  void sse_encode_git_commit_change_entry(
+    GitCommitChangeEntry self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_String(self.path, serializer);
+    sse_encode_opt_String(self.oldPath, serializer);
+    sse_encode_git_change_status(self.status, serializer);
+    sse_encode_opt_box_autoadd_u_32(self.added, serializer);
+    sse_encode_opt_box_autoadd_u_32(self.removed, serializer);
+  }
+
+  @protected
+  void sse_encode_git_commit_compare_result(
+    GitCommitCompareResult self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_git_commit_compare_summary(self.summary, serializer);
+    sse_encode_list_git_commit_change_entry(self.entries, serializer);
+  }
+
+  @protected
+  void sse_encode_git_commit_compare_status(
+    GitCommitCompareStatus self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_i_32(self.index, serializer);
+  }
+
+  @protected
+  void sse_encode_git_commit_compare_summary(
+    GitCommitCompareSummary self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_String(self.commitOid, serializer);
+    sse_encode_opt_String(self.parentOid, serializer);
+    sse_encode_String(self.compareRef, serializer);
+    sse_encode_String(self.baseRef, serializer);
+    sse_encode_u_32(self.changedFiles, serializer);
+    sse_encode_git_commit_compare_status(self.status, serializer);
+    sse_encode_opt_String(self.errorMessage, serializer);
+  }
+
+  @protected
   void sse_encode_git_diff_file(GitDiffFile self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_String(self.path, serializer);
@@ -4842,6 +5468,67 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   void sse_encode_git_error_kind(GitErrorKind self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_i_32(self.index, serializer);
+  }
+
+  @protected
+  void sse_encode_git_history_item(
+    GitHistoryItem self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_String(self.id, serializer);
+    sse_encode_list_String(self.parentIds, serializer);
+    sse_encode_String(self.subject, serializer);
+    sse_encode_String(self.message, serializer);
+    sse_encode_opt_String(self.displayId, serializer);
+    sse_encode_opt_String(self.author, serializer);
+    sse_encode_opt_String(self.authorEmail, serializer);
+    sse_encode_opt_box_autoadd_i_64(self.timestamp, serializer);
+    sse_encode_list_git_history_item_ref(self.references, serializer);
+  }
+
+  @protected
+  void sse_encode_git_history_item_ref(
+    GitHistoryItemRef self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_String(self.id, serializer);
+    sse_encode_String(self.name, serializer);
+    sse_encode_opt_String(self.revision, serializer);
+    sse_encode_opt_box_autoadd_git_history_ref_category(
+      self.category,
+      serializer,
+    );
+  }
+
+  @protected
+  void sse_encode_git_history_ref_category(
+    GitHistoryRefCategory self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_i_32(self.index, serializer);
+  }
+
+  @protected
+  void sse_encode_git_history_result(
+    GitHistoryResult self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_list_git_history_item(self.items, serializer);
+    sse_encode_opt_box_autoadd_git_history_item_ref(
+      self.currentRef,
+      serializer,
+    );
+    sse_encode_opt_box_autoadd_git_history_item_ref(self.remoteRef, serializer);
+    sse_encode_opt_box_autoadd_git_history_item_ref(self.baseRef, serializer);
+    sse_encode_opt_String(self.mergeBase, serializer);
+    sse_encode_bool(self.hasIncomingChanges, serializer);
+    sse_encode_bool(self.hasOutgoingChanges, serializer);
+    sse_encode_bool(self.hasMore, serializer);
+    sse_encode_u_32(self.limit, serializer);
   }
 
   @protected
@@ -4960,6 +5647,18 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  void sse_encode_list_git_commit_change_entry(
+    List<GitCommitChangeEntry> self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_i_32(self.length, serializer);
+    for (final item in self) {
+      sse_encode_git_commit_change_entry(item, serializer);
+    }
+  }
+
+  @protected
   void sse_encode_list_git_diff_file(
     List<GitDiffFile> self,
     SseSerializer serializer,
@@ -4980,6 +5679,30 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     sse_encode_i_32(self.length, serializer);
     for (final item in self) {
       sse_encode_git_diff_line(item, serializer);
+    }
+  }
+
+  @protected
+  void sse_encode_list_git_history_item(
+    List<GitHistoryItem> self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_i_32(self.length, serializer);
+    for (final item in self) {
+      sse_encode_git_history_item(item, serializer);
+    }
+  }
+
+  @protected
+  void sse_encode_list_git_history_item_ref(
+    List<GitHistoryItemRef> self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_i_32(self.length, serializer);
+    for (final item in self) {
+      sse_encode_git_history_item_ref(item, serializer);
     }
   }
 
@@ -5164,6 +5887,45 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     sse_encode_bool(self != null, serializer);
     if (self != null) {
       sse_encode_box_autoadd_git_change_entry(self, serializer);
+    }
+  }
+
+  @protected
+  void sse_encode_opt_box_autoadd_git_history_item_ref(
+    GitHistoryItemRef? self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    sse_encode_bool(self != null, serializer);
+    if (self != null) {
+      sse_encode_box_autoadd_git_history_item_ref(self, serializer);
+    }
+  }
+
+  @protected
+  void sse_encode_opt_box_autoadd_git_history_ref_category(
+    GitHistoryRefCategory? self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    sse_encode_bool(self != null, serializer);
+    if (self != null) {
+      sse_encode_box_autoadd_git_history_ref_category(self, serializer);
+    }
+  }
+
+  @protected
+  void sse_encode_opt_box_autoadd_i_64(
+    PlatformInt64? self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    sse_encode_bool(self != null, serializer);
+    if (self != null) {
+      sse_encode_box_autoadd_i_64(self, serializer);
     }
   }
 

--- a/lib/src/rust/frb_generated.io.dart
+++ b/lib/src/rust/frb_generated.io.dart
@@ -56,6 +56,17 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   GitChangeEntry dco_decode_box_autoadd_git_change_entry(dynamic raw);
 
   @protected
+  GitHistoryItemRef dco_decode_box_autoadd_git_history_item_ref(dynamic raw);
+
+  @protected
+  GitHistoryRefCategory dco_decode_box_autoadd_git_history_ref_category(
+    dynamic raw,
+  );
+
+  @protected
+  PlatformInt64 dco_decode_box_autoadd_i_64(dynamic raw);
+
+  @protected
   SourceControlWatcherHandle
   dco_decode_box_autoadd_source_control_watcher_handle(dynamic raw);
 
@@ -109,6 +120,18 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   GitChangeTreeRowKind dco_decode_git_change_tree_row_kind(dynamic raw);
 
   @protected
+  GitCommitChangeEntry dco_decode_git_commit_change_entry(dynamic raw);
+
+  @protected
+  GitCommitCompareResult dco_decode_git_commit_compare_result(dynamic raw);
+
+  @protected
+  GitCommitCompareStatus dco_decode_git_commit_compare_status(dynamic raw);
+
+  @protected
+  GitCommitCompareSummary dco_decode_git_commit_compare_summary(dynamic raw);
+
+  @protected
   GitDiffFile dco_decode_git_diff_file(dynamic raw);
 
   @protected
@@ -125,6 +148,18 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   GitErrorKind dco_decode_git_error_kind(dynamic raw);
+
+  @protected
+  GitHistoryItem dco_decode_git_history_item(dynamic raw);
+
+  @protected
+  GitHistoryItemRef dco_decode_git_history_item_ref(dynamic raw);
+
+  @protected
+  GitHistoryRefCategory dco_decode_git_history_ref_category(dynamic raw);
+
+  @protected
+  GitHistoryResult dco_decode_git_history_result(dynamic raw);
 
   @protected
   GitRepositoryState dco_decode_git_repository_state(dynamic raw);
@@ -160,10 +195,21 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   List<GitChangeTreeRow> dco_decode_list_git_change_tree_row(dynamic raw);
 
   @protected
+  List<GitCommitChangeEntry> dco_decode_list_git_commit_change_entry(
+    dynamic raw,
+  );
+
+  @protected
   List<GitDiffFile> dco_decode_list_git_diff_file(dynamic raw);
 
   @protected
   List<GitDiffLine> dco_decode_list_git_diff_line(dynamic raw);
+
+  @protected
+  List<GitHistoryItem> dco_decode_list_git_history_item(dynamic raw);
+
+  @protected
+  List<GitHistoryItemRef> dco_decode_list_git_history_item_ref(dynamic raw);
 
   @protected
   List<GitStashEntry> dco_decode_list_git_stash_entry(dynamic raw);
@@ -223,6 +269,19 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   GitChangeEntry? dco_decode_opt_box_autoadd_git_change_entry(dynamic raw);
+
+  @protected
+  GitHistoryItemRef? dco_decode_opt_box_autoadd_git_history_item_ref(
+    dynamic raw,
+  );
+
+  @protected
+  GitHistoryRefCategory? dco_decode_opt_box_autoadd_git_history_ref_category(
+    dynamic raw,
+  );
+
+  @protected
+  PlatformInt64? dco_decode_opt_box_autoadd_i_64(dynamic raw);
 
   @protected
   int? dco_decode_opt_box_autoadd_u_32(dynamic raw);
@@ -402,6 +461,19 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  GitHistoryItemRef sse_decode_box_autoadd_git_history_item_ref(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  GitHistoryRefCategory sse_decode_box_autoadd_git_history_ref_category(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  PlatformInt64 sse_decode_box_autoadd_i_64(SseDeserializer deserializer);
+
+  @protected
   SourceControlWatcherHandle
   sse_decode_box_autoadd_source_control_watcher_handle(
     SseDeserializer deserializer,
@@ -463,6 +535,26 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  GitCommitChangeEntry sse_decode_git_commit_change_entry(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  GitCommitCompareResult sse_decode_git_commit_compare_result(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  GitCommitCompareStatus sse_decode_git_commit_compare_status(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  GitCommitCompareSummary sse_decode_git_commit_compare_summary(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   GitDiffFile sse_decode_git_diff_file(SseDeserializer deserializer);
 
   @protected
@@ -479,6 +571,22 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   GitErrorKind sse_decode_git_error_kind(SseDeserializer deserializer);
+
+  @protected
+  GitHistoryItem sse_decode_git_history_item(SseDeserializer deserializer);
+
+  @protected
+  GitHistoryItemRef sse_decode_git_history_item_ref(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  GitHistoryRefCategory sse_decode_git_history_ref_category(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  GitHistoryResult sse_decode_git_history_result(SseDeserializer deserializer);
 
   @protected
   GitRepositoryState sse_decode_git_repository_state(
@@ -524,10 +632,25 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  List<GitCommitChangeEntry> sse_decode_list_git_commit_change_entry(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   List<GitDiffFile> sse_decode_list_git_diff_file(SseDeserializer deserializer);
 
   @protected
   List<GitDiffLine> sse_decode_list_git_diff_line(SseDeserializer deserializer);
+
+  @protected
+  List<GitHistoryItem> sse_decode_list_git_history_item(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  List<GitHistoryItemRef> sse_decode_list_git_history_item_ref(
+    SseDeserializer deserializer,
+  );
 
   @protected
   List<GitStashEntry> sse_decode_list_git_stash_entry(
@@ -607,6 +730,19 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   GitChangeEntry? sse_decode_opt_box_autoadd_git_change_entry(
     SseDeserializer deserializer,
   );
+
+  @protected
+  GitHistoryItemRef? sse_decode_opt_box_autoadd_git_history_item_ref(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  GitHistoryRefCategory? sse_decode_opt_box_autoadd_git_history_ref_category(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  PlatformInt64? sse_decode_opt_box_autoadd_i_64(SseDeserializer deserializer);
 
   @protected
   int? sse_decode_opt_box_autoadd_u_32(SseDeserializer deserializer);
@@ -833,6 +969,24 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  void sse_encode_box_autoadd_git_history_item_ref(
+    GitHistoryItemRef self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_box_autoadd_git_history_ref_category(
+    GitHistoryRefCategory self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_box_autoadd_i_64(
+    PlatformInt64 self,
+    SseSerializer serializer,
+  );
+
+  @protected
   void sse_encode_box_autoadd_source_control_watcher_handle(
     SourceControlWatcherHandle self,
     SseSerializer serializer,
@@ -911,6 +1065,30 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  void sse_encode_git_commit_change_entry(
+    GitCommitChangeEntry self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_git_commit_compare_result(
+    GitCommitCompareResult self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_git_commit_compare_status(
+    GitCommitCompareStatus self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_git_commit_compare_summary(
+    GitCommitCompareSummary self,
+    SseSerializer serializer,
+  );
+
+  @protected
   void sse_encode_git_diff_file(GitDiffFile self, SseSerializer serializer);
 
   @protected
@@ -930,6 +1108,30 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void sse_encode_git_error_kind(GitErrorKind self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_git_history_item(
+    GitHistoryItem self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_git_history_item_ref(
+    GitHistoryItemRef self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_git_history_ref_category(
+    GitHistoryRefCategory self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_git_history_result(
+    GitHistoryResult self,
+    SseSerializer serializer,
+  );
 
   @protected
   void sse_encode_git_repository_state(
@@ -986,6 +1188,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  void sse_encode_list_git_commit_change_entry(
+    List<GitCommitChangeEntry> self,
+    SseSerializer serializer,
+  );
+
+  @protected
   void sse_encode_list_git_diff_file(
     List<GitDiffFile> self,
     SseSerializer serializer,
@@ -994,6 +1202,18 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_list_git_diff_line(
     List<GitDiffLine> self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_list_git_history_item(
+    List<GitHistoryItem> self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_list_git_history_item_ref(
+    List<GitHistoryItemRef> self,
     SseSerializer serializer,
   );
 
@@ -1087,6 +1307,24 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_opt_box_autoadd_git_change_entry(
     GitChangeEntry? self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_opt_box_autoadd_git_history_item_ref(
+    GitHistoryItemRef? self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_opt_box_autoadd_git_history_ref_category(
+    GitHistoryRefCategory? self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_opt_box_autoadd_i_64(
+    PlatformInt64? self,
     SseSerializer serializer,
   );
 

--- a/lib/src/rust/frb_generated.web.dart
+++ b/lib/src/rust/frb_generated.web.dart
@@ -58,6 +58,17 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   GitChangeEntry dco_decode_box_autoadd_git_change_entry(dynamic raw);
 
   @protected
+  GitHistoryItemRef dco_decode_box_autoadd_git_history_item_ref(dynamic raw);
+
+  @protected
+  GitHistoryRefCategory dco_decode_box_autoadd_git_history_ref_category(
+    dynamic raw,
+  );
+
+  @protected
+  PlatformInt64 dco_decode_box_autoadd_i_64(dynamic raw);
+
+  @protected
   SourceControlWatcherHandle
   dco_decode_box_autoadd_source_control_watcher_handle(dynamic raw);
 
@@ -111,6 +122,18 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   GitChangeTreeRowKind dco_decode_git_change_tree_row_kind(dynamic raw);
 
   @protected
+  GitCommitChangeEntry dco_decode_git_commit_change_entry(dynamic raw);
+
+  @protected
+  GitCommitCompareResult dco_decode_git_commit_compare_result(dynamic raw);
+
+  @protected
+  GitCommitCompareStatus dco_decode_git_commit_compare_status(dynamic raw);
+
+  @protected
+  GitCommitCompareSummary dco_decode_git_commit_compare_summary(dynamic raw);
+
+  @protected
   GitDiffFile dco_decode_git_diff_file(dynamic raw);
 
   @protected
@@ -127,6 +150,18 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   GitErrorKind dco_decode_git_error_kind(dynamic raw);
+
+  @protected
+  GitHistoryItem dco_decode_git_history_item(dynamic raw);
+
+  @protected
+  GitHistoryItemRef dco_decode_git_history_item_ref(dynamic raw);
+
+  @protected
+  GitHistoryRefCategory dco_decode_git_history_ref_category(dynamic raw);
+
+  @protected
+  GitHistoryResult dco_decode_git_history_result(dynamic raw);
 
   @protected
   GitRepositoryState dco_decode_git_repository_state(dynamic raw);
@@ -162,10 +197,21 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   List<GitChangeTreeRow> dco_decode_list_git_change_tree_row(dynamic raw);
 
   @protected
+  List<GitCommitChangeEntry> dco_decode_list_git_commit_change_entry(
+    dynamic raw,
+  );
+
+  @protected
   List<GitDiffFile> dco_decode_list_git_diff_file(dynamic raw);
 
   @protected
   List<GitDiffLine> dco_decode_list_git_diff_line(dynamic raw);
+
+  @protected
+  List<GitHistoryItem> dco_decode_list_git_history_item(dynamic raw);
+
+  @protected
+  List<GitHistoryItemRef> dco_decode_list_git_history_item_ref(dynamic raw);
 
   @protected
   List<GitStashEntry> dco_decode_list_git_stash_entry(dynamic raw);
@@ -225,6 +271,19 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   GitChangeEntry? dco_decode_opt_box_autoadd_git_change_entry(dynamic raw);
+
+  @protected
+  GitHistoryItemRef? dco_decode_opt_box_autoadd_git_history_item_ref(
+    dynamic raw,
+  );
+
+  @protected
+  GitHistoryRefCategory? dco_decode_opt_box_autoadd_git_history_ref_category(
+    dynamic raw,
+  );
+
+  @protected
+  PlatformInt64? dco_decode_opt_box_autoadd_i_64(dynamic raw);
 
   @protected
   int? dco_decode_opt_box_autoadd_u_32(dynamic raw);
@@ -404,6 +463,19 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  GitHistoryItemRef sse_decode_box_autoadd_git_history_item_ref(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  GitHistoryRefCategory sse_decode_box_autoadd_git_history_ref_category(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  PlatformInt64 sse_decode_box_autoadd_i_64(SseDeserializer deserializer);
+
+  @protected
   SourceControlWatcherHandle
   sse_decode_box_autoadd_source_control_watcher_handle(
     SseDeserializer deserializer,
@@ -465,6 +537,26 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  GitCommitChangeEntry sse_decode_git_commit_change_entry(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  GitCommitCompareResult sse_decode_git_commit_compare_result(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  GitCommitCompareStatus sse_decode_git_commit_compare_status(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  GitCommitCompareSummary sse_decode_git_commit_compare_summary(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   GitDiffFile sse_decode_git_diff_file(SseDeserializer deserializer);
 
   @protected
@@ -481,6 +573,22 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   GitErrorKind sse_decode_git_error_kind(SseDeserializer deserializer);
+
+  @protected
+  GitHistoryItem sse_decode_git_history_item(SseDeserializer deserializer);
+
+  @protected
+  GitHistoryItemRef sse_decode_git_history_item_ref(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  GitHistoryRefCategory sse_decode_git_history_ref_category(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  GitHistoryResult sse_decode_git_history_result(SseDeserializer deserializer);
 
   @protected
   GitRepositoryState sse_decode_git_repository_state(
@@ -526,10 +634,25 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  List<GitCommitChangeEntry> sse_decode_list_git_commit_change_entry(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   List<GitDiffFile> sse_decode_list_git_diff_file(SseDeserializer deserializer);
 
   @protected
   List<GitDiffLine> sse_decode_list_git_diff_line(SseDeserializer deserializer);
+
+  @protected
+  List<GitHistoryItem> sse_decode_list_git_history_item(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  List<GitHistoryItemRef> sse_decode_list_git_history_item_ref(
+    SseDeserializer deserializer,
+  );
 
   @protected
   List<GitStashEntry> sse_decode_list_git_stash_entry(
@@ -609,6 +732,19 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   GitChangeEntry? sse_decode_opt_box_autoadd_git_change_entry(
     SseDeserializer deserializer,
   );
+
+  @protected
+  GitHistoryItemRef? sse_decode_opt_box_autoadd_git_history_item_ref(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  GitHistoryRefCategory? sse_decode_opt_box_autoadd_git_history_ref_category(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  PlatformInt64? sse_decode_opt_box_autoadd_i_64(SseDeserializer deserializer);
 
   @protected
   int? sse_decode_opt_box_autoadd_u_32(SseDeserializer deserializer);
@@ -835,6 +971,24 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  void sse_encode_box_autoadd_git_history_item_ref(
+    GitHistoryItemRef self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_box_autoadd_git_history_ref_category(
+    GitHistoryRefCategory self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_box_autoadd_i_64(
+    PlatformInt64 self,
+    SseSerializer serializer,
+  );
+
+  @protected
   void sse_encode_box_autoadd_source_control_watcher_handle(
     SourceControlWatcherHandle self,
     SseSerializer serializer,
@@ -913,6 +1067,30 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  void sse_encode_git_commit_change_entry(
+    GitCommitChangeEntry self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_git_commit_compare_result(
+    GitCommitCompareResult self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_git_commit_compare_status(
+    GitCommitCompareStatus self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_git_commit_compare_summary(
+    GitCommitCompareSummary self,
+    SseSerializer serializer,
+  );
+
+  @protected
   void sse_encode_git_diff_file(GitDiffFile self, SseSerializer serializer);
 
   @protected
@@ -932,6 +1110,30 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void sse_encode_git_error_kind(GitErrorKind self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_git_history_item(
+    GitHistoryItem self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_git_history_item_ref(
+    GitHistoryItemRef self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_git_history_ref_category(
+    GitHistoryRefCategory self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_git_history_result(
+    GitHistoryResult self,
+    SseSerializer serializer,
+  );
 
   @protected
   void sse_encode_git_repository_state(
@@ -988,6 +1190,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  void sse_encode_list_git_commit_change_entry(
+    List<GitCommitChangeEntry> self,
+    SseSerializer serializer,
+  );
+
+  @protected
   void sse_encode_list_git_diff_file(
     List<GitDiffFile> self,
     SseSerializer serializer,
@@ -996,6 +1204,18 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_list_git_diff_line(
     List<GitDiffLine> self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_list_git_history_item(
+    List<GitHistoryItem> self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_list_git_history_item_ref(
+    List<GitHistoryItemRef> self,
     SseSerializer serializer,
   );
 
@@ -1089,6 +1309,24 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_opt_box_autoadd_git_change_entry(
     GitChangeEntry? self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_opt_box_autoadd_git_history_item_ref(
+    GitHistoryItemRef? self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_opt_box_autoadd_git_history_ref_category(
+    GitHistoryRefCategory? self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_opt_box_autoadd_i_64(
+    PlatformInt64? self,
     SseSerializer serializer,
   );
 

--- a/lib/src/shared/infra/git/git_backend.dart
+++ b/lib/src/shared/infra/git/git_backend.dart
@@ -84,6 +84,26 @@ abstract interface class GitBackend {
   /// when [filePath] is provided.
   Future<GitDiffResult> diffAll({required String path, String? filePath});
 
+  /// Loads commit history for the repository containing [path].
+  Future<GitHistoryResult> history(String path, {int? limit, String? baseRef});
+
+  /// Lists files changed by [commitId] compared with its first parent.
+  Future<GitCommitCompareResult> commitCompare({
+    required String path,
+    required String commitId,
+  });
+
+  /// Loads a read-only diff for [commitOid] compared with [parentOid], or the
+  /// root empty tree when [parentOid] is null. When [filePath] is omitted, all
+  /// files changed by the commit are returned as a combined diff.
+  Future<GitDiffResult> commitDiff({
+    required String path,
+    required String commitOid,
+    String? parentOid,
+    String? filePath,
+    String? oldPath,
+  });
+
   /// Branch/upstream/divergence information for the repository containing
   /// [path].
   Future<GitRepositoryState> repositoryState(String path);

--- a/lib/src/shared/infra/git/git_diff_models.dart
+++ b/lib/src/shared/infra/git/git_diff_models.dart
@@ -14,7 +14,18 @@ enum GitChangeArea {
   };
 }
 
-enum GitChangeStatus { modified, added, deleted, renamed, copied, untracked }
+enum GitChangeStatus {
+  modified('M'),
+  added('A'),
+  deleted('D'),
+  renamed('R'),
+  copied('C'),
+  untracked('U');
+
+  const GitChangeStatus(this.badge);
+
+  final String badge;
+}
 
 enum GitChangeTreeRowKind { directory, file }
 
@@ -288,6 +299,7 @@ class GitDiffFile {
     this.isLarge = false,
     this.truncated = false,
     this.linePreviewTruncated = false,
+    this.sourceLabel,
   });
 
   final String path;
@@ -301,6 +313,7 @@ class GitDiffFile {
   final bool isLarge;
   final bool truncated;
   final bool linePreviewTruncated;
+  final String? sourceLabel;
 }
 
 class GitDiffLine {
@@ -324,3 +337,163 @@ class GitDiffLine {
   final String text;
   final GitDiffLineKind kind;
 }
+
+enum GitHistoryRefCategory { branches, remoteBranches, tags, commits }
+
+enum GitCommitCompareStatus { ready, invalidCommit, error }
+
+class GitHistoryItemRef {
+  const GitHistoryItemRef({
+    required this.id,
+    required this.name,
+    this.revision,
+    this.category,
+    this.color,
+  });
+
+  final String id;
+  final String name;
+  final String? revision;
+  final GitHistoryRefCategory? category;
+  final GitHistoryGraphColorId? color;
+
+  GitHistoryItemRef copyWith({GitHistoryGraphColorId? color}) {
+    return GitHistoryItemRef(
+      id: id,
+      name: name,
+      revision: revision,
+      category: category,
+      color: color ?? this.color,
+    );
+  }
+}
+
+class GitHistoryItem {
+  const GitHistoryItem({
+    required this.id,
+    required this.parentIds,
+    required this.subject,
+    required this.message,
+    this.displayId,
+    this.author,
+    this.authorEmail,
+    this.timestamp,
+    this.references = const <GitHistoryItemRef>[],
+  });
+
+  final String id;
+  final List<String> parentIds;
+  final String subject;
+  final String message;
+  final String? displayId;
+  final String? author;
+  final String? authorEmail;
+  final DateTime? timestamp;
+  final List<GitHistoryItemRef> references;
+
+  GitHistoryItem copyWith({List<GitHistoryItemRef>? references}) {
+    return GitHistoryItem(
+      id: id,
+      parentIds: parentIds,
+      subject: subject,
+      message: message,
+      displayId: displayId,
+      author: author,
+      authorEmail: authorEmail,
+      timestamp: timestamp,
+      references: references ?? this.references,
+    );
+  }
+}
+
+class GitHistoryResult {
+  const GitHistoryResult({
+    required this.items,
+    required this.hasIncomingChanges,
+    required this.hasOutgoingChanges,
+    required this.hasMore,
+    required this.limit,
+    this.currentRef,
+    this.remoteRef,
+    this.baseRef,
+    this.mergeBase,
+  });
+
+  final List<GitHistoryItem> items;
+  final GitHistoryItemRef? currentRef;
+  final GitHistoryItemRef? remoteRef;
+  final GitHistoryItemRef? baseRef;
+  final String? mergeBase;
+  final bool hasIncomingChanges;
+  final bool hasOutgoingChanges;
+  final bool hasMore;
+  final int limit;
+}
+
+class GitCommitChangeEntry {
+  const GitCommitChangeEntry({
+    required this.path,
+    required this.status,
+    this.oldPath,
+    this.added,
+    this.removed,
+  });
+
+  final String path;
+  final String? oldPath;
+  final GitChangeStatus status;
+  final int? added;
+  final int? removed;
+}
+
+class GitCommitCompareSummary {
+  const GitCommitCompareSummary({
+    required this.commitOid,
+    required this.parentOid,
+    required this.compareRef,
+    required this.baseRef,
+    required this.changedFiles,
+    required this.status,
+    this.errorMessage,
+  });
+
+  final String commitOid;
+  final String? parentOid;
+  final String compareRef;
+  final String baseRef;
+  final int changedFiles;
+  final GitCommitCompareStatus status;
+  final String? errorMessage;
+}
+
+class GitCommitCompareResult {
+  const GitCommitCompareResult({required this.summary, required this.entries});
+
+  final GitCommitCompareSummary summary;
+  final List<GitCommitChangeEntry> entries;
+}
+
+enum GitHistoryGraphColorId {
+  ref,
+  remoteRef,
+  baseRef,
+  lane1,
+  lane2,
+  lane3,
+  lane4,
+  lane5,
+}
+
+const GitHistoryGraphColorId gitHistoryRefColor = GitHistoryGraphColorId.ref;
+const GitHistoryGraphColorId gitHistoryRemoteRefColor =
+    GitHistoryGraphColorId.remoteRef;
+const GitHistoryGraphColorId gitHistoryBaseRefColor =
+    GitHistoryGraphColorId.baseRef;
+const List<GitHistoryGraphColorId> gitHistoryLaneColors =
+    <GitHistoryGraphColorId>[
+      GitHistoryGraphColorId.lane1,
+      GitHistoryGraphColorId.lane2,
+      GitHistoryGraphColorId.lane3,
+      GitHistoryGraphColorId.lane4,
+      GitHistoryGraphColorId.lane5,
+    ];

--- a/lib/src/shared/infra/git/git_history_graph.dart
+++ b/lib/src/shared/infra/git/git_history_graph.dart
@@ -1,0 +1,501 @@
+import 'package:alera/src/shared/infra/git/git_diff_models.dart';
+
+const String gitHistoryIncomingChangesId = 'git-history-incoming-changes';
+const String gitHistoryOutgoingChangesId = 'git-history-outgoing-changes';
+
+class GitHistoryGraphNode {
+  const GitHistoryGraphNode({required this.id, required this.color});
+
+  final String id;
+  final GitHistoryGraphColorId color;
+}
+
+class GitHistoryItemViewModel {
+  const GitHistoryItemViewModel({
+    required this.historyItem,
+    required this.inputSwimlanes,
+    required this.outputSwimlanes,
+    required this.kind,
+  });
+
+  final GitHistoryItem historyItem;
+  final List<GitHistoryGraphNode> inputSwimlanes;
+  final List<GitHistoryGraphNode> outputSwimlanes;
+  final GitHistoryItemViewModelKind kind;
+
+  GitHistoryItemViewModel copyWith({
+    List<GitHistoryGraphNode>? inputSwimlanes,
+    List<GitHistoryGraphNode>? outputSwimlanes,
+  }) {
+    return GitHistoryItemViewModel(
+      historyItem: historyItem,
+      inputSwimlanes: inputSwimlanes ?? this.inputSwimlanes,
+      outputSwimlanes: outputSwimlanes ?? this.outputSwimlanes,
+      kind: kind,
+    );
+  }
+}
+
+enum GitHistoryItemViewModelKind {
+  head,
+  node,
+  incomingChanges,
+  outgoingChanges,
+}
+
+Map<String, GitHistoryGraphColorId?> buildDefaultGitHistoryColorMap({
+  GitHistoryItemRef? currentRef,
+  GitHistoryItemRef? remoteRef,
+  GitHistoryItemRef? baseRef,
+}) {
+  return <String, GitHistoryGraphColorId?>{
+    if (currentRef != null) currentRef.id: gitHistoryRefColor,
+    if (remoteRef != null) remoteRef.id: gitHistoryRemoteRefColor,
+    if (baseRef != null) baseRef.id: gitHistoryBaseRefColor,
+  };
+}
+
+List<GitHistoryItemViewModel> buildGitHistoryViewModels(
+  GitHistoryResult result,
+) {
+  return buildGitHistoryViewModelsFromItems(
+    result.items,
+    colorMap: buildDefaultGitHistoryColorMap(
+      currentRef: result.currentRef,
+      remoteRef: result.remoteRef,
+      baseRef: result.baseRef,
+    ),
+    currentRef: result.currentRef,
+    remoteRef: result.remoteRef,
+    baseRef: result.baseRef,
+    addIncomingChanges: result.hasIncomingChanges,
+    addOutgoingChanges: result.hasOutgoingChanges,
+    mergeBase: result.mergeBase,
+  );
+}
+
+List<GitHistoryItemViewModel> buildGitHistoryViewModelsFromItems(
+  List<GitHistoryItem> historyItems, {
+  Map<String, GitHistoryGraphColorId?> colorMap =
+      const <String, GitHistoryGraphColorId?>{},
+  GitHistoryItemRef? currentRef,
+  GitHistoryItemRef? remoteRef,
+  GitHistoryItemRef? baseRef,
+  bool addIncomingChanges = false,
+  bool addOutgoingChanges = false,
+  String? mergeBase,
+}) {
+  var colorIndex = -1;
+  final viewModels = <GitHistoryItemViewModel>[];
+
+  for (final historyItem in historyItems) {
+    final kind = historyItem.id == currentRef?.revision
+        ? GitHistoryItemViewModelKind.head
+        : GitHistoryItemViewModelKind.node;
+    final inputSwimlanes =
+        (viewModels.lastOrNull?.outputSwimlanes ??
+                const <GitHistoryGraphNode>[])
+            .map(_cloneNode)
+            .toList(growable: true);
+    final outputSwimlanes = <GitHistoryGraphNode>[];
+    var firstParentAdded = false;
+
+    if (historyItem.parentIds.isNotEmpty) {
+      for (final node in inputSwimlanes) {
+        if (node.id == historyItem.id) {
+          if (!firstParentAdded) {
+            outputSwimlanes.add(
+              GitHistoryGraphNode(
+                id: historyItem.parentIds.first,
+                color: _labelColor(historyItem, colorMap) ?? node.color,
+              ),
+            );
+            firstParentAdded = true;
+          }
+          continue;
+        }
+        outputSwimlanes.add(_cloneNode(node));
+      }
+    }
+
+    for (
+      var index = firstParentAdded ? 1 : 0;
+      index < historyItem.parentIds.length;
+      index += 1
+    ) {
+      var color = index == 0
+          ? _labelColor(historyItem, colorMap)
+          : _parentLabelColor(
+              historyItems,
+              historyItem.parentIds[index],
+              colorMap,
+            );
+      if (color == null) {
+        colorIndex = _rotate(colorIndex + 1, gitHistoryLaneColors.length);
+        color = gitHistoryLaneColors[colorIndex];
+      }
+      outputSwimlanes.add(
+        GitHistoryGraphNode(id: historyItem.parentIds[index], color: color),
+      );
+    }
+
+    final references =
+        historyItem.references
+            .map((itemRef) {
+              var color = colorMap[itemRef.id];
+              if (colorMap.containsKey(itemRef.id) && color == null) {
+                final inputIndex = inputSwimlanes.indexWhere(
+                  (node) => node.id == historyItem.id,
+                );
+                final circleIndex = inputIndex == -1
+                    ? inputSwimlanes.length
+                    : inputIndex;
+                if (circleIndex < outputSwimlanes.length) {
+                  color = outputSwimlanes[circleIndex].color;
+                } else if (circleIndex < inputSwimlanes.length) {
+                  color = inputSwimlanes[circleIndex].color;
+                } else {
+                  color = gitHistoryRefColor;
+                }
+              }
+              return itemRef.copyWith(color: color);
+            })
+            .toList(growable: false)
+          ..sort(
+            (a, b) => compareGitHistoryRefs(
+              a,
+              b,
+              currentRef: currentRef,
+              remoteRef: remoteRef,
+              baseRef: baseRef,
+            ),
+          );
+
+    viewModels.add(
+      GitHistoryItemViewModel(
+        historyItem: historyItem.copyWith(references: references),
+        inputSwimlanes: List<GitHistoryGraphNode>.unmodifiable(inputSwimlanes),
+        outputSwimlanes: List<GitHistoryGraphNode>.unmodifiable(
+          outputSwimlanes,
+        ),
+        kind: kind,
+      ),
+    );
+  }
+
+  _addIncomingOutgoingChangesHistoryItems(
+    viewModels,
+    currentRef: currentRef,
+    remoteRef: remoteRef,
+    addIncomingChanges: addIncomingChanges,
+    addOutgoingChanges: addOutgoingChanges,
+    mergeBase: mergeBase,
+  );
+
+  return viewModels;
+}
+
+int compareGitHistoryRefs(
+  GitHistoryItemRef a,
+  GitHistoryItemRef b, {
+  GitHistoryItemRef? currentRef,
+  GitHistoryItemRef? remoteRef,
+  GitHistoryItemRef? baseRef,
+}) {
+  int order(GitHistoryItemRef itemRef) {
+    if (itemRef.id == currentRef?.id) {
+      return 1;
+    }
+    if (itemRef.id == remoteRef?.id) {
+      return 2;
+    }
+    if (itemRef.id == baseRef?.id) {
+      return 3;
+    }
+    if (itemRef.color != null) {
+      return 4;
+    }
+    return 99;
+  }
+
+  return order(a).compareTo(order(b));
+}
+
+int gitHistoryItemLaneIndex(GitHistoryItemViewModel viewModel) {
+  final inputIndex = viewModel.inputSwimlanes.indexWhere(
+    (node) => node.id == viewModel.historyItem.id,
+  );
+  return inputIndex == -1 ? viewModel.inputSwimlanes.length : inputIndex;
+}
+
+int gitHistoryMergeParentLaneIndex(
+  GitHistoryItemViewModel viewModel,
+  String parentId,
+) {
+  return _findLastIndex(
+    viewModel.outputSwimlanes,
+    (node) => node.id == parentId,
+  );
+}
+
+GitHistoryGraphNode _cloneNode(GitHistoryGraphNode node) {
+  return GitHistoryGraphNode(id: node.id, color: node.color);
+}
+
+GitHistoryGraphColorId? _labelColor(
+  GitHistoryItem item,
+  Map<String, GitHistoryGraphColorId?> colorMap,
+) {
+  if (item.id == gitHistoryIncomingChangesId) {
+    return gitHistoryRemoteRefColor;
+  }
+  if (item.id == gitHistoryOutgoingChangesId) {
+    return gitHistoryRefColor;
+  }
+  for (final itemRef in item.references) {
+    if (colorMap.containsKey(itemRef.id)) {
+      return colorMap[itemRef.id];
+    }
+  }
+  return null;
+}
+
+GitHistoryGraphColorId? _parentLabelColor(
+  List<GitHistoryItem> items,
+  String parentId,
+  Map<String, GitHistoryGraphColorId?> colorMap,
+) {
+  for (final item in items) {
+    if (item.id == parentId) {
+      return _labelColor(item, colorMap);
+    }
+  }
+  return null;
+}
+
+void _addIncomingOutgoingChangesHistoryItems(
+  List<GitHistoryItemViewModel> viewModels, {
+  GitHistoryItemRef? currentRef,
+  GitHistoryItemRef? remoteRef,
+  bool addIncomingChanges = false,
+  bool addOutgoingChanges = false,
+  String? mergeBase,
+}) {
+  if (currentRef?.revision == remoteRef?.revision || mergeBase == null) {
+    return;
+  }
+  if (addIncomingChanges &&
+      remoteRef != null &&
+      remoteRef.revision != mergeBase) {
+    _addIncomingChangesHistoryItem(viewModels, remoteRef, mergeBase);
+  }
+  if (addOutgoingChanges &&
+      currentRef?.revision != null &&
+      currentRef!.revision != mergeBase) {
+    _addOutgoingChangesHistoryItem(viewModels, currentRef, mergeBase);
+  }
+}
+
+void _addIncomingChangesHistoryItem(
+  List<GitHistoryItemViewModel> viewModels,
+  GitHistoryItemRef remoteRef,
+  String mergeBase,
+) {
+  final beforeIndex = _findLastIndex(
+    viewModels,
+    (viewModel) =>
+        viewModel.outputSwimlanes.any((node) => node.id == mergeBase),
+  );
+  final afterIndex = viewModels.indexWhere(
+    (viewModel) => viewModel.historyItem.id == mergeBase,
+  );
+  if (afterIndex == -1) {
+    return;
+  }
+  final before = beforeIndex == -1 ? null : viewModels[beforeIndex];
+  final incomingChangeMerged =
+      before?.historyItem.parentIds.length == 2 &&
+      before!.historyItem.parentIds.contains(mergeBase);
+  if (incomingChangeMerged) {
+    return;
+  }
+  final after = viewModels[afterIndex];
+  final inputSwimlanes = (before?.outputSwimlanes ?? after.inputSwimlanes)
+      .map((node) => _remoteBoundaryInputNode(node, mergeBase))
+      .toList(growable: true);
+  final outputSwimlanes = after.inputSwimlanes.map(_cloneNode).toList();
+  _ensureIncomingRemoteLane(inputSwimlanes, outputSwimlanes, mergeBase);
+
+  if (before != null) {
+    viewModels[beforeIndex] = before.copyWith(
+      inputSwimlanes: before.inputSwimlanes
+          .map((node) => _remoteBoundaryInputNode(node, mergeBase))
+          .toList(growable: false),
+      outputSwimlanes: inputSwimlanes.map(_cloneNode).toList(growable: false),
+    );
+  }
+
+  final displayIdLength =
+      viewModels.firstOrNull?.historyItem.displayId?.length ?? 0;
+  viewModels.insert(
+    afterIndex,
+    GitHistoryItemViewModel(
+      historyItem: GitHistoryItem(
+        id: gitHistoryIncomingChangesId,
+        parentIds: <String>[mergeBase],
+        subject: 'Incoming Changes',
+        message: '',
+        displayId: List<String>.filled(displayIdLength, '0').join(),
+        author: remoteRef.name,
+      ),
+      inputSwimlanes: List<GitHistoryGraphNode>.unmodifiable(inputSwimlanes),
+      outputSwimlanes: List<GitHistoryGraphNode>.unmodifiable(outputSwimlanes),
+      kind: GitHistoryItemViewModelKind.incomingChanges,
+    ),
+  );
+  viewModels[afterIndex + 1] = after.copyWith(
+    inputSwimlanes: outputSwimlanes.map(_cloneNode).toList(growable: false),
+  );
+}
+
+void _addOutgoingChangesHistoryItem(
+  List<GitHistoryItemViewModel> viewModels,
+  GitHistoryItemRef currentRef,
+  String mergeBase,
+) {
+  final currentRevision = currentRef.revision;
+  if (currentRevision == null) {
+    return;
+  }
+  final currentIndex = viewModels.indexWhere(
+    (viewModel) =>
+        viewModel.kind == GitHistoryItemViewModelKind.head &&
+        viewModel.historyItem.id == currentRevision,
+  );
+  final anchorIndex = currentIndex == -1
+      ? _firstVisibleOutgoingIndex(viewModels, mergeBase)
+      : currentIndex;
+  if (anchorIndex == -1) {
+    return;
+  }
+  final anchorRevision = currentIndex == -1
+      ? viewModels[anchorIndex].historyItem.id
+      : currentRevision;
+  final displayIdLength =
+      viewModels.firstOrNull?.historyItem.displayId?.length ?? 0;
+  final inputSwimlanes = viewModels[anchorIndex].inputSwimlanes
+      .map(_cloneNode)
+      .toList(growable: false);
+  final outputSwimlanes = inputSwimlanes.map(_cloneNode).toList(growable: true)
+    ..add(GitHistoryGraphNode(id: anchorRevision, color: gitHistoryRefColor));
+  viewModels.insert(
+    anchorIndex,
+    GitHistoryItemViewModel(
+      historyItem: GitHistoryItem(
+        id: gitHistoryOutgoingChangesId,
+        parentIds: <String>[anchorRevision],
+        subject: 'Outgoing Changes',
+        message: '',
+        displayId: List<String>.filled(displayIdLength, '0').join(),
+        author: currentRef.name,
+      ),
+      inputSwimlanes: inputSwimlanes,
+      outputSwimlanes: List<GitHistoryGraphNode>.unmodifiable(outputSwimlanes),
+      kind: GitHistoryItemViewModelKind.outgoingChanges,
+    ),
+  );
+  viewModels[anchorIndex + 1] = viewModels[anchorIndex + 1].copyWith(
+    inputSwimlanes: <GitHistoryGraphNode>[
+      ...viewModels[anchorIndex + 1].inputSwimlanes,
+      GitHistoryGraphNode(id: anchorRevision, color: gitHistoryRefColor),
+    ],
+  );
+}
+
+int _firstVisibleOutgoingIndex(
+  List<GitHistoryItemViewModel> viewModels,
+  String mergeBase,
+) {
+  final mergeBaseIndex = viewModels.indexWhere(
+    (viewModel) => viewModel.historyItem.id == mergeBase,
+  );
+  final endIndex = mergeBaseIndex == -1 ? viewModels.length : mergeBaseIndex;
+  for (var index = 0; index < endIndex; index += 1) {
+    final itemId = viewModels[index].historyItem.id;
+    if (itemId == gitHistoryIncomingChangesId ||
+        itemId == gitHistoryOutgoingChangesId) {
+      continue;
+    }
+    return index;
+  }
+  return -1;
+}
+
+GitHistoryGraphNode _remoteBoundaryInputNode(
+  GitHistoryGraphNode node,
+  String mergeBase,
+) {
+  if (node.id == mergeBase && node.color == gitHistoryRemoteRefColor) {
+    return const GitHistoryGraphNode(
+      id: gitHistoryIncomingChangesId,
+      color: gitHistoryRemoteRefColor,
+    );
+  }
+  return _cloneNode(node);
+}
+
+void _ensureIncomingRemoteLane(
+  List<GitHistoryGraphNode> inputSwimlanes,
+  List<GitHistoryGraphNode> outputSwimlanes,
+  String mergeBase,
+) {
+  if (!_hasNode(outputSwimlanes, mergeBase, gitHistoryRemoteRefColor)) {
+    final localMergeBaseIndex = outputSwimlanes.indexWhere(
+      (node) => node.id == mergeBase && node.color == gitHistoryRefColor,
+    );
+    outputSwimlanes.insert(
+      localMergeBaseIndex == -1
+          ? inputSwimlanes.length
+          : localMergeBaseIndex + 1,
+      GitHistoryGraphNode(id: mergeBase, color: gitHistoryRemoteRefColor),
+    );
+  }
+  if (_hasNode(
+    inputSwimlanes,
+    gitHistoryIncomingChangesId,
+    gitHistoryRemoteRefColor,
+  )) {
+    return;
+  }
+  final remoteMergeBaseIndex = outputSwimlanes.indexWhere(
+    (node) => node.id == mergeBase && node.color == gitHistoryRemoteRefColor,
+  );
+  inputSwimlanes.insert(
+    remoteMergeBaseIndex == -1 ? inputSwimlanes.length : remoteMergeBaseIndex,
+    const GitHistoryGraphNode(
+      id: gitHistoryIncomingChangesId,
+      color: gitHistoryRemoteRefColor,
+    ),
+  );
+}
+
+bool _hasNode(
+  List<GitHistoryGraphNode> nodes,
+  String id,
+  GitHistoryGraphColorId color,
+) {
+  return nodes.any((node) => node.id == id && node.color == color);
+}
+
+int _findLastIndex<T>(List<T> items, bool Function(T item) predicate) {
+  for (var index = items.length - 1; index >= 0; index -= 1) {
+    if (predicate(items[index])) {
+      return index;
+    }
+  }
+  return -1;
+}
+
+int _rotate(int index, int length) {
+  return ((index % length) + length) % length;
+}

--- a/lib/src/shared/infra/git/rust_git_backend.dart
+++ b/lib/src/shared/infra/git/rust_git_backend.dart
@@ -132,6 +132,47 @@ class RustGitBackend implements GitBackend {
       });
 
   @override
+  Future<GitHistoryResult> history(
+    String path, {
+    int? limit,
+    String? baseRef,
+  }) => _guard(() async {
+    final result = await rust.gitHistory(
+      path: path,
+      limit: limit,
+      baseRef: baseRef,
+    );
+    return _toHistoryResult(result);
+  });
+
+  @override
+  Future<GitCommitCompareResult> commitCompare({
+    required String path,
+    required String commitId,
+  }) => _guard(() async {
+    final result = await rust.gitCommitCompare(path: path, commitId: commitId);
+    return _toCommitCompareResult(result);
+  });
+
+  @override
+  Future<GitDiffResult> commitDiff({
+    required String path,
+    required String commitOid,
+    String? parentOid,
+    String? filePath,
+    String? oldPath,
+  }) => _guard(() async {
+    final result = await rust.gitCommitDiff(
+      path: path,
+      commitOid: commitOid,
+      parentOid: parentOid,
+      filePath: filePath,
+      oldPath: oldPath,
+    );
+    return _toDiffResult(result, sourceLabel: 'Commit');
+  });
+
+  @override
   Future<GitRepositoryState> repositoryState(String path) => _guard(() async {
     final state = await rust.gitRepositoryState(path: path);
     return GitRepositoryState(
@@ -310,7 +351,10 @@ class RustGitBackend implements GitBackend {
     );
   }
 
-  GitDiffResult _toDiffResult(rust.GitDiffResult result) {
+  GitDiffResult _toDiffResult(
+    rust.GitDiffResult result, {
+    String? sourceLabel,
+  }) {
     return GitDiffResult(
       truncated: result.truncated,
       files: result.files
@@ -327,9 +371,93 @@ class RustGitBackend implements GitBackend {
               isLarge: file.isLarge,
               truncated: file.truncated,
               linePreviewTruncated: file.linePreviewTruncated,
+              sourceLabel: sourceLabel,
             ),
           )
           .toList(growable: false),
+    );
+  }
+
+  GitHistoryResult _toHistoryResult(rust.GitHistoryResult result) {
+    return GitHistoryResult(
+      items: result.items.map(_toHistoryItem).toList(growable: false),
+      currentRef: result.currentRef == null
+          ? null
+          : _toHistoryItemRef(result.currentRef!),
+      remoteRef: result.remoteRef == null
+          ? null
+          : _toHistoryItemRef(result.remoteRef!),
+      baseRef: result.baseRef == null
+          ? null
+          : _toHistoryItemRef(result.baseRef!),
+      mergeBase: result.mergeBase,
+      hasIncomingChanges: result.hasIncomingChanges,
+      hasOutgoingChanges: result.hasOutgoingChanges,
+      hasMore: result.hasMore,
+      limit: result.limit,
+    );
+  }
+
+  GitHistoryItem _toHistoryItem(rust.GitHistoryItem item) {
+    final timestamp = item.timestamp;
+    return GitHistoryItem(
+      id: item.id,
+      parentIds: item.parentIds,
+      subject: item.subject,
+      message: item.message,
+      displayId: item.displayId,
+      author: item.author,
+      authorEmail: item.authorEmail,
+      timestamp: timestamp == null
+          ? null
+          : DateTime.fromMillisecondsSinceEpoch(timestamp, isUtc: true),
+      references: item.references
+          .map(_toHistoryItemRef)
+          .toList(growable: false),
+    );
+  }
+
+  GitHistoryItemRef _toHistoryItemRef(rust.GitHistoryItemRef itemRef) {
+    return GitHistoryItemRef(
+      id: itemRef.id,
+      name: itemRef.name,
+      revision: itemRef.revision,
+      category: itemRef.category == null
+          ? null
+          : _toHistoryRefCategory(itemRef.category!),
+    );
+  }
+
+  GitCommitCompareResult _toCommitCompareResult(
+    rust.GitCommitCompareResult result,
+  ) {
+    return GitCommitCompareResult(
+      summary: _toCommitCompareSummary(result.summary),
+      entries: result.entries.map(_toCommitChangeEntry).toList(growable: false),
+    );
+  }
+
+  GitCommitCompareSummary _toCommitCompareSummary(
+    rust.GitCommitCompareSummary summary,
+  ) {
+    return GitCommitCompareSummary(
+      commitOid: summary.commitOid,
+      parentOid: summary.parentOid,
+      compareRef: summary.compareRef,
+      baseRef: summary.baseRef,
+      changedFiles: summary.changedFiles,
+      status: _toCommitCompareStatus(summary.status),
+      errorMessage: summary.errorMessage,
+    );
+  }
+
+  GitCommitChangeEntry _toCommitChangeEntry(rust.GitCommitChangeEntry entry) {
+    return GitCommitChangeEntry(
+      path: entry.path,
+      oldPath: entry.oldPath,
+      status: _toStatus(entry.status),
+      added: entry.added,
+      removed: entry.removed,
     );
   }
 
@@ -367,6 +495,29 @@ class RustGitBackend implements GitBackend {
       rust.GitDiffLineKind.hunk => GitDiffLineKind.hunk,
       rust.GitDiffLineKind.header => GitDiffLineKind.header,
       rust.GitDiffLineKind.context => GitDiffLineKind.context,
+    };
+  }
+
+  GitHistoryRefCategory _toHistoryRefCategory(
+    rust.GitHistoryRefCategory category,
+  ) {
+    return switch (category) {
+      rust.GitHistoryRefCategory.branches => GitHistoryRefCategory.branches,
+      rust.GitHistoryRefCategory.remoteBranches =>
+        GitHistoryRefCategory.remoteBranches,
+      rust.GitHistoryRefCategory.tags => GitHistoryRefCategory.tags,
+      rust.GitHistoryRefCategory.commits => GitHistoryRefCategory.commits,
+    };
+  }
+
+  GitCommitCompareStatus _toCommitCompareStatus(
+    rust.GitCommitCompareStatus status,
+  ) {
+    return switch (status) {
+      rust.GitCommitCompareStatus.ready => GitCommitCompareStatus.ready,
+      rust.GitCommitCompareStatus.invalidCommit =>
+        GitCommitCompareStatus.invalidCommit,
+      rust.GitCommitCompareStatus.error => GitCommitCompareStatus.error,
     };
   }
 

--- a/roadmap.md
+++ b/roadmap.md
@@ -75,7 +75,7 @@ Comprehensive feature roadmap for Alera. Each feature is scored on two axes:
 | Commit and PR messages with AI | 3 | 4 | Shipped | AI-generated commit messages (PR descriptions planned) |
 | Conflict view and resolver | 4 | 4 | Planned | Visual conflict display with merge controls |
 | Conflict resolution with AI | 4 | 3 | Planned | AI-assisted three-way merge conflict resolution |
-| Git history panel with graph | 4 | 4 | Planned | Commit history browser with visual branch/merge graph |
+| Git history panel with graph | 4 | 4 | Shipped | Collapsible Source Control commits section with HEAD/upstream graph and commit diff tabs |
 | Diff annotations & inline comments | 4 | 3 | Planned | Comment threads on diff lines with popovers |
 | Send diff annotations to agent | 3 | 4 | Planned | Send annotated diffs directly to agents for action |
 | Image diff | 3 | 2 | Planned | Side-by-side image comparison for binary diffs |

--- a/rust/src/api/git.rs
+++ b/rust/src/api/git.rs
@@ -9,6 +9,10 @@ use git2::{
 
 #[path = "git_diff_impl.rs"]
 mod git_diff_impl;
+#[path = "git_diff_paths.rs"]
+mod git_diff_paths;
+#[path = "git_history_impl.rs"]
+mod git_history_impl;
 
 pub struct GitWorktreeEntry {
     pub path: String,
@@ -121,6 +125,77 @@ pub struct GitDiffFile {
 pub struct GitDiffResult {
     pub files: Vec<GitDiffFile>,
     pub truncated: bool,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum GitHistoryRefCategory {
+    Branches,
+    RemoteBranches,
+    Tags,
+    Commits,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct GitHistoryItemRef {
+    pub id: String,
+    pub name: String,
+    pub revision: Option<String>,
+    pub category: Option<GitHistoryRefCategory>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct GitHistoryItem {
+    pub id: String,
+    pub parent_ids: Vec<String>,
+    pub subject: String,
+    pub message: String,
+    pub display_id: Option<String>,
+    pub author: Option<String>,
+    pub author_email: Option<String>,
+    pub timestamp: Option<i64>,
+    pub references: Vec<GitHistoryItemRef>,
+}
+
+pub struct GitHistoryResult {
+    pub items: Vec<GitHistoryItem>,
+    pub current_ref: Option<GitHistoryItemRef>,
+    pub remote_ref: Option<GitHistoryItemRef>,
+    pub base_ref: Option<GitHistoryItemRef>,
+    pub merge_base: Option<String>,
+    pub has_incoming_changes: bool,
+    pub has_outgoing_changes: bool,
+    pub has_more: bool,
+    pub limit: u32,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum GitCommitCompareStatus {
+    Ready,
+    InvalidCommit,
+    Error,
+}
+
+pub struct GitCommitChangeEntry {
+    pub path: String,
+    pub old_path: Option<String>,
+    pub status: GitChangeStatus,
+    pub added: Option<u32>,
+    pub removed: Option<u32>,
+}
+
+pub struct GitCommitCompareSummary {
+    pub commit_oid: String,
+    pub parent_oid: Option<String>,
+    pub compare_ref: String,
+    pub base_ref: String,
+    pub changed_files: u32,
+    pub status: GitCommitCompareStatus,
+    pub error_message: Option<String>,
+}
+
+pub struct GitCommitCompareResult {
+    pub summary: GitCommitCompareSummary,
+    pub entries: Vec<GitCommitChangeEntry>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -296,6 +371,31 @@ pub fn git_diff(
 
 pub fn git_diff_all(path: String, file_path: Option<String>) -> Result<GitDiffResult, GitError> {
     git_diff_impl::git_diff_all(path, file_path)
+}
+
+pub fn git_history(
+    path: String,
+    limit: Option<u32>,
+    base_ref: Option<String>,
+) -> Result<GitHistoryResult, GitError> {
+    git_history_impl::git_history(path, limit, base_ref)
+}
+
+pub fn git_commit_compare(
+    path: String,
+    commit_id: String,
+) -> Result<GitCommitCompareResult, GitError> {
+    git_diff_impl::git_commit_compare(path, commit_id)
+}
+
+pub fn git_commit_diff(
+    path: String,
+    commit_oid: String,
+    parent_oid: Option<String>,
+    file_path: Option<String>,
+    old_path: Option<String>,
+) -> Result<GitDiffResult, GitError> {
+    git_diff_impl::git_commit_diff(path, commit_oid, parent_oid, file_path, old_path)
 }
 
 pub fn git_repository_state(path: String) -> Result<GitRepositoryState, GitError> {

--- a/rust/src/api/git_diff_combined.rs
+++ b/rust/src/api/git_diff_combined.rs
@@ -1,8 +1,8 @@
 use git2::Repository;
 
+use super::super::git_diff_paths::GitPathContext;
 use super::{
     diff_file_for_area,
-    git_diff_paths::GitPathContext,
     git_diff_render::{diff_lines_byte_len, truncate_diff_lines_to_bytes},
     GitChangeArea, GitDiffFile, GitDiffResult, GitError, MAX_DIFF_PATCH_BYTES,
 };

--- a/rust/src/api/git_diff_edge_tests.rs
+++ b/rust/src/api/git_diff_edge_tests.rs
@@ -339,6 +339,108 @@ fn git_diff_does_not_select_copy_delta_by_source_path() {
 }
 
 #[test]
+fn git_commit_diff_prefers_copied_destination_over_shared_source_path() {
+    let repo = init_repo();
+    let source = repo
+        .path()
+        .join("packages")
+        .join("app")
+        .join("lib")
+        .join("foo.dart");
+    let copy_a = repo.path().join("packages").join("aaa").join("foo.dart");
+    let copy_b = repo.path().join("packages").join("bbb").join("foo.dart");
+    std::fs::create_dir_all(source.parent().unwrap()).expect("create source dir");
+    std::fs::create_dir_all(copy_a.parent().unwrap()).expect("create copy a dir");
+    std::fs::create_dir_all(copy_b.parent().unwrap()).expect("create copy b dir");
+    std::fs::write(&source, "base\n").expect("write source");
+    run_git(repo.path(), &["add", "."]);
+    run_git(repo.path(), &["commit", "-m", "add source"]);
+
+    std::fs::copy(&source, &copy_a).expect("copy source a");
+    std::fs::copy(&source, &copy_b).expect("copy source b");
+    std::fs::write(&source, "base\nsource change\n").expect("modify source");
+    run_git(
+        repo.path(),
+        &[
+            "add",
+            "packages/app/lib/foo.dart",
+            "packages/aaa/foo.dart",
+            "packages/bbb/foo.dart",
+        ],
+    );
+    run_git(repo.path(), &["commit", "-m", "copy source twice"]);
+
+    let git_repo = git2::Repository::open(repo.path()).expect("open repo");
+    let commit = git_repo
+        .head()
+        .expect("head")
+        .peel_to_commit()
+        .expect("head commit");
+    let diff = git_commit_diff(
+        path_str(repo.path()),
+        commit.id().to_string(),
+        Some(commit.parent_id(0).expect("parent").to_string()),
+        Some("packages/bbb/foo.dart".to_string()),
+        Some("packages/app/lib/foo.dart".to_string()),
+    )
+    .unwrap();
+
+    assert_eq!(diff.files.len(), 1);
+    assert_eq!(diff.files[0].path, "packages/bbb/foo.dart");
+    assert_eq!(
+        diff.files[0].old_path.as_deref(),
+        Some("packages/app/lib/foo.dart")
+    );
+    assert_eq!(diff.files[0].status, GitChangeStatus::Copied);
+    assert!(!diff_text(&diff.files[0]).contains("packages/aaa/foo.dart"));
+}
+
+#[test]
+fn git_commit_compare_ignores_copy_sources_outside_scoped_workspace() {
+    let repo = init_repo();
+    let source = repo
+        .path()
+        .join("packages")
+        .join("app")
+        .join("lib")
+        .join("foo.dart");
+    let copy = repo.path().join("packages").join("other").join("foo.dart");
+    std::fs::create_dir_all(source.parent().unwrap()).expect("create source dir");
+    std::fs::create_dir_all(copy.parent().unwrap()).expect("create copy dir");
+    std::fs::write(&source, "base\n").expect("write source");
+    run_git(repo.path(), &["add", "."]);
+    run_git(repo.path(), &["commit", "-m", "add source"]);
+
+    std::fs::copy(&source, &copy).expect("copy source");
+    std::fs::write(&source, "base\nsource change\n").expect("modify source");
+    run_git(
+        repo.path(),
+        &[
+            "add",
+            "packages/app/lib/foo.dart",
+            "packages/other/foo.dart",
+        ],
+    );
+    run_git(repo.path(), &["commit", "-m", "copy source out"]);
+
+    let git_repo = git2::Repository::open(repo.path()).expect("open repo");
+    let commit = git_repo
+        .head()
+        .expect("head")
+        .peel_to_commit()
+        .expect("head commit");
+    let compare = git_commit_compare(
+        path_str(&repo.path().join("packages/app")),
+        commit.id().to_string(),
+    )
+    .unwrap();
+
+    assert_eq!(compare.entries.len(), 1);
+    assert_eq!(compare.entries[0].path, "lib/foo.dart");
+    assert_eq!(compare.entries[0].status, GitChangeStatus::Modified);
+}
+
+#[test]
 fn git_diff_treats_star_pathspec_characters_as_literals() {
     let repo = init_repo();
     std::fs::write(repo.path().join("*.txt"), "literal star\n").expect("write star file");

--- a/rust/src/api/git_diff_impl.rs
+++ b/rust/src/api/git_diff_impl.rs
@@ -1,30 +1,35 @@
+use std::collections::HashMap;
 use std::path::Path;
 
 use git2::{
-    Delta, Diff, DiffFindOptions, DiffOptions, Repository, Status, StatusEntry, StatusOptions,
+    Delta, Diff, DiffFindOptions, DiffFormat, DiffLineType, DiffOptions, Oid, Repository, Status,
+    StatusEntry, StatusOptions,
 };
 
 use super::{
     open_repo, GitChangeArea, GitChangeEntry, GitChangeGroup, GitChangeStatus, GitChangeTreeRow,
-    GitChangeTreeRowKind, GitDiffFile, GitDiffLine, GitDiffLineKind, GitDiffResult, GitError,
+    GitChangeTreeRowKind, GitCommitChangeEntry, GitCommitCompareResult, GitCommitCompareStatus,
+    GitCommitCompareSummary, GitDiffFile, GitDiffLine, GitDiffLineKind, GitDiffResult, GitError,
     GitErrorKind, GitStatusResult,
 };
 
 #[path = "git_diff_combined.rs"]
 mod git_diff_combined;
-#[path = "git_diff_paths.rs"]
-mod git_diff_paths;
 #[path = "git_diff_render.rs"]
 mod git_diff_render;
 #[path = "git_diff_untracked.rs"]
 mod git_diff_untracked;
 
 use git_diff_combined::{append_combined_diff_file, git_diff_all_for_file};
-use git_diff_paths::GitPathContext;
 use git_diff_render::render_diff_for_path;
 use git_diff_untracked::untracked_diff_file;
 
+use super::git_diff_paths::GitPathContext;
+
 pub(super) const MAX_DIFF_PATCH_BYTES: usize = 512 * 1024;
+
+type LineStats = (Option<u32>, Option<u32>);
+type CommitDiffLineStatsByPath = HashMap<String, LineStats>;
 
 pub(super) fn git_status(path: String) -> Result<GitStatusResult, GitError> {
     let repo = open_repo(&path)?;
@@ -116,6 +121,109 @@ pub(super) fn git_diff_all(
     Ok(GitDiffResult { files, truncated })
 }
 
+pub(super) fn git_commit_compare(
+    path: String,
+    commit_id: String,
+) -> Result<GitCommitCompareResult, GitError> {
+    let repo = open_repo(&path)?;
+    let commit = match repo.revparse_single(&format!("{commit_id}^{{commit}}")) {
+        Ok(object) => match object.peel_to_commit() {
+            Ok(commit) => commit,
+            Err(_) => return Ok(invalid_commit_compare(commit_id)),
+        },
+        Err(_) => return Ok(invalid_commit_compare(commit_id)),
+    };
+    let commit_oid = commit.id();
+    let parent_oid = commit.parent_id(0).ok();
+    let mut summary = GitCommitCompareSummary {
+        commit_oid: commit_oid.to_string(),
+        parent_oid: parent_oid.map(|oid| oid.to_string()),
+        compare_ref: short_oid(commit_oid),
+        base_ref: parent_oid
+            .map(short_oid)
+            .unwrap_or_else(|| "empty tree".to_string()),
+        changed_files: 0,
+        status: GitCommitCompareStatus::Ready,
+        error_message: None,
+    };
+    match commit_change_entries(&repo, &path, parent_oid, commit_oid) {
+        Ok(entries) => {
+            summary.changed_files = entries.len() as u32;
+            Ok(GitCommitCompareResult { summary, entries })
+        }
+        Err(error) => Ok(GitCommitCompareResult {
+            summary: GitCommitCompareSummary {
+                status: GitCommitCompareStatus::Error,
+                error_message: Some(error.context),
+                ..summary
+            },
+            entries: Vec::new(),
+        }),
+    }
+}
+
+pub(super) fn git_commit_diff(
+    path: String,
+    commit_oid: String,
+    parent_oid: Option<String>,
+    file_path: Option<String>,
+    old_path: Option<String>,
+) -> Result<GitDiffResult, GitError> {
+    let repo = open_repo(&path)?;
+    let paths = GitPathContext::new(&repo, &path)?;
+    let commit_oid = Oid::from_str(&commit_oid).map_err(GitError::from_git2)?;
+    let parent_oid = parent_oid
+        .as_deref()
+        .map(Oid::from_str)
+        .transpose()
+        .map_err(GitError::from_git2)?;
+    if let Some(file_path) = file_path {
+        let repo_path = paths.to_repo_path(&file_path);
+        let old_repo_path = old_path
+            .as_deref()
+            .map(|old_path| paths.to_repo_path(old_path));
+        let mut diff = diff_for_commit_range(
+            &repo,
+            parent_oid,
+            commit_oid,
+            &[repo_path.as_str(), old_repo_path.as_deref().unwrap_or("")],
+        )?;
+        let file = commit_diff_file_for_path(
+            &repo,
+            &paths,
+            &mut diff,
+            &repo_path,
+            old_repo_path.as_deref(),
+        )?;
+        return Ok(GitDiffResult {
+            files: file.into_iter().collect(),
+            truncated: false,
+        });
+    }
+
+    let mut diff = diff_for_commit_range(&repo, parent_oid, commit_oid, &[])?;
+    let mut files = Vec::new();
+    let mut total_bytes = 0usize;
+    let mut truncated = false;
+    let selections = commit_diff_selections(&diff)?;
+    for selection in selections {
+        let Some(file) = commit_diff_file_for_path(
+            &repo,
+            &paths,
+            &mut diff,
+            &selection.path,
+            selection.old_path.as_deref(),
+        )?
+        else {
+            continue;
+        };
+        if append_combined_diff_file(&mut files, &mut total_bytes, &mut truncated, file) {
+            break;
+        }
+    }
+    Ok(GitDiffResult { files, truncated })
+}
+
 fn status_options() -> StatusOptions {
     let mut options = StatusOptions::new();
     options
@@ -142,7 +250,10 @@ fn status_entry_to_change(
             };
             let repo_path = delta_path(&delta, false)?;
             let old_path = old_path_for_delta(&delta)?;
-            let Some(path) = visible_workspace_path(paths, &repo_path, old_path.as_deref()) else {
+            let change_status = change_status_for_delta(delta.status(), area);
+            let Some(path) =
+                visible_workspace_path(paths, &repo_path, old_path.as_deref(), change_status)
+            else {
                 return Ok(None);
             };
             let mut change = GitChangeEntry {
@@ -151,7 +262,7 @@ fn status_entry_to_change(
                     .as_deref()
                     .and_then(|old_path| paths.to_workspace_path(old_path)),
                 area,
-                status: change_status_for_delta(delta.status(), area),
+                status: change_status,
                 added: None,
                 removed: None,
                 is_binary: delta.old_file().is_binary() || delta.new_file().is_binary(),
@@ -219,7 +330,10 @@ fn status_entry_to_change(
             };
             let repo_path = delta_path(&delta, false)?;
             let old_path = old_path_for_delta(&delta)?;
-            let Some(path) = visible_workspace_path(paths, &repo_path, old_path.as_deref()) else {
+            let change_status = change_status_for_delta(delta.status(), area);
+            let Some(path) =
+                visible_workspace_path(paths, &repo_path, old_path.as_deref(), change_status)
+            else {
                 return Ok(None);
             };
             let mut change = GitChangeEntry {
@@ -228,7 +342,7 @@ fn status_entry_to_change(
                     .as_deref()
                     .and_then(|old_path| paths.to_workspace_path(old_path)),
                 area,
-                status: change_status_for_delta(delta.status(), area),
+                status: change_status,
                 added: None,
                 removed: None,
                 is_binary: delta.old_file().is_binary() || delta.new_file().is_binary(),
@@ -308,9 +422,12 @@ fn diff_file_for_area(
             if rendered.lines.is_empty() {
                 return Ok(None);
             }
-            let Some(path) =
-                visible_workspace_path(paths, &selection.path, selection.old_path.as_deref())
-            else {
+            let Some(path) = visible_workspace_path(
+                paths,
+                &selection.path,
+                selection.old_path.as_deref(),
+                selection.status,
+            ) else {
                 return Ok(None);
             };
             Ok(Some(GitDiffFile {
@@ -347,6 +464,207 @@ fn untracked_placeholder_diff_file(path: String) -> GitDiffFile {
         truncated: false,
         line_preview_truncated: false,
     }
+}
+
+fn invalid_commit_compare(commit_id: String) -> GitCommitCompareResult {
+    GitCommitCompareResult {
+        summary: GitCommitCompareSummary {
+            commit_oid: String::new(),
+            parent_oid: None,
+            compare_ref: commit_id.clone(),
+            base_ref: "parent".to_string(),
+            changed_files: 0,
+            status: GitCommitCompareStatus::InvalidCommit,
+            error_message: Some(format!(
+                "Commit {commit_id} could not be resolved in this repository."
+            )),
+        },
+        entries: Vec::new(),
+    }
+}
+
+fn commit_change_entries(
+    repo: &Repository,
+    workspace_path: &str,
+    parent_oid: Option<Oid>,
+    commit_oid: Oid,
+) -> Result<Vec<GitCommitChangeEntry>, GitError> {
+    let paths = GitPathContext::new(repo, workspace_path)?;
+    let mut diff = diff_for_commit_range(repo, parent_oid, commit_oid, &[])?;
+    let stats = commit_diff_stats_by_path(&mut diff)?;
+    let selections = commit_diff_selections(&diff)?;
+    let mut entries = Vec::new();
+    for selection in selections {
+        let Some(path) = visible_workspace_path(
+            &paths,
+            &selection.path,
+            selection.old_path.as_deref(),
+            selection.status,
+        ) else {
+            continue;
+        };
+        let old_path = selection
+            .old_path
+            .as_deref()
+            .and_then(|old_path| paths.to_workspace_path(old_path));
+        let (added, removed) = stats.get(&selection.path).copied().unwrap_or((None, None));
+        entries.push(GitCommitChangeEntry {
+            path,
+            old_path,
+            status: selection.status,
+            added,
+            removed,
+        });
+    }
+    entries.sort_by(|a, b| a.path.cmp(&b.path));
+    Ok(entries)
+}
+
+fn commit_diff_file_for_path(
+    _repo: &Repository,
+    paths: &GitPathContext,
+    diff: &mut Diff<'_>,
+    repo_path: &str,
+    old_repo_path: Option<&str>,
+) -> Result<Option<GitDiffFile>, GitError> {
+    let selections = commit_diff_selections(diff)?;
+    let selection = selections
+        .iter()
+        .find(|selection| {
+            selected_delta_matches_path(
+                delta_for_status(selection.status),
+                &selection.path,
+                selection.old_path.as_deref(),
+                repo_path,
+            )
+        })
+        .or_else(|| {
+            old_repo_path.and_then(|old_repo_path| {
+                selections.iter().find(|selection| {
+                    selection.status == GitChangeStatus::Renamed
+                        && selection.old_path.as_deref() == Some(old_repo_path)
+                })
+            })
+        });
+    let Some(selection) = selection else {
+        return Ok(None);
+    };
+    let rendered = render_diff_for_path(diff, &selection.path)?;
+    let Some(path) = visible_workspace_path(
+        paths,
+        &selection.path,
+        selection.old_path.as_deref(),
+        selection.status,
+    ) else {
+        return Ok(None);
+    };
+    Ok(Some(GitDiffFile {
+        path,
+        old_path: selection
+            .old_path
+            .as_deref()
+            .and_then(|old_path| paths.to_workspace_path(old_path)),
+        area: GitChangeArea::Staged,
+        status: selection.status,
+        lines: rendered.lines,
+        added: Some(rendered.added),
+        removed: Some(rendered.removed),
+        is_binary: rendered.is_binary,
+        is_large: false,
+        truncated: rendered.truncated,
+        line_preview_truncated: rendered.line_preview_truncated,
+    }))
+}
+
+fn diff_for_commit_range<'repo>(
+    repo: &'repo Repository,
+    parent_oid: Option<Oid>,
+    commit_oid: Oid,
+    pathspecs: &[&str],
+) -> Result<Diff<'repo>, GitError> {
+    let commit = repo.find_commit(commit_oid).map_err(GitError::from_git2)?;
+    let commit_tree = commit.tree().map_err(GitError::from_git2)?;
+    let parent_tree = parent_oid
+        .map(|oid| {
+            repo.find_commit(oid)
+                .and_then(|commit| commit.tree())
+                .map_err(GitError::from_git2)
+        })
+        .transpose()?;
+    let mut options = DiffOptions::new();
+    let mut has_pathspec = false;
+    for pathspec in pathspecs.iter().filter(|pathspec| !pathspec.is_empty()) {
+        options.pathspec(pathspec);
+        has_pathspec = true;
+    }
+    if has_pathspec {
+        options.disable_pathspec_match(true);
+    }
+    let mut diff = repo
+        .diff_tree_to_tree(parent_tree.as_ref(), Some(&commit_tree), Some(&mut options))
+        .map_err(GitError::from_git2)?;
+    let mut find_options = DiffFindOptions::new();
+    find_options.renames(true).copies(true);
+    diff.find_similar(Some(&mut find_options))
+        .map_err(GitError::from_git2)?;
+    Ok(diff)
+}
+
+fn commit_diff_selections(diff: &Diff<'_>) -> Result<Vec<DiffSelection>, GitError> {
+    let mut selections = Vec::new();
+    for delta in diff.deltas() {
+        let path = delta_path(&delta, false)?;
+        let old_path = old_path_for_delta(&delta)?;
+        selections.push(DiffSelection {
+            path,
+            old_path,
+            status: change_status_for_delta(delta.status(), GitChangeArea::Staged),
+        });
+    }
+    Ok(selections)
+}
+
+fn commit_diff_stats_by_path(diff: &mut Diff<'_>) -> Result<CommitDiffLineStatsByPath, GitError> {
+    let mut stats = HashMap::<String, (u32, u32)>::new();
+    diff.print(DiffFormat::Patch, |delta, _hunk, line| {
+        let Ok(path) = delta_path(&delta, false) else {
+            return true;
+        };
+        let entry = stats.entry(path).or_insert((0, 0));
+        match line.origin_value() {
+            DiffLineType::Addition => entry.0 = entry.0.saturating_add(line.num_lines()),
+            DiffLineType::Deletion => entry.1 = entry.1.saturating_add(line.num_lines()),
+            _ => {}
+        }
+        true
+    })
+    .map_err(GitError::from_git2)?;
+    Ok(stats
+        .into_iter()
+        .map(|(path, (added, removed))| {
+            (
+                path,
+                (
+                    if added > 0 { Some(added) } else { None },
+                    if removed > 0 { Some(removed) } else { None },
+                ),
+            )
+        })
+        .collect())
+}
+
+fn delta_for_status(status: GitChangeStatus) -> Delta {
+    match status {
+        GitChangeStatus::Added | GitChangeStatus::Untracked => Delta::Added,
+        GitChangeStatus::Deleted => Delta::Deleted,
+        GitChangeStatus::Renamed => Delta::Renamed,
+        GitChangeStatus::Copied => Delta::Copied,
+        GitChangeStatus::Modified => Delta::Modified,
+    }
+}
+
+fn short_oid(oid: Oid) -> String {
+    oid.to_string().chars().take(7).collect()
 }
 
 struct DiffSelection {
@@ -389,10 +707,15 @@ fn visible_workspace_path(
     paths: &GitPathContext,
     repo_path: &str,
     old_path: Option<&str>,
+    status: GitChangeStatus,
 ) -> Option<String> {
-    paths
-        .to_workspace_path(repo_path)
-        .or_else(|| old_path.and_then(|old_path| paths.to_workspace_path(old_path)))
+    paths.to_workspace_path(repo_path).or_else(|| {
+        if matches!(status, GitChangeStatus::Renamed | GitChangeStatus::Deleted) {
+            old_path.and_then(|old_path| paths.to_workspace_path(old_path))
+        } else {
+            None
+        }
+    })
 }
 
 fn diff_for_area<'repo>(

--- a/rust/src/api/git_diff_paths.rs
+++ b/rust/src/api/git_diff_paths.rs
@@ -23,6 +23,10 @@ impl GitPathContext {
         Ok(Self { workspace_prefix })
     }
 
+    pub(super) fn is_workspace_root(&self) -> bool {
+        self.workspace_prefix.is_empty()
+    }
+
     pub(super) fn to_workspace_path(&self, repo_path: &str) -> Option<String> {
         let repo_path = normalize_repo_path(repo_path);
         if self.workspace_prefix.is_empty() {

--- a/rust/src/api/git_history_impl.rs
+++ b/rust/src/api/git_history_impl.rs
@@ -1,0 +1,460 @@
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::path::Path;
+
+use git2::{BranchType, ErrorCode, Oid, Repository, Sort};
+
+use super::git_diff_paths::GitPathContext;
+use super::{
+    current_head_commit, head_branch_name, open_repo, GitError, GitHistoryItem, GitHistoryItemRef,
+    GitHistoryRefCategory, GitHistoryResult,
+};
+
+const DEFAULT_HISTORY_LIMIT: u32 = 50;
+const MAX_HISTORY_LIMIT: u32 = 200;
+
+pub(super) fn git_history(
+    path: String,
+    limit: Option<u32>,
+    base_ref: Option<String>,
+) -> Result<GitHistoryResult, GitError> {
+    let repo = open_repo(&path)?;
+    let paths = GitPathContext::new(&repo, &path)?;
+    let limit = limit
+        .unwrap_or(DEFAULT_HISTORY_LIMIT)
+        .clamp(1, MAX_HISTORY_LIMIT);
+    let Some(head) = current_head_commit(&repo)? else {
+        return Ok(GitHistoryResult {
+            items: Vec::new(),
+            current_ref: None,
+            remote_ref: None,
+            base_ref: None,
+            merge_base: None,
+            has_incoming_changes: false,
+            has_outgoing_changes: false,
+            has_more: false,
+            limit,
+        });
+    };
+    let head_oid = head.id();
+    let branch_name = head_branch_name(&repo);
+    let current_ref = resolve_current_ref(&repo, &branch_name, head_oid)?;
+    let remote_ref = resolve_upstream_ref(&repo, &branch_name)?;
+    let remote_oid = remote_ref
+        .as_ref()
+        .and_then(|remote| remote.revision.as_deref())
+        .and_then(|value| Oid::from_str(value).ok());
+    let base_ref = resolve_named_ref(&repo, base_ref.as_deref())?.filter(|base| {
+        base.id != current_ref.id
+            && remote_ref
+                .as_ref()
+                .is_none_or(|remote| remote.id != base.id)
+    });
+    let merge_base_oid = if let Some(remote_oid) = remote_oid {
+        if remote_oid != head_oid {
+            repo.merge_base(head_oid, remote_oid).ok()
+        } else {
+            None
+        }
+    } else {
+        None
+    };
+    let refs_by_oid = refs_by_oid(&repo)?;
+    let mut revwalk = repo.revwalk().map_err(GitError::from_git2)?;
+    revwalk.push(head_oid).map_err(GitError::from_git2)?;
+    if let Some(remote_oid) = remote_oid.filter(|remote_oid| *remote_oid != head_oid) {
+        revwalk.push(remote_oid).map_err(GitError::from_git2)?;
+    }
+    revwalk
+        .set_sorting(Sort::TOPOLOGICAL | Sort::TIME)
+        .map_err(GitError::from_git2)?;
+    let mut parsed = Vec::new();
+    for oid in revwalk {
+        let oid = oid.map_err(GitError::from_git2)?;
+        let commit = repo.find_commit(oid).map_err(GitError::from_git2)?;
+        if !commit_touches_workspace(&repo, &paths, &commit)? {
+            continue;
+        }
+        parsed.push(history_item_from_commit(&commit, refs_by_oid.get(&oid)));
+        if parsed.len() > limit as usize {
+            break;
+        }
+    }
+    let has_more = parsed.len() > limit as usize;
+    parsed.truncate(limit as usize);
+    let visible_ids = parsed
+        .iter()
+        .filter_map(|item| Oid::from_str(&item.id).ok())
+        .collect::<HashSet<_>>();
+    let scoped_merge_base_oid = if paths.is_workspace_root() {
+        merge_base_oid
+    } else {
+        merge_base_oid
+            .map(|oid| scoped_visible_ancestor_oids(&repo, &visible_ids, oid))
+            .transpose()?
+            .and_then(|ancestors| ancestors.into_iter().next())
+    };
+    let merge_base = scoped_merge_base_oid.map(|oid| oid.to_string());
+    if !paths.is_workspace_root() {
+        rewrite_history_parents_to_visible_ancestors(&repo, &visible_ids, &mut parsed)?;
+    }
+    let has_incoming_changes =
+        if let (Some(remote_oid), Some(merge_base_oid)) = (remote_oid, merge_base_oid) {
+            remote_oid != merge_base_oid
+                && range_has_workspace_changes(&repo, &paths, merge_base_oid, remote_oid)?
+        } else {
+            false
+        };
+    let has_outgoing_changes =
+        if let (Some(remote_oid), Some(merge_base_oid)) = (remote_oid, merge_base_oid) {
+            remote_oid != head_oid
+                && head_oid != merge_base_oid
+                && range_has_workspace_changes(&repo, &paths, merge_base_oid, head_oid)?
+        } else {
+            false
+        };
+
+    Ok(GitHistoryResult {
+        items: parsed,
+        current_ref: Some(current_ref),
+        remote_ref,
+        base_ref,
+        merge_base,
+        has_incoming_changes,
+        has_outgoing_changes,
+        has_more,
+        limit,
+    })
+}
+
+fn resolve_current_ref(
+    repo: &Repository,
+    branch_name: &str,
+    head_oid: Oid,
+) -> Result<GitHistoryItemRef, GitError> {
+    if branch_name != "HEAD" {
+        return Ok(GitHistoryItemRef {
+            id: format!("refs/heads/{branch_name}"),
+            name: branch_name.to_string(),
+            revision: Some(head_oid.to_string()),
+            category: Some(GitHistoryRefCategory::Branches),
+        });
+    }
+    let _ = repo;
+    Ok(GitHistoryItemRef {
+        id: head_oid.to_string(),
+        name: short_oid(head_oid),
+        revision: Some(head_oid.to_string()),
+        category: Some(GitHistoryRefCategory::Commits),
+    })
+}
+
+fn resolve_upstream_ref(
+    repo: &Repository,
+    branch_name: &str,
+) -> Result<Option<GitHistoryItemRef>, GitError> {
+    if branch_name == "HEAD" {
+        return Ok(None);
+    }
+    let Ok(local) = repo.find_branch(branch_name, BranchType::Local) else {
+        return Ok(None);
+    };
+    let Ok(upstream) = local.upstream() else {
+        return Ok(None);
+    };
+    let Some(oid) = upstream.get().target() else {
+        return Ok(None);
+    };
+    let full_name = upstream.get().name().unwrap_or_default();
+    Ok(Some(history_ref_from_full_name(
+        full_name,
+        upstream
+            .name()
+            .map_err(GitError::from_git2)?
+            .unwrap_or(full_name),
+        oid,
+    )))
+}
+
+fn resolve_named_ref(
+    repo: &Repository,
+    name: Option<&str>,
+) -> Result<Option<GitHistoryItemRef>, GitError> {
+    let Some(name) = name.map(str::trim).filter(|name| !name.is_empty()) else {
+        return Ok(None);
+    };
+    if name.starts_with('-') {
+        return Ok(None);
+    }
+    let object = match repo.revparse_single(name) {
+        Ok(object) => object,
+        Err(error)
+            if matches!(
+                error.code(),
+                ErrorCode::NotFound | ErrorCode::Ambiguous | ErrorCode::InvalidSpec
+            ) =>
+        {
+            return Ok(None);
+        }
+        Err(error) => return Err(GitError::from_git2(error)),
+    };
+    let commit = match object.peel_to_commit() {
+        Ok(commit) => commit,
+        Err(_) => return Ok(None),
+    };
+    let full_name = repo
+        .find_reference(name)
+        .ok()
+        .and_then(|reference| reference.name().ok().map(ToString::to_string));
+    Ok(Some(history_ref_from_full_name(
+        full_name.as_deref().unwrap_or(name),
+        name,
+        commit.id(),
+    )))
+}
+
+fn refs_by_oid(repo: &Repository) -> Result<HashMap<Oid, Vec<GitHistoryItemRef>>, GitError> {
+    let mut output: HashMap<Oid, Vec<GitHistoryItemRef>> = HashMap::new();
+    let references = repo.references().map_err(GitError::from_git2)?;
+    for reference in references {
+        let reference = reference.map_err(GitError::from_git2)?;
+        let Ok(full_name) = reference.name() else {
+            continue;
+        };
+        if full_name == "HEAD" || full_name.ends_with("/HEAD") {
+            continue;
+        }
+        let category = category_for_ref(full_name);
+        if category.is_none() {
+            continue;
+        }
+        let oid = if category == Some(GitHistoryRefCategory::Tags) {
+            reference
+                .peel_to_commit()
+                .ok()
+                .map(|commit| commit.id())
+                .or_else(|| reference.target())
+        } else {
+            reference
+                .target()
+                .or_else(|| reference.peel_to_commit().ok().map(|commit| commit.id()))
+        };
+        let Some(oid) = oid else {
+            continue;
+        };
+        output
+            .entry(oid)
+            .or_default()
+            .push(history_ref_from_full_name(
+                full_name,
+                short_name_for_ref(full_name),
+                oid,
+            ));
+    }
+    for refs in output.values_mut() {
+        refs.sort_by(compare_refs);
+    }
+    Ok(output)
+}
+
+fn commit_touches_workspace(
+    repo: &Repository,
+    paths: &GitPathContext,
+    commit: &git2::Commit<'_>,
+) -> Result<bool, GitError> {
+    if paths.is_workspace_root() {
+        return Ok(true);
+    }
+    let commit_tree = commit.tree().map_err(GitError::from_git2)?;
+    let parent_tree = commit
+        .parent_id(0)
+        .ok()
+        .map(|oid| {
+            repo.find_commit(oid)
+                .and_then(|commit| commit.tree())
+                .map_err(GitError::from_git2)
+        })
+        .transpose()?;
+    let diff = repo
+        .diff_tree_to_tree(parent_tree.as_ref(), Some(&commit_tree), None)
+        .map_err(GitError::from_git2)?;
+    for delta in diff.deltas() {
+        let new_path = delta.new_file().path().map(repo_path_string);
+        let old_path = delta.old_file().path().map(repo_path_string);
+        if new_path
+            .as_deref()
+            .is_some_and(|path| paths.to_workspace_path(path).is_some())
+            || old_path
+                .as_deref()
+                .is_some_and(|path| paths.to_workspace_path(path).is_some())
+        {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+fn range_has_workspace_changes(
+    repo: &Repository,
+    paths: &GitPathContext,
+    base_oid: Oid,
+    tip_oid: Oid,
+) -> Result<bool, GitError> {
+    if tip_oid == base_oid {
+        return Ok(false);
+    }
+    if paths.is_workspace_root() {
+        return Ok(true);
+    }
+    let mut revwalk = repo.revwalk().map_err(GitError::from_git2)?;
+    revwalk.push(tip_oid).map_err(GitError::from_git2)?;
+    revwalk.hide(base_oid).map_err(GitError::from_git2)?;
+    for oid in revwalk {
+        let oid = oid.map_err(GitError::from_git2)?;
+        let commit = repo.find_commit(oid).map_err(GitError::from_git2)?;
+        if commit_touches_workspace(repo, paths, &commit)? {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+fn rewrite_history_parents_to_visible_ancestors(
+    repo: &Repository,
+    visible_ids: &HashSet<Oid>,
+    items: &mut [GitHistoryItem],
+) -> Result<(), GitError> {
+    for item in items {
+        let mut seen = HashSet::new();
+        let mut parent_ids = Vec::new();
+        for parent_id in &item.parent_ids {
+            let Ok(parent_oid) = Oid::from_str(parent_id) else {
+                continue;
+            };
+            for ancestor_oid in scoped_visible_ancestor_oids(repo, visible_ids, parent_oid)? {
+                if seen.insert(ancestor_oid) {
+                    parent_ids.push(ancestor_oid.to_string());
+                }
+            }
+        }
+        item.parent_ids = parent_ids;
+    }
+    Ok(())
+}
+
+fn scoped_visible_ancestor_oids(
+    repo: &Repository,
+    visible_ids: &HashSet<Oid>,
+    start_oid: Oid,
+) -> Result<Vec<Oid>, GitError> {
+    if visible_ids.contains(&start_oid) {
+        return Ok(vec![start_oid]);
+    }
+    let mut output = Vec::new();
+    let mut seen = HashSet::from([start_oid]);
+    let mut queue = VecDeque::from([start_oid]);
+    while let Some(oid) = queue.pop_front() {
+        let commit = repo.find_commit(oid).map_err(GitError::from_git2)?;
+        for parent_oid in commit.parent_ids() {
+            if !seen.insert(parent_oid) {
+                continue;
+            }
+            if visible_ids.contains(&parent_oid) {
+                output.push(parent_oid);
+            } else {
+                queue.push_back(parent_oid);
+            }
+        }
+    }
+    Ok(output)
+}
+
+fn history_item_from_commit(
+    commit: &git2::Commit<'_>,
+    references: Option<&Vec<GitHistoryItemRef>>,
+) -> GitHistoryItem {
+    let message = commit.message().unwrap_or_default().trim_end().to_string();
+    let subject = message
+        .lines()
+        .next()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .unwrap_or("(no commit message)")
+        .to_string();
+    GitHistoryItem {
+        id: commit.id().to_string(),
+        parent_ids: commit.parent_ids().map(|oid| oid.to_string()).collect(),
+        subject,
+        message,
+        display_id: Some(short_oid(commit.id())),
+        author: commit.author().name().ok().map(ToString::to_string),
+        author_email: commit.author().email().ok().map(ToString::to_string),
+        timestamp: Some(commit.author().when().seconds().saturating_mul(1000)),
+        references: references.cloned().unwrap_or_default(),
+    }
+}
+
+fn history_ref_from_full_name(full_name: &str, fallback_name: &str, oid: Oid) -> GitHistoryItemRef {
+    let category = category_for_ref(full_name).unwrap_or(GitHistoryRefCategory::Commits);
+    GitHistoryItemRef {
+        id: full_name.to_string(),
+        name: short_name_for_ref(full_name)
+            .strip_prefix("tag: ")
+            .unwrap_or_else(|| short_name_for_ref(fallback_name))
+            .to_string(),
+        revision: Some(oid.to_string()),
+        category: Some(category),
+    }
+}
+
+fn category_for_ref(full_name: &str) -> Option<GitHistoryRefCategory> {
+    if full_name.starts_with("refs/heads/") {
+        Some(GitHistoryRefCategory::Branches)
+    } else if full_name.starts_with("refs/remotes/") {
+        Some(GitHistoryRefCategory::RemoteBranches)
+    } else if full_name.starts_with("refs/tags/") {
+        Some(GitHistoryRefCategory::Tags)
+    } else {
+        None
+    }
+}
+
+fn short_name_for_ref(full_name: &str) -> &str {
+    full_name
+        .strip_prefix("refs/heads/")
+        .or_else(|| full_name.strip_prefix("refs/remotes/"))
+        .or_else(|| full_name.strip_prefix("refs/tags/"))
+        .unwrap_or(full_name)
+}
+
+fn compare_refs(a: &GitHistoryItemRef, b: &GitHistoryItemRef) -> std::cmp::Ordering {
+    ref_order(a)
+        .cmp(&ref_order(b))
+        .then_with(|| a.name.cmp(&b.name))
+}
+
+fn ref_order(reference: &GitHistoryItemRef) -> u8 {
+    match reference.category {
+        Some(GitHistoryRefCategory::Branches) => 1,
+        Some(GitHistoryRefCategory::RemoteBranches) => 2,
+        Some(GitHistoryRefCategory::Tags) => 3,
+        _ => 99,
+    }
+}
+
+fn short_oid(oid: Oid) -> String {
+    oid.to_string().chars().take(7).collect()
+}
+
+fn repo_path_string(path: &Path) -> String {
+    path.components()
+        .filter_map(|component| {
+            let text = component.as_os_str().to_string_lossy();
+            if text.is_empty() {
+                None
+            } else {
+                Some(text.to_string())
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("/")
+}

--- a/rust/src/api/git_tests.rs
+++ b/rust/src/api/git_tests.rs
@@ -161,6 +161,170 @@ fn repository_state_includes_head_message() {
 }
 
 #[test]
+fn git_history_includes_upstream_only_commits() {
+    let source = init_repo();
+    let bare = tempfile::tempdir().expect("bare remote");
+    run_git(bare.path(), &["init", "--bare"]);
+    run_git(
+        source.path(),
+        &["remote", "add", "origin", &path_str(bare.path())],
+    );
+    run_git(source.path(), &["push", "-u", "origin", "main"]);
+    run_git(bare.path(), &["symbolic-ref", "HEAD", "refs/heads/main"]);
+
+    let clone_parent = tempfile::tempdir().expect("clone parent");
+    run_git(
+        clone_parent.path(),
+        &["clone", &path_str(bare.path()), "checkout"],
+    );
+    let clone_path = clone_parent.path().join("checkout");
+    configure_git_identity(&clone_path);
+
+    commit_file(
+        source.path(),
+        "remote-only.txt",
+        "remote\n",
+        "remote only change",
+    );
+    run_git(source.path(), &["push"]);
+    run_git(&clone_path, &["fetch", "origin"]);
+
+    let history = git_history(path_str(&clone_path), Some(50), None).unwrap();
+
+    assert!(history.has_incoming_changes);
+    assert_eq!(history.remote_ref.unwrap().name, "origin/main");
+    assert!(history
+        .items
+        .iter()
+        .any(|item| item.subject == "remote only change"));
+}
+
+#[test]
+fn git_history_refs_peel_annotated_tags_to_commits() {
+    let repo = init_repo();
+    run_git(repo.path(), &["tag", "-a", "v1.0.0", "-m", "release v1"]);
+
+    let history = git_history(path_str(repo.path()), Some(50), None).unwrap();
+
+    let initial = history
+        .items
+        .iter()
+        .find(|item| item.subject == "initial")
+        .expect("initial commit in history");
+    assert!(initial.references.iter().any(|reference| {
+        reference.name == "v1.0.0" && reference.category == Some(GitHistoryRefCategory::Tags)
+    }));
+}
+
+#[test]
+fn git_history_filters_commits_for_scoped_workspace_path() {
+    let repo = init_repo();
+    std::fs::create_dir_all(repo.path().join("packages/app/lib")).expect("create app dir");
+    std::fs::create_dir_all(repo.path().join("packages/other/lib")).expect("create other dir");
+    commit_file(
+        repo.path(),
+        "packages/app/lib/main.dart",
+        "app\n",
+        "app change",
+    );
+    commit_file(repo.path(), "README.md", "hello\nroot\n", "root change");
+    commit_file(
+        repo.path(),
+        "packages/other/lib/main.dart",
+        "other\n",
+        "other change",
+    );
+    commit_file(
+        repo.path(),
+        "packages/app/lib/main.dart",
+        "app\napp 2\n",
+        "app change 2",
+    );
+
+    let history = git_history(path_str(&repo.path().join("packages/app")), Some(50), None).unwrap();
+    let subjects = history
+        .items
+        .iter()
+        .map(|item| item.subject.as_str())
+        .collect::<Vec<_>>();
+
+    assert!(subjects.contains(&"app change"));
+    assert!(subjects.contains(&"app change 2"));
+    assert!(!subjects.contains(&"other change"));
+    assert!(!subjects.contains(&"root change"));
+    assert!(!subjects.contains(&"initial"));
+    let older = history
+        .items
+        .iter()
+        .find(|item| item.subject == "app change")
+        .expect("older scoped commit");
+    let newer = history
+        .items
+        .iter()
+        .find(|item| item.subject == "app change 2")
+        .expect("newer scoped commit");
+    assert_eq!(newer.parent_ids, vec![older.id.clone()]);
+}
+
+#[test]
+fn git_history_suppresses_divergence_markers_outside_scoped_workspace_path() {
+    let source = init_repo();
+    std::fs::create_dir_all(source.path().join("packages/app/lib")).expect("create app dir");
+    std::fs::create_dir_all(source.path().join("packages/other/lib")).expect("create other dir");
+    commit_file(
+        source.path(),
+        "packages/app/lib/main.dart",
+        "app\n",
+        "app change",
+    );
+    let bare = tempfile::tempdir().expect("bare remote");
+    run_git(bare.path(), &["init", "--bare"]);
+    run_git(
+        source.path(),
+        &["remote", "add", "origin", &path_str(bare.path())],
+    );
+    run_git(source.path(), &["push", "-u", "origin", "main"]);
+    run_git(bare.path(), &["symbolic-ref", "HEAD", "refs/heads/main"]);
+
+    let clone_parent = tempfile::tempdir().expect("clone parent");
+    run_git(
+        clone_parent.path(),
+        &["clone", &path_str(bare.path()), "checkout"],
+    );
+    let clone_path = clone_parent.path().join("checkout");
+    configure_git_identity(&clone_path);
+
+    commit_file(
+        source.path(),
+        "packages/other/remote.dart",
+        "remote\n",
+        "remote other change",
+    );
+    run_git(source.path(), &["push"]);
+    run_git(&clone_path, &["fetch", "origin"]);
+    std::fs::create_dir_all(clone_path.join("packages/other")).expect("create clone other dir");
+    commit_file(
+        &clone_path,
+        "packages/other/local.dart",
+        "local\n",
+        "local other change",
+    );
+
+    let history = git_history(path_str(&clone_path.join("packages/app")), Some(50), None).unwrap();
+    let subjects = history
+        .items
+        .iter()
+        .map(|item| item.subject.as_str())
+        .collect::<Vec<_>>();
+
+    assert!(!history.has_incoming_changes);
+    assert!(!history.has_outgoing_changes);
+    assert!(subjects.contains(&"app change"));
+    assert!(!subjects.contains(&"remote other change"));
+    assert!(!subjects.contains(&"local other change"));
+}
+
+#[test]
 fn creates_lists_and_removes_worktree() {
     let repo = init_repo();
     let worktree_base = tempfile::tempdir().expect("tempdir");

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -38,7 +38,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.12.0";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -1983816553;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -1007517553;
 
 // Section: executor
 
@@ -338,12 +338,12 @@ fn wire__crate__api__git__delete_branch_impl(
                 flutter_rust_bridge::for_generated::SseDeserializer::new(message);
             let api_repo_path = <String>::sse_decode(&mut deserializer);
             let api_branch = <String>::sse_decode(&mut deserializer);
-            let api__force = <bool>::sse_decode(&mut deserializer);
+            let api_force = <bool>::sse_decode(&mut deserializer);
             deserializer.end();
             move |context| {
                 transform_result_sse::<_, crate::api::git::GitError>((move || {
                     let output_ok =
-                        crate::api::git::delete_branch(api_repo_path, api_branch, api__force)?;
+                        crate::api::git::delete_branch(api_repo_path, api_branch, api_force)?;
                     Ok(output_ok)
                 })())
             }
@@ -453,6 +453,83 @@ fn wire__crate__api__git__git_commit_amend_impl(
             move |context| {
                 transform_result_sse::<_, crate::api::git::GitError>((move || {
                     let output_ok = crate::api::git::git_commit_amend(api_path, api_message)?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
+fn wire__crate__api__git__git_commit_compare_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "git_commit_compare",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_path = <String>::sse_decode(&mut deserializer);
+            let api_commit_id = <String>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, crate::api::git::GitError>((move || {
+                    let output_ok = crate::api::git::git_commit_compare(api_path, api_commit_id)?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
+fn wire__crate__api__git__git_commit_diff_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "git_commit_diff",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_path = <String>::sse_decode(&mut deserializer);
+            let api_commit_oid = <String>::sse_decode(&mut deserializer);
+            let api_parent_oid = <Option<String>>::sse_decode(&mut deserializer);
+            let api_file_path = <Option<String>>::sse_decode(&mut deserializer);
+            let api_old_path = <Option<String>>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, crate::api::git::GitError>((move || {
+                    let output_ok = crate::api::git::git_commit_diff(
+                        api_path,
+                        api_commit_oid,
+                        api_parent_oid,
+                        api_file_path,
+                        api_old_path,
+                    )?;
                     Ok(output_ok)
                 })())
             }
@@ -625,6 +702,42 @@ fn wire__crate__api__git__git_fetch_impl(
             move |context| {
                 transform_result_sse::<_, crate::api::git::GitError>((move || {
                     let output_ok = crate::api::git::git_fetch(api_path)?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
+fn wire__crate__api__git__git_history_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "git_history",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_path = <String>::sse_decode(&mut deserializer);
+            let api_limit = <Option<u32>>::sse_decode(&mut deserializer);
+            let api_base_ref = <Option<String>>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, crate::api::git::GitError>((move || {
+                    let output_ok =
+                        crate::api::git::git_history(api_path, api_limit, api_base_ref)?;
                     Ok(output_ok)
                 })())
             }
@@ -2408,6 +2521,72 @@ impl SseDecode for crate::api::git::GitChangeTreeRowKind {
     }
 }
 
+impl SseDecode for crate::api::git::GitCommitChangeEntry {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_path = <String>::sse_decode(deserializer);
+        let mut var_oldPath = <Option<String>>::sse_decode(deserializer);
+        let mut var_status = <crate::api::git::GitChangeStatus>::sse_decode(deserializer);
+        let mut var_added = <Option<u32>>::sse_decode(deserializer);
+        let mut var_removed = <Option<u32>>::sse_decode(deserializer);
+        return crate::api::git::GitCommitChangeEntry {
+            path: var_path,
+            old_path: var_oldPath,
+            status: var_status,
+            added: var_added,
+            removed: var_removed,
+        };
+    }
+}
+
+impl SseDecode for crate::api::git::GitCommitCompareResult {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_summary = <crate::api::git::GitCommitCompareSummary>::sse_decode(deserializer);
+        let mut var_entries =
+            <Vec<crate::api::git::GitCommitChangeEntry>>::sse_decode(deserializer);
+        return crate::api::git::GitCommitCompareResult {
+            summary: var_summary,
+            entries: var_entries,
+        };
+    }
+}
+
+impl SseDecode for crate::api::git::GitCommitCompareStatus {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut inner = <i32>::sse_decode(deserializer);
+        return match inner {
+            0 => crate::api::git::GitCommitCompareStatus::Ready,
+            1 => crate::api::git::GitCommitCompareStatus::InvalidCommit,
+            2 => crate::api::git::GitCommitCompareStatus::Error,
+            _ => unreachable!("Invalid variant for GitCommitCompareStatus: {}", inner),
+        };
+    }
+}
+
+impl SseDecode for crate::api::git::GitCommitCompareSummary {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_commitOid = <String>::sse_decode(deserializer);
+        let mut var_parentOid = <Option<String>>::sse_decode(deserializer);
+        let mut var_compareRef = <String>::sse_decode(deserializer);
+        let mut var_baseRef = <String>::sse_decode(deserializer);
+        let mut var_changedFiles = <u32>::sse_decode(deserializer);
+        let mut var_status = <crate::api::git::GitCommitCompareStatus>::sse_decode(deserializer);
+        let mut var_errorMessage = <Option<String>>::sse_decode(deserializer);
+        return crate::api::git::GitCommitCompareSummary {
+            commit_oid: var_commitOid,
+            parent_oid: var_parentOid,
+            compare_ref: var_compareRef,
+            base_ref: var_baseRef,
+            changed_files: var_changedFiles,
+            status: var_status,
+            error_message: var_errorMessage,
+        };
+    }
+}
+
 impl SseDecode for crate::api::git::GitDiffFile {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -2512,6 +2691,93 @@ impl SseDecode for crate::api::git::GitErrorKind {
             15 => crate::api::git::GitErrorKind::MissingIdentity,
             16 => crate::api::git::GitErrorKind::Internal,
             _ => unreachable!("Invalid variant for GitErrorKind: {}", inner),
+        };
+    }
+}
+
+impl SseDecode for crate::api::git::GitHistoryItem {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_id = <String>::sse_decode(deserializer);
+        let mut var_parentIds = <Vec<String>>::sse_decode(deserializer);
+        let mut var_subject = <String>::sse_decode(deserializer);
+        let mut var_message = <String>::sse_decode(deserializer);
+        let mut var_displayId = <Option<String>>::sse_decode(deserializer);
+        let mut var_author = <Option<String>>::sse_decode(deserializer);
+        let mut var_authorEmail = <Option<String>>::sse_decode(deserializer);
+        let mut var_timestamp = <Option<i64>>::sse_decode(deserializer);
+        let mut var_references =
+            <Vec<crate::api::git::GitHistoryItemRef>>::sse_decode(deserializer);
+        return crate::api::git::GitHistoryItem {
+            id: var_id,
+            parent_ids: var_parentIds,
+            subject: var_subject,
+            message: var_message,
+            display_id: var_displayId,
+            author: var_author,
+            author_email: var_authorEmail,
+            timestamp: var_timestamp,
+            references: var_references,
+        };
+    }
+}
+
+impl SseDecode for crate::api::git::GitHistoryItemRef {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_id = <String>::sse_decode(deserializer);
+        let mut var_name = <String>::sse_decode(deserializer);
+        let mut var_revision = <Option<String>>::sse_decode(deserializer);
+        let mut var_category =
+            <Option<crate::api::git::GitHistoryRefCategory>>::sse_decode(deserializer);
+        return crate::api::git::GitHistoryItemRef {
+            id: var_id,
+            name: var_name,
+            revision: var_revision,
+            category: var_category,
+        };
+    }
+}
+
+impl SseDecode for crate::api::git::GitHistoryRefCategory {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut inner = <i32>::sse_decode(deserializer);
+        return match inner {
+            0 => crate::api::git::GitHistoryRefCategory::Branches,
+            1 => crate::api::git::GitHistoryRefCategory::RemoteBranches,
+            2 => crate::api::git::GitHistoryRefCategory::Tags,
+            3 => crate::api::git::GitHistoryRefCategory::Commits,
+            _ => unreachable!("Invalid variant for GitHistoryRefCategory: {}", inner),
+        };
+    }
+}
+
+impl SseDecode for crate::api::git::GitHistoryResult {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_items = <Vec<crate::api::git::GitHistoryItem>>::sse_decode(deserializer);
+        let mut var_currentRef =
+            <Option<crate::api::git::GitHistoryItemRef>>::sse_decode(deserializer);
+        let mut var_remoteRef =
+            <Option<crate::api::git::GitHistoryItemRef>>::sse_decode(deserializer);
+        let mut var_baseRef =
+            <Option<crate::api::git::GitHistoryItemRef>>::sse_decode(deserializer);
+        let mut var_mergeBase = <Option<String>>::sse_decode(deserializer);
+        let mut var_hasIncomingChanges = <bool>::sse_decode(deserializer);
+        let mut var_hasOutgoingChanges = <bool>::sse_decode(deserializer);
+        let mut var_hasMore = <bool>::sse_decode(deserializer);
+        let mut var_limit = <u32>::sse_decode(deserializer);
+        return crate::api::git::GitHistoryResult {
+            items: var_items,
+            current_ref: var_currentRef,
+            remote_ref: var_remoteRef,
+            base_ref: var_baseRef,
+            merge_base: var_mergeBase,
+            has_incoming_changes: var_hasIncomingChanges,
+            has_outgoing_changes: var_hasOutgoingChanges,
+            has_more: var_hasMore,
+            limit: var_limit,
         };
     }
 }
@@ -2654,6 +2920,20 @@ impl SseDecode for Vec<crate::api::git::GitChangeTreeRow> {
     }
 }
 
+impl SseDecode for Vec<crate::api::git::GitCommitChangeEntry> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut len_ = <i32>::sse_decode(deserializer);
+        let mut ans_ = Vec::with_capacity(len_ as usize);
+        for idx_ in 0..len_ {
+            ans_.push(<crate::api::git::GitCommitChangeEntry>::sse_decode(
+                deserializer,
+            ));
+        }
+        return ans_;
+    }
+}
+
 impl SseDecode for Vec<crate::api::git::GitDiffFile> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -2673,6 +2953,32 @@ impl SseDecode for Vec<crate::api::git::GitDiffLine> {
         let mut ans_ = Vec::with_capacity(len_ as usize);
         for idx_ in 0..len_ {
             ans_.push(<crate::api::git::GitDiffLine>::sse_decode(deserializer));
+        }
+        return ans_;
+    }
+}
+
+impl SseDecode for Vec<crate::api::git::GitHistoryItem> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut len_ = <i32>::sse_decode(deserializer);
+        let mut ans_ = Vec::with_capacity(len_ as usize);
+        for idx_ in 0..len_ {
+            ans_.push(<crate::api::git::GitHistoryItem>::sse_decode(deserializer));
+        }
+        return ans_;
+    }
+}
+
+impl SseDecode for Vec<crate::api::git::GitHistoryItemRef> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut len_ = <i32>::sse_decode(deserializer);
+        let mut ans_ = Vec::with_capacity(len_ as usize);
+        for idx_ in 0..len_ {
+            ans_.push(<crate::api::git::GitHistoryItemRef>::sse_decode(
+                deserializer,
+            ));
         }
         return ans_;
     }
@@ -2893,6 +3199,43 @@ impl SseDecode for Option<crate::api::git::GitChangeEntry> {
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         if (<bool>::sse_decode(deserializer)) {
             return Some(<crate::api::git::GitChangeEntry>::sse_decode(deserializer));
+        } else {
+            return None;
+        }
+    }
+}
+
+impl SseDecode for Option<crate::api::git::GitHistoryItemRef> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        if (<bool>::sse_decode(deserializer)) {
+            return Some(<crate::api::git::GitHistoryItemRef>::sse_decode(
+                deserializer,
+            ));
+        } else {
+            return None;
+        }
+    }
+}
+
+impl SseDecode for Option<crate::api::git::GitHistoryRefCategory> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        if (<bool>::sse_decode(deserializer)) {
+            return Some(<crate::api::git::GitHistoryRefCategory>::sse_decode(
+                deserializer,
+            ));
+        } else {
+            return None;
+        }
+    }
+}
+
+impl SseDecode for Option<i64> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        if (<bool>::sse_decode(deserializer)) {
+            return Some(<i64>::sse_decode(deserializer));
         } else {
             return None;
         }
@@ -3462,163 +3805,166 @@ fn pde_ffi_dispatcher_primary_impl(
         ),
         10 => wire__crate__api__git__git_commit_impl(port, ptr, rust_vec_len, data_len),
         11 => wire__crate__api__git__git_commit_amend_impl(port, ptr, rust_vec_len, data_len),
-        12 => wire__crate__api__git__git_diff_impl(port, ptr, rust_vec_len, data_len),
-        13 => wire__crate__api__git__git_diff_all_impl(port, ptr, rust_vec_len, data_len),
-        14 => wire__crate__api__git__git_discard_impl(port, ptr, rust_vec_len, data_len),
-        15 => wire__crate__api__git__git_discard_area_impl(port, ptr, rust_vec_len, data_len),
-        16 => wire__crate__api__git__git_fetch_impl(port, ptr, rust_vec_len, data_len),
-        17 => wire__crate__api__git__git_list_stashes_impl(port, ptr, rust_vec_len, data_len),
-        18 => wire__crate__api__git__git_pull_impl(port, ptr, rust_vec_len, data_len),
-        19 => wire__crate__api__git__git_push_impl(port, ptr, rust_vec_len, data_len),
-        20 => wire__crate__api__git__git_repository_state_impl(port, ptr, rust_vec_len, data_len),
-        21 => wire__crate__api__git__git_stage_impl(port, ptr, rust_vec_len, data_len),
-        22 => wire__crate__api__git__git_stage_area_impl(port, ptr, rust_vec_len, data_len),
-        23 => wire__crate__api__git__git_stash_impl(port, ptr, rust_vec_len, data_len),
-        24 => wire__crate__api__git__git_stash_pop_impl(port, ptr, rust_vec_len, data_len),
-        25 => wire__crate__api__git__git_status_impl(port, ptr, rust_vec_len, data_len),
-        26 => wire__crate__api__git__git_status_for_path_impl(port, ptr, rust_vec_len, data_len),
-        27 => wire__crate__api__git__git_unstage_impl(port, ptr, rust_vec_len, data_len),
-        28 => wire__crate__api__git__git_unstage_area_impl(port, ptr, rust_vec_len, data_len),
-        29 => wire__crate__api__init_app_impl(port, ptr, rust_vec_len, data_len),
-        30 => wire__crate__api__git__is_git_repository_impl(port, ptr, rust_vec_len, data_len),
-        31 => wire__crate__api__git__is_valid_branch_name_impl(port, ptr, rust_vec_len, data_len),
-        32 => wire__crate__api__git__list_branches_impl(port, ptr, rust_vec_len, data_len),
-        33 => wire__crate__api__workspace_files__list_workspace_children_impl(
+        12 => wire__crate__api__git__git_commit_compare_impl(port, ptr, rust_vec_len, data_len),
+        13 => wire__crate__api__git__git_commit_diff_impl(port, ptr, rust_vec_len, data_len),
+        14 => wire__crate__api__git__git_diff_impl(port, ptr, rust_vec_len, data_len),
+        15 => wire__crate__api__git__git_diff_all_impl(port, ptr, rust_vec_len, data_len),
+        16 => wire__crate__api__git__git_discard_impl(port, ptr, rust_vec_len, data_len),
+        17 => wire__crate__api__git__git_discard_area_impl(port, ptr, rust_vec_len, data_len),
+        18 => wire__crate__api__git__git_fetch_impl(port, ptr, rust_vec_len, data_len),
+        19 => wire__crate__api__git__git_history_impl(port, ptr, rust_vec_len, data_len),
+        20 => wire__crate__api__git__git_list_stashes_impl(port, ptr, rust_vec_len, data_len),
+        21 => wire__crate__api__git__git_pull_impl(port, ptr, rust_vec_len, data_len),
+        22 => wire__crate__api__git__git_push_impl(port, ptr, rust_vec_len, data_len),
+        23 => wire__crate__api__git__git_repository_state_impl(port, ptr, rust_vec_len, data_len),
+        24 => wire__crate__api__git__git_stage_impl(port, ptr, rust_vec_len, data_len),
+        25 => wire__crate__api__git__git_stage_area_impl(port, ptr, rust_vec_len, data_len),
+        26 => wire__crate__api__git__git_stash_impl(port, ptr, rust_vec_len, data_len),
+        27 => wire__crate__api__git__git_stash_pop_impl(port, ptr, rust_vec_len, data_len),
+        28 => wire__crate__api__git__git_status_impl(port, ptr, rust_vec_len, data_len),
+        29 => wire__crate__api__git__git_status_for_path_impl(port, ptr, rust_vec_len, data_len),
+        30 => wire__crate__api__git__git_unstage_impl(port, ptr, rust_vec_len, data_len),
+        31 => wire__crate__api__git__git_unstage_area_impl(port, ptr, rust_vec_len, data_len),
+        32 => wire__crate__api__init_app_impl(port, ptr, rust_vec_len, data_len),
+        33 => wire__crate__api__git__is_git_repository_impl(port, ptr, rust_vec_len, data_len),
+        34 => wire__crate__api__git__is_valid_branch_name_impl(port, ptr, rust_vec_len, data_len),
+        35 => wire__crate__api__git__list_branches_impl(port, ptr, rust_vec_len, data_len),
+        36 => wire__crate__api__workspace_files__list_workspace_children_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        34 => wire__crate__api__git__list_worktrees_impl(port, ptr, rust_vec_len, data_len),
-        35 => wire__crate__api__workspace_files__move_workspace_entry_impl(
+        37 => wire__crate__api__git__list_worktrees_impl(port, ptr, rust_vec_len, data_len),
+        38 => wire__crate__api__workspace_files__move_workspace_entry_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        36 => wire__crate__api__workspace_search__preview_workspace_replace_impl(
+        39 => wire__crate__api__workspace_search__preview_workspace_replace_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        37 => wire__crate__api__workspace_files__project_workspace_explorer_tree_impl(
+        40 => wire__crate__api__workspace_files__project_workspace_explorer_tree_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        38 => wire__crate__api__workspace_files__read_workspace_editor_text_file_impl(
+        41 => wire__crate__api__workspace_files__read_workspace_editor_text_file_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        39 => wire__crate__api__workspace_files__read_workspace_text_file_impl(
+        42 => wire__crate__api__workspace_files__read_workspace_text_file_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        40 => wire__crate__api__git__refresh_source_branch_impl(port, ptr, rust_vec_len, data_len),
-        41 => wire__crate__api__git__remove_worktree_impl(port, ptr, rust_vec_len, data_len),
-        42 => wire__crate__api__workspace_files__rename_workspace_entry_impl(
+        43 => wire__crate__api__git__refresh_source_branch_impl(port, ptr, rust_vec_len, data_len),
+        44 => wire__crate__api__git__remove_worktree_impl(port, ptr, rust_vec_len, data_len),
+        45 => wire__crate__api__workspace_files__rename_workspace_entry_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        43 => wire__crate__api__merman_viewer__render_merman_workspace_file_impl(
+        46 => wire__crate__api__merman_viewer__render_merman_workspace_file_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        44 => wire__crate__api__workspace_search__replace_workspace_matches_impl(
+        47 => wire__crate__api__workspace_search__replace_workspace_matches_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        45 => wire__crate__api__workspace_search__search_workspace_impl(
+        48 => wire__crate__api__workspace_search__search_workspace_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        46 => wire__crate__api__agent_hooks__set_agent_hook_enabled_agents_impl(
+        49 => wire__crate__api__agent_hooks__set_agent_hook_enabled_agents_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        47 => wire__crate__api__agent_hooks__start_agent_hook_receiver_impl(
+        50 => wire__crate__api__agent_hooks__start_agent_hook_receiver_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        48 => wire__crate__api__workspace_files__start_source_control_watcher_impl(
+        51 => wire__crate__api__workspace_files__start_source_control_watcher_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        49 => wire__crate__api__workspace_files__start_workspace_explorer_watcher_impl(
+        52 => wire__crate__api__workspace_files__start_workspace_explorer_watcher_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        50 => wire__crate__api__agent_hooks__stop_agent_hook_receiver_impl(
+        53 => wire__crate__api__agent_hooks__stop_agent_hook_receiver_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        51 => wire__crate__api__workspace_files__stop_source_control_watcher_impl(
+        54 => wire__crate__api__workspace_files__stop_source_control_watcher_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        52 => wire__crate__api__workspace_files__stop_workspace_explorer_watcher_impl(
+        55 => wire__crate__api__workspace_files__stop_workspace_explorer_watcher_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        53 => wire__crate__api__workspace_files__update_workspace_explorer_watcher_impl(
+        56 => wire__crate__api__workspace_files__update_workspace_explorer_watcher_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        54 => wire__crate__api__agent_hooks__watch_agent_hook_event_batches_impl(
+        57 => wire__crate__api__agent_hooks__watch_agent_hook_event_batches_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        55 => wire__crate__api__workspace_files__watch_source_control_events_impl(
+        58 => wire__crate__api__workspace_files__watch_source_control_events_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        56 => wire__crate__api__workspace_files__watch_workspace_explorer_events_impl(
+        59 => wire__crate__api__workspace_files__watch_workspace_explorer_events_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        57 => wire__crate__api__workspace_files__write_workspace_editor_text_file_impl(
+        60 => wire__crate__api__workspace_files__write_workspace_editor_text_file_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        58 => wire__crate__api__workspace_files__write_workspace_text_file_impl(
+        61 => wire__crate__api__workspace_files__write_workspace_text_file_impl(
             port,
             ptr,
             rust_vec_len,
@@ -3852,6 +4198,99 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::git::GitChangeTreeRowKind>
     }
 }
 // Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::git::GitCommitChangeEntry {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.path.into_into_dart().into_dart(),
+            self.old_path.into_into_dart().into_dart(),
+            self.status.into_into_dart().into_dart(),
+            self.added.into_into_dart().into_dart(),
+            self.removed.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::git::GitCommitChangeEntry
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::git::GitCommitChangeEntry>
+    for crate::api::git::GitCommitChangeEntry
+{
+    fn into_into_dart(self) -> crate::api::git::GitCommitChangeEntry {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::git::GitCommitCompareResult {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.summary.into_into_dart().into_dart(),
+            self.entries.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::git::GitCommitCompareResult
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::git::GitCommitCompareResult>
+    for crate::api::git::GitCommitCompareResult
+{
+    fn into_into_dart(self) -> crate::api::git::GitCommitCompareResult {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::git::GitCommitCompareStatus {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        match self {
+            Self::Ready => 0.into_dart(),
+            Self::InvalidCommit => 1.into_dart(),
+            Self::Error => 2.into_dart(),
+            _ => unreachable!(),
+        }
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::git::GitCommitCompareStatus
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::git::GitCommitCompareStatus>
+    for crate::api::git::GitCommitCompareStatus
+{
+    fn into_into_dart(self) -> crate::api::git::GitCommitCompareStatus {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::git::GitCommitCompareSummary {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.commit_oid.into_into_dart().into_dart(),
+            self.parent_oid.into_into_dart().into_dart(),
+            self.compare_ref.into_into_dart().into_dart(),
+            self.base_ref.into_into_dart().into_dart(),
+            self.changed_files.into_into_dart().into_dart(),
+            self.status.into_into_dart().into_dart(),
+            self.error_message.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::git::GitCommitCompareSummary
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::git::GitCommitCompareSummary>
+    for crate::api::git::GitCommitCompareSummary
+{
+    fn into_into_dart(self) -> crate::api::git::GitCommitCompareSummary {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
 impl flutter_rust_bridge::IntoDart for crate::api::git::GitDiffFile {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
         [
@@ -3987,6 +4426,108 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::git::GitErrorKind>
     for crate::api::git::GitErrorKind
 {
     fn into_into_dart(self) -> crate::api::git::GitErrorKind {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::git::GitHistoryItem {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.id.into_into_dart().into_dart(),
+            self.parent_ids.into_into_dart().into_dart(),
+            self.subject.into_into_dart().into_dart(),
+            self.message.into_into_dart().into_dart(),
+            self.display_id.into_into_dart().into_dart(),
+            self.author.into_into_dart().into_dart(),
+            self.author_email.into_into_dart().into_dart(),
+            self.timestamp.into_into_dart().into_dart(),
+            self.references.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::git::GitHistoryItem
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::git::GitHistoryItem>
+    for crate::api::git::GitHistoryItem
+{
+    fn into_into_dart(self) -> crate::api::git::GitHistoryItem {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::git::GitHistoryItemRef {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.id.into_into_dart().into_dart(),
+            self.name.into_into_dart().into_dart(),
+            self.revision.into_into_dart().into_dart(),
+            self.category.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::git::GitHistoryItemRef
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::git::GitHistoryItemRef>
+    for crate::api::git::GitHistoryItemRef
+{
+    fn into_into_dart(self) -> crate::api::git::GitHistoryItemRef {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::git::GitHistoryRefCategory {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        match self {
+            Self::Branches => 0.into_dart(),
+            Self::RemoteBranches => 1.into_dart(),
+            Self::Tags => 2.into_dart(),
+            Self::Commits => 3.into_dart(),
+            _ => unreachable!(),
+        }
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::git::GitHistoryRefCategory
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::git::GitHistoryRefCategory>
+    for crate::api::git::GitHistoryRefCategory
+{
+    fn into_into_dart(self) -> crate::api::git::GitHistoryRefCategory {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::git::GitHistoryResult {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.items.into_into_dart().into_dart(),
+            self.current_ref.into_into_dart().into_dart(),
+            self.remote_ref.into_into_dart().into_dart(),
+            self.base_ref.into_into_dart().into_dart(),
+            self.merge_base.into_into_dart().into_dart(),
+            self.has_incoming_changes.into_into_dart().into_dart(),
+            self.has_outgoing_changes.into_into_dart().into_dart(),
+            self.has_more.into_into_dart().into_dart(),
+            self.limit.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::git::GitHistoryResult
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::git::GitHistoryResult>
+    for crate::api::git::GitHistoryResult
+{
+    fn into_into_dart(self) -> crate::api::git::GitHistoryResult {
         self
     }
 }
@@ -4965,6 +5506,55 @@ impl SseEncode for crate::api::git::GitChangeTreeRowKind {
     }
 }
 
+impl SseEncode for crate::api::git::GitCommitChangeEntry {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <String>::sse_encode(self.path, serializer);
+        <Option<String>>::sse_encode(self.old_path, serializer);
+        <crate::api::git::GitChangeStatus>::sse_encode(self.status, serializer);
+        <Option<u32>>::sse_encode(self.added, serializer);
+        <Option<u32>>::sse_encode(self.removed, serializer);
+    }
+}
+
+impl SseEncode for crate::api::git::GitCommitCompareResult {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <crate::api::git::GitCommitCompareSummary>::sse_encode(self.summary, serializer);
+        <Vec<crate::api::git::GitCommitChangeEntry>>::sse_encode(self.entries, serializer);
+    }
+}
+
+impl SseEncode for crate::api::git::GitCommitCompareStatus {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <i32>::sse_encode(
+            match self {
+                crate::api::git::GitCommitCompareStatus::Ready => 0,
+                crate::api::git::GitCommitCompareStatus::InvalidCommit => 1,
+                crate::api::git::GitCommitCompareStatus::Error => 2,
+                _ => {
+                    unimplemented!("");
+                }
+            },
+            serializer,
+        );
+    }
+}
+
+impl SseEncode for crate::api::git::GitCommitCompareSummary {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <String>::sse_encode(self.commit_oid, serializer);
+        <Option<String>>::sse_encode(self.parent_oid, serializer);
+        <String>::sse_encode(self.compare_ref, serializer);
+        <String>::sse_encode(self.base_ref, serializer);
+        <u32>::sse_encode(self.changed_files, serializer);
+        <crate::api::git::GitCommitCompareStatus>::sse_encode(self.status, serializer);
+        <Option<String>>::sse_encode(self.error_message, serializer);
+    }
+}
+
 impl SseEncode for crate::api::git::GitDiffFile {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -5053,6 +5643,64 @@ impl SseEncode for crate::api::git::GitErrorKind {
             },
             serializer,
         );
+    }
+}
+
+impl SseEncode for crate::api::git::GitHistoryItem {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <String>::sse_encode(self.id, serializer);
+        <Vec<String>>::sse_encode(self.parent_ids, serializer);
+        <String>::sse_encode(self.subject, serializer);
+        <String>::sse_encode(self.message, serializer);
+        <Option<String>>::sse_encode(self.display_id, serializer);
+        <Option<String>>::sse_encode(self.author, serializer);
+        <Option<String>>::sse_encode(self.author_email, serializer);
+        <Option<i64>>::sse_encode(self.timestamp, serializer);
+        <Vec<crate::api::git::GitHistoryItemRef>>::sse_encode(self.references, serializer);
+    }
+}
+
+impl SseEncode for crate::api::git::GitHistoryItemRef {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <String>::sse_encode(self.id, serializer);
+        <String>::sse_encode(self.name, serializer);
+        <Option<String>>::sse_encode(self.revision, serializer);
+        <Option<crate::api::git::GitHistoryRefCategory>>::sse_encode(self.category, serializer);
+    }
+}
+
+impl SseEncode for crate::api::git::GitHistoryRefCategory {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <i32>::sse_encode(
+            match self {
+                crate::api::git::GitHistoryRefCategory::Branches => 0,
+                crate::api::git::GitHistoryRefCategory::RemoteBranches => 1,
+                crate::api::git::GitHistoryRefCategory::Tags => 2,
+                crate::api::git::GitHistoryRefCategory::Commits => 3,
+                _ => {
+                    unimplemented!("");
+                }
+            },
+            serializer,
+        );
+    }
+}
+
+impl SseEncode for crate::api::git::GitHistoryResult {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <Vec<crate::api::git::GitHistoryItem>>::sse_encode(self.items, serializer);
+        <Option<crate::api::git::GitHistoryItemRef>>::sse_encode(self.current_ref, serializer);
+        <Option<crate::api::git::GitHistoryItemRef>>::sse_encode(self.remote_ref, serializer);
+        <Option<crate::api::git::GitHistoryItemRef>>::sse_encode(self.base_ref, serializer);
+        <Option<String>>::sse_encode(self.merge_base, serializer);
+        <bool>::sse_encode(self.has_incoming_changes, serializer);
+        <bool>::sse_encode(self.has_outgoing_changes, serializer);
+        <bool>::sse_encode(self.has_more, serializer);
+        <u32>::sse_encode(self.limit, serializer);
     }
 }
 
@@ -5158,6 +5806,16 @@ impl SseEncode for Vec<crate::api::git::GitChangeTreeRow> {
     }
 }
 
+impl SseEncode for Vec<crate::api::git::GitCommitChangeEntry> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <i32>::sse_encode(self.len() as _, serializer);
+        for item in self {
+            <crate::api::git::GitCommitChangeEntry>::sse_encode(item, serializer);
+        }
+    }
+}
+
 impl SseEncode for Vec<crate::api::git::GitDiffFile> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -5174,6 +5832,26 @@ impl SseEncode for Vec<crate::api::git::GitDiffLine> {
         <i32>::sse_encode(self.len() as _, serializer);
         for item in self {
             <crate::api::git::GitDiffLine>::sse_encode(item, serializer);
+        }
+    }
+}
+
+impl SseEncode for Vec<crate::api::git::GitHistoryItem> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <i32>::sse_encode(self.len() as _, serializer);
+        for item in self {
+            <crate::api::git::GitHistoryItem>::sse_encode(item, serializer);
+        }
+    }
+}
+
+impl SseEncode for Vec<crate::api::git::GitHistoryItemRef> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <i32>::sse_encode(self.len() as _, serializer);
+        for item in self {
+            <crate::api::git::GitHistoryItemRef>::sse_encode(item, serializer);
         }
     }
 }
@@ -5348,6 +6026,36 @@ impl SseEncode for Option<crate::api::git::GitChangeEntry> {
         <bool>::sse_encode(self.is_some(), serializer);
         if let Some(value) = self {
             <crate::api::git::GitChangeEntry>::sse_encode(value, serializer);
+        }
+    }
+}
+
+impl SseEncode for Option<crate::api::git::GitHistoryItemRef> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <bool>::sse_encode(self.is_some(), serializer);
+        if let Some(value) = self {
+            <crate::api::git::GitHistoryItemRef>::sse_encode(value, serializer);
+        }
+    }
+}
+
+impl SseEncode for Option<crate::api::git::GitHistoryRefCategory> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <bool>::sse_encode(self.is_some(), serializer);
+        if let Some(value) = self {
+            <crate::api::git::GitHistoryRefCategory>::sse_encode(value, serializer);
+        }
+    }
+}
+
+impl SseEncode for Option<i64> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <bool>::sse_encode(self.is_some(), serializer);
+        if let Some(value) = self {
+            <i64>::sse_encode(value, serializer);
         }
     }
 }

--- a/test/unit/fake_git_backend.dart
+++ b/test/unit/fake_git_backend.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:alera/src/shared/infra/git/git_backend.dart';
 import 'package:alera/src/shared/infra/git/git_diff_models.dart';
 import 'package:alera/src/shared/infra/git/git_exception.dart';
@@ -77,6 +79,27 @@ class FakeGitBackend implements GitBackend {
   GitStatusResult gitStatusResult = const GitStatusResult(entries: []);
   GitDiffResult gitDiffResult = const GitDiffResult(files: []);
   GitDiffResult gitDiffAllResult = const GitDiffResult(files: []);
+  GitHistoryResult gitHistoryResult = const GitHistoryResult(
+    items: <GitHistoryItem>[],
+    hasIncomingChanges: false,
+    hasOutgoingChanges: false,
+    hasMore: false,
+    limit: 50,
+  );
+  final List<Future<GitHistoryResult>> gitHistoryResultQueue =
+      <Future<GitHistoryResult>>[];
+  GitCommitCompareResult gitCommitCompareResult = const GitCommitCompareResult(
+    summary: GitCommitCompareSummary(
+      commitOid: 'abc123',
+      parentOid: 'def456',
+      compareRef: 'abc123',
+      baseRef: 'def456',
+      changedFiles: 0,
+      status: GitCommitCompareStatus.ready,
+    ),
+    entries: <GitCommitChangeEntry>[],
+  );
+  GitDiffResult gitCommitDiffResult = const GitDiffResult(files: []);
   GitRepositoryState gitRepositoryStateResult = const GitRepositoryState(
     branch: 'main',
   );
@@ -84,6 +107,9 @@ class FakeGitBackend implements GitBackend {
   String gitCommitOid = 'abc123';
 
   GitException? statusError;
+  GitException? historyError;
+  GitException? commitCompareError;
+  GitException? commitDiffError;
   GitException? stageError;
   GitException? stageAreaError;
   GitException? unstageError;
@@ -318,6 +344,71 @@ class FakeGitBackend implements GitBackend {
       }),
     );
     return gitDiffAllResult;
+  }
+
+  @override
+  Future<GitHistoryResult> history(
+    String path, {
+    int? limit,
+    String? baseRef,
+  }) async {
+    calls.add(
+      GitBackendCall('history', <String, Object?>{
+        'path': path,
+        'limit': limit,
+        'baseRef': baseRef,
+      }),
+    );
+    final error = historyError;
+    if (error != null) {
+      throw error;
+    }
+    if (gitHistoryResultQueue.isNotEmpty) {
+      return gitHistoryResultQueue.removeAt(0);
+    }
+    return gitHistoryResult;
+  }
+
+  @override
+  Future<GitCommitCompareResult> commitCompare({
+    required String path,
+    required String commitId,
+  }) async {
+    calls.add(
+      GitBackendCall('commitCompare', <String, Object?>{
+        'path': path,
+        'commitId': commitId,
+      }),
+    );
+    final error = commitCompareError;
+    if (error != null) {
+      throw error;
+    }
+    return gitCommitCompareResult;
+  }
+
+  @override
+  Future<GitDiffResult> commitDiff({
+    required String path,
+    required String commitOid,
+    String? parentOid,
+    String? filePath,
+    String? oldPath,
+  }) async {
+    calls.add(
+      GitBackendCall('commitDiff', <String, Object?>{
+        'path': path,
+        'commitOid': commitOid,
+        'parentOid': parentOid,
+        'filePath': filePath,
+        'oldPath': oldPath,
+      }),
+    );
+    final error = commitDiffError;
+    if (error != null) {
+      throw error;
+    }
+    return gitCommitDiffResult;
   }
 
   @override

--- a/test/unit/git_history_graph_test.dart
+++ b/test/unit/git_history_graph_test.dart
@@ -1,0 +1,172 @@
+import 'package:alera/src/shared/infra/git/git_diff_models.dart';
+import 'package:alera/src/shared/infra/git/git_history_graph.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('buildGitHistoryViewModels', () {
+    test('adds incoming and outgoing boundary rows for divergent branches', () {
+      const currentRef = GitHistoryItemRef(
+        id: 'refs/heads/main',
+        name: 'main',
+        revision: 'local',
+      );
+      const remoteRef = GitHistoryItemRef(
+        id: 'refs/remotes/origin/main',
+        name: 'origin/main',
+        revision: 'remote',
+      );
+      const result = GitHistoryResult(
+        currentRef: currentRef,
+        remoteRef: remoteRef,
+        mergeBase: 'base',
+        hasIncomingChanges: true,
+        hasOutgoingChanges: true,
+        hasMore: false,
+        limit: 50,
+        items: <GitHistoryItem>[
+          GitHistoryItem(
+            id: 'local',
+            parentIds: <String>['base'],
+            subject: 'Local Commit',
+            message: 'Local Commit',
+            displayId: 'local',
+            references: <GitHistoryItemRef>[currentRef],
+          ),
+          GitHistoryItem(
+            id: 'remote',
+            parentIds: <String>['base'],
+            subject: 'Remote Commit',
+            message: 'Remote Commit',
+            displayId: 'remote',
+            references: <GitHistoryItemRef>[remoteRef],
+          ),
+          GitHistoryItem(
+            id: 'base',
+            parentIds: <String>[],
+            subject: 'Base Commit',
+            message: 'Base Commit',
+            displayId: 'base',
+          ),
+        ],
+      );
+
+      final viewModels = buildGitHistoryViewModels(result);
+      final ids = viewModels
+          .map((viewModel) => viewModel.historyItem.id)
+          .toList(growable: false);
+
+      expect(ids, contains(gitHistoryOutgoingChangesId));
+      expect(ids, contains(gitHistoryIncomingChangesId));
+      expect(
+        ids.indexOf(gitHistoryOutgoingChangesId),
+        lessThan(ids.indexOf('local')),
+      );
+      expect(
+        ids.indexOf(gitHistoryIncomingChangesId),
+        lessThan(ids.indexOf('base')),
+      );
+    });
+
+    test('colors current and remote refs before rendering rows', () {
+      const currentRef = GitHistoryItemRef(
+        id: 'refs/heads/main',
+        name: 'main',
+        revision: 'head',
+      );
+      const remoteRef = GitHistoryItemRef(
+        id: 'refs/remotes/origin/main',
+        name: 'origin/main',
+        revision: 'head',
+      );
+      const result = GitHistoryResult(
+        currentRef: currentRef,
+        remoteRef: remoteRef,
+        hasIncomingChanges: false,
+        hasOutgoingChanges: false,
+        hasMore: false,
+        limit: 50,
+        items: <GitHistoryItem>[
+          GitHistoryItem(
+            id: 'head',
+            parentIds: <String>[],
+            subject: 'Head Commit',
+            message: 'Head Commit',
+            references: <GitHistoryItemRef>[remoteRef, currentRef],
+          ),
+        ],
+      );
+
+      final references = buildGitHistoryViewModels(
+        result,
+      ).single.historyItem.references;
+
+      expect(references.first.id, currentRef.id);
+      expect(references.first.color, GitHistoryGraphColorId.ref);
+      expect(references.last.id, remoteRef.id);
+      expect(references.last.color, GitHistoryGraphColorId.remoteRef);
+    });
+
+    test('adds outgoing boundary when head revision is filtered out', () {
+      const currentRef = GitHistoryItemRef(
+        id: 'refs/heads/main',
+        name: 'main',
+        revision: 'head',
+      );
+      const remoteRef = GitHistoryItemRef(
+        id: 'refs/remotes/origin/main',
+        name: 'origin/main',
+        revision: 'base',
+      );
+      const result = GitHistoryResult(
+        currentRef: currentRef,
+        remoteRef: remoteRef,
+        mergeBase: 'base',
+        hasIncomingChanges: false,
+        hasOutgoingChanges: true,
+        hasMore: false,
+        limit: 50,
+        items: <GitHistoryItem>[
+          GitHistoryItem(
+            id: 'scoped-local',
+            parentIds: <String>['base'],
+            subject: 'Scoped Local Commit',
+            message: 'Scoped Local Commit',
+            displayId: 'scoped',
+          ),
+          GitHistoryItem(
+            id: 'base',
+            parentIds: <String>[],
+            subject: 'Base Commit',
+            message: 'Base Commit',
+            displayId: 'base',
+            references: <GitHistoryItemRef>[remoteRef],
+          ),
+        ],
+      );
+
+      final viewModels = buildGitHistoryViewModels(result);
+      final ids = viewModels
+          .map((viewModel) => viewModel.historyItem.id)
+          .toList(growable: false);
+      final outgoing = viewModels.singleWhere(
+        (viewModel) => viewModel.historyItem.id == gitHistoryOutgoingChangesId,
+      );
+
+      expect(ids.indexOf(gitHistoryOutgoingChangesId), 0);
+      expect(ids.indexOf('scoped-local'), 1);
+      expect(outgoing.historyItem.parentIds, <String>['scoped-local']);
+      expect(
+        viewModels[1].inputSwimlanes,
+        contains(
+          isA<GitHistoryGraphNode>()
+              .having((node) => node.id, 'id', 'scoped-local')
+              .having(
+                (node) => node.color,
+                'color',
+                GitHistoryGraphColorId.ref,
+              ),
+        ),
+      );
+    });
+  });
+}

--- a/test/unit/workspace_tab_service_test.dart
+++ b/test/unit/workspace_tab_service_test.dart
@@ -382,6 +382,63 @@ void main() {
       expect(repository.tabs, hasLength(2));
     });
 
+    test(
+      'openOrCreateGitCommitDiffTab creates and reuses commit diff tabs independently',
+      () async {
+        final repository = _FakeWorkbenchRepository();
+        final service = WorkspaceTabService(
+          repository: repository,
+          now: () => DateTime.utc(2026, 5, 21, 1),
+        );
+
+        final workingTreeTab = await service.openOrCreateGitDiffTab(
+          workspaceId: 'workspace-1',
+          relativePath: 'packages/app/lib/main.dart',
+          area: GitChangeArea.unstaged,
+          scope: WorkspaceGitDiffScope.file,
+          gitDiffRoot: 'packages/app',
+        );
+        final first = await service.openOrCreateGitCommitDiffTab(
+          workspaceId: 'workspace-1',
+          relativePath: './packages\\app\\lib\\main.dart',
+          oldPath: './packages\\app\\lib\\old_main.dart',
+          scope: WorkspaceGitDiffScope.file,
+          gitDiffRoot: './packages\\app',
+          commitOid: 'abc123456789',
+          parentOid: 'def987654321',
+          compareRef: 'abc1234',
+          subject: 'Add Main',
+          message: 'Add Main\n\nBody',
+        );
+        final second = await service.openOrCreateGitCommitDiffTab(
+          workspaceId: 'workspace-1',
+          relativePath: 'packages/app/lib/main.dart',
+          oldPath: 'packages/app/lib/old_main.dart',
+          scope: WorkspaceGitDiffScope.file,
+          gitDiffRoot: 'packages/app',
+          commitOid: 'abc123456789',
+          parentOid: 'def987654321',
+          compareRef: 'abc1234',
+        );
+
+        expect(first.id, isNot(workingTreeTab.id));
+        expect(second.id, first.id);
+        expect(first.kind, WorkspaceTabKind.gitDiff);
+        expect(first.title, 'main.dart abc1234');
+        expect(first.gitDiffSource, WorkspaceGitDiffSource.commit);
+        expect(first.gitDiffScope, WorkspaceGitDiffScope.file);
+        expect(first.filePath, 'packages/app/lib/main.dart');
+        expect(first.gitDiffOldPath, 'packages/app/lib/old_main.dart');
+        expect(first.gitDiffRoot, 'packages/app');
+        expect(first.gitDiffCommitOid, 'abc123456789');
+        expect(first.gitDiffParentOid, 'def987654321');
+        expect(first.gitDiffCompareRef, 'abc1234');
+        expect(first.gitDiffCommitSubject, 'Add Main');
+        expect(first.gitDiffCommitMessage, 'Add Main\n\nBody');
+        expect(repository.tabs, hasLength(2));
+      },
+    );
+
     test('updates git diff roots after a folder move', () async {
       final repository = _FakeWorkbenchRepository()
         ..tabs.add(
@@ -412,6 +469,62 @@ void main() {
       expect(result.updatedTabs.single.gitDiffRoot, 'modules/app');
       expect(repository.tabs.single.gitDiffRoot, 'modules/app');
       expect(repository.tabs.single.title, 'app changes');
+    });
+
+    test('does not retarget commit diff tabs after a folder move', () async {
+      final repository = _FakeWorkbenchRepository()
+        ..tabs.addAll(<WorkspaceTabRecord>[
+          WorkspaceTabRecord(
+            id: 'working-tree-tab',
+            workspaceId: 'workspace-1',
+            kind: WorkspaceTabKind.gitDiff,
+            title: 'app changes',
+            createdAt: DateTime.utc(2026, 5, 21),
+            updatedAt: DateTime.utc(2026, 5, 21),
+            payload: const <String, Object?>{
+              workspaceTabGitDiffScopePayloadKey: 'all',
+              workspaceTabGitDiffRootPayloadKey: 'packages/app',
+            },
+          ),
+          WorkspaceTabRecord(
+            id: 'commit-tab',
+            workspaceId: 'workspace-1',
+            kind: WorkspaceTabKind.gitDiff,
+            title: 'main.dart abc1234',
+            createdAt: DateTime.utc(2026, 5, 21),
+            updatedAt: DateTime.utc(2026, 5, 21),
+            payload: const <String, Object?>{
+              workspaceTabGitDiffSourcePayloadKey: 'commit',
+              workspaceTabFilePathPayloadKey: 'packages/app/lib/main.dart',
+              workspaceTabGitDiffOldPathPayloadKey:
+                  'packages/app/lib/old_main.dart',
+              workspaceTabGitDiffScopePayloadKey: 'file',
+              workspaceTabGitDiffRootPayloadKey: 'packages/app',
+              workspaceTabGitDiffCommitOidPayloadKey: 'abc123456789',
+              workspaceTabGitDiffParentOidPayloadKey: 'def987654321',
+              workspaceTabGitDiffCompareRefPayloadKey: 'abc1234',
+            },
+          ),
+        ]);
+      final service = WorkspaceTabService(
+        repository: repository,
+        now: () => DateTime.utc(2026, 5, 21, 1),
+      );
+
+      final result = await service.updateFileTabPathsAfterMove(
+        workspaceId: 'workspace-1',
+        oldRelativePath: 'packages',
+        newRelativePath: 'modules',
+      );
+
+      expect(result.updatedTabs.single.id, 'working-tree-tab');
+      expect(repository.tabs[0].gitDiffRoot, 'modules/app');
+      expect(repository.tabs[1].filePath, 'packages/app/lib/main.dart');
+      expect(
+        repository.tabs[1].gitDiffOldPath,
+        'packages/app/lib/old_main.dart',
+      );
+      expect(repository.tabs[1].gitDiffRoot, 'packages/app');
     });
 
     test('updates git diff roots and file paths after a folder move', () async {

--- a/test/widget/workspace_explorer_test.dart
+++ b/test/widget/workspace_explorer_test.dart
@@ -604,6 +604,18 @@ void main() {
               onOpenFile: (_) {},
               onOpenGitDiff:
                   ({relativePath, area, gitDiffRoot, required scope}) async {},
+              onOpenGitCommitDiff:
+                  ({
+                    relativePath,
+                    oldPath,
+                    required scope,
+                    gitDiffRoot,
+                    required commitOid,
+                    parentOid,
+                    required compareRef,
+                    subject,
+                    message,
+                  }) async {},
               onOpenSearchMatch: (_) {},
               onPathMoved: (_, _) async {},
             ),
@@ -643,6 +655,18 @@ void main() {
               onOpenFile: (_) {},
               onOpenGitDiff:
                   ({relativePath, area, gitDiffRoot, required scope}) async {},
+              onOpenGitCommitDiff:
+                  ({
+                    relativePath,
+                    oldPath,
+                    required scope,
+                    gitDiffRoot,
+                    required commitOid,
+                    parentOid,
+                    required compareRef,
+                    subject,
+                    message,
+                  }) async {},
               onOpenSearchMatch: (_) {},
               onPathMoved: (_, _) async {},
             ),
@@ -682,6 +706,18 @@ void main() {
               onOpenFile: (_) {},
               onOpenGitDiff:
                   ({relativePath, area, gitDiffRoot, required scope}) async {},
+              onOpenGitCommitDiff:
+                  ({
+                    relativePath,
+                    oldPath,
+                    required scope,
+                    gitDiffRoot,
+                    required commitOid,
+                    parentOid,
+                    required compareRef,
+                    subject,
+                    message,
+                  }) async {},
               onOpenSearchMatch: (_) {},
               onPathMoved: (_, _) async {},
             ),
@@ -717,6 +753,18 @@ void main() {
               onOpenFile: (_) {},
               onOpenGitDiff:
                   ({relativePath, area, gitDiffRoot, required scope}) async {},
+              onOpenGitCommitDiff:
+                  ({
+                    relativePath,
+                    oldPath,
+                    required scope,
+                    gitDiffRoot,
+                    required commitOid,
+                    parentOid,
+                    required compareRef,
+                    subject,
+                    message,
+                  }) async {},
               onOpenSearchMatch: (_) {},
               onPathMoved: (_, _) async {},
             ),
@@ -822,6 +870,18 @@ Widget _workspaceContextSidebar(Workspace workspace) {
     onSetGitDiffViewMode: (_) {},
     onOpenFile: (_) {},
     onOpenGitDiff: ({relativePath, area, gitDiffRoot, required scope}) async {},
+    onOpenGitCommitDiff:
+        ({
+          relativePath,
+          oldPath,
+          required scope,
+          gitDiffRoot,
+          required commitOid,
+          parentOid,
+          required compareRef,
+          subject,
+          message,
+        }) async {},
     onOpenSearchMatch: (_) {},
     onPathMoved: (_, _) async {},
   );

--- a/test/widget/workspace_git_diff_panel_test.dart
+++ b/test/widget/workspace_git_diff_panel_test.dart
@@ -68,6 +68,18 @@ void main() {
                       gitDiffRoot,
                       required scope,
                     }) async {},
+                onOpenGitCommitDiff:
+                    ({
+                      relativePath,
+                      oldPath,
+                      required scope,
+                      gitDiffRoot,
+                      required commitOid,
+                      parentOid,
+                      required compareRef,
+                      subject,
+                      message,
+                    }) async {},
               ),
             ),
           ),
@@ -130,6 +142,18 @@ void main() {
                       relativePath,
                       gitDiffRoot,
                       required scope,
+                    }) async {},
+                onOpenGitCommitDiff:
+                    ({
+                      relativePath,
+                      oldPath,
+                      required scope,
+                      gitDiffRoot,
+                      required commitOid,
+                      parentOid,
+                      required compareRef,
+                      subject,
+                      message,
                     }) async {},
               ),
             ),
@@ -244,6 +268,368 @@ void main() {
 
     expect(cleared, isTrue);
   });
+
+  testWidgets('commits panel loads history and opens commit file diffs', (
+    tester,
+  ) async {
+    final backend = FakeGitBackend()
+      ..gitRepositoryStateResult = const GitRepositoryState(
+        branch: 'main',
+        upstream: 'origin/main',
+      )
+      ..gitHistoryResult = GitHistoryResult(
+        currentRef: const GitHistoryItemRef(
+          id: 'refs/heads/main',
+          name: 'main',
+          revision: 'abc123456789',
+        ),
+        hasIncomingChanges: false,
+        hasOutgoingChanges: false,
+        hasMore: false,
+        limit: 50,
+        items: <GitHistoryItem>[
+          GitHistoryItem(
+            id: 'abc123456789',
+            parentIds: const <String>['def987654321'],
+            subject: 'Add Feature',
+            message: 'Add Feature\n\nBody',
+            displayId: 'abc1234',
+            author: 'Leynier',
+            timestamp: DateTime.utc(2026, 7, 4, 12),
+          ),
+        ],
+      )
+      ..gitCommitCompareResult = const GitCommitCompareResult(
+        summary: GitCommitCompareSummary(
+          commitOid: 'abc123456789',
+          parentOid: 'def987654321',
+          compareRef: 'abc1234',
+          baseRef: 'def9876',
+          changedFiles: 1,
+          status: GitCommitCompareStatus.ready,
+        ),
+        entries: <GitCommitChangeEntry>[
+          GitCommitChangeEntry(
+            path: 'lib/new.dart',
+            oldPath: 'lib/old.dart',
+            status: GitChangeStatus.renamed,
+            added: 3,
+            removed: 1,
+          ),
+        ],
+      );
+    final opened =
+        <
+          ({
+            String? relativePath,
+            String? oldPath,
+            WorkspaceGitDiffScope scope,
+            String? gitDiffRoot,
+            String commitOid,
+            String? parentOid,
+            String compareRef,
+            String? subject,
+            String? message,
+          })
+        >[];
+
+    await _pumpPanel(
+      tester,
+      backend: backend,
+      onOpenGitCommitDiff:
+          ({
+            relativePath,
+            oldPath,
+            required scope,
+            gitDiffRoot,
+            required commitOid,
+            parentOid,
+            required compareRef,
+            subject,
+            message,
+          }) async {
+            opened.add((
+              relativePath: relativePath,
+              oldPath: oldPath,
+              scope: scope,
+              gitDiffRoot: gitDiffRoot,
+              commitOid: commitOid,
+              parentOid: parentOid,
+              compareRef: compareRef,
+              subject: subject,
+              message: message,
+            ));
+          },
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Commits'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Add Feature'), findsOneWidget);
+    expect(
+      backend.calls.where((call) => call.method == 'history').single.args,
+      <String, Object?>{'path': '/tmp/project', 'limit': 50, 'baseRef': null},
+    );
+
+    await tester.tap(find.text('Add Feature'));
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('lib/old.dart -> lib/new.dart'), findsOneWidget);
+    expect(
+      backend.calls.where((call) => call.method == 'commitCompare').single.args,
+      <String, Object?>{'path': '/tmp/project', 'commitId': 'abc123456789'},
+    );
+
+    await tester.tap(find.textContaining('lib/old.dart -> lib/new.dart'));
+    await tester.pumpAndSettle();
+
+    expect(opened.single.relativePath, 'lib/new.dart');
+    expect(opened.single.oldPath, 'lib/old.dart');
+    expect(opened.single.scope, WorkspaceGitDiffScope.file);
+    expect(opened.single.gitDiffRoot, isNull);
+    expect(opened.single.commitOid, 'abc123456789');
+    expect(opened.single.parentOid, 'def987654321');
+    expect(opened.single.compareRef, 'abc1234');
+    expect(opened.single.subject, 'Add Feature');
+    expect(opened.single.message, 'Add Feature\n\nBody');
+  });
+
+  testWidgets('collapsed commits panel reloads after successful git actions', (
+    tester,
+  ) async {
+    final backend = FakeGitBackend()
+      ..gitRepositoryStateResult = const GitRepositoryState(
+        branch: 'main',
+        upstream: 'origin/main',
+      )
+      ..gitStatusResult = const GitStatusResult(
+        entries: <GitChangeEntry>[
+          GitChangeEntry(
+            path: 'lib/new.dart',
+            area: GitChangeArea.untracked,
+            status: GitChangeStatus.untracked,
+          ),
+        ],
+      )
+      ..gitHistoryResult = const GitHistoryResult(
+        currentRef: GitHistoryItemRef(
+          id: 'refs/heads/main',
+          name: 'main',
+          revision: 'old123',
+        ),
+        hasIncomingChanges: false,
+        hasOutgoingChanges: false,
+        hasMore: false,
+        limit: 50,
+        items: <GitHistoryItem>[
+          GitHistoryItem(
+            id: 'old123',
+            parentIds: <String>[],
+            subject: 'Old Commit',
+            message: 'Old Commit',
+          ),
+        ],
+      );
+
+    await _pumpPanel(tester, backend: backend);
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Commits'));
+    await tester.pumpAndSettle();
+    expect(find.text('Old Commit'), findsOneWidget);
+
+    await tester.tap(find.text('Commits'));
+    await tester.pumpAndSettle();
+    backend.gitHistoryResult = const GitHistoryResult(
+      currentRef: GitHistoryItemRef(
+        id: 'refs/heads/main',
+        name: 'main',
+        revision: 'new123',
+      ),
+      hasIncomingChanges: false,
+      hasOutgoingChanges: false,
+      hasMore: false,
+      limit: 50,
+      items: <GitHistoryItem>[
+        GitHistoryItem(
+          id: 'new123',
+          parentIds: <String>['old123'],
+          subject: 'New Commit',
+          message: 'New Commit',
+        ),
+      ],
+    );
+
+    await tester.tap(find.text('Stage All'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Commits'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('New Commit'), findsOneWidget);
+    expect(
+      backend.calls.where((call) => call.method == 'history'),
+      hasLength(2),
+    );
+  });
+
+  testWidgets('collapsed commits panel ignores stale in-flight history loads', (
+    tester,
+  ) async {
+    final firstHistory = Completer<GitHistoryResult>();
+    final backend = FakeGitBackend()
+      ..gitRepositoryStateResult = const GitRepositoryState(
+        branch: 'main',
+        upstream: 'origin/main',
+      )
+      ..gitStatusResult = const GitStatusResult(
+        entries: <GitChangeEntry>[
+          GitChangeEntry(
+            path: 'lib/new.dart',
+            area: GitChangeArea.untracked,
+            status: GitChangeStatus.untracked,
+          ),
+        ],
+      )
+      ..gitHistoryResultQueue.add(firstHistory.future);
+
+    await _pumpPanel(tester, backend: backend);
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Commits'));
+    await tester.pump();
+    await tester.tap(find.text('Commits'));
+    await tester.pump();
+
+    backend.gitHistoryResult = const GitHistoryResult(
+      currentRef: GitHistoryItemRef(
+        id: 'refs/heads/main',
+        name: 'main',
+        revision: 'new123',
+      ),
+      hasIncomingChanges: false,
+      hasOutgoingChanges: false,
+      hasMore: false,
+      limit: 50,
+      items: <GitHistoryItem>[
+        GitHistoryItem(
+          id: 'new123',
+          parentIds: <String>[],
+          subject: 'New Commit',
+          message: 'New Commit',
+        ),
+      ],
+    );
+    await tester.tap(find.text('Stage All'));
+    await tester.pumpAndSettle();
+
+    firstHistory.complete(
+      const GitHistoryResult(
+        currentRef: GitHistoryItemRef(
+          id: 'refs/heads/main',
+          name: 'main',
+          revision: 'old123',
+        ),
+        hasIncomingChanges: false,
+        hasOutgoingChanges: false,
+        hasMore: false,
+        limit: 50,
+        items: <GitHistoryItem>[
+          GitHistoryItem(
+            id: 'old123',
+            parentIds: <String>[],
+            subject: 'Old Commit',
+            message: 'Old Commit',
+          ),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Commits'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('New Commit'), findsOneWidget);
+    expect(find.text('Old Commit'), findsNothing);
+    expect(
+      backend.calls.where((call) => call.method == 'history'),
+      hasLength(2),
+    );
+  });
+
+  testWidgets(
+    'expanded commits panel reloads when watch summary is unchanged',
+    (tester) async {
+      final watcher = FakeSourceControlWatcher();
+      final backend = FakeGitBackend()
+        ..gitRepositoryStateResult = const GitRepositoryState(
+          branch: 'main',
+          upstream: 'origin/main',
+          headMessage: 'Old Commit',
+        )
+        ..gitHistoryResult = const GitHistoryResult(
+          currentRef: GitHistoryItemRef(
+            id: 'refs/heads/main',
+            name: 'main',
+            revision: 'old123',
+          ),
+          hasIncomingChanges: false,
+          hasOutgoingChanges: false,
+          hasMore: false,
+          limit: 50,
+          items: <GitHistoryItem>[
+            GitHistoryItem(
+              id: 'old123',
+              parentIds: <String>[],
+              subject: 'Old Commit',
+              message: 'Old Commit',
+            ),
+          ],
+        );
+
+      await _pumpPanel(tester, backend: backend, watcher: watcher);
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Commits'));
+      await tester.pumpAndSettle();
+      expect(find.text('Old Commit'), findsOneWidget);
+
+      backend
+        ..gitRepositoryStateResult = const GitRepositoryState(
+          branch: 'main',
+          upstream: 'origin/main',
+          headMessage: 'Old Commit',
+        )
+        ..gitHistoryResult = const GitHistoryResult(
+          currentRef: GitHistoryItemRef(
+            id: 'refs/heads/main',
+            name: 'main',
+            revision: 'new123',
+          ),
+          hasIncomingChanges: false,
+          hasOutgoingChanges: false,
+          hasMore: false,
+          limit: 50,
+          items: <GitHistoryItem>[
+            GitHistoryItem(
+              id: 'new123',
+              parentIds: <String>['old123'],
+              subject: 'New Commit',
+              message: 'New Commit',
+            ),
+          ],
+        );
+      watcher.emitChange();
+      await tester.pump(const Duration(milliseconds: 300));
+      await tester.pumpAndSettle();
+
+      expect(find.text('New Commit'), findsOneWidget);
+      expect(find.text('Old Commit'), findsNothing);
+      expect(
+        backend.calls.where((call) => call.method == 'history'),
+        hasLength(2),
+      );
+    },
+  );
 
   testWidgets('primary source control action is compact and clickable', (
     tester,
@@ -1089,9 +1475,11 @@ Future<void> _pumpPanel(
   Workspace? workspace,
   GitDiffViewMode viewMode = GitDiffViewMode.flat,
   WorkspaceSourceControlScope? sourceControlScope,
+  FakeSourceControlWatcher? watcher,
   AiTextGenerationService? service,
   AleraSettings settings = AleraSettings.defaults,
   OpenGitDiffTabCallback? onOpenGitDiff,
+  OpenGitCommitDiffTabCallback? onOpenGitCommitDiff,
   VoidCallback? onClearSourceControlRoot,
 }) {
   final resolvedWorkspace = workspace ?? _workspace();
@@ -1100,7 +1488,7 @@ Future<void> _pumpPanel(
       overrides: [
         gitBackendProvider.overrideWithValue(backend),
         sourceControlWatcherProvider.overrideWithValue(
-          FakeSourceControlWatcher(),
+          watcher ?? FakeSourceControlWatcher(),
         ),
         settingsControllerProvider.overrideWith(
           () => _PanelSettingsController(settings),
@@ -1122,6 +1510,19 @@ Future<void> _pumpPanel(
               onOpenGitDiff:
                   onOpenGitDiff ??
                   ({area, relativePath, gitDiffRoot, required scope}) async {},
+              onOpenGitCommitDiff:
+                  onOpenGitCommitDiff ??
+                  ({
+                    relativePath,
+                    oldPath,
+                    required scope,
+                    gitDiffRoot,
+                    required commitOid,
+                    parentOid,
+                    required compareRef,
+                    subject,
+                    message,
+                  }) async {},
               onClearSourceControlRoot: onClearSourceControlRoot,
             ),
           ),

--- a/test/widget/workspace_git_diff_surface_test.dart
+++ b/test/widget/workspace_git_diff_surface_test.dart
@@ -319,6 +319,53 @@ void main() {
     expect(find.text('+0'), findsNothing);
     expect(find.text('-0'), findsNothing);
   });
+
+  testWidgets('diff surface loads commit diffs from commit payload', (
+    tester,
+  ) async {
+    final backend = FakeGitBackend()
+      ..gitCommitDiffResult = const GitDiffResult(
+        files: <GitDiffFile>[
+          GitDiffFile(
+            path: 'lib/main.dart',
+            area: GitChangeArea.staged,
+            status: GitChangeStatus.modified,
+            lines: <GitDiffLine>[GitDiffLine.addition('+new')],
+            sourceLabel: 'Commit',
+          ),
+        ],
+      );
+
+    await _pumpDiffSurface(
+      tester,
+      backend: backend,
+      tab: _diffTab(
+        source: WorkspaceGitDiffSource.commit,
+        filePath: 'packages/app/lib/main.dart',
+        title: 'main.dart abc1234',
+        scope: WorkspaceGitDiffScope.file,
+        area: null,
+        gitDiffRoot: 'packages/app',
+        commitOid: 'abc123456789',
+        parentOid: 'def987654321',
+        compareRef: 'abc1234',
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      backend.calls.where((call) => call.method == 'commitDiff').single.args,
+      <String, Object?>{
+        'path': '/tmp/project/packages/app',
+        'commitOid': 'abc123456789',
+        'parentOid': 'def987654321',
+        'filePath': 'lib/main.dart',
+        'oldPath': null,
+      },
+    );
+    expect(find.text('Commit · lib/main.dart'), findsOneWidget);
+    expect(_openFileButton(tester).onPressed, isNull);
+  });
 }
 
 Future<void> _pumpDiffSurface(
@@ -373,13 +420,41 @@ Workspace _workspace() {
 }
 
 WorkspaceTabRecord _diffTab({
+  WorkspaceGitDiffSource source = WorkspaceGitDiffSource.workingTree,
   WorkspaceGitDiffScope scope = WorkspaceGitDiffScope.file,
   String filePath = 'lib/large.dart',
   String title = 'large.dart unstaged',
   GitChangeArea? area = GitChangeArea.unstaged,
   String? gitDiffRoot,
+  String? oldPath,
+  String? commitOid,
+  String? parentOid,
+  String? compareRef,
 }) {
   final now = DateTime.utc(2026, 6, 6);
+  final payload = <String, Object?>{
+    workspaceTabGitDiffSourcePayloadKey: source.key,
+    workspaceTabGitDiffScopePayloadKey: scope.key,
+    workspaceTabFilePathPayloadKey: filePath,
+  };
+  if (area != null) {
+    payload[workspaceTabGitDiffAreaPayloadKey] = area.key;
+  }
+  if (oldPath != null) {
+    payload[workspaceTabGitDiffOldPathPayloadKey] = oldPath;
+  }
+  if (commitOid != null) {
+    payload[workspaceTabGitDiffCommitOidPayloadKey] = commitOid;
+  }
+  if (parentOid != null) {
+    payload[workspaceTabGitDiffParentOidPayloadKey] = parentOid;
+  }
+  if (compareRef != null) {
+    payload[workspaceTabGitDiffCompareRefPayloadKey] = compareRef;
+  }
+  if (gitDiffRoot != null) {
+    payload[workspaceTabGitDiffRootPayloadKey] = gitDiffRoot;
+  }
   return WorkspaceTabRecord(
     id: 'tab-1',
     workspaceId: 'workspace-1',
@@ -387,17 +462,7 @@ WorkspaceTabRecord _diffTab({
     title: title,
     createdAt: now,
     updatedAt: now,
-    payload: <String, Object?>{
-      workspaceTabGitDiffScopePayloadKey: scope.key,
-      workspaceTabFilePathPayloadKey: filePath,
-      if (area != null) workspaceTabGitDiffAreaPayloadKey: area.key,
-      ...switch (gitDiffRoot) {
-        null => const <String, Object?>{},
-        final root => <String, Object?>{
-          workspaceTabGitDiffRootPayloadKey: root,
-        },
-      },
-    },
+    payload: payload,
   );
 }
 


### PR DESCRIPTION
## summary
- add a collapsible Source Control commits panel with graph lanes, refs, divergence markers, refresh, copy actions, and expandable commit file changes
- add commit/history GitBackend APIs through the Rust layer and commit diff tabs for commit and file comparisons
- cover scoped histories, annotated tags, copies/renames, stale reloads, and commit diff tab behavior

## validation
- codex review --uncommitted (no findings)
- flutter analyze
- flutter test -x golden
- flutter test test/unit/git_history_graph_test.dart test/unit/workspace_tab_service_test.dart test/widget/workspace_git_diff_panel_test.dart test/widget/workspace_git_diff_surface_test.dart
- make rust-test

## notes
- roadmap updated for the shipped Git history panel; no additional contributor documentation changes were needed