### PR TITLE
feat: cap dashboard lists at five and name main workspace after project

### DIFF
--- a/integration_test/alera_smoke_flow_test.dart
+++ b/integration_test/alera_smoke_flow_test.dart
@@ -31,7 +31,8 @@ void main() {
         await tempRoot.delete(recursive: true);
       }
     });
-    final projectDir = Directory(p.join(tempRoot.path, 'sample-project'))
+    const projectName = 'sample-project';
+    final projectDir = Directory(p.join(tempRoot.path, projectName))
       ..createSync(recursive: true);
 
     final db = AleraDatabase(executor: NativeDatabase.memory());
@@ -81,11 +82,11 @@ void main() {
     );
     await tester.tap(submitButton);
 
-    await _pumpUntilFound(tester, find.text('Main'));
+    await _pumpUntilFound(tester, find.text(projectName));
 
-    await tester.ensureVisible(find.text('Main').last);
+    await tester.ensureVisible(find.text(projectName).last);
     await tester.pumpAndSettle();
-    await tester.tap(find.text('Main').last);
+    await tester.tap(find.text(projectName).last);
     await _pumpUntilFound(tester, find.byTooltip('New Terminal'));
     await _pumpUntilFound(tester, find.text('E2E terminal: Terminal 1'));
 

--- a/lib/src/features/workbench/application/workspace_service.dart
+++ b/lib/src/features/workbench/application/workspace_service.dart
@@ -143,7 +143,7 @@ class WorkspaceService {
                 Workspace(
                   id: _uuid.v4(),
                   projectId: project.id,
-                  name: 'Main',
+                  name: project.name,
                   branch: branch,
                   path: project.repoPath,
                   createdAt: now,

--- a/lib/src/features/workbench/presentation/welcome_dashboard_columns.dart
+++ b/lib/src/features/workbench/presentation/welcome_dashboard_columns.dart
@@ -1,5 +1,33 @@
 part of 'welcome_dashboard.dart';
 
+const int _maxDashboardItems = 5;
+
+class _MoreItemsHint extends StatelessWidget {
+  const _MoreItemsHint({required this.count, this.padding});
+
+  final int count;
+
+  final EdgeInsets? padding;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding:
+          padding ??
+          const EdgeInsets.symmetric(
+            horizontal: AleraTokens.space16,
+            vertical: AleraTokens.space8,
+          ),
+      child: Text(
+        '+$count More',
+        style: Theme.of(
+          context,
+        ).textTheme.bodySmall?.copyWith(color: AleraTokens.foregroundFaint),
+      ),
+    );
+  }
+}
+
 class _Header extends StatelessWidget {
   const _Header({required this.theme});
 
@@ -119,6 +147,10 @@ class _RightColumn extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final projects = state.projects;
+    final visibleProjectCount = projects.length > _maxDashboardItems
+        ? _maxDashboardItems
+        : projects.length;
+    final hiddenProjectCount = projects.length - visibleProjectCount;
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -164,10 +196,14 @@ class _RightColumn extends ConsumerWidget {
               : ListView.separated(
                   shrinkWrap: true,
                   physics: const NeverScrollableScrollPhysics(),
-                  itemCount: projects.length,
+                  itemCount:
+                      visibleProjectCount + (hiddenProjectCount > 0 ? 1 : 0),
                   separatorBuilder: (context, index) =>
                       const Divider(height: 1, color: AleraTokens.borderSubtle),
                   itemBuilder: (context, index) {
+                    if (index == visibleProjectCount) {
+                      return _MoreItemsHint(count: hiddenProjectCount);
+                    }
                     final Project project = projects[index];
                     final workspaces = state.workspacesFor(project.id);
 
@@ -215,7 +251,9 @@ class _RightColumn extends ConsumerWidget {
                           else
                             Column(
                               children: [
-                                for (final Workspace ws in workspaces)
+                                for (final Workspace ws in workspaces.take(
+                                  _maxDashboardItems,
+                                ))
                                   Padding(
                                     padding: const EdgeInsets.only(
                                       top: AleraTokens.space4,
@@ -327,6 +365,15 @@ class _RightColumn extends ConsumerWidget {
                                           ],
                                         ],
                                       ),
+                                    ),
+                                  ),
+                                if (workspaces.length > _maxDashboardItems)
+                                  _MoreItemsHint(
+                                    count:
+                                        workspaces.length - _maxDashboardItems,
+                                    padding: const EdgeInsets.only(
+                                      left: AleraTokens.space12,
+                                      top: AleraTokens.space4,
                                     ),
                                   ),
                               ],

--- a/lib/src/features/workbench/presentation/workspace_graph_indicators.dart
+++ b/lib/src/features/workbench/presentation/workspace_graph_indicators.dart
@@ -19,7 +19,7 @@ class WorkspaceRoleBadge extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     if (workspace.isMain) {
-      return const AleraBadge(label: 'Default');
+      return const AleraBadge(label: 'default');
     }
     return const SizedBox.shrink();
   }

--- a/test/unit/workspace_service_core_test_cases.dart
+++ b/test/unit/workspace_service_core_test_cases.dart
@@ -16,7 +16,7 @@ void _registerWorkspaceServiceCoreTests() {
       final workspace = await service.ensureMainWorkspace(project);
 
       expect(workspace.projectId, project.id);
-      expect(workspace.name, 'Main');
+      expect(workspace.name, project.name);
       expect(workspace.branch, 'main');
       expect(workspace.path, project.repoPath);
       expect(workspace.kind, WorkspaceKind.main);
@@ -31,7 +31,7 @@ void _registerWorkspaceServiceCoreTests() {
     final workspace = await service.ensureMainWorkspace(folderProject);
 
     expect(workspace.projectId, folderProject.id);
-    expect(workspace.name, 'Main');
+    expect(workspace.name, folderProject.name);
     expect(workspace.branch, isNull);
     expect(workspace.path, folderProject.repoPath);
     expect(workspace.kind, WorkspaceKind.main);

--- a/test/widget/welcome_dashboard_test.dart
+++ b/test/widget/welcome_dashboard_test.dart
@@ -145,6 +145,78 @@ void main() {
       findsOneWidget,
     );
   });
+
+  testWidgets('caps the project list at five with a +N More hint', (
+    tester,
+  ) async {
+    final now = DateTime.utc(2026, 5, 22);
+    final projects = <Project>[
+      for (var i = 1; i <= 7; i++)
+        Project(
+          id: 'project-$i',
+          name: 'Project $i',
+          repoPath: '/repo/project-$i',
+          createdAt: now,
+          updatedAt: now,
+        ),
+    ];
+
+    await pumpDashboard(
+      tester,
+      state: WorkbenchState(
+        projects: projects,
+        workspacesByProject: const <String, List<Workspace>>{},
+        bootstrapped: true,
+      ),
+    );
+
+    expect(find.text('Project 1'), findsOneWidget);
+    expect(find.text('Project 5'), findsOneWidget);
+    expect(find.text('Project 6'), findsNothing);
+    expect(find.text('Project 7'), findsNothing);
+    expect(find.text('+2 More'), findsOneWidget);
+  });
+
+  testWidgets('caps the workspace list at five with a +N More hint', (
+    tester,
+  ) async {
+    final now = DateTime.utc(2026, 5, 22);
+    final project = Project(
+      id: 'project-1',
+      name: 'Alera',
+      repoPath: '/repo/alera',
+      createdAt: now,
+      updatedAt: now,
+    );
+    final workspaces = <Workspace>[
+      for (var i = 1; i <= 7; i++)
+        Workspace(
+          id: 'workspace-$i',
+          projectId: project.id,
+          name: 'Workspace $i',
+          path: '/repo/alera/ws-$i',
+          createdAt: now,
+          updatedAt: now,
+          kind: WorkspaceKind.linked,
+          status: WorkspaceStatus.active,
+        ),
+    ];
+
+    await pumpDashboard(
+      tester,
+      state: WorkbenchState(
+        projects: <Project>[project],
+        workspacesByProject: <String, List<Workspace>>{project.id: workspaces},
+        bootstrapped: true,
+      ),
+    );
+
+    expect(find.text('Workspace 1'), findsOneWidget);
+    expect(find.text('Workspace 5'), findsOneWidget);
+    expect(find.text('Workspace 6'), findsNothing);
+    expect(find.text('Workspace 7'), findsNothing);
+    expect(find.text('+2 More'), findsOneWidget);
+  });
 }
 
 class _WelcomeDashboardController extends WorkbenchController {

--- a/test/widget/workspace_graph_indicators_test.dart
+++ b/test/widget/workspace_graph_indicators_test.dart
@@ -39,13 +39,12 @@ void main() {
   }
 
   group('WorkspaceRoleBadge', () {
-    testWidgets('shows Default for the main workspace', (tester) async {
+    testWidgets('shows default for the main workspace', (tester) async {
       await pump(
         tester,
         WorkspaceRoleBadge(workspace: workspace(kind: WorkspaceKind.main)),
       );
-      expect(find.text('Default'), findsOneWidget);
-      expect(find.text('default'), findsNothing);
+      expect(find.text('default'), findsOneWidget);
       expect(find.text('Primary'), findsNothing);
       expect(find.text('Child'), findsNothing);
     });
@@ -57,7 +56,6 @@ void main() {
         tester,
         WorkspaceRoleBadge(workspace: workspace(parentWorkspaceId: 'parent')),
       );
-      expect(find.text('Default'), findsNothing);
       expect(find.text('default'), findsNothing);
       expect(find.text('Child'), findsNothing);
       expect(find.text('Primary'), findsNothing);
@@ -65,7 +63,6 @@ void main() {
 
     testWidgets('renders nothing for a plain linked workspace', (tester) async {
       await pump(tester, WorkspaceRoleBadge(workspace: workspace()));
-      expect(find.text('Default'), findsNothing);
       expect(find.text('default'), findsNothing);
       expect(find.text('Primary'), findsNothing);
       expect(find.text('Child'), findsNothing);


### PR DESCRIPTION
## Summary

- Limit the welcome dashboard to five projects and five workspaces per project, surfacing a `+N More` hint for the overflow (static, non-clickable).
- Lowercase the main-workspace role badge from `Default` to `default`.
- Name a newly created main workspace after its project instead of the hardcoded `Main` literal. The branch is unaffected (it stays in `Workspace.branch`); only the display name changes.

## Notes

- The `Main` name was a hardcoded literal in `WorkspaceService.ensureMainWorkspace`, not derived from the branch. Only first-time main-workspace creation changes; `copyWith` omits `name`, so custom names are preserved.
- Badge casing (`Default` -> `default`) is byte-identical in the CI golden (both 7 chars under the Ahem harness font), so no golden regeneration was needed; the golden test stays green.

## Validation

- `flutter analyze` clean on touched files.
- Unit + widget suite: 1212 tests pass locally. The only local failures are environmental and unrelated (CLI `~/bin` install + native PTY/ghostty tests unavailable in this sandbox).
- Added two widget tests covering the five-item cap + `+N More` hint for both projects and workspaces.
- Updated `workspace_service` and `workspace_graph_indicators` assertions for the new behavior.

## Risk

- UI-only behavior change; no schema, storage, or protocol impact. No update/release risk.