### PR TITLE
[codex] feat: add orchestration runtime workflow

### DIFF
--- a/docs/orchestration.md
+++ b/docs/orchestration.md
@@ -1,0 +1,70 @@
+# Inter-Agent Orchestration
+
+Alera's orchestration system lets multiple coding agents coordinate through structured messaging, a task DAG, dispatch with retry tracking, decision gates, and an automated coordinator loop. The design ports the semantics of Orca's orchestration system (see `reference_projects/orca`) into Alera's Rust sidecar architecture.
+
+## Architecture
+
+The engine lives in the **runtime-host sidecar** (`rust/alera-cli`, binary `alera`), not in the Flutter app:
+
+- **State** is persisted in the existing `RuntimeStore` SQLite database (`rust/alera-core/src/runtime/`): five tables — `orchestrationMessages`, `orchestrationTasks`, `orchestrationDispatchContexts`, `orchestrationDecisionGates`, `orchestrationCoordinatorRuns` — created by the same migration pass as the rest of the runtime schema.
+- **Verbs** are `alera orchestration ...` CLI subcommands (`rust/alera-cli/src/cli_orchestration.rs`) that RPC into the running runtime-host over the existing socket protocol. There is no direct-store fallback: waiters, agent presence, and the coordinator are in-process host state, so a live host is required (the CLI auto-starts one).
+- **Engine modules** live under `rust/alera-cli/src/terminal_host/orchestration/` (formatter, preamble, lifecycle reconciliation, group resolution, agent presence, waiter registry, coordinator ticker) with request handlers in `terminal_host/server/orchestration_requests.rs` and `terminal_host/server/coordinator_requests.rs`. All state mutation runs inside the single `ServerActor`.
+- The host advertises the additive `orchestration` runtime capability. Protocol version stays at 3; older hosts remain usable for non-orchestration verbs.
+
+## Identity
+
+Each PTY session's handle is its session id, injected into the terminal environment as `ALERA_TERMINAL_HANDLE` at spawn (`terminal_host/session.rs`). This is the same id the app uses to key agent status entries, so no mapping table is needed. CLI verbs resolve `--from`/`--terminal` from that variable when omitted.
+
+## Idle Detection and Push-On-Idle
+
+The Flutter app detects agent state via agent-status hooks (working / waiting / blocked / done). A keepAlive forwarder (`lib/src/features/agent_status/application/agent_status_host_forwarder.dart`) diffs transitions and batches them to the host via the `orchestration.agentStatus` request.
+
+The host keeps an agent presence registry per handle. State mapping:
+
+- `done` → injection-ready: pending messages are formatted as banners and written into the PTY, followed 500 ms later by a separate Enter (Claude Code treats a large write as a paste and swallows an inline `\r`). Cursor-type agents get no auto-Enter — injected text stays as editable prompt input.
+- `working` / `waiting` / `blocked` → busy. `waiting` can mean an approval or user-input prompt, so auto-injection waits until the agent reports `done`.
+- removed → presence cleared; messages stay queued for explicit `check` or the next injection-ready transition.
+
+Messages track `read` (consumed by `check`) and `delivered_at` (auto-injected) independently, so push-on-idle delivers at most once while `check` still sees delivered-but-unread messages. `delivered_at` is stamped only after the deferred Enter succeeds; failures leave the batch queued for the next idle transition.
+
+Without the app running, push-on-idle and `@agent`/`@idle` groups degrade gracefully: messages queue and remain readable via `check`.
+
+## Key Invariants (ported from Orca)
+
+1. A task without deps starts `ready`; a task with deps starts `ready` only when all existing deps are already completed, `failed` when any dep has failed, and otherwise `pending`.
+2. Completing or failing a task refreshes pending dependents in the same transaction (`update_orchestration_task_status`): completed deps promote children to `ready`; failed deps fail children instead of stranding them.
+3. One active dispatch per terminal.
+4. `failure_count` carries forward across a task's dispatch retries; at 3 failures the dispatch is `circuit_broken` and the task `failed`; below the threshold the task returns to `ready` (not `pending`, which would strand it).
+5. `worker_done` authority requires taskId + dispatchId + sender handle to match the *active* dispatch (`lifecycle_reconciliation.rs`) — a stale retry cannot complete or fail the current dispatch. A `worker_done` subject of `Failed: ...` consumes dispatch failure/circuit-breaker budget instead of completing the task.
+6. Heartbeats record only while the dispatch is `dispatched`.
+7. Gate create is accepted only for `ready` or `dispatched` tasks. It sets the task `blocked` and completes any active dispatch; gate resolve returns the task to `ready` with the resolution injected into the next preamble.
+8. Lifecycle messages reconcile before waking blocked waiters, so the dispatch lock is released by the time a coordinator reads the result.
+9. Long-poll waiters (`check --wait`, `ask`) have a server-side deadline (600 s max) and die with their client connection.
+
+## Coordinator
+
+`orchestration run` starts a background ticker inside the host (one active run at a time; the run keeps the host alive). Each tick executes in the actor: process coordinator inbox (worker_done/heartbeat reconcile, authorized escalation → fail dispatch, authorized decision_gate → create gate) → re-assert gate blocks → warn hung dispatches (no heartbeat for 10 minutes; warn-only) → dispatch ready tasks (default max 4 concurrent, one new worker terminal per tick when none idle) → check convergence (all tasks completed/failed).
+
+The automated coordinator only dispatches to injection-ready agents whose prompts can be auto-submitted. Cursor-type agents are skipped by `run` because their injected text intentionally remains editable; use manual `dispatch --inject` or a Claude-style worker for unattended coordinator loops.
+
+Dispatch pre-flight probes worktree drift via `alera_core::git::probe_base_drift` (git2 `graph_ahead_behind` + revwalk, no fetch). More than 20 commits behind skips the dispatch silently — retried next tick without burning circuit budget — unless the spec contains `allow-stale-base: true` on its own line (the directive is stripped before the worker sees the spec).
+
+Task decomposition is the caller's responsibility: `run` refuses to start with zero tasks.
+
+## Worker Terminals
+
+`alera tab create --command "claude" --spawn` mints a terminal tab whose payload carries `initialCommand` and `spawnOnCreate`. The app starts flagged tabs eagerly on arrival (`workbench_controller_sync.dart`) and writes the command once, only on new PTY creation — never on reattach (`terminal_runtime_session_handle.dart`). The coordinator uses the same mechanism when it needs a worker and none is idle.
+
+**v1 limitation**: worker creation requires the app to be connected — agent hook environments are built app-side. A headless host queues work until an app connects or a worker appears.
+
+## JSON Shape
+
+Orchestration payloads serialize with snake_case fields and Orca's exact status strings (`worker_done`, `circuit_broken`, ...) so agent-facing skills and docs stay portable between Orca and Alera. This intentionally diverges from Alera's camelCase convention and is confined to orchestration rows.
+
+## Testing
+
+- `cargo test -p alera-core --features runtime` — store invariants (DAG promotion, circuit breaker, heartbeat guard, read/delivered independence, gates, resets).
+- `cargo test -p alera-cli` — engine unit tests (reconciliation authority branches, preamble content, formatter, group resolution, presence, waiter type filters) and the end-to-end suite `tests/orchestration_conformance.rs` (real host binary, raw TCP: send/check/reply, wait wakeups + type filtering, ask/reply, DAG dispatch, gates, push-on-idle against a live PTY).
+- `flutter test test/unit/agent_status_host_forwarder_test.dart` — the app-side presence forwarder.
+
+The agent-facing usage guide is `skills/alera-orchestration/SKILL.md`.

--- a/lib/src/features/agent_status/application/agent_status_host_forwarder.dart
+++ b/lib/src/features/agent_status/application/agent_status_host_forwarder.dart
@@ -1,0 +1,178 @@
+import 'dart:async';
+
+import 'package:alera/src/features/agent_status/application/agent_status_controller.dart';
+import 'package:alera/src/features/agent_status/domain/agent_status.dart';
+import 'package:alera/src/features/workbench/infra/terminal_host/terminal_host_protocol.dart';
+import 'package:alera/src/shared/infra/runtime/runtime_host_providers.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'agent_status_host_forwarder.g.dart';
+
+/// Forwards agent status transitions to the runtime-host so it can run
+/// push-on-idle orchestration message delivery and resolve @agent groups.
+/// The host keys presence by terminal session id, which doubles as the
+/// orchestration terminal handle.
+@Riverpod(keepAlive: true)
+AgentStatusHostForwarder agentStatusHostForwarder(Ref ref) {
+  final forwarder = AgentStatusHostForwarder(
+    client: ref.watch(runtimeHostClientProvider),
+  );
+  ref.listen<Map<String, AgentStatusEntry>>(
+    agentStatusControllerProvider,
+    (previous, next) => forwarder.onStatusChanged(previous, next),
+    fireImmediately: true,
+  );
+  ref.onDispose(forwarder.dispose);
+  return forwarder;
+}
+
+class AgentStatusHostForwarder {
+  AgentStatusHostForwarder({
+    required this.client,
+    this.debounce = const Duration(milliseconds: 100),
+  }) {
+    _runtimeEventSub = client.runtimeEvents.listen((event) {
+      if (event.name == aleraRuntimeHostConnectedEvent) {
+        replayPresenceSnapshot();
+      }
+    });
+  }
+
+  final RuntimeHostClient client;
+  final Duration debounce;
+
+  final Map<String, Map<String, Object?>> _pending =
+      <String, Map<String, Object?>>{};
+  Map<String, AgentStatusEntry> _lastSeen = const <String, AgentStatusEntry>{};
+  late final StreamSubscription<RuntimeHostEvent> _runtimeEventSub;
+  Timer? _timer;
+  bool _disposed = false;
+
+  void onStatusChanged(
+    Map<String, AgentStatusEntry>? previous,
+    Map<String, AgentStatusEntry> next,
+  ) {
+    if (_disposed) {
+      return;
+    }
+    final before = previous ?? _lastSeen;
+    for (final entry in next.values) {
+      final prior = before[entry.terminalSessionId];
+      if (prior != null &&
+          prior.state == entry.state &&
+          prior.agentType == entry.agentType) {
+        continue;
+      }
+      _pending[entry.terminalSessionId] = <String, Object?>{
+        'terminalSessionId': entry.terminalSessionId,
+        'workspaceId': entry.workspaceId,
+        'tabId': entry.tabId,
+        'agentType': entry.agentType.key,
+        'state': entry.state.key,
+      };
+    }
+    for (final sessionId in before.keys) {
+      if (!next.containsKey(sessionId)) {
+        _pending[sessionId] = <String, Object?>{
+          'terminalSessionId': sessionId,
+          'removed': true,
+        };
+      }
+    }
+    _lastSeen = next;
+    if (_pending.isEmpty) {
+      return;
+    }
+    _timer ??= Timer(debounce, _flush);
+  }
+
+  void replayPresenceSnapshot() {
+    if (_disposed || _lastSeen.isEmpty) {
+      return;
+    }
+    for (final entry in _lastSeen.values) {
+      _pending[entry.terminalSessionId] = <String, Object?>{
+        'terminalSessionId': entry.terminalSessionId,
+        'workspaceId': entry.workspaceId,
+        'tabId': entry.tabId,
+        'agentType': entry.agentType.key,
+        'state': entry.state.key,
+      };
+    }
+    _timer ??= Timer(debounce, _flush);
+  }
+
+  void _flush() {
+    _timer = null;
+    if (_disposed || _pending.isEmpty) {
+      return;
+    }
+    final entries = _pending.values.toList(growable: false);
+    _pending.clear();
+    unawaited(
+      client
+          .runtimeRequest('orchestration.agentStatus', <String, Object?>{
+            'entries': entries,
+          })
+          .then<void>(
+            (_) {},
+            onError: (Object error) {
+              if (!_isPermanentOrchestrationCapabilityError(error)) {
+                _retry(entries);
+              }
+            },
+          ),
+    );
+  }
+
+  void _retry(List<Map<String, Object?>> entries) {
+    if (_disposed) {
+      return;
+    }
+    for (final entry in entries) {
+      final sessionId = entry['terminalSessionId'];
+      if (sessionId is String &&
+          sessionId.isNotEmpty &&
+          _retryEntryIsFresh(sessionId, entry)) {
+        _pending.putIfAbsent(sessionId, () => entry);
+      }
+    }
+    if (_pending.isNotEmpty) {
+      _timer ??= Timer(_retryDelay, _flush);
+    }
+  }
+
+  bool _retryEntryIsFresh(String sessionId, Map<String, Object?> entry) {
+    final current = _lastSeen[sessionId];
+    if (entry['removed'] == true) {
+      return current == null;
+    }
+    if (current == null) {
+      return false;
+    }
+    return entry['state'] == current.state.key &&
+        entry['agentType'] == current.agentType.key &&
+        entry['workspaceId'] == current.workspaceId &&
+        entry['tabId'] == current.tabId;
+  }
+
+  Duration get _retryDelay =>
+      debounce == Duration.zero ? const Duration(milliseconds: 1) : debounce;
+
+  void dispose() {
+    if (_disposed) {
+      return;
+    }
+    _disposed = true;
+    unawaited(_runtimeEventSub.cancel());
+    _timer?.cancel();
+    _timer = null;
+    _pending.clear();
+  }
+}
+
+bool _isPermanentOrchestrationCapabilityError(Object error) {
+  final message = error is StateError ? error.message : error.toString();
+  return message.contains('does not support orchestration') &&
+      message.contains('Restart Alera');
+}

--- a/lib/src/features/agent_status/application/agent_status_host_forwarder.g.dart
+++ b/lib/src/features/agent_status/application/agent_status_host_forwarder.g.dart
@@ -1,0 +1,71 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'agent_status_host_forwarder.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// Forwards agent status transitions to the runtime-host so it can run
+/// push-on-idle orchestration message delivery and resolve @agent groups.
+/// The host keys presence by terminal session id, which doubles as the
+/// orchestration terminal handle.
+
+@ProviderFor(agentStatusHostForwarder)
+final agentStatusHostForwarderProvider = AgentStatusHostForwarderProvider._();
+
+/// Forwards agent status transitions to the runtime-host so it can run
+/// push-on-idle orchestration message delivery and resolve @agent groups.
+/// The host keys presence by terminal session id, which doubles as the
+/// orchestration terminal handle.
+
+final class AgentStatusHostForwarderProvider
+    extends
+        $FunctionalProvider<
+          AgentStatusHostForwarder,
+          AgentStatusHostForwarder,
+          AgentStatusHostForwarder
+        >
+    with $Provider<AgentStatusHostForwarder> {
+  /// Forwards agent status transitions to the runtime-host so it can run
+  /// push-on-idle orchestration message delivery and resolve @agent groups.
+  /// The host keys presence by terminal session id, which doubles as the
+  /// orchestration terminal handle.
+  AgentStatusHostForwarderProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'agentStatusHostForwarderProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$agentStatusHostForwarderHash();
+
+  @$internal
+  @override
+  $ProviderElement<AgentStatusHostForwarder> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  AgentStatusHostForwarder create(Ref ref) {
+    return agentStatusHostForwarder(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(AgentStatusHostForwarder value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<AgentStatusHostForwarder>(value),
+    );
+  }
+}
+
+String _$agentStatusHostForwarderHash() =>
+    r'b2183e311105188ff4ce90e9c4a2736836cae91d';

--- a/lib/src/features/shell/presentation/alera_shell_page.dart
+++ b/lib/src/features/shell/presentation/alera_shell_page.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:alera/src/app/providers.dart';
 import 'package:alera/src/app/theme/alera_tokens.dart';
+import 'package:alera/src/features/agent_status/application/agent_status_host_forwarder.dart';
 import 'package:alera/src/design_system/feedback/alera_toast.dart';
 import 'package:alera/src/design_system/icons/alera_icons.dart';
 import 'package:alera/src/design_system/layout/alera_confirm_dialog.dart';
@@ -104,6 +105,7 @@ class _AleraShellPageBodyState extends ConsumerState<_AleraShellPageBody> {
     ref.watch(agentHookReceiverLifecycleCoordinatorProvider);
     ref.watch(agentHookInstallerCoordinatorProvider);
     ref.watch(agentStatusNotificationCoordinatorProvider);
+    ref.watch(agentStatusHostForwarderProvider);
     ref.watch(agentAwakeCoordinatorProvider);
     ref.watch(terminalRuntimeExitCoordinatorProvider);
     ref.watch(workspaceActivityCoordinatorProvider);

--- a/lib/src/features/workbench/application/workbench_controller_internals.dart
+++ b/lib/src/features/workbench/application/workbench_controller_internals.dart
@@ -30,6 +30,7 @@ mixin _WorkbenchControllerInternals on _$WorkbenchController {
   final Set<String> _ensuringMainWorkspaceProjectIds = <String>{};
   final Set<String> _loadingLayoutWorkspaceIds = <String>{};
   final Set<String> _closingTabWorkspaceIds = <String>{};
+  final Set<String> _eagerlySpawnedTabIds = <String>{};
 
   bool _bootstrapStarted = false;
 

--- a/lib/src/features/workbench/application/workbench_controller_sync.dart
+++ b/lib/src/features/workbench/application/workbench_controller_sync.dart
@@ -222,6 +222,7 @@ mixin _WorkbenchControllerSync
   }
 
   void _onTabsChanged(String workspaceId, List<WorkspaceTabRecord> tabs) {
+    _eagerlySpawnRequestedTerminals(workspaceId, tabs);
     final nextTabs = Map<String, List<WorkspaceTabRecord>>.from(
       state.tabsByWorkspace,
     )..[workspaceId] = tabs;
@@ -247,5 +248,55 @@ mixin _WorkbenchControllerSync
     );
     unawaited(_repository.upsertWorkbenchLayout(layout));
     _ensureSelectionHasTab();
+  }
+
+  /// Terminal tabs flagged `spawnOnCreate` (orchestration-created workers)
+  /// start their PTY as soon as the record arrives, without waiting for a
+  /// TerminalSurface to become visible. Attempted ids are tracked so a tab
+  /// is only eagerly started once per app session.
+  void _eagerlySpawnRequestedTerminals(
+    String workspaceId,
+    List<WorkspaceTabRecord> tabs,
+  ) {
+    final workspace = _workspaceForEagerSpawn(workspaceId);
+    if (workspace == null) {
+      return;
+    }
+    for (final tab in tabs) {
+      if (tab.kind != WorkspaceTabKind.terminal ||
+          !tab.spawnOnCreate ||
+          !_eagerlySpawnedTabIds.add(tab.id)) {
+        continue;
+      }
+      try {
+        final session = ref
+            .read(terminalRuntimeProvider)
+            .sessionFor(workspace: workspace, tab: tab);
+        unawaited(() async {
+          try {
+            await session.ensureStarted();
+          } catch (_) {
+            // Fall through to clear the retry guard below.
+          }
+          if (!session.isRunning) {
+            _eagerlySpawnedTabIds.remove(tab.id);
+          }
+        }());
+      } catch (_) {
+        // A failed eager start falls back to the normal visible-spawn path.
+        _eagerlySpawnedTabIds.remove(tab.id);
+      }
+    }
+  }
+
+  Workspace? _workspaceForEagerSpawn(String workspaceId) {
+    for (final workspaces in state.workspacesByProject.values) {
+      for (final workspace in workspaces) {
+        if (workspace.id == workspaceId) {
+          return workspace;
+        }
+      }
+    }
+    return null;
   }
 }

--- a/lib/src/features/workbench/domain/workspace_tab_record.dart
+++ b/lib/src/features/workbench/domain/workspace_tab_record.dart
@@ -34,6 +34,8 @@ enum WorkspaceTabKind {
 
 const String workspaceTabManualTitlePayloadKey = 'manualTitle';
 const String workspaceTabTerminalSessionIdPayloadKey = 'terminalSessionId';
+const String workspaceTabInitialCommandPayloadKey = 'initialCommand';
+const String workspaceTabSpawnOnCreatePayloadKey = 'spawnOnCreate';
 const String workspaceTabFilePathPayloadKey = 'filePath';
 const String workspaceTabFileRolePayloadKey = 'fileRole';
 const String workspaceTabFileRoleMermanPreview = 'mermanPreview';
@@ -122,6 +124,17 @@ class WorkspaceTabRecord with WorkspaceTabRecordMappable {
     final value = payload[workspaceTabTerminalSessionIdPayloadKey];
     return value is String && value.trim().isNotEmpty ? value : id;
   }
+
+  /// Command written into the terminal after the shell starts, e.g. an agent
+  /// CLI launched by an orchestration coordinator. Only ever run once, on the
+  /// session creation attach.
+  String? get initialCommand =>
+      _nonEmptyPayloadString(workspaceTabInitialCommandPayloadKey);
+
+  /// Whether the terminal session should start as soon as the tab record
+  /// appears, without waiting for the tab to become visible.
+  bool get spawnOnCreate =>
+      payload[workspaceTabSpawnOnCreatePayloadKey] == true;
 
   String? get filePath {
     final value = payload[workspaceTabFilePathPayloadKey];

--- a/lib/src/features/workbench/infra/terminal_host/terminal_host_client.dart
+++ b/lib/src/features/workbench/infra/terminal_host/terminal_host_client.dart
@@ -215,7 +215,9 @@ final class SocketTerminalHostClient
     if (_disposed) {
       throw StateError('Terminal host client is disposed.');
     }
-    final connection = await _connectRuntime();
+    final connection = await _connectRuntime(
+      requireOrchestration: type.startsWith('orchestration.'),
+    );
     return _requestOnConnection(connection, type, payload, timeout: timeout);
   }
 
@@ -263,37 +265,80 @@ final class SocketTerminalHostClient
     return next;
   }
 
-  Future<_TerminalHostConnection> _connectRuntime() async {
-    if (_runtimeConnection case final connection?) {
+  Future<_TerminalHostConnection> _connectRuntime({
+    bool requireOrchestration = false,
+  }) async {
+    if (_runtimeConnection case final connection?
+        when _supportsRuntime(connection, requireOrchestration)) {
       return Future<_TerminalHostConnection>.value(connection);
     }
-    if (_terminalConnection case final connection?
-        when connection.supportsRuntime) {
-      _runtimeConnection = connection;
-      return Future<_TerminalHostConnection>.value(connection);
+    if (_terminalConnection case final connection?) {
+      if (_supportsRuntime(connection, requireOrchestration)) {
+        _runtimeConnection = connection;
+        return Future<_TerminalHostConnection>.value(connection);
+      }
+      _throwIfOrchestrationWouldSplitPtyHost(connection, requireOrchestration);
     }
     final future = _runtimeConnectionFuture;
     if (future != null) {
-      return future;
+      final connection = await _waitForRuntimeConnectionFuture(
+        future,
+        requireOrchestration: requireOrchestration,
+      );
+      if (connection != null &&
+          _supportsRuntime(connection, requireOrchestration)) {
+        return connection;
+      }
     }
     final terminalFuture = _terminalConnectionFuture;
     if (terminalFuture != null) {
       final connection = await terminalFuture;
-      if (connection.supportsRuntime) {
+      if (_supportsRuntime(connection, requireOrchestration)) {
         _runtimeConnection = connection;
         return connection;
       }
+      _throwIfOrchestrationWouldSplitPtyHost(connection, requireOrchestration);
     }
-    if (_runtimeConnection case final connection?) {
+    if (_runtimeConnection case final connection?
+        when _supportsRuntime(connection, requireOrchestration)) {
       return connection;
     }
     final nextFuture = _runtimeConnectionFuture;
     if (nextFuture != null) {
-      return nextFuture;
+      final connection = await _waitForRuntimeConnectionFuture(
+        nextFuture,
+        requireOrchestration: requireOrchestration,
+      );
+      if (connection != null &&
+          _supportsRuntime(connection, requireOrchestration)) {
+        return connection;
+      }
     }
-    final next = _openRuntimeConnection();
+    late final Future<_TerminalHostConnection> next;
+    next = _openRuntimeConnection(requireOrchestration: requireOrchestration)
+        .whenComplete(() {
+          if (identical(_runtimeConnectionFuture, next)) {
+            _runtimeConnectionFuture = null;
+          }
+        });
     _runtimeConnectionFuture = next;
     return next;
+  }
+
+  Future<_TerminalHostConnection?> _waitForRuntimeConnectionFuture(
+    Future<_TerminalHostConnection> future, {
+    required bool requireOrchestration,
+  }) async {
+    try {
+      return await future;
+    } catch (_) {
+      if (requireOrchestration) {
+        rethrow;
+      }
+      // A strict orchestration probe can reject a live pre-orchestration host;
+      // normal runtime callers should retry without inheriting that error.
+      return null;
+    }
   }
 
   Future<_TerminalHostConnection> _openTerminalConnection() async {
@@ -325,21 +370,33 @@ final class SocketTerminalHostClient
         return connection;
       }
     }
-    return _launchAndConnect(runtime, runtime.controlFile);
+    return _launchAndConnect(
+      runtime,
+      runtime.controlFile,
+      requireOrchestration: false,
+    );
   }
 
-  Future<_TerminalHostConnection> _openRuntimeConnection() async {
+  Future<_TerminalHostConnection> _openRuntimeConnection({
+    bool requireOrchestration = false,
+  }) async {
     final runtime = await _runtimePaths();
     final control = await _readControl(runtime.controlFile);
-    if (control?.supportsRuntime == true) {
+    if (_controlSupportsRuntime(control, requireOrchestration)) {
       try {
         return await _connectToControl(control!, _HostConnectionRole.runtime);
       } catch (_) {
         await _deleteControlFile(runtime.controlFile);
       }
     }
+    if (requireOrchestration && control != null) {
+      if (await _controlAcceptsHello(control)) {
+        throw StateError(_orchestrationHostRestartRequiredMessage);
+      }
+      await _deleteControlFile(runtime.controlFile);
+    }
     final runtimeControl = await _readControl(runtime.runtimeControlFile);
-    if (runtimeControl?.supportsRuntime == true) {
+    if (_controlSupportsRuntime(runtimeControl, requireOrchestration)) {
       try {
         return await _connectToControl(
           runtimeControl!,
@@ -349,16 +406,26 @@ final class SocketTerminalHostClient
         await _deleteControlFile(runtime.runtimeControlFile);
       }
     }
+    if (requireOrchestration && runtimeControl != null) {
+      if (await _controlAcceptsHello(runtimeControl)) {
+        throw StateError(_orchestrationHostRestartRequiredMessage);
+      }
+      await _deleteControlFile(runtime.runtimeControlFile);
+    }
     return _launchAndConnect(
       runtime,
-      control == null ? runtime.controlFile : runtime.runtimeControlFile,
+      control == null || requireOrchestration
+          ? runtime.controlFile
+          : runtime.runtimeControlFile,
+      requireOrchestration: requireOrchestration,
     );
   }
 
   Future<_TerminalHostConnection> _launchAndConnect(
     _TerminalHostPaths runtime,
-    File controlFile,
-  ) async {
+    File controlFile, {
+    required bool requireOrchestration,
+  }) async {
     final token = _newToken();
     await _launcher.start(
       runtimeDir: runtime.runtimeDir.path,
@@ -373,7 +440,7 @@ final class SocketTerminalHostClient
       final nextControl = await _readControl(controlFile);
       if (nextControl == null ||
           nextControl.token != token ||
-          !nextControl.supportsRuntime) {
+          !_controlSupportsRuntime(nextControl, requireOrchestration)) {
         continue;
       }
       try {
@@ -400,6 +467,7 @@ final class SocketTerminalHostClient
     final connection = _TerminalHostConnection(
       socket,
       supportsRuntime: control.supportsRuntime,
+      supportsOrchestration: control.supportsOrchestration,
     );
     final lineSub = connection.lines.listen(
       (line) => _handleLine(connection, line),
@@ -433,6 +501,7 @@ final class SocketTerminalHostClient
       'payload': <String, Object?>{
         'protocolVersion': aleraTerminalHostProtocolVersion,
         'token': control.token,
+        'clientKind': 'app',
       },
     });
     return connection;
@@ -452,6 +521,13 @@ final class SocketTerminalHostClient
     if (id == 0) {
       if (message['ok'] != true) {
         _handleConnectionClosed(connection); // coverage:ignore-line
+      } else if (connection.supportsRuntime && !_runtimeEvents.isClosed) {
+        _runtimeEvents.add(
+          const RuntimeHostEvent(
+            aleraRuntimeHostConnectedEvent,
+            <String, Object?>{},
+          ),
+        );
       }
       return;
     }
@@ -566,6 +642,9 @@ final class SocketTerminalHostClient
             capabilities.contains(aleraRuntimeHostCapability) &&
             capabilities.contains(aleraRuntimeHostBootstrapCapability) &&
             capabilities.contains(aleraRuntimeHostManagedWorkspaceCapability),
+        supportsOrchestration: capabilities.contains(
+          aleraRuntimeHostOrchestrationCapability,
+        ),
       );
     } catch (_) {
       return null;
@@ -605,18 +684,82 @@ final class SocketTerminalHostClient
     unawaited(_events.close());
     unawaited(_runtimeEvents.close());
   }
+
+  bool _supportsRuntime(
+    _TerminalHostConnection connection,
+    bool requireOrchestration,
+  ) {
+    return connection.supportsRuntime &&
+        (!requireOrchestration || connection.supportsOrchestration);
+  }
+
+  bool _controlSupportsRuntime(
+    _TerminalHostControl? control,
+    bool requireOrchestration,
+  ) {
+    return control?.supportsRuntime == true &&
+        (!requireOrchestration || control!.supportsOrchestration);
+  }
+
+  void _throwIfOrchestrationWouldSplitPtyHost(
+    _TerminalHostConnection connection,
+    bool requireOrchestration,
+  ) {
+    if (requireOrchestration && !_supportsRuntime(connection, true)) {
+      throw StateError(_orchestrationHostRestartRequiredMessage);
+    }
+  }
+
+  Future<bool> _controlAcceptsHello(_TerminalHostControl control) async {
+    Socket? socket;
+    try {
+      socket = await Socket.connect(
+        InternetAddress.loopbackIPv4,
+        control.port,
+        timeout: _terminalHostConnectTimeout,
+      );
+      final lines = socket
+          .cast<List<int>>()
+          .transform(utf8.decoder)
+          .transform(const LineSplitter());
+      socket.writeln(
+        jsonEncode(<String, Object?>{
+          'id': 0,
+          'type': 'hello',
+          'payload': <String, Object?>{
+            'protocolVersion': aleraTerminalHostProtocolVersion,
+            'token': control.token,
+          },
+        }),
+      );
+      final line = await lines.first.timeout(_terminalHostConnectTimeout);
+      final message = asTerminalHostMap(
+        jsonDecode(line),
+        'Terminal host hello response',
+      );
+      return message['id'] == 0 && message['ok'] == true;
+    } catch (_) {
+      return false;
+    } finally {
+      socket?.destroy();
+    }
+  }
 }
 
 final class _TerminalHostConnection {
-  _TerminalHostConnection(this._socket, {required this.supportsRuntime})
-    : lines = _socket
-          .cast<List<int>>()
-          .transform(utf8.decoder)
-          .transform(const LineSplitter())
-          .asBroadcastStream();
+  _TerminalHostConnection(
+    this._socket, {
+    required this.supportsRuntime,
+    required this.supportsOrchestration,
+  }) : lines = _socket
+           .cast<List<int>>()
+           .transform(utf8.decoder)
+           .transform(const LineSplitter())
+           .asBroadcastStream();
 
   final Socket _socket;
   final bool supportsRuntime;
+  final bool supportsOrchestration;
   final Stream<String> lines;
 
   void write(Map<String, Object?> message) {
@@ -645,11 +788,13 @@ final class _TerminalHostControl {
     required this.port,
     required this.token,
     required this.supportsRuntime,
+    required this.supportsOrchestration,
   });
 
   final int port;
   final String token;
   final bool supportsRuntime;
+  final bool supportsOrchestration;
 }
 
 final class _PendingHostRequest {
@@ -663,3 +808,5 @@ enum _HostConnectionRole { terminal, runtime }
 
 const Duration _terminalHostConnectTimeout = Duration(seconds: 2);
 const Duration _terminalHostRequestTimeout = Duration(seconds: 10);
+const String _orchestrationHostRestartRequiredMessage =
+    'The running terminal host does not support orchestration. Restart Alera to replace the terminal host before using orchestration.';

--- a/lib/src/features/workbench/infra/terminal_host/terminal_host_protocol.dart
+++ b/lib/src/features/workbench/infra/terminal_host/terminal_host_protocol.dart
@@ -10,6 +10,8 @@ const String aleraRuntimeHostCapability = 'runtimeStore';
 const String aleraRuntimeHostBootstrapCapability = 'sshTargetBootstrap';
 const String aleraRuntimeHostManagedWorkspaceCapability =
     'managedWorkspaceLifecycle';
+const String aleraRuntimeHostOrchestrationCapability = 'orchestration';
+const String aleraRuntimeHostConnectedEvent = 'runtimeHostConnected';
 const int defaultTerminalHostEmptyShutdownDelaySeconds = 30;
 const int defaultTerminalHostDetachedSessionShutdownDelaySeconds = 60 * 60;
 const int defaultTerminalHostScrollbackBytes = 10 * 1000 * 1000;

--- a/lib/src/features/workbench/presentation/terminal_runtime_session_handle.dart
+++ b/lib/src/features/workbench/presentation/terminal_runtime_session_handle.dart
@@ -356,6 +356,22 @@ class _XtermTerminalSessionHandle extends TerminalSessionHandle {
           }
           await Future<void>.delayed(const Duration(milliseconds: 120));
         }
+        // Orchestration-created worker tabs carry an initial command (e.g. an
+        // agent CLI). It runs only when the PTY process was newly created —
+        // never on reattach — and as a plain shell command so the terminal
+        // stays interactive after the agent exits.
+        final initialCommand = _tab.initialCommand;
+        if (_running &&
+            session.startedNewProcess &&
+            initialCommand != null &&
+            initialCommand.isNotEmpty) {
+          await Future<void>.delayed(const Duration(milliseconds: 120));
+          if (!_disposed &&
+              _activePtyGeneration == generation &&
+              identical(_ptySession, session)) {
+            session.writeBytes(utf8.encode('$initialCommand\n'));
+          }
+        }
         return !_disposed &&
             _activePtyGeneration == generation &&
             identical(_ptySession, session);

--- a/readme.md
+++ b/readme.md
@@ -76,6 +76,10 @@ Open multiple terminals per workspace, organised in tabs. Run Claude Code in one
 
 Managed lifecycle hooks for Claude, Codex, Amp, OpenCode, Antigravity, Cursor, Copilot and Pi stream agent events into Alera. You can see which agents are **idle, working, or waiting on input** without staring at every terminal.
 
+### 🕸️ Inter-agent orchestration
+
+Agents coordinate with each other through the `alera orchestration` CLI: persistent inter-agent messaging with push-on-idle delivery straight into agent prompts, a task DAG with dependencies, dispatch with retry tracking and a circuit breaker, human-in-the-loop decision gates, and an automated coordinator loop that drives worker agents to completion.
+
 ### 💾 Persistent terminal sessions
 
 Close Alera. Reboot. Reopen. Your terminals, their scrollback, their layouts, and the processes you launched are still there. Long-running agent runs survive restarts instead of vanishing with the window.
@@ -104,7 +108,6 @@ Alera is shipping fast. A non-exhaustive list of what's on the roadmap:
 - **Git operations UI**: stage, commit, push, resolve conflicts visually
 - **Embedded browser & browser use**: give agents a real browser to drive
 - **GitHub / GitLab / Linear / CI integrations**: PRs, issues and checks linked per worktree
-- **Orchestration between agents**: inter-agent messaging, task dispatch, coordinator loops
 - **Voice, automations, MCP management, skills, and more**
 
 See the full [roadmap](roadmap.md) for the complete picture, including difficulty/utility scoring per feature.

--- a/roadmap.md
+++ b/roadmap.md
@@ -17,7 +17,7 @@ Comprehensive feature roadmap for Alera. Each feature is scored on two axes:
 | Agent awake service | 2 | 3 | Shipped | Prevent system sleep while agents work (caffeinate / lid-sleep) |
 | Agent trust presets | 2 | 3 | Planned | Per-agent permission and trust configuration |
 | Agent interrupt intent | 2 | 4 | Planned | Graceful agent interruption protocol |
-| Orchestration between agents | 5 | 5 | Planned | Inter-agent messaging, task dispatch, coordinator loop, decision gates |
+| Orchestration between agents | 5 | 5 | Shipped | Inter-agent messaging with push-on-idle delivery, task DAG, dispatch with circuit breaker, decision gates, coordinator loop (`alera orchestration`) |
 
 ---
 
@@ -239,7 +239,7 @@ Comprehensive feature roadmap for Alera. Each feature is scored on two axes:
 | Diff panel | 4 | Shipped |
 | Diffs per file | 3 | Shipped |
 | Git status with operations | 4 | Shipped |
-| Orchestration between agents | 5 | Planned |
+| Orchestration between agents | 5 | Shipped |
 | Quick Open / Command Palette | 3 | Planned |
 | Activity feed | 3 | Planned |
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -36,6 +36,7 @@ dependencies = [
  "chrono",
  "clap",
  "ed25519-dalek",
+ "git2",
  "hex",
  "portable-pty",
  "reqwest",

--- a/rust/alera-cli/Cargo.toml
+++ b/rust/alera-cli/Cargo.toml
@@ -44,3 +44,4 @@ toml = "0.8"
 tempfile = "3"
 serde_json = "1"
 base64 = "0.22"
+git2 = { version = "0.21", default-features = false }

--- a/rust/alera-cli/src/cli.rs
+++ b/rust/alera-cli/src/cli.rs
@@ -1,5 +1,6 @@
 use clap::{Args, Parser, Subcommand, ValueEnum};
 
+use crate::cli_orchestration::OrchestrationCommand;
 use crate::terminal_host::protocol::{
     DEFAULT_DETACHED_SESSION_SHUTDOWN_DELAY_SECONDS, DEFAULT_EMPTY_SHUTDOWN_DELAY_SECONDS,
     DEFAULT_SCROLLBACK_BYTES, TERMINAL_HOST_COMMAND,
@@ -45,6 +46,9 @@ pub enum Command {
     /// Manage SSH targets known by the Home Runtime.
     #[command(name = "ssh-target")]
     SshTarget(SshTargetCommand),
+
+    /// Inter-agent orchestration: messaging, task DAG, dispatch, gates, coordinator.
+    Orchestration(OrchestrationCommand),
 }
 
 /// Arguments for `alera runtime-host` and `alera terminal-host`. Names and
@@ -341,6 +345,14 @@ pub struct TabCreateArgs {
     pub title: String,
     #[arg(long, default_value = "terminal")]
     pub kind: String,
+    /// Initial command executed in the terminal after the shell starts
+    /// (terminal tabs only), e.g. an agent CLI like "claude".
+    #[arg(long, value_name = "text")]
+    pub command: Option<String>,
+    /// Start the terminal session as soon as the tab is created, even
+    /// before it becomes visible in the app.
+    #[arg(long)]
+    pub spawn: bool,
 }
 
 #[derive(Debug, Args)]

--- a/rust/alera-cli/src/cli_orchestration.rs
+++ b/rust/alera-cli/src/cli_orchestration.rs
@@ -1,0 +1,349 @@
+use clap::{Args, Subcommand};
+
+use crate::cli::{OutputArgs, RuntimeDirArgs};
+
+/// `alera orchestration ...` — inter-agent messaging, task DAG, dispatch,
+/// decision gates, and the coordinator loop. All verbs are RPC calls to the
+/// running runtime-host; there is no direct-store fallback because waiters,
+/// presence, and the coordinator are in-process host state.
+#[derive(Debug, Args)]
+pub struct OrchestrationCommand {
+    #[command(flatten)]
+    pub runtime: RuntimeDirArgs,
+    #[command(flatten)]
+    pub output: OutputArgs,
+    #[command(subcommand)]
+    pub action: OrchestrationAction,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum OrchestrationAction {
+    /// Send a message to a terminal handle or @group address.
+    Send(OrchestrationSendArgs),
+    /// Read messages for a terminal (unread by default; marks them read).
+    Check(OrchestrationCheckArgs),
+    /// Reply to a message by id.
+    Reply(OrchestrationReplyArgs),
+    /// List recent messages across all recipients.
+    Inbox(OrchestrationInboxArgs),
+    /// Ask another agent a question and block until it answers.
+    Ask(OrchestrationAskArgs),
+    /// Create a task in the orchestration DAG.
+    #[command(name = "task-create")]
+    TaskCreate(OrchestrationTaskCreateArgs),
+    /// List tasks, optionally filtered by status.
+    #[command(name = "task-list")]
+    TaskList(OrchestrationTaskListArgs),
+    /// Update a task's status.
+    #[command(name = "task-update")]
+    TaskUpdate(OrchestrationTaskUpdateArgs),
+    /// Dispatch a ready task to a terminal.
+    Dispatch(OrchestrationDispatchArgs),
+    /// Show the dispatch state and preamble for a task.
+    #[command(name = "dispatch-show")]
+    DispatchShow(OrchestrationDispatchShowArgs),
+    /// Create a decision gate that blocks a task until resolved.
+    #[command(name = "gate-create")]
+    GateCreate(OrchestrationGateCreateArgs),
+    /// Resolve a pending decision gate.
+    #[command(name = "gate-resolve")]
+    GateResolve(OrchestrationGateResolveArgs),
+    /// List decision gates.
+    #[command(name = "gate-list")]
+    GateList(OrchestrationGateListArgs),
+    /// Start the background coordinator loop.
+    Run(OrchestrationRunArgs),
+    /// Stop the active coordinator loop.
+    #[command(name = "run-stop")]
+    RunStop,
+    /// List live terminals with agent presence.
+    #[command(name = "terminal-list")]
+    TerminalList,
+    /// Clear orchestration state (default: everything).
+    Reset(OrchestrationResetArgs),
+}
+
+#[derive(Debug, Args)]
+pub struct OrchestrationSendArgs {
+    /// Recipient terminal handle or @group (@all, @idle, @workspace:<id>, @claude, ...).
+    #[arg(long = "to", value_name = "handle|@group")]
+    pub to: String,
+
+    /// Message subject.
+    #[arg(long = "subject", value_name = "text")]
+    pub subject: String,
+
+    /// Sender handle. Defaults to ALERA_TERMINAL_HANDLE.
+    #[arg(long = "from", value_name = "handle")]
+    pub from: Option<String>,
+
+    /// Message body.
+    #[arg(long = "body", value_name = "text")]
+    pub body: Option<String>,
+
+    /// Message type: status|dispatch|worker_done|merge_ready|escalation|handoff|decision_gate|heartbeat.
+    #[arg(long = "type", value_name = "type")]
+    pub message_type: Option<String>,
+
+    /// Priority: normal|high|urgent.
+    #[arg(long = "priority", value_name = "level")]
+    pub priority: Option<String>,
+
+    /// Thread id to attach this message to.
+    #[arg(long = "thread-id", value_name = "id")]
+    pub thread_id: Option<String>,
+
+    /// Raw JSON payload. Prefer the structured flags below on Windows shells.
+    #[arg(long = "payload", value_name = "json", conflicts_with_all = ["task_id", "dispatch_id", "files_modified", "report_path", "phase"])]
+    pub payload: Option<String>,
+
+    /// Structured payload: task id (for worker_done/heartbeat/escalation).
+    #[arg(long = "task-id", value_name = "id")]
+    pub task_id: Option<String>,
+
+    /// Structured payload: dispatch context id (for worker_done/heartbeat/escalation).
+    #[arg(long = "dispatch-id", value_name = "id")]
+    pub dispatch_id: Option<String>,
+
+    /// Structured payload: comma-separated modified file paths.
+    #[arg(long = "files-modified", value_name = "csv")]
+    pub files_modified: Option<String>,
+
+    /// Structured payload: path to a long-form artifact.
+    #[arg(long = "report-path", value_name = "path")]
+    pub report_path: Option<String>,
+
+    /// Structured payload: current work phase (heartbeats).
+    #[arg(long = "phase", value_name = "text")]
+    pub phase: Option<String>,
+}
+
+#[derive(Debug, Args)]
+pub struct OrchestrationCheckArgs {
+    /// Terminal handle to check. Defaults to ALERA_TERMINAL_HANDLE.
+    #[arg(long = "terminal", value_name = "handle")]
+    pub terminal: Option<String>,
+
+    /// Return all messages (read and unread) without marking anything read.
+    #[arg(long = "all")]
+    pub all: bool,
+
+    /// Comma-separated message types to filter by.
+    #[arg(long = "types", value_name = "type,...")]
+    pub types: Option<String>,
+
+    /// Format messages as injectable banners.
+    #[arg(long = "inject")]
+    pub inject: bool,
+
+    /// Block until a matching message arrives or the timeout expires.
+    #[arg(long = "wait")]
+    pub wait: bool,
+
+    /// Wait timeout in milliseconds (default 120000).
+    #[arg(long = "timeout-ms", value_name = "ms")]
+    pub timeout_ms: Option<u64>,
+
+    /// Maximum messages returned with --all.
+    #[arg(long = "limit", value_name = "n")]
+    pub limit: Option<i64>,
+}
+
+#[derive(Debug, Args)]
+pub struct OrchestrationReplyArgs {
+    /// Message id to reply to.
+    #[arg(long = "id", value_name = "msg_id")]
+    pub id: String,
+
+    /// Reply body.
+    #[arg(long = "body", value_name = "text")]
+    pub body: String,
+}
+
+#[derive(Debug, Args)]
+pub struct OrchestrationInboxArgs {
+    /// Restrict to one terminal handle.
+    #[arg(long = "terminal", value_name = "handle")]
+    pub terminal: Option<String>,
+
+    /// Maximum messages returned (default 50).
+    #[arg(long = "limit", value_name = "n")]
+    pub limit: Option<i64>,
+}
+
+#[derive(Debug, Args)]
+pub struct OrchestrationAskArgs {
+    /// Terminal handle to ask (single handle, not a group).
+    #[arg(long = "to", value_name = "handle")]
+    pub to: String,
+
+    /// The question text.
+    #[arg(long = "question", value_name = "text")]
+    pub question: String,
+
+    /// Asker handle. Defaults to ALERA_TERMINAL_HANDLE.
+    #[arg(long = "from", value_name = "handle")]
+    pub from: Option<String>,
+
+    /// Optional comma-separated answer options.
+    #[arg(long = "options", value_name = "csv")]
+    pub options: Option<String>,
+
+    /// Wait timeout in milliseconds (default 120000).
+    #[arg(long = "timeout-ms", value_name = "ms")]
+    pub timeout_ms: Option<u64>,
+}
+
+#[derive(Debug, Args)]
+pub struct OrchestrationTaskCreateArgs {
+    /// The task brief the dispatched worker receives.
+    #[arg(long = "spec", value_name = "text")]
+    pub spec: String,
+
+    /// Short title for listings.
+    #[arg(long = "task-title", value_name = "text")]
+    pub task_title: Option<String>,
+
+    /// JSON array of task ids this task depends on.
+    #[arg(long = "deps", value_name = "json_array")]
+    pub deps: Option<String>,
+
+    /// Parent task id.
+    #[arg(long = "parent", value_name = "task_id")]
+    pub parent: Option<String>,
+}
+
+#[derive(Debug, Args)]
+pub struct OrchestrationTaskListArgs {
+    /// Filter by status: pending|ready|dispatched|completed|failed|blocked.
+    #[arg(long = "status", value_name = "status", conflicts_with = "ready")]
+    pub status: Option<String>,
+
+    /// Shorthand for --status ready.
+    #[arg(long = "ready")]
+    pub ready: bool,
+}
+
+#[derive(Debug, Args)]
+pub struct OrchestrationTaskUpdateArgs {
+    /// Task id.
+    #[arg(long = "id", value_name = "task_id")]
+    pub id: String,
+
+    /// New status: pending|ready|dispatched|completed|failed|blocked.
+    #[arg(long = "status", value_name = "status")]
+    pub status: String,
+
+    /// JSON result blob to store with the task.
+    #[arg(long = "result", value_name = "json")]
+    pub result: Option<String>,
+}
+
+#[derive(Debug, Args)]
+pub struct OrchestrationDispatchArgs {
+    /// Task id to dispatch (must be ready).
+    #[arg(long = "task", value_name = "task_id")]
+    pub task: String,
+
+    /// Target terminal handle.
+    #[arg(long = "to", value_name = "handle")]
+    pub to: String,
+
+    /// Coordinator handle embedded in the preamble. Defaults to ALERA_TERMINAL_HANDLE.
+    #[arg(long = "from", value_name = "handle")]
+    pub from: Option<String>,
+
+    /// Inject the preamble into the target terminal (requires a running agent).
+    #[arg(long = "inject")]
+    pub inject: bool,
+
+    /// Build the preamble without mutating any state.
+    #[arg(long = "dry-run")]
+    pub dry_run: bool,
+
+    /// Include the full preamble text in the response.
+    #[arg(long = "return-preamble")]
+    pub return_preamble: bool,
+}
+
+#[derive(Debug, Args)]
+pub struct OrchestrationDispatchShowArgs {
+    /// Task id to inspect.
+    #[arg(long = "task", value_name = "task_id")]
+    pub task: String,
+}
+
+#[derive(Debug, Args)]
+pub struct OrchestrationGateCreateArgs {
+    /// Task id the gate blocks.
+    #[arg(long = "task", value_name = "task_id")]
+    pub task: String,
+
+    /// The question for the human/coordinator.
+    #[arg(long = "question", value_name = "text")]
+    pub question: String,
+
+    /// JSON array of options.
+    #[arg(long = "options", value_name = "json_array")]
+    pub options: Option<String>,
+}
+
+#[derive(Debug, Args)]
+pub struct OrchestrationGateResolveArgs {
+    /// Gate id.
+    #[arg(long = "id", value_name = "gate_id")]
+    pub id: String,
+
+    /// The resolution text fed into the next dispatch preamble.
+    #[arg(long = "resolution", value_name = "text")]
+    pub resolution: String,
+}
+
+#[derive(Debug, Args)]
+pub struct OrchestrationGateListArgs {
+    /// Filter by task id.
+    #[arg(long = "task", value_name = "task_id")]
+    pub task: Option<String>,
+
+    /// Filter by status: pending|resolved|timeout.
+    #[arg(long = "status", value_name = "status")]
+    pub status: Option<String>,
+}
+
+#[derive(Debug, Args)]
+pub struct OrchestrationRunArgs {
+    /// Run objective recorded on the coordinator run.
+    #[arg(long = "spec", value_name = "text")]
+    pub spec: String,
+
+    /// Coordinator handle. Defaults to ALERA_TERMINAL_HANDLE.
+    #[arg(long = "from", value_name = "handle")]
+    pub from: Option<String>,
+
+    /// Poll interval in milliseconds (default 2000).
+    #[arg(long = "poll-interval-ms", value_name = "ms")]
+    pub poll_interval_ms: Option<u64>,
+
+    /// Maximum concurrent dispatches (default 4).
+    #[arg(long = "max-concurrent", value_name = "n")]
+    pub max_concurrent: Option<u64>,
+
+    /// Workspace id that scopes worker terminals and drift checks.
+    #[arg(long = "workspace", value_name = "workspace_id")]
+    pub workspace: Option<String>,
+}
+
+#[derive(Debug, Args)]
+pub struct OrchestrationResetArgs {
+    /// Clear everything (default when no scope flag is given).
+    #[arg(long = "all")]
+    pub all: bool,
+
+    /// Clear tasks, dispatch contexts, gates, and coordinator runs.
+    #[arg(long = "tasks")]
+    pub tasks: bool,
+
+    /// Clear messages.
+    #[arg(long = "messages")]
+    pub messages: bool,
+}

--- a/rust/alera-cli/src/main.rs
+++ b/rust/alera-cli/src/main.rs
@@ -1,5 +1,7 @@
 mod cli;
+mod cli_orchestration;
 mod managed_workspace;
+mod orchestration_commands;
 mod runtime_archive;
 mod runtime_host_client;
 mod ssh_bootstrap;
@@ -74,6 +76,9 @@ async fn run() -> i32 {
         Command::Tag(command) => run_tag_command(command).await,
         Command::Tab(command) => run_tab_command(command).await,
         Command::SshTarget(command) => run_ssh_target_command(command).await,
+        Command::Orchestration(command) => {
+            orchestration_commands::run_orchestration_command(command).await
+        }
     }
 }
 
@@ -761,6 +766,22 @@ fn tab_from_args(args: TabCreateArgs) -> Result<WorkspaceTabRecord, String> {
                 SUPPORTED_TAB_KINDS.join(", ")
             )
         })?;
+    if (args.command.is_some() || args.spawn) && kind != "terminal" {
+        return Err("--command and --spawn are only supported for terminal tabs.".to_string());
+    }
+    let mut payload = serde_json::Map::new();
+    payload.insert("terminalSessionId".to_string(), json!(id));
+    if let Some(command) = args
+        .command
+        .as_deref()
+        .map(str::trim)
+        .filter(|command| !command.is_empty())
+    {
+        payload.insert("initialCommand".to_string(), json!(command));
+    }
+    if args.spawn {
+        payload.insert("spawnOnCreate".to_string(), json!(true));
+    }
     Ok(WorkspaceTabRecord {
         id: id.clone(),
         workspace_id: args.workspace_id,
@@ -768,7 +789,7 @@ fn tab_from_args(args: TabCreateArgs) -> Result<WorkspaceTabRecord, String> {
         title: args.title,
         created_at: now,
         updated_at: now,
-        payload: json!({ "terminalSessionId": id }),
+        payload: Value::Object(payload),
     })
 }
 

--- a/rust/alera-cli/src/orchestration_commands.rs
+++ b/rust/alera-cli/src/orchestration_commands.rs
@@ -1,0 +1,743 @@
+use serde_json::{json, Map, Value};
+
+use crate::cli::RuntimeDirArgs;
+use crate::cli_orchestration::{
+    OrchestrationAction, OrchestrationAskArgs, OrchestrationCheckArgs, OrchestrationCommand,
+    OrchestrationSendArgs,
+};
+use crate::runtime_host_client::RuntimeHostRpcClient;
+use crate::terminal_host::protocol::RUNTIME_HOST_ORCHESTRATION_CAPABILITY;
+
+const USAGE_EXIT_CODE: i32 = 64;
+/// Grace added to the server-side wait deadline so the client outlives it.
+const WAIT_CLIENT_GRACE_MS: u64 = 5_000;
+const DEFAULT_WAIT_TIMEOUT_MS: u64 = 120_000;
+
+const LIFECYCLE_TYPES: &[&str] = &["worker_done", "heartbeat"];
+
+pub async fn run_orchestration_command(command: OrchestrationCommand) -> i32 {
+    let runtime = command.runtime;
+    let json_output = command.output.json;
+    match command.action {
+        OrchestrationAction::Send(args) => match build_send_payload(args) {
+            Ok(payload) => {
+                request(&runtime, "orchestration.send", payload, json_output, None).await
+            }
+            Err(message) => usage_error(&message),
+        },
+        OrchestrationAction::Check(args) => run_check(&runtime, args, json_output).await,
+        OrchestrationAction::Reply(args) => {
+            request(
+                &runtime,
+                "orchestration.reply",
+                json!({ "id": args.id, "body": args.body }),
+                json_output,
+                None,
+            )
+            .await
+        }
+        OrchestrationAction::Inbox(args) => {
+            let mut payload = Map::new();
+            insert_opt(&mut payload, "terminal", args.terminal);
+            if let Some(limit) = args.limit {
+                payload.insert("limit".to_string(), json!(limit));
+            }
+            request(
+                &runtime,
+                "orchestration.inbox",
+                Value::Object(payload),
+                json_output,
+                None,
+            )
+            .await
+        }
+        OrchestrationAction::Ask(args) => run_ask(&runtime, args, json_output).await,
+        OrchestrationAction::TaskCreate(args) => {
+            let deps: Vec<String> = match args.deps.as_deref() {
+                None => Vec::new(),
+                Some(raw) => match serde_json::from_str(raw) {
+                    Ok(deps) => deps,
+                    Err(_) => return usage_error("--deps must be a JSON array of task ids."),
+                },
+            };
+            request(
+                &runtime,
+                "orchestration.taskCreate",
+                json!({
+                    "spec": args.spec,
+                    "taskTitle": args.task_title,
+                    "deps": deps,
+                    "parent": args.parent,
+                    "createdBy": terminal_handle_env(),
+                }),
+                json_output,
+                None,
+            )
+            .await
+        }
+        OrchestrationAction::TaskList(args) => {
+            let status = if args.ready {
+                Some("ready".to_string())
+            } else {
+                args.status
+            };
+            let mut payload = Map::new();
+            insert_opt(&mut payload, "status", status);
+            request(
+                &runtime,
+                "orchestration.taskList",
+                Value::Object(payload),
+                json_output,
+                None,
+            )
+            .await
+        }
+        OrchestrationAction::TaskUpdate(args) => {
+            request(
+                &runtime,
+                "orchestration.taskUpdate",
+                json!({
+                    "id": args.id,
+                    "status": args.status,
+                    "result": args.result,
+                }),
+                json_output,
+                None,
+            )
+            .await
+        }
+        OrchestrationAction::Dispatch(args) => {
+            let Some(from) = args.from.or_else(terminal_handle_env) else {
+                return usage_error(
+                    "--from is required (or set ALERA_TERMINAL_HANDLE) so the preamble can name the coordinator.",
+                );
+            };
+            request(
+                &runtime,
+                "orchestration.dispatch",
+                json!({
+                    "task": args.task,
+                    "to": args.to,
+                    "from": from,
+                    "inject": args.inject,
+                    "dryRun": args.dry_run,
+                    "returnPreamble": args.return_preamble,
+                }),
+                json_output,
+                None,
+            )
+            .await
+        }
+        OrchestrationAction::DispatchShow(args) => {
+            request(
+                &runtime,
+                "orchestration.dispatchShow",
+                json!({ "task": args.task }),
+                json_output,
+                None,
+            )
+            .await
+        }
+        OrchestrationAction::GateCreate(args) => {
+            let options: Vec<String> = match args.options.as_deref() {
+                None => Vec::new(),
+                Some(raw) => match serde_json::from_str(raw) {
+                    Ok(options) => options,
+                    Err(_) => return usage_error("--options must be a JSON array of strings."),
+                },
+            };
+            request(
+                &runtime,
+                "orchestration.gateCreate",
+                json!({
+                    "task": args.task,
+                    "question": args.question,
+                    "options": options,
+                }),
+                json_output,
+                None,
+            )
+            .await
+        }
+        OrchestrationAction::GateResolve(args) => {
+            request(
+                &runtime,
+                "orchestration.gateResolve",
+                json!({ "id": args.id, "resolution": args.resolution }),
+                json_output,
+                None,
+            )
+            .await
+        }
+        OrchestrationAction::GateList(args) => {
+            let mut payload = Map::new();
+            insert_opt(&mut payload, "task", args.task);
+            insert_opt(&mut payload, "status", args.status);
+            request(
+                &runtime,
+                "orchestration.gateList",
+                Value::Object(payload),
+                json_output,
+                None,
+            )
+            .await
+        }
+        OrchestrationAction::Run(args) => {
+            let Some(from) = args.from.or_else(terminal_handle_env) else {
+                return usage_error(
+                    "--from is required (or set ALERA_TERMINAL_HANDLE) so workers can contact the coordinator.",
+                );
+            };
+            request(
+                &runtime,
+                "orchestration.run",
+                json!({
+                    "spec": args.spec,
+                    "from": from,
+                    "pollIntervalMs": args.poll_interval_ms,
+                    "maxConcurrent": args.max_concurrent,
+                    "workspace": args.workspace,
+                }),
+                json_output,
+                None,
+            )
+            .await
+        }
+        OrchestrationAction::RunStop => {
+            request(
+                &runtime,
+                "orchestration.runStop",
+                json!({}),
+                json_output,
+                None,
+            )
+            .await
+        }
+        OrchestrationAction::TerminalList => {
+            request(
+                &runtime,
+                "orchestration.terminals",
+                json!({}),
+                json_output,
+                None,
+            )
+            .await
+        }
+        OrchestrationAction::Reset(args) => {
+            request(
+                &runtime,
+                "orchestration.reset",
+                json!({
+                    "all": args.all,
+                    "tasks": args.tasks,
+                    "messages": args.messages,
+                }),
+                json_output,
+                None,
+            )
+            .await
+        }
+    }
+}
+
+fn build_send_payload(args: OrchestrationSendArgs) -> Result<Value, String> {
+    let Some(from) = args.from.or_else(terminal_handle_env) else {
+        return Err(
+            "--from is required (or run inside an Alera terminal where ALERA_TERMINAL_HANDLE is set)."
+                .to_string(),
+        );
+    };
+    // Client-side mirror of the server rule so the error is immediate.
+    if let Some(message_type) = args.message_type.as_deref() {
+        if LIFECYCLE_TYPES.contains(&message_type) && args.to.starts_with('@') {
+            return Err(format!(
+                "{message_type} messages cannot be sent to a group address."
+            ));
+        }
+    }
+    let payload_json = build_structured_payload(
+        args.payload,
+        args.task_id,
+        args.dispatch_id,
+        args.files_modified,
+        args.report_path,
+        args.phase,
+    )?;
+    let mut payload = Map::new();
+    payload.insert("from".to_string(), json!(from));
+    payload.insert("to".to_string(), json!(args.to));
+    payload.insert("subject".to_string(), json!(args.subject));
+    insert_opt(&mut payload, "body", args.body);
+    insert_opt(&mut payload, "type", args.message_type);
+    insert_opt(&mut payload, "priority", args.priority);
+    insert_opt(&mut payload, "threadId", args.thread_id);
+    insert_opt(&mut payload, "payload", payload_json);
+    Ok(Value::Object(payload))
+}
+
+/// Structured payload flags exist because raw JSON in `--payload` is fragile
+/// under Windows PowerShell quoting; the CLI assembles the JSON itself.
+fn build_structured_payload(
+    raw: Option<String>,
+    task_id: Option<String>,
+    dispatch_id: Option<String>,
+    files_modified: Option<String>,
+    report_path: Option<String>,
+    phase: Option<String>,
+) -> Result<Option<String>, String> {
+    if let Some(raw) = raw {
+        if serde_json::from_str::<Value>(&raw).is_err() {
+            return Err("--payload must be valid JSON.".to_string());
+        }
+        return Ok(Some(raw));
+    }
+    let mut payload = Map::new();
+    if let Some(task_id) = task_id {
+        payload.insert("taskId".to_string(), json!(task_id));
+    }
+    if let Some(dispatch_id) = dispatch_id {
+        payload.insert("dispatchId".to_string(), json!(dispatch_id));
+    }
+    if let Some(files) = files_modified {
+        let files: Vec<String> = files
+            .split(',')
+            .map(str::trim)
+            .filter(|entry| !entry.is_empty())
+            .map(str::to_string)
+            .collect();
+        payload.insert("filesModified".to_string(), json!(files));
+    }
+    if let Some(report_path) = report_path {
+        payload.insert("reportPath".to_string(), json!(report_path));
+    }
+    if let Some(phase) = phase {
+        payload.insert("phase".to_string(), json!(phase));
+    }
+    if payload.is_empty() {
+        return Ok(None);
+    }
+    Ok(Some(Value::Object(payload).to_string()))
+}
+
+async fn run_check(
+    runtime: &RuntimeDirArgs,
+    args: OrchestrationCheckArgs,
+    json_output: bool,
+) -> i32 {
+    let Some(terminal) = args.terminal.or_else(terminal_handle_env) else {
+        return usage_error(
+            "--terminal is required (or run inside an Alera terminal where ALERA_TERMINAL_HANDLE is set).",
+        );
+    };
+    let types: Vec<String> = args
+        .types
+        .as_deref()
+        .map(|raw| {
+            raw.split(',')
+                .map(str::trim)
+                .filter(|entry| !entry.is_empty())
+                .map(str::to_string)
+                .collect()
+        })
+        .unwrap_or_default();
+    let timeout_ms = args.timeout_ms.unwrap_or(DEFAULT_WAIT_TIMEOUT_MS);
+    let mut payload = Map::new();
+    payload.insert("terminal".to_string(), json!(terminal));
+    payload.insert("all".to_string(), json!(args.all));
+    payload.insert("wait".to_string(), json!(args.wait));
+    payload.insert("inject".to_string(), json!(args.inject));
+    if !types.is_empty() {
+        payload.insert("types".to_string(), json!(types));
+    }
+    if args.wait {
+        payload.insert("timeoutMs".to_string(), json!(timeout_ms));
+    }
+    if let Some(limit) = args.limit {
+        payload.insert("limit".to_string(), json!(limit));
+    }
+    let deadline = args
+        .wait
+        .then_some(timeout_ms.saturating_add(WAIT_CLIENT_GRACE_MS));
+    request(
+        runtime,
+        "orchestration.check",
+        Value::Object(payload),
+        json_output,
+        deadline,
+    )
+    .await
+}
+
+async fn run_ask(runtime: &RuntimeDirArgs, args: OrchestrationAskArgs, json_output: bool) -> i32 {
+    let Some(from) = args.from.or_else(terminal_handle_env) else {
+        return usage_error(
+            "--from is required (or run inside an Alera terminal where ALERA_TERMINAL_HANDLE is set).",
+        );
+    };
+    if args.to.starts_with('@') {
+        return usage_error("ask requires a single terminal handle, not a group address.");
+    }
+    let timeout_ms = args.timeout_ms.unwrap_or(DEFAULT_WAIT_TIMEOUT_MS);
+    let payload = json!({
+        "from": from,
+        "to": args.to,
+        "question": args.question,
+        "options": args.options,
+        "timeoutMs": timeout_ms,
+    });
+    let value = match request_value(
+        runtime,
+        "orchestration.ask",
+        payload,
+        Some(timeout_ms.saturating_add(WAIT_CLIENT_GRACE_MS)),
+    )
+    .await
+    {
+        Ok(value) => value,
+        Err(error) => {
+            eprintln!("{error}");
+            return 1;
+        }
+    };
+    let answered = value
+        .get("answered")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    if json_output {
+        println!("{value}");
+    } else if answered {
+        let body = value
+            .get("reply")
+            .and_then(|reply| reply.get("body"))
+            .and_then(Value::as_str)
+            .unwrap_or("");
+        println!("{body}");
+    } else {
+        eprintln!("ask timed out with no reply");
+    }
+    // A timeout is a runtime failure so scripted callers can branch on it.
+    if answered {
+        0
+    } else {
+        1
+    }
+}
+
+async fn request(
+    runtime: &RuntimeDirArgs,
+    request_type: &str,
+    payload: Value,
+    json_output: bool,
+    deadline_ms: Option<u64>,
+) -> i32 {
+    match request_value(runtime, request_type, payload, deadline_ms).await {
+        Ok(value) => {
+            if json_output {
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&value).unwrap_or_else(|_| "{}".to_string())
+                );
+            } else {
+                println!("{}", human_summary(request_type, &value));
+            }
+            0
+        }
+        Err(error) => {
+            eprintln!("{error}");
+            1
+        }
+    }
+}
+
+async fn request_value(
+    runtime: &RuntimeDirArgs,
+    request_type: &str,
+    payload: Value,
+    deadline_ms: Option<u64>,
+) -> anyhow::Result<Value> {
+    let mut client = RuntimeHostRpcClient::connect_or_start_with_required_capability(
+        &crate::runtime_dir(runtime),
+        RUNTIME_HOST_ORCHESTRATION_CAPABILITY,
+    )
+    .await?;
+    match deadline_ms {
+        Some(deadline_ms) => {
+            client
+                .request_value_with_deadline(request_type, &payload, deadline_ms)
+                .await
+        }
+        None => client.request_value(request_type, &payload).await,
+    }
+}
+
+fn human_summary(request_type: &str, value: &Value) -> String {
+    match request_type {
+        "orchestration.send" => {
+            let recipients = value
+                .get("recipients")
+                .and_then(Value::as_array)
+                .map(|entries| entries.len())
+                .unwrap_or(0);
+            format!("message sent to {recipients} recipient(s)")
+        }
+        "orchestration.check" => {
+            if let Some(formatted) = value.get("formatted").and_then(Value::as_str) {
+                if !formatted.is_empty() {
+                    return formatted.to_string();
+                }
+            }
+            check_message_summary(value)
+        }
+        "orchestration.reply" => "reply sent".to_string(),
+        "orchestration.inbox" => {
+            let count = value
+                .get("messages")
+                .and_then(Value::as_array)
+                .map(|messages| messages.len())
+                .unwrap_or(0);
+            format!("{count} message(s)")
+        }
+        "orchestration.taskCreate" => value
+            .get("id")
+            .and_then(Value::as_str)
+            .map(|id| format!("task created: {id}"))
+            .unwrap_or_else(|| "task created".to_string()),
+        "orchestration.taskList" => {
+            let count = value
+                .get("tasks")
+                .and_then(Value::as_array)
+                .map(|tasks| tasks.len())
+                .unwrap_or(0);
+            format!("{count} task(s)")
+        }
+        "orchestration.taskUpdate" => "task updated".to_string(),
+        "orchestration.dispatch" => value
+            .get("preamble")
+            .and_then(Value::as_str)
+            .map(str::to_string)
+            .unwrap_or_else(|| {
+                if value
+                    .get("dryRun")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false)
+                {
+                    "dispatch dry run".to_string()
+                } else {
+                    "task dispatched".to_string()
+                }
+            }),
+        "orchestration.dispatchShow" => {
+            serde_json::to_string_pretty(value).unwrap_or_else(|_| "dispatch context".to_string())
+        }
+        "orchestration.gateCreate" => value
+            .get("id")
+            .and_then(Value::as_str)
+            .map(|id| format!("gate created: {id}"))
+            .unwrap_or_else(|| "gate created".to_string()),
+        "orchestration.gateResolve" => "gate resolved".to_string(),
+        "orchestration.gateList" => {
+            let count = value
+                .get("gates")
+                .and_then(Value::as_array)
+                .map(|gates| gates.len())
+                .unwrap_or(0);
+            format!("{count} gate(s)")
+        }
+        "orchestration.run" => value
+            .get("runId")
+            .and_then(Value::as_str)
+            .map(|id| format!("coordinator run started: {id}"))
+            .unwrap_or_else(|| "coordinator run started".to_string()),
+        "orchestration.runStop" => "coordinator run stopped".to_string(),
+        "orchestration.terminals" => {
+            let count = value
+                .get("terminals")
+                .and_then(Value::as_array)
+                .map(|terminals| terminals.len())
+                .unwrap_or(0);
+            format!("{count} terminal(s)")
+        }
+        "orchestration.reset" => "orchestration state reset".to_string(),
+        _ => serde_json::to_string_pretty(value).unwrap_or_else(|_| "ok".to_string()),
+    }
+}
+
+fn check_message_summary(value: &Value) -> String {
+    let Some(messages) = value.get("messages").and_then(Value::as_array) else {
+        return "0 message(s)".to_string();
+    };
+    if messages.is_empty() {
+        return "0 message(s)".to_string();
+    }
+    messages
+        .iter()
+        .map(check_message_item_summary)
+        .collect::<Vec<_>>()
+        .join("\n\n")
+}
+
+fn check_message_item_summary(message: &Value) -> String {
+    let id = message.get("id").and_then(Value::as_str).unwrap_or("");
+    let from = message
+        .get("from_handle")
+        .and_then(Value::as_str)
+        .unwrap_or("<unknown>");
+    let message_type = message
+        .get("type")
+        .and_then(Value::as_str)
+        .unwrap_or("status");
+    let subject = message
+        .get("subject")
+        .and_then(Value::as_str)
+        .unwrap_or("<no subject>");
+    let mut lines = vec![
+        format!("From: {from} ({message_type})"),
+        format!("Subject: {subject}"),
+    ];
+    if let Some(body) = message
+        .get("body")
+        .and_then(Value::as_str)
+        .filter(|body| !body.is_empty())
+    {
+        lines.push(body.to_string());
+    }
+    if let Some(payload) = message
+        .get("payload")
+        .and_then(Value::as_str)
+        .filter(|payload| !payload.is_empty())
+    {
+        lines.push(format!("[Payload: {payload}]"));
+    }
+    if !id.is_empty() {
+        lines.push(format!(
+            "[Reply: alera orchestration reply --id {id} --body \"...\"]"
+        ));
+    }
+    lines.join("\n")
+}
+
+fn insert_opt(payload: &mut Map<String, Value>, key: &str, value: Option<String>) {
+    if let Some(value) = value {
+        payload.insert(key.to_string(), json!(value));
+    }
+}
+
+fn terminal_handle_env() -> Option<String> {
+    std::env::var("ALERA_TERMINAL_HANDLE")
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+fn usage_error(message: &str) -> i32 {
+    eprintln!("{message}");
+    USAGE_EXIT_CODE
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn structured_payload_assembles_json() {
+        let payload = build_structured_payload(
+            None,
+            Some("task_1".to_string()),
+            Some("ctx_1".to_string()),
+            Some("a.rs, b.rs".to_string()),
+            Some("/tmp/report.md".to_string()),
+            Some("implementing".to_string()),
+        )
+        .unwrap()
+        .unwrap();
+        let value: Value = serde_json::from_str(&payload).unwrap();
+        assert_eq!(value["taskId"], "task_1");
+        assert_eq!(value["dispatchId"], "ctx_1");
+        assert_eq!(value["filesModified"], json!(["a.rs", "b.rs"]));
+        assert_eq!(value["reportPath"], "/tmp/report.md");
+        assert_eq!(value["phase"], "implementing");
+    }
+
+    #[test]
+    fn raw_payload_must_be_valid_json() {
+        assert!(build_structured_payload(
+            Some("{not json".to_string()),
+            None,
+            None,
+            None,
+            None,
+            None
+        )
+        .is_err());
+        let passthrough =
+            build_structured_payload(Some("{\"x\":1}".to_string()), None, None, None, None, None)
+                .unwrap();
+        assert_eq!(passthrough.as_deref(), Some("{\"x\":1}"));
+    }
+
+    #[test]
+    fn empty_structured_payload_is_none() {
+        let payload = build_structured_payload(None, None, None, None, None, None).unwrap();
+        assert!(payload.is_none());
+    }
+
+    #[test]
+    fn dispatch_summary_prints_dry_run_preamble() {
+        let summary = human_summary(
+            "orchestration.dispatch",
+            &json!({
+                "dryRun": true,
+                "preamble": "handoff text to paste"
+            }),
+        );
+        assert_eq!(summary, "handoff text to paste");
+    }
+
+    #[test]
+    fn dispatch_summary_prints_returned_preamble() {
+        let summary = human_summary(
+            "orchestration.dispatch",
+            &json!({
+                "dispatch": {
+                    "id": "ctx_1"
+                },
+                "preamble": "manual injection text"
+            }),
+        );
+        assert_eq!(summary, "manual injection text");
+    }
+
+    #[test]
+    fn dispatch_summary_labels_dry_run_without_preamble() {
+        let summary = human_summary("orchestration.dispatch", &json!({ "dryRun": true }));
+        assert_eq!(summary, "dispatch dry run");
+    }
+
+    #[test]
+    fn default_check_summary_prints_message_contents() {
+        let summary = human_summary(
+            "orchestration.check",
+            &json!({
+                "messages": [{
+                    "id": "msg_1",
+                    "from_handle": "coord",
+                    "to_handle": "worker",
+                    "subject": "Follow up",
+                    "body": "Please rerun tests.",
+                    "type": "status",
+                    "priority": "normal",
+                    "thread_id": null,
+                    "payload": "{\"taskId\":\"task_1\"}",
+                    "read": false,
+                    "sequence": 1,
+                    "created_at": "2026-07-05 19:00:00",
+                    "delivered_at": null
+                }]
+            }),
+        );
+        assert!(summary.contains("From: coord (status)"));
+        assert!(summary.contains("Subject: Follow up"));
+        assert!(summary.contains("Please rerun tests."));
+        assert!(summary.contains("alera orchestration reply --id msg_1"));
+    }
+}

--- a/rust/alera-cli/src/runtime_host_client.rs
+++ b/rust/alera-cli/src/runtime_host_client.rs
@@ -53,11 +53,27 @@ struct RuntimeHostFrame {
 
 impl RuntimeHostRpcClient {
     pub(crate) async fn connect(runtime_dir: &Path) -> Result<Option<Self>> {
+        Self::connect_with_capability(runtime_dir, None).await
+    }
+
+    pub(crate) async fn connect_with_required_capability(
+        runtime_dir: &Path,
+        required_capability: &str,
+    ) -> Result<Option<Self>> {
+        Self::connect_with_capability(runtime_dir, Some(required_capability)).await
+    }
+
+    async fn connect_with_capability(
+        runtime_dir: &Path,
+        required_capability: Option<&str>,
+    ) -> Result<Option<Self>> {
         for control_path in [
             runtime_dir.join(CONTROL_FILE_NAME),
             runtime_dir.join(RUNTIME_CONTROL_FILE_NAME),
         ] {
-            if let Some(client) = Self::connect_control_file(&control_path).await? {
+            if let Some(client) =
+                Self::connect_control_file(&control_path, required_capability).await?
+            {
                 return Ok(Some(client));
             }
         }
@@ -68,6 +84,22 @@ impl RuntimeHostRpcClient {
         if let Some(client) = Self::connect(runtime_dir).await? {
             return Ok(client);
         }
+        Self::start(runtime_dir, None).await
+    }
+
+    pub(crate) async fn connect_or_start_with_required_capability(
+        runtime_dir: &Path,
+        required_capability: &str,
+    ) -> Result<Self> {
+        if let Some(client) =
+            Self::connect_with_required_capability(runtime_dir, required_capability).await?
+        {
+            return Ok(client);
+        }
+        Self::start(runtime_dir, Some(required_capability)).await
+    }
+
+    async fn start(runtime_dir: &Path, required_capability: Option<&str>) -> Result<Self> {
         tokio::fs::create_dir_all(runtime_dir).await?;
         let control_file = runtime_dir.join(RUNTIME_CONTROL_FILE_NAME);
         let _ = tokio::fs::remove_file(&control_file).await;
@@ -95,7 +127,9 @@ impl RuntimeHostRpcClient {
 
         let deadline = Instant::now() + STARTUP_TIMEOUT;
         while Instant::now() < deadline {
-            if let Some(client) = Self::connect_control_file(&control_file).await? {
+            if let Some(client) =
+                Self::connect_control_file(&control_file, required_capability).await?
+            {
                 return Ok(client);
             }
             sleep(Duration::from_millis(100)).await;
@@ -103,7 +137,10 @@ impl RuntimeHostRpcClient {
         Err(anyhow!("timed out waiting for alera runtime-host to start"))
     }
 
-    async fn connect_control_file(control_path: &Path) -> Result<Option<Self>> {
+    async fn connect_control_file(
+        control_path: &Path,
+        required_capability: Option<&str>,
+    ) -> Result<Option<Self>> {
         let contents = match tokio::fs::read_to_string(&control_path).await {
             Ok(contents) => contents,
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
@@ -113,10 +150,27 @@ impl RuntimeHostRpcClient {
             Ok(control) => control,
             Err(_) => return Ok(None),
         };
-        if !control.is_usable() {
+        if !control.is_protocol_compatible() {
+            return Ok(None);
+        }
+        if required_capability.is_none() && !control.is_usable(None) {
             return Ok(None);
         }
 
+        let Some(client) = Self::connect_control(&control).await? else {
+            return Ok(None);
+        };
+        if !control.is_usable(required_capability) {
+            let required = required_capability.unwrap_or("requested");
+            return Err(anyhow!(
+                "A live Alera runtime host does not support {required}. Restart Alera and retry."
+            ));
+        }
+
+        Ok(Some(client))
+    }
+
+    async fn connect_control(control: &RuntimeHostControl) -> Result<Option<Self>> {
         let address = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), control.port);
         let stream = match timeout(CONNECT_TIMEOUT, TcpStream::connect(address)).await {
             Ok(Ok(stream)) => stream,
@@ -146,6 +200,31 @@ impl RuntimeHostRpcClient {
         let value = self.request_value(request_type, payload).await?;
         serde_json::from_value(value)
             .with_context(|| format!("runtime host response for {request_type} was invalid"))
+    }
+
+    /// Like `request_value` but bounded by a client-side deadline. Used by
+    /// wait-capable orchestration verbs so a vanished host cannot hang the
+    /// CLI past the server-side wait timeout.
+    pub(crate) async fn request_value_with_deadline<P>(
+        &mut self,
+        request_type: &str,
+        payload: &P,
+        deadline_ms: u64,
+    ) -> Result<Value>
+    where
+        P: Serialize + ?Sized,
+    {
+        match timeout(
+            Duration::from_millis(deadline_ms),
+            self.request_value(request_type, payload),
+        )
+        .await
+        {
+            Ok(result) => result,
+            Err(_) => Err(anyhow!(
+                "runtime host did not answer {request_type} within {deadline_ms}ms"
+            )),
+        }
     }
 
     pub(crate) async fn request_value<P>(
@@ -192,9 +271,12 @@ impl RuntimeHostRpcClient {
 }
 
 impl RuntimeHostControl {
-    fn is_usable(&self) -> bool {
-        self.protocol_version == PROTOCOL_VERSION
-            && !self.token.is_empty()
+    fn is_protocol_compatible(&self) -> bool {
+        self.protocol_version == PROTOCOL_VERSION && !self.token.is_empty()
+    }
+
+    fn is_usable(&self, required_capability: Option<&str>) -> bool {
+        self.is_protocol_compatible()
             && self
                 .runtime_capabilities
                 .iter()
@@ -207,5 +289,136 @@ impl RuntimeHostControl {
                 .runtime_capabilities
                 .iter()
                 .any(|capability| capability == RUNTIME_HOST_MANAGED_WORKSPACE_CAPABILITY)
+            && match required_capability {
+                None => true,
+                Some(required) => self
+                    .runtime_capabilities
+                    .iter()
+                    .any(|capability| capability == required),
+            }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::terminal_host::protocol::RUNTIME_HOST_ORCHESTRATION_CAPABILITY;
+
+    fn control(capabilities: &[&str]) -> RuntimeHostControl {
+        RuntimeHostControl {
+            protocol_version: PROTOCOL_VERSION,
+            port: 1234,
+            token: "token".to_string(),
+            runtime_capabilities: capabilities.iter().map(|value| value.to_string()).collect(),
+        }
+    }
+
+    #[test]
+    fn required_capability_must_be_advertised() {
+        let base = [
+            RUNTIME_HOST_CAPABILITY,
+            RUNTIME_HOST_BOOTSTRAP_CAPABILITY,
+            RUNTIME_HOST_MANAGED_WORKSPACE_CAPABILITY,
+        ];
+        assert!(control(&base).is_usable(None));
+        assert!(!control(&base).is_usable(Some(RUNTIME_HOST_ORCHESTRATION_CAPABILITY)));
+
+        let with_orchestration = [
+            RUNTIME_HOST_CAPABILITY,
+            RUNTIME_HOST_BOOTSTRAP_CAPABILITY,
+            RUNTIME_HOST_MANAGED_WORKSPACE_CAPABILITY,
+            RUNTIME_HOST_ORCHESTRATION_CAPABILITY,
+        ];
+        assert!(control(&with_orchestration).is_usable(Some(RUNTIME_HOST_ORCHESTRATION_CAPABILITY)));
+    }
+
+    #[tokio::test]
+    async fn live_host_missing_required_capability_requires_restart() {
+        let (port, server) = start_hello_server().await;
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join(CONTROL_FILE_NAME),
+            serde_json::to_string(&json!({
+                "protocolVersion": PROTOCOL_VERSION,
+                "port": port,
+                "token": "token",
+                "runtimeCapabilities": [
+                    RUNTIME_HOST_CAPABILITY,
+                    RUNTIME_HOST_BOOTSTRAP_CAPABILITY,
+                    RUNTIME_HOST_MANAGED_WORKSPACE_CAPABILITY,
+                ],
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        let error = match RuntimeHostRpcClient::connect_with_required_capability(
+            dir.path(),
+            RUNTIME_HOST_ORCHESTRATION_CAPABILITY,
+        )
+        .await
+        {
+            Ok(_) => panic!("expected a restart-required capability error"),
+            Err(error) => error,
+        };
+
+        assert!(error.to_string().contains("Restart Alera"));
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn live_host_missing_baseline_capability_requires_restart_for_orchestration() {
+        let (port, server) = start_hello_server().await;
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join(CONTROL_FILE_NAME),
+            serde_json::to_string(&json!({
+                "protocolVersion": PROTOCOL_VERSION,
+                "port": port,
+                "token": "token",
+                "runtimeCapabilities": [
+                    RUNTIME_HOST_CAPABILITY,
+                    RUNTIME_HOST_ORCHESTRATION_CAPABILITY,
+                ],
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        let error = match RuntimeHostRpcClient::connect_with_required_capability(
+            dir.path(),
+            RUNTIME_HOST_ORCHESTRATION_CAPABILITY,
+        )
+        .await
+        {
+            Ok(_) => panic!("expected a restart-required capability error"),
+            Err(error) => error,
+        };
+
+        assert!(error.to_string().contains("Restart Alera"));
+        server.await.unwrap();
+    }
+
+    async fn start_hello_server() -> (u16, tokio::task::JoinHandle<()>) {
+        let listener = tokio::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
+            .await
+            .unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server = tokio::spawn(async move {
+            let (socket, _) = listener.accept().await.unwrap();
+            let (read_half, mut write_half) = socket.into_split();
+            let mut lines = BufReader::new(read_half).lines();
+            let line = lines.next_line().await.unwrap().unwrap();
+            let request: Value = serde_json::from_str(&line).unwrap();
+            let response = json!({
+                "id": request["id"],
+                "ok": true,
+                "payload": {},
+            });
+            let mut bytes = serde_json::to_vec(&response).unwrap();
+            bytes.push(b'\n');
+            write_half.write_all(&bytes).await.unwrap();
+        });
+        (port, server)
     }
 }

--- a/rust/alera-cli/src/terminal_host/control_file.rs
+++ b/rust/alera-cli/src/terminal_host/control_file.rs
@@ -6,7 +6,7 @@ use serde_json::json;
 
 use crate::terminal_host::protocol::{
     PROTOCOL_VERSION, RUNTIME_HOST_BOOTSTRAP_CAPABILITY, RUNTIME_HOST_CAPABILITY,
-    RUNTIME_HOST_MANAGED_WORKSPACE_CAPABILITY,
+    RUNTIME_HOST_MANAGED_WORKSPACE_CAPABILITY, RUNTIME_HOST_ORCHESTRATION_CAPABILITY,
 };
 
 /// Publishes the host's socket metadata to the control file the app reads.
@@ -23,6 +23,7 @@ pub fn write_control_file(path: &Path, port: u16, token: &str) -> std::io::Resul
             RUNTIME_HOST_CAPABILITY,
             RUNTIME_HOST_BOOTSTRAP_CAPABILITY,
             RUNTIME_HOST_MANAGED_WORKSPACE_CAPABILITY,
+            RUNTIME_HOST_ORCHESTRATION_CAPABILITY,
         ],
         "startedAt": Utc::now().to_rfc3339_opts(SecondsFormat::Millis, true),
     });
@@ -68,6 +69,7 @@ mod tests {
                 RUNTIME_HOST_CAPABILITY,
                 RUNTIME_HOST_BOOTSTRAP_CAPABILITY,
                 RUNTIME_HOST_MANAGED_WORKSPACE_CAPABILITY,
+                RUNTIME_HOST_ORCHESTRATION_CAPABILITY,
             ])
         );
         assert_eq!(value["pid"], json!(std::process::id()));

--- a/rust/alera-cli/src/terminal_host/mod.rs
+++ b/rust/alera-cli/src/terminal_host/mod.rs
@@ -3,6 +3,7 @@ pub mod client;
 pub mod control_file;
 pub mod history_store;
 pub mod host_error;
+pub mod orchestration;
 pub mod protocol;
 pub mod server;
 pub mod session;

--- a/rust/alera-cli/src/terminal_host/orchestration/agent_presence.rs
+++ b/rust/alera-cli/src/terminal_host/orchestration/agent_presence.rs
@@ -1,0 +1,154 @@
+use std::collections::HashMap;
+
+/// Agent state as reported by the Flutter app's agent-status hooks.
+/// `Waiting` includes approval and user-input prompts, so it is not safe for
+/// auto-submitted injection. Only `Done` means the agent has returned to an
+/// empty prompt where push-on-idle delivery can submit text safely.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AgentPresenceState {
+    Working,
+    Waiting,
+    Blocked,
+    Done,
+}
+
+impl AgentPresenceState {
+    pub fn parse(value: &str) -> Option<Self> {
+        match value {
+            "working" => Some(AgentPresenceState::Working),
+            "waiting" => Some(AgentPresenceState::Waiting),
+            "blocked" => Some(AgentPresenceState::Blocked),
+            "done" => Some(AgentPresenceState::Done),
+            _ => None,
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            AgentPresenceState::Working => "working",
+            AgentPresenceState::Waiting => "waiting",
+            AgentPresenceState::Blocked => "blocked",
+            AgentPresenceState::Done => "done",
+        }
+    }
+
+    /// Only `done` accepts push-on-idle injection: `waiting` can mean an
+    /// approval or user-input prompt, where an injected Enter could answer the
+    /// prompt instead of submitting a new orchestration message.
+    pub fn accepts_injection(self) -> bool {
+        matches!(self, AgentPresenceState::Done)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct AgentPresence {
+    pub agent_type: String,
+    pub state: AgentPresenceState,
+}
+
+/// Last known agent presence per terminal handle, fed by the Flutter app's
+/// `orchestration.agentStatus` forwarding. Cleared when a session exits.
+#[derive(Debug, Default)]
+pub struct AgentPresenceRegistry {
+    entries: HashMap<String, AgentPresence>,
+}
+
+impl AgentPresenceRegistry {
+    /// Records a presence update. Returns true when this update is a
+    /// transition into an injection-ready state (used to trigger
+    /// push-on-idle delivery).
+    pub fn update(&mut self, handle: &str, agent_type: String, state: AgentPresenceState) -> bool {
+        let was_ready = self
+            .entries
+            .get(handle)
+            .map(|entry| entry.state.accepts_injection())
+            .unwrap_or(false);
+        self.entries
+            .insert(handle.to_string(), AgentPresence { agent_type, state });
+        state.accepts_injection() && !was_ready
+    }
+
+    pub fn remove(&mut self, handle: &str) {
+        self.entries.remove(handle);
+    }
+
+    pub fn clear(&mut self) {
+        self.entries.clear();
+    }
+
+    pub fn get(&self, handle: &str) -> Option<&AgentPresence> {
+        self.entries.get(handle)
+    }
+
+    pub fn is_injection_ready(&self, handle: &str) -> bool {
+        self.entries
+            .get(handle)
+            .map(|entry| entry.state.accepts_injection())
+            .unwrap_or(false)
+    }
+
+    pub fn agent_type(&self, handle: &str) -> Option<&str> {
+        self.entries
+            .get(handle)
+            .map(|entry| entry.agent_type.as_str())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn transition_into_idle_reports_ready() {
+        let mut registry = AgentPresenceRegistry::default();
+        assert!(!registry.update("t1", "claude".into(), AgentPresenceState::Waiting));
+        // Repeated waiting is not injection-ready.
+        assert!(!registry.update("t1", "claude".into(), AgentPresenceState::Waiting));
+        assert!(!registry.update("t1", "claude".into(), AgentPresenceState::Working));
+        assert!(!registry.update("t1", "claude".into(), AgentPresenceState::Waiting));
+        assert!(registry.update("t1", "claude".into(), AgentPresenceState::Done));
+        // Repeated done is not a fresh transition.
+        assert!(!registry.update("t1", "claude".into(), AgentPresenceState::Done));
+        assert!(!registry.update("t1", "claude".into(), AgentPresenceState::Waiting));
+
+        assert!(!registry.update("t2", "claude".into(), AgentPresenceState::Working));
+        assert!(registry.update("t2", "claude".into(), AgentPresenceState::Done));
+    }
+
+    #[test]
+    fn waiting_blocked_and_working_do_not_accept_injection() {
+        let mut registry = AgentPresenceRegistry::default();
+        registry.update("t1", "codex".into(), AgentPresenceState::Waiting);
+        assert!(!registry.is_injection_ready("t1"));
+        registry.update("t1", "codex".into(), AgentPresenceState::Blocked);
+        assert!(!registry.is_injection_ready("t1"));
+        registry.update("t1", "codex".into(), AgentPresenceState::Working);
+        assert!(!registry.is_injection_ready("t1"));
+    }
+
+    #[test]
+    fn done_accepts_injection() {
+        let mut registry = AgentPresenceRegistry::default();
+        assert!(registry.update("t1", "codex".into(), AgentPresenceState::Done));
+        assert!(registry.is_injection_ready("t1"));
+    }
+
+    #[test]
+    fn remove_clears_presence() {
+        let mut registry = AgentPresenceRegistry::default();
+        registry.update("t1", "claude".into(), AgentPresenceState::Waiting);
+        registry.remove("t1");
+        assert!(registry.get("t1").is_none());
+        assert!(!registry.is_injection_ready("t1"));
+    }
+
+    #[test]
+    fn clear_removes_all_presence() {
+        let mut registry = AgentPresenceRegistry::default();
+        registry.update("t1", "claude".into(), AgentPresenceState::Waiting);
+        registry.update("t2", "codex".into(), AgentPresenceState::Working);
+        registry.clear();
+        assert!(registry.get("t1").is_none());
+        assert!(registry.get("t2").is_none());
+    }
+}

--- a/rust/alera-cli/src/terminal_host/orchestration/coordinator_loop.rs
+++ b/rust/alera-cli/src/terminal_host/orchestration/coordinator_loop.rs
@@ -1,0 +1,106 @@
+use std::time::Duration;
+
+use tokio::sync::mpsc::UnboundedSender;
+use tokio::task::JoinHandle;
+
+/// Default coordinator cadence, mirroring Orca.
+pub const COORDINATOR_DEFAULT_POLL_MS: u64 = 2_000;
+pub const COORDINATOR_MAX_CONCURRENT_DEFAULT: usize = 4;
+/// A dispatch with no heartbeat for 2x the 5-minute heartbeat cadence is
+/// considered hung. Warn-only: killing a slow-but-correct worker costs more
+/// than a hung worker holding a slot.
+pub const COORDINATOR_HUNG_THRESHOLD_MINUTES: i64 = 10;
+/// Worktrees more than this many commits behind their base are skipped at
+/// dispatch pre-flight (silently retried next tick) unless the spec carries
+/// `allow-stale-base: true`.
+pub const COORDINATOR_DISPATCH_STALE_THRESHOLD: u64 = 20;
+
+/// Configuration captured when `orchestration.run` starts a coordinator.
+#[derive(Debug, Clone)]
+pub struct CoordinatorConfig {
+    pub run_id: String,
+    pub coordinator_handle: Option<String>,
+    pub poll_interval_ms: u64,
+    pub max_concurrent: usize,
+    pub workspace_id: Option<String>,
+}
+
+/// The host-side handle for the single active coordinator: a ticker task that
+/// enqueues `CoordinatorTick` commands. All actual work happens inside the
+/// server actor so PTY and store mutations stay single-threaded.
+pub struct CoordinatorHandle {
+    pub config: CoordinatorConfig,
+    ticker: JoinHandle<()>,
+}
+
+impl CoordinatorHandle {
+    pub fn start<C: Send + 'static>(
+        config: CoordinatorConfig,
+        inbox: UnboundedSender<C>,
+        make_tick: impl Fn(String) -> C + Send + 'static,
+    ) -> Self {
+        let run_id = config.run_id.clone();
+        let poll = Duration::from_millis(config.poll_interval_ms.max(250));
+        let ticker = tokio::spawn(async move {
+            loop {
+                tokio::time::sleep(poll).await;
+                if inbox.send(make_tick(run_id.clone())).is_err() {
+                    break;
+                }
+            }
+        });
+        CoordinatorHandle { config, ticker }
+    }
+
+    pub fn stop(&self) {
+        self.ticker.abort();
+    }
+}
+
+impl Drop for CoordinatorHandle {
+    fn drop(&mut self) {
+        self.ticker.abort();
+    }
+}
+
+/// The ISO-8601-ish (SQLite `datetime('now')` shaped) threshold string for the
+/// hung-dispatch query: now minus the hung threshold, second precision UTC.
+pub fn hung_dispatch_threshold_iso(now: chrono::DateTime<chrono::Utc>) -> String {
+    (now - chrono::Duration::minutes(COORDINATOR_HUNG_THRESHOLD_MINUTES))
+        .format("%Y-%m-%d %H:%M:%S")
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hung_threshold_matches_sqlite_shape() {
+        let now = chrono::DateTime::parse_from_rfc3339("2026-07-05T12:30:00Z")
+            .unwrap()
+            .with_timezone(&chrono::Utc);
+        assert_eq!(hung_dispatch_threshold_iso(now), "2026-07-05 12:20:00");
+    }
+
+    #[tokio::test]
+    async fn ticker_emits_and_stop_aborts() {
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<String>();
+        let handle = CoordinatorHandle::start(
+            CoordinatorConfig {
+                run_id: "run_1".to_string(),
+                coordinator_handle: None,
+                poll_interval_ms: 250,
+                max_concurrent: 4,
+                workspace_id: None,
+            },
+            tx,
+            |run_id| run_id,
+        );
+        let first = tokio::time::timeout(Duration::from_secs(2), rx.recv())
+            .await
+            .expect("tick within deadline");
+        assert_eq!(first.as_deref(), Some("run_1"));
+        handle.stop();
+    }
+}

--- a/rust/alera-cli/src/terminal_host/orchestration/dispatch_preamble.rs
+++ b/rust/alera-cli/src/terminal_host/orchestration/dispatch_preamble.rs
@@ -1,0 +1,260 @@
+/// 5 minutes is frequent enough that the coordinator's stale-heartbeat check
+/// (threshold 10 min) catches a hung worker within one tick, and infrequent
+/// enough to avoid inbox spam on long tasks.
+pub const HEARTBEAT_INTERVAL_MIN: u32 = 5;
+
+pub struct BaseDrift {
+    pub base: String,
+    pub behind: u64,
+    pub recent_subjects: Vec<String>,
+}
+
+pub struct PreambleParams<'a> {
+    pub task_id: &'a str,
+    /// Completion and heartbeat payloads attribute activity to a specific
+    /// dispatch context (not just a task): a retried task has multiple
+    /// dispatch contexts, and keying worker_done/heartbeat on dispatchId
+    /// prevents stale messages from a previously-failed dispatch from
+    /// completing or refreshing the retry.
+    pub dispatch_id: &'a str,
+    pub task_spec: &'a str,
+    pub coordinator_handle: &'a str,
+    /// Populated by the coordinator's dispatch pre-flight only when the
+    /// target worktree is behind its tracking remote. Callers must NOT
+    /// pre-populate this with empty data; the drift section is a
+    /// loud-but-rare signal.
+    pub base_drift: Option<&'a BaseDrift>,
+    /// Appended when the task had a resolved decision gate: the worker sees
+    /// the human's answer from line 1 of the re-dispatch.
+    pub gate_resolution: Option<&'a GateResolution>,
+}
+
+pub struct GateResolution {
+    pub question: String,
+    pub resolution: String,
+}
+
+/// The dispatch preamble teaches agents Alera's CLI commands for structured
+/// communication. Behavioral rules live as inline comments above the relevant
+/// CLI example, not as a separate prose block — LLM readers anchor on
+/// examples and skim trailing prose, so rules must land at the point of use.
+pub fn build_dispatch_preamble(params: &PreambleParams<'_>) -> String {
+    let PreambleParams {
+        task_id,
+        dispatch_id,
+        coordinator_handle,
+        ..
+    } = params;
+    let header = format!(
+        r#"You are working inside Alera, a multi-agent IDE. You are a dispatched worker.
+Your coordinator's terminal handle is: {coordinator_handle}
+Your task ID is: {task_id}
+
+You talk to the coordinator only through the CLI commands below. Do not use
+Slack, GitHub comments, or any other channel to reach a human during the run.
+
+=== CLI COMMANDS ===
+
+  # Report task completion (REQUIRED when done — even on failure).
+  #
+  # RULE: --body must be a 3-sentence executive summary (what you did,
+  # what you found, what's left). Never send an empty body; the coordinator
+  # reads the body first and only opens artifacts if it needs more detail.
+  # If you produced a long-form artifact, include its path as
+  # payload.reportPath so the coordinator can find it without a file search.
+  #
+  # RULE: send worker_done exactly once. Failure is still a worker_done
+  # with subject like "Failed: <reason>" — never silently exit.
+  # Include BOTH taskId and dispatchId in the payload so a late completion
+  # from a failed retry cannot complete the current dispatch.
+  alera orchestration send --to {coordinator_handle} --type worker_done --subject "<short status>" --body "<3-sentence summary: what you did, what you found, what's left>" --task-id {task_id} --dispatch-id {dispatch_id} --files-modified "path/a,path/b" --report-path "<optional: path to the full artifact>"
+
+  # BEHAVIOR RULE: send a heartbeat every {heartbeat} minutes
+  # while actively working on the task. The coordinator uses this to
+  # distinguish "still thinking" from "hung / crashed." Skip heartbeats only
+  # while blocked inside `check --wait` or `ask` — those calls are
+  # themselves liveness signals.
+  #
+  # Include BOTH taskId and dispatchId in the payload: the coordinator
+  # attributes the heartbeat to the specific dispatch context, not just
+  # the task, so a straggler heartbeat from a previously-failed dispatch
+  # cannot mask a hung retry.
+  alera orchestration send --to {coordinator_handle} --type heartbeat --subject "alive" --task-id {task_id} --dispatch-id {dispatch_id} --phase "<short: investigating|implementing|reviewing|waiting>"
+
+  # Ask the coordinator a question and block until it answers.
+  #
+  # BEHAVIOR RULE #1 (MUST NOT VIOLATE):
+  # NEVER use AskUserQuestion; use `alera orchestration ask` or send
+  # --type decision_gate. AskUserQuestion opens a local TUI prompt that the
+  # coordinator cannot see and cannot answer — your session will hang forever
+  # waiting on a human. Every interactive question goes through `ask` below.
+  #
+  # The `ask` verb is a thin wrapper: it sends a decision_gate message and
+  # blocks until the coordinator replies, then prints the reply body. Use it
+  # anywhere you would otherwise have reached for AskUserQuestion.
+  alera orchestration ask --to {coordinator_handle} --question "<your question>" --options "<optional,comma,separated>" --timeout-ms 600000
+
+  # Escalate a blocker or failure (pre-completion, when you need the
+  # coordinator to do something before you can continue):
+  alera orchestration send --to {coordinator_handle} --type escalation --subject "Blocked: <reason>" --body "<details>" --task-id {task_id} --dispatch-id {dispatch_id}
+
+  # Check for messages from the coordinator:
+  alera orchestration check
+
+=== AFTER YOU SEND worker_done ===
+
+Keep the shell session open for a grace period (10 minutes) in case the
+coordinator sends a follow-up or re-dispatches you. Poll with
+`alera orchestration check` every 2 minutes during that window. If no
+follow-up arrives, you may exit after the grace period — the coordinator
+will not expect further output from you.
+
+If the coordinator re-dispatches you (you will receive a fresh preamble +
+TASK block), reset your polling and start the new task. Do not respond
+to the previous task's follow-ups after a re-dispatch."#,
+        heartbeat = HEARTBEAT_INTERVAL_MIN,
+    );
+
+    let drift = params
+        .base_drift
+        .filter(|drift| drift.behind > 0)
+        .map(build_drift_section)
+        .unwrap_or_default();
+    let gate = params
+        .gate_resolution
+        .map(build_gate_section)
+        .unwrap_or_default();
+
+    format!(
+        "{header}{drift}{gate}\n\n=== TASK ===\n{spec}",
+        spec = params.task_spec
+    )
+}
+
+/// Defense-in-depth: the worker sees the drift from line 1 instead of
+/// discovering it via stale line numbers in artifacts later.
+fn build_drift_section(drift: &BaseDrift) -> String {
+    let subjects = drift
+        .recent_subjects
+        .iter()
+        .map(|subject| format!("  - {subject}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    format!(
+        "\n\n--- BASE DRIFT ---\nYour worktree HEAD is {behind} commits behind {base}. The 5 most recent\nsubjects on {base} NOT in your worktree:\n{subjects}\n\nIf any look relevant to your task, either pull them in (`git fetch && git rebase {base}` or equivalent) or escalate to the coordinator before starting.\n---",
+        behind = drift.behind,
+        base = drift.base,
+    )
+}
+
+fn build_gate_section(gate: &GateResolution) -> String {
+    format!(
+        "\n\n--- DECISION GATE RESOLVED ---\nQuestion: {question}\nResolution: {resolution}\n---",
+        question = gate.question,
+        resolution = gate.resolution,
+    )
+}
+
+/// Scans the spec for a literal `allow-stale-base: true` line (canonical
+/// form only, no regex) and returns whether it was present plus the spec
+/// with the directive stripped so the worker's TASK block never sees it.
+pub fn parse_allow_stale_base_from_spec(spec: &str) -> (bool, String) {
+    let mut allowed = false;
+    let kept: Vec<&str> = spec
+        .lines()
+        .filter(|line| {
+            if line.trim() == "allow-stale-base: true" {
+                allowed = true;
+                false
+            } else {
+                true
+            }
+        })
+        .collect();
+    (allowed, kept.join("\n"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn params<'a>(
+        drift: Option<&'a BaseDrift>,
+        gate: Option<&'a GateResolution>,
+    ) -> PreambleParams<'a> {
+        PreambleParams {
+            task_id: "task_1",
+            dispatch_id: "ctx_1",
+            task_spec: "Fix the login button CSS",
+            coordinator_handle: "term_coord",
+            base_drift: drift,
+            gate_resolution: gate,
+        }
+    }
+
+    #[test]
+    fn preamble_contains_contract_commands() {
+        let preamble = build_dispatch_preamble(&params(None, None));
+        assert!(preamble.contains("Your task ID is: task_1"));
+        assert!(preamble.contains("--task-id task_1 --dispatch-id ctx_1"));
+        assert!(preamble.contains("--type worker_done"));
+        assert!(preamble.contains("--type heartbeat"));
+        assert!(preamble.contains("NEVER use AskUserQuestion"));
+        assert!(preamble.contains("alera orchestration ask --to term_coord"));
+        assert!(preamble.contains("=== TASK ===\nFix the login button CSS"));
+        assert!(!preamble.contains("\\\n"));
+        assert!(!preamble.contains("BASE DRIFT"));
+        assert!(!preamble.contains("DECISION GATE RESOLVED"));
+    }
+
+    #[test]
+    fn drift_section_appended_only_when_behind() {
+        let drift = BaseDrift {
+            base: "origin/main".to_string(),
+            behind: 25,
+            recent_subjects: vec!["fix: a".to_string(), "feat: b".to_string()],
+        };
+        let preamble = build_dispatch_preamble(&params(Some(&drift), None));
+        assert!(preamble.contains("--- BASE DRIFT ---"));
+        assert!(preamble.contains("25 commits behind origin/main"));
+        assert!(preamble.contains("  - fix: a"));
+        assert!(preamble.contains("git fetch && git rebase origin/main"));
+        assert!(!preamble.contains("git pull --rebase\norigin/main"));
+
+        let zero = BaseDrift {
+            base: "origin/main".to_string(),
+            behind: 0,
+            recent_subjects: vec![],
+        };
+        let clean = build_dispatch_preamble(&params(Some(&zero), None));
+        assert!(!clean.contains("BASE DRIFT"));
+    }
+
+    #[test]
+    fn gate_resolution_appended() {
+        let gate = GateResolution {
+            question: "Proceed with migration?".to_string(),
+            resolution: "Yes, but keep backups".to_string(),
+        };
+        let preamble = build_dispatch_preamble(&params(None, Some(&gate)));
+        assert!(preamble.contains("--- DECISION GATE RESOLVED ---"));
+        assert!(preamble.contains("Question: Proceed with migration?"));
+        assert!(preamble.contains("Resolution: Yes, but keep backups"));
+    }
+
+    #[test]
+    fn allow_stale_base_is_parsed_and_stripped() {
+        let spec = "Do the thing\nallow-stale-base: true\nCarefully.";
+        let (allowed, stripped) = parse_allow_stale_base_from_spec(spec);
+        assert!(allowed);
+        assert_eq!(stripped, "Do the thing\nCarefully.");
+
+        let (not_allowed, unchanged) = parse_allow_stale_base_from_spec("Do the thing");
+        assert!(!not_allowed);
+        assert_eq!(unchanged, "Do the thing");
+
+        // Non-canonical forms are not honored.
+        let (loose, _) = parse_allow_stale_base_from_spec("allow-stale-base:true");
+        assert!(!loose);
+    }
+}

--- a/rust/alera-cli/src/terminal_host/orchestration/group_resolution.rs
+++ b/rust/alera-cli/src/terminal_host/orchestration/group_resolution.rs
@@ -1,0 +1,185 @@
+use super::agent_presence::AgentPresenceRegistry;
+
+/// Agent-name groups matched against the presence registry's agent type
+/// (reported by the app's agent-status hooks), not terminal titles.
+const AGENT_NAME_GROUPS: &[&str] = &[
+    "claude", "codex", "copilot", "cursor", "agy", "opencode", "pi", "amp",
+];
+
+/// A live terminal candidate for group resolution.
+pub struct GroupResolutionTerminal {
+    pub handle: String,
+    pub workspace_id: Option<String>,
+}
+
+pub fn is_group_address(to: &str) -> bool {
+    to.starts_with('@')
+}
+
+/// Resolves a recipient address to concrete terminal handles at send time:
+/// one message record per recipient (same thread), so each recipient keeps
+/// independent read tracking. Unknown groups resolve to empty rather than
+/// erroring so callers can distinguish "valid group, no current members"
+/// from programming errors.
+pub fn resolve_group_address(
+    to: &str,
+    sender_handle: &str,
+    terminals: &[GroupResolutionTerminal],
+    presence: &AgentPresenceRegistry,
+) -> Vec<String> {
+    if !is_group_address(to) {
+        return vec![to.to_string()];
+    }
+    let group = to.to_lowercase();
+
+    if group == "@all" {
+        // Broadcast to every terminal except the sender to avoid
+        // self-delivery loops.
+        return terminals
+            .iter()
+            .filter(|terminal| terminal.handle != sender_handle)
+            .map(|terminal| terminal.handle.clone())
+            .collect();
+    }
+
+    if group == "@idle" {
+        // Only agents whose presence reports an injection-ready state,
+        // useful for dispatching to available agents without interrupting
+        // busy ones.
+        return terminals
+            .iter()
+            .filter(|terminal| {
+                terminal.handle != sender_handle && presence.is_injection_ready(&terminal.handle)
+            })
+            .map(|terminal| terminal.handle.clone())
+            .collect();
+    }
+
+    if let Some(workspace_id) = group.strip_prefix("@workspace:") {
+        // Preserve the original casing of the id from the raw address.
+        let raw_id = &to["@workspace:".len()..];
+        let _ = workspace_id;
+        return terminals
+            .iter()
+            .filter(|terminal| {
+                terminal.handle != sender_handle && terminal.workspace_id.as_deref() == Some(raw_id)
+            })
+            .map(|terminal| terminal.handle.clone())
+            .collect();
+    }
+
+    let agent_name = &group[1..];
+    if AGENT_NAME_GROUPS.contains(&agent_name) {
+        return terminals
+            .iter()
+            .filter(|terminal| {
+                terminal.handle != sender_handle
+                    && presence.agent_type(&terminal.handle) == Some(agent_name)
+            })
+            .map(|terminal| terminal.handle.clone())
+            .collect();
+    }
+
+    Vec::new()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::agent_presence::AgentPresenceState;
+    use super::*;
+
+    fn terminal(handle: &str, workspace: Option<&str>) -> GroupResolutionTerminal {
+        GroupResolutionTerminal {
+            handle: handle.to_string(),
+            workspace_id: workspace.map(str::to_string),
+        }
+    }
+
+    fn presence_with(entries: &[(&str, &str, AgentPresenceState)]) -> AgentPresenceRegistry {
+        let mut registry = AgentPresenceRegistry::default();
+        for (handle, agent, state) in entries {
+            registry.update(handle, (*agent).to_string(), *state);
+        }
+        registry
+    }
+
+    #[test]
+    fn point_to_point_passes_through() {
+        let handles =
+            resolve_group_address("term_x", "term_a", &[], &AgentPresenceRegistry::default());
+        assert_eq!(handles, vec!["term_x".to_string()]);
+    }
+
+    #[test]
+    fn all_excludes_sender() {
+        let terminals = [
+            terminal("a", None),
+            terminal("b", None),
+            terminal("c", None),
+        ];
+        let handles =
+            resolve_group_address("@all", "b", &terminals, &AgentPresenceRegistry::default());
+        assert_eq!(handles, vec!["a".to_string(), "c".to_string()]);
+    }
+
+    #[test]
+    fn idle_uses_presence_registry() {
+        let terminals = [
+            terminal("a", None),
+            terminal("b", None),
+            terminal("c", None),
+        ];
+        let presence = presence_with(&[
+            ("a", "claude", AgentPresenceState::Waiting),
+            ("b", "claude", AgentPresenceState::Done),
+            ("c", "claude", AgentPresenceState::Working),
+        ]);
+        let handles = resolve_group_address("@idle", "sender", &terminals, &presence);
+        assert_eq!(handles, vec!["b".to_string()]);
+    }
+
+    #[test]
+    fn workspace_group_filters_by_workspace_id() {
+        let terminals = [
+            terminal("a", Some("ws-1")),
+            terminal("b", Some("ws-2")),
+            terminal("c", Some("ws-1")),
+        ];
+        let handles = resolve_group_address(
+            "@workspace:ws-1",
+            "c",
+            &terminals,
+            &AgentPresenceRegistry::default(),
+        );
+        assert_eq!(handles, vec!["a".to_string()]);
+    }
+
+    #[test]
+    fn agent_group_matches_presence_agent_type() {
+        let terminals = [
+            terminal("a", None),
+            terminal("b", None),
+            terminal("c", None),
+        ];
+        let presence = presence_with(&[
+            ("a", "claude", AgentPresenceState::Working),
+            ("b", "codex", AgentPresenceState::Waiting),
+        ]);
+        let claude = resolve_group_address("@claude", "sender", &terminals, &presence);
+        assert_eq!(claude, vec!["a".to_string()]);
+        let codex = resolve_group_address("@codex", "sender", &terminals, &presence);
+        assert_eq!(codex, vec!["b".to_string()]);
+    }
+
+    #[test]
+    fn unknown_group_resolves_to_empty() {
+        let terminals = [terminal("a", None)];
+        let handles = resolve_group_address(
+            "@nonsense",
+            "sender",
+            &terminals,
+            &AgentPresenceRegistry::default(),
+        );
+        assert!(handles.is_empty());
+    }
+}

--- a/rust/alera-cli/src/terminal_host/orchestration/lifecycle_reconciliation.rs
+++ b/rust/alera-cli/src/terminal_host/orchestration/lifecycle_reconciliation.rs
@@ -1,0 +1,582 @@
+use alera_core::runtime::{
+    OrchestrationDispatchStatus, OrchestrationMessage, OrchestrationMessageType,
+    OrchestrationTaskStatus, RuntimeStore,
+};
+use anyhow::Result;
+use serde_json::Value;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LifecycleReconciliation {
+    Ignored,
+    Completed {
+        task_id: String,
+        dispatch_id: String,
+    },
+    Failed {
+        task_id: String,
+        dispatch_id: String,
+    },
+    HeartbeatRecorded {
+        dispatch_id: String,
+    },
+}
+
+fn object_payload(message: &OrchestrationMessage) -> serde_json::Map<String, Value> {
+    message
+        .payload
+        .as_deref()
+        .and_then(|payload| serde_json::from_str::<Value>(payload).ok())
+        .and_then(|value| match value {
+            Value::Object(map) => Some(map),
+            _ => None,
+        })
+        .unwrap_or_default()
+}
+
+fn payload_string(payload: &serde_json::Map<String, Value>, key: &str) -> Option<String> {
+    payload
+        .get(key)
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+}
+
+fn worker_done_indicates_failure(subject: &str) -> bool {
+    let subject = subject.trim();
+    subject.eq_ignore_ascii_case("failed")
+        || subject
+            .get(..7)
+            .is_some_and(|prefix| prefix.eq_ignore_ascii_case("failed:"))
+}
+
+fn failure_summary(message: &OrchestrationMessage) -> String {
+    let body = message.body.trim();
+    if body.is_empty() {
+        message.subject.clone()
+    } else {
+        format!("{}: {body}", message.subject)
+    }
+}
+
+/// Applies a lifecycle message (worker_done / heartbeat) to the store with
+/// full authority checks. Non-lifecycle messages are ignored.
+pub async fn reconcile_lifecycle_message(
+    store: &RuntimeStore,
+    message: &OrchestrationMessage,
+    log: &mut impl FnMut(String),
+) -> Result<LifecycleReconciliation> {
+    match message.message_type {
+        OrchestrationMessageType::WorkerDone => reconcile_worker_done(store, message, log).await,
+        OrchestrationMessageType::Heartbeat => reconcile_heartbeat(store, message, log).await,
+        _ => Ok(LifecycleReconciliation::Ignored),
+    }
+}
+
+async fn reconcile_heartbeat(
+    store: &RuntimeStore,
+    message: &OrchestrationMessage,
+    log: &mut impl FnMut(String),
+) -> Result<LifecycleReconciliation> {
+    let payload = object_payload(message);
+    let Some(dispatch_id) = payload_string(&payload, "dispatchId") else {
+        log(format!(
+            "Heartbeat from {} missing dispatchId; ignored",
+            message.from_handle
+        ));
+        return Ok(LifecycleReconciliation::Ignored);
+    };
+    let Some(task_id) = payload_string(&payload, "taskId") else {
+        log(format!(
+            "Heartbeat from {} missing taskId; ignored",
+            message.from_handle
+        ));
+        return Ok(LifecycleReconciliation::Ignored);
+    };
+    let Some(dispatch) = store.orchestration_dispatch_by_id(&dispatch_id).await? else {
+        log(format!(
+            "Warning: heartbeat for unknown dispatch {dispatch_id}"
+        ));
+        return Ok(LifecycleReconciliation::Ignored);
+    };
+    if dispatch.task_id != task_id {
+        log(format!(
+            "Warning: heartbeat dispatch {dispatch_id} belongs to {}, not {task_id}",
+            dispatch.task_id
+        ));
+        return Ok(LifecycleReconciliation::Ignored);
+    }
+    if dispatch.assignee_handle.as_deref() != Some(message.from_handle.as_str()) {
+        log(format!(
+            "Warning: heartbeat for dispatch {dispatch_id} came from {}, expected {}",
+            message.from_handle,
+            dispatch.assignee_handle.as_deref().unwrap_or("<unknown>")
+        ));
+        return Ok(LifecycleReconciliation::Ignored);
+    }
+    // dispatchId-specific writes let the store ignore late heartbeats for
+    // completed/failed retries without masking a newer hung dispatch.
+    if store.record_orchestration_heartbeat(&dispatch_id).await? {
+        Ok(LifecycleReconciliation::HeartbeatRecorded { dispatch_id })
+    } else {
+        log(format!(
+            "Warning: heartbeat for inactive dispatch {dispatch_id} ignored"
+        ));
+        Ok(LifecycleReconciliation::Ignored)
+    }
+}
+
+/// taskId alone is not a completion authority; retried tasks can have stale
+/// worker_done messages racing the current active dispatch. All of taskId,
+/// dispatchId, and the sender handle must match the active dispatch.
+async fn reconcile_worker_done(
+    store: &RuntimeStore,
+    message: &OrchestrationMessage,
+    log: &mut impl FnMut(String),
+) -> Result<LifecycleReconciliation> {
+    log(format!(
+        "Worker done: {} — {}",
+        message.from_handle, message.subject
+    ));
+    let payload = object_payload(message);
+    let Some(task_id) = payload_string(&payload, "taskId") else {
+        log(format!(
+            "Warning: worker_done without taskId from {}",
+            message.from_handle
+        ));
+        return Ok(LifecycleReconciliation::Ignored);
+    };
+    let Some(dispatch_id) = payload_string(&payload, "dispatchId") else {
+        log(format!(
+            "Warning: worker_done without dispatchId from {}",
+            message.from_handle
+        ));
+        return Ok(LifecycleReconciliation::Ignored);
+    };
+    let Some(task) = store.orchestration_task_by_id(&task_id).await? else {
+        log(format!("Warning: worker_done for unknown task {task_id}"));
+        return Ok(LifecycleReconciliation::Ignored);
+    };
+    let Some(dispatch) = store.orchestration_dispatch_by_id(&dispatch_id).await? else {
+        log(format!(
+            "Warning: worker_done for unknown dispatch {dispatch_id}"
+        ));
+        return Ok(LifecycleReconciliation::Ignored);
+    };
+    if dispatch.task_id != task_id {
+        log(format!(
+            "Warning: worker_done dispatch {dispatch_id} belongs to {}, not {task_id}",
+            dispatch.task_id
+        ));
+        return Ok(LifecycleReconciliation::Ignored);
+    }
+    if dispatch.assignee_handle.as_deref() != Some(message.from_handle.as_str()) {
+        log(format!(
+            "Warning: worker_done for dispatch {dispatch_id} came from {}, expected {}",
+            message.from_handle,
+            dispatch.assignee_handle.as_deref().unwrap_or("<unknown>")
+        ));
+        return Ok(LifecycleReconciliation::Ignored);
+    }
+    // send-time reconciliation can complete the pair before the coordinator
+    // reads the message; the later read still needs to observe completion.
+    if dispatch.status == OrchestrationDispatchStatus::Completed
+        && task.status == OrchestrationTaskStatus::Completed
+    {
+        return Ok(LifecycleReconciliation::Completed {
+            task_id,
+            dispatch_id,
+        });
+    }
+    if dispatch.status != OrchestrationDispatchStatus::Dispatched {
+        log(format!(
+            "Warning: worker_done for inactive dispatch {dispatch_id} ignored"
+        ));
+        return Ok(LifecycleReconciliation::Ignored);
+    }
+    let active = store
+        .active_orchestration_dispatch_for_task(&task_id)
+        .await?;
+    if active.map(|active| active.id) != Some(dispatch_id.clone())
+        || task.status != OrchestrationTaskStatus::Dispatched
+    {
+        log(format!(
+            "Warning: worker_done for stale dispatch {dispatch_id} ignored"
+        ));
+        return Ok(LifecycleReconciliation::Ignored);
+    }
+
+    if worker_done_indicates_failure(&message.subject) {
+        let failed = store
+            .fail_orchestration_dispatch(&dispatch_id, &failure_summary(message))
+            .await?;
+        log(format!(
+            "Task {task_id} worker_done failed dispatch {dispatch_id} ({} failures)",
+            failed.failure_count
+        ));
+        return Ok(LifecycleReconciliation::Failed {
+            task_id,
+            dispatch_id,
+        });
+    }
+
+    let files_modified: Vec<String> = payload
+        .get("filesModified")
+        .and_then(Value::as_array)
+        .map(|values| {
+            values
+                .iter()
+                .filter_map(Value::as_str)
+                .map(str::to_string)
+                .collect()
+        })
+        .unwrap_or_default();
+    let result = serde_json::json!({
+        "completedBy": message.from_handle,
+        "filesModified": files_modified,
+        "completedAt": message.created_at,
+    })
+    .to_string();
+    store
+        .update_orchestration_task_status(
+            &task_id,
+            OrchestrationTaskStatus::Completed,
+            Some(&result),
+        )
+        .await?;
+    log(format!("Task {task_id} completed"));
+    Ok(LifecycleReconciliation::Completed {
+        task_id,
+        dispatch_id,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alera_core::runtime::{
+        NewOrchestrationMessage, NewOrchestrationTask, OrchestrationMessagePriority,
+    };
+
+    async fn store() -> (tempfile::TempDir, RuntimeStore) {
+        let dir = tempfile::tempdir().unwrap();
+        let store = RuntimeStore::open(dir.path()).await.unwrap();
+        (dir, store)
+    }
+
+    async fn insert_message(
+        store: &RuntimeStore,
+        from: &str,
+        message_type: OrchestrationMessageType,
+        payload: Option<Value>,
+    ) -> OrchestrationMessage {
+        insert_message_with_subject(store, from, message_type, "done", "summary", payload).await
+    }
+
+    async fn insert_message_with_subject(
+        store: &RuntimeStore,
+        from: &str,
+        message_type: OrchestrationMessageType,
+        subject: &str,
+        body: &str,
+        payload: Option<Value>,
+    ) -> OrchestrationMessage {
+        store
+            .insert_orchestration_message(NewOrchestrationMessage {
+                from_handle: from.to_string(),
+                to_handle: "coord".to_string(),
+                subject: subject.to_string(),
+                body: body.to_string(),
+                message_type,
+                priority: OrchestrationMessagePriority::Normal,
+                thread_id: None,
+                payload: payload.map(|value| value.to_string()),
+            })
+            .await
+            .unwrap()
+    }
+
+    async fn dispatched_task(store: &RuntimeStore, handle: &str) -> (String, String) {
+        let task = store
+            .create_orchestration_task(NewOrchestrationTask {
+                spec: "work".to_string(),
+                task_title: None,
+                display_name: None,
+                deps: vec![],
+                parent_id: None,
+                created_by_terminal_handle: None,
+            })
+            .await
+            .unwrap();
+        let dispatch = store
+            .create_orchestration_dispatch(&task.id, handle)
+            .await
+            .unwrap();
+        (task.id, dispatch.id)
+    }
+
+    #[tokio::test]
+    async fn worker_done_with_full_authority_completes_task() {
+        let (_dir, store) = store().await;
+        let (task_id, dispatch_id) = dispatched_task(&store, "term_1").await;
+        let message = insert_message(
+            &store,
+            "term_1",
+            OrchestrationMessageType::WorkerDone,
+            Some(serde_json::json!({
+                "taskId": task_id,
+                "dispatchId": dispatch_id,
+                "filesModified": ["a.rs", "b.rs"],
+            })),
+        )
+        .await;
+
+        let mut logs = Vec::new();
+        let outcome = reconcile_lifecycle_message(&store, &message, &mut |line| logs.push(line))
+            .await
+            .unwrap();
+        assert_eq!(
+            outcome,
+            LifecycleReconciliation::Completed {
+                task_id: task_id.clone(),
+                dispatch_id
+            }
+        );
+        let task = store
+            .orchestration_task_by_id(&task_id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(task.status, OrchestrationTaskStatus::Completed);
+        assert!(task.result.unwrap().contains("a.rs"));
+    }
+
+    #[tokio::test]
+    async fn failed_worker_done_consumes_dispatch_failure_instead_of_completing() {
+        let (_dir, store) = store().await;
+        let (task_id, dispatch_id) = dispatched_task(&store, "term_1").await;
+        let message = insert_message_with_subject(
+            &store,
+            "term_1",
+            OrchestrationMessageType::WorkerDone,
+            "Failed: tests did not pass",
+            "cargo test failed",
+            Some(serde_json::json!({
+                "taskId": task_id,
+                "dispatchId": dispatch_id,
+            })),
+        )
+        .await;
+
+        let mut logs = Vec::new();
+        let outcome = reconcile_lifecycle_message(&store, &message, &mut |line| logs.push(line))
+            .await
+            .unwrap();
+        assert_eq!(
+            outcome,
+            LifecycleReconciliation::Failed {
+                task_id: task_id.clone(),
+                dispatch_id: dispatch_id.clone(),
+            }
+        );
+        let dispatch = store
+            .orchestration_dispatch_by_id(&dispatch_id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(dispatch.status, OrchestrationDispatchStatus::Failed);
+        assert_eq!(dispatch.failure_count, 1);
+        assert!(dispatch.last_failure.unwrap().contains("cargo test failed"));
+        let task = store
+            .orchestration_task_by_id(&task_id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(task.status, OrchestrationTaskStatus::Ready);
+    }
+
+    #[tokio::test]
+    async fn worker_done_missing_ids_is_ignored() {
+        let (_dir, store) = store().await;
+        let (task_id, _dispatch_id) = dispatched_task(&store, "term_1").await;
+
+        let no_payload =
+            insert_message(&store, "term_1", OrchestrationMessageType::WorkerDone, None).await;
+        let missing_dispatch = insert_message(
+            &store,
+            "term_1",
+            OrchestrationMessageType::WorkerDone,
+            Some(serde_json::json!({"taskId": task_id})),
+        )
+        .await;
+
+        let mut sink = |_line: String| {};
+        for message in [no_payload, missing_dispatch] {
+            let outcome = reconcile_lifecycle_message(&store, &message, &mut sink)
+                .await
+                .unwrap();
+            assert_eq!(outcome, LifecycleReconciliation::Ignored);
+        }
+        let task = store
+            .orchestration_task_by_id(&task_id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(task.status, OrchestrationTaskStatus::Dispatched);
+    }
+
+    #[tokio::test]
+    async fn worker_done_from_wrong_handle_is_ignored() {
+        let (_dir, store) = store().await;
+        let (task_id, dispatch_id) = dispatched_task(&store, "term_1").await;
+        let message = insert_message(
+            &store,
+            "impostor",
+            OrchestrationMessageType::WorkerDone,
+            Some(serde_json::json!({"taskId": task_id, "dispatchId": dispatch_id})),
+        )
+        .await;
+
+        let mut sink = |_line: String| {};
+        let outcome = reconcile_lifecycle_message(&store, &message, &mut sink)
+            .await
+            .unwrap();
+        assert_eq!(outcome, LifecycleReconciliation::Ignored);
+    }
+
+    #[tokio::test]
+    async fn worker_done_for_stale_dispatch_is_ignored() {
+        let (_dir, store) = store().await;
+        let (task_id, first_dispatch) = dispatched_task(&store, "term_1").await;
+        // First dispatch fails; a retry becomes the active dispatch.
+        store
+            .fail_orchestration_dispatch(&first_dispatch, "crash")
+            .await
+            .unwrap();
+        store
+            .create_orchestration_dispatch(&task_id, "term_2")
+            .await
+            .unwrap();
+
+        let message = insert_message(
+            &store,
+            "term_1",
+            OrchestrationMessageType::WorkerDone,
+            Some(serde_json::json!({"taskId": task_id, "dispatchId": first_dispatch})),
+        )
+        .await;
+        let mut sink = |_line: String| {};
+        let outcome = reconcile_lifecycle_message(&store, &message, &mut sink)
+            .await
+            .unwrap();
+        assert_eq!(outcome, LifecycleReconciliation::Ignored);
+        let task = store
+            .orchestration_task_by_id(&task_id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(task.status, OrchestrationTaskStatus::Dispatched);
+    }
+
+    #[tokio::test]
+    async fn worker_done_is_idempotent_after_completion() {
+        let (_dir, store) = store().await;
+        let (task_id, dispatch_id) = dispatched_task(&store, "term_1").await;
+        let payload = serde_json::json!({"taskId": task_id, "dispatchId": dispatch_id});
+        let first = insert_message(
+            &store,
+            "term_1",
+            OrchestrationMessageType::WorkerDone,
+            Some(payload.clone()),
+        )
+        .await;
+        let second = insert_message(
+            &store,
+            "term_1",
+            OrchestrationMessageType::WorkerDone,
+            Some(payload),
+        )
+        .await;
+
+        let mut sink = |_line: String| {};
+        reconcile_lifecycle_message(&store, &first, &mut sink)
+            .await
+            .unwrap();
+        let replay = reconcile_lifecycle_message(&store, &second, &mut sink)
+            .await
+            .unwrap();
+        assert_eq!(
+            replay,
+            LifecycleReconciliation::Completed {
+                task_id,
+                dispatch_id
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn heartbeat_requires_current_dispatch_authority() {
+        let (_dir, store) = store().await;
+        let (task_id, dispatch_id) = dispatched_task(&store, "term_1").await;
+
+        let missing =
+            insert_message(&store, "term_1", OrchestrationMessageType::Heartbeat, None).await;
+        let missing_task = insert_message(
+            &store,
+            "term_1",
+            OrchestrationMessageType::Heartbeat,
+            Some(serde_json::json!({"dispatchId": dispatch_id})),
+        )
+        .await;
+        let wrong_task = insert_message(
+            &store,
+            "term_1",
+            OrchestrationMessageType::Heartbeat,
+            Some(serde_json::json!({"taskId": "other_task", "dispatchId": dispatch_id})),
+        )
+        .await;
+        let wrong_handle = insert_message(
+            &store,
+            "term_2",
+            OrchestrationMessageType::Heartbeat,
+            Some(serde_json::json!({"taskId": task_id, "dispatchId": dispatch_id})),
+        )
+        .await;
+        let valid = insert_message(
+            &store,
+            "term_1",
+            OrchestrationMessageType::Heartbeat,
+            Some(serde_json::json!({"taskId": task_id, "dispatchId": dispatch_id})),
+        )
+        .await;
+
+        let mut sink = |_line: String| {};
+        for message in [missing, missing_task, wrong_task, wrong_handle] {
+            assert_eq!(
+                reconcile_lifecycle_message(&store, &message, &mut sink)
+                    .await
+                    .unwrap(),
+                LifecycleReconciliation::Ignored
+            );
+        }
+        assert_eq!(
+            reconcile_lifecycle_message(&store, &valid, &mut sink)
+                .await
+                .unwrap(),
+            LifecycleReconciliation::HeartbeatRecorded { dispatch_id }
+        );
+    }
+
+    #[tokio::test]
+    async fn non_lifecycle_messages_are_ignored() {
+        let (_dir, store) = store().await;
+        let message =
+            insert_message(&store, "term_1", OrchestrationMessageType::Status, None).await;
+        let mut sink = |_line: String| {};
+        assert_eq!(
+            reconcile_lifecycle_message(&store, &message, &mut sink)
+                .await
+                .unwrap(),
+            LifecycleReconciliation::Ignored
+        );
+    }
+}

--- a/rust/alera-cli/src/terminal_host/orchestration/message_delivery.rs
+++ b/rust/alera-cli/src/terminal_host/orchestration/message_delivery.rs
@@ -1,0 +1,24 @@
+/// Delay between writing the injected banner and the follow-up Enter.
+/// Claude Code treats a large single write as a paste and swallows an
+/// inlined `\r`, so the Enter must arrive as a separate write. Tuned for
+/// Claude Code; other agents share the constant so cadence tuning stays a
+/// one-line change.
+pub const DEFERRED_ENTER_DELAY_MS: u64 = 500;
+
+/// Agents whose injected text stays as editable prompt input: no auto-Enter,
+/// submit stays under user control.
+pub fn skips_auto_enter(agent_type: Option<&str>) -> bool {
+    matches!(agent_type, Some("cursor"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cursor_skips_auto_enter() {
+        assert!(skips_auto_enter(Some("cursor")));
+        assert!(!skips_auto_enter(Some("claude")));
+        assert!(!skips_auto_enter(None));
+    }
+}

--- a/rust/alera-cli/src/terminal_host/orchestration/message_formatter.rs
+++ b/rust/alera-cli/src/terminal_host/orchestration/message_formatter.rs
@@ -1,0 +1,107 @@
+use alera_core::runtime::{OrchestrationMessage, OrchestrationMessagePriority};
+
+const BANNER_WIDTH: usize = 60;
+
+/// Rich message banners help agents (and humans reading terminal output)
+/// quickly parse message metadata. Priority indicators surface urgent
+/// messages visually; the reply hint reduces friction for agent-to-agent
+/// responses.
+pub fn format_message_banner(message: &OrchestrationMessage) -> String {
+    let priority_tag = match message.priority {
+        OrchestrationMessagePriority::Urgent => " [URGENT]",
+        OrchestrationMessagePriority::High => " [HIGH]",
+        OrchestrationMessagePriority::Normal => "",
+    };
+    let sender_name = message.from_handle.to_uppercase();
+    let mut lines = vec![format!(
+        "──── From: {sender_name} ({from}){priority_tag} ({message_type}) ────",
+        from = message.from_handle,
+        message_type = message.message_type.as_str(),
+    )];
+    lines.push(format!("Subject: {}", message.subject));
+    if !message.body.is_empty() {
+        lines.push(message.body.clone());
+    }
+    if let Some(payload) = &message.payload {
+        lines.push(format!("[Payload: {payload}]"));
+    }
+    lines.push(format!(
+        "[Reply: alera orchestration reply --id {} --body \"...\"]",
+        message.id
+    ));
+    lines.push("─".repeat(BANNER_WIDTH));
+    lines.join("\n")
+}
+
+/// Grouping banners under a single wrapper line lets agents detect the
+/// message block boundary and parse each banner individually.
+pub fn format_messages_for_injection(messages: &[OrchestrationMessage]) -> String {
+    if messages.is_empty() {
+        return String::new();
+    }
+    let banners = messages
+        .iter()
+        .map(format_message_banner)
+        .collect::<Vec<_>>()
+        .join("\n\n");
+    format!(
+        "\n--- Orchestration Messages ({}) ---\n{banners}\n---\n",
+        messages.len()
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alera_core::runtime::OrchestrationMessageType;
+
+    fn message(priority: OrchestrationMessagePriority) -> OrchestrationMessage {
+        OrchestrationMessage {
+            id: "msg_1".to_string(),
+            from_handle: "term_a".to_string(),
+            to_handle: "term_b".to_string(),
+            subject: "Build done".to_string(),
+            body: "All green.".to_string(),
+            message_type: OrchestrationMessageType::Status,
+            priority,
+            thread_id: None,
+            payload: Some("{\"x\":1}".to_string()),
+            read: false,
+            sequence: 1,
+            created_at: "2026-01-01 00:00:00".to_string(),
+            delivered_at: None,
+        }
+    }
+
+    #[test]
+    fn banner_includes_metadata_and_reply_hint() {
+        let banner = format_message_banner(&message(OrchestrationMessagePriority::Urgent));
+        assert!(banner.contains("From: TERM_A (term_a) [URGENT] (status)"));
+        assert!(banner.contains("Subject: Build done"));
+        assert!(banner.contains("All green."));
+        assert!(banner.contains("[Payload: {\"x\":1}]"));
+        assert!(banner.contains("alera orchestration reply --id msg_1"));
+    }
+
+    #[test]
+    fn normal_priority_has_no_tag() {
+        let banner = format_message_banner(&message(OrchestrationMessagePriority::Normal));
+        assert!(banner.contains("From: TERM_A (term_a) (status)"));
+    }
+
+    #[test]
+    fn injection_wrapper_counts_messages() {
+        let batch = [
+            message(OrchestrationMessagePriority::Normal),
+            message(OrchestrationMessagePriority::High),
+        ];
+        let formatted = format_messages_for_injection(&batch);
+        assert!(formatted.starts_with("\n--- Orchestration Messages (2) ---\n"));
+        assert!(formatted.ends_with("\n---\n"));
+    }
+
+    #[test]
+    fn empty_batch_formats_to_empty_string() {
+        assert!(format_messages_for_injection(&[]).is_empty());
+    }
+}

--- a/rust/alera-cli/src/terminal_host/orchestration/message_waiters.rs
+++ b/rust/alera-cli/src/terminal_host/orchestration/message_waiters.rs
@@ -1,0 +1,235 @@
+use alera_core::runtime::OrchestrationMessageType;
+
+/// What a blocked request is waiting for.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WaitKind {
+    /// `check --wait`: any new message for the handle, optionally filtered
+    /// by message type.
+    Check {
+        type_filter: Vec<OrchestrationMessageType>,
+        inject: bool,
+    },
+    /// `ask`: a reply in a specific thread addressed to the asker, strictly
+    /// after the question's sequence number.
+    Ask {
+        thread_id: String,
+        after_sequence: i64,
+    },
+}
+
+/// A client request parked until a matching message arrives or the deadline
+/// fires. Waiters are dropped when their client disconnects.
+#[derive(Debug)]
+pub struct MessageWaiter {
+    pub waiter_id: u64,
+    pub client_id: u64,
+    pub request_id: i64,
+    pub handle: String,
+    pub kind: WaitKind,
+}
+
+/// Registry of parked long-poll requests, owned by the server actor.
+#[derive(Debug, Default)]
+pub struct MessageWaiterRegistry {
+    next_id: u64,
+    waiters: Vec<MessageWaiter>,
+}
+
+impl MessageWaiterRegistry {
+    pub fn register(
+        &mut self,
+        client_id: u64,
+        request_id: i64,
+        handle: String,
+        kind: WaitKind,
+    ) -> u64 {
+        self.next_id += 1;
+        let waiter_id = self.next_id;
+        self.waiters.push(MessageWaiter {
+            waiter_id,
+            client_id,
+            request_id,
+            handle,
+            kind,
+        });
+        waiter_id
+    }
+
+    pub fn repark(&mut self, waiter: MessageWaiter) {
+        self.waiters.push(waiter);
+    }
+
+    /// Removes and returns the waiters that should wake for a message of
+    /// `message_type` addressed to `to_handle`. Waiters whose type filter
+    /// does not include the arriving type stay parked, so a coordinator
+    /// waiting for worker_done is not woken by heartbeat noise.
+    pub fn take_matching(
+        &mut self,
+        to_handle: &str,
+        message_type: OrchestrationMessageType,
+    ) -> Vec<MessageWaiter> {
+        let (woken, parked): (Vec<_>, Vec<_>) = std::mem::take(&mut self.waiters)
+            .into_iter()
+            .partition(|waiter| {
+                waiter.handle == to_handle
+                    && match &waiter.kind {
+                        WaitKind::Check { type_filter, .. } => {
+                            type_filter.is_empty() || type_filter.contains(&message_type)
+                        }
+                        // Ask waiters wake on any message to the handle;
+                        // the handler re-checks the thread and re-parks
+                        // on a miss.
+                        WaitKind::Ask { .. } => true,
+                    }
+            });
+        self.waiters = parked;
+        woken
+    }
+
+    pub fn take_by_id(&mut self, waiter_id: u64) -> Option<MessageWaiter> {
+        let index = self
+            .waiters
+            .iter()
+            .position(|waiter| waiter.waiter_id == waiter_id)?;
+        Some(self.waiters.remove(index))
+    }
+
+    pub fn remove_client(&mut self, client_id: u64) {
+        self.waiters.retain(|waiter| waiter.client_id != client_id);
+    }
+
+    #[cfg(test)]
+    pub fn is_empty(&self) -> bool {
+        self.waiters.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn type_filter_skips_non_matching_wakeups() {
+        let mut registry = MessageWaiterRegistry::default();
+        registry.register(
+            1,
+            10,
+            "coord".to_string(),
+            WaitKind::Check {
+                type_filter: vec![OrchestrationMessageType::WorkerDone],
+                inject: false,
+            },
+        );
+
+        // Heartbeat noise must not wake a worker_done waiter.
+        let woken = registry.take_matching("coord", OrchestrationMessageType::Heartbeat);
+        assert!(woken.is_empty());
+        assert!(!registry.is_empty());
+
+        let woken = registry.take_matching("coord", OrchestrationMessageType::WorkerDone);
+        assert_eq!(woken.len(), 1);
+        assert!(registry.is_empty());
+    }
+
+    #[test]
+    fn empty_filter_wakes_on_any_type() {
+        let mut registry = MessageWaiterRegistry::default();
+        registry.register(
+            1,
+            10,
+            "coord".to_string(),
+            WaitKind::Check {
+                type_filter: vec![],
+                inject: false,
+            },
+        );
+        let woken = registry.take_matching("coord", OrchestrationMessageType::Status);
+        assert_eq!(woken.len(), 1);
+    }
+
+    #[test]
+    fn only_matching_handle_wakes() {
+        let mut registry = MessageWaiterRegistry::default();
+        registry.register(
+            1,
+            10,
+            "a".to_string(),
+            WaitKind::Check {
+                type_filter: vec![],
+                inject: false,
+            },
+        );
+        registry.register(
+            2,
+            11,
+            "b".to_string(),
+            WaitKind::Check {
+                type_filter: vec![],
+                inject: false,
+            },
+        );
+        let woken = registry.take_matching("a", OrchestrationMessageType::Status);
+        assert_eq!(woken.len(), 1);
+        assert_eq!(woken[0].handle, "a");
+        assert!(!registry.is_empty());
+    }
+
+    #[test]
+    fn ask_waiters_wake_on_any_message_to_handle() {
+        let mut registry = MessageWaiterRegistry::default();
+        registry.register(
+            1,
+            10,
+            "worker".to_string(),
+            WaitKind::Ask {
+                thread_id: "msg_1".to_string(),
+                after_sequence: 5,
+            },
+        );
+        let woken = registry.take_matching("worker", OrchestrationMessageType::Status);
+        assert_eq!(woken.len(), 1);
+    }
+
+    #[test]
+    fn client_disconnect_drops_its_waiters() {
+        let mut registry = MessageWaiterRegistry::default();
+        registry.register(
+            1,
+            10,
+            "a".to_string(),
+            WaitKind::Check {
+                type_filter: vec![],
+                inject: false,
+            },
+        );
+        registry.register(
+            2,
+            11,
+            "a".to_string(),
+            WaitKind::Check {
+                type_filter: vec![],
+                inject: false,
+            },
+        );
+        registry.remove_client(1);
+        let woken = registry.take_matching("a", OrchestrationMessageType::Status);
+        assert_eq!(woken.len(), 1);
+        assert_eq!(woken[0].client_id, 2);
+    }
+
+    #[test]
+    fn take_by_id_removes_the_waiter() {
+        let mut registry = MessageWaiterRegistry::default();
+        let id = registry.register(
+            1,
+            10,
+            "a".to_string(),
+            WaitKind::Check {
+                type_filter: vec![],
+                inject: false,
+            },
+        );
+        assert!(registry.take_by_id(id).is_some());
+        assert!(registry.take_by_id(id).is_none());
+    }
+}

--- a/rust/alera-cli/src/terminal_host/orchestration/mod.rs
+++ b/rust/alera-cli/src/terminal_host/orchestration/mod.rs
@@ -1,0 +1,8 @@
+pub mod agent_presence;
+pub mod coordinator_loop;
+pub mod dispatch_preamble;
+pub mod group_resolution;
+pub mod lifecycle_reconciliation;
+pub mod message_delivery;
+pub mod message_formatter;
+pub mod message_waiters;

--- a/rust/alera-cli/src/terminal_host/protocol.rs
+++ b/rust/alera-cli/src/terminal_host/protocol.rs
@@ -12,6 +12,9 @@ pub const PROTOCOL_VERSION: i64 = 3;
 pub const RUNTIME_HOST_CAPABILITY: &str = "runtimeStore";
 pub const RUNTIME_HOST_BOOTSTRAP_CAPABILITY: &str = "sshTargetBootstrap";
 pub const RUNTIME_HOST_MANAGED_WORKSPACE_CAPABILITY: &str = "managedWorkspaceLifecycle";
+// Advertised additively: older hosts stay usable for non-orchestration verbs,
+// so clients must feature-check this capability instead of the protocol version.
+pub const RUNTIME_HOST_ORCHESTRATION_CAPABILITY: &str = "orchestration";
 
 // Retained for the later packaging/resolver phase (sidecar discovery).
 #[allow(dead_code)]

--- a/rust/alera-cli/src/terminal_host/server.rs
+++ b/rust/alera-cli/src/terminal_host/server.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::net::Ipv4Addr;
 use std::path::PathBuf;
 use std::time::Duration;
@@ -18,9 +18,18 @@ use crate::terminal_host::client::{connection_loop, ClientHandle};
 use crate::terminal_host::control_file;
 use crate::terminal_host::history_store::TerminalHostHistoryStore;
 use crate::terminal_host::host_error::{HostError, HostResult};
+use crate::terminal_host::orchestration::agent_presence::AgentPresenceRegistry;
+use crate::terminal_host::orchestration::coordinator_loop::CoordinatorHandle;
+use crate::terminal_host::orchestration::message_delivery::{
+    skips_auto_enter, DEFERRED_ENTER_DELAY_MS,
+};
+use crate::terminal_host::orchestration::message_formatter::format_messages_for_injection;
+use crate::terminal_host::orchestration::message_waiters::MessageWaiterRegistry;
 use crate::terminal_host::protocol::{event, TerminalHostConfig};
 use crate::terminal_host::session::{PtyEvent, Session};
 
+mod coordinator_requests;
+mod orchestration_requests;
 mod requests;
 
 /// Delay before a debounced checkpoint write fires.
@@ -76,11 +85,26 @@ pub enum ServerCommand {
         request_id: i64,
         result: HostResult<Value>,
     },
+    /// A parked `check --wait`/`ask` request hit its server-side deadline.
+    OrchestrationWaitTimeout {
+        waiter_id: u64,
+    },
+    /// Fires the deferred Enter after an injected orchestration banner.
+    OrchestrationDeferredEnter {
+        session_id: String,
+        session_instance_id: u64,
+        message_ids: Vec<String>,
+    },
+    /// One coordinator loop iteration, enqueued by the ticker task.
+    CoordinatorTick {
+        run_id: String,
+    },
 }
 
 struct ClientState {
     handle: ClientHandle,
     authenticated: bool,
+    app_client: bool,
 }
 
 struct SshBootstrapJobState {
@@ -123,6 +147,10 @@ pub async fn run_terminal_host_server(
         managed_workspace_jobs: 0,
         clients: HashMap::new(),
         pending_output_writes: HashMap::new(),
+        agent_presence: AgentPresenceRegistry::default(),
+        orchestration_waiters: MessageWaiterRegistry::default(),
+        orchestration_delivery_in_flight: HashSet::new(),
+        coordinator: None,
         inbox,
         shutdown_gen: 0,
         disposed: false,
@@ -175,6 +203,10 @@ struct ServerActor {
     managed_workspace_jobs: usize,
     clients: HashMap<u64, ClientState>,
     pending_output_writes: HashMap<String, Vec<JoinHandle<()>>>,
+    agent_presence: AgentPresenceRegistry,
+    orchestration_waiters: MessageWaiterRegistry,
+    orchestration_delivery_in_flight: HashSet<String>,
+    coordinator: Option<CoordinatorHandle>,
     inbox: UnboundedSender<ServerCommand>,
     shutdown_gen: u64,
     disposed: bool,
@@ -189,6 +221,7 @@ impl ServerActor {
                     ClientState {
                         handle,
                         authenticated: false,
+                        app_client: false,
                     },
                 );
             }
@@ -232,6 +265,126 @@ impl ServerActor {
                 self.handle_managed_workspace_removed(client_id, request_id, result)
                     .await
             }
+            ServerCommand::OrchestrationWaitTimeout { waiter_id } => {
+                self.handle_orchestration_wait_timeout(waiter_id).await
+            }
+            ServerCommand::OrchestrationDeferredEnter {
+                session_id,
+                session_instance_id,
+                message_ids,
+            } => {
+                self.handle_orchestration_deferred_enter(
+                    session_id,
+                    session_instance_id,
+                    message_ids,
+                )
+                .await
+            }
+            ServerCommand::CoordinatorTick { run_id } => self.handle_coordinator_tick(run_id).await,
+        }
+    }
+
+    // --- Orchestration push-on-idle delivery -------------------------------
+
+    /// Delivers undelivered unread messages into a terminal whose agent just
+    /// became injection-ready. The Enter is written after a delay as a
+    /// separate write; `delivered_at` is stamped only after that second write
+    /// succeeds, so a failure anywhere requeues the batch for the next idle
+    /// transition.
+    pub(super) async fn deliver_pending_messages(&mut self, handle: &str) {
+        let running = self.sessions.get(handle).is_some_and(Session::running);
+        if !running {
+            return;
+        }
+        if self.orchestration_delivery_in_flight.contains(handle) {
+            return;
+        }
+        let messages = match self
+            .runtime_store
+            .undelivered_unread_orchestration_messages(handle)
+            .await
+        {
+            Ok(messages) if !messages.is_empty() => messages,
+            _ => return,
+        };
+        let formatted = format_messages_for_injection(&messages);
+        let Some(session) = self.sessions.get_mut(handle) else {
+            return;
+        };
+        session.write(formatted.as_bytes());
+        let session_instance_id = session.instance_id();
+        let ids: Vec<String> = messages.iter().map(|message| message.id.clone()).collect();
+        if skips_auto_enter(self.agent_presence.agent_type(handle)) {
+            // Editable-prompt agents: no auto-submit, but the text landed, so
+            // the batch counts as delivered.
+            let _ = self
+                .runtime_store
+                .mark_orchestration_messages_delivered(&ids)
+                .await;
+            return;
+        }
+        self.orchestration_delivery_in_flight
+            .insert(handle.to_string());
+        let inbox = self.inbox.clone();
+        let session_id = handle.to_string();
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(DEFERRED_ENTER_DELAY_MS)).await;
+            let _ = inbox.send(ServerCommand::OrchestrationDeferredEnter {
+                session_id,
+                session_instance_id,
+                message_ids: ids,
+            });
+        });
+    }
+
+    /// Send-time hook: deliver immediately only when the recipient's agent is
+    /// already idle right now.
+    pub(super) async fn deliver_pending_messages_if_idle(&mut self, handle: &str) {
+        if self.agent_presence.is_injection_ready(handle) {
+            self.deliver_pending_messages(handle).await;
+        }
+    }
+
+    async fn handle_orchestration_deferred_enter(
+        &mut self,
+        session_id: String,
+        session_instance_id: u64,
+        message_ids: Vec<String>,
+    ) {
+        let had_delivery_in_flight =
+            !message_ids.is_empty() && self.orchestration_delivery_in_flight.remove(&session_id);
+        let skip_auto_enter =
+            message_ids.is_empty() && skips_auto_enter(self.agent_presence.agent_type(&session_id));
+        let current_instance_id = self.sessions.get(&session_id).map(Session::instance_id);
+        if current_instance_id != Some(session_instance_id) {
+            if had_delivery_in_flight && self.agent_presence.is_injection_ready(&session_id) {
+                self.deliver_pending_messages(&session_id).await;
+            }
+            return;
+        }
+        let Some(session) = self.sessions.get_mut(&session_id) else {
+            return;
+        };
+        if !session.running() {
+            // Terminal closed in the 500ms window: leave delivered_at NULL so
+            // the batch is redelivered on the next idle transition.
+            return;
+        }
+        if skip_auto_enter {
+            return;
+        }
+        session.write(b"\r");
+        let delivered = message_ids.is_empty()
+            || self
+                .runtime_store
+                .mark_orchestration_messages_delivered(&message_ids)
+                .await
+                .is_ok();
+        if had_delivery_in_flight
+            && delivered
+            && self.agent_presence.is_injection_ready(&session_id)
+        {
+            self.deliver_pending_messages(&session_id).await;
         }
     }
 
@@ -484,18 +637,57 @@ impl ServerActor {
     }
 
     async fn handle_session_exit(&mut self, session_id: String, exit_code: i32) {
+        let reason = format!("terminal exited with code {exit_code}");
+        self.cleanup_orchestration_for_closed_session(&session_id, &reason)
+            .await;
         self.flush_output_batch(&session_id);
         let broadcast = self.sessions.get_mut(&session_id).and_then(|session| {
             let payload = session.handle_exit(exit_code)?;
             let clients: Vec<u64> = session.clients.iter().copied().collect();
             Some((event("exit", payload), clients))
         });
-        let Some((frame, clients)) = broadcast else {
+        if let Some((frame, clients)) = broadcast {
+            self.broadcast(&clients, frame);
+            self.immediate_checkpoint(&session_id).await;
+        }
+        self.schedule_shutdown_if_idle();
+    }
+
+    async fn cleanup_orchestration_for_closed_session(&mut self, session_id: &str, reason: &str) {
+        // The agent (if any) died with its PTY; stale presence must not keep
+        // attracting group messages or push-on-idle deliveries.
+        self.agent_presence.remove(session_id);
+        self.fail_active_dispatch_for_closed_session(session_id, reason)
+            .await;
+    }
+
+    async fn fail_active_dispatch_for_closed_session(&self, session_id: &str, reason: &str) {
+        let dispatch = match self
+            .runtime_store
+            .active_orchestration_dispatch_for_handle(session_id)
+            .await
+        {
+            Ok(dispatch) => dispatch,
+            Err(error) => {
+                eprintln!(
+                    "failed to inspect active orchestration dispatch for exited terminal {session_id}: {error}"
+                );
+                return;
+            }
+        };
+        let Some(dispatch) = dispatch else {
             return;
         };
-        self.broadcast(&clients, frame);
-        self.immediate_checkpoint(&session_id).await;
-        self.schedule_shutdown_if_idle();
+        if let Err(error) = self
+            .runtime_store
+            .fail_orchestration_dispatch(&dispatch.id, reason)
+            .await
+        {
+            eprintln!(
+                "failed to mark orchestration dispatch {} failed after terminal close: {error}",
+                dispatch.id
+            );
+        }
     }
 
     fn handle_output_batch_tick(&mut self, session_id: String, generation: u64) {
@@ -615,6 +807,11 @@ impl ServerActor {
         }
         let store = self.store.clone();
         for session_id in session_ids {
+            self.cleanup_orchestration_for_closed_session(
+                &session_id,
+                "terminal was explicitly terminated",
+            )
+            .await;
             self.flush_output_batch(&session_id);
             self.await_output_writes(&session_id).await;
             if let Some(mut session) = self.sessions.remove(&session_id) {
@@ -638,9 +835,12 @@ impl ServerActor {
     // --- Client lifecycle -------------------------------------------------
 
     async fn dispose_client(&mut self, client_id: u64) {
-        if !self.clients.contains_key(&client_id) {
+        let Some(disconnecting_client) = self.clients.get(&client_id) else {
             return;
-        }
+        };
+        let disconnects_app_client = disconnecting_client.app_client;
+        // Parked long-poll requests die with their connection.
+        self.orchestration_waiters.remove_client(client_id);
         let session_ids: Vec<String> = self.sessions.keys().cloned().collect();
         for session_id in session_ids {
             self.flush_output_batch(&session_id);
@@ -651,6 +851,9 @@ impl ServerActor {
         }
         // Dropping the handle ends the connection loop and closes the socket.
         self.clients.remove(&client_id);
+        if disconnects_app_client && !self.has_app_clients() {
+            self.agent_presence.clear();
+        }
         self.schedule_shutdown_if_idle();
     }
 
@@ -720,6 +923,12 @@ impl ServerActor {
         self.clients.values().any(|client| client.authenticated)
     }
 
+    fn has_app_clients(&self) -> bool {
+        self.clients
+            .values()
+            .any(|client| client.authenticated && client.app_client)
+    }
+
     fn has_running_sessions(&self) -> bool {
         self.sessions.values().any(Session::running)
     }
@@ -737,6 +946,7 @@ impl ServerActor {
             || self.has_authenticated_clients()
             || self.has_active_bootstrap_jobs()
             || self.has_active_managed_workspace_jobs()
+            || self.coordinator.is_some()
         {
             self.cancel_shutdown_timer();
             return;
@@ -788,6 +998,8 @@ impl ServerActor {
         let store = self.store.clone();
         let session_ids: Vec<String> = self.sessions.keys().cloned().collect();
         for session_id in session_ids {
+            self.cleanup_orchestration_for_closed_session(&session_id, "terminal host shut down")
+                .await;
             self.flush_output_batch(&session_id);
             self.await_output_writes(&session_id).await;
             if let Some(mut session) = self.sessions.remove(&session_id) {
@@ -801,6 +1013,11 @@ impl ServerActor {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::terminal_host::history_store::TerminalHostCheckpoint;
+    use crate::terminal_host::orchestration::agent_presence::AgentPresenceState;
+    use alera_core::runtime::{
+        NewOrchestrationTask, OrchestrationDispatchStatus, OrchestrationTaskStatus,
+    };
 
     #[tokio::test]
     async fn stale_ssh_bootstrap_progress_is_not_broadcast() {
@@ -832,9 +1049,14 @@ mod tests {
                 ClientState {
                     handle: ClientHandle { out },
                     authenticated: true,
+                    app_client: true,
                 },
             )]),
             pending_output_writes: HashMap::new(),
+            agent_presence: AgentPresenceRegistry::default(),
+            orchestration_waiters: MessageWaiterRegistry::default(),
+            orchestration_delivery_in_flight: HashSet::new(),
+            coordinator: None,
             inbox,
             shutdown_gen: 0,
             disposed: false,
@@ -854,5 +1076,338 @@ mod tests {
             actor.ssh_bootstrap_jobs["remote"].status,
             SshBootstrapStatus::Installing
         );
+    }
+
+    #[tokio::test]
+    async fn run_stop_clears_persisted_run_without_in_memory_ticker() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = TerminalHostHistoryStore::open(dir.path()).await.unwrap();
+        let runtime_store = RuntimeStore::open(dir.path()).await.unwrap();
+        let run = runtime_store
+            .create_orchestration_coordinator_run("coordinate", Some("coord"), 1000)
+            .await
+            .unwrap();
+        let (inbox, _rx) = mpsc::unbounded_channel();
+        let mut actor = ServerActor {
+            runtime_dir: dir.path().to_path_buf(),
+            control_file_path: dir.path().join("runtime-host.json"),
+            token: "token".to_string(),
+            config: TerminalHostConfig::default(),
+            store,
+            runtime_store,
+            sessions: HashMap::new(),
+            ssh_bootstrap_jobs: HashMap::new(),
+            managed_workspace_jobs: 0,
+            clients: HashMap::new(),
+            pending_output_writes: HashMap::new(),
+            agent_presence: AgentPresenceRegistry::default(),
+            orchestration_waiters: MessageWaiterRegistry::default(),
+            orchestration_delivery_in_flight: HashSet::new(),
+            coordinator: None,
+            inbox,
+            shutdown_gen: 0,
+            disposed: false,
+        };
+
+        let response = actor.orchestration_run_stop().await.unwrap();
+        assert_eq!(response["runId"], json!(run.id));
+        assert_eq!(response["status"], json!("failed"));
+        assert!(actor
+            .runtime_store
+            .active_orchestration_coordinator_run()
+            .await
+            .unwrap()
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn terminal_exit_fails_active_orchestration_dispatch() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = TerminalHostHistoryStore::open(dir.path()).await.unwrap();
+        let runtime_store = RuntimeStore::open(dir.path()).await.unwrap();
+        let task = runtime_store
+            .create_orchestration_task(NewOrchestrationTask {
+                spec: "do work".to_string(),
+                task_title: None,
+                display_name: None,
+                deps: Vec::new(),
+                parent_id: None,
+                created_by_terminal_handle: None,
+            })
+            .await
+            .unwrap();
+        let dispatch = runtime_store
+            .create_orchestration_dispatch(&task.id, "term-1")
+            .await
+            .unwrap();
+        let (inbox, _rx) = mpsc::unbounded_channel();
+        let mut actor = ServerActor {
+            runtime_dir: dir.path().to_path_buf(),
+            control_file_path: dir.path().join("runtime-host.json"),
+            token: "token".to_string(),
+            config: TerminalHostConfig::default(),
+            store,
+            runtime_store,
+            sessions: HashMap::new(),
+            ssh_bootstrap_jobs: HashMap::new(),
+            managed_workspace_jobs: 0,
+            clients: HashMap::new(),
+            pending_output_writes: HashMap::new(),
+            agent_presence: AgentPresenceRegistry::default(),
+            orchestration_waiters: MessageWaiterRegistry::default(),
+            orchestration_delivery_in_flight: HashSet::new(),
+            coordinator: None,
+            inbox,
+            shutdown_gen: 0,
+            disposed: false,
+        };
+
+        actor.handle_session_exit("term-1".to_string(), 9).await;
+
+        let updated_dispatch = actor
+            .runtime_store
+            .orchestration_dispatch_by_id(&dispatch.id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(updated_dispatch.status, OrchestrationDispatchStatus::Failed);
+        assert_eq!(updated_dispatch.failure_count, 1);
+        assert_eq!(
+            updated_dispatch.last_failure.as_deref(),
+            Some("terminal exited with code 9")
+        );
+        let updated_task = actor
+            .runtime_store
+            .orchestration_task_by_id(&task.id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(updated_task.status, OrchestrationTaskStatus::Ready);
+    }
+
+    #[tokio::test]
+    async fn host_dispose_fails_active_orchestration_dispatch() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = TerminalHostHistoryStore::open(dir.path()).await.unwrap();
+        let runtime_store = RuntimeStore::open(dir.path()).await.unwrap();
+        let task = runtime_store
+            .create_orchestration_task(NewOrchestrationTask {
+                spec: "do work".to_string(),
+                task_title: None,
+                display_name: None,
+                deps: Vec::new(),
+                parent_id: None,
+                created_by_terminal_handle: None,
+            })
+            .await
+            .unwrap();
+        let dispatch = runtime_store
+            .create_orchestration_dispatch(&task.id, "term-1")
+            .await
+            .unwrap();
+        store
+            .upsert(TerminalHostCheckpoint {
+                session_id: "term-1".to_string(),
+                workspace_id: "workspace-1".to_string(),
+                tab_id: "tab-1".to_string(),
+                working_directory: "/tmp".to_string(),
+                running: false,
+                exit_code: None,
+                ended_at: None,
+                updated_at: chrono::Utc::now(),
+                buffer: Vec::new(),
+            })
+            .await
+            .unwrap();
+        let session = Session::restore_exited(
+            "term-1".to_string(),
+            "workspace-1".to_string(),
+            "tab-1".to_string(),
+            &store,
+            1024,
+        )
+        .await
+        .unwrap();
+        let (inbox, _rx) = mpsc::unbounded_channel();
+        let mut actor = ServerActor {
+            runtime_dir: dir.path().to_path_buf(),
+            control_file_path: dir.path().join("runtime-host.json"),
+            token: "token".to_string(),
+            config: TerminalHostConfig::default(),
+            store,
+            runtime_store,
+            sessions: HashMap::from([("term-1".to_string(), session)]),
+            ssh_bootstrap_jobs: HashMap::new(),
+            managed_workspace_jobs: 0,
+            clients: HashMap::new(),
+            pending_output_writes: HashMap::new(),
+            agent_presence: AgentPresenceRegistry::default(),
+            orchestration_waiters: MessageWaiterRegistry::default(),
+            orchestration_delivery_in_flight: HashSet::new(),
+            coordinator: None,
+            inbox,
+            shutdown_gen: 0,
+            disposed: false,
+        };
+
+        actor.dispose().await;
+
+        let updated_dispatch = actor
+            .runtime_store
+            .orchestration_dispatch_by_id(&dispatch.id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(updated_dispatch.status, OrchestrationDispatchStatus::Failed);
+        assert_eq!(updated_dispatch.failure_count, 1);
+        assert_eq!(
+            updated_dispatch.last_failure.as_deref(),
+            Some("terminal host shut down")
+        );
+        let updated_task = actor
+            .runtime_store
+            .orchestration_task_by_id(&task.id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(updated_task.status, OrchestrationTaskStatus::Ready);
+    }
+
+    #[tokio::test]
+    async fn coordinator_does_not_spawn_worker_tab_for_cli_only_client() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = TerminalHostHistoryStore::open(dir.path()).await.unwrap();
+        let runtime_store = RuntimeStore::open(dir.path()).await.unwrap();
+        runtime_store
+            .create_orchestration_task(NewOrchestrationTask {
+                spec: "do work".to_string(),
+                task_title: None,
+                display_name: None,
+                deps: Vec::new(),
+                parent_id: None,
+                created_by_terminal_handle: None,
+            })
+            .await
+            .unwrap();
+        let (inbox, _rx) = mpsc::unbounded_channel();
+        let (out, _out_rx) = mpsc::unbounded_channel();
+        let mut actor = ServerActor {
+            runtime_dir: dir.path().to_path_buf(),
+            control_file_path: dir.path().join("runtime-host.json"),
+            token: "token".to_string(),
+            config: TerminalHostConfig::default(),
+            store,
+            runtime_store,
+            sessions: HashMap::new(),
+            ssh_bootstrap_jobs: HashMap::new(),
+            managed_workspace_jobs: 0,
+            clients: HashMap::from([(
+                1,
+                ClientState {
+                    handle: ClientHandle { out },
+                    authenticated: true,
+                    app_client: false,
+                },
+            )]),
+            pending_output_writes: HashMap::new(),
+            agent_presence: AgentPresenceRegistry::default(),
+            orchestration_waiters: MessageWaiterRegistry::default(),
+            orchestration_delivery_in_flight: HashSet::new(),
+            coordinator: None,
+            inbox,
+            shutdown_gen: 0,
+            disposed: false,
+        };
+        let response = actor
+            .orchestration_run(&json!({
+                "spec": "coordinate",
+                "from": "coord",
+                "workspace": "workspace-1",
+                "pollIntervalMs": 600_000,
+            }))
+            .await
+            .unwrap();
+
+        actor
+            .handle(ServerCommand::CoordinatorTick {
+                run_id: response["runId"].as_str().unwrap().to_string(),
+            })
+            .await;
+
+        assert!(actor
+            .runtime_store
+            .list_workspace_tabs("workspace-1")
+            .await
+            .unwrap()
+            .is_empty());
+    }
+
+    #[tokio::test]
+    async fn last_app_client_disconnect_clears_agent_presence() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = TerminalHostHistoryStore::open(dir.path()).await.unwrap();
+        let runtime_store = RuntimeStore::open(dir.path()).await.unwrap();
+        let (inbox, _rx) = mpsc::unbounded_channel();
+        let (first_app_out, _first_app_rx) = mpsc::unbounded_channel();
+        let (second_app_out, _second_app_rx) = mpsc::unbounded_channel();
+        let (cli_out, _cli_rx) = mpsc::unbounded_channel();
+        let mut actor = ServerActor {
+            runtime_dir: dir.path().to_path_buf(),
+            control_file_path: dir.path().join("runtime-host.json"),
+            token: "token".to_string(),
+            config: TerminalHostConfig::default(),
+            store,
+            runtime_store,
+            sessions: HashMap::new(),
+            ssh_bootstrap_jobs: HashMap::new(),
+            managed_workspace_jobs: 0,
+            clients: HashMap::from([
+                (
+                    1,
+                    ClientState {
+                        handle: ClientHandle { out: first_app_out },
+                        authenticated: true,
+                        app_client: true,
+                    },
+                ),
+                (
+                    2,
+                    ClientState {
+                        handle: ClientHandle {
+                            out: second_app_out,
+                        },
+                        authenticated: true,
+                        app_client: true,
+                    },
+                ),
+                (
+                    3,
+                    ClientState {
+                        handle: ClientHandle { out: cli_out },
+                        authenticated: true,
+                        app_client: false,
+                    },
+                ),
+            ]),
+            pending_output_writes: HashMap::new(),
+            agent_presence: AgentPresenceRegistry::default(),
+            orchestration_waiters: MessageWaiterRegistry::default(),
+            orchestration_delivery_in_flight: HashSet::new(),
+            coordinator: None,
+            inbox,
+            shutdown_gen: 0,
+            disposed: false,
+        };
+        actor
+            .agent_presence
+            .update("term-1", "claude".to_string(), AgentPresenceState::Done);
+
+        actor.dispose_client(3).await;
+        assert!(actor.agent_presence.is_injection_ready("term-1"));
+        actor.dispose_client(1).await;
+        assert!(actor.agent_presence.is_injection_ready("term-1"));
+        actor.dispose_client(2).await;
+
+        assert!(actor.agent_presence.get("term-1").is_none());
     }
 }

--- a/rust/alera-cli/src/terminal_host/server/coordinator_requests.rs
+++ b/rust/alera-cli/src/terminal_host/server/coordinator_requests.rs
@@ -1,0 +1,760 @@
+use alera_core::runtime::{
+    OrchestrationCoordinatorStatus, OrchestrationGateStatus, OrchestrationMessageType,
+    OrchestrationTaskStatus, WorkspaceStatus,
+};
+use serde_json::{json, Value};
+
+use crate::terminal_host::host_error::{HostError, HostResult};
+use crate::terminal_host::orchestration::agent_presence::AgentPresenceState;
+use crate::terminal_host::orchestration::coordinator_loop::{
+    hung_dispatch_threshold_iso, CoordinatorConfig, CoordinatorHandle, COORDINATOR_DEFAULT_POLL_MS,
+    COORDINATOR_DISPATCH_STALE_THRESHOLD, COORDINATOR_MAX_CONCURRENT_DEFAULT,
+};
+use crate::terminal_host::orchestration::dispatch_preamble::{
+    build_dispatch_preamble, parse_allow_stale_base_from_spec, BaseDrift, GateResolution,
+    PreambleParams,
+};
+use crate::terminal_host::orchestration::lifecycle_reconciliation::{
+    reconcile_lifecycle_message, LifecycleReconciliation,
+};
+use crate::terminal_host::orchestration::message_delivery::skips_auto_enter;
+use crate::terminal_host::protocol::event;
+use crate::terminal_host::session::Session;
+
+use super::{ServerActor, ServerCommand};
+
+const PENDING_WORKER_TAB_GRACE_SECONDS: i64 = 120;
+
+fn state_error(error: impl std::fmt::Display) -> HostError {
+    HostError::state(error.to_string())
+}
+
+fn payload_value(message: &alera_core::runtime::OrchestrationMessage) -> Option<Value> {
+    message
+        .payload
+        .as_deref()
+        .and_then(|payload| serde_json::from_str::<Value>(payload).ok())
+}
+
+fn payload_string(payload: Option<&Value>, key: &str) -> Option<String> {
+    payload?
+        .get(key)
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+}
+
+impl ServerActor {
+    // --- run / run-stop -----------------------------------------------------
+
+    pub(super) async fn orchestration_run(&mut self, payload: &Value) -> HostResult<Value> {
+        if self.coordinator.is_some() {
+            return Err(HostError::state("a coordinator run is already active"));
+        }
+        let spec = payload
+            .get("spec")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| HostError::format("spec is required."))?;
+        let coordinator_handle = payload
+            .get("from")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_string)
+            .ok_or_else(|| HostError::format("from is required."))?;
+        let poll_interval_ms = payload
+            .get("pollIntervalMs")
+            .and_then(Value::as_u64)
+            .unwrap_or(COORDINATOR_DEFAULT_POLL_MS);
+        let max_concurrent = payload
+            .get("maxConcurrent")
+            .and_then(Value::as_u64)
+            .map(|value| value.max(1) as usize)
+            .unwrap_or(COORDINATOR_MAX_CONCURRENT_DEFAULT);
+        let workspace_id = payload
+            .get("workspace")
+            .and_then(Value::as_str)
+            .map(str::to_string);
+
+        // Decomposition is the caller's responsibility in v1: the coordinator
+        // manages the DAG, it does not invent it.
+        let tasks = self
+            .runtime_store
+            .list_orchestration_tasks(None)
+            .await
+            .map_err(state_error)?;
+        if tasks.is_empty() {
+            return Err(HostError::state(
+                "no orchestration tasks exist; create tasks with task-create before run",
+            ));
+        }
+
+        let run = self
+            .runtime_store
+            .create_orchestration_coordinator_run(
+                spec,
+                Some(&coordinator_handle),
+                poll_interval_ms as i64,
+            )
+            .await
+            .map_err(state_error)?;
+        let config = CoordinatorConfig {
+            run_id: run.id.clone(),
+            coordinator_handle: Some(coordinator_handle),
+            poll_interval_ms,
+            max_concurrent,
+            workspace_id,
+        };
+        self.coordinator = Some(CoordinatorHandle::start(
+            config,
+            self.inbox.clone(),
+            |run_id| ServerCommand::CoordinatorTick { run_id },
+        ));
+        self.cancel_shutdown_timer();
+        Ok(json!({ "runId": run.id, "status": "running" }))
+    }
+
+    pub(super) async fn orchestration_run_stop(&mut self) -> HostResult<Value> {
+        let Some(handle) = self.coordinator.take() else {
+            let Some(run) = self
+                .runtime_store
+                .active_orchestration_coordinator_run()
+                .await
+                .map_err(state_error)?
+            else {
+                return Err(HostError::state("no coordinator run is active"));
+            };
+            self.runtime_store
+                .finish_orchestration_coordinator_run(
+                    &run.id,
+                    OrchestrationCoordinatorStatus::Failed,
+                )
+                .await
+                .map_err(state_error)?;
+            self.schedule_shutdown_if_idle();
+            return Ok(json!({ "runId": run.id, "status": "failed" }));
+        };
+        handle.stop();
+        self.runtime_store
+            .finish_orchestration_coordinator_run(
+                &handle.config.run_id,
+                OrchestrationCoordinatorStatus::Failed,
+            )
+            .await
+            .map_err(state_error)?;
+        self.schedule_shutdown_if_idle();
+        Ok(json!({ "runId": handle.config.run_id, "status": "failed" }))
+    }
+
+    // --- tick ---------------------------------------------------------------
+
+    /// One coordinator tick, executed inside the actor. Order mirrors Orca:
+    /// process messages -> re-assert gate blocks -> warn stale dispatches ->
+    /// dispatch ready tasks -> check convergence.
+    pub(super) async fn handle_coordinator_tick(&mut self, run_id: String) {
+        let Some(handle) = &self.coordinator else {
+            return;
+        };
+        if handle.config.run_id != run_id {
+            return;
+        }
+        let config = handle.config.clone();
+
+        if let Err(error) = self.coordinator_process_messages(&config).await {
+            self.coordinator_log(&format!("message processing failed: {error}"));
+        }
+        if let Err(error) = self.coordinator_assert_gate_blocks().await {
+            self.coordinator_log(&format!("gate check failed: {error}"));
+        }
+        if let Err(error) = self.coordinator_warn_stale_dispatches().await {
+            self.coordinator_log(&format!("stale check failed: {error}"));
+        }
+        if let Err(error) = self.coordinator_dispatch_ready_tasks(&config).await {
+            self.coordinator_log(&format!("dispatch failed: {error}"));
+        }
+        match self.coordinator_check_convergence().await {
+            Ok(Some(final_status)) => {
+                let _ = self
+                    .runtime_store
+                    .finish_orchestration_coordinator_run(&run_id, final_status)
+                    .await;
+                if let Some(handle) = self.coordinator.take() {
+                    handle.stop();
+                }
+                self.coordinator_log(&format!(
+                    "coordinator run {run_id} finished: {}",
+                    final_status.as_str()
+                ));
+                self.schedule_shutdown_if_idle();
+            }
+            Ok(None) => {}
+            Err(error) => self.coordinator_log(&format!("convergence check failed: {error}")),
+        }
+    }
+
+    /// Coordinator inbox: worker_done/heartbeat reconcile, escalations fail
+    /// the dispatch (circuit breaker), decision_gate messages create gates.
+    async fn coordinator_process_messages(
+        &mut self,
+        config: &CoordinatorConfig,
+    ) -> anyhow::Result<()> {
+        let Some(coordinator_handle) = &config.coordinator_handle else {
+            return Ok(());
+        };
+        let messages = self
+            .runtime_store
+            .unread_orchestration_coordinator_messages(coordinator_handle)
+            .await?;
+        if messages.is_empty() {
+            return Ok(());
+        }
+        let mut logs = Vec::new();
+        let mut read_ids = Vec::new();
+        for message in &messages {
+            let mark_read = match message.message_type {
+                OrchestrationMessageType::WorkerDone | OrchestrationMessageType::Heartbeat => {
+                    let mut sink = |line: String| logs.push(line);
+                    let outcome =
+                        reconcile_lifecycle_message(&self.runtime_store, message, &mut sink)
+                            .await?;
+                    match outcome {
+                        LifecycleReconciliation::Completed { task_id, .. } => {
+                            logs.push(format!("task {task_id} completed"));
+                        }
+                        LifecycleReconciliation::Failed { task_id, .. } => {
+                            logs.push(format!("task {task_id} failed"));
+                        }
+                        _ => {}
+                    }
+                    true
+                }
+                OrchestrationMessageType::Escalation => {
+                    logs.push(format!(
+                        "escalation from {}: {}",
+                        message.from_handle, message.subject
+                    ));
+                    let payload = payload_value(message);
+                    let task_id = payload_string(payload.as_ref(), "taskId");
+                    let dispatch_id = payload_string(payload.as_ref(), "dispatchId");
+                    if let Some(task_id) = task_id {
+                        if let Some(dispatch) = self
+                            .runtime_store
+                            .active_orchestration_dispatch_for_task(&task_id)
+                            .await?
+                        {
+                            let assignee_matches = dispatch.assignee_handle.as_deref()
+                                == Some(message.from_handle.as_str());
+                            let dispatch_matches =
+                                dispatch_id.as_deref() == Some(dispatch.id.as_str());
+                            if !assignee_matches || !dispatch_matches {
+                                logs.push(format!("stale escalation for task {task_id} ignored"));
+                            } else {
+                                let failed = self
+                                    .runtime_store
+                                    .fail_orchestration_dispatch(&dispatch.id, &message.subject)
+                                    .await?;
+                                logs.push(format!(
+                                    "dispatch {} failed ({} failures)",
+                                    failed.id, failed.failure_count
+                                ));
+                            }
+                        }
+                    }
+                    true
+                }
+                OrchestrationMessageType::DecisionGate => {
+                    let payload = payload_value(message);
+                    let task_id = payload_string(payload.as_ref(), "taskId");
+                    let dispatch_id = payload_string(payload.as_ref(), "dispatchId");
+                    if let Some(task_id) = task_id {
+                        let question = payload
+                            .as_ref()
+                            .and_then(|value| value.get("question").and_then(Value::as_str))
+                            .unwrap_or(&message.subject)
+                            .to_string();
+                        let active = self
+                            .runtime_store
+                            .active_orchestration_dispatch_for_task(&task_id)
+                            .await?;
+                        let sender_owns_active_dispatch = active.as_ref().is_some_and(|dispatch| {
+                            dispatch.assignee_handle.as_deref()
+                                == Some(message.from_handle.as_str())
+                                && dispatch_id.as_deref() == Some(dispatch.id.as_str())
+                        });
+                        if !sender_owns_active_dispatch {
+                            logs.push(format!("stale decision gate for task {task_id} ignored"));
+                        } else {
+                            match self
+                                .runtime_store
+                                .create_orchestration_gate(&task_id, &question, &[])
+                                .await
+                            {
+                                Ok(_) => logs.push(format!("gate created for task {task_id}")),
+                                Err(error) => {
+                                    logs.push(format!("gate for task {task_id} ignored: {error}"))
+                                }
+                            }
+                        }
+                        true
+                    } else {
+                        false
+                    }
+                    // Worker-side `ask` questions carry no taskId; they are
+                    // answered by a human/agent via `reply`, not by gates.
+                }
+                _ => false,
+            };
+            if mark_read {
+                read_ids.push(message.id.clone());
+            }
+        }
+        if !read_ids.is_empty() {
+            self.runtime_store
+                .mark_orchestration_messages_read(&read_ids)
+                .await?;
+        }
+        for line in logs {
+            self.coordinator_log(&line);
+        }
+        Ok(())
+    }
+
+    /// Invariant: a task with a pending gate stays blocked.
+    async fn coordinator_assert_gate_blocks(&mut self) -> anyhow::Result<()> {
+        let pending_gates = self
+            .runtime_store
+            .list_orchestration_gates(None, Some(OrchestrationGateStatus::Pending))
+            .await?;
+        for gate in pending_gates {
+            if let Some(task) = self
+                .runtime_store
+                .orchestration_task_by_id(&gate.task_id)
+                .await?
+            {
+                if task.status != OrchestrationTaskStatus::Blocked
+                    && task.status != OrchestrationTaskStatus::Completed
+                    && task.status != OrchestrationTaskStatus::Failed
+                {
+                    let _ = self
+                        .runtime_store
+                        .update_orchestration_task_status(
+                            &task.id,
+                            OrchestrationTaskStatus::Blocked,
+                            None,
+                        )
+                        .await;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Warn-only hung detection: a dispatch with no heartbeat past the
+    /// threshold is reported but never auto-failed.
+    async fn coordinator_warn_stale_dispatches(&mut self) -> anyhow::Result<()> {
+        let threshold = hung_dispatch_threshold_iso(chrono::Utc::now());
+        let stale = self
+            .runtime_store
+            .stale_orchestration_dispatches(&threshold)
+            .await?;
+        for dispatch in stale {
+            self.coordinator_log(&format!(
+                "dispatch {} on {} has no heartbeat since {} — possibly hung",
+                dispatch.id,
+                dispatch.assignee_handle.as_deref().unwrap_or("<unknown>"),
+                dispatch
+                    .last_heartbeat_at
+                    .as_deref()
+                    .or(dispatch.dispatched_at.as_deref())
+                    .unwrap_or("dispatch")
+            ));
+        }
+        Ok(())
+    }
+
+    async fn coordinator_dispatch_ready_tasks(
+        &mut self,
+        config: &CoordinatorConfig,
+    ) -> anyhow::Result<()> {
+        let ready = self
+            .runtime_store
+            .list_orchestration_tasks(Some(OrchestrationTaskStatus::Ready))
+            .await?;
+        if ready.is_empty() {
+            return Ok(());
+        }
+        let dispatched = self
+            .runtime_store
+            .list_orchestration_tasks(Some(OrchestrationTaskStatus::Dispatched))
+            .await?;
+        let mut slots = config.max_concurrent.saturating_sub(dispatched.len());
+        if slots == 0 {
+            return Ok(());
+        }
+
+        let mut idle_terminals = self.coordinator_available_terminals(config).await?;
+        if idle_terminals.is_empty() {
+            // One worker terminal per tick: the app spawns it eagerly and the
+            // agent's presence appears before the next dispatch attempt.
+            if self.coordinator_pending_worker_tabs(config).await? > 0 {
+                self.coordinator_log("waiting for a spawned worker terminal to report presence");
+                return Ok(());
+            }
+            self.coordinator_create_worker_terminal(config, &ready)
+                .await?;
+            return Ok(());
+        }
+
+        for task in ready {
+            if slots == 0 || idle_terminals.is_empty() {
+                break;
+            }
+            let handle = idle_terminals[0].clone();
+            match self
+                .coordinator_dispatch_task(config, &task.id, &handle)
+                .await
+            {
+                Ok(true) => {
+                    idle_terminals.remove(0);
+                    slots -= 1;
+                }
+                Ok(false) => {}
+                Err(error) => {
+                    idle_terminals.remove(0);
+                    self.coordinator_log(&format!("dispatch of {} failed: {error}", task.id));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Idle worker candidates: running sessions in the scoped workspace with
+    /// injection-ready agent presence, no active dispatch, and not the
+    /// coordinator's own terminal.
+    async fn coordinator_available_terminals(
+        &mut self,
+        config: &CoordinatorConfig,
+    ) -> anyhow::Result<Vec<String>> {
+        let mut candidates = Vec::new();
+        let session_ids: Vec<(String, String, bool)> = self
+            .sessions
+            .iter()
+            .map(|(session_id, session)| {
+                (
+                    session_id.clone(),
+                    session.workspace_id.clone(),
+                    session.running(),
+                )
+            })
+            .collect();
+        for (session_id, workspace_id, running) in session_ids {
+            if !running {
+                continue;
+            }
+            if let Some(scope) = &config.workspace_id {
+                if &workspace_id != scope {
+                    continue;
+                }
+            }
+            if config.coordinator_handle.as_deref() == Some(session_id.as_str()) {
+                continue;
+            }
+            if !self.agent_presence.is_injection_ready(&session_id) {
+                continue;
+            }
+            if skips_auto_enter(self.agent_presence.agent_type(&session_id)) {
+                continue;
+            }
+            let busy = self
+                .runtime_store
+                .active_orchestration_dispatch_for_handle(&session_id)
+                .await?
+                .is_some();
+            if !busy {
+                candidates.push(session_id);
+            }
+        }
+        Ok(candidates)
+    }
+
+    async fn coordinator_pending_worker_tabs(
+        &self,
+        config: &CoordinatorConfig,
+    ) -> anyhow::Result<usize> {
+        let Some(workspace_id) = &config.workspace_id else {
+            return Ok(0);
+        };
+        let tabs = self.runtime_store.list_workspace_tabs(workspace_id).await?;
+        let now = chrono::Utc::now();
+        let mut pending = 0;
+        for tab in tabs.into_iter().filter(|tab| tab.kind == "terminal") {
+            let Some((handle, created_at)) = (|| {
+                let fallback_id = tab.id;
+                let created_at = tab.created_at;
+                let payload = tab.payload.as_object()?;
+                let is_spawned_worker = payload.get("spawnOnCreate").and_then(Value::as_bool)
+                    == Some(true)
+                    && payload.get("initialCommand").and_then(Value::as_str) == Some("claude");
+                if !is_spawned_worker {
+                    return None;
+                }
+                payload
+                    .get("terminalSessionId")
+                    .and_then(Value::as_str)
+                    .filter(|handle| !handle.is_empty())
+                    .map(str::to_string)
+                    .or(Some(fallback_id))
+                    .map(|handle| (handle, created_at))
+            })() else {
+                continue;
+            };
+            if now.signed_duration_since(created_at)
+                > chrono::Duration::seconds(PENDING_WORKER_TAB_GRACE_SECONDS)
+            {
+                continue;
+            }
+            if !self
+                .sessions
+                .get(&handle)
+                .is_some_and(|session| session.running())
+            {
+                pending += 1;
+                continue;
+            }
+            let Some(presence) = self.agent_presence.get(&handle) else {
+                pending += 1;
+                continue;
+            };
+            if presence.state.accepts_injection() {
+                continue;
+            }
+            if presence.state == AgentPresenceState::Done {
+                continue;
+            }
+            let active_dispatch = self
+                .runtime_store
+                .active_orchestration_dispatch_for_handle(&handle)
+                .await?
+                .is_some();
+            if !active_dispatch {
+                pending += 1;
+            }
+        }
+        Ok(pending)
+    }
+
+    /// Mints a terminal tab with spawnOnCreate + the default agent command.
+    /// Requires the app to be connected (it owns PTY spawn + hook env); with
+    /// no app this logs and retries next tick — documented v1 limitation.
+    async fn coordinator_create_worker_terminal(
+        &mut self,
+        config: &CoordinatorConfig,
+        ready: &[alera_core::runtime::OrchestrationTask],
+    ) -> anyhow::Result<()> {
+        let Some(workspace_id) = &config.workspace_id else {
+            self.coordinator_log(
+                "no idle worker terminals and no --workspace scope; cannot create workers",
+            );
+            return Ok(());
+        };
+        if !self.has_app_clients() {
+            self.coordinator_log(
+                "no idle worker terminals and no app connected to spawn one; waiting",
+            );
+            return Ok(());
+        }
+        let Some(workspace) = self.runtime_store.find_workspace(workspace_id).await? else {
+            self.coordinator_log(&format!(
+                "workspace {workspace_id} not found; cannot create worker terminal"
+            ));
+            return Ok(());
+        };
+        if workspace.status != WorkspaceStatus::Active {
+            self.coordinator_log(&format!(
+                "workspace {workspace_id} is not active; cannot create worker terminal"
+            ));
+            return Ok(());
+        }
+        let spec_preview: String = ready
+            .first()
+            .map(|task| task.spec.chars().take(40).collect())
+            .unwrap_or_else(|| "orchestration".to_string());
+        let now = chrono::Utc::now();
+        let id = uuid::Uuid::new_v4().to_string();
+        let tab = alera_core::runtime::WorkspaceTabRecord {
+            id: id.clone(),
+            workspace_id: workspace_id.clone(),
+            kind: "terminal".to_string(),
+            title: format!("Worker: {spec_preview}"),
+            created_at: now,
+            updated_at: now,
+            payload: json!({
+                "terminalSessionId": id,
+                "initialCommand": "claude",
+                "spawnOnCreate": true,
+            }),
+        };
+        self.runtime_store.upsert_workspace_tab(tab).await?;
+        self.broadcast_authenticated(event("workspaceTabsChanged", json!({})));
+        self.coordinator_log(&format!("created worker terminal tab {id}"));
+        Ok(())
+    }
+
+    /// Dispatch with the stale-base pre-flight: a drift beyond the threshold
+    /// silently skips (task stays ready, retried next tick) so circuit budget
+    /// is not burned on a recoverable fetch-and-retry situation.
+    async fn coordinator_dispatch_task(
+        &mut self,
+        config: &CoordinatorConfig,
+        task_id: &str,
+        handle: &str,
+    ) -> anyhow::Result<bool> {
+        let Some(task) = self.runtime_store.orchestration_task_by_id(task_id).await? else {
+            return Ok(false);
+        };
+        let (allow_stale, stripped_spec) = parse_allow_stale_base_from_spec(&task.spec);
+        let drift = self.coordinator_probe_drift(config).await;
+        if let Some(drift) = &drift {
+            if drift.behind > COORDINATOR_DISPATCH_STALE_THRESHOLD && !allow_stale {
+                self.coordinator_log(&format!(
+                    "worktree is {} commits behind {}; skipping dispatch of {task_id} this tick",
+                    drift.behind, drift.base
+                ));
+                return Ok(false);
+            }
+        }
+        let gates = self
+            .runtime_store
+            .list_orchestration_gates(Some(task_id), Some(OrchestrationGateStatus::Resolved))
+            .await?;
+        let gate_resolution = gates.into_iter().last().map(|gate| GateResolution {
+            question: gate.question,
+            resolution: gate.resolution.unwrap_or_default(),
+        });
+
+        let dispatch = self
+            .runtime_store
+            .create_orchestration_dispatch(task_id, handle)
+            .await?;
+        let preamble = build_dispatch_preamble(&PreambleParams {
+            task_id,
+            dispatch_id: &dispatch.id,
+            task_spec: &stripped_spec,
+            coordinator_handle: config
+                .coordinator_handle
+                .as_deref()
+                .unwrap_or("coordinator"),
+            base_drift: drift.as_ref(),
+            gate_resolution: gate_resolution.as_ref(),
+        });
+        let session_instance_id = self
+            .sessions
+            .get_mut(handle)
+            .filter(|session| Session::running(session))
+            .map(|session| {
+                session.write(preamble.as_bytes());
+                session.instance_id()
+            });
+        let Some(session_instance_id) = session_instance_id else {
+            self.runtime_store
+                .fail_orchestration_dispatch(&dispatch.id, "terminal not writable")
+                .await?;
+            return Ok(false);
+        };
+        let inbox = self.inbox.clone();
+        let session_id = handle.to_string();
+        tokio::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_millis(
+                crate::terminal_host::orchestration::message_delivery::DEFERRED_ENTER_DELAY_MS,
+            ))
+            .await;
+            let _ = inbox.send(ServerCommand::OrchestrationDeferredEnter {
+                session_id,
+                session_instance_id,
+                message_ids: Vec::new(),
+            });
+        });
+        self.coordinator_log(&format!("dispatched {task_id} to {handle}"));
+        Ok(true)
+    }
+
+    async fn coordinator_probe_drift(&self, config: &CoordinatorConfig) -> Option<BaseDrift> {
+        let workspace_id = config.workspace_id.as_deref()?;
+        let workspace = self
+            .runtime_store
+            .find_workspace(workspace_id)
+            .await
+            .ok()??;
+        let path = workspace.path.clone();
+        // git2 walks are blocking; run off the actor thread.
+        let drift = tokio::task::spawn_blocking(move || {
+            alera_core::git::probe_base_drift(&path).ok().flatten()
+        })
+        .await
+        .ok()??;
+        Some(BaseDrift {
+            base: drift.base,
+            behind: drift.behind,
+            recent_subjects: drift.recent_subjects,
+        })
+    }
+
+    /// Done when every task is completed or failed. Stuck (only blocked left)
+    /// keeps the loop alive but logs the situation.
+    async fn coordinator_check_convergence(
+        &mut self,
+    ) -> anyhow::Result<Option<OrchestrationCoordinatorStatus>> {
+        let tasks = self.runtime_store.list_orchestration_tasks(None).await?;
+        if tasks.is_empty() {
+            return Ok(Some(OrchestrationCoordinatorStatus::Failed));
+        }
+        let all_terminal = tasks.iter().all(|task| {
+            matches!(
+                task.status,
+                OrchestrationTaskStatus::Completed | OrchestrationTaskStatus::Failed
+            )
+        });
+        if all_terminal {
+            let any_failed = tasks
+                .iter()
+                .any(|task| task.status == OrchestrationTaskStatus::Failed);
+            return Ok(Some(if any_failed {
+                OrchestrationCoordinatorStatus::Failed
+            } else {
+                OrchestrationCoordinatorStatus::Completed
+            }));
+        }
+        let has_actionable = tasks.iter().any(|task| {
+            matches!(
+                task.status,
+                OrchestrationTaskStatus::Ready | OrchestrationTaskStatus::Dispatched
+            )
+        });
+        if !has_actionable {
+            if tasks
+                .iter()
+                .any(|task| task.status == OrchestrationTaskStatus::Blocked)
+            {
+                self.coordinator_log(
+                    "coordinator stuck: blocked tasks remain; resolve decision gates to continue",
+                );
+            } else {
+                self.coordinator_log(
+                    "coordinator run failed: pending tasks have no active dependencies",
+                );
+                return Ok(Some(OrchestrationCoordinatorStatus::Failed));
+            }
+        }
+        Ok(None)
+    }
+
+    fn coordinator_log(&self, message: &str) {
+        eprintln!("[coordinator] {message}");
+        self.broadcast_authenticated(event(
+            "orchestrationCoordinatorLog",
+            json!({ "message": message }),
+        ));
+    }
+}

--- a/rust/alera-cli/src/terminal_host/server/orchestration_requests.rs
+++ b/rust/alera-cli/src/terminal_host/server/orchestration_requests.rs
@@ -1,0 +1,907 @@
+use std::time::Duration;
+
+use alera_core::runtime::{
+    NewOrchestrationMessage, NewOrchestrationTask, OrchestrationGateStatus, OrchestrationMessage,
+    OrchestrationMessagePriority, OrchestrationMessageType, OrchestrationTaskStatus,
+};
+use serde_json::{json, Value};
+
+use crate::terminal_host::host_error::{HostError, HostResult};
+use crate::terminal_host::orchestration::agent_presence::AgentPresenceState;
+use crate::terminal_host::orchestration::dispatch_preamble::{
+    build_dispatch_preamble, parse_allow_stale_base_from_spec, GateResolution, PreambleParams,
+};
+use crate::terminal_host::orchestration::group_resolution::{
+    is_group_address, resolve_group_address, GroupResolutionTerminal,
+};
+use crate::terminal_host::orchestration::lifecycle_reconciliation::reconcile_lifecycle_message;
+use crate::terminal_host::orchestration::message_formatter::format_messages_for_injection;
+use crate::terminal_host::orchestration::message_waiters::{MessageWaiter, WaitKind};
+use crate::terminal_host::protocol::{error_response, ok_response};
+use crate::terminal_host::session::Session;
+
+use super::{ServerActor, ServerCommand};
+
+/// Server-side ceiling for `check --wait`/`ask` so a parked request can never
+/// outlive a misbehaving client that skipped its own timeout.
+const MAX_WAIT_TIMEOUT_MS: u64 = 600_000;
+const DEFAULT_WAIT_TIMEOUT_MS: u64 = 120_000;
+
+fn optional_string(payload: &Value, key: &str) -> Option<String> {
+    payload
+        .get(key)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+}
+
+fn require_string(payload: &Value, key: &str) -> HostResult<String> {
+    optional_string(payload, key).ok_or_else(|| HostError::format(format!("{key} is required.")))
+}
+
+fn parse_message_type(payload: &Value) -> HostResult<OrchestrationMessageType> {
+    match payload.get("type").and_then(Value::as_str) {
+        None => Ok(OrchestrationMessageType::Status),
+        Some(raw) => OrchestrationMessageType::parse(raw)
+            .ok_or_else(|| HostError::format(format!("unknown message type: {raw}"))),
+    }
+}
+
+fn parse_priority(payload: &Value) -> HostResult<OrchestrationMessagePriority> {
+    match payload.get("priority").and_then(Value::as_str) {
+        None => Ok(OrchestrationMessagePriority::Normal),
+        Some(raw) => OrchestrationMessagePriority::parse(raw)
+            .ok_or_else(|| HostError::format(format!("unknown message priority: {raw}"))),
+    }
+}
+
+fn parse_type_filter(payload: &Value) -> HostResult<Vec<OrchestrationMessageType>> {
+    let Some(types) = payload.get("types") else {
+        return Ok(Vec::new());
+    };
+    let Some(items) = types.as_array() else {
+        return Err(HostError::format("types must be an array of strings."));
+    };
+    items
+        .iter()
+        .map(|item| {
+            item.as_str()
+                .and_then(OrchestrationMessageType::parse)
+                .ok_or_else(|| HostError::format(format!("unknown message type: {item}")))
+        })
+        .collect()
+}
+
+fn wait_timeout_ms(payload: &Value) -> u64 {
+    payload
+        .get("timeoutMs")
+        .and_then(Value::as_u64)
+        .unwrap_or(DEFAULT_WAIT_TIMEOUT_MS)
+        .min(MAX_WAIT_TIMEOUT_MS)
+}
+
+fn state_error(error: impl std::fmt::Display) -> HostError {
+    HostError::state(error.to_string())
+}
+
+impl ServerActor {
+    /// Handles `orchestration.*` requests. Wait-capable verbs return
+    /// `Ok(None)` when the request parked a waiter; the response is written
+    /// later by a wake or timeout.
+    pub(super) async fn handle_orchestration_request(
+        &mut self,
+        client_id: u64,
+        request_id: i64,
+        request_type: &str,
+        payload: &Value,
+    ) -> HostResult<Option<Value>> {
+        self.require_auth(client_id)?;
+        match request_type {
+            "orchestration.send" => self.orchestration_send(payload).await.map(Some),
+            "orchestration.check" => {
+                self.orchestration_check(client_id, request_id, payload)
+                    .await
+            }
+            "orchestration.reply" => self.orchestration_reply(payload).await.map(Some),
+            "orchestration.inbox" => self.orchestration_inbox(payload).await.map(Some),
+            "orchestration.ask" => self.orchestration_ask(client_id, request_id, payload).await,
+            "orchestration.agentStatus" => self.orchestration_agent_status(payload).await.map(Some),
+            "orchestration.terminals" => Ok(Some(self.orchestration_terminals())),
+            "orchestration.taskCreate" => self.orchestration_task_create(payload).await.map(Some),
+            "orchestration.taskList" => self.orchestration_task_list(payload).await.map(Some),
+            "orchestration.taskUpdate" => self.orchestration_task_update(payload).await.map(Some),
+            "orchestration.dispatch" => self.orchestration_dispatch(payload).await.map(Some),
+            "orchestration.dispatchShow" => {
+                self.orchestration_dispatch_show(payload).await.map(Some)
+            }
+            "orchestration.gateCreate" => self.orchestration_gate_create(payload).await.map(Some),
+            "orchestration.gateResolve" => self.orchestration_gate_resolve(payload).await.map(Some),
+            "orchestration.gateList" => self.orchestration_gate_list(payload).await.map(Some),
+            "orchestration.run" => self.orchestration_run(payload).await.map(Some),
+            "orchestration.runStop" => self.orchestration_run_stop().await.map(Some),
+            "orchestration.reset" => self.orchestration_reset(payload).await.map(Some),
+            other => Err(HostError::state(format!(
+                "Unknown orchestration request: {other}"
+            ))),
+        }
+    }
+
+    // --- send -------------------------------------------------------------
+
+    async fn orchestration_send(&mut self, payload: &Value) -> HostResult<Value> {
+        let from_handle = require_string(payload, "from")?;
+        let to = require_string(payload, "to")?;
+        let subject = require_string(payload, "subject")?;
+        let body = optional_string(payload, "body").unwrap_or_default();
+        let message_type = parse_message_type(payload)?;
+        let priority = parse_priority(payload)?;
+        let message_payload = optional_string(payload, "payload");
+        let explicit_thread_id = optional_string(payload, "threadId");
+
+        if message_type.is_lifecycle() && is_group_address(&to) {
+            return Err(HostError::state(format!(
+                "{} messages cannot be sent to a group address",
+                message_type.as_str()
+            )));
+        }
+
+        let recipients = resolve_group_address(
+            &to,
+            &from_handle,
+            &self.group_resolution_terminals(),
+            &self.agent_presence,
+        );
+        if recipients.is_empty() {
+            return Err(HostError::state(format!("No recipients resolved for {to}")));
+        }
+
+        // Group fan-out shares a thread id so replies converge.
+        let thread_id = if recipients.len() > 1 {
+            explicit_thread_id.or_else(|| Some(generated_group_thread_id()))
+        } else {
+            explicit_thread_id
+        };
+
+        let mut inserted = Vec::new();
+        for recipient in &recipients {
+            let message = self
+                .runtime_store
+                .insert_orchestration_message(NewOrchestrationMessage {
+                    from_handle: from_handle.clone(),
+                    to_handle: recipient.clone(),
+                    subject: subject.clone(),
+                    body: body.clone(),
+                    message_type,
+                    priority,
+                    thread_id: thread_id.clone(),
+                    payload: message_payload.clone(),
+                })
+                .await
+                .map_err(state_error)?;
+            inserted.push(message);
+        }
+
+        // Lifecycle messages reconcile BEFORE waking waiters so the dispatch
+        // lock is released by the time the coordinator reads the result.
+        if message_type.is_lifecycle() {
+            for message in &inserted {
+                let mut log = |line: String| eprintln!("[orchestration] {line}");
+                let _ = reconcile_lifecycle_message(&self.runtime_store, message, &mut log).await;
+            }
+        }
+
+        for recipient in &recipients {
+            self.deliver_pending_messages_if_idle(recipient).await;
+            self.notify_message_arrived(recipient, message_type).await;
+        }
+        self.broadcast_authenticated(crate::terminal_host::protocol::event(
+            "orchestrationMessagesChanged",
+            json!({}),
+        ));
+
+        Ok(json!({
+            "messages": inserted,
+            "recipients": recipients,
+        }))
+    }
+
+    // --- check ------------------------------------------------------------
+
+    async fn orchestration_check(
+        &mut self,
+        client_id: u64,
+        request_id: i64,
+        payload: &Value,
+    ) -> HostResult<Option<Value>> {
+        let handle = require_string(payload, "terminal")?;
+        let all = payload.get("all").and_then(Value::as_bool).unwrap_or(false);
+        let wait = payload
+            .get("wait")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        let inject = payload
+            .get("inject")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        let type_filter = parse_type_filter(payload)?;
+
+        if all {
+            // `--all` is a read-only view: never marks read, never waits.
+            let limit = payload.get("limit").and_then(Value::as_i64).unwrap_or(100);
+            let filter = if type_filter.is_empty() {
+                None
+            } else {
+                Some(type_filter.as_slice())
+            };
+            let messages = self
+                .runtime_store
+                .all_orchestration_messages_for_handle(&handle, filter, limit)
+                .await
+                .map_err(state_error)?;
+            return Ok(Some(check_response(&messages, inject)));
+        }
+
+        let messages = self.consume_unread_messages(&handle, &type_filter).await?;
+        if !messages.is_empty() || !wait {
+            return Ok(Some(check_response(&messages, inject)));
+        }
+
+        // Nothing unread and the caller asked to wait: park the request.
+        let waiter_id = self.orchestration_waiters.register(
+            client_id,
+            request_id,
+            handle,
+            WaitKind::Check {
+                type_filter,
+                inject,
+            },
+        );
+        self.spawn_wait_timeout(waiter_id, wait_timeout_ms(payload));
+        Ok(None)
+    }
+
+    /// Reads unread messages (optionally filtered), reconciles lifecycle
+    /// messages inline, and marks them read.
+    async fn consume_unread_messages(
+        &mut self,
+        handle: &str,
+        type_filter: &[OrchestrationMessageType],
+    ) -> HostResult<Vec<OrchestrationMessage>> {
+        let filter = if type_filter.is_empty() {
+            None
+        } else {
+            Some(type_filter)
+        };
+        let messages = self
+            .runtime_store
+            .unread_orchestration_messages(handle, filter)
+            .await
+            .map_err(state_error)?;
+        if messages.is_empty() {
+            return Ok(messages);
+        }
+        for message in &messages {
+            if message.message_type.is_lifecycle() {
+                let mut log = |line: String| eprintln!("[orchestration] {line}");
+                let _ = reconcile_lifecycle_message(&self.runtime_store, message, &mut log).await;
+            }
+        }
+        let ids: Vec<String> = messages.iter().map(|message| message.id.clone()).collect();
+        self.runtime_store
+            .mark_orchestration_messages_read(&ids)
+            .await
+            .map_err(state_error)?;
+        Ok(messages)
+    }
+
+    // --- reply ------------------------------------------------------------
+
+    async fn orchestration_reply(&mut self, payload: &Value) -> HostResult<Value> {
+        let message_id = require_string(payload, "id")?;
+        let body = require_string(payload, "body")?;
+        let original = self
+            .runtime_store
+            .orchestration_message_by_id(&message_id)
+            .await
+            .map_err(state_error)?
+            .ok_or_else(|| HostError::state(format!("message not found: {message_id}")))?;
+        self.runtime_store
+            .mark_orchestration_messages_read(std::slice::from_ref(&original.id))
+            .await
+            .map_err(state_error)?;
+        let reply = self
+            .runtime_store
+            .insert_orchestration_message(NewOrchestrationMessage {
+                from_handle: original.to_handle.clone(),
+                to_handle: original.from_handle.clone(),
+                subject: format!("Re: {}", original.subject),
+                body,
+                message_type: OrchestrationMessageType::Status,
+                priority: OrchestrationMessagePriority::Normal,
+                thread_id: original
+                    .thread_id
+                    .clone()
+                    .or_else(|| Some(original.id.clone())),
+                payload: None,
+            })
+            .await
+            .map_err(state_error)?;
+        let recipient = reply.to_handle.clone();
+        self.deliver_pending_messages_if_idle(&recipient).await;
+        self.notify_message_arrived(&recipient, OrchestrationMessageType::Status)
+            .await;
+        Ok(json!(reply))
+    }
+
+    // --- inbox ------------------------------------------------------------
+
+    async fn orchestration_inbox(&mut self, payload: &Value) -> HostResult<Value> {
+        let limit = payload.get("limit").and_then(Value::as_i64).unwrap_or(50);
+        let messages = match optional_string(payload, "terminal") {
+            Some(handle) => self
+                .runtime_store
+                .all_orchestration_messages_for_handle(&handle, None, limit)
+                .await
+                .map_err(state_error)?,
+            None => self
+                .runtime_store
+                .orchestration_inbox(limit)
+                .await
+                .map_err(state_error)?,
+        };
+        Ok(json!({ "messages": messages }))
+    }
+
+    // --- ask --------------------------------------------------------------
+
+    async fn orchestration_ask(
+        &mut self,
+        client_id: u64,
+        request_id: i64,
+        payload: &Value,
+    ) -> HostResult<Option<Value>> {
+        let from_handle = require_string(payload, "from")?;
+        let to = require_string(payload, "to")?;
+        if is_group_address(&to) {
+            return Err(HostError::state(
+                "ask requires a single terminal handle, not a group address",
+            ));
+        }
+        let question = require_string(payload, "question")?;
+        let options = optional_string(payload, "options");
+        let body = match &options {
+            Some(options) => format!("{question}\nOptions: {options}"),
+            None => question.clone(),
+        };
+        let message = self
+            .runtime_store
+            .insert_orchestration_message(NewOrchestrationMessage {
+                from_handle: from_handle.clone(),
+                to_handle: to.clone(),
+                subject: format!("Question: {question}"),
+                body,
+                message_type: OrchestrationMessageType::DecisionGate,
+                priority: OrchestrationMessagePriority::High,
+                thread_id: None,
+                payload: None,
+            })
+            .await
+            .map_err(state_error)?;
+        // The question is its own thread root: replies inherit thread_id =
+        // message id via `reply`.
+        self.deliver_pending_messages_if_idle(&to).await;
+        self.notify_message_arrived(&to, OrchestrationMessageType::DecisionGate)
+            .await;
+
+        let waiter_id = self.orchestration_waiters.register(
+            client_id,
+            request_id,
+            from_handle,
+            WaitKind::Ask {
+                thread_id: message.id.clone(),
+                after_sequence: message.sequence,
+            },
+        );
+        self.spawn_wait_timeout(waiter_id, wait_timeout_ms(payload));
+        Ok(None)
+    }
+
+    // --- agent status forwarding -------------------------------------------
+
+    async fn orchestration_agent_status(&mut self, payload: &Value) -> HostResult<Value> {
+        let Some(entries) = payload.get("entries").and_then(Value::as_array) else {
+            return Err(HostError::format("entries must be an array."));
+        };
+        let mut became_ready = Vec::new();
+        for entry in entries {
+            let Some(handle) = entry
+                .get("terminalSessionId")
+                .and_then(Value::as_str)
+                .filter(|value| !value.is_empty())
+            else {
+                continue;
+            };
+            let removed = entry
+                .get("removed")
+                .and_then(Value::as_bool)
+                .unwrap_or(false);
+            if removed {
+                self.cleanup_orchestration_for_closed_session(handle, "agent status was removed")
+                    .await;
+                continue;
+            }
+            let Some(state) = entry
+                .get("state")
+                .and_then(Value::as_str)
+                .and_then(AgentPresenceState::parse)
+            else {
+                continue;
+            };
+            let agent_type = entry
+                .get("agentType")
+                .and_then(Value::as_str)
+                .unwrap_or("unknown")
+                .to_string();
+            if self.agent_presence.update(handle, agent_type, state) {
+                became_ready.push(handle.to_string());
+            }
+        }
+        // A transition into an injection-ready state flushes that handle's
+        // undelivered queue (push-on-idle).
+        for handle in became_ready {
+            self.deliver_pending_messages(&handle).await;
+        }
+        Ok(json!({}))
+    }
+
+    // --- terminals ---------------------------------------------------------
+
+    pub(super) fn orchestration_terminals(&self) -> Value {
+        let terminals: Vec<Value> = self
+            .sessions
+            .iter()
+            .map(|(session_id, session)| {
+                let presence = self.agent_presence.get(session_id);
+                json!({
+                    "handle": session_id,
+                    "workspaceId": session.workspace_id,
+                    "tabId": session.tab_id,
+                    "running": session.running(),
+                    "agentType": presence.map(|entry| entry.agent_type.clone()),
+                    "agentState": presence.map(|entry| entry.state.as_str()),
+                })
+            })
+            .collect();
+        json!({ "terminals": terminals })
+    }
+
+    pub(super) fn group_resolution_terminals(&self) -> Vec<GroupResolutionTerminal> {
+        self.sessions
+            .iter()
+            .filter(|(_, session)| session.running())
+            .map(|(session_id, session)| GroupResolutionTerminal {
+                handle: session_id.clone(),
+                workspace_id: Some(session.workspace_id.clone()),
+            })
+            .collect()
+    }
+
+    // --- tasks --------------------------------------------------------------
+
+    async fn orchestration_task_create(&mut self, payload: &Value) -> HostResult<Value> {
+        let spec = require_string(payload, "spec")?;
+        let deps: Vec<String> = payload
+            .get("deps")
+            .and_then(Value::as_array)
+            .map(|items| {
+                items
+                    .iter()
+                    .filter_map(Value::as_str)
+                    .map(str::to_string)
+                    .collect()
+            })
+            .unwrap_or_default();
+        let task = self
+            .runtime_store
+            .create_orchestration_task(NewOrchestrationTask {
+                spec,
+                task_title: optional_string(payload, "taskTitle"),
+                display_name: None,
+                deps,
+                parent_id: optional_string(payload, "parent"),
+                created_by_terminal_handle: optional_string(payload, "createdBy"),
+            })
+            .await
+            .map_err(state_error)?;
+        Ok(json!(task))
+    }
+
+    async fn orchestration_task_list(&mut self, payload: &Value) -> HostResult<Value> {
+        let status = match optional_string(payload, "status") {
+            None => None,
+            Some(raw) => Some(
+                OrchestrationTaskStatus::parse(&raw)
+                    .ok_or_else(|| HostError::format(format!("unknown task status: {raw}")))?,
+            ),
+        };
+        let tasks = self
+            .runtime_store
+            .list_orchestration_tasks(status)
+            .await
+            .map_err(state_error)?;
+        Ok(json!({ "tasks": tasks }))
+    }
+
+    async fn orchestration_task_update(&mut self, payload: &Value) -> HostResult<Value> {
+        let id = require_string(payload, "id")?;
+        let status_raw = require_string(payload, "status")?;
+        let status = OrchestrationTaskStatus::parse(&status_raw)
+            .ok_or_else(|| HostError::format(format!("unknown task status: {status_raw}")))?;
+        let result = optional_string(payload, "result");
+        let task = self
+            .runtime_store
+            .update_orchestration_task_status(&id, status, result.as_deref())
+            .await
+            .map_err(state_error)?;
+        Ok(json!(task))
+    }
+
+    // --- dispatch -------------------------------------------------------------
+
+    async fn orchestration_dispatch(&mut self, payload: &Value) -> HostResult<Value> {
+        let task_id = require_string(payload, "task")?;
+        let to = require_string(payload, "to")?;
+        let from = require_string(payload, "from")?;
+        let inject = payload
+            .get("inject")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        let dry_run = payload
+            .get("dryRun")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        let return_preamble = payload
+            .get("returnPreamble")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+
+        let task = self
+            .runtime_store
+            .orchestration_task_by_id(&task_id)
+            .await
+            .map_err(state_error)?
+            .ok_or_else(|| HostError::state(format!("orchestration task not found: {task_id}")))?;
+        let (_allow_stale, stripped_spec) = parse_allow_stale_base_from_spec(&task.spec);
+        let gate_resolution = self.latest_resolved_gate(&task_id).await?;
+
+        if dry_run {
+            // Builds the preamble without mutating any state; the dispatch id
+            // is a placeholder that a real dispatch will replace.
+            let preamble = build_dispatch_preamble(&PreambleParams {
+                task_id: &task_id,
+                dispatch_id: "ctx_dryrun",
+                task_spec: &stripped_spec,
+                coordinator_handle: &from,
+                base_drift: None,
+                gate_resolution: gate_resolution.as_ref(),
+            });
+            return Ok(json!({ "dryRun": true, "preamble": preamble }));
+        }
+
+        if inject {
+            // Refuse to dump a preamble into a bare shell: injection requires
+            // a recognized agent to be running in the target terminal.
+            let session_running = self.sessions.get(&to).is_some_and(Session::running);
+            if !session_running {
+                return Err(HostError::state(format!(
+                    "terminal {to} is not running; cannot inject"
+                )));
+            }
+            if self.agent_presence.get(&to).is_none() {
+                return Err(HostError::state(format!(
+                    "no agent detected in terminal {to}; use --dry-run and paste the preamble manually"
+                )));
+            }
+            if !self.agent_presence.is_injection_ready(&to) {
+                return Err(HostError::state(format!(
+                    "agent in terminal {to} is not idle; cannot inject"
+                )));
+            }
+        }
+
+        let dispatch = self
+            .runtime_store
+            .create_orchestration_dispatch(&task_id, &to)
+            .await
+            .map_err(state_error)?;
+        let preamble = build_dispatch_preamble(&PreambleParams {
+            task_id: &task_id,
+            dispatch_id: &dispatch.id,
+            task_spec: &stripped_spec,
+            coordinator_handle: &from,
+            base_drift: None,
+            gate_resolution: gate_resolution.as_ref(),
+        });
+
+        if inject {
+            let Some(session) = self.sessions.get_mut(&to) else {
+                let _ = self
+                    .runtime_store
+                    .fail_orchestration_dispatch(&dispatch.id, "terminal session vanished")
+                    .await;
+                return Err(HostError::state(format!("terminal {to} vanished")));
+            };
+            session.write(preamble.as_bytes());
+            let session_instance_id = session.instance_id();
+            let inbox = self.inbox.clone();
+            let session_id = to.clone();
+            tokio::spawn(async move {
+                tokio::time::sleep(Duration::from_millis(
+                    crate::terminal_host::orchestration::message_delivery::DEFERRED_ENTER_DELAY_MS,
+                ))
+                .await;
+                let _ = inbox.send(ServerCommand::OrchestrationDeferredEnter {
+                    session_id,
+                    session_instance_id,
+                    message_ids: Vec::new(),
+                });
+            });
+        }
+
+        let mut response = json!({ "dispatch": dispatch, "taskId": task_id });
+        if return_preamble || !inject {
+            response["preamble"] = Value::String(preamble);
+        }
+        Ok(response)
+    }
+
+    async fn orchestration_dispatch_show(&mut self, payload: &Value) -> HostResult<Value> {
+        let task_id = require_string(payload, "task")?;
+        let active = self
+            .runtime_store
+            .active_orchestration_dispatch_for_task(&task_id)
+            .await
+            .map_err(state_error)?;
+        let history = self
+            .runtime_store
+            .list_orchestration_dispatches_for_task(&task_id)
+            .await
+            .map_err(state_error)?;
+        Ok(json!({ "active": active, "history": history }))
+    }
+
+    async fn latest_resolved_gate(&self, task_id: &str) -> HostResult<Option<GateResolution>> {
+        let gates = self
+            .runtime_store
+            .list_orchestration_gates(Some(task_id), Some(OrchestrationGateStatus::Resolved))
+            .await
+            .map_err(state_error)?;
+        Ok(gates.into_iter().last().map(|gate| GateResolution {
+            question: gate.question,
+            resolution: gate.resolution.unwrap_or_default(),
+        }))
+    }
+
+    // --- gates --------------------------------------------------------------
+
+    async fn orchestration_gate_create(&mut self, payload: &Value) -> HostResult<Value> {
+        let task_id = require_string(payload, "task")?;
+        let question = require_string(payload, "question")?;
+        let options: Vec<String> = payload
+            .get("options")
+            .and_then(Value::as_array)
+            .map(|items| {
+                items
+                    .iter()
+                    .filter_map(Value::as_str)
+                    .map(str::to_string)
+                    .collect()
+            })
+            .unwrap_or_default();
+        let gate = self
+            .runtime_store
+            .create_orchestration_gate(&task_id, &question, &options)
+            .await
+            .map_err(state_error)?;
+        Ok(json!(gate))
+    }
+
+    async fn orchestration_gate_resolve(&mut self, payload: &Value) -> HostResult<Value> {
+        let gate_id = require_string(payload, "id")?;
+        let resolution = require_string(payload, "resolution")?;
+        let gate = self
+            .runtime_store
+            .resolve_orchestration_gate(&gate_id, &resolution)
+            .await
+            .map_err(state_error)?;
+        Ok(json!(gate))
+    }
+
+    async fn orchestration_gate_list(&mut self, payload: &Value) -> HostResult<Value> {
+        let task_id = optional_string(payload, "task");
+        let status = match optional_string(payload, "status") {
+            None => None,
+            Some(raw) => Some(
+                OrchestrationGateStatus::parse(&raw)
+                    .ok_or_else(|| HostError::format(format!("unknown gate status: {raw}")))?,
+            ),
+        };
+        let gates = self
+            .runtime_store
+            .list_orchestration_gates(task_id.as_deref(), status)
+            .await
+            .map_err(state_error)?;
+        Ok(json!({ "gates": gates }))
+    }
+
+    // --- reset --------------------------------------------------------------
+
+    async fn orchestration_reset(&mut self, payload: &Value) -> HostResult<Value> {
+        let tasks = payload
+            .get("tasks")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        let messages = payload
+            .get("messages")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        // No explicit scope means reset everything, mirroring Orca's --all
+        // default.
+        let all =
+            (!tasks && !messages) || payload.get("all").and_then(Value::as_bool).unwrap_or(false);
+        if all || tasks {
+            if let Some(handle) = self.coordinator.take() {
+                handle.stop();
+            }
+            self.runtime_store
+                .reset_orchestration_tasks()
+                .await
+                .map_err(state_error)?;
+        }
+        if all || messages {
+            self.runtime_store
+                .reset_orchestration_messages()
+                .await
+                .map_err(state_error)?;
+        }
+        Ok(json!({
+            "tasks": all || tasks,
+            "messages": all || messages,
+        }))
+    }
+
+    // --- waiter plumbing ----------------------------------------------------
+
+    /// Wakes parked `check --wait`/`ask` requests that match a newly arrived
+    /// message and writes their responses.
+    pub(super) async fn notify_message_arrived(
+        &mut self,
+        to_handle: &str,
+        message_type: OrchestrationMessageType,
+    ) {
+        let woken = self
+            .orchestration_waiters
+            .take_matching(to_handle, message_type);
+        for waiter in woken {
+            self.resolve_waiter(waiter).await;
+        }
+    }
+
+    async fn resolve_waiter(&mut self, waiter: MessageWaiter) {
+        match waiter.kind.clone() {
+            WaitKind::Check {
+                type_filter,
+                inject,
+            } => {
+                let filter = type_filter.clone();
+                match self.consume_unread_messages(&waiter.handle, &filter).await {
+                    Ok(messages) if messages.is_empty() => {
+                        // Raced with another consumer: re-park with the same
+                        // waiter id so the original timeout still expires it.
+                        self.orchestration_waiters.repark(waiter);
+                    }
+                    Ok(messages) => {
+                        self.client_write(
+                            waiter.client_id,
+                            ok_response(waiter.request_id, check_response(&messages, inject)),
+                        );
+                    }
+                    Err(error) => {
+                        self.client_write(
+                            waiter.client_id,
+                            error_response(waiter.request_id, &error),
+                        );
+                    }
+                }
+            }
+            WaitKind::Ask {
+                thread_id,
+                after_sequence,
+            } => {
+                match self
+                    .runtime_store
+                    .orchestration_thread_messages_for(&thread_id, &waiter.handle, after_sequence)
+                    .await
+                {
+                    Ok(replies) if replies.is_empty() => {
+                        // The wake was for an unrelated message; keep waiting
+                        // under the original waiter id so its timeout remains
+                        // authoritative.
+                        self.orchestration_waiters.repark(waiter);
+                    }
+                    Ok(mut replies) => {
+                        let ids: Vec<String> =
+                            replies.iter().map(|reply| reply.id.clone()).collect();
+                        let _ = self
+                            .runtime_store
+                            .mark_orchestration_messages_read(&ids)
+                            .await;
+                        let reply = replies.remove(0);
+                        self.client_write(
+                            waiter.client_id,
+                            ok_response(
+                                waiter.request_id,
+                                json!({ "answered": true, "reply": reply }),
+                            ),
+                        );
+                    }
+                    Err(error) => {
+                        self.client_write(
+                            waiter.client_id,
+                            error_response(waiter.request_id, &HostError::state(error.to_string())),
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    pub(super) async fn handle_orchestration_wait_timeout(&mut self, waiter_id: u64) {
+        let Some(waiter) = self.orchestration_waiters.take_by_id(waiter_id) else {
+            return;
+        };
+        let mut payload = match waiter.kind {
+            WaitKind::Check { inject, .. } => check_response(&[], inject),
+            WaitKind::Ask { .. } => json!({ "answered": false, "timedOut": true }),
+        };
+        payload["timedOut"] = Value::Bool(true);
+        self.client_write(waiter.client_id, ok_response(waiter.request_id, payload));
+    }
+
+    fn spawn_wait_timeout(&self, waiter_id: u64, timeout_ms: u64) {
+        let inbox = self.inbox.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(timeout_ms)).await;
+            let _ = inbox.send(ServerCommand::OrchestrationWaitTimeout { waiter_id });
+        });
+    }
+}
+
+fn generated_group_thread_id() -> String {
+    format!("thread_{}", uuid::Uuid::new_v4().simple())
+}
+
+fn check_response(messages: &[OrchestrationMessage], inject: bool) -> Value {
+    let mut response = json!({ "messages": messages });
+    if inject {
+        response["formatted"] = Value::String(format_messages_for_injection(messages));
+    }
+    response
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+
+    use super::*;
+
+    #[test]
+    fn generated_group_thread_ids_are_unique() {
+        let ids = (0..512)
+            .map(|_| generated_group_thread_id())
+            .collect::<HashSet<_>>();
+
+        assert_eq!(ids.len(), 512);
+    }
+}

--- a/rust/alera-cli/src/terminal_host/server/requests.rs
+++ b/rust/alera-cli/src/terminal_host/server/requests.rs
@@ -16,6 +16,7 @@ use crate::terminal_host::protocol::{
     decode_bytes, error_response, event, int_or, ok_response, require_object, TerminalHostConfig,
     TerminalHostLaunch, PROTOCOL_VERSION, RUNTIME_HOST_BOOTSTRAP_CAPABILITY,
     RUNTIME_HOST_CAPABILITY, RUNTIME_HOST_MANAGED_WORKSPACE_CAPABILITY,
+    RUNTIME_HOST_ORCHESTRATION_CAPABILITY,
 };
 use crate::terminal_host::session::Session;
 
@@ -62,6 +63,22 @@ impl ServerActor {
                             }
                             return;
                         }
+                    }
+                    if request_type.starts_with("orchestration.") {
+                        match self
+                            .handle_orchestration_request(client_id, id, &request_type, &payload)
+                            .await
+                        {
+                            // A parked waiter answers later (wake or timeout).
+                            Ok(None) => return,
+                            Ok(Some(value)) => {
+                                self.client_write(client_id, ok_response(id, value));
+                            }
+                            Err(error) => {
+                                self.client_write(client_id, error_response(id, &error));
+                            }
+                        }
+                        return;
                     }
                 }
                 self.handle_request(client_id, &request_type, &payload)
@@ -211,6 +228,8 @@ impl ServerActor {
                 }
                 if let Some(client) = self.clients.get_mut(&client_id) {
                     client.authenticated = true;
+                    client.app_client =
+                        payload.get("clientKind").and_then(Value::as_str) == Some("app");
                 }
                 self.cancel_shutdown_timer();
                 Ok(json!({}))
@@ -275,6 +294,11 @@ impl ServerActor {
                 let session_id = self.require_session(payload)?;
                 self.flush_output_batch(&session_id);
                 self.await_output_writes(&session_id).await;
+                self.cleanup_orchestration_for_closed_session(
+                    &session_id,
+                    "terminal was explicitly terminated",
+                )
+                .await;
                 let store = self.store.clone();
                 if let Some(mut session) = self.sessions.remove(&session_id) {
                     session.terminate(true, &store).await;
@@ -291,6 +315,7 @@ impl ServerActor {
                         RUNTIME_HOST_CAPABILITY,
                         RUNTIME_HOST_BOOTSTRAP_CAPABILITY,
                         RUNTIME_HOST_MANAGED_WORKSPACE_CAPABILITY,
+                        RUNTIME_HOST_ORCHESTRATION_CAPABILITY,
                     ],
                     "authenticated": true,
                 }))

--- a/rust/alera-cli/src/terminal_host/session.rs
+++ b/rust/alera-cli/src/terminal_host/session.rs
@@ -1,5 +1,6 @@
 use std::collections::HashSet;
 use std::io::{Read, Write};
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use chrono::{DateTime, Utc};
 use portable_pty::{native_pty_system, ChildKiller, CommandBuilder, MasterPty, PtySize};
@@ -12,6 +13,11 @@ use crate::terminal_host::protocol::{encode_bytes, TerminalHostLaunch};
 
 /// Bytes read from the PTY per `read` call.
 const READ_CHUNK_BYTES: usize = 8192;
+static NEXT_SESSION_INSTANCE_ID: AtomicU64 = AtomicU64::new(1);
+
+fn next_session_instance_id() -> u64 {
+    NEXT_SESSION_INSTANCE_ID.fetch_add(1, Ordering::Relaxed)
+}
 
 /// A message produced by a session's PTY reader thread.
 #[derive(Debug)]
@@ -31,6 +37,7 @@ pub struct OutputBatch {
 /// other state transitions are driven by the single server actor that owns this
 /// struct, so no internal locking is required.
 pub struct Session {
+    instance_id: u64,
     pub id: String,
     pub workspace_id: String,
     pub tab_id: String,
@@ -87,6 +94,11 @@ impl Session {
         for (key, value) in &launch.environment {
             command.env(key, value);
         }
+        // The orchestration identity: agents inside this PTY self-identify in
+        // `alera orchestration` commands without an RPC round-trip. The handle
+        // is the session id, which is also the key the app uses for agent
+        // status entries.
+        command.env("ALERA_TERMINAL_HANDLE", &id);
         // The working directory is persisted as session metadata; shell startup
         // preparation owns any cwd changes that should happen inside the PTY.
 
@@ -108,6 +120,7 @@ impl Session {
             .map_err(|error| HostError::state(error.to_string()))?;
 
         let mut session = Session {
+            instance_id: next_session_instance_id(),
             id,
             workspace_id,
             tab_id,
@@ -153,6 +166,7 @@ impl Session {
             (Some(checkpoint.exit_code.unwrap_or(0)), checkpoint.ended_at)
         };
         Some(Session {
+            instance_id: next_session_instance_id(),
             id: session_id,
             workspace_id,
             tab_id,
@@ -178,6 +192,10 @@ impl Session {
 
     pub fn running(&self) -> bool {
         self.running
+    }
+
+    pub fn instance_id(&self) -> u64 {
+        self.instance_id
     }
 
     pub fn set_max_bytes(&mut self, max_bytes: usize) {
@@ -427,6 +445,7 @@ mod tests {
 
     fn test_session() -> Session {
         Session {
+            instance_id: next_session_instance_id(),
             id: "session-1".to_string(),
             workspace_id: "workspace-1".to_string(),
             tab_id: "tab-1".to_string(),

--- a/rust/alera-cli/tests/orchestration_conformance.rs
+++ b/rust/alera-cli/tests/orchestration_conformance.rs
@@ -1,0 +1,594 @@
+//! End-to-end orchestration conformance. Spawns the real `alera runtime-host`
+//! binary, connects raw TCP clients, and exercises messaging, long-poll
+//! waits, tasks, dispatch, gates, agent presence, and push-on-idle delivery
+//! against a live PTY.
+
+use std::io::{BufRead, BufReader, Write};
+use std::net::TcpStream;
+use std::process::{Child, Command};
+use std::time::{Duration, Instant};
+
+use base64::engine::general_purpose::STANDARD;
+use base64::Engine as _;
+use serde_json::{json, Value};
+
+const PROTOCOL_VERSION: i64 = 3;
+
+struct HostGuard(Child);
+
+impl Drop for HostGuard {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+fn read_control(path: &std::path::Path) -> Option<(u16, String)> {
+    let contents = std::fs::read_to_string(path).ok()?;
+    let value: Value = serde_json::from_str(&contents).ok()?;
+    let port = value.get("port")?.as_u64()? as u16;
+    let token = value.get("token")?.as_str()?.to_string();
+    Some((port, token))
+}
+
+fn spawn_host(
+    runtime_dir: &std::path::Path,
+    control_path: &std::path::Path,
+    token: &str,
+) -> (HostGuard, u16) {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_alera"));
+    command.args([
+        "runtime-host",
+        "--runtime-dir",
+        runtime_dir.to_str().unwrap(),
+        "--control-file",
+        control_path.to_str().unwrap(),
+        "--token",
+        token,
+        "--empty-shutdown-delay-seconds",
+        "60",
+        "--detached-session-shutdown-delay-seconds",
+        "60",
+    ]);
+    let child = command.spawn().expect("failed to spawn alera runtime-host");
+    let guard = HostGuard(child);
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        if let Some((port, _)) = read_control(control_path) {
+            return (guard, port);
+        }
+        assert!(Instant::now() < deadline, "control file was never written");
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+fn send(writer: &mut TcpStream, message: Value) {
+    let mut line = serde_json::to_vec(&message).unwrap();
+    line.push(b'\n');
+    writer.write_all(&line).unwrap();
+    writer.flush().unwrap();
+}
+
+fn read_message(reader: &mut BufReader<TcpStream>) -> Value {
+    let mut line = String::new();
+    let read = reader
+        .read_line(&mut line)
+        .expect("timed out or failed reading from host");
+    assert!(read > 0, "host closed the connection unexpectedly");
+    serde_json::from_str(line.trim_end()).expect("host sent invalid JSON")
+}
+
+fn read_response(reader: &mut BufReader<TcpStream>, id: i64) -> Value {
+    loop {
+        let message = read_message(reader);
+        if message.get("id") == Some(&json!(id)) {
+            return message;
+        }
+    }
+}
+
+fn connect(port: u16) -> (TcpStream, BufReader<TcpStream>) {
+    let stream = TcpStream::connect(("127.0.0.1", port)).unwrap();
+    stream
+        .set_read_timeout(Some(Duration::from_secs(15)))
+        .unwrap();
+    let writer = stream.try_clone().unwrap();
+    (writer, BufReader::new(stream))
+}
+
+fn handshake(writer: &mut TcpStream, reader: &mut BufReader<TcpStream>, token: &str) {
+    send(
+        writer,
+        json!({"id": 0, "type": "hello", "payload": {"protocolVersion": PROTOCOL_VERSION, "token": token}}),
+    );
+    let hello = read_response(reader, 0);
+    assert_eq!(hello["ok"], json!(true), "handshake rejected: {hello}");
+}
+
+fn request(
+    writer: &mut TcpStream,
+    reader: &mut BufReader<TcpStream>,
+    id: i64,
+    request_type: &str,
+    payload: Value,
+) -> Value {
+    send(
+        writer,
+        json!({"id": id, "type": request_type, "payload": payload}),
+    );
+    read_response(reader, id)
+}
+
+fn expect_ok(response: Value) -> Value {
+    assert_eq!(response["ok"], json!(true), "request failed: {response}");
+    response["payload"].clone()
+}
+
+struct Host {
+    _dir: tempfile::TempDir,
+    _guard: HostGuard,
+    port: u16,
+    token: String,
+}
+
+fn start_host() -> Host {
+    let dir = tempfile::tempdir().unwrap();
+    let control_path = dir.path().join("runtime-host.json");
+    let token = "orchestration-test-token".to_string();
+    let (guard, port) = spawn_host(dir.path(), &control_path, &token);
+    Host {
+        _dir: dir,
+        _guard: guard,
+        port,
+        token,
+    }
+}
+
+#[test]
+fn send_check_reply_roundtrip() {
+    let host = start_host();
+    let (mut writer, mut reader) = connect(host.port);
+    handshake(&mut writer, &mut reader, &host.token);
+
+    let sent = expect_ok(request(
+        &mut writer,
+        &mut reader,
+        1,
+        "orchestration.send",
+        json!({"from": "a", "to": "b", "subject": "hi", "body": "hello there"}),
+    ));
+    assert_eq!(sent["recipients"], json!(["b"]));
+    let message_id = sent["messages"][0]["id"].as_str().unwrap().to_string();
+
+    // First check consumes the unread message.
+    let checked = expect_ok(request(
+        &mut writer,
+        &mut reader,
+        2,
+        "orchestration.check",
+        json!({"terminal": "b", "inject": true}),
+    ));
+    assert_eq!(checked["messages"][0]["id"], json!(message_id));
+    let formatted = checked["formatted"].as_str().unwrap();
+    assert!(formatted.contains("--- Orchestration Messages (1) ---"));
+    assert!(formatted.contains("alera orchestration reply --id"));
+
+    // Second check is empty (read/delivered independence handled in unit tests).
+    let empty = expect_ok(request(
+        &mut writer,
+        &mut reader,
+        3,
+        "orchestration.check",
+        json!({"terminal": "b"}),
+    ));
+    assert_eq!(empty["messages"], json!([]));
+
+    // Reply flows back to the original sender with the thread inherited.
+    let reply = expect_ok(request(
+        &mut writer,
+        &mut reader,
+        4,
+        "orchestration.reply",
+        json!({"id": message_id, "body": "ack"}),
+    ));
+    assert_eq!(reply["to_handle"], json!("a"));
+    assert_eq!(reply["thread_id"], json!(message_id));
+    let back = expect_ok(request(
+        &mut writer,
+        &mut reader,
+        5,
+        "orchestration.check",
+        json!({"terminal": "a"}),
+    ));
+    assert_eq!(back["messages"][0]["subject"], json!("Re: hi"));
+}
+
+#[test]
+fn check_wait_wakes_on_matching_type_only() {
+    let host = start_host();
+    let (mut coordinator_writer, mut coordinator_reader) = connect(host.port);
+    handshake(
+        &mut coordinator_writer,
+        &mut coordinator_reader,
+        &host.token,
+    );
+    let (mut sender_writer, mut sender_reader) = connect(host.port);
+    handshake(&mut sender_writer, &mut sender_reader, &host.token);
+
+    // Park a waiter filtered to worker_done.
+    send(
+        &mut coordinator_writer,
+        json!({"id": 10, "type": "orchestration.check", "payload": {
+            "terminal": "coord", "wait": true, "types": ["worker_done"], "timeoutMs": 10_000
+        }}),
+    );
+    std::thread::sleep(Duration::from_millis(300));
+
+    // A status message must NOT wake the worker_done waiter.
+    expect_ok(request(
+        &mut sender_writer,
+        &mut sender_reader,
+        11,
+        "orchestration.send",
+        json!({"from": "w", "to": "coord", "subject": "noise", "type": "status"}),
+    ));
+    std::thread::sleep(Duration::from_millis(300));
+
+    // The worker_done wakes it. Task/dispatch ids are bogus, so lifecycle
+    // reconciliation ignores it, but delivery to the waiter still happens.
+    expect_ok(request(
+        &mut sender_writer,
+        &mut sender_reader,
+        12,
+        "orchestration.send",
+        json!({"from": "w", "to": "coord", "subject": "done", "type": "worker_done",
+               "payload": "{\"taskId\":\"t\",\"dispatchId\":\"d\"}"}),
+    ));
+    let woken = read_response(&mut coordinator_reader, 10);
+    assert_eq!(woken["ok"], json!(true));
+    let messages = woken["payload"]["messages"].as_array().unwrap();
+    assert_eq!(messages.len(), 1);
+    assert_eq!(messages[0]["type"], json!("worker_done"));
+}
+
+#[test]
+fn check_wait_times_out_cleanly() {
+    let host = start_host();
+    let (mut writer, mut reader) = connect(host.port);
+    handshake(&mut writer, &mut reader, &host.token);
+    let timed_out = expect_ok(request(
+        &mut writer,
+        &mut reader,
+        20,
+        "orchestration.check",
+        json!({"terminal": "nobody", "wait": true, "timeoutMs": 700}),
+    ));
+    assert_eq!(timed_out["timedOut"], json!(true));
+    assert_eq!(timed_out["messages"], json!([]));
+}
+
+#[test]
+fn ask_blocks_until_reply() {
+    let host = start_host();
+    let (mut worker_writer, mut worker_reader) = connect(host.port);
+    handshake(&mut worker_writer, &mut worker_reader, &host.token);
+    let (mut coordinator_writer, mut coordinator_reader) = connect(host.port);
+    handshake(
+        &mut coordinator_writer,
+        &mut coordinator_reader,
+        &host.token,
+    );
+
+    send(
+        &mut worker_writer,
+        json!({"id": 30, "type": "orchestration.ask", "payload": {
+            "from": "worker", "to": "coord", "question": "Which db?",
+            "options": "sqlite,postgres", "timeoutMs": 10_000
+        }}),
+    );
+    std::thread::sleep(Duration::from_millis(300));
+
+    let inbox = expect_ok(request(
+        &mut coordinator_writer,
+        &mut coordinator_reader,
+        31,
+        "orchestration.check",
+        json!({"terminal": "coord", "types": ["decision_gate"]}),
+    ));
+    let question_id = inbox["messages"][0]["id"].as_str().unwrap().to_string();
+    expect_ok(request(
+        &mut coordinator_writer,
+        &mut coordinator_reader,
+        32,
+        "orchestration.reply",
+        json!({"id": question_id, "body": "sqlite"}),
+    ));
+
+    let answered = read_response(&mut worker_reader, 30);
+    assert_eq!(answered["ok"], json!(true));
+    assert_eq!(answered["payload"]["answered"], json!(true));
+    assert_eq!(answered["payload"]["reply"]["body"], json!("sqlite"));
+}
+
+#[test]
+fn task_dag_dispatch_and_worker_done() {
+    let host = start_host();
+    let (mut writer, mut reader) = connect(host.port);
+    handshake(&mut writer, &mut reader, &host.token);
+
+    let task_a = expect_ok(request(
+        &mut writer,
+        &mut reader,
+        40,
+        "orchestration.taskCreate",
+        json!({"spec": "implement A"}),
+    ));
+    let a_id = task_a["id"].as_str().unwrap().to_string();
+    assert_eq!(task_a["status"], json!("ready"));
+    let task_b = expect_ok(request(
+        &mut writer,
+        &mut reader,
+        41,
+        "orchestration.taskCreate",
+        json!({"spec": "test A", "deps": [a_id]}),
+    ));
+    assert_eq!(task_b["status"], json!("pending"));
+    let b_id = task_b["id"].as_str().unwrap().to_string();
+
+    // Dry-run builds a preamble without mutating anything.
+    let dry = expect_ok(request(
+        &mut writer,
+        &mut reader,
+        42,
+        "orchestration.dispatch",
+        json!({"task": a_id, "to": "w1", "from": "coord", "dryRun": true}),
+    ));
+    assert!(dry["preamble"]
+        .as_str()
+        .unwrap()
+        .contains("NEVER use AskUserQuestion"));
+
+    let dispatched = expect_ok(request(
+        &mut writer,
+        &mut reader,
+        43,
+        "orchestration.dispatch",
+        json!({"task": a_id, "to": "w1", "from": "coord"}),
+    ));
+    let dispatch_id = dispatched["dispatch"]["id"].as_str().unwrap().to_string();
+    assert!(dispatched["preamble"]
+        .as_str()
+        .unwrap()
+        .contains(&dispatch_id));
+
+    // worker_done from the assignee with matching ids completes A and
+    // promotes B in one send.
+    expect_ok(request(
+        &mut writer,
+        &mut reader,
+        44,
+        "orchestration.send",
+        json!({"from": "w1", "to": "coord", "subject": "done", "type": "worker_done",
+               "payload": format!("{{\"taskId\":\"{a_id}\",\"dispatchId\":\"{dispatch_id}\"}}")}),
+    ));
+    let tasks = expect_ok(request(
+        &mut writer,
+        &mut reader,
+        45,
+        "orchestration.taskList",
+        json!({}),
+    ));
+    let by_id: std::collections::HashMap<&str, &str> = tasks["tasks"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|task| {
+            (
+                task["id"].as_str().unwrap(),
+                task["status"].as_str().unwrap(),
+            )
+        })
+        .collect();
+    assert_eq!(by_id[a_id.as_str()], "completed");
+    assert_eq!(by_id[b_id.as_str()], "ready");
+}
+
+#[test]
+fn gate_blocks_and_resolution_feeds_next_preamble() {
+    let host = start_host();
+    let (mut writer, mut reader) = connect(host.port);
+    handshake(&mut writer, &mut reader, &host.token);
+
+    let task = expect_ok(request(
+        &mut writer,
+        &mut reader,
+        50,
+        "orchestration.taskCreate",
+        json!({"spec": "risky change"}),
+    ));
+    let task_id = task["id"].as_str().unwrap().to_string();
+    let gate = expect_ok(request(
+        &mut writer,
+        &mut reader,
+        51,
+        "orchestration.gateCreate",
+        json!({"task": task_id, "question": "Proceed?", "options": ["yes", "no"]}),
+    ));
+    let gate_id = gate["id"].as_str().unwrap().to_string();
+
+    let blocked = expect_ok(request(
+        &mut writer,
+        &mut reader,
+        52,
+        "orchestration.taskList",
+        json!({"status": "blocked"}),
+    ));
+    assert_eq!(blocked["tasks"][0]["id"], json!(task_id));
+
+    expect_ok(request(
+        &mut writer,
+        &mut reader,
+        53,
+        "orchestration.gateResolve",
+        json!({"id": gate_id, "resolution": "yes, carefully"}),
+    ));
+    let dispatched = expect_ok(request(
+        &mut writer,
+        &mut reader,
+        54,
+        "orchestration.dispatch",
+        json!({"task": task_id, "to": "w1", "from": "coord", "returnPreamble": true}),
+    ));
+    let preamble = dispatched["preamble"].as_str().unwrap();
+    assert!(preamble.contains("DECISION GATE RESOLVED"));
+    assert!(preamble.contains("yes, carefully"));
+}
+
+#[test]
+#[cfg(unix)]
+fn push_on_idle_delivers_into_live_pty() {
+    let host = start_host();
+    let (mut writer, mut reader) = connect(host.port);
+    handshake(&mut writer, &mut reader, &host.token);
+
+    // A real PTY running `cat`: everything written to it is echoed to output.
+    let session_id = "orchestration-pty-1";
+    let created = expect_ok(request(
+        &mut writer,
+        &mut reader,
+        60,
+        "createOrAttach",
+        json!({
+            "sessionId": session_id,
+            "workspaceId": "ws-1",
+            "tabId": "tab-1",
+            "workingDirectory": "/tmp",
+            "launch": {
+                "shell": "/bin/cat",
+                "arguments": [],
+                "environment": {"PATH": "/usr/bin:/bin", "TERM": "xterm"}
+            },
+            "cols": 120,
+            "rows": 40
+        }),
+    ));
+    assert_eq!(created["running"], json!(true));
+
+    // Queue a message while the agent is busy: no delivery yet.
+    expect_ok(request(
+        &mut writer,
+        &mut reader,
+        61,
+        "orchestration.agentStatus",
+        json!({"entries": [{"terminalSessionId": session_id, "agentType": "claude", "state": "working"}]}),
+    ));
+    expect_ok(request(
+        &mut writer,
+        &mut reader,
+        62,
+        "orchestration.send",
+        json!({"from": "coord", "to": session_id, "subject": "next step", "body": "run the tests"}),
+    ));
+
+    // The transition to done flushes the queue into the PTY.
+    expect_ok(request(
+        &mut writer,
+        &mut reader,
+        63,
+        "orchestration.agentStatus",
+        json!({"entries": [{"terminalSessionId": session_id, "agentType": "claude", "state": "done"}]}),
+    ));
+
+    // Collect PTY output events until the banner (echoed by cat) appears.
+    let deadline = Instant::now() + Duration::from_secs(10);
+    let mut output = String::new();
+    while Instant::now() < deadline {
+        let message = read_message(&mut reader);
+        if message.get("event") == Some(&json!("output"))
+            && message["payload"]["sessionId"] == json!(session_id)
+        {
+            let bytes = STANDARD
+                .decode(message["payload"]["dataBase64"].as_str().unwrap())
+                .unwrap();
+            output.push_str(&String::from_utf8_lossy(&bytes));
+            if output.contains("Orchestration Messages (1)") && output.contains("next step") {
+                break;
+            }
+        }
+    }
+    assert!(
+        output.contains("Orchestration Messages (1)"),
+        "banner never reached the PTY; captured: {output}"
+    );
+    assert!(output.contains("Subject: next step"));
+
+    // After the deferred Enter, the message is stamped delivered: a second
+    // done transition must not redeliver it.
+    std::thread::sleep(Duration::from_millis(900));
+    expect_ok(request(
+        &mut writer,
+        &mut reader,
+        64,
+        "orchestration.agentStatus",
+        json!({"entries": [{"terminalSessionId": session_id, "agentType": "claude", "state": "working"}]}),
+    ));
+    expect_ok(request(
+        &mut writer,
+        &mut reader,
+        65,
+        "orchestration.agentStatus",
+        json!({"entries": [{"terminalSessionId": session_id, "agentType": "claude", "state": "done"}]}),
+    ));
+    // Drain events briefly; a redelivered banner would echo again.
+    let quiet_deadline = Instant::now() + Duration::from_secs(2);
+    let mut redelivered = String::new();
+    reader
+        .get_mut()
+        .set_read_timeout(Some(Duration::from_millis(300)))
+        .unwrap();
+    while Instant::now() < quiet_deadline {
+        let mut line = String::new();
+        match reader.read_line(&mut line) {
+            Ok(0) => break,
+            Ok(_) => {
+                let message: Value = serde_json::from_str(line.trim_end()).unwrap();
+                if message.get("event") == Some(&json!("output")) {
+                    let bytes = STANDARD
+                        .decode(message["payload"]["dataBase64"].as_str().unwrap())
+                        .unwrap();
+                    redelivered.push_str(&String::from_utf8_lossy(&bytes));
+                }
+            }
+            Err(_) => break,
+        }
+    }
+    assert!(
+        !redelivered.contains("Orchestration Messages"),
+        "message was redelivered after being marked delivered: {redelivered}"
+    );
+}
+
+#[test]
+fn lifecycle_to_group_and_unknown_recipients_are_rejected() {
+    let host = start_host();
+    let (mut writer, mut reader) = connect(host.port);
+    handshake(&mut writer, &mut reader, &host.token);
+
+    let group_lifecycle = request(
+        &mut writer,
+        &mut reader,
+        70,
+        "orchestration.send",
+        json!({"from": "a", "to": "@all", "subject": "x", "type": "worker_done"}),
+    );
+    assert_eq!(group_lifecycle["ok"], json!(false));
+
+    let no_recipients = request(
+        &mut writer,
+        &mut reader,
+        71,
+        "orchestration.send",
+        json!({"from": "a", "to": "@all", "subject": "x"}),
+    );
+    assert_eq!(no_recipients["ok"], json!(false));
+}

--- a/rust/alera-cli/tests/orchestration_review_regressions.rs
+++ b/rust/alera-cli/tests/orchestration_review_regressions.rs
@@ -1,0 +1,2018 @@
+use std::io::{BufRead, BufReader, Write};
+use std::net::TcpStream;
+use std::path::Path;
+use std::process::{Child, Command};
+use std::time::{Duration, Instant};
+
+use base64::engine::general_purpose::STANDARD;
+use base64::Engine as _;
+use serde_json::{json, Value};
+
+const PROTOCOL_VERSION: i64 = 3;
+
+struct HostGuard(Child);
+
+impl Drop for HostGuard {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+struct Host {
+    _dir: tempfile::TempDir,
+    _guard: HostGuard,
+    port: u16,
+    token: String,
+}
+
+fn read_control(path: &std::path::Path) -> Option<(u16, String)> {
+    let contents = std::fs::read_to_string(path).ok()?;
+    let value: Value = serde_json::from_str(&contents).ok()?;
+    let port = value.get("port")?.as_u64()? as u16;
+    let token = value.get("token")?.as_str()?.to_string();
+    Some((port, token))
+}
+
+fn start_host() -> Host {
+    let dir = tempfile::tempdir().unwrap();
+    let control_path = dir.path().join("runtime-host.json");
+    let token = "orchestration-review-test-token".to_string();
+    let mut command = Command::new(env!("CARGO_BIN_EXE_alera"));
+    command.args([
+        "runtime-host",
+        "--runtime-dir",
+        dir.path().to_str().unwrap(),
+        "--control-file",
+        control_path.to_str().unwrap(),
+        "--token",
+        &token,
+        "--empty-shutdown-delay-seconds",
+        "60",
+        "--detached-session-shutdown-delay-seconds",
+        "60",
+    ]);
+    let child = command.spawn().expect("failed to spawn alera runtime-host");
+    let guard = HostGuard(child);
+    let deadline = Instant::now() + Duration::from_secs(10);
+    let port = loop {
+        if let Some((port, _)) = read_control(&control_path) {
+            break port;
+        }
+        assert!(Instant::now() < deadline, "control file was never written");
+        std::thread::sleep(Duration::from_millis(50));
+    };
+    Host {
+        _dir: dir,
+        _guard: guard,
+        port,
+        token,
+    }
+}
+
+fn connect(port: u16) -> (TcpStream, BufReader<TcpStream>) {
+    let stream = TcpStream::connect(("127.0.0.1", port)).unwrap();
+    stream
+        .set_read_timeout(Some(Duration::from_secs(15)))
+        .unwrap();
+    let writer = stream.try_clone().unwrap();
+    (writer, BufReader::new(stream))
+}
+
+fn send(writer: &mut TcpStream, message: Value) {
+    let mut line = serde_json::to_vec(&message).unwrap();
+    line.push(b'\n');
+    writer.write_all(&line).unwrap();
+    writer.flush().unwrap();
+}
+
+fn read_message(reader: &mut BufReader<TcpStream>) -> Value {
+    let mut line = String::new();
+    let read = reader
+        .read_line(&mut line)
+        .expect("timed out or failed reading from host");
+    assert!(read > 0, "host closed the connection unexpectedly");
+    serde_json::from_str(line.trim_end()).expect("host sent invalid JSON")
+}
+
+fn read_response(reader: &mut BufReader<TcpStream>, id: i64) -> Value {
+    loop {
+        let message = read_message(reader);
+        if message.get("id") == Some(&json!(id)) {
+            return message;
+        }
+    }
+}
+
+fn handshake(writer: &mut TcpStream, reader: &mut BufReader<TcpStream>, token: &str) {
+    send(
+        writer,
+        json!({"id": 0, "type": "hello", "payload": {"protocolVersion": PROTOCOL_VERSION, "token": token}}),
+    );
+    let hello = read_response(reader, 0);
+    assert_eq!(hello["ok"], json!(true), "handshake rejected: {hello}");
+}
+
+fn handshake_app(writer: &mut TcpStream, reader: &mut BufReader<TcpStream>, token: &str) {
+    send(
+        writer,
+        json!({"id": 0, "type": "hello", "payload": {"protocolVersion": PROTOCOL_VERSION, "token": token, "clientKind": "app"}}),
+    );
+    let hello = read_response(reader, 0);
+    assert_eq!(hello["ok"], json!(true), "handshake rejected: {hello}");
+}
+
+fn seed_workspace(writer: &mut TcpStream, reader: &mut BufReader<TcpStream>, workspace_id: &str) {
+    seed_workspace_with_path(writer, reader, workspace_id, Path::new("/tmp"));
+}
+
+fn seed_workspace_with_path(
+    writer: &mut TcpStream,
+    reader: &mut BufReader<TcpStream>,
+    workspace_id: &str,
+    workspace_path: &Path,
+) {
+    expect_ok(request(
+        writer,
+        reader,
+        9_000,
+        "workspace.upsert",
+        json!({
+            "id": workspace_id,
+            "instanceId": format!("{workspace_id}-instance"),
+            "hostId": "local",
+            "projectId": "project-1",
+            "name": "Workspace",
+            "branch": null,
+            "path": workspace_path.to_string_lossy().to_string(),
+            "createdAt": "2026-07-06T00:00:00.000Z",
+            "updatedAt": "2026-07-06T00:00:00.000Z",
+            "kind": "main",
+            "status": "active",
+            "sourceBranch": null,
+            "reusesExistingBranch": false,
+            "tagIds": [],
+            "tagNames": [],
+            "parentWorkspaceId": null,
+            "childCount": 0
+        }),
+    ));
+}
+
+#[cfg(unix)]
+fn worktree_behind_upstream(behind: usize) -> tempfile::TempDir {
+    let dir = tempfile::tempdir().unwrap();
+    let mut options = git2::RepositoryInitOptions::new();
+    options.initial_head("main");
+    let repo = git2::Repository::init_opts(dir.path(), &options).unwrap();
+    repo.remote("origin", dir.path().to_str().unwrap()).unwrap();
+
+    let base = commit_fixture_file(&repo, Some("HEAD"), None, "base\n", "base");
+    let mut parent = base;
+    for index in 0..behind {
+        parent = commit_fixture_file(
+            &repo,
+            None,
+            Some(parent),
+            &format!("upstream {index}\n"),
+            &format!("upstream {index}"),
+        );
+    }
+
+    repo.reference("refs/remotes/origin/main", parent, true, "seed upstream")
+        .unwrap();
+    let mut config = repo.config().unwrap();
+    config.set_str("branch.main.remote", "origin").unwrap();
+    config
+        .set_str("branch.main.merge", "refs/heads/main")
+        .unwrap();
+    drop(config);
+    drop(repo);
+    dir
+}
+
+#[cfg(unix)]
+fn commit_fixture_file(
+    repo: &git2::Repository,
+    update_ref: Option<&str>,
+    parent: Option<git2::Oid>,
+    contents: &str,
+    message: &str,
+) -> git2::Oid {
+    std::fs::write(repo.workdir().unwrap().join("drift.txt"), contents).unwrap();
+    let mut index = repo.index().unwrap();
+    index.add_path(Path::new("drift.txt")).unwrap();
+    index.write().unwrap();
+    let tree_id = index.write_tree().unwrap();
+    let tree = repo.find_tree(tree_id).unwrap();
+    let signature = git2::Signature::now("Alera Test", "alera@example.com").unwrap();
+    let parent_commit = parent.map(|oid| repo.find_commit(oid).unwrap());
+    let parents = parent_commit.iter().collect::<Vec<_>>();
+    repo.commit(update_ref, &signature, &signature, message, &tree, &parents)
+        .unwrap()
+}
+
+fn request(
+    writer: &mut TcpStream,
+    reader: &mut BufReader<TcpStream>,
+    id: i64,
+    request_type: &str,
+    payload: Value,
+) -> Value {
+    send(
+        writer,
+        json!({"id": id, "type": request_type, "payload": payload}),
+    );
+    read_response(reader, id)
+}
+
+fn expect_ok(response: Value) -> Value {
+    assert_eq!(response["ok"], json!(true), "request failed: {response}");
+    response["payload"].clone()
+}
+
+fn collect_output(
+    reader: &mut BufReader<TcpStream>,
+    session_id: &str,
+    duration: Duration,
+) -> String {
+    let deadline = Instant::now() + duration;
+    let mut output = String::new();
+    reader
+        .get_mut()
+        .set_read_timeout(Some(Duration::from_millis(300)))
+        .unwrap();
+    while Instant::now() < deadline {
+        let mut line = String::new();
+        match reader.read_line(&mut line) {
+            Ok(0) => break,
+            Ok(_) => {
+                let message: Value = serde_json::from_str(line.trim_end()).unwrap();
+                if message.get("event") == Some(&json!("output"))
+                    && message["payload"]["sessionId"] == json!(session_id)
+                {
+                    let bytes = STANDARD
+                        .decode(message["payload"]["dataBase64"].as_str().unwrap())
+                        .unwrap();
+                    output.push_str(&String::from_utf8_lossy(&bytes));
+                }
+            }
+            Err(_) => {}
+        }
+    }
+    reader
+        .get_mut()
+        .set_read_timeout(Some(Duration::from_secs(15)))
+        .unwrap();
+    output
+}
+
+#[cfg(unix)]
+fn attach_shell_session(
+    writer: &mut TcpStream,
+    reader: &mut BufReader<TcpStream>,
+    id: i64,
+    session_id: &str,
+    workspace_id: &str,
+    tab_id: &str,
+    arguments: &[&str],
+) {
+    expect_ok(request(
+        writer,
+        reader,
+        id,
+        "createOrAttach",
+        json!({
+            "sessionId": session_id,
+            "workspaceId": workspace_id,
+            "tabId": tab_id,
+            "workingDirectory": "/tmp",
+            "launch": {
+                "shell": "/bin/sh",
+                "arguments": arguments,
+                "environment": {"PATH": "/usr/bin:/bin", "TERM": "xterm"}
+            },
+            "cols": 120,
+            "rows": 40
+        }),
+    ));
+}
+
+fn occurrences(haystack: &str, needle: &str) -> usize {
+    haystack.match_indices(needle).count()
+}
+
+#[test]
+fn waited_check_with_inject_returns_formatted_banner() {
+    let host = start_host();
+    let (mut waiter_writer, mut waiter_reader) = connect(host.port);
+    handshake(&mut waiter_writer, &mut waiter_reader, &host.token);
+    let (mut sender_writer, mut sender_reader) = connect(host.port);
+    handshake(&mut sender_writer, &mut sender_reader, &host.token);
+
+    send(
+        &mut waiter_writer,
+        json!({"id": 10, "type": "orchestration.check", "payload": {
+            "terminal": "worker", "wait": true, "inject": true, "timeoutMs": 5000
+        }}),
+    );
+    std::thread::sleep(Duration::from_millis(200));
+    expect_ok(request(
+        &mut sender_writer,
+        &mut sender_reader,
+        11,
+        "orchestration.send",
+        json!({"from": "coord", "to": "worker", "subject": "hello", "body": "body"}),
+    ));
+
+    let response = read_response(&mut waiter_reader, 10);
+    assert_eq!(response["ok"], json!(true));
+    let formatted = response["payload"]["formatted"].as_str().unwrap();
+    assert!(formatted.contains("Orchestration Messages (1)"));
+    assert!(formatted.contains("Subject: hello"));
+}
+
+#[test]
+fn ask_timeout_survives_unrelated_message_wake() {
+    let host = start_host();
+    let (mut worker_writer, mut worker_reader) = connect(host.port);
+    handshake(&mut worker_writer, &mut worker_reader, &host.token);
+    let (mut coordinator_writer, mut coordinator_reader) = connect(host.port);
+    handshake(
+        &mut coordinator_writer,
+        &mut coordinator_reader,
+        &host.token,
+    );
+
+    send(
+        &mut worker_writer,
+        json!({"id": 20, "type": "orchestration.ask", "payload": {
+            "from": "worker", "to": "coord", "question": "Which path?", "timeoutMs": 700
+        }}),
+    );
+    std::thread::sleep(Duration::from_millis(200));
+    expect_ok(request(
+        &mut coordinator_writer,
+        &mut coordinator_reader,
+        21,
+        "orchestration.send",
+        json!({"from": "coord", "to": "worker", "subject": "unrelated", "body": "noise"}),
+    ));
+
+    let response = read_response(&mut worker_reader, 20);
+    assert_eq!(response["ok"], json!(true));
+    assert_eq!(response["payload"]["answered"], json!(false));
+    assert_eq!(response["payload"]["timedOut"], json!(true));
+}
+
+#[test]
+#[cfg(unix)]
+fn push_on_idle_does_not_duplicate_in_flight_batches() {
+    let host = start_host();
+    let (mut writer, mut reader) = connect(host.port);
+    handshake(&mut writer, &mut reader, &host.token);
+    let session_id = "orchestration-review-pty";
+
+    expect_ok(request(
+        &mut writer,
+        &mut reader,
+        30,
+        "createOrAttach",
+        json!({
+            "sessionId": session_id,
+            "workspaceId": "ws-1",
+            "tabId": "tab-1",
+            "workingDirectory": "/tmp",
+            "launch": {
+                "shell": "/bin/sh",
+                "arguments": ["-lc", "stty -echo; cat"],
+                "environment": {"PATH": "/usr/bin:/bin", "TERM": "xterm"}
+            },
+            "cols": 120,
+            "rows": 40
+        }),
+    ));
+    std::thread::sleep(Duration::from_millis(700));
+    let _ = collect_output(&mut reader, session_id, Duration::from_millis(400));
+    expect_ok(request(
+        &mut writer,
+        &mut reader,
+        31,
+        "orchestration.agentStatus",
+        json!({"entries": [{"terminalSessionId": session_id, "agentType": "claude", "state": "done"}]}),
+    ));
+    expect_ok(request(
+        &mut writer,
+        &mut reader,
+        32,
+        "orchestration.send",
+        json!({"from": "coord", "to": session_id, "subject": "first", "body": "one"}),
+    ));
+    expect_ok(request(
+        &mut writer,
+        &mut reader,
+        33,
+        "orchestration.send",
+        json!({"from": "coord", "to": session_id, "subject": "second", "body": "two"}),
+    ));
+
+    let output = collect_output(&mut reader, session_id, Duration::from_secs(4));
+    assert_eq!(occurrences(&output, "Subject: first"), 1, "{output}");
+    assert_eq!(occurrences(&output, "Subject: second"), 1, "{output}");
+}
+
+#[test]
+#[cfg(unix)]
+fn waiting_status_does_not_push_into_approval_prompt() {
+    let host = start_host();
+    let (mut writer, mut reader) = connect(host.port);
+    handshake(&mut writer, &mut reader, &host.token);
+    let session_id = "waiting-approval-session";
+
+    attach_shell_session(
+        &mut writer,
+        &mut reader,
+        331,
+        session_id,
+        "ws-1",
+        "tab-1",
+        &["-lc", "stty -echo; cat"],
+    );
+    std::thread::sleep(Duration::from_millis(700));
+    let _ = collect_output(&mut reader, session_id, Duration::from_millis(400));
+    expect_ok(request(
+        &mut writer,
+        &mut reader,
+        332,
+        "orchestration.send",
+        json!({"from": "coord", "to": session_id, "subject": "approval-safe", "body": "do not inject yet"}),
+    ));
+    expect_ok(request(
+        &mut writer,
+        &mut reader,
+        333,
+        "orchestration.agentStatus",
+        json!({"entries": [{"terminalSessionId": session_id, "agentType": "claude", "state": "waiting"}]}),
+    ));
+
+    let waiting_output = collect_output(&mut reader, session_id, Duration::from_millis(900));
+    assert!(
+        !waiting_output.contains("approval-safe"),
+        "waiting approval prompt received injected banner: {waiting_output}"
+    );
+
+    expect_ok(request(
+        &mut writer,
+        &mut reader,
+        334,
+        "orchestration.agentStatus",
+        json!({"entries": [{"terminalSessionId": session_id, "agentType": "claude", "state": "done"}]}),
+    ));
+    let done_output = collect_output(&mut reader, session_id, Duration::from_secs(3));
+    assert!(
+        done_output.contains("Subject: approval-safe"),
+        "done transition did not receive queued banner: {done_output}"
+    );
+}
+
+#[test]
+#[cfg(unix)]
+fn deferred_delivery_requeues_when_session_instance_is_replaced() {
+    let host = start_host();
+    let (mut writer, mut reader) = connect(host.port);
+    handshake(&mut writer, &mut reader, &host.token);
+    let session_id = "replaced-delivery-session";
+
+    attach_shell_session(
+        &mut writer,
+        &mut reader,
+        34,
+        session_id,
+        "ws-1",
+        "tab-old",
+        &["-lc", "stty -echo; sleep 10"],
+    );
+    expect_ok(request(
+        &mut writer,
+        &mut reader,
+        35,
+        "orchestration.agentStatus",
+        json!({"entries": [{"terminalSessionId": session_id, "agentType": "claude", "state": "done"}]}),
+    ));
+    expect_ok(request(
+        &mut writer,
+        &mut reader,
+        36,
+        "orchestration.send",
+        json!({"from": "coord", "to": session_id, "subject": "replacement delivery", "body": "redeliver me"}),
+    ));
+
+    std::thread::sleep(Duration::from_millis(100));
+    expect_ok(request(
+        &mut writer,
+        &mut reader,
+        37,
+        "terminate",
+        json!({"sessionId": session_id}),
+    ));
+    attach_shell_session(
+        &mut writer,
+        &mut reader,
+        38,
+        session_id,
+        "ws-1",
+        "tab-new",
+        &["-lc", "stty -echo; cat"],
+    );
+    expect_ok(request(
+        &mut writer,
+        &mut reader,
+        39,
+        "orchestration.agentStatus",
+        json!({"entries": [{"terminalSessionId": session_id, "agentType": "claude", "state": "done"}]}),
+    ));
+
+    let output = collect_output(&mut reader, session_id, Duration::from_secs(3));
+    assert!(
+        output.contains("Subject: replacement delivery"),
+        "replacement session did not receive the queued banner: {output}"
+    );
+}
+
+#[test]
+fn check_all_applies_type_filter() {
+    let host = start_host();
+    let (mut writer, mut reader) = connect(host.port);
+    handshake(&mut writer, &mut reader, &host.token);
+
+    expect_ok(request(
+        &mut writer,
+        &mut reader,
+        40,
+        "orchestration.send",
+        json!({"from": "worker", "to": "coord", "subject": "status", "body": "noise"}),
+    ));
+    expect_ok(request(
+        &mut writer,
+        &mut reader,
+        41,
+        "orchestration.send",
+        json!({"from": "worker", "to": "coord", "type": "worker_done", "subject": "done", "body": "complete"}),
+    ));
+
+    let payload = expect_ok(request(
+        &mut writer,
+        &mut reader,
+        42,
+        "orchestration.check",
+        json!({"terminal": "coord", "all": true, "types": ["worker_done"]}),
+    ));
+    let messages = payload["messages"].as_array().unwrap();
+    assert_eq!(messages.len(), 1, "{payload}");
+    assert_eq!(messages[0]["type"], json!("worker_done"));
+    assert_eq!(messages[0]["subject"], json!("done"));
+}
+
+#[test]
+#[cfg(unix)]
+fn broadcast_group_sends_get_distinct_default_threads() {
+    let host = start_host();
+    let (mut writer, mut reader) = connect(host.port);
+    handshake(&mut writer, &mut reader, &host.token);
+
+    for (id, handle) in [(431, "worker-a"), (432, "worker-b")] {
+        attach_shell_session(
+            &mut writer,
+            &mut reader,
+            id,
+            handle,
+            "ws-1",
+            handle,
+            &["-lc", "stty -echo; cat"],
+        );
+    }
+
+    expect_ok(request(
+        &mut writer,
+        &mut reader,
+        43,
+        "orchestration.send",
+        json!({"from": "coord", "to": "@all", "subject": "first", "body": "one"}),
+    ));
+    expect_ok(request(
+        &mut writer,
+        &mut reader,
+        44,
+        "orchestration.send",
+        json!({"from": "coord", "to": "@all", "subject": "second", "body": "two"}),
+    ));
+
+    let payload = expect_ok(request(
+        &mut writer,
+        &mut reader,
+        45,
+        "orchestration.check",
+        json!({"terminal": "worker-a", "all": true}),
+    ));
+    let messages = payload["messages"].as_array().unwrap();
+    assert_eq!(messages.len(), 2, "{payload}");
+    let first_thread = messages[0]["thread_id"].as_str().unwrap();
+    let second_thread = messages[1]["thread_id"].as_str().unwrap();
+    assert_ne!(first_thread, second_thread, "{payload}");
+}
+
+#[test]
+fn coordinator_run_requires_from_handle() {
+    let host = start_host();
+    let (mut writer, mut reader) = connect(host.port);
+    handshake(&mut writer, &mut reader, &host.token);
+
+    let response = request(
+        &mut writer,
+        &mut reader,
+        40,
+        "orchestration.run",
+        json!({"spec": "coordinate"}),
+    );
+    assert_eq!(response["ok"], json!(false));
+    assert!(response["error"]
+        .as_str()
+        .unwrap()
+        .contains("from is required"));
+}
+
+#[test]
+fn stale_escalations_do_not_fail_current_dispatch() {
+    let host = start_host();
+    let (mut writer, mut reader) = connect(host.port);
+    handshake(&mut writer, &mut reader, &host.token);
+
+    let task = expect_ok(request(
+        &mut writer,
+        &mut reader,
+        50,
+        "orchestration.taskCreate",
+        json!({"spec": "do work"}),
+    ));
+    let task_id = task["id"].as_str().unwrap().to_string();
+    let first = expect_ok(request(
+        &mut writer,
+        &mut reader,
+        51,
+        "orchestration.dispatch",
+        json!({"task": &task_id, "to": "worker", "from": "coord"}),
+    ));
+    let first_dispatch = first["dispatch"]["id"].as_str().unwrap().to_string();
+    expect_ok(request(
+        &mut writer,
+        &mut reader,
+        52,
+        "orchestration.send",
+        json!({
+            "from": "worker",
+            "to": "coord",
+            "type": "worker_done",
+            "subject": "Failed: first attempt",
+            "body": "failed",
+            "payload": json!({"taskId": &task_id, "dispatchId": &first_dispatch}).to_string()
+        }),
+    ));
+    let second = expect_ok(request(
+        &mut writer,
+        &mut reader,
+        53,
+        "orchestration.dispatch",
+        json!({"task": &task_id, "to": "worker", "from": "coord"}),
+    ));
+    let second_dispatch = second["dispatch"]["id"].as_str().unwrap().to_string();
+    expect_ok(request(
+        &mut writer,
+        &mut reader,
+        54,
+        "orchestration.run",
+        json!({"from": "coord", "spec": "coordinate", "pollIntervalMs": 100}),
+    ));
+
+    expect_ok(request(
+        &mut writer,
+        &mut reader,
+        55,
+        "orchestration.send",
+        json!({
+            "from": "intruder",
+            "to": "coord",
+            "type": "escalation",
+            "subject": "Blocked: wrong terminal",
+            "payload": json!({"taskId": &task_id}).to_string()
+        }),
+    ));
+    expect_ok(request(
+        &mut writer,
+        &mut reader,
+        56,
+        "orchestration.send",
+        json!({
+            "from": "worker",
+            "to": "coord",
+            "type": "escalation",
+            "subject": "Blocked: missing dispatch",
+            "payload": json!({"taskId": &task_id}).to_string()
+        }),
+    ));
+    expect_ok(request(
+        &mut writer,
+        &mut reader,
+        57,
+        "orchestration.send",
+        json!({
+            "from": "worker",
+            "to": "coord",
+            "type": "escalation",
+            "subject": "Blocked: stale retry",
+            "payload": json!({"taskId": &task_id, "dispatchId": &first_dispatch}).to_string()
+        }),
+    ));
+
+    std::thread::sleep(Duration::from_millis(700));
+    let show = expect_ok(request(
+        &mut writer,
+        &mut reader,
+        58,
+        "orchestration.dispatchShow",
+        json!({"task": &task_id}),
+    ));
+    assert_eq!(show["active"]["id"], json!(second_dispatch));
+    assert_eq!(show["active"]["status"], json!("dispatched"));
+
+    expect_ok(request(
+        &mut writer,
+        &mut reader,
+        59,
+        "orchestration.runStop",
+        json!({}),
+    ));
+}
+
+#[test]
+fn stale_decision_gates_do_not_block_current_dispatch() {
+    let host = start_host();
+    let (mut writer, mut reader) = connect(host.port);
+    handshake(&mut writer, &mut reader, &host.token);
+
+    let task = expect_ok(request(
+        &mut writer,
+        &mut reader,
+        60,
+        "orchestration.taskCreate",
+        json!({"spec": "choose a path"}),
+    ));
+    let task_id = task["id"].as_str().unwrap().to_string();
+    let first = expect_ok(request(
+        &mut writer,
+        &mut reader,
+        61,
+        "orchestration.dispatch",
+        json!({"task": &task_id, "to": "worker", "from": "coord"}),
+    ));
+    let first_dispatch = first["dispatch"]["id"].as_str().unwrap().to_string();
+    expect_ok(request(
+        &mut writer,
+        &mut reader,
+        62,
+        "orchestration.send",
+        json!({
+            "from": "worker",
+            "to": "coord",
+            "type": "worker_done",
+            "subject": "Failed: first attempt",
+            "body": "failed",
+            "payload": json!({"taskId": &task_id, "dispatchId": &first_dispatch}).to_string()
+        }),
+    ));
+    let second = expect_ok(request(
+        &mut writer,
+        &mut reader,
+        63,
+        "orchestration.dispatch",
+        json!({"task": &task_id, "to": "worker", "from": "coord"}),
+    ));
+    let second_dispatch = second["dispatch"]["id"].as_str().unwrap().to_string();
+    expect_ok(request(
+        &mut writer,
+        &mut reader,
+        64,
+        "orchestration.run",
+        json!({"from": "coord", "spec": "coordinate", "pollIntervalMs": 100}),
+    ));
+
+    expect_ok(request(
+        &mut writer,
+        &mut reader,
+        65,
+        "orchestration.send",
+        json!({
+            "from": "worker",
+            "to": "coord",
+            "type": "decision_gate",
+            "subject": "Question: missing dispatch",
+            "payload": json!({"taskId": &task_id, "question": "missing?"}).to_string()
+        }),
+    ));
+    expect_ok(request(
+        &mut writer,
+        &mut reader,
+        66,
+        "orchestration.send",
+        json!({
+            "from": "worker",
+            "to": "coord",
+            "type": "decision_gate",
+            "subject": "Question: stale retry",
+            "payload": json!({"taskId": &task_id, "dispatchId": &first_dispatch, "question": "stale?"}).to_string()
+        }),
+    ));
+
+    std::thread::sleep(Duration::from_millis(700));
+    let gates = expect_ok(request(
+        &mut writer,
+        &mut reader,
+        67,
+        "orchestration.gateList",
+        json!({"task": &task_id}),
+    ));
+    assert_eq!(gates["gates"].as_array().unwrap().len(), 0, "{gates}");
+    let show = expect_ok(request(
+        &mut writer,
+        &mut reader,
+        68,
+        "orchestration.dispatchShow",
+        json!({"task": &task_id}),
+    ));
+    assert_eq!(show["active"]["id"], json!(second_dispatch));
+    assert_eq!(show["active"]["status"], json!("dispatched"));
+
+    expect_ok(request(
+        &mut writer,
+        &mut reader,
+        69,
+        "orchestration.runStop",
+        json!({}),
+    ));
+}
+
+#[test]
+#[cfg(unix)]
+fn injected_dispatch_requires_idle_agent_presence() {
+    let host = start_host();
+    let (mut writer, mut reader) = connect(host.port);
+    handshake(&mut writer, &mut reader, &host.token);
+    let session_id = "busy-worker";
+
+    expect_ok(request(
+        &mut writer,
+        &mut reader,
+        60,
+        "createOrAttach",
+        json!({
+            "sessionId": session_id,
+            "workspaceId": "ws-1",
+            "tabId": "tab-1",
+            "workingDirectory": "/tmp",
+            "launch": {
+                "shell": "/bin/sh",
+                "arguments": ["-lc", "stty -echo; cat"],
+                "environment": {"PATH": "/usr/bin:/bin", "TERM": "xterm"}
+            },
+            "cols": 120,
+            "rows": 40
+        }),
+    ));
+    expect_ok(request(
+        &mut writer,
+        &mut reader,
+        61,
+        "orchestration.agentStatus",
+        json!({"entries": [{"terminalSessionId": session_id, "agentType": "claude", "state": "working"}]}),
+    ));
+    let task = expect_ok(request(
+        &mut writer,
+        &mut reader,
+        62,
+        "orchestration.taskCreate",
+        json!({"spec": "busy injection"}),
+    ));
+    let task_id = task["id"].as_str().unwrap().to_string();
+
+    let response = request(
+        &mut writer,
+        &mut reader,
+        63,
+        "orchestration.dispatch",
+        json!({"task": &task_id, "to": session_id, "from": "coord", "inject": true}),
+    );
+    assert_eq!(response["ok"], json!(false));
+    assert!(response["error"].as_str().unwrap().contains("not idle"));
+
+    let show = expect_ok(request(
+        &mut writer,
+        &mut reader,
+        64,
+        "orchestration.dispatchShow",
+        json!({"task": &task_id}),
+    ));
+    assert!(show["active"].is_null());
+    assert!(show["history"].as_array().unwrap().is_empty());
+}
+
+#[test]
+#[cfg(unix)]
+fn explicit_terminal_termination_fails_active_dispatch() {
+    let host = start_host();
+    let (mut writer, mut reader) = connect(host.port);
+    handshake(&mut writer, &mut reader, &host.token);
+    let session_id = "terminated-worker";
+
+    expect_ok(request(
+        &mut writer,
+        &mut reader,
+        65,
+        "createOrAttach",
+        json!({
+            "sessionId": session_id,
+            "workspaceId": "ws-1",
+            "tabId": "tab-1",
+            "workingDirectory": "/tmp",
+            "launch": {
+                "shell": "/bin/sh",
+                "arguments": ["-lc", "stty -echo; cat"],
+                "environment": {"PATH": "/usr/bin:/bin", "TERM": "xterm"}
+            },
+            "cols": 120,
+            "rows": 40
+        }),
+    ));
+    let task = expect_ok(request(
+        &mut writer,
+        &mut reader,
+        66,
+        "orchestration.taskCreate",
+        json!({"spec": "active dispatch should fail on close"}),
+    ));
+    let task_id = task["id"].as_str().unwrap().to_string();
+    expect_ok(request(
+        &mut writer,
+        &mut reader,
+        67,
+        "orchestration.dispatch",
+        json!({"task": &task_id, "to": session_id, "from": "coord"}),
+    ));
+
+    expect_ok(request(
+        &mut writer,
+        &mut reader,
+        68,
+        "terminate",
+        json!({"sessionId": session_id}),
+    ));
+    let show = expect_ok(request(
+        &mut writer,
+        &mut reader,
+        69,
+        "orchestration.dispatchShow",
+        json!({"task": &task_id}),
+    ));
+    assert!(show["active"].is_null(), "{show}");
+    assert_eq!(show["history"][0]["status"], json!("failed"), "{show}");
+    assert!(
+        show["history"][0]["last_failure"]
+            .as_str()
+            .unwrap()
+            .contains("explicitly terminated"),
+        "{show}"
+    );
+}
+
+#[test]
+#[cfg(unix)]
+fn removed_agent_status_fails_active_dispatch() {
+    let host = start_host();
+    let (mut writer, mut reader) = connect(host.port);
+    handshake(&mut writer, &mut reader, &host.token);
+    let session_id = "removed-status-worker";
+
+    expect_ok(request(
+        &mut writer,
+        &mut reader,
+        111,
+        "createOrAttach",
+        json!({
+            "sessionId": session_id,
+            "workspaceId": "ws-1",
+            "tabId": "tab-1",
+            "workingDirectory": "/tmp",
+            "launch": {
+                "shell": "/bin/sh",
+                "arguments": ["-lc", "stty -echo; cat"],
+                "environment": {"PATH": "/usr/bin:/bin", "TERM": "xterm"}
+            },
+            "cols": 120,
+            "rows": 40
+        }),
+    ));
+    let task = expect_ok(request(
+        &mut writer,
+        &mut reader,
+        112,
+        "orchestration.taskCreate",
+        json!({"spec": "active dispatch should fail on removed status"}),
+    ));
+    let task_id = task["id"].as_str().unwrap().to_string();
+    expect_ok(request(
+        &mut writer,
+        &mut reader,
+        113,
+        "orchestration.dispatch",
+        json!({"task": &task_id, "to": session_id, "from": "coord"}),
+    ));
+
+    expect_ok(request(
+        &mut writer,
+        &mut reader,
+        114,
+        "orchestration.agentStatus",
+        json!({"entries": [{"terminalSessionId": session_id, "removed": true}]}),
+    ));
+    let show = expect_ok(request(
+        &mut writer,
+        &mut reader,
+        115,
+        "orchestration.dispatchShow",
+        json!({"task": &task_id}),
+    ));
+    assert!(show["active"].is_null(), "{show}");
+    assert_eq!(show["history"][0]["status"], json!("failed"), "{show}");
+    assert!(
+        show["history"][0]["last_failure"]
+            .as_str()
+            .unwrap()
+            .contains("agent status was removed"),
+        "{show}"
+    );
+}
+
+#[test]
+#[cfg(unix)]
+fn dispatch_injection_respects_cursor_skip_auto_enter() {
+    let host = start_host();
+    let (mut writer, mut reader) = connect(host.port);
+    handshake(&mut writer, &mut reader, &host.token);
+    let session_id = "cursor-worker";
+
+    expect_ok(request(
+        &mut writer,
+        &mut reader,
+        66,
+        "createOrAttach",
+        json!({
+            "sessionId": session_id,
+            "workspaceId": "ws-1",
+            "tabId": "tab-1",
+            "workingDirectory": "/tmp",
+            "launch": {
+                "shell": "/bin/sh",
+                "arguments": ["-lc", "stty -echo; cat"],
+                "environment": {"PATH": "/usr/bin:/bin", "TERM": "xterm"}
+            },
+            "cols": 120,
+            "rows": 40
+        }),
+    ));
+    std::thread::sleep(Duration::from_millis(700));
+    let _ = collect_output(&mut reader, session_id, Duration::from_millis(400));
+    expect_ok(request(
+        &mut writer,
+        &mut reader,
+        67,
+        "orchestration.agentStatus",
+        json!({"entries": [{"terminalSessionId": session_id, "agentType": "cursor", "state": "done"}]}),
+    ));
+    let task = expect_ok(request(
+        &mut writer,
+        &mut reader,
+        68,
+        "orchestration.taskCreate",
+        json!({"spec": "cursor should keep this editable"}),
+    ));
+    let task_id = task["id"].as_str().unwrap().to_string();
+
+    expect_ok(request(
+        &mut writer,
+        &mut reader,
+        69,
+        "orchestration.dispatch",
+        json!({"task": &task_id, "to": session_id, "from": "coord", "inject": true}),
+    ));
+
+    let output = collect_output(&mut reader, session_id, Duration::from_secs(2));
+    assert!(
+        !output.contains("cursor should keep this editable"),
+        "cursor dispatch task line was submitted instead of left editable: {output}"
+    );
+}
+
+#[test]
+#[cfg(unix)]
+fn coordinator_skips_cursor_workers_that_do_not_auto_submit() {
+    let host = start_host();
+    let (mut writer, mut reader) = connect(host.port);
+    handshake(&mut writer, &mut reader, &host.token);
+    let session_id = "cursor-coordinator-worker";
+
+    attach_shell_session(
+        &mut writer,
+        &mut reader,
+        1160,
+        session_id,
+        "ws-1",
+        "tab-1",
+        &["-lc", "stty -echo; cat"],
+    );
+    std::thread::sleep(Duration::from_millis(700));
+    let _ = collect_output(&mut reader, session_id, Duration::from_millis(400));
+    expect_ok(request(
+        &mut writer,
+        &mut reader,
+        1161,
+        "orchestration.agentStatus",
+        json!({"entries": [{"terminalSessionId": session_id, "agentType": "cursor", "state": "done"}]}),
+    ));
+    let task = expect_ok(request(
+        &mut writer,
+        &mut reader,
+        1162,
+        "orchestration.taskCreate",
+        json!({"spec": "cursor must not be auto-dispatched"}),
+    ));
+    let task_id = task["id"].as_str().unwrap().to_string();
+
+    expect_ok(request(
+        &mut writer,
+        &mut reader,
+        1163,
+        "orchestration.run",
+        json!({
+            "from": "coord",
+            "spec": "coordinate",
+            "pollIntervalMs": 100,
+            "workspace": "ws-1"
+        }),
+    ));
+    std::thread::sleep(Duration::from_millis(350));
+
+    let show = expect_ok(request(
+        &mut writer,
+        &mut reader,
+        1164,
+        "orchestration.dispatchShow",
+        json!({"task": &task_id}),
+    ));
+    assert!(show["active"].is_null(), "{show}");
+    assert!(show["history"].as_array().unwrap().is_empty(), "{show}");
+    let ready = expect_ok(request(
+        &mut writer,
+        &mut reader,
+        1165,
+        "orchestration.taskList",
+        json!({"status": "ready"}),
+    ));
+    assert_eq!(ready["tasks"][0]["id"], json!(task_id), "{ready}");
+
+    expect_ok(request(
+        &mut writer,
+        &mut reader,
+        1166,
+        "orchestration.runStop",
+        json!({}),
+    ));
+}
+
+#[test]
+fn coordinator_run_does_not_consume_taskless_decision_gate() {
+    let host = start_host();
+    let (mut writer, mut reader) = connect(host.port);
+    handshake(&mut writer, &mut reader, &host.token);
+
+    expect_ok(request(
+        &mut writer,
+        &mut reader,
+        70,
+        "orchestration.taskCreate",
+        json!({"spec": "keep run active"}),
+    ));
+    expect_ok(request(
+        &mut writer,
+        &mut reader,
+        71,
+        "orchestration.run",
+        json!({"from": "coord", "spec": "coordinate", "pollIntervalMs": 100}),
+    ));
+    expect_ok(request(
+        &mut writer,
+        &mut reader,
+        72,
+        "orchestration.send",
+        json!({
+            "from": "worker",
+            "to": "coord",
+            "type": "decision_gate",
+            "subject": "Question: Which path?",
+            "body": "Which path?"
+        }),
+    ));
+
+    std::thread::sleep(Duration::from_millis(500));
+    let inbox = expect_ok(request(
+        &mut writer,
+        &mut reader,
+        73,
+        "orchestration.check",
+        json!({"terminal": "coord", "types": ["decision_gate"]}),
+    ));
+    assert_eq!(inbox["messages"].as_array().unwrap().len(), 1);
+    assert_eq!(
+        inbox["messages"][0]["subject"],
+        json!("Question: Which path?")
+    );
+
+    expect_ok(request(
+        &mut writer,
+        &mut reader,
+        74,
+        "orchestration.runStop",
+        json!({}),
+    ));
+}
+
+#[test]
+fn coordinator_run_does_not_consume_unhandled_status_message() {
+    let host = start_host();
+    let (mut writer, mut reader) = connect(host.port);
+    handshake(&mut writer, &mut reader, &host.token);
+
+    expect_ok(request(
+        &mut writer,
+        &mut reader,
+        76,
+        "orchestration.taskCreate",
+        json!({"spec": "keep run active"}),
+    ));
+    expect_ok(request(
+        &mut writer,
+        &mut reader,
+        77,
+        "orchestration.run",
+        json!({"from": "coord", "spec": "coordinate", "pollIntervalMs": 100}),
+    ));
+    expect_ok(request(
+        &mut writer,
+        &mut reader,
+        78,
+        "orchestration.send",
+        json!({
+            "from": "worker",
+            "to": "coord",
+            "type": "status",
+            "subject": "Progress",
+            "body": "Still working"
+        }),
+    ));
+
+    std::thread::sleep(Duration::from_millis(500));
+    let inbox = expect_ok(request(
+        &mut writer,
+        &mut reader,
+        79,
+        "orchestration.check",
+        json!({"terminal": "coord", "types": ["status"]}),
+    ));
+    assert_eq!(inbox["messages"].as_array().unwrap().len(), 1);
+    assert_eq!(inbox["messages"][0]["subject"], json!("Progress"));
+
+    expect_ok(request(
+        &mut writer,
+        &mut reader,
+        80,
+        "orchestration.runStop",
+        json!({}),
+    ));
+}
+
+#[test]
+#[cfg(unix)]
+fn coordinator_reuses_idle_worker_after_stale_base_skip() {
+    let repo_dir = worktree_behind_upstream(21);
+    let host = start_host();
+    let (mut writer, mut reader) = connect(host.port);
+    handshake(&mut writer, &mut reader, &host.token);
+    seed_workspace_with_path(&mut writer, &mut reader, "ws-stale", repo_dir.path());
+
+    let skipped = expect_ok(request(
+        &mut writer,
+        &mut reader,
+        85,
+        "orchestration.taskCreate",
+        json!({"spec": "blocked by stale base"}),
+    ));
+    let skipped_task_id = skipped["id"].as_str().unwrap().to_string();
+    std::thread::sleep(Duration::from_millis(1_100));
+    let allowed = expect_ok(request(
+        &mut writer,
+        &mut reader,
+        86,
+        "orchestration.taskCreate",
+        json!({"spec": "allow-stale-base: true\ncan still dispatch"}),
+    ));
+    let allowed_task_id = allowed["id"].as_str().unwrap().to_string();
+
+    attach_shell_session(
+        &mut writer,
+        &mut reader,
+        87,
+        "idle-worker",
+        "ws-stale",
+        "idle-worker-tab",
+        &["-lc", "stty -echo; cat"],
+    );
+    expect_ok(request(
+        &mut writer,
+        &mut reader,
+        88,
+        "orchestration.agentStatus",
+        json!({"entries": [{"terminalSessionId": "idle-worker", "agentType": "claude", "state": "done"}]}),
+    ));
+    expect_ok(request(
+        &mut writer,
+        &mut reader,
+        89,
+        "orchestration.run",
+        json!({
+            "from": "coord",
+            "spec": "coordinate",
+            "pollIntervalMs": 100,
+            "maxConcurrent": 1,
+            "workspace": "ws-stale"
+        }),
+    ));
+
+    std::thread::sleep(Duration::from_millis(700));
+    let skipped_show = expect_ok(request(
+        &mut writer,
+        &mut reader,
+        90,
+        "orchestration.dispatchShow",
+        json!({"task": &skipped_task_id}),
+    ));
+    assert!(skipped_show["active"].is_null(), "{skipped_show}");
+    let allowed_show = expect_ok(request(
+        &mut writer,
+        &mut reader,
+        91,
+        "orchestration.dispatchShow",
+        json!({"task": &allowed_task_id}),
+    ));
+    assert_eq!(
+        allowed_show["active"]["status"],
+        json!("dispatched"),
+        "{allowed_show}"
+    );
+    assert_eq!(
+        allowed_show["active"]["assignee_handle"],
+        json!("idle-worker"),
+        "{allowed_show}"
+    );
+
+    expect_ok(request(
+        &mut writer,
+        &mut reader,
+        92,
+        "orchestration.runStop",
+        json!({}),
+    ));
+}
+
+#[test]
+fn coordinator_waits_for_spawned_worker_presence_before_creating_another() {
+    let host = start_host();
+    let (mut writer, mut reader) = connect(host.port);
+    handshake_app(&mut writer, &mut reader, &host.token);
+    seed_workspace(&mut writer, &mut reader, "ws-1");
+
+    expect_ok(request(
+        &mut writer,
+        &mut reader,
+        80,
+        "orchestration.taskCreate",
+        json!({"spec": "needs a worker"}),
+    ));
+    expect_ok(request(
+        &mut writer,
+        &mut reader,
+        81,
+        "orchestration.run",
+        json!({
+            "from": "coord",
+            "spec": "coordinate",
+            "pollIntervalMs": 100,
+            "workspace": "ws-1"
+        }),
+    ));
+
+    std::thread::sleep(Duration::from_millis(550));
+    let tabs = expect_ok(request(
+        &mut writer,
+        &mut reader,
+        82,
+        "tab.list",
+        json!({"workspaceId": "ws-1"}),
+    ));
+    assert_eq!(tabs.as_array().unwrap().len(), 1, "{tabs}");
+    assert_eq!(tabs[0]["payload"]["spawnOnCreate"], json!(true));
+    assert_eq!(tabs[0]["payload"]["initialCommand"], json!("claude"));
+
+    std::thread::sleep(Duration::from_millis(350));
+    let tabs = expect_ok(request(
+        &mut writer,
+        &mut reader,
+        83,
+        "tab.list",
+        json!({"workspaceId": "ws-1"}),
+    ));
+    assert_eq!(tabs.as_array().unwrap().len(), 1, "{tabs}");
+
+    expect_ok(request(
+        &mut writer,
+        &mut reader,
+        84,
+        "orchestration.runStop",
+        json!({}),
+    ));
+}
+
+#[test]
+#[cfg(unix)]
+fn coordinator_waits_for_spawned_claude_presence_after_initial_command_write() {
+    let host = start_host();
+    let (mut writer, mut reader) = connect(host.port);
+    handshake_app(&mut writer, &mut reader, &host.token);
+    seed_workspace(&mut writer, &mut reader, "ws-1");
+
+    let task = expect_ok(request(
+        &mut writer,
+        &mut reader,
+        116,
+        "orchestration.taskCreate",
+        json!({"spec": "dispatch after spawned Claude starts"}),
+    ));
+    let task_id = task["id"].as_str().unwrap().to_string();
+    expect_ok(request(
+        &mut writer,
+        &mut reader,
+        117,
+        "orchestration.run",
+        json!({
+            "from": "coord",
+            "spec": "coordinate",
+            "pollIntervalMs": 100,
+            "workspace": "ws-1"
+        }),
+    ));
+
+    std::thread::sleep(Duration::from_millis(550));
+    let tabs = expect_ok(request(
+        &mut writer,
+        &mut reader,
+        118,
+        "tab.list",
+        json!({"workspaceId": "ws-1"}),
+    ));
+    assert_eq!(tabs.as_array().unwrap().len(), 1, "{tabs}");
+    let tab_id = tabs[0]["id"].as_str().unwrap().to_string();
+    let worker_handle = tabs[0]["payload"]["terminalSessionId"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    expect_ok(request(
+        &mut writer,
+        &mut reader,
+        119,
+        "createOrAttach",
+        json!({
+            "sessionId": worker_handle,
+            "workspaceId": "ws-1",
+            "tabId": tab_id,
+            "workingDirectory": "/tmp",
+            "launch": {
+                "shell": "/bin/sh",
+                "arguments": ["-lc", "stty -echo; cat"],
+                "environment": {"PATH": "/usr/bin:/bin", "TERM": "xterm"}
+            },
+            "cols": 120,
+            "rows": 40
+        }),
+    ));
+    expect_ok(request(
+        &mut writer,
+        &mut reader,
+        120,
+        "write",
+        json!({"sessionId": worker_handle, "dataBase64": STANDARD.encode("claude\n")}),
+    ));
+
+    std::thread::sleep(Duration::from_millis(650));
+    let show = expect_ok(request(
+        &mut writer,
+        &mut reader,
+        121,
+        "orchestration.dispatchShow",
+        json!({"task": &task_id}),
+    ));
+    assert!(show["active"].is_null(), "{show}");
+
+    expect_ok(request(
+        &mut writer,
+        &mut reader,
+        122,
+        "orchestration.agentStatus",
+        json!({"entries": [{"terminalSessionId": worker_handle, "agentType": "claude", "state": "done"}]}),
+    ));
+
+    std::thread::sleep(Duration::from_millis(650));
+    let show = expect_ok(request(
+        &mut writer,
+        &mut reader,
+        123,
+        "orchestration.dispatchShow",
+        json!({"task": &task_id}),
+    ));
+    assert_eq!(show["active"]["status"], json!("dispatched"), "{show}");
+    assert_eq!(
+        show["active"]["assignee_handle"],
+        json!(worker_handle),
+        "{show}"
+    );
+
+    expect_ok(request(
+        &mut writer,
+        &mut reader,
+        124,
+        "orchestration.runStop",
+        json!({}),
+    ));
+}
+
+#[test]
+fn coordinator_counts_booting_worker_presence_as_pending() {
+    let host = start_host();
+    let (mut writer, mut reader) = connect(host.port);
+    handshake_app(&mut writer, &mut reader, &host.token);
+    seed_workspace(&mut writer, &mut reader, "ws-1");
+
+    expect_ok(request(
+        &mut writer,
+        &mut reader,
+        95,
+        "orchestration.taskCreate",
+        json!({"spec": "needs one booting worker"}),
+    ));
+    expect_ok(request(
+        &mut writer,
+        &mut reader,
+        96,
+        "orchestration.run",
+        json!({
+            "from": "coord",
+            "spec": "coordinate",
+            "pollIntervalMs": 100,
+            "workspace": "ws-1"
+        }),
+    ));
+
+    std::thread::sleep(Duration::from_millis(550));
+    let tabs = expect_ok(request(
+        &mut writer,
+        &mut reader,
+        97,
+        "tab.list",
+        json!({"workspaceId": "ws-1"}),
+    ));
+    assert_eq!(tabs.as_array().unwrap().len(), 1, "{tabs}");
+    let worker_handle = tabs[0]["payload"]["terminalSessionId"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    expect_ok(request(
+        &mut writer,
+        &mut reader,
+        98,
+        "orchestration.agentStatus",
+        json!({"entries": [{"terminalSessionId": worker_handle, "agentType": "claude", "state": "working"}]}),
+    ));
+
+    std::thread::sleep(Duration::from_millis(450));
+    let tabs = expect_ok(request(
+        &mut writer,
+        &mut reader,
+        99,
+        "tab.list",
+        json!({"workspaceId": "ws-1"}),
+    ));
+    assert_eq!(tabs.as_array().unwrap().len(), 1, "{tabs}");
+
+    expect_ok(request(
+        &mut writer,
+        &mut reader,
+        100,
+        "orchestration.runStop",
+        json!({}),
+    ));
+}
+
+#[test]
+#[cfg(unix)]
+fn coordinator_does_not_count_busy_spawned_worker_as_pending() {
+    let host = start_host();
+    let (mut writer, mut reader) = connect(host.port);
+    handshake_app(&mut writer, &mut reader, &host.token);
+    seed_workspace(&mut writer, &mut reader, "ws-1");
+    let worker_handle = "busy-spawned-worker";
+    let now = chrono::Utc::now().to_rfc3339();
+
+    let first = expect_ok(request(
+        &mut writer,
+        &mut reader,
+        101,
+        "orchestration.taskCreate",
+        json!({"spec": "first concurrent task"}),
+    ));
+    let first_task_id = first["id"].as_str().unwrap().to_string();
+    expect_ok(request(
+        &mut writer,
+        &mut reader,
+        102,
+        "orchestration.taskCreate",
+        json!({"spec": "second concurrent task"}),
+    ));
+    expect_ok(request(
+        &mut writer,
+        &mut reader,
+        103,
+        "tab.upsert",
+        json!({
+            "id": "busy-spawned-worker-tab",
+            "workspaceId": "ws-1",
+            "kind": "terminal",
+            "title": "Worker: busy",
+            "createdAt": now,
+            "updatedAt": now,
+            "payload": {
+                "terminalSessionId": worker_handle,
+                "initialCommand": "claude",
+                "spawnOnCreate": true
+            }
+        }),
+    ));
+    expect_ok(request(
+        &mut writer,
+        &mut reader,
+        104,
+        "createOrAttach",
+        json!({
+            "sessionId": worker_handle,
+            "workspaceId": "ws-1",
+            "tabId": "busy-spawned-worker-tab",
+            "workingDirectory": "/tmp",
+            "launch": {
+                "shell": "/bin/sh",
+                "arguments": ["-lc", "stty -echo; cat"],
+                "environment": {"PATH": "/usr/bin:/bin", "TERM": "xterm"}
+            },
+            "cols": 120,
+            "rows": 40
+        }),
+    ));
+    expect_ok(request(
+        &mut writer,
+        &mut reader,
+        105,
+        "orchestration.dispatch",
+        json!({"task": &first_task_id, "to": worker_handle, "from": "coord"}),
+    ));
+    expect_ok(request(
+        &mut writer,
+        &mut reader,
+        106,
+        "orchestration.agentStatus",
+        json!({"entries": [{"terminalSessionId": worker_handle, "agentType": "claude", "state": "working"}]}),
+    ));
+    expect_ok(request(
+        &mut writer,
+        &mut reader,
+        107,
+        "orchestration.run",
+        json!({
+            "from": "coord",
+            "spec": "coordinate",
+            "pollIntervalMs": 100,
+            "maxConcurrent": 2,
+            "workspace": "ws-1"
+        }),
+    ));
+
+    std::thread::sleep(Duration::from_millis(550));
+    let tabs = expect_ok(request(
+        &mut writer,
+        &mut reader,
+        109,
+        "tab.list",
+        json!({"workspaceId": "ws-1"}),
+    ));
+    assert_eq!(tabs.as_array().unwrap().len(), 2, "{tabs}");
+
+    expect_ok(request(
+        &mut writer,
+        &mut reader,
+        110,
+        "orchestration.runStop",
+        json!({}),
+    ));
+}
+
+#[test]
+#[cfg(unix)]
+fn coordinator_reuses_done_spawned_worker_instead_of_spawning_replacement() {
+    let host = start_host();
+    let (mut writer, mut reader) = connect(host.port);
+    handshake_app(&mut writer, &mut reader, &host.token);
+    seed_workspace(&mut writer, &mut reader, "ws-1");
+    let worker_handle = "done-spawned-worker";
+    let now = chrono::Utc::now().to_rfc3339();
+
+    let task = expect_ok(request(
+        &mut writer,
+        &mut reader,
+        123,
+        "orchestration.taskCreate",
+        json!({"spec": "needs a replacement worker"}),
+    ));
+    let task_id = task["id"].as_str().unwrap().to_string();
+    expect_ok(request(
+        &mut writer,
+        &mut reader,
+        124,
+        "tab.upsert",
+        json!({
+            "id": "done-spawned-worker-tab",
+            "workspaceId": "ws-1",
+            "kind": "terminal",
+            "title": "Worker: done",
+            "createdAt": now,
+            "updatedAt": now,
+            "payload": {
+                "terminalSessionId": worker_handle,
+                "initialCommand": "claude",
+                "spawnOnCreate": true
+            }
+        }),
+    ));
+    expect_ok(request(
+        &mut writer,
+        &mut reader,
+        125,
+        "createOrAttach",
+        json!({
+            "sessionId": worker_handle,
+            "workspaceId": "ws-1",
+            "tabId": "done-spawned-worker-tab",
+            "workingDirectory": "/tmp",
+            "launch": {
+                "shell": "/bin/sh",
+                "arguments": ["-lc", "stty -echo; cat"],
+                "environment": {"PATH": "/usr/bin:/bin", "TERM": "xterm"}
+            },
+            "cols": 120,
+            "rows": 40
+        }),
+    ));
+    expect_ok(request(
+        &mut writer,
+        &mut reader,
+        126,
+        "orchestration.agentStatus",
+        json!({"entries": [{"terminalSessionId": worker_handle, "agentType": "claude", "state": "done"}]}),
+    ));
+    expect_ok(request(
+        &mut writer,
+        &mut reader,
+        127,
+        "orchestration.run",
+        json!({
+            "from": "coord",
+            "spec": "coordinate",
+            "pollIntervalMs": 100,
+            "workspace": "ws-1"
+        }),
+    ));
+
+    std::thread::sleep(Duration::from_millis(550));
+    let tabs = expect_ok(request(
+        &mut writer,
+        &mut reader,
+        128,
+        "tab.list",
+        json!({"workspaceId": "ws-1"}),
+    ));
+    assert_eq!(tabs.as_array().unwrap().len(), 1, "{tabs}");
+    let show = expect_ok(request(
+        &mut writer,
+        &mut reader,
+        129,
+        "orchestration.dispatchShow",
+        json!({"task": &task_id}),
+    ));
+    assert_eq!(show["active"]["status"], json!("dispatched"), "{show}");
+    assert_eq!(
+        show["active"]["assignee_handle"],
+        json!(worker_handle),
+        "{show}"
+    );
+
+    expect_ok(request(
+        &mut writer,
+        &mut reader,
+        130,
+        "orchestration.runStop",
+        json!({}),
+    ));
+}
+
+#[test]
+fn coordinator_ignores_stale_spawned_worker_tabs_when_creating_replacement() {
+    let host = start_host();
+    let (mut writer, mut reader) = connect(host.port);
+    handshake_app(&mut writer, &mut reader, &host.token);
+    seed_workspace(&mut writer, &mut reader, "ws-1");
+
+    expect_ok(request(
+        &mut writer,
+        &mut reader,
+        85,
+        "tab.upsert",
+        json!({
+            "id": "stale-worker-tab",
+            "workspaceId": "ws-1",
+            "kind": "terminal",
+            "title": "Worker: stale",
+            "createdAt": "2000-01-01T00:00:00Z",
+            "updatedAt": "2000-01-01T00:00:00Z",
+            "payload": {
+                "terminalSessionId": "stale-worker-tab",
+                "initialCommand": "claude",
+                "spawnOnCreate": true
+            }
+        }),
+    ));
+    expect_ok(request(
+        &mut writer,
+        &mut reader,
+        86,
+        "orchestration.taskCreate",
+        json!({"spec": "needs a replacement worker"}),
+    ));
+    expect_ok(request(
+        &mut writer,
+        &mut reader,
+        87,
+        "orchestration.run",
+        json!({
+            "from": "coord",
+            "spec": "coordinate",
+            "pollIntervalMs": 100,
+            "workspace": "ws-1"
+        }),
+    ));
+
+    std::thread::sleep(Duration::from_millis(550));
+    let tabs = expect_ok(request(
+        &mut writer,
+        &mut reader,
+        88,
+        "tab.list",
+        json!({"workspaceId": "ws-1"}),
+    ));
+    assert_eq!(tabs.as_array().unwrap().len(), 2, "{tabs}");
+
+    expect_ok(request(
+        &mut writer,
+        &mut reader,
+        89,
+        "orchestration.runStop",
+        json!({}),
+    ));
+}
+
+#[test]
+fn coordinator_does_not_create_worker_tab_for_missing_workspace() {
+    let host = start_host();
+    let (mut writer, mut reader) = connect(host.port);
+    handshake_app(&mut writer, &mut reader, &host.token);
+
+    expect_ok(request(
+        &mut writer,
+        &mut reader,
+        131,
+        "orchestration.taskCreate",
+        json!({"spec": "needs a worker"}),
+    ));
+    expect_ok(request(
+        &mut writer,
+        &mut reader,
+        132,
+        "orchestration.run",
+        json!({
+            "from": "coord",
+            "spec": "coordinate",
+            "pollIntervalMs": 100,
+            "workspace": "missing-workspace"
+        }),
+    ));
+
+    std::thread::sleep(Duration::from_millis(550));
+    let tabs = expect_ok(request(
+        &mut writer,
+        &mut reader,
+        133,
+        "tab.list",
+        json!({"workspaceId": "missing-workspace"}),
+    ));
+    assert_eq!(tabs.as_array().unwrap().len(), 0, "{tabs}");
+
+    expect_ok(request(
+        &mut writer,
+        &mut reader,
+        134,
+        "orchestration.runStop",
+        json!({}),
+    ));
+}
+
+#[test]
+fn reset_tasks_stops_active_coordinator() {
+    let host = start_host();
+    let (mut writer, mut reader) = connect(host.port);
+    handshake(&mut writer, &mut reader, &host.token);
+
+    expect_ok(request(
+        &mut writer,
+        &mut reader,
+        70,
+        "orchestration.taskCreate",
+        json!({"spec": "first"}),
+    ));
+    expect_ok(request(
+        &mut writer,
+        &mut reader,
+        71,
+        "orchestration.run",
+        json!({"from": "coord", "spec": "coordinate", "pollIntervalMs": 10_000}),
+    ));
+    expect_ok(request(
+        &mut writer,
+        &mut reader,
+        72,
+        "orchestration.reset",
+        json!({"tasks": true}),
+    ));
+    expect_ok(request(
+        &mut writer,
+        &mut reader,
+        73,
+        "orchestration.taskCreate",
+        json!({"spec": "second"}),
+    ));
+    let rerun = request(
+        &mut writer,
+        &mut reader,
+        74,
+        "orchestration.run",
+        json!({"from": "coord", "spec": "coordinate again", "pollIntervalMs": 10_000}),
+    );
+    assert_eq!(rerun["ok"], json!(true), "rerun failed: {rerun}");
+    expect_ok(request(
+        &mut writer,
+        &mut reader,
+        75,
+        "orchestration.runStop",
+        json!({}),
+    ));
+}

--- a/rust/alera-core/src/git.rs
+++ b/rust/alera-core/src/git.rs
@@ -590,3 +590,86 @@ fn is_path_occupied(path: &str) -> bool {
         Err(_) => target.exists(),
     }
 }
+
+/// How far a worktree's HEAD trails its upstream tracking branch, plus the
+/// most recent upstream-only commit subjects for the dispatch preamble.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GitBaseDrift {
+    pub base: String,
+    pub behind: u64,
+    pub recent_subjects: Vec<String>,
+}
+
+const BASE_DRIFT_SUBJECT_LIMIT: usize = 5;
+
+/// Measures drift between a worktree's HEAD and its upstream tracking branch
+/// without fetching. Returns `None` when the branch has no upstream — a
+/// worktree with no tracking base has nothing to drift from.
+pub fn probe_base_drift(worktree_path: &str) -> Result<Option<GitBaseDrift>, GitError> {
+    let repo = open_repo(worktree_path)?;
+    let head = match repo.head() {
+        Ok(head) => head,
+        // Unborn/empty worktrees cannot be behind anything.
+        Err(error) if error.code() == ErrorCode::UnbornBranch => return Ok(None),
+        Err(error) => return Err(GitError::from_git2(error)),
+    };
+    let Some(head_oid) = head.target() else {
+        return Ok(None);
+    };
+    if repo.head_detached().unwrap_or(false) {
+        return Ok(None);
+    }
+    let branch_name = match head.shorthand() {
+        Ok(name) => name.to_string(),
+        Err(_) => return Ok(None),
+    };
+    let branch = match repo.find_branch(&branch_name, BranchType::Local) {
+        Ok(branch) => branch,
+        Err(error) if error.code() == ErrorCode::NotFound => return Ok(None),
+        Err(error) => return Err(GitError::from_git2(error)),
+    };
+    let upstream = match branch.upstream() {
+        Ok(upstream) => upstream,
+        Err(error) if error.code() == ErrorCode::NotFound => return Ok(None),
+        Err(error) => return Err(GitError::from_git2(error)),
+    };
+    let upstream_name = upstream
+        .name()
+        .map_err(GitError::from_git2)?
+        .unwrap_or("upstream")
+        .to_string();
+    let Some(upstream_oid) = upstream.get().target() else {
+        return Ok(None);
+    };
+    let (_ahead, behind) = repo
+        .graph_ahead_behind(head_oid, upstream_oid)
+        .map_err(GitError::from_git2)?;
+    if behind == 0 {
+        return Ok(Some(GitBaseDrift {
+            base: upstream_name,
+            behind: 0,
+            recent_subjects: Vec::new(),
+        }));
+    }
+    // Walk upstream-only commits (upstream, hiding HEAD) for the newest
+    // subjects the worktree has not seen.
+    let mut walk = repo.revwalk().map_err(GitError::from_git2)?;
+    walk.push(upstream_oid).map_err(GitError::from_git2)?;
+    walk.hide(head_oid).map_err(GitError::from_git2)?;
+    let mut recent_subjects = Vec::new();
+    for oid in walk.take(BASE_DRIFT_SUBJECT_LIMIT) {
+        let oid = oid.map_err(GitError::from_git2)?;
+        let commit = repo.find_commit(oid).map_err(GitError::from_git2)?;
+        let subject = commit
+            .summary()
+            .map_err(GitError::from_git2)?
+            .unwrap_or("<no subject>")
+            .to_string();
+        recent_subjects.push(subject);
+    }
+    Ok(Some(GitBaseDrift {
+        base: upstream_name,
+        behind: behind as u64,
+        recent_subjects,
+    }))
+}

--- a/rust/alera-core/src/runtime/mod.rs
+++ b/rust/alera-core/src/runtime/mod.rs
@@ -1,5 +1,15 @@
 mod models;
+mod orchestration_dispatch_store;
+mod orchestration_message_store;
+mod orchestration_models;
+#[cfg(test)]
+mod orchestration_store_tests;
+mod orchestration_task_store;
 mod store;
 
 pub use models::*;
+pub use orchestration_dispatch_store::ORCHESTRATION_CIRCUIT_BREAKER_THRESHOLD;
+pub use orchestration_message_store::NewOrchestrationMessage;
+pub use orchestration_models::*;
+pub use orchestration_task_store::NewOrchestrationTask;
 pub use store::*;

--- a/rust/alera-core/src/runtime/orchestration_dispatch_store.rs
+++ b/rust/alera-core/src/runtime/orchestration_dispatch_store.rs
@@ -1,0 +1,507 @@
+use anyhow::{anyhow, bail, Result};
+use sqlx::sqlite::SqliteRow;
+use sqlx::Row;
+
+use super::orchestration_message_store::orchestration_id;
+use super::orchestration_task_store::{
+    parse_string_array, refresh_pending_dependents_after_task_status,
+};
+use super::{
+    OrchestrationCoordinatorRun, OrchestrationCoordinatorStatus, OrchestrationDecisionGate,
+    OrchestrationDispatchContext, OrchestrationDispatchStatus, OrchestrationGateStatus,
+    OrchestrationTaskStatus, RuntimeStore,
+};
+
+pub const ORCHESTRATION_CIRCUIT_BREAKER_THRESHOLD: i64 = 3;
+
+const DISPATCH_COLUMNS: &str = "id, task_id, assignee_handle, status, failure_count, \
+     last_failure, dispatched_at, completed_at, created_at, last_heartbeat_at";
+
+const GATE_COLUMNS: &str =
+    "id, task_id, question, options, status, resolution, created_at, resolved_at";
+
+const RUN_COLUMNS: &str =
+    "id, spec, status, coordinator_handle, poll_interval_ms, created_at, completed_at";
+
+fn dispatch_from_row(row: SqliteRow) -> Result<OrchestrationDispatchContext> {
+    let status_raw: String = row.try_get("status")?;
+    Ok(OrchestrationDispatchContext {
+        id: row.try_get("id")?,
+        task_id: row.try_get("task_id")?,
+        assignee_handle: row.try_get("assignee_handle")?,
+        status: OrchestrationDispatchStatus::parse(&status_raw)
+            .unwrap_or(OrchestrationDispatchStatus::Pending),
+        failure_count: row.try_get("failure_count")?,
+        last_failure: row.try_get("last_failure")?,
+        dispatched_at: row.try_get("dispatched_at")?,
+        completed_at: row.try_get("completed_at")?,
+        created_at: row.try_get("created_at")?,
+        last_heartbeat_at: row.try_get("last_heartbeat_at")?,
+    })
+}
+
+fn gate_from_row(row: SqliteRow) -> Result<OrchestrationDecisionGate> {
+    let status_raw: String = row.try_get("status")?;
+    let options_raw: String = row.try_get("options")?;
+    Ok(OrchestrationDecisionGate {
+        id: row.try_get("id")?,
+        task_id: row.try_get("task_id")?,
+        question: row.try_get("question")?,
+        options: parse_string_array(&options_raw),
+        status: OrchestrationGateStatus::parse(&status_raw)
+            .unwrap_or(OrchestrationGateStatus::Pending),
+        resolution: row.try_get("resolution")?,
+        created_at: row.try_get("created_at")?,
+        resolved_at: row.try_get("resolved_at")?,
+    })
+}
+
+fn run_from_row(row: SqliteRow) -> Result<OrchestrationCoordinatorRun> {
+    let status_raw: String = row.try_get("status")?;
+    Ok(OrchestrationCoordinatorRun {
+        id: row.try_get("id")?,
+        spec: row.try_get("spec")?,
+        status: OrchestrationCoordinatorStatus::parse(&status_raw)
+            .unwrap_or(OrchestrationCoordinatorStatus::Idle),
+        coordinator_handle: row.try_get("coordinator_handle")?,
+        poll_interval_ms: row.try_get("poll_interval_ms")?,
+        created_at: row.try_get("created_at")?,
+        completed_at: row.try_get("completed_at")?,
+    })
+}
+
+impl RuntimeStore {
+    // --- Dispatch contexts ---
+
+    /// Assigns a ready task to a terminal. Enforces the single-active-dispatch
+    /// lock per terminal and carries the failure count forward across retries
+    /// so the circuit breaker accumulates.
+    pub async fn create_orchestration_dispatch(
+        &self,
+        task_id: &str,
+        assignee_handle: &str,
+    ) -> Result<OrchestrationDispatchContext> {
+        let mut tx = self.pool().begin().await?;
+        let task_status: Option<String> =
+            sqlx::query("SELECT status FROM orchestrationTasks WHERE id = ?")
+                .bind(task_id)
+                .fetch_optional(&mut *tx)
+                .await?
+                .map(|row| row.try_get("status"))
+                .transpose()?;
+        match task_status.as_deref() {
+            None => bail!("orchestration task not found: {task_id}"),
+            Some("ready") => {}
+            Some(other) => bail!("task {task_id} is not ready (status: {other})"),
+        }
+        let busy: Option<String> = sqlx::query(
+            "SELECT id FROM orchestrationDispatchContexts \
+             WHERE assignee_handle = ? AND status IN ('pending','dispatched') LIMIT 1",
+        )
+        .bind(assignee_handle)
+        .fetch_optional(&mut *tx)
+        .await?
+        .map(|row| row.try_get("id"))
+        .transpose()?;
+        if busy.is_some() {
+            bail!("terminal {assignee_handle} already has an active dispatch");
+        }
+        let carried_failures: i64 = sqlx::query(
+            "SELECT COALESCE(MAX(failure_count), 0) AS count \
+             FROM orchestrationDispatchContexts WHERE task_id = ?",
+        )
+        .bind(task_id)
+        .fetch_one(&mut *tx)
+        .await?
+        .try_get("count")?;
+        let id = orchestration_id("ctx");
+        sqlx::query(
+            "INSERT INTO orchestrationDispatchContexts \
+             (id, task_id, assignee_handle, status, failure_count, dispatched_at) \
+             VALUES (?, ?, ?, 'dispatched', ?, datetime('now'))",
+        )
+        .bind(&id)
+        .bind(task_id)
+        .bind(assignee_handle)
+        .bind(carried_failures)
+        .execute(&mut *tx)
+        .await?;
+        sqlx::query("UPDATE orchestrationTasks SET status = 'dispatched' WHERE id = ?")
+            .bind(task_id)
+            .execute(&mut *tx)
+            .await?;
+        tx.commit().await?;
+        self.orchestration_dispatch_by_id(&id)
+            .await?
+            .ok_or_else(|| anyhow!("inserted dispatch context not found"))
+    }
+
+    pub async fn orchestration_dispatch_by_id(
+        &self,
+        id: &str,
+    ) -> Result<Option<OrchestrationDispatchContext>> {
+        let row = sqlx::query(&format!(
+            "SELECT {DISPATCH_COLUMNS} FROM orchestrationDispatchContexts WHERE id = ?"
+        ))
+        .bind(id)
+        .fetch_optional(self.pool())
+        .await?;
+        row.map(dispatch_from_row).transpose()
+    }
+
+    /// The current active dispatch for a task, if any.
+    pub async fn active_orchestration_dispatch_for_task(
+        &self,
+        task_id: &str,
+    ) -> Result<Option<OrchestrationDispatchContext>> {
+        let row = sqlx::query(&format!(
+            "SELECT {DISPATCH_COLUMNS} FROM orchestrationDispatchContexts \
+             WHERE task_id = ? AND status IN ('pending','dispatched') \
+             ORDER BY rowid DESC LIMIT 1"
+        ))
+        .bind(task_id)
+        .fetch_optional(self.pool())
+        .await?;
+        row.map(dispatch_from_row).transpose()
+    }
+
+    pub async fn active_orchestration_dispatch_for_handle(
+        &self,
+        assignee_handle: &str,
+    ) -> Result<Option<OrchestrationDispatchContext>> {
+        let row = sqlx::query(&format!(
+            "SELECT {DISPATCH_COLUMNS} FROM orchestrationDispatchContexts \
+             WHERE assignee_handle = ? AND status IN ('pending','dispatched') \
+             ORDER BY rowid DESC LIMIT 1"
+        ))
+        .bind(assignee_handle)
+        .fetch_optional(self.pool())
+        .await?;
+        row.map(dispatch_from_row).transpose()
+    }
+
+    pub async fn list_orchestration_dispatches_for_task(
+        &self,
+        task_id: &str,
+    ) -> Result<Vec<OrchestrationDispatchContext>> {
+        let rows = sqlx::query(&format!(
+            "SELECT {DISPATCH_COLUMNS} FROM orchestrationDispatchContexts \
+             WHERE task_id = ? ORDER BY rowid ASC"
+        ))
+        .bind(task_id)
+        .fetch_all(self.pool())
+        .await?;
+        rows.into_iter().map(dispatch_from_row).collect()
+    }
+
+    /// Records a dispatch failure. Below the circuit-breaker threshold the
+    /// task returns to `ready` (deps are already satisfied — `pending` would
+    /// strand it because promotion only runs when a dep completes). At the
+    /// threshold the dispatch is circuit-broken and the task fails.
+    pub async fn fail_orchestration_dispatch(
+        &self,
+        dispatch_id: &str,
+        error: &str,
+    ) -> Result<OrchestrationDispatchContext> {
+        let mut tx = self.pool().begin().await?;
+        let row = sqlx::query(&format!(
+            "SELECT {DISPATCH_COLUMNS} FROM orchestrationDispatchContexts WHERE id = ?"
+        ))
+        .bind(dispatch_id)
+        .fetch_optional(&mut *tx)
+        .await?;
+        let ctx = row
+            .map(dispatch_from_row)
+            .transpose()?
+            .ok_or_else(|| anyhow!("dispatch context not found: {dispatch_id}"))?;
+        let new_failure_count = ctx.failure_count + 1;
+        let circuit_broken = new_failure_count >= ORCHESTRATION_CIRCUIT_BREAKER_THRESHOLD;
+        let dispatch_status = if circuit_broken {
+            OrchestrationDispatchStatus::CircuitBroken
+        } else {
+            OrchestrationDispatchStatus::Failed
+        };
+        let task_status = if circuit_broken {
+            OrchestrationTaskStatus::Failed
+        } else {
+            OrchestrationTaskStatus::Ready
+        };
+        sqlx::query(
+            "UPDATE orchestrationDispatchContexts \
+             SET status = ?, failure_count = ?, last_failure = ?, completed_at = datetime('now') \
+             WHERE id = ?",
+        )
+        .bind(dispatch_status.as_str())
+        .bind(new_failure_count)
+        .bind(error)
+        .bind(dispatch_id)
+        .execute(&mut *tx)
+        .await?;
+        sqlx::query(
+            "UPDATE orchestrationTasks \
+             SET status = ?, \
+                 completed_at = CASE WHEN ? = 'failed' THEN datetime('now') ELSE NULL END \
+             WHERE id = ?",
+        )
+        .bind(task_status.as_str())
+        .bind(task_status.as_str())
+        .bind(&ctx.task_id)
+        .execute(&mut *tx)
+        .await?;
+        if task_status == OrchestrationTaskStatus::Failed {
+            refresh_pending_dependents_after_task_status(&mut tx, &ctx.task_id).await?;
+        }
+        tx.commit().await?;
+        self.orchestration_dispatch_by_id(dispatch_id)
+            .await?
+            .ok_or_else(|| anyhow!("dispatch context not found after update: {dispatch_id}"))
+    }
+
+    /// Records a heartbeat only while the dispatch is still active, so a
+    /// straggler from a completed or failed context cannot refresh liveness.
+    pub async fn record_orchestration_heartbeat(&self, dispatch_id: &str) -> Result<bool> {
+        let result = sqlx::query(
+            "UPDATE orchestrationDispatchContexts \
+             SET last_heartbeat_at = datetime('now') \
+             WHERE id = ? AND status = 'dispatched'",
+        )
+        .bind(dispatch_id)
+        .execute(self.pool())
+        .await?;
+        Ok(result.rows_affected() > 0)
+    }
+
+    /// Dispatched contexts whose dispatch and last heartbeat both predate the
+    /// threshold (ISO lexicographic comparison).
+    pub async fn stale_orchestration_dispatches(
+        &self,
+        threshold_iso: &str,
+    ) -> Result<Vec<OrchestrationDispatchContext>> {
+        let rows = sqlx::query(&format!(
+            "SELECT {DISPATCH_COLUMNS} FROM orchestrationDispatchContexts \
+             WHERE status = 'dispatched' AND dispatched_at < ? \
+             AND (last_heartbeat_at IS NULL OR last_heartbeat_at < ?)"
+        ))
+        .bind(threshold_iso)
+        .bind(threshold_iso)
+        .fetch_all(self.pool())
+        .await?;
+        rows.into_iter().map(dispatch_from_row).collect()
+    }
+
+    // --- Decision gates ---
+
+    /// Creates a gate: blocks the task and completes its active dispatch so
+    /// the worker terminal is released while the question is pending.
+    pub async fn create_orchestration_gate(
+        &self,
+        task_id: &str,
+        question: &str,
+        options: &[String],
+    ) -> Result<OrchestrationDecisionGate> {
+        let mut tx = self.pool().begin().await?;
+        let task_status: Option<String> =
+            sqlx::query("SELECT status FROM orchestrationTasks WHERE id = ?")
+                .bind(task_id)
+                .fetch_optional(&mut *tx)
+                .await?
+                .map(|row| row.try_get("status"))
+                .transpose()?;
+        match task_status.as_deref() {
+            None => bail!("orchestration task not found: {task_id}"),
+            Some("ready") | Some("dispatched") => {}
+            Some(other) => bail!("task {task_id} cannot be gated while {other}"),
+        }
+        let id = orchestration_id("gate");
+        sqlx::query(
+            "INSERT INTO orchestrationDecisionGates (id, task_id, question, options) \
+             VALUES (?, ?, ?, ?)",
+        )
+        .bind(&id)
+        .bind(task_id)
+        .bind(question)
+        .bind(serde_json::to_string(options)?)
+        .execute(&mut *tx)
+        .await?;
+        sqlx::query(
+            "UPDATE orchestrationDispatchContexts \
+             SET status = 'completed', completed_at = datetime('now') \
+             WHERE task_id = ? AND status IN ('pending','dispatched')",
+        )
+        .bind(task_id)
+        .execute(&mut *tx)
+        .await?;
+        sqlx::query("UPDATE orchestrationTasks SET status = 'blocked' WHERE id = ?")
+            .bind(task_id)
+            .execute(&mut *tx)
+            .await?;
+        tx.commit().await?;
+        self.orchestration_gate_by_id(&id)
+            .await?
+            .ok_or_else(|| anyhow!("inserted decision gate not found"))
+    }
+
+    pub async fn orchestration_gate_by_id(
+        &self,
+        id: &str,
+    ) -> Result<Option<OrchestrationDecisionGate>> {
+        let row = sqlx::query(&format!(
+            "SELECT {GATE_COLUMNS} FROM orchestrationDecisionGates WHERE id = ?"
+        ))
+        .bind(id)
+        .fetch_optional(self.pool())
+        .await?;
+        row.map(gate_from_row).transpose()
+    }
+
+    /// Resolves a gate and returns the task to `ready` when it is still
+    /// blocked, so the coordinator can re-dispatch it with the resolution
+    /// included in the next preamble.
+    pub async fn resolve_orchestration_gate(
+        &self,
+        gate_id: &str,
+        resolution: &str,
+    ) -> Result<OrchestrationDecisionGate> {
+        let mut tx = self.pool().begin().await?;
+        let row = sqlx::query(&format!(
+            "SELECT {GATE_COLUMNS} FROM orchestrationDecisionGates WHERE id = ?"
+        ))
+        .bind(gate_id)
+        .fetch_optional(&mut *tx)
+        .await?;
+        let gate = row
+            .map(gate_from_row)
+            .transpose()?
+            .ok_or_else(|| anyhow!("decision gate not found: {gate_id}"))?;
+        if gate.status != OrchestrationGateStatus::Pending {
+            bail!("decision gate {gate_id} is not pending");
+        }
+        sqlx::query(
+            "UPDATE orchestrationDecisionGates \
+             SET status = 'resolved', resolution = ?, resolved_at = datetime('now') \
+             WHERE id = ?",
+        )
+        .bind(resolution)
+        .bind(gate_id)
+        .execute(&mut *tx)
+        .await?;
+        sqlx::query(
+            "UPDATE orchestrationTasks SET status = 'ready' \
+             WHERE id = ? AND status = 'blocked'",
+        )
+        .bind(&gate.task_id)
+        .execute(&mut *tx)
+        .await?;
+        tx.commit().await?;
+        self.orchestration_gate_by_id(gate_id)
+            .await?
+            .ok_or_else(|| anyhow!("decision gate not found after update: {gate_id}"))
+    }
+
+    pub async fn list_orchestration_gates(
+        &self,
+        task_id: Option<&str>,
+        status: Option<OrchestrationGateStatus>,
+    ) -> Result<Vec<OrchestrationDecisionGate>> {
+        let mut sql = format!("SELECT {GATE_COLUMNS} FROM orchestrationDecisionGates");
+        let mut clauses = Vec::new();
+        if task_id.is_some() {
+            clauses.push("task_id = ?");
+        }
+        if status.is_some() {
+            clauses.push("status = ?");
+        }
+        if !clauses.is_empty() {
+            sql.push_str(" WHERE ");
+            sql.push_str(&clauses.join(" AND "));
+        }
+        sql.push_str(" ORDER BY created_at ASC, rowid ASC");
+        let mut query = sqlx::query(&sql);
+        if let Some(task_id) = task_id {
+            query = query.bind(task_id);
+        }
+        if let Some(status) = status {
+            query = query.bind(status.as_str());
+        }
+        let rows = query.fetch_all(self.pool()).await?;
+        rows.into_iter().map(gate_from_row).collect()
+    }
+
+    // --- Coordinator runs ---
+
+    pub async fn create_orchestration_coordinator_run(
+        &self,
+        spec: &str,
+        coordinator_handle: Option<&str>,
+        poll_interval_ms: i64,
+    ) -> Result<OrchestrationCoordinatorRun> {
+        let mut tx = self.pool().begin().await?;
+        let active: Option<String> = sqlx::query(
+            "SELECT id FROM orchestrationCoordinatorRuns WHERE status = 'running' LIMIT 1",
+        )
+        .fetch_optional(&mut *tx)
+        .await?
+        .map(|row| row.try_get("id"))
+        .transpose()?;
+        if let Some(active_id) = active {
+            bail!("a coordinator run is already active: {active_id}");
+        }
+        let id = orchestration_id("run");
+        sqlx::query(
+            "INSERT INTO orchestrationCoordinatorRuns \
+             (id, spec, status, coordinator_handle, poll_interval_ms) \
+             VALUES (?, ?, 'running', ?, ?)",
+        )
+        .bind(&id)
+        .bind(spec)
+        .bind(coordinator_handle)
+        .bind(poll_interval_ms)
+        .execute(&mut *tx)
+        .await?;
+        tx.commit().await?;
+        self.orchestration_coordinator_run_by_id(&id)
+            .await?
+            .ok_or_else(|| anyhow!("inserted coordinator run not found"))
+    }
+
+    pub async fn orchestration_coordinator_run_by_id(
+        &self,
+        id: &str,
+    ) -> Result<Option<OrchestrationCoordinatorRun>> {
+        let row = sqlx::query(&format!(
+            "SELECT {RUN_COLUMNS} FROM orchestrationCoordinatorRuns WHERE id = ?"
+        ))
+        .bind(id)
+        .fetch_optional(self.pool())
+        .await?;
+        row.map(run_from_row).transpose()
+    }
+
+    pub async fn active_orchestration_coordinator_run(
+        &self,
+    ) -> Result<Option<OrchestrationCoordinatorRun>> {
+        let row = sqlx::query(&format!(
+            "SELECT {RUN_COLUMNS} FROM orchestrationCoordinatorRuns \
+             WHERE status = 'running' ORDER BY created_at DESC LIMIT 1"
+        ))
+        .fetch_optional(self.pool())
+        .await?;
+        row.map(run_from_row).transpose()
+    }
+
+    pub async fn finish_orchestration_coordinator_run(
+        &self,
+        id: &str,
+        status: OrchestrationCoordinatorStatus,
+    ) -> Result<()> {
+        sqlx::query(
+            "UPDATE orchestrationCoordinatorRuns \
+             SET status = ?, completed_at = datetime('now') WHERE id = ?",
+        )
+        .bind(status.as_str())
+        .bind(id)
+        .execute(self.pool())
+        .await?;
+        Ok(())
+    }
+}

--- a/rust/alera-core/src/runtime/orchestration_message_store.rs
+++ b/rust/alera-core/src/runtime/orchestration_message_store.rs
@@ -1,0 +1,341 @@
+use anyhow::Result;
+use sqlx::sqlite::SqliteRow;
+use sqlx::Row;
+use uuid::Uuid;
+
+use super::{
+    OrchestrationMessage, OrchestrationMessagePriority, OrchestrationMessageType, RuntimeStore,
+};
+
+// Timestamps in orchestration tables use SQLite's datetime('now') TEXT shape
+// (UTC, second precision) so threshold comparisons can rely on lexicographic
+// ordering, mirroring the Orca reference implementation.
+pub(super) const ORCHESTRATION_SCHEMA: &[&str] = &[
+    "CREATE TABLE IF NOT EXISTS orchestrationMessages (
+        id TEXT NOT NULL,
+        from_handle TEXT NOT NULL,
+        to_handle TEXT NOT NULL,
+        subject TEXT NOT NULL,
+        body TEXT NOT NULL DEFAULT '',
+        type TEXT NOT NULL DEFAULT 'status'
+            CHECK(type IN ('status','dispatch','worker_done','merge_ready',
+                           'escalation','handoff','decision_gate','heartbeat')),
+        priority TEXT NOT NULL DEFAULT 'normal'
+            CHECK(priority IN ('normal','high','urgent')),
+        thread_id TEXT,
+        payload TEXT,
+        read INTEGER NOT NULL DEFAULT 0,
+        sequence INTEGER PRIMARY KEY AUTOINCREMENT,
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        delivered_at TEXT
+    );",
+    "CREATE UNIQUE INDEX IF NOT EXISTS orchestrationMessagesIdIdx ON orchestrationMessages(id);",
+    "CREATE INDEX IF NOT EXISTS orchestrationMessagesInboxIdx ON orchestrationMessages(to_handle, read);",
+    "CREATE INDEX IF NOT EXISTS orchestrationMessagesUndeliveredIdx ON orchestrationMessages(to_handle, read, delivered_at, sequence);",
+    "CREATE INDEX IF NOT EXISTS orchestrationMessagesThreadIdx ON orchestrationMessages(thread_id);",
+    "CREATE TABLE IF NOT EXISTS orchestrationTasks (
+        id TEXT PRIMARY KEY,
+        parent_id TEXT,
+        created_by_terminal_handle TEXT,
+        task_title TEXT,
+        display_name TEXT,
+        spec TEXT NOT NULL,
+        status TEXT NOT NULL DEFAULT 'pending'
+            CHECK(status IN ('pending','ready','dispatched','completed','failed','blocked')),
+        deps TEXT NOT NULL DEFAULT '[]',
+        result TEXT,
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        completed_at TEXT
+    );",
+    "CREATE INDEX IF NOT EXISTS orchestrationTasksStatusIdx ON orchestrationTasks(status);",
+    "CREATE INDEX IF NOT EXISTS orchestrationTasksParentIdx ON orchestrationTasks(parent_id);",
+    "CREATE TABLE IF NOT EXISTS orchestrationDispatchContexts (
+        id TEXT PRIMARY KEY,
+        task_id TEXT NOT NULL,
+        assignee_handle TEXT,
+        status TEXT NOT NULL DEFAULT 'pending'
+            CHECK(status IN ('pending','dispatched','completed','failed','circuit_broken')),
+        failure_count INTEGER NOT NULL DEFAULT 0,
+        last_failure TEXT,
+        dispatched_at TEXT,
+        completed_at TEXT,
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        last_heartbeat_at TEXT
+    );",
+    "CREATE INDEX IF NOT EXISTS orchestrationDispatchTaskIdx ON orchestrationDispatchContexts(task_id);",
+    "CREATE INDEX IF NOT EXISTS orchestrationDispatchStatusIdx ON orchestrationDispatchContexts(status);",
+    "CREATE TABLE IF NOT EXISTS orchestrationDecisionGates (
+        id TEXT PRIMARY KEY,
+        task_id TEXT NOT NULL,
+        question TEXT NOT NULL,
+        options TEXT NOT NULL DEFAULT '[]',
+        status TEXT NOT NULL DEFAULT 'pending'
+            CHECK(status IN ('pending','resolved','timeout')),
+        resolution TEXT,
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        resolved_at TEXT
+    );",
+    "CREATE INDEX IF NOT EXISTS orchestrationGatesTaskIdx ON orchestrationDecisionGates(task_id);",
+    "CREATE TABLE IF NOT EXISTS orchestrationCoordinatorRuns (
+        id TEXT PRIMARY KEY,
+        spec TEXT NOT NULL,
+        status TEXT NOT NULL DEFAULT 'idle'
+            CHECK(status IN ('idle','running','completed','failed')),
+        coordinator_handle TEXT,
+        poll_interval_ms INTEGER NOT NULL DEFAULT 2000,
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        completed_at TEXT
+    );",
+];
+
+// Future enum widening: SQLite cannot ALTER a CHECK constraint, so adding a
+// message type or status value requires an Orca-style table rebuild migration.
+
+pub struct NewOrchestrationMessage {
+    pub from_handle: String,
+    pub to_handle: String,
+    pub subject: String,
+    pub body: String,
+    pub message_type: OrchestrationMessageType,
+    pub priority: OrchestrationMessagePriority,
+    pub thread_id: Option<String>,
+    pub payload: Option<String>,
+}
+
+pub(super) fn orchestration_id(prefix: &str) -> String {
+    let hex = Uuid::new_v4().simple().to_string();
+    format!("{prefix}_{}", &hex[..16])
+}
+
+const MESSAGE_COLUMNS: &str = "id, from_handle, to_handle, subject, body, type, priority, \
+     thread_id, payload, read, sequence, created_at, delivered_at";
+
+fn message_from_row(row: SqliteRow) -> Result<OrchestrationMessage> {
+    let type_raw: String = row.try_get("type")?;
+    let priority_raw: String = row.try_get("priority")?;
+    Ok(OrchestrationMessage {
+        id: row.try_get("id")?,
+        from_handle: row.try_get("from_handle")?,
+        to_handle: row.try_get("to_handle")?,
+        subject: row.try_get("subject")?,
+        body: row.try_get("body")?,
+        message_type: OrchestrationMessageType::parse(&type_raw)
+            .unwrap_or(OrchestrationMessageType::Status),
+        priority: OrchestrationMessagePriority::parse(&priority_raw).unwrap_or_default(),
+        thread_id: row.try_get("thread_id")?,
+        payload: row.try_get("payload")?,
+        read: row.try_get::<i64, _>("read")? != 0,
+        sequence: row.try_get("sequence")?,
+        created_at: row.try_get("created_at")?,
+        delivered_at: row.try_get("delivered_at")?,
+    })
+}
+
+fn id_placeholders(count: usize) -> String {
+    let mut placeholders = "?,".repeat(count);
+    placeholders.pop();
+    placeholders
+}
+
+impl RuntimeStore {
+    pub async fn insert_orchestration_message(
+        &self,
+        message: NewOrchestrationMessage,
+    ) -> Result<OrchestrationMessage> {
+        let id = orchestration_id("msg");
+        sqlx::query(
+            "INSERT INTO orchestrationMessages \
+             (id, from_handle, to_handle, subject, body, type, priority, thread_id, payload) \
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        )
+        .bind(&id)
+        .bind(&message.from_handle)
+        .bind(&message.to_handle)
+        .bind(&message.subject)
+        .bind(&message.body)
+        .bind(message.message_type.as_str())
+        .bind(message.priority.as_str())
+        .bind(&message.thread_id)
+        .bind(&message.payload)
+        .execute(self.pool())
+        .await?;
+        self.orchestration_message_by_id(&id)
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("inserted orchestration message not found"))
+    }
+
+    pub async fn orchestration_message_by_id(
+        &self,
+        id: &str,
+    ) -> Result<Option<OrchestrationMessage>> {
+        let row = sqlx::query(&format!(
+            "SELECT {MESSAGE_COLUMNS} FROM orchestrationMessages WHERE id = ?"
+        ))
+        .bind(id)
+        .fetch_optional(self.pool())
+        .await?;
+        row.map(message_from_row).transpose()
+    }
+
+    pub async fn unread_orchestration_messages(
+        &self,
+        to_handle: &str,
+        types: Option<&[OrchestrationMessageType]>,
+    ) -> Result<Vec<OrchestrationMessage>> {
+        let mut sql = format!(
+            "SELECT {MESSAGE_COLUMNS} FROM orchestrationMessages \
+             WHERE to_handle = ? AND read = 0"
+        );
+        if let Some(types) = types {
+            if !types.is_empty() {
+                sql.push_str(&format!(" AND type IN ({})", id_placeholders(types.len())));
+            }
+        }
+        sql.push_str(" ORDER BY sequence ASC");
+        let mut query = sqlx::query(&sql).bind(to_handle);
+        if let Some(types) = types {
+            for message_type in types {
+                query = query.bind(message_type.as_str());
+            }
+        }
+        let rows = query.fetch_all(self.pool()).await?;
+        rows.into_iter().map(message_from_row).collect()
+    }
+
+    pub async fn unread_orchestration_coordinator_messages(
+        &self,
+        to_handle: &str,
+    ) -> Result<Vec<OrchestrationMessage>> {
+        let rows = sqlx::query(&format!(
+            "SELECT {MESSAGE_COLUMNS} FROM orchestrationMessages \
+             WHERE to_handle = ? AND read = 0 AND ( \
+               type IN ('worker_done', 'heartbeat', 'escalation') \
+               OR ( \
+                 type = 'decision_gate' \
+                 AND CASE \
+                   WHEN payload IS NOT NULL AND json_valid(payload) \
+                   THEN COALESCE(json_extract(payload, '$.taskId'), '') != '' \
+                   ELSE 0 \
+                 END \
+               ) \
+             ) \
+             ORDER BY sequence ASC"
+        ))
+        .bind(to_handle)
+        .fetch_all(self.pool())
+        .await?;
+        rows.into_iter().map(message_from_row).collect()
+    }
+
+    pub async fn undelivered_unread_orchestration_messages(
+        &self,
+        to_handle: &str,
+    ) -> Result<Vec<OrchestrationMessage>> {
+        let rows = sqlx::query(&format!(
+            "SELECT {MESSAGE_COLUMNS} FROM orchestrationMessages \
+             WHERE to_handle = ? AND read = 0 AND delivered_at IS NULL \
+             ORDER BY sequence ASC"
+        ))
+        .bind(to_handle)
+        .fetch_all(self.pool())
+        .await?;
+        rows.into_iter().map(message_from_row).collect()
+    }
+
+    pub async fn all_orchestration_messages_for_handle(
+        &self,
+        to_handle: &str,
+        types: Option<&[OrchestrationMessageType]>,
+        limit: i64,
+    ) -> Result<Vec<OrchestrationMessage>> {
+        let mut sql = format!(
+            "SELECT {MESSAGE_COLUMNS} FROM orchestrationMessages \
+             WHERE to_handle = ?"
+        );
+        if let Some(types) = types {
+            if !types.is_empty() {
+                sql.push_str(&format!(" AND type IN ({})", id_placeholders(types.len())));
+            }
+        }
+        sql.push_str(" ORDER BY sequence DESC LIMIT ?");
+        let mut query = sqlx::query(&sql).bind(to_handle);
+        if let Some(types) = types {
+            for message_type in types {
+                query = query.bind(message_type.as_str());
+            }
+        }
+        let rows = query.bind(limit).fetch_all(self.pool()).await?;
+        rows.into_iter().map(message_from_row).collect()
+    }
+
+    pub async fn orchestration_inbox(&self, limit: i64) -> Result<Vec<OrchestrationMessage>> {
+        let rows = sqlx::query(&format!(
+            "SELECT {MESSAGE_COLUMNS} FROM orchestrationMessages \
+             ORDER BY sequence DESC LIMIT ?"
+        ))
+        .bind(limit)
+        .fetch_all(self.pool())
+        .await?;
+        rows.into_iter().map(message_from_row).collect()
+    }
+
+    pub async fn mark_orchestration_messages_read(&self, ids: &[String]) -> Result<()> {
+        if ids.is_empty() {
+            return Ok(());
+        }
+        let sql = format!(
+            "UPDATE orchestrationMessages SET read = 1 WHERE id IN ({})",
+            id_placeholders(ids.len())
+        );
+        let mut query = sqlx::query(&sql);
+        for id in ids {
+            query = query.bind(id);
+        }
+        query.execute(self.pool()).await?;
+        Ok(())
+    }
+
+    pub async fn mark_orchestration_messages_delivered(&self, ids: &[String]) -> Result<()> {
+        if ids.is_empty() {
+            return Ok(());
+        }
+        let sql = format!(
+            "UPDATE orchestrationMessages SET delivered_at = datetime('now') WHERE id IN ({})",
+            id_placeholders(ids.len())
+        );
+        let mut query = sqlx::query(&sql);
+        for id in ids {
+            query = query.bind(id);
+        }
+        query.execute(self.pool()).await?;
+        Ok(())
+    }
+
+    /// Replies addressed to `to_handle` in a thread, strictly after `after_sequence`.
+    /// Powers the blocking `ask` loop.
+    pub async fn orchestration_thread_messages_for(
+        &self,
+        thread_id: &str,
+        to_handle: &str,
+        after_sequence: i64,
+    ) -> Result<Vec<OrchestrationMessage>> {
+        let rows = sqlx::query(&format!(
+            "SELECT {MESSAGE_COLUMNS} FROM orchestrationMessages \
+             WHERE thread_id = ? AND to_handle = ? AND sequence > ? \
+             ORDER BY sequence ASC"
+        ))
+        .bind(thread_id)
+        .bind(to_handle)
+        .bind(after_sequence)
+        .fetch_all(self.pool())
+        .await?;
+        rows.into_iter().map(message_from_row).collect()
+    }
+
+    pub async fn reset_orchestration_messages(&self) -> Result<()> {
+        sqlx::query("DELETE FROM orchestrationMessages")
+            .execute(self.pool())
+            .await?;
+        Ok(())
+    }
+}

--- a/rust/alera-core/src/runtime/orchestration_models.rs
+++ b/rust/alera-core/src/runtime/orchestration_models.rs
@@ -1,0 +1,283 @@
+use serde::{Deserialize, Serialize};
+
+// Orchestration rows serialize with snake_case field and enum values on
+// purpose: the CLI JSON output mirrors Orca's orchestration payload shapes so
+// agent-facing skills and docs stay portable between the two systems.
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum OrchestrationMessageType {
+    Status,
+    Dispatch,
+    WorkerDone,
+    MergeReady,
+    Escalation,
+    Handoff,
+    DecisionGate,
+    Heartbeat,
+}
+
+impl OrchestrationMessageType {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            OrchestrationMessageType::Status => "status",
+            OrchestrationMessageType::Dispatch => "dispatch",
+            OrchestrationMessageType::WorkerDone => "worker_done",
+            OrchestrationMessageType::MergeReady => "merge_ready",
+            OrchestrationMessageType::Escalation => "escalation",
+            OrchestrationMessageType::Handoff => "handoff",
+            OrchestrationMessageType::DecisionGate => "decision_gate",
+            OrchestrationMessageType::Heartbeat => "heartbeat",
+        }
+    }
+
+    pub fn parse(value: &str) -> Option<Self> {
+        match value {
+            "status" => Some(OrchestrationMessageType::Status),
+            "dispatch" => Some(OrchestrationMessageType::Dispatch),
+            "worker_done" => Some(OrchestrationMessageType::WorkerDone),
+            "merge_ready" => Some(OrchestrationMessageType::MergeReady),
+            "escalation" => Some(OrchestrationMessageType::Escalation),
+            "handoff" => Some(OrchestrationMessageType::Handoff),
+            "decision_gate" => Some(OrchestrationMessageType::DecisionGate),
+            "heartbeat" => Some(OrchestrationMessageType::Heartbeat),
+            _ => None,
+        }
+    }
+
+    pub fn is_lifecycle(self) -> bool {
+        matches!(
+            self,
+            OrchestrationMessageType::WorkerDone | OrchestrationMessageType::Heartbeat
+        )
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum OrchestrationMessagePriority {
+    #[default]
+    Normal,
+    High,
+    Urgent,
+}
+
+impl OrchestrationMessagePriority {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            OrchestrationMessagePriority::Normal => "normal",
+            OrchestrationMessagePriority::High => "high",
+            OrchestrationMessagePriority::Urgent => "urgent",
+        }
+    }
+
+    pub fn parse(value: &str) -> Option<Self> {
+        match value {
+            "normal" => Some(OrchestrationMessagePriority::Normal),
+            "high" => Some(OrchestrationMessagePriority::High),
+            "urgent" => Some(OrchestrationMessagePriority::Urgent),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum OrchestrationTaskStatus {
+    Pending,
+    Ready,
+    Dispatched,
+    Completed,
+    Failed,
+    Blocked,
+}
+
+impl OrchestrationTaskStatus {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            OrchestrationTaskStatus::Pending => "pending",
+            OrchestrationTaskStatus::Ready => "ready",
+            OrchestrationTaskStatus::Dispatched => "dispatched",
+            OrchestrationTaskStatus::Completed => "completed",
+            OrchestrationTaskStatus::Failed => "failed",
+            OrchestrationTaskStatus::Blocked => "blocked",
+        }
+    }
+
+    pub fn parse(value: &str) -> Option<Self> {
+        match value {
+            "pending" => Some(OrchestrationTaskStatus::Pending),
+            "ready" => Some(OrchestrationTaskStatus::Ready),
+            "dispatched" => Some(OrchestrationTaskStatus::Dispatched),
+            "completed" => Some(OrchestrationTaskStatus::Completed),
+            "failed" => Some(OrchestrationTaskStatus::Failed),
+            "blocked" => Some(OrchestrationTaskStatus::Blocked),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum OrchestrationDispatchStatus {
+    Pending,
+    Dispatched,
+    Completed,
+    Failed,
+    CircuitBroken,
+}
+
+impl OrchestrationDispatchStatus {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            OrchestrationDispatchStatus::Pending => "pending",
+            OrchestrationDispatchStatus::Dispatched => "dispatched",
+            OrchestrationDispatchStatus::Completed => "completed",
+            OrchestrationDispatchStatus::Failed => "failed",
+            OrchestrationDispatchStatus::CircuitBroken => "circuit_broken",
+        }
+    }
+
+    pub fn parse(value: &str) -> Option<Self> {
+        match value {
+            "pending" => Some(OrchestrationDispatchStatus::Pending),
+            "dispatched" => Some(OrchestrationDispatchStatus::Dispatched),
+            "completed" => Some(OrchestrationDispatchStatus::Completed),
+            "failed" => Some(OrchestrationDispatchStatus::Failed),
+            "circuit_broken" => Some(OrchestrationDispatchStatus::CircuitBroken),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum OrchestrationGateStatus {
+    Pending,
+    Resolved,
+    Timeout,
+}
+
+impl OrchestrationGateStatus {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            OrchestrationGateStatus::Pending => "pending",
+            OrchestrationGateStatus::Resolved => "resolved",
+            OrchestrationGateStatus::Timeout => "timeout",
+        }
+    }
+
+    pub fn parse(value: &str) -> Option<Self> {
+        match value {
+            "pending" => Some(OrchestrationGateStatus::Pending),
+            "resolved" => Some(OrchestrationGateStatus::Resolved),
+            "timeout" => Some(OrchestrationGateStatus::Timeout),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum OrchestrationCoordinatorStatus {
+    Idle,
+    Running,
+    Completed,
+    Failed,
+}
+
+impl OrchestrationCoordinatorStatus {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            OrchestrationCoordinatorStatus::Idle => "idle",
+            OrchestrationCoordinatorStatus::Running => "running",
+            OrchestrationCoordinatorStatus::Completed => "completed",
+            OrchestrationCoordinatorStatus::Failed => "failed",
+        }
+    }
+
+    pub fn parse(value: &str) -> Option<Self> {
+        match value {
+            "idle" => Some(OrchestrationCoordinatorStatus::Idle),
+            "running" => Some(OrchestrationCoordinatorStatus::Running),
+            "completed" => Some(OrchestrationCoordinatorStatus::Completed),
+            "failed" => Some(OrchestrationCoordinatorStatus::Failed),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct OrchestrationMessage {
+    pub id: String,
+    pub from_handle: String,
+    pub to_handle: String,
+    pub subject: String,
+    pub body: String,
+    #[serde(rename = "type")]
+    pub message_type: OrchestrationMessageType,
+    pub priority: OrchestrationMessagePriority,
+    pub thread_id: Option<String>,
+    pub payload: Option<String>,
+    pub read: bool,
+    pub sequence: i64,
+    pub created_at: String,
+    pub delivered_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct OrchestrationTask {
+    pub id: String,
+    pub parent_id: Option<String>,
+    pub created_by_terminal_handle: Option<String>,
+    pub task_title: Option<String>,
+    pub display_name: Option<String>,
+    pub spec: String,
+    pub status: OrchestrationTaskStatus,
+    pub deps: Vec<String>,
+    pub result: Option<String>,
+    pub created_at: String,
+    pub completed_at: Option<String>,
+    /// Populated by list-with-dispatch queries: the active dispatch, if any.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub assignee_handle: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dispatch_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct OrchestrationDispatchContext {
+    pub id: String,
+    pub task_id: String,
+    pub assignee_handle: Option<String>,
+    pub status: OrchestrationDispatchStatus,
+    pub failure_count: i64,
+    pub last_failure: Option<String>,
+    pub dispatched_at: Option<String>,
+    pub completed_at: Option<String>,
+    pub created_at: String,
+    pub last_heartbeat_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct OrchestrationDecisionGate {
+    pub id: String,
+    pub task_id: String,
+    pub question: String,
+    pub options: Vec<String>,
+    pub status: OrchestrationGateStatus,
+    pub resolution: Option<String>,
+    pub created_at: String,
+    pub resolved_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct OrchestrationCoordinatorRun {
+    pub id: String,
+    pub spec: String,
+    pub status: OrchestrationCoordinatorStatus,
+    pub coordinator_handle: Option<String>,
+    pub poll_interval_ms: i64,
+    pub created_at: String,
+    pub completed_at: Option<String>,
+}

--- a/rust/alera-core/src/runtime/orchestration_store_tests.rs
+++ b/rust/alera-core/src/runtime/orchestration_store_tests.rs
@@ -1,0 +1,845 @@
+use super::*;
+
+async fn store() -> (tempfile::TempDir, RuntimeStore) {
+    let dir = tempfile::tempdir().unwrap();
+    let store = RuntimeStore::open(dir.path()).await.unwrap();
+    (dir, store)
+}
+
+fn message(
+    from: &str,
+    to: &str,
+    message_type: OrchestrationMessageType,
+) -> NewOrchestrationMessage {
+    NewOrchestrationMessage {
+        from_handle: from.to_string(),
+        to_handle: to.to_string(),
+        subject: "subject".to_string(),
+        body: "body".to_string(),
+        message_type,
+        priority: OrchestrationMessagePriority::Normal,
+        thread_id: None,
+        payload: None,
+    }
+}
+
+fn task(spec: &str, deps: Vec<String>) -> NewOrchestrationTask {
+    NewOrchestrationTask {
+        spec: spec.to_string(),
+        task_title: None,
+        display_name: None,
+        deps,
+        parent_id: None,
+        created_by_terminal_handle: None,
+    }
+}
+
+#[tokio::test]
+async fn read_and_delivered_are_independent() {
+    let (_dir, store) = store().await;
+    let msg = store
+        .insert_orchestration_message(message("a", "b", OrchestrationMessageType::Status))
+        .await
+        .unwrap();
+
+    // Delivering does not consume the unread state.
+    store
+        .mark_orchestration_messages_delivered(std::slice::from_ref(&msg.id))
+        .await
+        .unwrap();
+    let unread = store
+        .unread_orchestration_messages("b", None)
+        .await
+        .unwrap();
+    assert_eq!(unread.len(), 1);
+    // But it is excluded from the push-on-idle queue.
+    let undelivered = store
+        .undelivered_unread_orchestration_messages("b")
+        .await
+        .unwrap();
+    assert!(undelivered.is_empty());
+
+    // Reading does not clear delivery state either.
+    store
+        .mark_orchestration_messages_read(std::slice::from_ref(&msg.id))
+        .await
+        .unwrap();
+    let refreshed = store
+        .orchestration_message_by_id(&msg.id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(refreshed.read);
+    assert!(refreshed.delivered_at.is_some());
+}
+
+#[tokio::test]
+async fn unread_filter_by_type_and_order() {
+    let (_dir, store) = store().await;
+    store
+        .insert_orchestration_message(message("a", "coord", OrchestrationMessageType::Status))
+        .await
+        .unwrap();
+    store
+        .insert_orchestration_message(message("a", "coord", OrchestrationMessageType::WorkerDone))
+        .await
+        .unwrap();
+    store
+        .insert_orchestration_message(message("a", "other", OrchestrationMessageType::WorkerDone))
+        .await
+        .unwrap();
+
+    let filtered = store
+        .unread_orchestration_messages("coord", Some(&[OrchestrationMessageType::WorkerDone]))
+        .await
+        .unwrap();
+    assert_eq!(filtered.len(), 1);
+    assert_eq!(
+        filtered[0].message_type,
+        OrchestrationMessageType::WorkerDone
+    );
+
+    let all = store
+        .unread_orchestration_messages("coord", None)
+        .await
+        .unwrap();
+    assert_eq!(all.len(), 2);
+    assert!(all[0].sequence < all[1].sequence);
+
+    let historical = store
+        .all_orchestration_messages_for_handle(
+            "coord",
+            Some(&[OrchestrationMessageType::WorkerDone]),
+            100,
+        )
+        .await
+        .unwrap();
+    assert_eq!(historical.len(), 1);
+    assert_eq!(
+        historical[0].message_type,
+        OrchestrationMessageType::WorkerDone
+    );
+}
+
+#[tokio::test]
+async fn coordinator_unread_messages_include_only_actionable_types() {
+    let (_dir, store) = store().await;
+    store
+        .insert_orchestration_message(message("a", "coord", OrchestrationMessageType::Status))
+        .await
+        .unwrap();
+    store
+        .insert_orchestration_message(message(
+            "a",
+            "coord",
+            OrchestrationMessageType::DecisionGate,
+        ))
+        .await
+        .unwrap();
+    let gate = store
+        .insert_orchestration_message(NewOrchestrationMessage {
+            payload: Some(serde_json::json!({"taskId": "task_1"}).to_string()),
+            ..message("a", "coord", OrchestrationMessageType::DecisionGate)
+        })
+        .await
+        .unwrap();
+    let done = store
+        .insert_orchestration_message(message("a", "coord", OrchestrationMessageType::WorkerDone))
+        .await
+        .unwrap();
+
+    let actionable = store
+        .unread_orchestration_coordinator_messages("coord")
+        .await
+        .unwrap();
+    assert_eq!(
+        actionable
+            .iter()
+            .map(|message| message.id.as_str())
+            .collect::<Vec<_>>(),
+        vec![gate.id.as_str(), done.id.as_str()]
+    );
+
+    let all_unread = store
+        .unread_orchestration_messages("coord", None)
+        .await
+        .unwrap();
+    assert_eq!(all_unread.len(), 4);
+}
+
+#[tokio::test]
+async fn thread_messages_scoped_to_recipient_after_sequence() {
+    let (_dir, store) = store().await;
+    let question = store
+        .insert_orchestration_message(NewOrchestrationMessage {
+            thread_id: Some("thread_1".to_string()),
+            ..message("worker", "coord", OrchestrationMessageType::DecisionGate)
+        })
+        .await
+        .unwrap();
+    // Reply addressed to worker in the same thread.
+    store
+        .insert_orchestration_message(NewOrchestrationMessage {
+            thread_id: Some("thread_1".to_string()),
+            ..message("coord", "worker", OrchestrationMessageType::Status)
+        })
+        .await
+        .unwrap();
+    // Unrelated message in the thread addressed elsewhere.
+    store
+        .insert_orchestration_message(NewOrchestrationMessage {
+            thread_id: Some("thread_1".to_string()),
+            ..message("coord", "someone", OrchestrationMessageType::Status)
+        })
+        .await
+        .unwrap();
+
+    let replies = store
+        .orchestration_thread_messages_for("thread_1", "worker", question.sequence)
+        .await
+        .unwrap();
+    assert_eq!(replies.len(), 1);
+    assert_eq!(replies[0].to_handle, "worker");
+}
+
+#[tokio::test]
+async fn task_initial_status_derived_from_deps() {
+    let (_dir, store) = store().await;
+    let root = store
+        .create_orchestration_task(task("root", vec![]))
+        .await
+        .unwrap();
+    assert_eq!(root.status, OrchestrationTaskStatus::Ready);
+
+    let child = store
+        .create_orchestration_task(task("child", vec![root.id.clone()]))
+        .await
+        .unwrap();
+    assert_eq!(child.status, OrchestrationTaskStatus::Pending);
+}
+
+#[tokio::test]
+async fn task_with_unknown_dep_is_rejected() {
+    let (_dir, store) = store().await;
+    let error = store
+        .create_orchestration_task(task("child", vec!["missing_task".to_string()]))
+        .await
+        .unwrap_err();
+
+    assert!(error
+        .to_string()
+        .contains("unknown orchestration task dependency: missing_task"));
+    assert!(store
+        .list_orchestration_tasks(None)
+        .await
+        .unwrap()
+        .is_empty());
+}
+
+#[tokio::test]
+async fn task_with_already_completed_deps_starts_ready() {
+    let (_dir, store) = store().await;
+    let root = store
+        .create_orchestration_task(task("root", vec![]))
+        .await
+        .unwrap();
+    store
+        .update_orchestration_task_status(&root.id, OrchestrationTaskStatus::Completed, None)
+        .await
+        .unwrap();
+
+    let child = store
+        .create_orchestration_task(task("child", vec![root.id.clone()]))
+        .await
+        .unwrap();
+    assert_eq!(child.status, OrchestrationTaskStatus::Ready);
+}
+
+#[tokio::test]
+async fn completing_task_promotes_dependents_when_all_deps_done() {
+    let (_dir, store) = store().await;
+    let a = store
+        .create_orchestration_task(task("a", vec![]))
+        .await
+        .unwrap();
+    let b = store
+        .create_orchestration_task(task("b", vec![]))
+        .await
+        .unwrap();
+    let c = store
+        .create_orchestration_task(task("c", vec![a.id.clone(), b.id.clone()]))
+        .await
+        .unwrap();
+
+    store
+        .update_orchestration_task_status(&a.id, OrchestrationTaskStatus::Completed, None)
+        .await
+        .unwrap();
+    let c_after_first = store
+        .orchestration_task_by_id(&c.id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(c_after_first.status, OrchestrationTaskStatus::Pending);
+
+    store
+        .update_orchestration_task_status(&b.id, OrchestrationTaskStatus::Completed, None)
+        .await
+        .unwrap();
+    let c_after_both = store
+        .orchestration_task_by_id(&c.id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(c_after_both.status, OrchestrationTaskStatus::Ready);
+}
+
+#[tokio::test]
+async fn failed_dependency_marks_pending_dependents_failed() {
+    let (_dir, store) = store().await;
+    let root = store
+        .create_orchestration_task(task("root", vec![]))
+        .await
+        .unwrap();
+    let child = store
+        .create_orchestration_task(task("child", vec![root.id.clone()]))
+        .await
+        .unwrap();
+    let grandchild = store
+        .create_orchestration_task(task("grandchild", vec![child.id.clone()]))
+        .await
+        .unwrap();
+
+    store
+        .update_orchestration_task_status(&root.id, OrchestrationTaskStatus::Failed, Some("boom"))
+        .await
+        .unwrap();
+    let child = store
+        .orchestration_task_by_id(&child.id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(child.status, OrchestrationTaskStatus::Failed);
+    let expected_result = format!("dependency failed: {}", root.id);
+    assert_eq!(child.result.as_deref(), Some(expected_result.as_str()));
+    let grandchild = store
+        .orchestration_task_by_id(&grandchild.id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(grandchild.status, OrchestrationTaskStatus::Failed);
+    let expected_result = format!("dependency failed: {}", child.id);
+    assert_eq!(grandchild.result.as_deref(), Some(expected_result.as_str()));
+}
+
+#[tokio::test]
+async fn task_with_already_failed_dep_starts_failed() {
+    let (_dir, store) = store().await;
+    let root = store
+        .create_orchestration_task(task("root", vec![]))
+        .await
+        .unwrap();
+    store
+        .update_orchestration_task_status(&root.id, OrchestrationTaskStatus::Failed, Some("boom"))
+        .await
+        .unwrap();
+
+    let child = store
+        .create_orchestration_task(task("child", vec![root.id.clone()]))
+        .await
+        .unwrap();
+    assert_eq!(child.status, OrchestrationTaskStatus::Failed);
+}
+
+#[tokio::test]
+async fn completing_task_closes_active_dispatch() {
+    let (_dir, store) = store().await;
+    let created = store
+        .create_orchestration_task(task("work", vec![]))
+        .await
+        .unwrap();
+    let dispatch = store
+        .create_orchestration_dispatch(&created.id, "term_1")
+        .await
+        .unwrap();
+    assert_eq!(dispatch.status, OrchestrationDispatchStatus::Dispatched);
+
+    store
+        .update_orchestration_task_status(&created.id, OrchestrationTaskStatus::Completed, None)
+        .await
+        .unwrap();
+    let refreshed = store
+        .orchestration_dispatch_by_id(&dispatch.id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(refreshed.status, OrchestrationDispatchStatus::Completed);
+    assert!(refreshed.completed_at.is_some());
+}
+
+#[tokio::test]
+async fn resetting_dispatched_task_to_ready_closes_active_dispatch() {
+    let (_dir, store) = store().await;
+    let created = store
+        .create_orchestration_task(task("work", vec![]))
+        .await
+        .unwrap();
+    let dispatch = store
+        .create_orchestration_dispatch(&created.id, "term_1")
+        .await
+        .unwrap();
+
+    let updated = store
+        .update_orchestration_task_status(&created.id, OrchestrationTaskStatus::Ready, None)
+        .await
+        .unwrap();
+    assert_eq!(updated.status, OrchestrationTaskStatus::Ready);
+
+    let refreshed = store
+        .orchestration_dispatch_by_id(&dispatch.id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(refreshed.status, OrchestrationDispatchStatus::Failed);
+    assert_eq!(
+        refreshed.last_failure.as_deref(),
+        Some("task status changed to ready")
+    );
+    assert!(refreshed.completed_at.is_some());
+    assert!(store
+        .active_orchestration_dispatch_for_task(&created.id)
+        .await
+        .unwrap()
+        .is_none());
+}
+
+#[tokio::test]
+async fn dispatch_requires_ready_task_and_free_terminal() {
+    let (_dir, store) = store().await;
+    let ready = store
+        .create_orchestration_task(task("ready", vec![]))
+        .await
+        .unwrap();
+    let dep = store
+        .create_orchestration_task(task("dep", vec![ready.id.clone()]))
+        .await
+        .unwrap();
+
+    // Pending task cannot be dispatched.
+    assert!(store
+        .create_orchestration_dispatch(&dep.id, "term_1")
+        .await
+        .is_err());
+
+    store
+        .create_orchestration_dispatch(&ready.id, "term_1")
+        .await
+        .unwrap();
+
+    // Same terminal cannot take a second active dispatch.
+    let other = store
+        .create_orchestration_task(task("other", vec![]))
+        .await
+        .unwrap();
+    let error = store
+        .create_orchestration_dispatch(&other.id, "term_1")
+        .await
+        .unwrap_err();
+    assert!(error.to_string().contains("active dispatch"));
+}
+
+#[tokio::test]
+async fn circuit_breaker_carries_failures_across_retries() {
+    let (_dir, store) = store().await;
+    let created = store
+        .create_orchestration_task(task("flaky", vec![]))
+        .await
+        .unwrap();
+
+    // Failure 1: task returns to ready, dispatch failed.
+    let first = store
+        .create_orchestration_dispatch(&created.id, "term_1")
+        .await
+        .unwrap();
+    let failed_first = store
+        .fail_orchestration_dispatch(&first.id, "boom")
+        .await
+        .unwrap();
+    assert_eq!(failed_first.status, OrchestrationDispatchStatus::Failed);
+    assert_eq!(failed_first.failure_count, 1);
+    let task_after_first = store
+        .orchestration_task_by_id(&created.id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(task_after_first.status, OrchestrationTaskStatus::Ready);
+    assert!(task_after_first.completed_at.is_none());
+
+    // Failure 2 on a different terminal: count carried forward.
+    let second = store
+        .create_orchestration_dispatch(&created.id, "term_2")
+        .await
+        .unwrap();
+    assert_eq!(second.failure_count, 1);
+    let failed_second = store
+        .fail_orchestration_dispatch(&second.id, "boom")
+        .await
+        .unwrap();
+    assert_eq!(failed_second.failure_count, 2);
+
+    // Failure 3: circuit breaks and the task fails.
+    let third = store
+        .create_orchestration_dispatch(&created.id, "term_3")
+        .await
+        .unwrap();
+    let failed_third = store
+        .fail_orchestration_dispatch(&third.id, "boom")
+        .await
+        .unwrap();
+    assert_eq!(
+        failed_third.status,
+        OrchestrationDispatchStatus::CircuitBroken
+    );
+    assert_eq!(
+        failed_third.failure_count,
+        ORCHESTRATION_CIRCUIT_BREAKER_THRESHOLD
+    );
+    let task_after_third = store
+        .orchestration_task_by_id(&created.id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(task_after_third.status, OrchestrationTaskStatus::Failed);
+    assert!(task_after_third.completed_at.is_some());
+}
+
+#[tokio::test]
+async fn heartbeat_recorded_only_while_dispatched() {
+    let (_dir, store) = store().await;
+    let created = store
+        .create_orchestration_task(task("hb", vec![]))
+        .await
+        .unwrap();
+    let dispatch = store
+        .create_orchestration_dispatch(&created.id, "term_1")
+        .await
+        .unwrap();
+
+    assert!(store
+        .record_orchestration_heartbeat(&dispatch.id)
+        .await
+        .unwrap());
+
+    store
+        .update_orchestration_task_status(&created.id, OrchestrationTaskStatus::Completed, None)
+        .await
+        .unwrap();
+    // Straggler heartbeat from a completed dispatch is ignored.
+    assert!(!store
+        .record_orchestration_heartbeat(&dispatch.id)
+        .await
+        .unwrap());
+}
+
+#[tokio::test]
+async fn stale_dispatch_query_uses_heartbeat_and_dispatch_time() {
+    let (_dir, store) = store().await;
+    let created = store
+        .create_orchestration_task(task("stale", vec![]))
+        .await
+        .unwrap();
+    let dispatch = store
+        .create_orchestration_dispatch(&created.id, "term_1")
+        .await
+        .unwrap();
+
+    // Threshold in the future: the dispatch (created now) is stale.
+    let stale = store
+        .stale_orchestration_dispatches("9999-01-01 00:00:00")
+        .await
+        .unwrap();
+    assert_eq!(stale.len(), 1);
+    assert_eq!(stale[0].id, dispatch.id);
+
+    // Threshold in the past: nothing stale.
+    let fresh = store
+        .stale_orchestration_dispatches("2000-01-01 00:00:00")
+        .await
+        .unwrap();
+    assert!(fresh.is_empty());
+}
+
+#[tokio::test]
+async fn gate_blocks_task_and_resolution_returns_it_to_ready() {
+    let (_dir, store) = store().await;
+    let created = store
+        .create_orchestration_task(task("gated", vec![]))
+        .await
+        .unwrap();
+    let dispatch = store
+        .create_orchestration_dispatch(&created.id, "term_1")
+        .await
+        .unwrap();
+
+    let gate = store
+        .create_orchestration_gate(
+            &created.id,
+            "Proceed?",
+            &["yes".to_string(), "no".to_string()],
+        )
+        .await
+        .unwrap();
+    assert_eq!(gate.status, OrchestrationGateStatus::Pending);
+
+    let blocked = store
+        .orchestration_task_by_id(&created.id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(blocked.status, OrchestrationTaskStatus::Blocked);
+    let released = store
+        .orchestration_dispatch_by_id(&dispatch.id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(released.status, OrchestrationDispatchStatus::Completed);
+
+    let resolved = store
+        .resolve_orchestration_gate(&gate.id, "yes")
+        .await
+        .unwrap();
+    assert_eq!(resolved.status, OrchestrationGateStatus::Resolved);
+    assert_eq!(resolved.resolution.as_deref(), Some("yes"));
+    let ready = store
+        .orchestration_task_by_id(&created.id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(ready.status, OrchestrationTaskStatus::Ready);
+
+    // A gate cannot be resolved twice.
+    assert!(store
+        .resolve_orchestration_gate(&gate.id, "no")
+        .await
+        .is_err());
+}
+
+#[tokio::test]
+async fn resolving_stale_gate_does_not_reopen_terminal_task() {
+    let (_dir, store) = store().await;
+    let created = store
+        .create_orchestration_task(task("gated", vec![]))
+        .await
+        .unwrap();
+    let _dispatch = store
+        .create_orchestration_dispatch(&created.id, "term_1")
+        .await
+        .unwrap();
+    let gate = store
+        .create_orchestration_gate(&created.id, "Proceed?", &["yes".to_string()])
+        .await
+        .unwrap();
+
+    store
+        .update_orchestration_task_status(
+            &created.id,
+            OrchestrationTaskStatus::Completed,
+            Some("manual completion"),
+        )
+        .await
+        .unwrap();
+
+    let resolved = store
+        .resolve_orchestration_gate(&gate.id, "yes")
+        .await
+        .unwrap();
+    assert_eq!(resolved.status, OrchestrationGateStatus::Resolved);
+    let completed = store
+        .orchestration_task_by_id(&created.id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(completed.status, OrchestrationTaskStatus::Completed);
+    assert_eq!(completed.result.as_deref(), Some("manual completion"));
+}
+
+#[tokio::test]
+async fn gate_rejects_inactive_or_terminal_tasks() {
+    let (_dir, store) = store().await;
+    let dep = store
+        .create_orchestration_task(task("dep", vec![]))
+        .await
+        .unwrap();
+    let pending = store
+        .create_orchestration_task(task("pending", vec![dep.id.clone()]))
+        .await
+        .unwrap();
+    assert!(store
+        .create_orchestration_gate(&pending.id, "Proceed?", &[])
+        .await
+        .is_err());
+
+    store
+        .update_orchestration_task_status(&dep.id, OrchestrationTaskStatus::Completed, None)
+        .await
+        .unwrap();
+    store
+        .update_orchestration_task_status(&pending.id, OrchestrationTaskStatus::Completed, None)
+        .await
+        .unwrap();
+    assert!(store
+        .create_orchestration_gate(&pending.id, "Proceed?", &[])
+        .await
+        .is_err());
+
+    let ready = store
+        .create_orchestration_task(task("ready", vec![]))
+        .await
+        .unwrap();
+    store
+        .create_orchestration_gate(&ready.id, "Pause?", &[])
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn gates_with_same_timestamp_keep_creation_order() {
+    let (_dir, store) = store().await;
+    let task = store
+        .create_orchestration_task(task("needs decisions", vec![]))
+        .await
+        .unwrap();
+
+    let first = store
+        .create_orchestration_gate(&task.id, "first?", &[])
+        .await
+        .unwrap();
+    store
+        .resolve_orchestration_gate(&first.id, "first answer")
+        .await
+        .unwrap();
+    let second = store
+        .create_orchestration_gate(&task.id, "second?", &[])
+        .await
+        .unwrap();
+    store
+        .resolve_orchestration_gate(&second.id, "second answer")
+        .await
+        .unwrap();
+
+    let timestamp = "2026-07-05 12:00:00";
+    sqlx::query(
+        "UPDATE orchestrationDecisionGates \
+         SET id = 'gate_z_old', created_at = ?, resolved_at = ? WHERE id = ?",
+    )
+    .bind(timestamp)
+    .bind(timestamp)
+    .bind(&first.id)
+    .execute(store.pool())
+    .await
+    .unwrap();
+    sqlx::query(
+        "UPDATE orchestrationDecisionGates \
+         SET id = 'gate_a_new', created_at = ?, resolved_at = ? WHERE id = ?",
+    )
+    .bind(timestamp)
+    .bind(timestamp)
+    .bind(&second.id)
+    .execute(store.pool())
+    .await
+    .unwrap();
+
+    let gates = store
+        .list_orchestration_gates(Some(&task.id), Some(OrchestrationGateStatus::Resolved))
+        .await
+        .unwrap();
+    assert_eq!(gates[0].id, "gate_z_old");
+    assert_eq!(gates[1].id, "gate_a_new");
+    assert_eq!(
+        gates.last().unwrap().resolution.as_deref(),
+        Some("second answer")
+    );
+}
+
+#[tokio::test]
+async fn single_active_coordinator_run() {
+    let (_dir, store) = store().await;
+    let run = store
+        .create_orchestration_coordinator_run("build things", Some("coord"), 2000)
+        .await
+        .unwrap();
+    assert_eq!(run.status, OrchestrationCoordinatorStatus::Running);
+
+    assert!(store
+        .create_orchestration_coordinator_run("another", None, 2000)
+        .await
+        .is_err());
+
+    store
+        .finish_orchestration_coordinator_run(&run.id, OrchestrationCoordinatorStatus::Completed)
+        .await
+        .unwrap();
+    assert!(store
+        .active_orchestration_coordinator_run()
+        .await
+        .unwrap()
+        .is_none());
+
+    // A new run can start once the previous one finished.
+    store
+        .create_orchestration_coordinator_run("next", None, 2000)
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn list_tasks_includes_active_dispatch_fields() {
+    let (_dir, store) = store().await;
+    let created = store
+        .create_orchestration_task(task("visible", vec![]))
+        .await
+        .unwrap();
+    let dispatch = store
+        .create_orchestration_dispatch(&created.id, "term_9")
+        .await
+        .unwrap();
+
+    let tasks = store.list_orchestration_tasks(None).await.unwrap();
+    assert_eq!(tasks.len(), 1);
+    assert_eq!(tasks[0].assignee_handle.as_deref(), Some("term_9"));
+    assert_eq!(tasks[0].dispatch_id.as_deref(), Some(dispatch.id.as_str()));
+
+    let ready_only = store
+        .list_orchestration_tasks(Some(OrchestrationTaskStatus::Ready))
+        .await
+        .unwrap();
+    assert!(ready_only.is_empty());
+}
+
+#[tokio::test]
+async fn reset_scopes_tasks_and_messages_independently() {
+    let (_dir, store) = store().await;
+    store
+        .insert_orchestration_message(message("a", "b", OrchestrationMessageType::Status))
+        .await
+        .unwrap();
+    let created = store
+        .create_orchestration_task(task("t", vec![]))
+        .await
+        .unwrap();
+    store
+        .create_orchestration_dispatch(&created.id, "term_1")
+        .await
+        .unwrap();
+
+    store.reset_orchestration_tasks().await.unwrap();
+    assert!(store
+        .list_orchestration_tasks(None)
+        .await
+        .unwrap()
+        .is_empty());
+    assert_eq!(store.orchestration_inbox(10).await.unwrap().len(), 1);
+
+    store.reset_orchestration_messages().await.unwrap();
+    assert!(store.orchestration_inbox(10).await.unwrap().is_empty());
+}

--- a/rust/alera-core/src/runtime/orchestration_task_store.rs
+++ b/rust/alera-core/src/runtime/orchestration_task_store.rs
@@ -1,0 +1,311 @@
+use anyhow::{anyhow, bail, Result};
+use sqlx::sqlite::SqliteRow;
+use sqlx::Row;
+use sqlx::{Sqlite, Transaction};
+
+use super::orchestration_message_store::orchestration_id;
+use super::{OrchestrationTask, OrchestrationTaskStatus, RuntimeStore};
+
+pub struct NewOrchestrationTask {
+    pub spec: String,
+    pub task_title: Option<String>,
+    pub display_name: Option<String>,
+    pub deps: Vec<String>,
+    pub parent_id: Option<String>,
+    pub created_by_terminal_handle: Option<String>,
+}
+
+const TASK_COLUMNS: &str = "id, parent_id, created_by_terminal_handle, task_title, \
+     display_name, spec, status, deps, result, created_at, completed_at";
+
+pub(super) fn parse_string_array(raw: &str) -> Vec<String> {
+    serde_json::from_str::<Vec<String>>(raw).unwrap_or_default()
+}
+
+fn task_from_row(row: SqliteRow) -> Result<OrchestrationTask> {
+    let status_raw: String = row.try_get("status")?;
+    let deps_raw: String = row.try_get("deps")?;
+    Ok(OrchestrationTask {
+        id: row.try_get("id")?,
+        parent_id: row.try_get("parent_id")?,
+        created_by_terminal_handle: row.try_get("created_by_terminal_handle")?,
+        task_title: row.try_get("task_title")?,
+        display_name: row.try_get("display_name")?,
+        spec: row.try_get("spec")?,
+        status: OrchestrationTaskStatus::parse(&status_raw)
+            .unwrap_or(OrchestrationTaskStatus::Pending),
+        deps: parse_string_array(&deps_raw),
+        result: row.try_get("result")?,
+        created_at: row.try_get("created_at")?,
+        completed_at: row.try_get("completed_at")?,
+        assignee_handle: None,
+        dispatch_id: None,
+    })
+}
+
+/// Derives UI display metadata from the spec when explicit titles are absent:
+/// the first non-empty spec line, truncated to 80 chars.
+fn derive_display_name(spec: &str) -> String {
+    let line = spec
+        .lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty())
+        .unwrap_or("task");
+    let mut name: String = line.chars().take(80).collect();
+    if line.chars().count() > 80 {
+        name.push('…');
+    }
+    name
+}
+
+async fn status_for_deps(
+    tx: &mut Transaction<'_, Sqlite>,
+    deps: &[String],
+) -> Result<OrchestrationTaskStatus> {
+    if deps.is_empty() {
+        return Ok(OrchestrationTaskStatus::Ready);
+    }
+    let mut all_completed = true;
+    for dep in deps {
+        let dep_status: Option<String> =
+            sqlx::query("SELECT status FROM orchestrationTasks WHERE id = ?")
+                .bind(dep)
+                .fetch_optional(&mut **tx)
+                .await?
+                .map(|dep_row| dep_row.try_get("status"))
+                .transpose()?;
+        match dep_status.as_deref() {
+            None => bail!("unknown orchestration task dependency: {dep}"),
+            Some("completed") => {}
+            Some("failed") => return Ok(OrchestrationTaskStatus::Failed),
+            _ => all_completed = false,
+        }
+    }
+    Ok(if all_completed {
+        OrchestrationTaskStatus::Ready
+    } else {
+        OrchestrationTaskStatus::Pending
+    })
+}
+
+pub(super) async fn refresh_pending_dependents_after_task_status(
+    tx: &mut Transaction<'_, Sqlite>,
+    changed_task_id: &str,
+) -> Result<()> {
+    let mut changed_ids = vec![changed_task_id.to_string()];
+    while let Some(changed_id) = changed_ids.pop() {
+        let pending =
+            sqlx::query("SELECT id, deps FROM orchestrationTasks WHERE status = 'pending'")
+                .fetch_all(&mut **tx)
+                .await?;
+        for row in pending {
+            let candidate_id: String = row.try_get("id")?;
+            let deps_raw: String = row.try_get("deps")?;
+            let deps = parse_string_array(&deps_raw);
+            if !deps.iter().any(|dep| dep == &changed_id) {
+                continue;
+            }
+            match status_for_deps(tx, &deps).await? {
+                OrchestrationTaskStatus::Ready => {
+                    sqlx::query("UPDATE orchestrationTasks SET status = 'ready' WHERE id = ?")
+                        .bind(&candidate_id)
+                        .execute(&mut **tx)
+                        .await?;
+                }
+                OrchestrationTaskStatus::Failed => {
+                    let result = format!("dependency failed: {changed_id}");
+                    sqlx::query(
+                        "UPDATE orchestrationTasks \
+                         SET status = 'failed', result = COALESCE(result, ?), completed_at = datetime('now') \
+                         WHERE id = ?",
+                    )
+                    .bind(result)
+                    .bind(&candidate_id)
+                    .execute(&mut **tx)
+                    .await?;
+                    changed_ids.push(candidate_id);
+                }
+                _ => {}
+            }
+        }
+    }
+    Ok(())
+}
+
+impl RuntimeStore {
+    pub async fn create_orchestration_task(
+        &self,
+        task: NewOrchestrationTask,
+    ) -> Result<OrchestrationTask> {
+        let id = orchestration_id("task");
+        let mut tx = self.pool().begin().await?;
+        let status = status_for_deps(&mut tx, &task.deps).await?;
+        let display_name = task
+            .display_name
+            .clone()
+            .or_else(|| task.task_title.clone())
+            .unwrap_or_else(|| derive_display_name(&task.spec));
+        sqlx::query(
+            "INSERT INTO orchestrationTasks \
+             (id, parent_id, created_by_terminal_handle, task_title, display_name, spec, status, deps) \
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        )
+        .bind(&id)
+        .bind(&task.parent_id)
+        .bind(&task.created_by_terminal_handle)
+        .bind(&task.task_title)
+        .bind(&display_name)
+        .bind(&task.spec)
+        .bind(status.as_str())
+        .bind(serde_json::to_string(&task.deps)?)
+        .execute(&mut *tx)
+        .await?;
+        tx.commit().await?;
+        self.orchestration_task_by_id(&id)
+            .await?
+            .ok_or_else(|| anyhow!("inserted orchestration task not found"))
+    }
+
+    pub async fn orchestration_task_by_id(&self, id: &str) -> Result<Option<OrchestrationTask>> {
+        let row = sqlx::query(&format!(
+            "SELECT {TASK_COLUMNS} FROM orchestrationTasks WHERE id = ?"
+        ))
+        .bind(id)
+        .fetch_optional(self.pool())
+        .await?;
+        row.map(task_from_row).transpose()
+    }
+
+    /// Lists tasks joined with their most-recent active dispatch context so a
+    /// coordinator can answer "who is working on task X" in one query.
+    pub async fn list_orchestration_tasks(
+        &self,
+        status: Option<OrchestrationTaskStatus>,
+    ) -> Result<Vec<OrchestrationTask>> {
+        let mut sql = format!(
+            "SELECT {TASK_COLUMNS}, \
+             (SELECT assignee_handle FROM orchestrationDispatchContexts \
+              WHERE task_id = orchestrationTasks.id AND status IN ('pending','dispatched') \
+              ORDER BY rowid DESC LIMIT 1) AS active_assignee, \
+             (SELECT id FROM orchestrationDispatchContexts \
+              WHERE task_id = orchestrationTasks.id AND status IN ('pending','dispatched') \
+              ORDER BY rowid DESC LIMIT 1) AS active_dispatch_id \
+             FROM orchestrationTasks"
+        );
+        if status.is_some() {
+            sql.push_str(" WHERE status = ?");
+        }
+        sql.push_str(" ORDER BY created_at ASC, id ASC");
+        let mut query = sqlx::query(&sql);
+        if let Some(status) = status {
+            query = query.bind(status.as_str());
+        }
+        let rows = query.fetch_all(self.pool()).await?;
+        rows.into_iter()
+            .map(|row| {
+                let assignee: Option<String> = row.try_get("active_assignee")?;
+                let dispatch_id: Option<String> = row.try_get("active_dispatch_id")?;
+                let mut task = task_from_row(row)?;
+                task.assignee_handle = assignee;
+                task.dispatch_id = dispatch_id;
+                Ok(task)
+            })
+            .collect()
+    }
+
+    /// Sets a task's status. Completing a task promotes dependents and closes
+    /// its active dispatch in the same transaction, so there is no window
+    /// where a dependency is satisfied but the child is still `pending`.
+    pub async fn update_orchestration_task_status(
+        &self,
+        id: &str,
+        status: OrchestrationTaskStatus,
+        result: Option<&str>,
+    ) -> Result<OrchestrationTask> {
+        let mut tx = self.pool().begin().await?;
+        let existing = sqlx::query("SELECT id FROM orchestrationTasks WHERE id = ?")
+            .bind(id)
+            .fetch_optional(&mut *tx)
+            .await?;
+        if existing.is_none() {
+            bail!("orchestration task not found: {id}");
+        }
+        let terminal = matches!(
+            status,
+            OrchestrationTaskStatus::Completed | OrchestrationTaskStatus::Failed
+        );
+        if terminal {
+            sqlx::query(
+                "UPDATE orchestrationTasks SET status = ?, result = COALESCE(?, result), \
+                 completed_at = datetime('now') WHERE id = ?",
+            )
+            .bind(status.as_str())
+            .bind(result)
+            .bind(id)
+            .execute(&mut *tx)
+            .await?;
+            // DAG refresh: completed deps promote dependents; failed deps make
+            // still-pending dependents terminal instead of leaving the run stuck.
+            refresh_pending_dependents_after_task_status(&mut tx, id).await?;
+            let dispatch_status = if status == OrchestrationTaskStatus::Completed {
+                "completed"
+            } else {
+                "failed"
+            };
+            sqlx::query(
+                "UPDATE orchestrationDispatchContexts \
+                 SET status = ?, completed_at = datetime('now') \
+                 WHERE task_id = ? AND status IN ('pending','dispatched')",
+            )
+            .bind(dispatch_status)
+            .bind(id)
+            .execute(&mut *tx)
+            .await?;
+        } else {
+            sqlx::query(
+                "UPDATE orchestrationTasks SET status = ?, result = COALESCE(?, result) \
+                 WHERE id = ?",
+            )
+            .bind(status.as_str())
+            .bind(result)
+            .bind(id)
+            .execute(&mut *tx)
+            .await?;
+            if status != OrchestrationTaskStatus::Dispatched {
+                let reason = format!("task status changed to {}", status.as_str());
+                sqlx::query(
+                    "UPDATE orchestrationDispatchContexts \
+                     SET status = 'failed', last_failure = COALESCE(last_failure, ?), \
+                     completed_at = datetime('now') \
+                     WHERE task_id = ? AND status IN ('pending','dispatched')",
+                )
+                .bind(reason)
+                .bind(id)
+                .execute(&mut *tx)
+                .await?;
+            }
+        }
+        tx.commit().await?;
+        self.orchestration_task_by_id(id)
+            .await?
+            .ok_or_else(|| anyhow!("orchestration task not found after update: {id}"))
+    }
+
+    pub async fn reset_orchestration_tasks(&self) -> Result<()> {
+        let mut tx = self.pool().begin().await?;
+        sqlx::query("DELETE FROM orchestrationTasks")
+            .execute(&mut *tx)
+            .await?;
+        sqlx::query("DELETE FROM orchestrationDispatchContexts")
+            .execute(&mut *tx)
+            .await?;
+        sqlx::query("DELETE FROM orchestrationDecisionGates")
+            .execute(&mut *tx)
+            .await?;
+        sqlx::query("DELETE FROM orchestrationCoordinatorRuns")
+            .execute(&mut *tx)
+            .await?;
+        tx.commit().await?;
+        Ok(())
+    }
+}

--- a/rust/alera-core/src/runtime/store.rs
+++ b/rust/alera-core/src/runtime/store.rs
@@ -62,6 +62,9 @@ impl RuntimeStore {
         for statement in RUNTIME_SCHEMA {
             sqlx::query(statement).execute(&self.pool).await?;
         }
+        for statement in super::orchestration_message_store::ORCHESTRATION_SCHEMA {
+            sqlx::query(statement).execute(&self.pool).await?;
+        }
         self.ensure_column("sshTargets", "installDir", "TEXT")
             .await?;
         self.ensure_column("sshTargets", "runtimeVersion", "TEXT")

--- a/skills/alera-cli/SKILL.md
+++ b/skills/alera-cli/SKILL.md
@@ -126,3 +126,7 @@ alera tab create --workspace-id <workspace-id> --title "Terminal" --kind termina
 - Run list/status commands before destructive operations so you have the exact IDs.
 - Keep user-created branches unless the user explicitly requests deletion or the workspace metadata shows Alera created the branch.
 - If a command fails because no runtime host is available, retry the same CLI command; managed commands auto-start the runtime host when possible.
+
+## Inter-Agent Orchestration
+
+For structured multi-agent coordination — inter-agent messaging, task DAGs, dispatching work to worker agents, decision gates, and coordinator loops — invoke the `alera-orchestration` skill. Its command surface lives under `alera orchestration ...`.

--- a/skills/alera-orchestration/SKILL.md
+++ b/skills/alera-orchestration/SKILL.md
@@ -1,0 +1,170 @@
+---
+name: alera-orchestration
+description: Use when coordinating multiple coding agents through Alera's orchestration system — inter-agent messaging, task DAGs with dependencies, dispatching work to worker agents, decision gates, or acting as a coordinator. For basic workspace and tab management, use the alera-cli skill instead.
+---
+
+# Alera Inter-Agent Orchestration
+
+Use this skill when the task involves coordinating multiple coding agents through Alera's orchestration system.
+
+## When To Use
+
+- You need to send messages between agent terminals
+- You need to decompose a spec into parallel subtasks with dependencies
+- You need to dispatch tasks to worker agents with structured feedback
+- You need to act as a coordinator managing a multi-agent workflow
+- You need decision gates for human-in-the-loop checkpoints
+
+## Preconditions
+
+- The `alera` CLI must be on PATH (Alera-managed terminals get it automatically).
+- All `alera orchestration` commands talk to the Alera runtime-host. If none is running, the CLI starts one automatically.
+- Push-on-idle message delivery and @agent groups require the Alera app to be running with agent status hooks enabled (the app forwards agent presence to the runtime-host). Messaging, tasks, dispatch bookkeeping, and gates work without the app.
+- Your own terminal handle is injected as `ALERA_TERMINAL_HANDLE` into every Alera-managed terminal. Omit `--from`/`--terminal` and the CLI resolves it from that variable.
+
+## Command Surface
+
+### Messaging
+
+Inter-agent messaging via a persistent SQLite-backed mail store. Messages are delivered automatically into a recipient terminal when its agent goes idle (push-on-idle).
+
+```bash
+alera orchestration send --to <handle|@group> --subject <text> [--from <handle>] [--body <text>] [--type <type>] [--priority <level>] [--thread-id <id>] [--payload <json>]
+alera orchestration check [--terminal <handle>] [--all] [--types <type,...>] [--inject] [--wait] [--timeout-ms <n>]
+alera orchestration reply --id <msg_id> --body <text>
+alera orchestration inbox [--terminal <handle>] [--limit <n>]
+alera orchestration ask --to <handle> --question <text> [--options <csv>] [--timeout-ms <n>]
+```
+
+Why: `--wait` blocks until a matching message arrives or the timeout expires (default 2 minutes). This replaces sleep+poll loops. If unread messages already exist, it returns immediately. Combine with `--types` to wait for specific message types (e.g. `--wait --types worker_done --timeout-ms 300000`).
+
+Why: `--inject` returns messages formatted as readable banners with priority indicators (`[HIGH]`, `[URGENT]`). Default output without `--json` shows the same banners.
+
+Why: on Windows PowerShell, raw JSON in `--payload` is fragile. Prefer the structured flags: `--task-id`, `--dispatch-id`, `--files-modified <csv>`, `--report-path <path>`, `--phase <text>` — the CLI assembles the JSON payload.
+
+**Message types**: `status` (general), `dispatch` (assign work), `worker_done` (signal completion), `merge_ready` (branch ready for merge), `escalation` (issue requiring attention), `handoff` (pass work to another agent), `decision_gate` (human-in-the-loop), `heartbeat` (liveness).
+
+**Priority levels**: `normal`, `high`, `urgent`.
+
+**Group addresses** resolve to terminal handles at send time (one message per recipient, shared thread):
+
+| Group | Resolves To |
+|-------|------------|
+| `@all` | All live terminal handles except sender |
+| `@idle` | Handles whose agent has reported `done` and can safely receive auto-submitted input |
+| `@claude` / `@codex` / `@copilot` / `@cursor` / `@agy` / `@opencode` / `@pi` / `@amp` | Handles running that agent (via agent status hooks) |
+| `@workspace:<id>` | All handles in a specific workspace |
+
+Lifecycle messages (`worker_done`, `heartbeat`) cannot be sent to a group address.
+
+### Tasks
+
+Task tracking with DAG dependencies. A task becomes `ready` when all tasks in its `deps` array are `completed`; if any dependency fails, pending dependents fail instead of staying stuck.
+
+```bash
+alera orchestration task-create --spec <text> [--task-title <text>] [--deps <json_array>] [--parent <task_id>]
+alera orchestration task-list [--status <status>] [--ready]
+alera orchestration task-update --id <task_id> --status <status> [--result <json>]
+```
+
+**Task statuses**: `pending` (waiting on deps), `ready` (deps met, dispatchable), `dispatched` (assigned to a terminal), `completed`, `failed`, `blocked` (waiting on a decision gate).
+
+Why: when a task is marked `completed`, the runtime automatically promotes any pending tasks whose deps are now all satisfied to `ready`. When a dependency is marked `failed`, pending dependents are marked `failed`. This is the DAG resolution step.
+
+### Dispatch
+
+Dispatch assigns a ready task to a terminal, optionally injecting the task spec + preamble so the agent knows how to report back.
+
+```bash
+alera orchestration dispatch --task <task_id> --to <handle> [--from <handle>] [--inject] [--dry-run] [--return-preamble]
+alera orchestration dispatch-show --task <task_id>
+```
+
+Why: `--inject` writes a preamble that teaches the agent to report `worker_done` (with taskId + dispatchId), send heartbeats every 5 minutes, and use `ask` instead of AskUserQuestion. It requires a recognized agent running in the target terminal; for a bare shell, use `--dry-run` and paste the preamble manually.
+
+Why: dispatch contexts are separate from tasks. A task can be dispatched, fail, and be re-dispatched — the task stays clean while dispatch contexts track retry state, and the failure count carries across retries.
+
+**Circuit breaker**: after 3 accumulated failures on a task, the dispatch context is marked `circuit_broken` and the task is marked `failed`, preventing infinite retry loops. Below the threshold a failed dispatch returns the task to `ready`.
+
+### Decision Gates
+
+Human-in-the-loop decision points that block a task until resolved.
+
+```bash
+alera orchestration gate-create --task <task_id> --question <text> [--options <json_array>]
+alera orchestration gate-resolve --id <gate_id> --resolution <text>
+alera orchestration gate-list [--task <task_id>] [--status <status>]
+```
+
+Why: creating a gate is accepted for `ready` or `dispatched` tasks, blocks the task, and completes any active dispatch (releasing the worker). Resolving a gate sets the task back to `ready` with the resolution included in the next dispatch preamble as a `DECISION GATE RESOLVED` section.
+
+**Gate statuses**: `pending`, `resolved`, `timeout`.
+
+### Coordinator
+
+Start an automated coordinator loop that dispatches ready tasks, processes `worker_done`/`escalation` messages, and advances the task DAG.
+
+```bash
+alera orchestration run --spec <text> [--from <handle>] [--poll-interval-ms <n>] [--max-concurrent <n>] [--workspace <workspace_id>]
+alera orchestration run-stop
+```
+
+Why: `run` returns immediately with a run id; the loop runs in the background inside the runtime-host. Query progress via `alera orchestration task-list`. Only one coordinator can run at a time. Tasks must be pre-created — decomposition is your responsibility as the coordinating agent.
+
+Why: `--workspace` scopes which terminals receive dispatches, enables the stale-base drift check (worktrees more than 20 commits behind their base are skipped unless the spec contains `allow-stale-base: true` on its own line), and lets the coordinator create worker terminal tabs when no idle worker exists (requires the app to be running).
+
+Coordinator worker selection only uses injection-ready agents that can auto-submit injected preambles. Cursor-style editable-prompt agents are visible in `terminal-list` and can receive manual `dispatch --inject`, but `run` skips them for unattended dispatch.
+
+### Terminals
+
+```bash
+alera orchestration terminal-list
+alera tab create --workspace-id <id> --title <text> --command "claude" --spawn
+```
+
+Why: `terminal-list` shows live terminal handles with workspace, agent type, and agent state — the coordinator's worker inventory. `tab create --command "claude" --spawn` creates a terminal tab that the app starts eagerly (even while invisible) and runs the agent CLI in it. After creating one, wait for its presence to appear in `terminal-list` before dispatching.
+
+### Lifecycle
+
+```bash
+alera orchestration reset [--all] [--tasks] [--messages]
+```
+
+Why: `--all` is the default when no scope flag is provided. `--tasks` clears tasks, dispatch contexts, decision gates, and coordinator runs but preserves messages.
+
+## Agent Guidance
+
+- When dispatched with a preamble, **always send `worker_done` when done** — exactly once, with both `--task-id` and `--dispatch-id`. Failure is still a `worker_done` with a subject like "Failed: <reason>"; never silently exit.
+- If blocked, send an `escalation` to the coordinator instead of stalling, including both `--task-id` and `--dispatch-id` when you were dispatched with a preamble. For questions, use `alera orchestration ask` — never AskUserQuestion, which the coordinator cannot see or answer.
+- Send a `heartbeat` every 5 minutes while actively working (skip while blocked inside `check --wait` or `ask` — those calls are themselves liveness signals). The coordinator warns about dispatches with no heartbeat for 10 minutes.
+- Use `alera orchestration check` to read incoming messages. They are also delivered automatically into your prompt when you go idle.
+- The coordinator uses `task-list --ready` as its external memory. Prefer querying orchestration state over tracking it in your context window.
+- When acting as coordinator: discover workers with `terminal-list`, create tasks with `task-create`, dispatch with `dispatch --inject`, and block on `check --wait --types worker_done,escalation --timeout-ms 300000` instead of sleep+poll loops.
+- `check --wait` returns the currently unread batch. If N workers finish near-simultaneously, loop on `check --wait` until all results are collected; after each return, mark progress and dispatch the next wave.
+- After receiving `worker_done` from a terminal, that terminal is idle — dispatch the next task to it immediately.
+- Keep dependency chains to 3-4 steps maximum. Prefer parallel waves of independent tasks over deep sequential chains.
+- Insert decision gates between phases for human oversight of risky operations.
+- Terminal handles equal the PTY session id and survive host restarts only while the session lives. Re-acquire handles with `terminal-list` if in doubt.
+
+## Coordinator Worked Example
+
+```bash
+# 1. Create a worker terminal running Claude Code (the app spawns it eagerly)
+alera tab --json create --workspace-id ws_123 --title "Worker 1" --command "claude" --spawn
+# → payload.terminalSessionId is the worker's future handle
+
+# 2. Wait for the agent to boot: poll terminal-list until agentState appears
+alera orchestration --json terminal-list
+
+# 3. Create and dispatch a task with preamble injection
+alera orchestration --json task-create --spec "Fix the login button CSS"
+# → id: task_...
+alera orchestration --json dispatch --task task_... --to <handle> --inject
+
+# 4. Block until the worker reports back (no sleep loops needed)
+alera orchestration --json check --wait --types worker_done,escalation --timeout-ms 300000
+
+# 5. On timeout with no messages, inspect state
+alera orchestration --json task-list
+alera orchestration --json dispatch-show --task task_...
+```

--- a/test/unit/agent_status_host_forwarder_test.dart
+++ b/test/unit/agent_status_host_forwarder_test.dart
@@ -1,0 +1,252 @@
+import 'dart:async';
+
+import 'package:alera/src/features/agent_status/application/agent_status_host_forwarder.dart';
+import 'package:alera/src/features/agent_status/domain/agent_status.dart';
+import 'package:alera/src/features/workbench/infra/terminal_host/terminal_host_protocol.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class _RecordingRuntimeHostClient implements RuntimeHostClient {
+  final List<(String, Map<String, Object?>)> requests =
+      <(String, Map<String, Object?>)>[];
+  final List<Completer<Object?>> queuedResults = <Completer<Object?>>[];
+  final StreamController<RuntimeHostEvent> _events =
+      StreamController<RuntimeHostEvent>.broadcast();
+  Object? error;
+  int attempts = 0;
+
+  @override
+  Stream<RuntimeHostEvent> get runtimeEvents => _events.stream;
+
+  void emitRuntimeHostConnected() {
+    _events.add(
+      const RuntimeHostEvent(
+        aleraRuntimeHostConnectedEvent,
+        <String, Object?>{},
+      ),
+    );
+  }
+
+  Future<void> dispose() => _events.close();
+
+  @override
+  Future<Object?> runtimeRequest(
+    String type, [
+    Map<String, Object?> payload = const <String, Object?>{},
+    Duration? timeout,
+  ]) async {
+    attempts += 1;
+    if (queuedResults.isNotEmpty) {
+      final result = queuedResults.removeAt(0);
+      final value = await result.future;
+      requests.add((type, payload));
+      return value;
+    }
+    if (error != null) {
+      throw error!;
+    }
+    requests.add((type, payload));
+    return null;
+  }
+}
+
+AgentStatusEntry _entry(
+  String sessionId, {
+  AgentStatusState state = AgentStatusState.working,
+  AgentType agentType = AgentType.claude,
+}) {
+  final now = DateTime.utc(2026, 7, 5);
+  return AgentStatusEntry(
+    terminalSessionId: sessionId,
+    workspaceId: 'ws-1',
+    tabId: 'tab-1',
+    agentType: agentType,
+    state: state,
+    prompt: '',
+    updatedAt: now,
+    stateStartedAt: now,
+  );
+}
+
+void main() {
+  late _RecordingRuntimeHostClient client;
+  late AgentStatusHostForwarder forwarder;
+
+  setUp(() {
+    client = _RecordingRuntimeHostClient();
+    forwarder = AgentStatusHostForwarder(
+      client: client,
+      debounce: Duration.zero,
+    );
+  });
+
+  tearDown(() async {
+    forwarder.dispose();
+    await client.dispose();
+  });
+
+  Future<void> pumpDebounce() async {
+    await Future<void>.delayed(const Duration(milliseconds: 5));
+  }
+
+  List<Map<String, Object?>> sentEntries() {
+    expect(client.requests, hasLength(1));
+    final (type, payload) = client.requests.single;
+    expect(type, 'orchestration.agentStatus');
+    return (payload['entries']! as List<Object?>).cast<Map<String, Object?>>();
+  }
+
+  test('forwards state transitions with session identity', () async {
+    forwarder.onStatusChanged(const <String, AgentStatusEntry>{}, {
+      's1': _entry('s1', state: AgentStatusState.waiting),
+    });
+    await pumpDebounce();
+
+    final entries = sentEntries();
+    expect(entries.single['terminalSessionId'], 's1');
+    expect(entries.single['state'], 'waiting');
+    expect(entries.single['agentType'], 'claude');
+    expect(entries.single['workspaceId'], 'ws-1');
+    expect(entries.single['tabId'], 'tab-1');
+  });
+
+  test('skips entries whose state and agent type are unchanged', () async {
+    final before = {'s1': _entry('s1'), 's2': _entry('s2')};
+    final after = {
+      's1': _entry('s1'),
+      's2': _entry('s2', state: AgentStatusState.waiting),
+    };
+    forwarder.onStatusChanged(before, after);
+    await pumpDebounce();
+
+    final entries = sentEntries();
+    expect(entries, hasLength(1));
+    expect(entries.single['terminalSessionId'], 's2');
+  });
+
+  test('replays current presence snapshot after host reconnect', () async {
+    forwarder.onStatusChanged(const <String, AgentStatusEntry>{}, {
+      's1': _entry('s1', state: AgentStatusState.waiting),
+    });
+    await pumpDebounce();
+    expect(client.requests, hasLength(1));
+    client.requests.clear();
+
+    client.emitRuntimeHostConnected();
+    await pumpDebounce();
+
+    final entries = sentEntries();
+    expect(entries.single['terminalSessionId'], 's1');
+    expect(entries.single['state'], 'waiting');
+  });
+
+  test('reports removed sessions', () async {
+    forwarder.onStatusChanged({
+      's1': _entry('s1'),
+    }, const <String, AgentStatusEntry>{});
+    await pumpDebounce();
+
+    final entries = sentEntries();
+    expect(entries.single['terminalSessionId'], 's1');
+    expect(entries.single['removed'], isTrue);
+  });
+
+  test('batches burst updates into one request', () async {
+    forwarder = AgentStatusHostForwarder(
+      client: client,
+      debounce: const Duration(milliseconds: 30),
+    );
+    forwarder.onStatusChanged(const <String, AgentStatusEntry>{}, {
+      's1': _entry('s1'),
+    });
+    forwarder.onStatusChanged(
+      {'s1': _entry('s1')},
+      {'s1': _entry('s1', state: AgentStatusState.waiting)},
+    );
+    await Future<void>.delayed(const Duration(milliseconds: 60));
+
+    final entries = sentEntries();
+    // The later transition supersedes the earlier one for the same session.
+    expect(entries, hasLength(1));
+    expect(entries.single['state'], 'waiting');
+  });
+
+  test('retries transport errors without losing presence', () async {
+    client.error = StateError('host gone');
+    forwarder.onStatusChanged(const <String, AgentStatusEntry>{}, {
+      's1': _entry('s1', state: AgentStatusState.waiting),
+    });
+    await pumpDebounce();
+    expect(client.attempts, greaterThan(0));
+    expect(client.requests, isEmpty);
+
+    client.error = null;
+    await pumpDebounce();
+
+    expect(client.requests, hasLength(1));
+    final entries = sentEntries();
+    expect(entries.single['terminalSessionId'], 's1');
+    expect(entries.single['state'], 'waiting');
+  });
+
+  test('does not retry permanent orchestration capability errors', () async {
+    client.error = StateError(
+      'The running terminal host does not support orchestration. Restart Alera to replace the terminal host before using orchestration.',
+    );
+    forwarder.onStatusChanged(const <String, AgentStatusEntry>{}, {
+      's1': _entry('s1', state: AgentStatusState.waiting),
+    });
+    await pumpDebounce();
+
+    expect(client.attempts, 1);
+    await pumpDebounce();
+    expect(client.attempts, 1);
+    expect(client.requests, isEmpty);
+
+    client.error = null;
+    client.emitRuntimeHostConnected();
+    await pumpDebounce();
+
+    final entries = sentEntries();
+    expect(entries.single['terminalSessionId'], 's1');
+    expect(entries.single['state'], 'waiting');
+  });
+
+  test('drops stale retries after a newer state is delivered', () async {
+    final waitingResult = Completer<Object?>();
+    final workingResult = Completer<Object?>();
+    client.queuedResults.addAll(<Completer<Object?>>[
+      waitingResult,
+      workingResult,
+    ]);
+
+    forwarder.onStatusChanged(const <String, AgentStatusEntry>{}, {
+      's1': _entry('s1', state: AgentStatusState.waiting),
+    });
+    await pumpDebounce();
+    forwarder.onStatusChanged(
+      {'s1': _entry('s1', state: AgentStatusState.waiting)},
+      {'s1': _entry('s1', state: AgentStatusState.working)},
+    );
+    await pumpDebounce();
+
+    workingResult.complete(null);
+    await pumpDebounce();
+    waitingResult.completeError(StateError('stale transport failure'));
+    await pumpDebounce();
+
+    expect(client.attempts, 2);
+    expect(client.requests, hasLength(1));
+    final entries = sentEntries();
+    expect(entries.single['terminalSessionId'], 's1');
+    expect(entries.single['state'], 'working');
+  });
+
+  test('does nothing after dispose', () async {
+    forwarder.dispose();
+    forwarder.onStatusChanged(const <String, AgentStatusEntry>{}, {
+      's1': _entry('s1'),
+    });
+    await pumpDebounce();
+    expect(client.requests, isEmpty);
+  });
+}

--- a/test/unit/terminal_host_client_test.dart
+++ b/test/unit/terminal_host_client_test.dart
@@ -91,6 +91,7 @@ void main() {
       'detach',
       'terminate',
     ]);
+    expect(server.payloadFor('hello')['clientKind'], 'app');
     final createPayload = server.payloadFor('createOrAttach');
     expect(createPayload['workingDirectory'], '/repo');
     expect(createPayload['cols'], 80);
@@ -132,6 +133,7 @@ void main() {
       applicationSupportDirectory: () async => tempDir,
     );
     addTearDown(client.dispose);
+    final connectedEvent = client.runtimeEvents.first;
     const config = TerminalHostConfig(
       emptyShutdownDelaySeconds: 5,
       detachedSessionShutdownDelaySeconds: 10,
@@ -144,6 +146,7 @@ void main() {
     expect(launcher.configs.single.toJson(), config.toJson());
     expect(server.requestTypes, <String>['hello', 'configure']);
     expect(server.payloadFor('configure'), config.toJson());
+    expect((await connectedEvent).name, aleraRuntimeHostConnectedEvent);
   });
 
   test(
@@ -624,6 +627,264 @@ void main() {
   );
 
   test(
+    'does not split orchestration from a live PTY host without capability',
+    () async {
+      final tempDir = await Directory.systemTemp.createTemp(
+        'alera-host-client-no-orchestration-capability-',
+      );
+      addTearDown(() async {
+        if (await tempDir.exists()) {
+          await tempDir.delete(recursive: true);
+        }
+      });
+      final legacyServer = await _TerminalHostTestServer.start();
+      addTearDown(legacyServer.dispose);
+      await _writeControlFile(
+        tempDir: tempDir,
+        port: legacyServer.port,
+        token: 'legacy-token',
+        includeRuntimeCapability: true,
+        includeBootstrapCapability: true,
+        includeManagedWorkspaceCapability: true,
+        includeOrchestrationCapability: false,
+      );
+      final launcher = _NoopTerminalHostLauncher();
+      final client = SocketTerminalHostClient(
+        launcher: launcher,
+        applicationSupportDirectory: () async => tempDir,
+      );
+      addTearDown(client.dispose);
+
+      await expectLater(
+        client.runtimeRequest('orchestration.agentStatus', <String, Object?>{
+          'entries': const <Object?>[],
+        }),
+        throwsA(
+          isA<StateError>().having(
+            (error) => error.message,
+            'message',
+            contains('Restart Alera'),
+          ),
+        ),
+      );
+
+      expect(launcher.starts, 0);
+      expect(legacyServer.requestTypes, <String>['hello']);
+    },
+  );
+
+  test(
+    'does not split orchestration from a live runtime control without capability',
+    () async {
+      final tempDir = await Directory.systemTemp.createTemp(
+        'alera-host-client-runtime-no-orchestration-capability-',
+      );
+      addTearDown(() async {
+        if (await tempDir.exists()) {
+          await tempDir.delete(recursive: true);
+        }
+      });
+      final legacyServer = await _TerminalHostTestServer.start();
+      addTearDown(legacyServer.dispose);
+      await _writeControlFile(
+        tempDir: tempDir,
+        fileName: 'runtime-host.json',
+        port: legacyServer.port,
+        token: 'legacy-token',
+        includeRuntimeCapability: true,
+        includeBootstrapCapability: true,
+        includeManagedWorkspaceCapability: true,
+        includeOrchestrationCapability: false,
+      );
+      final launcher = _NoopTerminalHostLauncher();
+      final client = SocketTerminalHostClient(
+        launcher: launcher,
+        applicationSupportDirectory: () async => tempDir,
+      );
+      addTearDown(client.dispose);
+
+      await expectLater(
+        client.runtimeRequest('orchestration.agentStatus', <String, Object?>{
+          'entries': const <Object?>[],
+        }),
+        throwsA(
+          isA<StateError>().having(
+            (error) => error.message,
+            'message',
+            contains('Restart Alera'),
+          ),
+        ),
+      );
+
+      expect(launcher.starts, 0);
+      expect(legacyServer.requestTypes, <String>['hello']);
+    },
+  );
+
+  test(
+    'failed orchestration capability checks do not poison runtime requests',
+    () async {
+      final tempDir = await Directory.systemTemp.createTemp(
+        'alera-host-client-orchestration-failure-runtime-retry-',
+      );
+      addTearDown(() async {
+        if (await tempDir.exists()) {
+          await tempDir.delete(recursive: true);
+        }
+      });
+      final legacyServer = await _TerminalHostTestServer.start();
+      addTearDown(legacyServer.dispose);
+      await _writeControlFile(
+        tempDir: tempDir,
+        port: legacyServer.port,
+        token: 'legacy-token',
+        includeRuntimeCapability: true,
+        includeBootstrapCapability: true,
+        includeManagedWorkspaceCapability: true,
+        includeOrchestrationCapability: false,
+      );
+      final launcher = _NoopTerminalHostLauncher();
+      final client = SocketTerminalHostClient(
+        launcher: launcher,
+        applicationSupportDirectory: () async => tempDir,
+      );
+      addTearDown(client.dispose);
+
+      await expectLater(
+        client.runtimeRequest('orchestration.agentStatus', <String, Object?>{
+          'entries': const <Object?>[],
+        }),
+        throwsA(isA<StateError>()),
+      );
+      await client.runtimeRequest('project.list');
+
+      expect(launcher.starts, 0);
+      expect(legacyServer.requestTypes, <String>[
+        'hello',
+        'hello',
+        'project.list',
+      ]);
+    },
+  );
+
+  test(
+    'normal runtime requests ignore in-flight orchestration capability failures',
+    () async {
+      final tempDir = await Directory.systemTemp.createTemp(
+        'alera-host-client-inflight-orchestration-failure-runtime-',
+      );
+      addTearDown(() async {
+        if (await tempDir.exists()) {
+          await tempDir.delete(recursive: true);
+        }
+      });
+      final releaseHello = Completer<void>();
+      final legacyServer = await _TerminalHostTestServer.start(
+        beforeResponse: (type) async {
+          if (type == 'hello') {
+            await releaseHello.future;
+          }
+        },
+      );
+      addTearDown(legacyServer.dispose);
+      await _writeControlFile(
+        tempDir: tempDir,
+        port: legacyServer.port,
+        token: 'legacy-token',
+        includeRuntimeCapability: true,
+        includeBootstrapCapability: true,
+        includeManagedWorkspaceCapability: true,
+        includeOrchestrationCapability: false,
+      );
+      final launcher = _NoopTerminalHostLauncher();
+      final client = SocketTerminalHostClient(
+        launcher: launcher,
+        applicationSupportDirectory: () async => tempDir,
+      );
+      addTearDown(client.dispose);
+
+      final orchestrationRequest = client.runtimeRequest(
+        'orchestration.agentStatus',
+        <String, Object?>{'entries': const <Object?>[]},
+      );
+      await _waitForServerRequestCount(legacyServer, 1);
+      final runtimeRequest = client.runtimeRequest('project.list');
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+
+      releaseHello.complete();
+      await expectLater(orchestrationRequest, throwsA(isA<StateError>()));
+      await runtimeRequest;
+
+      expect(launcher.starts, 0);
+      expect(legacyServer.requestTypes, <String>[
+        'hello',
+        'hello',
+        'project.list',
+      ]);
+    },
+  );
+
+  test(
+    'does not split orchestration from an in-flight host without capability',
+    () async {
+      final tempDir = await Directory.systemTemp.createTemp(
+        'alera-host-client-inflight-no-orchestration-',
+      );
+      addTearDown(() async {
+        if (await tempDir.exists()) {
+          await tempDir.delete(recursive: true);
+        }
+      });
+      final legacyServer = await _TerminalHostTestServer.start();
+      addTearDown(legacyServer.dispose);
+      final runtimeServer = await _TerminalHostTestServer.start();
+      addTearDown(runtimeServer.dispose);
+      final releaseFirstLaunch = Completer<void>();
+      final launcher = _QueuedTerminalHostLauncher(<_QueuedTerminalHostLaunch>[
+        _QueuedTerminalHostLaunch(
+          server: legacyServer,
+          beforePublish: releaseFirstLaunch.future,
+          includeOrchestrationCapability: false,
+        ),
+        _QueuedTerminalHostLaunch(server: runtimeServer),
+      ]);
+      final client = SocketTerminalHostClient(
+        launcher: launcher,
+        applicationSupportDirectory: () async => tempDir,
+      );
+      addTearDown(client.dispose);
+
+      final firstRequest = client.runtimeRequest('project.list');
+      await _waitForQueuedLauncherStarts(launcher, 1);
+      final orchestrationRequest = client.runtimeRequest(
+        'orchestration.agentStatus',
+        <String, Object?>{'entries': const <Object?>[]},
+      );
+      releaseFirstLaunch.complete();
+
+      await firstRequest;
+      await expectLater(
+        orchestrationRequest,
+        throwsA(
+          isA<StateError>().having(
+            (error) => error.message,
+            'message',
+            contains('Restart Alera'),
+          ),
+        ),
+      );
+
+      expect(launcher.starts, 1);
+      expect(legacyServer.requestTypes, <String>[
+        'hello',
+        'project.list',
+        'hello',
+      ]);
+      expect(runtimeServer.requestTypes, isEmpty);
+    },
+  );
+
+  test(
     'reuses a runtime control for terminal requests when no legacy exists',
     () async {
       final tempDir = await Directory.systemTemp.createTemp(
@@ -688,13 +949,38 @@ Future<void> _waitForLauncherStart(_FakeTerminalHostLauncher launcher) async {
   expect(launcher.starts, greaterThan(0));
 }
 
+Future<void> _waitForQueuedLauncherStarts(
+  _QueuedTerminalHostLauncher launcher,
+  int expected,
+) async {
+  final deadline = DateTime.now().add(const Duration(seconds: 1));
+  while (launcher.starts < expected && DateTime.now().isBefore(deadline)) {
+    await Future<void>.delayed(const Duration(milliseconds: 1));
+  }
+  expect(launcher.starts, greaterThanOrEqualTo(expected));
+}
+
+Future<void> _waitForServerRequestCount(
+  _TerminalHostTestServer server,
+  int expected,
+) async {
+  final deadline = DateTime.now().add(const Duration(seconds: 1));
+  while (server.requests.length < expected &&
+      DateTime.now().isBefore(deadline)) {
+    await Future<void>.delayed(const Duration(milliseconds: 1));
+  }
+  expect(server.requests.length, greaterThanOrEqualTo(expected));
+}
+
 Future<void> _writeControlFile({
   required Directory tempDir,
+  String fileName = 'host.json',
   required int port,
   required String token,
   bool includeRuntimeCapability = true,
   bool includeBootstrapCapability = true,
   bool includeManagedWorkspaceCapability = true,
+  bool includeOrchestrationCapability = true,
 }) async {
   final runtimeDir = Directory(p.join(tempDir.path, 'terminal_host'));
   await runtimeDir.create(recursive: true);
@@ -709,13 +995,15 @@ Future<void> _writeControlFile({
       if (includeBootstrapCapability) aleraRuntimeHostBootstrapCapability,
       if (includeManagedWorkspaceCapability)
         aleraRuntimeHostManagedWorkspaceCapability,
+      if (includeOrchestrationCapability)
+        aleraRuntimeHostOrchestrationCapability,
     ],
   ];
   if (capabilities.isNotEmpty) {
     payload['runtimeCapabilities'] = capabilities;
   }
   await File(
-    p.join(runtimeDir.path, 'host.json'),
+    p.join(runtimeDir.path, fileName),
   ).writeAsString(jsonEncode(payload));
 }
 
@@ -750,6 +1038,54 @@ final class _FakeTerminalHostLauncher implements TerminalHostProcessLauncher {
           aleraRuntimeHostCapability,
           aleraRuntimeHostBootstrapCapability,
           aleraRuntimeHostManagedWorkspaceCapability,
+          aleraRuntimeHostOrchestrationCapability,
+        ],
+      }),
+    );
+  }
+}
+
+final class _QueuedTerminalHostLaunch {
+  const _QueuedTerminalHostLaunch({
+    required this.server,
+    this.beforePublish,
+    this.includeOrchestrationCapability = true,
+  });
+
+  final _TerminalHostTestServer server;
+  final Future<void>? beforePublish;
+  final bool includeOrchestrationCapability;
+}
+
+final class _QueuedTerminalHostLauncher implements TerminalHostProcessLauncher {
+  _QueuedTerminalHostLauncher(this._launches);
+
+  final List<_QueuedTerminalHostLaunch> _launches;
+  int starts = 0;
+
+  @override
+  Future<void> start({
+    required String runtimeDir,
+    required String controlFilePath,
+    required String token,
+    required TerminalHostConfig config,
+  }) async {
+    final launch = _launches[starts];
+    starts += 1;
+    launch.server.token = token;
+    await launch.beforePublish;
+    await File(controlFilePath).parent.create(recursive: true);
+    await File(controlFilePath).writeAsString(
+      jsonEncode(<String, Object?>{
+        'protocolVersion': aleraTerminalHostProtocolVersion,
+        'port': launch.server.port,
+        'token': token,
+        'runtimeCapabilities': <String>[
+          aleraRuntimeHostCapability,
+          aleraRuntimeHostBootstrapCapability,
+          aleraRuntimeHostManagedWorkspaceCapability,
+          if (launch.includeOrchestrationCapability)
+            aleraRuntimeHostOrchestrationCapability,
         ],
       }),
     );
@@ -775,17 +1111,20 @@ final class _TerminalHostTestServer {
     this._server, {
     this.errorForType,
     this.closeForType,
+    this.beforeResponse,
   });
 
   static Future<_TerminalHostTestServer> start({
     String? errorForType,
     String? closeForType,
+    Future<void> Function(String type)? beforeResponse,
   }) async {
     final socket = await ServerSocket.bind(InternetAddress.loopbackIPv4, 0);
     final server = _TerminalHostTestServer._(
       socket,
       errorForType: errorForType,
       closeForType: closeForType,
+      beforeResponse: beforeResponse,
     );
     server._sub = socket.listen(server._accept, onError: (_) {});
     return server;
@@ -794,6 +1133,7 @@ final class _TerminalHostTestServer {
   final ServerSocket _server;
   final String? errorForType;
   final String? closeForType;
+  final Future<void> Function(String type)? beforeResponse;
   final List<Map<String, Object?>> requests = <Map<String, Object?>>[];
   StreamSubscription<Socket>? _sub;
   Socket? _client;
@@ -818,22 +1158,26 @@ final class _TerminalHostTestServer {
         .cast<List<int>>()
         .transform(utf8.decoder)
         .transform(const LineSplitter())
-        .listen(_handleLine, onError: (_) {});
+        .listen(
+          (line) => unawaited(_handleLine(socket, line)),
+          onError: (_) {},
+        );
   }
 
-  void _handleLine(String line) {
+  Future<void> _handleLine(Socket socket, String line) async {
     final request = Map<String, Object?>.from(jsonDecode(line) as Map);
     final payload = Map<String, Object?>.from(request['payload'] as Map);
     request['payload'] = payload;
     requests.add(request);
     final id = request['id'] as int;
     final type = request['type'] as String;
+    await beforeResponse?.call(type);
     if (type == closeForType) {
-      _client!.destroy();
+      socket.destroy();
       return;
     }
     if (type == errorForType) {
-      _client!.writeln(
+      socket.writeln(
         jsonEncode(<String, Object?>{
           'id': id,
           'ok': false,
@@ -843,7 +1187,7 @@ final class _TerminalHostTestServer {
       return;
     }
     if (type == 'createOrAttach') {
-      _client!.writeln(
+      socket.writeln(
         jsonEncode(<String, Object?>{
           'id': id,
           'ok': true,
@@ -858,7 +1202,7 @@ final class _TerminalHostTestServer {
       return;
     }
     if (type == 'setOutputPaused') {
-      _client!.writeln(
+      socket.writeln(
         jsonEncode(<String, Object?>{
           'id': id,
           'ok': true,
@@ -870,7 +1214,7 @@ final class _TerminalHostTestServer {
       );
       return;
     }
-    _client!.writeln(
+    socket.writeln(
       jsonEncode(<String, Object?>{
         'id': id,
         'ok': true,

--- a/test/unit/workbench_controller_lifecycle_test_cases.dart
+++ b/test/unit/workbench_controller_lifecycle_test_cases.dart
@@ -202,6 +202,42 @@ void _registerWorkbenchControllerLifecycleTests() {
     );
   });
 
+  test('retries eager terminal spawn after startup error', () async {
+    await _controller.bootstrap();
+    final workspace = await _selectMainWorkspace(_controller, _harness);
+    await _flushUntil(
+      () => _harness.workbenchRepository.hasTabWatcher(workspace.id),
+    );
+    final tab = WorkspaceTabRecord(
+      id: 'spawn-tab',
+      workspaceId: workspace.id,
+      title: 'Worker',
+      createdAt: DateTime.utc(2026, 5, 22, 2),
+      updatedAt: DateTime.utc(2026, 5, 22, 2),
+      payload: const <String, Object?>{
+        workspaceTabTerminalSessionIdPayloadKey: 'spawn-session',
+        workspaceTabInitialCommandPayloadKey: 'claude',
+        workspaceTabSpawnOnCreatePayloadKey: true,
+      },
+    );
+    final session =
+        _harness.terminalRuntime.sessionFor(workspace: workspace, tab: tab)
+            as _FakeTerminalSessionHandle;
+    session.failStarts = true;
+
+    await _harness.workbenchRepository.upsertWorkspaceTab(tab);
+    await _flushUntil(() => session.ensureStartedCalls == 1);
+    expect(session.isRunning, isFalse);
+    expect(session.errorMessage, isNotNull);
+
+    session.failStarts = false;
+    _harness.workbenchRepository.emitTabs(workspace.id);
+    await _flushUntil(() => session.ensureStartedCalls == 2);
+
+    expect(session.isRunning, isTrue);
+    expect(session.errorMessage, isNull);
+  });
+
   test('path sync closes markdown viewer tabs renamed away from md', () async {
     await _controller.bootstrap();
     final workspace = await _selectMainWorkspace(_controller, _harness);

--- a/test/unit/workbench_controller_test.dart
+++ b/test/unit/workbench_controller_test.dart
@@ -24,8 +24,10 @@ import 'package:alera/src/features/workbench/domain/workspace_tab_record.dart';
 import 'package:alera/src/features/workbench/domain/workbench_layout.dart';
 import 'package:alera/src/features/workbench/domain/workspace.dart';
 import 'package:alera/src/features/workbench/domain/workspace_creation_result.dart';
+import 'package:alera/src/features/workbench/presentation/terminal_runtime.dart';
 import 'package:alera/src/shared/infra/git/git_providers.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:path/path.dart' as p;
 

--- a/test/unit/workbench_controller_test_harness.dart
+++ b/test/unit/workbench_controller_test_harness.dart
@@ -64,6 +64,7 @@ class _WorkbenchHarness {
         workspaceDirectory: p.join(tempDir.path, 'workspaces'),
       ),
     );
+    terminalRuntime = _FakeTerminalRuntime();
     container = ProviderContainer(
       overrides: [
         gitBackendProvider.overrideWithValue(gitBackend),
@@ -87,6 +88,7 @@ class _WorkbenchHarness {
           viewPrefsRepository,
         ),
         settingsControllerProvider.overrideWithValue(settings),
+        terminalRuntimeProvider.overrideWithValue(terminalRuntime),
       ],
     );
     _controller = container.read(workbenchControllerProvider.notifier);
@@ -100,6 +102,7 @@ class _WorkbenchHarness {
   late final FakeGitBackend gitBackend;
   late final _FakeWorkbenchViewPrefsRepository viewPrefsRepository;
   late final _FakeWorktreeSetupRunner worktreeSetupRunner;
+  late final _FakeTerminalRuntime terminalRuntime;
   late final ProviderContainer container;
   late final WorkbenchController _controller;
 
@@ -119,12 +122,125 @@ class _WorkbenchHarness {
 
   Future<void> dispose() async {
     container.dispose();
+    await terminalRuntime.dispose();
     await projectRepository.dispose();
     await workbenchRepository.dispose();
     if (tempDir.existsSync()) {
       tempDir.deleteSync(recursive: true);
     }
   }
+}
+
+class _FakeTerminalRuntime implements TerminalRuntime {
+  final Map<String, _FakeTerminalSessionHandle> sessions =
+      <String, _FakeTerminalSessionHandle>{};
+  final StreamController<TerminalRuntimeExitEvent> _exits =
+      StreamController<TerminalRuntimeExitEvent>.broadcast();
+
+  @override
+  Stream<TerminalRuntimeExitEvent> get exits => _exits.stream;
+
+  @override
+  TerminalSessionHandle sessionFor({
+    required Workspace workspace,
+    required WorkspaceTabRecord tab,
+  }) {
+    return sessions.putIfAbsent(
+      tab.id,
+      () => _FakeTerminalSessionHandle(
+        tabId: tab.id,
+        workspaceId: workspace.id,
+        displayTitle: tab.title,
+      ),
+    );
+  }
+
+  @override
+  void closeTab(String tabId) {
+    sessions.remove(tabId)?.dispose();
+  }
+
+  @override
+  void closeWorkspace(String workspaceId) {
+    final tabIds = <String>[
+      for (final entry in sessions.entries)
+        if (entry.value.workspaceId == workspaceId) entry.key,
+    ];
+    for (final tabId in tabIds) {
+      closeTab(tabId);
+    }
+  }
+
+  @override
+  Future<void> dispose() => _exits.close();
+}
+
+class _FakeTerminalSessionHandle extends TerminalSessionHandle {
+  _FakeTerminalSessionHandle({
+    required this.tabId,
+    required this.workspaceId,
+    required this.displayTitle,
+  });
+
+  @override
+  final String tabId;
+
+  @override
+  final String workspaceId;
+
+  @override
+  final String displayTitle;
+
+  int ensureStartedCalls = 0;
+  bool failStarts = false;
+  bool _running = false;
+  String? _errorMessage;
+
+  @override
+  bool get isRunning => _running;
+
+  @override
+  bool get isStarting => false;
+
+  @override
+  String? get errorMessage => _errorMessage;
+
+  @override
+  Future<void> ensureStarted() async {
+    ensureStartedCalls += 1;
+    if (failStarts) {
+      _running = false;
+      _errorMessage = 'failed to start';
+      notifyListeners();
+      return;
+    }
+    _running = true;
+    _errorMessage = null;
+    notifyListeners();
+  }
+
+  @override
+  Future<void> restart() async {
+    _running = false;
+    await ensureStarted();
+  }
+
+  @override
+  TerminalVisibilityLease acquireVisibility() {
+    return const NoopTerminalVisibilityLease();
+  }
+
+  @override
+  Widget buildView({
+    Key? key,
+    bool autofocus = false,
+    FocusOnKeyEventCallback? onKeyEvent,
+  }) {
+    return SizedBox(key: key);
+  }
+
+  @override
+  void requestFocus() {}
 }
 
 class _FakeWorkspaceGraphRepository implements WorkspaceGraphRepository {


### PR DESCRIPTION
## Summary

- Add the orchestration runtime workflow across the Rust terminal host, runtime store, CLI commands, and coordinator dispatch paths.
- Wire Dart runtime host/orchestration client behavior and agent status forwarding.
- Document orchestration usage and add regression/conformance coverage for the new paths.

## Validation

- `codex review --uncommitted` until no actionable findings
- `git diff --check`
- `cargo fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `flutter analyze`

## Notes

- The branch is rebased on the current `origin/main` before opening this PR.