### PR TITLE
fix: persist left sidebar width across sessions

### DIFF
--- a/lib/src/features/shell/presentation/alera_shell_page.dart
+++ b/lib/src/features/shell/presentation/alera_shell_page.dart
@@ -445,7 +445,7 @@ bool _canShowContextSidebar({
 }) {
   final leftWidth = state.collapsed
       ? AleraTokens.sidebarCollapsedWidth
-      : AleraTokens.sidebarDefaultWidth;
+      : state.viewPrefs.sidebarWidth;
   final rightWidth = state.viewPrefs.rightSidebarVisible
       ? state.viewPrefs.rightSidebarWidth
       : AleraTokens.sidebarCollapsedWidth;

--- a/lib/src/features/workbench/application/workbench_controller_view_prefs.dart
+++ b/lib/src/features/workbench/application/workbench_controller_view_prefs.dart
@@ -399,9 +399,9 @@ mixin _WorkbenchControllerViewPrefs
       AleraTokens.sidebarMinWidth,
       AleraTokens.sidebarMaxWidth,
     );
-    if ((state.sidebarWidth - clamped).abs() < 0.5) {
+    if ((state.viewPrefs.sidebarWidth - clamped).abs() < 0.5) {
       return;
     }
-    state = state.copyWith(sidebarWidth: clamped);
+    _updateViewPrefs(state.viewPrefs.copyWith(sidebarWidth: clamped));
   }
 }

--- a/lib/src/features/workbench/application/workbench_state.dart
+++ b/lib/src/features/workbench/application/workbench_state.dart
@@ -1,4 +1,3 @@
-import 'package:alera/src/app/theme/alera_tokens.dart';
 import 'package:alera/src/features/projects/domain/project.dart';
 import 'package:alera/src/features/workbench/domain/workspace_tab_record.dart';
 import 'package:alera/src/features/workbench/domain/workbench_layout.dart';
@@ -23,7 +22,6 @@ class WorkbenchState with WorkbenchStateMappable {
     this.error,
     this.searchQuery = '',
     this.collapsed = false,
-    this.sidebarWidth = AleraTokens.sidebarDefaultWidth,
   });
 
   final List<Project> projects;
@@ -38,7 +36,6 @@ class WorkbenchState with WorkbenchStateMappable {
   final String? error;
   final String searchQuery;
   final bool collapsed;
-  final double sidebarWidth;
 
   /// Project ids that are visually expanded in the sidebar. Computed as the
   /// inverse of [WorkbenchViewPrefs.collapsedProjectIds] over the currently

--- a/lib/src/features/workbench/application/workbench_state.mapper.dart
+++ b/lib/src/features/workbench/application/workbench_state.mapper.dart
@@ -117,13 +117,6 @@ class WorkbenchStateMapper extends ClassMapperBase<WorkbenchState> {
     opt: true,
     def: false,
   );
-  static double _$sidebarWidth(WorkbenchState v) => v.sidebarWidth;
-  static const Field<WorkbenchState, double> _f$sidebarWidth = Field(
-    'sidebarWidth',
-    _$sidebarWidth,
-    opt: true,
-    def: AleraTokens.sidebarDefaultWidth,
-  );
 
   @override
   final MappableFields<WorkbenchState> fields = const {
@@ -139,7 +132,6 @@ class WorkbenchStateMapper extends ClassMapperBase<WorkbenchState> {
     #error: _f$error,
     #searchQuery: _f$searchQuery,
     #collapsed: _f$collapsed,
-    #sidebarWidth: _f$sidebarWidth,
   };
 
   static WorkbenchState _instantiate(DecodingData data) {
@@ -156,7 +148,6 @@ class WorkbenchStateMapper extends ClassMapperBase<WorkbenchState> {
       error: data.dec(_f$error),
       searchQuery: data.dec(_f$searchQuery),
       collapsed: data.dec(_f$collapsed),
-      sidebarWidth: data.dec(_f$sidebarWidth),
     );
   }
 
@@ -261,7 +252,6 @@ abstract class WorkbenchStateCopyWith<$R, $In extends WorkbenchState, $Out>
     String? error,
     String? searchQuery,
     bool? collapsed,
-    double? sidebarWidth,
   });
   WorkbenchStateCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(
     Then<$Out2, $R2> t,
@@ -343,7 +333,6 @@ class _WorkbenchStateCopyWithImpl<$R, $Out>
     Object? error = $none,
     String? searchQuery,
     bool? collapsed,
-    double? sidebarWidth,
   }) => $apply(
     FieldCopyWithData({
       if (projects != null) #projects: projects,
@@ -360,7 +349,6 @@ class _WorkbenchStateCopyWithImpl<$R, $Out>
       if (error != $none) #error: error,
       if (searchQuery != null) #searchQuery: searchQuery,
       if (collapsed != null) #collapsed: collapsed,
-      if (sidebarWidth != null) #sidebarWidth: sidebarWidth,
     }),
   );
   @override
