### PR TITLE
[codex] refine workspace sidebar hierarchy

### DIFF
--- a/lib/src/features/workbench/application/workbench_controller.dart
+++ b/lib/src/features/workbench/application/workbench_controller.dart
@@ -8,6 +8,7 @@ import 'package:alera/src/features/projects/domain/project.dart';
 import 'package:alera/src/features/workbench/application/workspace_tab_service.dart';
 import 'package:alera/src/features/workbench/application/workbench_repository.dart';
 import 'package:alera/src/features/workbench/application/workbench_providers.dart';
+import 'package:alera/src/features/workbench/application/workbench_listing.dart';
 import 'package:alera/src/features/workbench/application/workbench_state.dart';
 import 'package:alera/src/features/workbench/application/workbench_view_prefs_repository.dart';
 import 'package:alera/src/features/workbench/application/workspace_activity_controller.dart';

--- a/lib/src/features/workbench/application/workbench_controller_view_prefs.dart
+++ b/lib/src/features/workbench/application/workbench_controller_view_prefs.dart
@@ -125,51 +125,42 @@ mixin _WorkbenchControllerViewPrefs
     );
   }
 
-  /// Collapses or expands the appropriate items depending on the active group
-  /// mode. In [WorkbenchGroupBy.project] this toggles every visible project
-  /// group; in [WorkbenchGroupBy.none] it toggles the sidebar-visible agent-run
-  /// list of the active workspace.
+  /// Collapses or expands every sidebar-visible grouping surface: project
+  /// groups, parent workspace child trees, and workspace agent-run sections.
   void toggleCollapseAll() {
     final prefs = state.viewPrefs;
-    if (prefs.groupBy == WorkbenchGroupBy.project) {
-      final selected = prefs.selectedProjectIds;
-      final visibleProjectIds = <String>[
-        for (final project in state.projects)
-          if (selected.isEmpty || selected.contains(project.id)) project.id,
-      ];
-      if (visibleProjectIds.isEmpty) {
-        return;
-      }
-      final allCollapsed = visibleProjectIds.every(
-        prefs.collapsedProjectIds.contains,
-      );
-      final next = Set<String>.from(prefs.collapsedProjectIds);
-      if (allCollapsed) {
-        next.removeAll(visibleProjectIds);
-      } else {
-        next.addAll(visibleProjectIds);
-      }
-      _updateViewPrefs(prefs.copyWith(collapsedProjectIds: next));
+    final targets = visibleSidebarCollapseTargets(state);
+    if (targets.isEmpty) {
       return;
     }
-    // Flat mode: toggle the expansion of every visible workspace.
-    final allWorkspaceIds = <String>[
-      for (final entry in state.workspacesByProject.entries)
-        for (final workspace in entry.value) workspace.id,
-    ];
-    if (allWorkspaceIds.isEmpty) {
-      return;
-    }
-    final anyExpanded = allWorkspaceIds.any(
-      prefs.expandedWorkspaceIds.contains,
+    final allCollapsed = targets.isCollapsed(prefs);
+    final actionTargets = allCollapsed
+        ? visibleSidebarCollapseTargets(
+            state,
+            includeCollapsedProjectDescendants: true,
+          )
+        : targets;
+    final nextProjects = Set<String>.from(prefs.collapsedProjectIds);
+    final nextParentWorkspaces = Set<String>.from(
+      prefs.collapsedParentWorkspaceIds,
     );
     final next = Set<String>.from(prefs.expandedWorkspaceIds);
-    if (anyExpanded) {
-      next.removeAll(allWorkspaceIds);
+    if (allCollapsed) {
+      nextProjects.removeAll(actionTargets.projectIds);
+      nextParentWorkspaces.removeAll(actionTargets.parentWorkspaceIds);
+      next.addAll(actionTargets.workspaceIds);
     } else {
-      next.addAll(allWorkspaceIds);
+      nextProjects.addAll(actionTargets.projectIds);
+      nextParentWorkspaces.addAll(actionTargets.parentWorkspaceIds);
+      next.removeAll(actionTargets.workspaceIds);
     }
-    _updateViewPrefs(prefs.copyWith(expandedWorkspaceIds: next));
+    _updateViewPrefs(
+      prefs.copyWith(
+        collapsedProjectIds: nextProjects,
+        collapsedParentWorkspaceIds: nextParentWorkspaces,
+        expandedWorkspaceIds: next,
+      ),
+    );
   }
 
   void toggleWorkspaceExpanded(String workspaceId) {

--- a/lib/src/features/workbench/application/workbench_listing.dart
+++ b/lib/src/features/workbench/application/workbench_listing.dart
@@ -13,6 +13,34 @@ sealed class WorkbenchSidebarRow {
   const WorkbenchSidebarRow();
 }
 
+class WorkbenchSidebarCollapseTargets {
+  const WorkbenchSidebarCollapseTargets({
+    required this.projectIds,
+    required this.workspaceIds,
+    required this.parentWorkspaceIds,
+  });
+
+  final Set<String> projectIds;
+  final Set<String> workspaceIds;
+  final Set<String> parentWorkspaceIds;
+
+  bool get isEmpty =>
+      projectIds.isEmpty && workspaceIds.isEmpty && parentWorkspaceIds.isEmpty;
+
+  bool isCollapsed(WorkbenchViewPrefs prefs) {
+    final projectsCollapsed = projectIds.every(
+      prefs.collapsedProjectIds.contains,
+    );
+    final childTreesCollapsed = parentWorkspaceIds.every(
+      prefs.collapsedParentWorkspaceIds.contains,
+    );
+    final agentsCollapsed = !workspaceIds.any(
+      prefs.expandedWorkspaceIds.contains,
+    );
+    return projectsCollapsed && childTreesCollapsed && agentsCollapsed;
+  }
+}
+
 class WorkbenchProjectHeaderRow extends WorkbenchSidebarRow {
   const WorkbenchProjectHeaderRow({
     required this.project,
@@ -315,6 +343,108 @@ bool workspaceMatchesTagFilter(WorkbenchViewPrefs prefs, Workspace workspace) {
   return workspace.tagIds.any(prefs.selectedTagIds.contains);
 }
 
+WorkbenchSidebarCollapseTargets visibleSidebarCollapseTargets(
+  WorkbenchState state, {
+  bool includeCollapsedProjectDescendants = false,
+}) {
+  final prefs = state.viewPrefs;
+  final query = state.searchQuery.trim().toLowerCase();
+  final filtersHideEmptyProjects =
+      query.isNotEmpty || prefs.selectedTagIds.isNotEmpty;
+  final visibleProjects = state.projects
+      .where((project) => _projectVisible(prefs, project))
+      .toList(growable: false);
+  final projectIds = <String>{};
+  final workspaceIds = <String>{};
+  final parentWorkspaceIds = <String>{};
+
+  Iterable<Workspace> visibleWorkspacesFor(Project project) {
+    return state
+        .workspacesFor(project.id)
+        .where(
+          (workspace) => _workspaceVisible(prefs, query, project, workspace),
+        );
+  }
+
+  void collectParentIds(Iterable<Workspace> workspaces) {
+    final ids = <String>{for (final workspace in workspaces) workspace.id};
+    for (final workspace in workspaces) {
+      final parentId = workspace.parentWorkspaceId;
+      if (parentId != null &&
+          parentId != workspace.id &&
+          ids.contains(parentId)) {
+        parentWorkspaceIds.add(parentId);
+      }
+    }
+  }
+
+  switch (prefs.groupBy) {
+    case WorkbenchGroupBy.project:
+      for (final project in visibleProjects) {
+        final workspaces = visibleWorkspacesFor(
+          project,
+        ).toList(growable: false);
+        if (filtersHideEmptyProjects && workspaces.isEmpty) {
+          continue;
+        }
+        projectIds.add(project.id);
+        if (includeCollapsedProjectDescendants ||
+            !prefs.collapsedProjectIds.contains(project.id)) {
+          workspaceIds.addAll(workspaces.map((workspace) => workspace.id));
+          collectParentIds(workspaces);
+        }
+      }
+    case WorkbenchGroupBy.none:
+      final workspaces = <Workspace>[];
+      for (final project in visibleProjects) {
+        workspaces.addAll(visibleWorkspacesFor(project));
+      }
+      workspaceIds.addAll(workspaces.map((workspace) => workspace.id));
+      collectParentIds(workspaces);
+  }
+
+  return WorkbenchSidebarCollapseTargets(
+    projectIds: projectIds,
+    workspaceIds: workspaceIds,
+    parentWorkspaceIds: parentWorkspaceIds,
+  );
+}
+
+bool _projectVisible(WorkbenchViewPrefs prefs, Project project) {
+  if (prefs.selectedProjectIds.isEmpty) {
+    return true;
+  }
+  return prefs.selectedProjectIds.contains(project.id);
+}
+
+bool _workspaceVisible(
+  WorkbenchViewPrefs prefs,
+  String query,
+  Project project,
+  Workspace workspace,
+) {
+  if (!workspaceMatchesTagFilter(prefs, workspace)) {
+    return false;
+  }
+  if (query.isEmpty) {
+    return true;
+  }
+  if (project.name.toLowerCase().contains(query)) {
+    return true;
+  }
+  if (workspace.name.toLowerCase().contains(query)) {
+    return true;
+  }
+  if (workspace.branch?.toLowerCase().contains(query) ?? false) {
+    return true;
+  }
+  final source = workspace.sourceBranch;
+  if (source != null && source.toLowerCase().contains(query)) {
+    return true;
+  }
+  return false;
+}
+
 /// The workspace-id order of the rendered rows, used to remember the previous
 /// ordering for [buildSidebarRows]'s active-row stabilization.
 List<String> workspaceOrderOfRows(List<WorkbenchSidebarRow> rows) {
@@ -331,24 +461,11 @@ int countVisibleWorkspaces(WorkbenchState state) {
   final query = state.searchQuery.trim().toLowerCase();
   var count = 0;
   for (final project in state.projects) {
-    if (prefs.selectedProjectIds.isNotEmpty &&
-        !prefs.selectedProjectIds.contains(project.id)) {
+    if (!_projectVisible(prefs, project)) {
       continue;
     }
     for (final workspace in state.workspacesFor(project.id)) {
-      if (!workspaceMatchesTagFilter(prefs, workspace)) {
-        continue;
-      }
-      if (query.isEmpty) {
-        count++;
-        continue;
-      }
-      final projectMatches = project.name.toLowerCase().contains(query);
-      final workspaceMatches =
-          workspace.name.toLowerCase().contains(query) ||
-          (workspace.branch?.toLowerCase().contains(query) ?? false) ||
-          (workspace.sourceBranch?.toLowerCase().contains(query) ?? false);
-      if (projectMatches || workspaceMatches) {
+      if (_workspaceVisible(prefs, query, project, workspace)) {
         count++;
       }
     }

--- a/lib/src/features/workbench/presentation/project_workbench_sidebar_body.dart
+++ b/lib/src/features/workbench/presentation/project_workbench_sidebar_body.dart
@@ -145,12 +145,12 @@ class _SidebarBody extends StatelessWidget {
     return const SizedBox.shrink();
   }
 
-  /// Base sidebar padding plus one step per nesting level, clamped so deep
-  /// trees keep usable row widths in a narrow sidebar.
+  /// Base sidebar padding plus one row-content step per nesting level, clamped
+  /// so deep trees keep usable row widths in a narrow sidebar.
   double _indentPadding(int indent) {
     const double base = AleraTokens.space8;
-    const double step = AleraTokens.space12;
-    const double max = base + 6 * step;
+    const double step = AleraTokens.space32;
+    const double max = base + 4 * step;
     final padding = base + indent * step;
     return padding > max ? max : padding;
   }

--- a/lib/src/features/workbench/presentation/project_workbench_workspace_rows.dart
+++ b/lib/src/features/workbench/presentation/project_workbench_workspace_rows.dart
@@ -62,6 +62,7 @@ class _WorkspaceRow extends StatefulWidget {
 }
 
 class _WorkspaceRowState extends State<_WorkspaceRow> {
+  static const int _maxInlineTags = 3;
   static const String _renameAction = 'rename';
   static const String _openFolderAction = 'open-folder';
   static const String _copyPathAction = 'copy-path';
@@ -170,31 +171,72 @@ class _WorkspaceRowState extends State<_WorkspaceRow> {
     }
   }
 
-  String _buildSecondaryLine() {
+  String _buildBranchLabel() {
     final branch = widget.workspace.branch;
-    final parts = <String>[
-      if (branch != null && branch.isNotEmpty)
-        branch
-      else if (widget.project.isFolder)
-        'Local Folder'
-      else
-        'Git Repository',
-    ];
-    final source = widget.workspace.sourceBranch;
-    if (!widget.workspace.isMain &&
-        !widget.workspace.reusesExistingBranch &&
-        source != null &&
-        source.isNotEmpty) {
-      parts.add('Base: $source');
+    if (branch != null && branch.isNotEmpty) {
+      return branch;
     }
-    return parts.join(' · ');
+    if (widget.project.isFolder) {
+      return 'Local Folder';
+    }
+    return 'Git Repository';
+  }
+
+  List<String> _tagLabels() {
+    final source = widget.workspace.tagNames.isNotEmpty
+        ? widget.workspace.tagNames
+        : widget.workspace.tagIds;
+    return source
+        .map((tag) => tag.trim())
+        .where((tag) => tag.isNotEmpty)
+        .toList(growable: false);
+  }
+
+  List<Widget> _buildMetadataChips() {
+    final branchLabel = _buildBranchLabel();
+    final tags = _tagLabels();
+    final chips = <Widget>[
+      if (widget.showProjectChip)
+        AleraChip(
+          leading: AleraIcons.folderSpecial,
+          label: widget.project.name,
+          tooltip: widget.project.name,
+        ),
+      AleraChip(
+        leading: AleraIcons.gitBranch,
+        label: branchLabel,
+        tooltip: branchLabel,
+      ),
+      for (final tag in tags.take(_maxInlineTags))
+        AleraChip(leading: AleraIcons.tag, label: '#$tag', tooltip: tag),
+    ];
+    final hiddenTags = tags.skip(_maxInlineTags).toList(growable: false);
+    if (hiddenTags.isNotEmpty) {
+      chips.add(
+        AleraChip(
+          leading: AleraIcons.tag,
+          label: '+${hiddenTags.length} Tags',
+          tooltip: hiddenTags.join(', '),
+        ),
+      );
+    }
+    final hostId = widget.workspace.hostId.trim();
+    if (hostId.isNotEmpty && hostId != 'local') {
+      chips.add(
+        AleraChip(
+          leading: AleraIcons.host,
+          label: hostId,
+          tooltip: 'Host: $hostId',
+        ),
+      );
+    }
+    return chips;
   }
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final isActive = widget.isActive;
-    final actionsVisible = _hovered || isActive;
     return MouseRegion(
       onEnter: (_) => setState(() => _hovered = true),
       onExit: (_) => setState(() => _hovered = false),
@@ -223,24 +265,6 @@ class _WorkspaceRowState extends State<_WorkspaceRow> {
                 child: Row(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: <Widget>[
-                    if (widget.hasVisibleChildren &&
-                        widget.onToggleChildren != null) ...<Widget>[
-                      Padding(
-                        padding: const EdgeInsets.only(top: 2),
-                        child: AleraIconButton(
-                          tooltip: widget.childrenCollapsed
-                              ? 'Show Child Workspaces'
-                              : 'Hide Child Workspaces',
-                          onPressed: widget.onToggleChildren!,
-                          icon: widget.childrenCollapsed
-                              ? AleraIcons.chevronRight
-                              : AleraIcons.chevronDown,
-                          iconSize: 12,
-                          minSize: 20,
-                        ),
-                      ),
-                      const SizedBox(width: AleraTokens.space2),
-                    ],
                     Padding(
                       padding: const EdgeInsets.only(top: 6),
                       child: widget.status == null
@@ -277,25 +301,11 @@ class _WorkspaceRowState extends State<_WorkspaceRow> {
                             ],
                           ),
                           const SizedBox(height: AleraTokens.space4),
-                          Row(
-                            children: <Widget>[
-                              if (widget.showProjectChip) ...<Widget>[
-                                Flexible(
-                                  child: AleraChip(label: widget.project.name),
-                                ),
-                                const SizedBox(width: AleraTokens.space6),
-                              ],
-                              Flexible(
-                                child: Text(
-                                  _buildSecondaryLine(),
-                                  maxLines: 1,
-                                  overflow: TextOverflow.ellipsis,
-                                  style: theme.textTheme.labelSmall?.copyWith(
-                                    color: AleraTokens.foregroundFaint,
-                                  ),
-                                ),
-                              ),
-                            ],
+                          Wrap(
+                            spacing: AleraTokens.space6,
+                            runSpacing: AleraTokens.space4,
+                            crossAxisAlignment: WrapCrossAlignment.center,
+                            children: _buildMetadataChips(),
                           ),
                           if (widget.agentRuns.isNotEmpty) ...<Widget>[
                             const SizedBox(height: AleraTokens.space6),
@@ -311,33 +321,25 @@ class _WorkspaceRowState extends State<_WorkspaceRow> {
                               onCloseTerminal: widget.onCloseTerminal,
                             ),
                           ],
-                          if (WorkspaceGraphChips.hasContent(
-                            widget.workspace,
-                          )) ...<Widget>[
-                            const SizedBox(height: AleraTokens.space6),
-                            WorkspaceGraphChips(workspace: widget.workspace),
-                          ],
                         ],
                       ),
                     ),
-                    if (widget.onDelete != null)
-                      IgnorePointer(
-                        ignoring: !actionsVisible,
-                        child: AnimatedOpacity(
-                          opacity: actionsVisible ? 1 : 0,
-                          duration: AleraTokens.durationFast,
-                          child: Padding(
-                            padding: const EdgeInsets.only(
-                              left: AleraTokens.space2,
-                            ),
-                            child: AleraIconButton(
-                              tooltip: 'Remove Workspace',
-                              onPressed: widget.onDelete!,
-                              icon: AleraIcons.delete,
-                              iconSize: 14,
-                              minSize: 24,
-                            ),
-                          ),
+                    if (widget.hasVisibleChildren &&
+                        widget.onToggleChildren != null)
+                      Padding(
+                        padding: const EdgeInsets.only(
+                          left: AleraTokens.space2,
+                        ),
+                        child: AleraIconButton(
+                          tooltip: widget.childrenCollapsed
+                              ? 'Show Child Workspaces'
+                              : 'Hide Child Workspaces',
+                          onPressed: widget.onToggleChildren!,
+                          icon: widget.childrenCollapsed
+                              ? AleraIcons.chevronRight
+                              : AleraIcons.chevronDown,
+                          iconSize: 14,
+                          minSize: 24,
                         ),
                       ),
                   ],

--- a/lib/src/features/workbench/presentation/widgets/workbench_sidebar_toolbar.dart
+++ b/lib/src/features/workbench/presentation/widgets/workbench_sidebar_toolbar.dart
@@ -26,27 +26,9 @@ class WorkbenchSidebarToolbar extends ConsumerWidget {
     final prefs = state.viewPrefs;
     final count = countVisibleWorkspaces(state);
 
-    final isProjectMode = prefs.groupBy == WorkbenchGroupBy.project;
-    final selected = prefs.selectedProjectIds;
-    final visibleProjects = state.projects
-        .where((p) => selected.isEmpty || selected.contains(p.id))
-        .toList(growable: false);
-    final allWorkspaceIds = <String>[
-      for (final project in visibleProjects)
-        for (final workspace in state.workspacesFor(project.id)) workspace.id,
-    ];
-    final anyExpanded = allWorkspaceIds.any(
-      prefs.expandedWorkspaceIds.contains,
-    );
-    final allCollapsed = isProjectMode
-        ? visibleProjects.isNotEmpty &&
-              visibleProjects.every(
-                (p) => prefs.collapsedProjectIds.contains(p.id),
-              )
-        : !anyExpanded;
-    final canCollapse = isProjectMode
-        ? visibleProjects.isNotEmpty
-        : allWorkspaceIds.isNotEmpty;
+    final collapseTargets = visibleSidebarCollapseTargets(state);
+    final allCollapsed = collapseTargets.isCollapsed(prefs);
+    final canCollapse = !collapseTargets.isEmpty;
     final hasGitProjects = state.projects.any(
       (project) => project.supportsLinkedWorkspaces,
     );

--- a/lib/src/features/workbench/presentation/workspace_graph_indicators.dart
+++ b/lib/src/features/workbench/presentation/workspace_graph_indicators.dart
@@ -6,11 +6,6 @@ import 'package:alera/src/features/workbench/domain/workspace.dart';
 import 'package:flutter/material.dart';
 
 /// Role badge shown next to a workspace name.
-///
-/// A workspace is either the project's primary worktree, a child of another
-/// workspace, or neither — so this renders at most one badge. It mirrors the
-/// `Primary` marker that already sits beside the name, keeping role markers
-/// visually parallel across the sidebar and the welcome dashboard.
 class WorkspaceRoleBadge extends StatelessWidget {
   const WorkspaceRoleBadge({super.key, required this.workspace});
 
@@ -19,21 +14,12 @@ class WorkspaceRoleBadge extends StatelessWidget {
   /// Whether [workspace] has a role to show. Callers use this to gate the
   /// adjacent spacer so the predicate lives in one place instead of being
   /// duplicated at every call site.
-  static bool hasRole(Workspace workspace) =>
-      workspace.isMain || workspace.parentWorkspaceId != null;
+  static bool hasRole(Workspace workspace) => workspace.isMain;
 
   @override
   Widget build(BuildContext context) {
     if (workspace.isMain) {
-      return const AleraBadge(label: 'Primary');
-    }
-    if (workspace.parentWorkspaceId != null) {
-      // Info-tinted text so the relationship role reads differently from the
-      // neutral "Primary" marker while keeping the same subtle fill.
-      return const AleraBadge(
-        label: 'Child',
-        foregroundColor: AleraTokens.info,
-      );
+      return const AleraBadge(label: 'Default');
     }
     return const SizedBox.shrink();
   }

--- a/test/unit/workbench_controller_view_prefs_test_cases.dart
+++ b/test/unit/workbench_controller_view_prefs_test_cases.dart
@@ -139,16 +139,30 @@ void _registerWorkbenchControllerViewPrefsTests() {
     )).workspace;
     await _flush();
 
+    _controller.setWorkspaceExpanded(mainWorkspace.id, true);
+    _controller.setWorkspaceExpanded(linkedWorkspace.id, true);
     _controller.toggleCollapseAll();
     expect(
       _controller.state.viewPrefs.collapsedProjectIds,
       contains(_harness.project.id),
+    );
+    expect(
+      _controller.state.viewPrefs.expandedWorkspaceIds,
+      isNot(contains(mainWorkspace.id)),
+    );
+    expect(
+      _controller.state.viewPrefs.expandedWorkspaceIds,
+      isNot(contains(linkedWorkspace.id)),
     );
 
     _controller.toggleCollapseAll();
     expect(
       _controller.state.viewPrefs.collapsedProjectIds,
       isNot(contains(_harness.project.id)),
+    );
+    expect(
+      _controller.state.viewPrefs.expandedWorkspaceIds,
+      containsAll(<String>[mainWorkspace.id, linkedWorkspace.id]),
     );
 
     _controller.setGroupBy(WorkbenchGroupBy.none);

--- a/test/widget/alera_shell_page_sidebar_states_test_cases.dart
+++ b/test/widget/alera_shell_page_sidebar_states_test_cases.dart
@@ -156,26 +156,13 @@ void _registerAleraShellSidebarStateTests() {
     expect(find.textContaining('deletes branch'), findsNothing);
   });
 
-  testWidgets('reused branch workspaces do not show base branch labels', (
+  testWidgets('workspace branch metadata omits base branch labels', (
     tester,
   ) async {
-    final seeded = _linkedWorkbenchState();
-    final workspaces = seeded.workspacesFor('project-1');
-    final reusedState = seeded.copyWith(
-      workspacesByProject: <String, List<Workspace>>{
-        'project-1': <Workspace>[
-          workspaces.first,
-          workspaces.last.copyWith(
-            sourceBranch: 'feature/login',
-            reusesExistingBranch: true,
-          ),
-        ],
-      },
-    );
+    await _pumpShell(tester, state: _linkedWorkbenchState());
 
-    await _pumpShell(tester, state: reusedState);
-
-    expect(find.textContaining('feature/login'), findsOneWidget);
+    expect(find.text('feature/login'), findsOneWidget);
+    expect(find.byIcon(AleraIcons.gitBranch), findsAtLeastNWidgets(2));
     expect(find.textContaining('Base:'), findsNothing);
   });
 
@@ -252,7 +239,129 @@ void _registerAleraShellSidebarStateTests() {
 
     expect(find.byType(AleraChip), findsAtLeastNWidgets(1));
     expect(find.text('Alera'), findsAtLeastNWidgets(1));
+    expect(find.byIcon(AleraIcons.folderSpecial), findsAtLeastNWidgets(1));
   });
+
+  testWidgets('workspace rows show tags inline without child role indicators', (
+    tester,
+  ) async {
+    final seeded = _linkedWorkbenchState(linkedExpanded: true);
+    final workspaces = seeded.workspacesFor('project-1');
+    final parent = workspaces.first.copyWith(childCount: 1);
+    final child = workspaces.last.copyWith(
+      parentWorkspaceId: parent.id,
+      tagNames: const <String>['frontend', 'review', 'qa', 'ux'],
+    );
+
+    await _pumpShell(
+      tester,
+      state: seeded.copyWith(
+        workspacesByProject: <String, List<Workspace>>{
+          'project-1': <Workspace>[parent, child],
+        },
+      ),
+    );
+
+    expect(find.text('#frontend'), findsOneWidget);
+    expect(find.text('#review'), findsOneWidget);
+    expect(find.text('#qa'), findsOneWidget);
+    expect(find.text('+1 Tags'), findsOneWidget);
+    expect(find.text('Child'), findsNothing);
+    expect(find.text('1 Child'), findsNothing);
+    expect(find.byTooltip('Remove Workspace'), findsNothing);
+    expect(find.byTooltip('Hide Child Workspaces'), findsOneWidget);
+  });
+
+  testWidgets('collapse all closes projects, child workspaces, and agents', (
+    tester,
+  ) async {
+    final seeded = _linkedWorkbenchState(linkedExpanded: true);
+    final workspaces = seeded.workspacesFor('project-1');
+    final parent = workspaces.first.copyWith(childCount: 1);
+    final child = workspaces.last.copyWith(parentWorkspaceId: parent.id);
+    final state = seeded.copyWith(
+      workspacesByProject: <String, List<Workspace>>{
+        'project-1': <Workspace>[parent, child],
+      },
+      viewPrefs: seeded.viewPrefs.copyWith(
+        expandedWorkspaceIds: <String>{parent.id, child.id},
+      ),
+    );
+    final harness = await _pumpShell(tester, state: state);
+
+    await tester.tap(find.byTooltip('Collapse All'));
+    await tester.pumpAndSettle();
+
+    expect(
+      harness.controller.state.viewPrefs.collapsedProjectIds,
+      contains('project-1'),
+    );
+    expect(
+      harness.controller.state.viewPrefs.collapsedParentWorkspaceIds,
+      contains(parent.id),
+    );
+    expect(
+      harness.controller.state.viewPrefs.expandedWorkspaceIds,
+      isNot(contains(parent.id)),
+    );
+    expect(
+      harness.controller.state.viewPrefs.expandedWorkspaceIds,
+      isNot(contains(child.id)),
+    );
+
+    await tester.tap(find.byTooltip('Expand All'));
+    await tester.pumpAndSettle();
+
+    expect(
+      harness.controller.state.viewPrefs.collapsedProjectIds,
+      isNot(contains('project-1')),
+    );
+    expect(
+      harness.controller.state.viewPrefs.collapsedParentWorkspaceIds,
+      isNot(contains(parent.id)),
+    );
+    expect(
+      harness.controller.state.viewPrefs.expandedWorkspaceIds,
+      containsAll(<String>[parent.id, child.id]),
+    );
+  });
+
+  testWidgets(
+    'expand all opens collapsed projects despite hidden agent state',
+    (tester) async {
+      final seeded = _linkedWorkbenchState(linkedExpanded: true);
+      final workspaces = seeded.workspacesFor('project-1');
+      final parent = workspaces.first.copyWith(childCount: 1);
+      final child = workspaces.last.copyWith(parentWorkspaceId: parent.id);
+      final state = seeded.copyWith(
+        workspacesByProject: <String, List<Workspace>>{
+          'project-1': <Workspace>[parent, child],
+        },
+        viewPrefs: seeded.viewPrefs.copyWith(
+          collapsedProjectIds: <String>{'project-1'},
+          collapsedParentWorkspaceIds: <String>{parent.id},
+          expandedWorkspaceIds: <String>{parent.id, child.id},
+        ),
+      );
+      final harness = await _pumpShell(tester, state: state);
+
+      await tester.tap(find.byTooltip('Expand All'));
+      await tester.pumpAndSettle();
+
+      expect(
+        harness.controller.state.viewPrefs.collapsedProjectIds,
+        isNot(contains('project-1')),
+      );
+      expect(
+        harness.controller.state.viewPrefs.collapsedParentWorkspaceIds,
+        isNot(contains(parent.id)),
+      );
+      expect(
+        harness.controller.state.viewPrefs.expandedWorkspaceIds,
+        containsAll(<String>[parent.id, child.id]),
+      );
+    },
+  );
 
   testWidgets('project rename failures surface an error toast event', (
     tester,

--- a/test/widget/alera_shell_page_test.dart
+++ b/test/widget/alera_shell_page_test.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:alera/src/app/providers.dart';
 import 'package:alera/src/app/theme/alera_tokens.dart';
 import 'package:alera/src/design_system/chips/alera_chip.dart';
+import 'package:alera/src/design_system/icons/alera_icons.dart';
 import 'package:alera/src/design_system/feedback/alera_status_dot.dart';
 import 'package:alera/src/design_system/feedback/alera_toast.dart';
 import 'package:alera/src/features/agent_status/domain/agent_status.dart';

--- a/test/widget/workspace_graph_indicators_test.dart
+++ b/test/widget/workspace_graph_indicators_test.dart
@@ -39,26 +39,34 @@ void main() {
   }
 
   group('WorkspaceRoleBadge', () {
-    testWidgets('shows Primary for the main workspace', (tester) async {
+    testWidgets('shows Default for the main workspace', (tester) async {
       await pump(
         tester,
         WorkspaceRoleBadge(workspace: workspace(kind: WorkspaceKind.main)),
       );
-      expect(find.text('Primary'), findsOneWidget);
+      expect(find.text('Default'), findsOneWidget);
+      expect(find.text('default'), findsNothing);
+      expect(find.text('Primary'), findsNothing);
       expect(find.text('Child'), findsNothing);
     });
 
-    testWidgets('shows Child when the workspace has a parent', (tester) async {
+    testWidgets('renders nothing when the workspace has a parent', (
+      tester,
+    ) async {
       await pump(
         tester,
         WorkspaceRoleBadge(workspace: workspace(parentWorkspaceId: 'parent')),
       );
-      expect(find.text('Child'), findsOneWidget);
+      expect(find.text('Default'), findsNothing);
+      expect(find.text('default'), findsNothing);
+      expect(find.text('Child'), findsNothing);
       expect(find.text('Primary'), findsNothing);
     });
 
     testWidgets('renders nothing for a plain linked workspace', (tester) async {
       await pump(tester, WorkspaceRoleBadge(workspace: workspace()));
+      expect(find.text('Default'), findsNothing);
+      expect(find.text('default'), findsNothing);
       expect(find.text('Primary'), findsNothing);
       expect(find.text('Child'), findsNothing);
     });
@@ -70,7 +78,7 @@ void main() {
       );
       expect(
         WorkspaceRoleBadge.hasRole(workspace(parentWorkspaceId: 'p')),
-        isTrue,
+        isFalse,
       );
       expect(WorkspaceRoleBadge.hasRole(workspace()), isFalse);
     });


### PR DESCRIPTION
## Summary

- Refines workspace hierarchy rendering in the left sidebar by removing parent/child count badges and aligning child workspaces with parent agent rows.
- Moves parent collapse controls into the row action slot, keeps workspace deletion on the context menu, and shows branch/tag metadata inline.
- Updates Collapse All / Expand All to include parent-child workspaces and agent rows, including hidden descendants under collapsed projects.

## Validation

- `git diff --check`
- `dart format --output=none --set-exit-if-changed ...`
- `flutter analyze --no-pub ...`
- `flutter test --no-pub test/unit/workbench_controller_test.dart`
- `flutter test --no-pub test/unit/workbench_listing_test.dart test/unit/workbench_view_prefs_test.dart`
- `flutter test --no-pub test/widget/workspace_graph_indicators_test.dart`
- `flutter test --no-pub test/widget/alera_shell_page_test.dart`