@@ -389,7 +377,6 @@ class _WorkbenchStateCopyWithImpl<$R, $Out>
     error: data.get(#error, or: $value.error),
     searchQuery: data.get(#searchQuery, or: $value.searchQuery),
     collapsed: data.get(#collapsed, or: $value.collapsed),
-    sidebarWidth: data.get(#sidebarWidth, or: $value.sidebarWidth),
   );
 
   @override

--- a/lib/src/features/workbench/domain/workbench_view_prefs.dart
+++ b/lib/src/features/workbench/domain/workbench_view_prefs.dart
@@ -1,3 +1,4 @@
+import 'package:alera/src/app/theme/alera_tokens.dart';
 import 'package:dart_mappable/dart_mappable.dart';
 
 part 'workbench_view_prefs.mapper.dart';
@@ -31,6 +32,7 @@ class WorkbenchViewPrefs with WorkbenchViewPrefsMappable {
     this.sourceControlRootByWorkspaceId = const <String, String>{},
     this.rightSidebarVisible = true,
     this.rightSidebarWidth = 280,
+    this.sidebarWidth = AleraTokens.sidebarDefaultWidth,
     this.activeContextPanelTab = WorkbenchContextPanelTab.explorer,
     this.explorerMode = WorkspaceExplorerMode.hideIgnored,
     this.gitDiffViewMode = GitDiffViewMode.tree,
@@ -66,6 +68,11 @@ class WorkbenchViewPrefs with WorkbenchViewPrefsMappable {
   final Map<String, String> sourceControlRootByWorkspaceId;
   final bool rightSidebarVisible;
   final double rightSidebarWidth;
+
+  /// Width of the left sidebar (project/workbench list panel). Persisted so
+  /// the user's preferred panel size survives app restarts.
+  final double sidebarWidth;
+
   final WorkbenchContextPanelTab activeContextPanelTab;
   final WorkspaceExplorerMode explorerMode;
   final GitDiffViewMode gitDiffViewMode;
@@ -82,6 +89,7 @@ class WorkbenchViewPrefs with WorkbenchViewPrefsMappable {
     sourceControlRootByWorkspaceId: <String, String>{},
     rightSidebarVisible: true,
     rightSidebarWidth: 280,
+    sidebarWidth: AleraTokens.sidebarDefaultWidth,
     activeContextPanelTab: WorkbenchContextPanelTab.explorer,
     explorerMode: WorkspaceExplorerMode.hideIgnored,
     gitDiffViewMode: GitDiffViewMode.tree,

--- a/lib/src/features/workbench/domain/workbench_view_prefs.mapper.dart
+++ b/lib/src/features/workbench/domain/workbench_view_prefs.mapper.dart
@@ -336,6 +336,13 @@ class WorkbenchViewPrefsMapper extends ClassMapperBase<WorkbenchViewPrefs> {
     opt: true,
     def: 280,
   );
+  static double _$sidebarWidth(WorkbenchViewPrefs v) => v.sidebarWidth;
+  static const Field<WorkbenchViewPrefs, double> _f$sidebarWidth = Field(
+    'sidebarWidth',
+    _$sidebarWidth,
+    opt: true,
+    def: AleraTokens.sidebarDefaultWidth,
+  );
   static WorkbenchContextPanelTab _$activeContextPanelTab(
     WorkbenchViewPrefs v,
   ) => v.activeContextPanelTab;
@@ -378,6 +385,7 @@ class WorkbenchViewPrefsMapper extends ClassMapperBase<WorkbenchViewPrefs> {
     #sourceControlRootByWorkspaceId: _f$sourceControlRootByWorkspaceId,
     #rightSidebarVisible: _f$rightSidebarVisible,
     #rightSidebarWidth: _f$rightSidebarWidth,
+    #sidebarWidth: _f$sidebarWidth,
     #activeContextPanelTab: _f$activeContextPanelTab,
     #explorerMode: _f$explorerMode,
     #gitDiffViewMode: _f$gitDiffViewMode,
@@ -398,6 +406,7 @@ class WorkbenchViewPrefsMapper extends ClassMapperBase<WorkbenchViewPrefs> {
       ),
       rightSidebarVisible: data.dec(_f$rightSidebarVisible),
       rightSidebarWidth: data.dec(_f$rightSidebarWidth),
+      sidebarWidth: data.dec(_f$sidebarWidth),
       activeContextPanelTab: data.dec(_f$activeContextPanelTab),
       explorerMode: data.dec(_f$explorerMode),
       gitDiffViewMode: data.dec(_f$gitDiffViewMode),
@@ -489,6 +498,7 @@ abstract class WorkbenchViewPrefsCopyWith<
     Map<String, String>? sourceControlRootByWorkspaceId,
     bool? rightSidebarVisible,
     double? rightSidebarWidth,
+    double? sidebarWidth,
     WorkbenchContextPanelTab? activeContextPanelTab,
     WorkspaceExplorerMode? explorerMode,
     GitDiffViewMode? gitDiffViewMode,
@@ -526,6 +536,7 @@ class _WorkbenchViewPrefsCopyWithImpl<$R, $Out>
     Map<String, String>? sourceControlRootByWorkspaceId,
     bool? rightSidebarVisible,
     double? rightSidebarWidth,
+    double? sidebarWidth,
     WorkbenchContextPanelTab? activeContextPanelTab,
     WorkspaceExplorerMode? explorerMode,
     GitDiffViewMode? gitDiffViewMode,
@@ -547,6 +558,7 @@ class _WorkbenchViewPrefsCopyWithImpl<$R, $Out>
       if (rightSidebarVisible != null)
         #rightSidebarVisible: rightSidebarVisible,
       if (rightSidebarWidth != null) #rightSidebarWidth: rightSidebarWidth,
+      if (sidebarWidth != null) #sidebarWidth: sidebarWidth,
       if (activeContextPanelTab != null)
         #activeContextPanelTab: activeContextPanelTab,
       if (explorerMode != null) #explorerMode: explorerMode,
@@ -587,6 +599,7 @@ class _WorkbenchViewPrefsCopyWithImpl<$R, $Out>
       #rightSidebarWidth,
       or: $value.rightSidebarWidth,
     ),
+    sidebarWidth: data.get(#sidebarWidth, or: $value.sidebarWidth),
     activeContextPanelTab: data.get(
       #activeContextPanelTab,
       or: $value.activeContextPanelTab,

--- a/lib/src/features/workbench/presentation/project_workbench_sidebar.dart
+++ b/lib/src/features/workbench/presentation/project_workbench_sidebar.dart
@@ -77,7 +77,7 @@ class _ProjectWorkbenchSidebarState
       );
     }
     return SizedBox(
-      width: state.sidebarWidth,
+      width: state.viewPrefs.sidebarWidth,
       child: Stack(
         children: <Widget>[
           Container(
@@ -146,7 +146,7 @@ class _ProjectWorkbenchSidebarState
             top: 0,
             bottom: 0,
             child: SidebarResizeHandle(
-              currentWidth: state.sidebarWidth,
+              currentWidth: state.viewPrefs.sidebarWidth,
               onResize: controller.setSidebarWidth,
             ),
           ),

--- a/test/unit/workbench_controller_view_prefs_test_cases.dart
+++ b/test/unit/workbench_controller_view_prefs_test_cases.dart
@@ -183,7 +183,7 @@ void _registerWorkbenchControllerViewPrefsTests() {
     );
     expect(_controller.state.searchQuery, 'terminal');
     expect(_controller.state.collapsed, isTrue);
-    expect(_controller.state.sidebarWidth, AleraTokens.sidebarMaxWidth);
+    expect(_controller.state.viewPrefs.sidebarWidth, AleraTokens.sidebarMaxWidth);
     expect(
       _harness.viewPrefsRepository.prefs.workspaceSort,
       WorkbenchSortBy.recent,

--- a/test/unit/workbench_controller_view_prefs_test_cases.dart
+++ b/test/unit/workbench_controller_view_prefs_test_cases.dart
@@ -183,7 +183,10 @@ void _registerWorkbenchControllerViewPrefsTests() {
     );
     expect(_controller.state.searchQuery, 'terminal');
     expect(_controller.state.collapsed, isTrue);
-    expect(_controller.state.viewPrefs.sidebarWidth, AleraTokens.sidebarMaxWidth);
+    expect(
+      _controller.state.viewPrefs.sidebarWidth,
+      AleraTokens.sidebarMaxWidth,
+    );
     expect(
       _harness.viewPrefsRepository.prefs.workspaceSort,
       WorkbenchSortBy.recent,

--- a/test/unit/workbench_view_prefs_test.dart
+++ b/test/unit/workbench_view_prefs_test.dart
@@ -1,4 +1,5 @@
 import 'package:dart_mappable/dart_mappable.dart';
+import 'package:alera/src/app/theme/alera_tokens.dart';
 import 'package:alera/src/features/workbench/domain/workbench_view_prefs.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -19,6 +20,10 @@ void main() {
       );
       expect(WorkbenchViewPrefs.defaults.rightSidebarVisible, isTrue);
       expect(WorkbenchViewPrefs.defaults.rightSidebarWidth, 280);
+      expect(
+        WorkbenchViewPrefs.defaults.sidebarWidth,
+        AleraTokens.sidebarDefaultWidth,
+      );
       expect(
         WorkbenchViewPrefs.defaults.activeContextPanelTab,
         WorkbenchContextPanelTab.explorer,
@@ -44,6 +49,7 @@ void main() {
         },
         rightSidebarVisible: false,
         rightSidebarWidth: 360,
+        sidebarWidth: 360,
         activeContextPanelTab: WorkbenchContextPanelTab.explorer,
         explorerMode: WorkspaceExplorerMode.showAll,
       );
@@ -63,6 +69,7 @@ void main() {
       });
       expect(restored.rightSidebarVisible, isFalse);
       expect(restored.rightSidebarWidth, 360);
+      expect(restored.sidebarWidth, 360);
       expect(restored.activeContextPanelTab, WorkbenchContextPanelTab.explorer);
       expect(restored.explorerMode, WorkspaceExplorerMode.showAll);
     });


### PR DESCRIPTION
Moves `sidebarWidth` from the ephemeral `WorkbenchState` to the persisted `WorkbenchViewPrefs`, mirroring the existing `rightSidebarWidth` pattern so the left side panel size is kept across sessions.

**Validation**
- `flutter analyze` clean on touched files
- Updated `workbench_view_prefs_test` and `workbench_controller_view_prefs_test_cases`