### PR TITLE
feat: support native app menu for settings and updates

### DIFF
--- a/lib/src/features/app_menu/presentation/alera_app_menu_scope.dart
+++ b/lib/src/features/app_menu/presentation/alera_app_menu_scope.dart
@@ -1,0 +1,321 @@
+import 'dart:async';
+
+import 'package:alera/src/app/providers.dart';
+import 'package:alera/src/app/theme/alera_tokens.dart';
+import 'package:alera/src/core/build_flavor.dart';
+import 'package:alera/src/features/app_menu/presentation/app_menu_actions.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Installs the desktop application menu.
+///
+/// - **macOS:** [PlatformMenuBar] (system menu bar; replaces MainMenu.xib).
+/// - **Windows / Linux:** Material [MenuBar] at the top of the window (Flutter
+///   engine does not implement native platform menus on these platforms).
+class AleraAppMenuScope extends ConsumerWidget {
+  const AleraAppMenuScope({super.key, required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    if (kIsWeb) {
+      return child;
+    }
+    return switch (defaultTargetPlatform) {
+      TargetPlatform.macOS => _MacOsPlatformMenuBar(child: child),
+      TargetPlatform.windows ||
+      TargetPlatform.linux => _DesktopMaterialMenuBar(child: child),
+      _ => child,
+    };
+  }
+}
+
+class _MacOsPlatformMenuBar extends ConsumerWidget {
+  const _MacOsPlatformMenuBar({required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    // Watch settings so the menu rebuilds when openSettings is remapped.
+    ref.watch(settingsControllerProvider.select((s) => s.keyboard));
+
+    return PlatformMenuBar(
+      menus: <PlatformMenuItem>[
+        PlatformMenu(
+          label: kAleraAppName,
+          menus: <PlatformMenuItem>[
+            PlatformMenuItem(
+              label: 'About $kAleraAppName',
+              onSelected: () {
+                unawaited(showAppMenuAbout(context));
+              },
+            ),
+            PlatformMenuItemGroup(
+              members: <PlatformMenuItem>[
+                PlatformMenuItem(
+                  label: 'Settings ...',
+                  // Do not register a platform shortcut: Mod+Comma is already
+                  // handled by KeyboardShortcutsScope. A duplicate native
+                  // accelerator can open Settings twice.
+                  onSelected: () {
+                    unawaited(openAppMenuSettings(context));
+                  },
+                ),
+                PlatformMenuItem(
+                  label: 'Check for Updates ...',
+                  onSelected: () {
+                    unawaited(checkForUpdatesFromAppMenu(context, ref));
+                  },
+                ),
+              ],
+            ),
+            if (PlatformProvidedMenuItem.hasMenu(
+              PlatformProvidedMenuItemType.servicesSubmenu,
+            ))
+              const PlatformProvidedMenuItem(
+                type: PlatformProvidedMenuItemType.servicesSubmenu,
+              ),
+            PlatformMenuItemGroup(
+              members: <PlatformMenuItem>[
+                if (PlatformProvidedMenuItem.hasMenu(
+                  PlatformProvidedMenuItemType.hide,
+                ))
+                  const PlatformProvidedMenuItem(
+                    type: PlatformProvidedMenuItemType.hide,
+                  ),
+                if (PlatformProvidedMenuItem.hasMenu(
+                  PlatformProvidedMenuItemType.hideOtherApplications,
+                ))
+                  const PlatformProvidedMenuItem(
+                    type: PlatformProvidedMenuItemType.hideOtherApplications,
+                  ),
+                if (PlatformProvidedMenuItem.hasMenu(
+                  PlatformProvidedMenuItemType.showAllApplications,
+                ))
+                  const PlatformProvidedMenuItem(
+                    type: PlatformProvidedMenuItemType.showAllApplications,
+                  ),
+              ],
+            ),
+            // Use the app-window close path so Quit flushes window state the
+            // same way Windows/Linux Exit does (platform terminate may skip it).
+            PlatformMenuItem(
+              label: 'Quit $kAleraAppName',
+              shortcut: const SingleActivator(
+                LogicalKeyboardKey.keyQ,
+                meta: true,
+              ),
+              onSelected: () {
+                unawaited(exitAppFromMenu(ref));
+              },
+            ),
+          ],
+        ),
+        PlatformMenu(
+          label: 'Edit',
+          menus: <PlatformMenuItem>[
+            PlatformMenuItemGroup(
+              members: <PlatformMenuItem>[
+                PlatformMenuItem(
+                  label: 'Undo',
+                  shortcut: const SingleActivator(
+                    LogicalKeyboardKey.keyZ,
+                    meta: true,
+                  ),
+                  onSelected: () {
+                    invokeFocusedTextIntent(
+                      const UndoTextIntent(SelectionChangedCause.keyboard),
+                    );
+                  },
+                ),
+                PlatformMenuItem(
+                  label: 'Redo',
+                  shortcut: const SingleActivator(
+                    LogicalKeyboardKey.keyZ,
+                    meta: true,
+                    shift: true,
+                  ),
+                  onSelected: () {
+                    invokeFocusedTextIntent(
+                      const RedoTextIntent(SelectionChangedCause.keyboard),
+                    );
+                  },
+                ),
+              ],
+            ),
+            PlatformMenuItemGroup(
+              members: <PlatformMenuItem>[
+                PlatformMenuItem(
+                  label: 'Cut',
+                  shortcut: const SingleActivator(
+                    LogicalKeyboardKey.keyX,
+                    meta: true,
+                  ),
+                  onSelected: () {
+                    invokeFocusedTextIntent(
+                      const CopySelectionTextIntent.cut(
+                        SelectionChangedCause.keyboard,
+                      ),
+                    );
+                  },
+                ),
+                PlatformMenuItem(
+                  label: 'Copy',
+                  shortcut: const SingleActivator(
+                    LogicalKeyboardKey.keyC,
+                    meta: true,
+                  ),
+                  onSelected: () {
+                    invokeFocusedTextIntent(CopySelectionTextIntent.copy);
+                  },
+                ),
+                PlatformMenuItem(
+                  label: 'Paste',
+                  shortcut: const SingleActivator(
+                    LogicalKeyboardKey.keyV,
+                    meta: true,
+                  ),
+                  onSelected: () {
+                    invokeFocusedTextIntent(
+                      const PasteTextIntent(SelectionChangedCause.keyboard),
+                    );
+                  },
+                ),
+                PlatformMenuItem(
+                  label: 'Select All',
+                  shortcut: const SingleActivator(
+                    LogicalKeyboardKey.keyA,
+                    meta: true,
+                  ),
+                  onSelected: () {
+                    invokeFocusedTextIntent(
+                      const SelectAllTextIntent(SelectionChangedCause.keyboard),
+                    );
+                  },
+                ),
+              ],
+            ),
+          ],
+        ),
+        PlatformMenu(
+          label: 'Window',
+          menus: <PlatformMenuItem>[
+            if (PlatformProvidedMenuItem.hasMenu(
+              PlatformProvidedMenuItemType.minimizeWindow,
+            ))
+              const PlatformProvidedMenuItem(
+                type: PlatformProvidedMenuItemType.minimizeWindow,
+              ),
+            if (PlatformProvidedMenuItem.hasMenu(
+              PlatformProvidedMenuItemType.zoomWindow,
+            ))
+              const PlatformProvidedMenuItem(
+                type: PlatformProvidedMenuItemType.zoomWindow,
+              ),
+            if (PlatformProvidedMenuItem.hasMenu(
+              PlatformProvidedMenuItemType.toggleFullScreen,
+            ))
+              const PlatformProvidedMenuItem(
+                type: PlatformProvidedMenuItemType.toggleFullScreen,
+              ),
+            if (PlatformProvidedMenuItem.hasMenu(
+              PlatformProvidedMenuItemType.arrangeWindowsInFront,
+            ))
+              const PlatformProvidedMenuItem(
+                type: PlatformProvidedMenuItemType.arrangeWindowsInFront,
+              ),
+          ],
+        ),
+      ],
+      child: child,
+    );
+  }
+}
+
+class _DesktopMaterialMenuBar extends ConsumerWidget {
+  const _DesktopMaterialMenuBar({required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final theme = Theme.of(context);
+    // Rebuild when openSettings binding changes so the display shortcut stays
+    // aligned with KeyboardShortcutsScope.
+    ref.watch(settingsControllerProvider.select((s) => s.keyboard));
+    final settingsShortcut = settingsMenuShortcut(ref);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: <Widget>[
+        Material(
+          color: AleraTokens.surface,
+          child: DecoratedBox(
+            decoration: const BoxDecoration(
+              border: Border(
+                bottom: BorderSide(color: AleraTokens.borderSubtle),
+              ),
+            ),
+            child: MenuBar(
+              style: MenuStyle(
+                backgroundColor: const WidgetStatePropertyAll<Color>(
+                  AleraTokens.surface,
+                ),
+                elevation: const WidgetStatePropertyAll<double>(0),
+                shape: const WidgetStatePropertyAll<OutlinedBorder>(
+                  RoundedRectangleBorder(),
+                ),
+                padding: const WidgetStatePropertyAll<EdgeInsetsGeometry>(
+                  EdgeInsets.symmetric(horizontal: AleraTokens.space4),
+                ),
+              ),
+              children: <Widget>[
+                SubmenuButton(
+                  menuChildren: <Widget>[
+                    MenuItemButton(
+                      onPressed: () {
+                        unawaited(openAppMenuSettings(context));
+                      },
+                      shortcut: settingsShortcut,
+                      child: const Text('Settings ...'),
+                    ),
+                    MenuItemButton(
+                      onPressed: () {
+                        unawaited(checkForUpdatesFromAppMenu(context, ref));
+                      },
+                      child: const Text('Check for Updates ...'),
+                    ),
+                    const Divider(),
+                    MenuItemButton(
+                      onPressed: () {
+                        unawaited(showAppMenuAbout(context));
+                      },
+                      child: Text('About $kAleraAppName'),
+                    ),
+                    MenuItemButton(
+                      onPressed: () {
+                        unawaited(exitAppFromMenu(ref));
+                      },
+                      child: const Text('Exit'),
+                    ),
+                  ],
+                  child: Text(
+                    kAleraAppName,
+                    style: theme.textTheme.labelLarge?.copyWith(
+                      color: AleraTokens.foreground,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+        Expanded(child: child),
+      ],
+    );
+  }
+}

--- a/lib/src/features/app_menu/presentation/app_menu_actions.dart
+++ b/lib/src/features/app_menu/presentation/app_menu_actions.dart
@@ -1,0 +1,144 @@
+import 'package:alera/src/app/providers.dart';
+import 'package:alera/src/app/theme/alera_tokens.dart';
+import 'package:alera/src/core/build_flavor.dart';
+import 'package:alera/src/design_system/feedback/alera_toast.dart';
+import 'package:alera/src/design_system/layout/alera_dialog.dart';
+import 'package:alera/src/features/app_window/application/app_window_providers.dart';
+import 'package:alera/src/features/keyboard/application/keybinding_resolver.dart';
+import 'package:alera/src/features/keyboard/domain/key_chord.dart';
+import 'package:alera/src/features/keyboard/domain/keyboard_action.dart';
+import 'package:alera/src/features/updater/domain/alera_update.dart';
+import 'package:alera/src/features/workbench/presentation/workbench_dialog_launchers.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+
+/// Shared actions for the desktop application menu (native on macOS,
+/// Material menu bar on Windows/Linux).
+
+typedef AppMenuPackageInfoLoader = Future<PackageInfo> Function();
+
+Future<void> openAppMenuSettings(BuildContext context) {
+  return openSettingsDialog(context);
+}
+
+Future<void> checkForUpdatesFromAppMenu(
+  BuildContext context,
+  WidgetRef ref,
+) async {
+  final controller = ref.read(aleraUpdateControllerProvider.notifier);
+  await controller.checkForUpdates();
+  if (!context.mounted) {
+    return;
+  }
+  final state = ref.read(aleraUpdateControllerProvider);
+  final message = state.message?.trim();
+  if (message == null || message.isEmpty) {
+    return;
+  }
+  AleraToast.show(
+    context,
+    message: message,
+    tone: _toastToneForUpdateStatus(state.status),
+  );
+}
+
+Future<void> showAppMenuAbout(
+  BuildContext context, {
+  AppMenuPackageInfoLoader loadPackageInfo = PackageInfo.fromPlatform,
+}) async {
+  final info = await loadPackageInfo();
+  if (!context.mounted) {
+    return;
+  }
+  final theme = Theme.of(context);
+  await showDialog<void>(
+    context: context,
+    builder: (dialogContext) {
+      return AleraDialog(
+        maxWidth: 360,
+        child: Padding(
+          padding: const EdgeInsets.all(AleraTokens.space20),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: <Widget>[
+              Text(kAleraAppName, style: theme.textTheme.titleMedium),
+              const SizedBox(height: AleraTokens.space8),
+              Text(
+                'Version ${info.version} (${info.buildNumber})',
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  color: AleraTokens.foregroundMuted,
+                ),
+              ),
+              const SizedBox(height: AleraTokens.space20),
+              Align(
+                alignment: Alignment.centerRight,
+                child: FilledButton(
+                  onPressed: () => Navigator.of(dialogContext).pop(),
+                  child: const Text('Close'),
+                ),
+              ),
+            ],
+          ),
+        ),
+      );
+    },
+  );
+}
+
+/// Closes through the app-window lifecycle (flush state, then destroy).
+Future<void> exitAppFromMenu(WidgetRef ref) {
+  return ref.read(appWindowControllerProvider).close();
+}
+
+/// Display-only menu shortcut for Settings, from the effective openSettings
+/// binding. Returns null when the action is disabled or has no binding.
+MenuSerializableShortcut? settingsMenuShortcut(WidgetRef ref) {
+  final keyboard = ref.read(settingsControllerProvider).keyboard;
+  final resolver = KeybindingResolver(settings: keyboard);
+  final chords = resolver.effectiveChords(KeyboardActionId.openSettings);
+  if (chords.isEmpty) {
+    return null;
+  }
+  return keyChordToMenuShortcut(
+    chords.first,
+    isMacOS: resolver.platform.isMacOS,
+  );
+}
+
+/// Converts a [KeyChord] into a [SingleActivator] for menu display.
+MenuSerializableShortcut keyChordToMenuShortcut(
+  KeyChord chord, {
+  required bool isMacOS,
+}) {
+  return SingleActivator(
+    chord.trigger,
+    control: chord.control || (!isMacOS && chord.useMod),
+    meta: chord.meta || (isMacOS && chord.useMod),
+    alt: chord.alt,
+    shift: chord.shift,
+  );
+}
+
+/// Invokes a text-editing intent on the primary focus, if any action handles it.
+void invokeFocusedTextIntent(Intent intent) {
+  final primaryContext = primaryFocus?.context;
+  if (primaryContext == null) {
+    return;
+  }
+  Actions.maybeInvoke<Intent>(primaryContext, intent);
+}
+
+AleraToastTone _toastToneForUpdateStatus(AleraUpdateStatus status) {
+  return switch (status) {
+    AleraUpdateStatus.error => AleraToastTone.error,
+    AleraUpdateStatus.available ||
+    AleraUpdateStatus.manualDownloadRequired ||
+    AleraUpdateStatus.downloaded => AleraToastTone.success,
+    AleraUpdateStatus.idle ||
+    AleraUpdateStatus.checking ||
+    AleraUpdateStatus.notAvailable ||
+    AleraUpdateStatus.downloading => AleraToastTone.info,
+  };
+}

--- a/lib/src/features/app_window/application/app_window_controller.dart
+++ b/lib/src/features/app_window/application/app_window_controller.dart
@@ -52,6 +52,12 @@ abstract interface class AppWindowController {
 
   Future<void> setPreventClose(bool value);
 
+  /// Requests a user-initiated window close (system close path).
+  ///
+  /// When prevent-close is enabled, this should emit the close event so the
+  /// lifecycle coordinator can flush state and destroy the window.
+  Future<void> close();
+
   Future<void> destroy();
 }
 

--- a/lib/src/features/app_window/infra/window_manager_app_window_controller.dart
+++ b/lib/src/features/app_window/infra/window_manager_app_window_controller.dart
@@ -54,6 +54,9 @@ class WindowManagerAppWindowController implements AppWindowController {
   Future<void> setTitle(String title) => _manager.setTitle(title);
 
   @override
+  Future<void> close() => _manager.close();
+
+  @override
   Future<void> destroy() => _manager.destroy();
 }
 

--- a/lib/src/features/shell/presentation/alera_shell_page.dart
+++ b/lib/src/features/shell/presentation/alera_shell_page.dart
@@ -6,6 +6,7 @@ import 'package:alera/src/features/agent_status/application/agent_status_host_fo
 import 'package:alera/src/design_system/feedback/alera_toast.dart';
 import 'package:alera/src/design_system/icons/alera_icons.dart';
 import 'package:alera/src/design_system/layout/alera_confirm_dialog.dart';
+import 'package:alera/src/features/app_menu/presentation/alera_app_menu_scope.dart';
 import 'package:alera/src/features/keyboard/presentation/keyboard_shortcuts_scope.dart';
 import 'package:alera/src/features/projects/domain/project.dart';
 import 'package:alera/src/features/workbench/application/workspace_file_service.dart';
@@ -132,143 +133,145 @@ class _AleraShellPageBodyState extends ConsumerState<_AleraShellPageBody> {
       prefs: state.viewPrefs,
     );
 
-    return Scaffold(
-      body: KeyboardShortcutsScope(
-        child: LayoutBuilder(
-          builder: (context, constraints) {
-            final showContextSidebar =
-                workspace != null &&
-                _canShowContextSidebar(
-                  shellWidth: constraints.maxWidth,
-                  state: state,
-                );
-            return Row(
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: <Widget>[
-                const ProjectWorkbenchSidebar(),
-                Expanded(
-                  child: _buildContent(
+    return AleraAppMenuScope(
+      child: Scaffold(
+        body: KeyboardShortcutsScope(
+          child: LayoutBuilder(
+            builder: (context, constraints) {
+              final showContextSidebar =
+                  workspace != null &&
+                  _canShowContextSidebar(
+                    shellWidth: constraints.maxWidth,
                     state: state,
-                    project: project,
-                    workspace: workspace,
-                    sourceControlScope: sourceControlScope,
+                  );
+              return Row(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: <Widget>[
+                  const ProjectWorkbenchSidebar(),
+                  Expanded(
+                    child: _buildContent(
+                      state: state,
+                      project: project,
+                      workspace: workspace,
+                      sourceControlScope: sourceControlScope,
+                    ),
                   ),
-                ),
-                if (workspace != null && showContextSidebar)
-                  WorkspaceContextSidebar(
-                    workspace: workspace,
-                    prefs: state.viewPrefs,
-                    sourceControlScope: sourceControlScope,
-                    sourceControlAvailable: sourceControlScope != null,
-                    focusedSourceControlRoot: canSelectSourceControlRoot
-                        ? state
-                              .viewPrefs
-                              .sourceControlRootByWorkspaceId[workspace.id]
-                        : null,
-                    onToggleVisible: controller.toggleRightSidebarVisible,
-                    onResize: controller.setRightSidebarWidth,
-                    onSetContextPanelTab: controller.setContextPanelTab,
-                    onSetExplorerMode: controller.setExplorerMode,
-                    onSetGitDiffViewMode: controller.setGitDiffViewMode,
-                    onFocusSourceControlFolder: canSelectSourceControlRoot
-                        ? (relativePath) {
-                            return controller.focusSourceControlFolder(
+                  if (workspace != null && showContextSidebar)
+                    WorkspaceContextSidebar(
+                      workspace: workspace,
+                      prefs: state.viewPrefs,
+                      sourceControlScope: sourceControlScope,
+                      sourceControlAvailable: sourceControlScope != null,
+                      focusedSourceControlRoot: canSelectSourceControlRoot
+                          ? state
+                                .viewPrefs
+                                .sourceControlRootByWorkspaceId[workspace.id]
+                          : null,
+                      onToggleVisible: controller.toggleRightSidebarVisible,
+                      onResize: controller.setRightSidebarWidth,
+                      onSetContextPanelTab: controller.setContextPanelTab,
+                      onSetExplorerMode: controller.setExplorerMode,
+                      onSetGitDiffViewMode: controller.setGitDiffViewMode,
+                      onFocusSourceControlFolder: canSelectSourceControlRoot
+                          ? (relativePath) {
+                              return controller.focusSourceControlFolder(
+                                workspace: workspace,
+                                relativePath: relativePath,
+                              );
+                            }
+                          : null,
+                      onClearSourceControlRoot: canSelectSourceControlRoot
+                          ? () {
+                              controller.clearFocusedSourceControlFolder(
+                                workspace: workspace,
+                              );
+                            }
+                          : null,
+                      onOpenFile: (relativePath) {
+                        unawaited(
+                          controller.openFileTab(
+                            workspace: workspace,
+                            relativePath: relativePath,
+                          ),
+                        );
+                      },
+                      onOpenGitDiff:
+                          ({relativePath, area, gitDiffRoot, required scope}) {
+                            return controller.openGitDiffTab(
                               workspace: workspace,
                               relativePath: relativePath,
+                              area: area,
+                              scope: scope,
+                              gitDiffRoot: gitDiffRoot,
                             );
-                          }
-                        : null,
-                    onClearSourceControlRoot: canSelectSourceControlRoot
-                        ? () {
-                            controller.clearFocusedSourceControlFolder(
+                          },
+                      onOpenGitCommitDiff:
+                          ({
+                            relativePath,
+                            oldPath,
+                            required scope,
+                            gitDiffRoot,
+                            required commitOid,
+                            parentOid,
+                            required compareRef,
+                            subject,
+                            message,
+                          }) {
+                            return controller.openGitCommitDiffTab(
                               workspace: workspace,
+                              relativePath: relativePath,
+                              oldPath: oldPath,
+                              scope: scope,
+                              gitDiffRoot: gitDiffRoot,
+                              commitOid: commitOid,
+                              parentOid: parentOid,
+                              compareRef: compareRef,
+                              subject: subject,
+                              message: message,
                             );
-                          }
-                        : null,
-                    onOpenFile: (relativePath) {
-                      unawaited(
-                        controller.openFileTab(
-                          workspace: workspace,
-                          relativePath: relativePath,
-                        ),
-                      );
-                    },
-                    onOpenGitDiff:
-                        ({relativePath, area, gitDiffRoot, required scope}) {
-                          return controller.openGitDiffTab(
+                          },
+                      onOpenSearchMatch: (target) {
+                        unawaited(() async {
+                          final tab = await controller.openEditorTab(
                             workspace: workspace,
-                            relativePath: relativePath,
-                            area: area,
-                            scope: scope,
-                            gitDiffRoot: gitDiffRoot,
+                            relativePath: target.relativePath,
                           );
-                        },
-                    onOpenGitCommitDiff:
-                        ({
-                          relativePath,
-                          oldPath,
-                          required scope,
-                          gitDiffRoot,
-                          required commitOid,
-                          parentOid,
-                          required compareRef,
-                          subject,
-                          message,
-                        }) {
-                          return controller.openGitCommitDiffTab(
-                            workspace: workspace,
-                            relativePath: relativePath,
-                            oldPath: oldPath,
-                            scope: scope,
-                            gitDiffRoot: gitDiffRoot,
-                            commitOid: commitOid,
-                            parentOid: parentOid,
-                            compareRef: compareRef,
-                            subject: subject,
-                            message: message,
-                          );
-                        },
-                    onOpenSearchMatch: (target) {
-                      unawaited(() async {
-                        final tab = await controller.openEditorTab(
+                          ref
+                              .read(editorSessionRegistryProvider)
+                              .reveal(
+                                tab.id,
+                                WorkspaceEditorRevealTarget(
+                                  line: target.line,
+                                  column: target.column,
+                                  matchLength: target.matchLength,
+                                ),
+                              );
+                        }());
+                      },
+                      onPathMoved: (oldRelativePath, newRelativePath) async {
+                        await controller.syncFileTabsAfterPathMove(
                           workspace: workspace,
-                          relativePath: target.relativePath,
+                          oldRelativePath: oldRelativePath,
+                          newRelativePath: newRelativePath,
                         );
                         ref
                             .read(editorSessionRegistryProvider)
-                            .reveal(
-                              tab.id,
-                              WorkspaceEditorRevealTarget(
-                                line: target.line,
-                                column: target.column,
-                                matchLength: target.matchLength,
-                              ),
+                            .updateDocumentPathsAfterMove(
+                              workspacePath: workspace.path,
+                              oldRelativePath: oldRelativePath,
+                              newRelativePath: newRelativePath,
                             );
-                      }());
-                    },
-                    onPathMoved: (oldRelativePath, newRelativePath) async {
-                      await controller.syncFileTabsAfterPathMove(
-                        workspace: workspace,
-                        oldRelativePath: oldRelativePath,
-                        newRelativePath: newRelativePath,
-                      );
-                      ref
-                          .read(editorSessionRegistryProvider)
-                          .updateDocumentPathsAfterMove(
-                            workspacePath: workspace.path,
-                            oldRelativePath: oldRelativePath,
-                            newRelativePath: newRelativePath,
-                          );
-                      controller.syncSourceControlRootAfterPathMove(
-                        workspace: workspace,
-                        oldRelativePath: oldRelativePath,
-                        newRelativePath: newRelativePath,
-                      );
-                    },
-                  ),
-              ],
-            );
-          },
+                        controller.syncSourceControlRootAfterPathMove(
+                          workspace: workspace,
+                          oldRelativePath: oldRelativePath,
+                          newRelativePath: newRelativePath,
+                        );
+                      },
+                    ),
+                ],
+              );
+            },
+          ),
         ),
       ),
     );

--- a/test/unit/app_window_state_test.dart
+++ b/test/unit/app_window_state_test.dart
@@ -278,6 +278,11 @@ class _FakeAppWindowController implements AppWindowController {
 
   @override
   Future<void> setTitle(String title) async {}
+
+  @override
+  Future<void> close() async {
+    emit((listener) => listener.onWindowClose());
+  }
 }
 
 Future<void> _waitFor(bool Function() condition) async {

--- a/test/widget/app_menu_test.dart
+++ b/test/widget/app_menu_test.dart
@@ -1,0 +1,309 @@
+import 'dart:async';
+
+import 'package:alera/src/app/providers.dart';
+import 'package:alera/src/app/theme/alera_dark_theme.dart';
+import 'package:alera/src/core/build_flavor.dart';
+import 'package:alera/src/design_system/feedback/alera_toast.dart';
+import 'package:alera/src/features/app_menu/presentation/alera_app_menu_scope.dart';
+import 'package:alera/src/features/app_menu/presentation/app_menu_actions.dart';
+import 'package:alera/src/features/app_window/application/app_window_controller.dart';
+import 'package:alera/src/features/app_window/application/app_window_providers.dart';
+import 'package:alera/src/features/settings/domain/alera_settings.dart';
+import 'package:alera/src/features/updater/domain/alera_update.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+
+void main() {
+  group('app menu actions', () {
+    testWidgets('openAppMenuSettings opens the settings dialog', (
+      tester,
+    ) async {
+      await _pumpActionHarness(
+        tester,
+        onPressed: (context, _) => openAppMenuSettings(context),
+      );
+
+      await tester.tap(find.text('Run'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+
+      expect(find.text('Application'), findsWidgets);
+    });
+
+    testWidgets('checkForUpdatesFromAppMenu runs check and shows toast', (
+      tester,
+    ) async {
+      final updateController = _FakeUpdateController(
+        AleraUpdateState(status: AleraUpdateStatus.idle, config: _config()),
+      );
+      final toastMessages = <String>[];
+      final sub = AleraToast.stream.listen((data) {
+        toastMessages.add(data.message);
+      });
+      addTearDown(sub.cancel);
+
+      await _pumpActionHarness(
+        tester,
+        updateController: updateController,
+        onPressed: (context, ref) => checkForUpdatesFromAppMenu(context, ref),
+      );
+
+      await tester.tap(find.text('Run'));
+      await tester.pump();
+      await tester.pump();
+
+      expect(updateController.checkForUpdatesCalls, 1);
+      expect(toastMessages, <String>['Alera is up to date.']);
+    });
+
+    testWidgets('showAppMenuAbout opens the about dialog', (tester) async {
+      await _pumpActionHarness(
+        tester,
+        onPressed: (context, _) => showAppMenuAbout(
+          context,
+          loadPackageInfo: () async => PackageInfo(
+            appName: kAleraAppName,
+            packageName: 'dev.leynier.alera',
+            version: '1.2.3',
+            buildNumber: '45',
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Run'));
+      await tester.pumpAndSettle();
+
+      expect(find.text(kAleraAppName), findsWidgets);
+      expect(find.text('Version 1.2.3 (45)'), findsOneWidget);
+      expect(find.text('Close'), findsOneWidget);
+    });
+
+    testWidgets('exitAppFromMenu closes the app window', (tester) async {
+      final window = _FakeAppWindowController();
+      await _pumpActionHarness(
+        tester,
+        window: window,
+        onPressed: (_, ref) => exitAppFromMenu(ref),
+      );
+
+      await tester.tap(find.text('Run'));
+      await tester.pump();
+
+      expect(window.closeCalls, 1);
+    });
+  });
+
+  group('AleraAppMenuScope', () {
+    testWidgets('shows Material menu bar items on Linux', (tester) async {
+      await _withPlatform(TargetPlatform.linux, () async {
+        await _pumpMenuScope(tester);
+
+        expect(find.byType(MenuBar), findsOneWidget);
+        expect(find.text(kAleraAppName), findsOneWidget);
+
+        await tester.tap(find.text(kAleraAppName));
+        await tester.pumpAndSettle();
+        expect(find.text('Settings ...'), findsOneWidget);
+        expect(find.text('Check for Updates ...'), findsOneWidget);
+        expect(find.text('About $kAleraAppName'), findsOneWidget);
+        expect(find.text('Exit'), findsOneWidget);
+      });
+    });
+
+    testWidgets('shows Material menu bar items on Windows', (tester) async {
+      await _withPlatform(TargetPlatform.windows, () async {
+        await _pumpMenuScope(tester);
+
+        expect(find.byType(MenuBar), findsOneWidget);
+        expect(find.text('Check for Updates ...'), findsNothing);
+
+        await tester.tap(find.text(kAleraAppName));
+        await tester.pumpAndSettle();
+        expect(find.text('Settings ...'), findsOneWidget);
+        expect(find.text('Check for Updates ...'), findsOneWidget);
+        expect(find.text('About $kAleraAppName'), findsOneWidget);
+        expect(find.text('Exit'), findsOneWidget);
+      });
+    });
+
+    testWidgets('uses PlatformMenuBar on macOS without in-window MenuBar', (
+      tester,
+    ) async {
+      await _withPlatform(TargetPlatform.macOS, () async {
+        await _pumpMenuScope(tester);
+
+        expect(find.byType(PlatformMenuBar), findsOneWidget);
+        expect(find.byType(MenuBar), findsNothing);
+      });
+    });
+  });
+}
+
+Future<void> _withPlatform(
+  TargetPlatform platform,
+  Future<void> Function() body,
+) async {
+  final previous = debugDefaultTargetPlatformOverride;
+  debugDefaultTargetPlatformOverride = platform;
+  try {
+    await body();
+  } finally {
+    debugDefaultTargetPlatformOverride = previous;
+  }
+}
+
+Future<void> _pumpActionHarness(
+  WidgetTester tester, {
+  required FutureOr<void> Function(BuildContext context, WidgetRef ref)
+  onPressed,
+  _FakeUpdateController? updateController,
+  _FakeAppWindowController? window,
+}) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        aleraUpdateControllerProvider.overrideWith(
+          () =>
+              updateController ??
+              _FakeUpdateController(
+                AleraUpdateState(
+                  status: AleraUpdateStatus.idle,
+                  config: _config(),
+                ),
+              ),
+        ),
+        appWindowControllerProvider.overrideWithValue(
+          window ?? _FakeAppWindowController(),
+        ),
+        settingsControllerProvider.overrideWith(
+          () => _FakeSettingsController(AleraSettings.defaults),
+        ),
+      ],
+      child: MaterialApp(
+        theme: buildAleraDarkTheme(),
+        home: Scaffold(
+          body: Consumer(
+            builder: (context, ref, _) {
+              return TextButton(
+                onPressed: () =>
+                    unawaited(Future<void>.sync(() => onPressed(context, ref))),
+                child: const Text('Run'),
+              );
+            },
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+Future<void> _pumpMenuScope(WidgetTester tester) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        aleraUpdateControllerProvider.overrideWith(
+          () => _FakeUpdateController(
+            AleraUpdateState(status: AleraUpdateStatus.idle, config: _config()),
+          ),
+        ),
+        appWindowControllerProvider.overrideWithValue(
+          _FakeAppWindowController(),
+        ),
+        settingsControllerProvider.overrideWith(
+          () => _FakeSettingsController(AleraSettings.defaults),
+        ),
+      ],
+      child: MaterialApp(
+        theme: buildAleraDarkTheme(),
+        home: const AleraAppMenuScope(child: Scaffold(body: SizedBox.expand())),
+      ),
+    ),
+  );
+  await tester.pump();
+}
+
+AleraUpdateConfig _config() {
+  return AleraUpdateConfig(
+    archiveUrl: Uri.parse('https://example.com/app-archive.json'),
+    releasePageUrl: Uri.parse('https://example.com/releases'),
+    channel: AleraUpdateChannel.stable,
+    autoInstallEnabled: true,
+    signedRelease: true,
+  );
+}
+
+class _FakeSettingsController extends SettingsController {
+  _FakeSettingsController(this._seed);
+
+  final AleraSettings _seed;
+
+  @override
+  AleraSettings build() => _seed;
+}
+
+class _FakeUpdateController extends AleraUpdateController {
+  _FakeUpdateController(this._seed);
+
+  final AleraUpdateState _seed;
+  int checkForUpdatesCalls = 0;
+
+  @override
+  AleraUpdateState build() => _seed;
+
+  @override
+  Future<void> checkForUpdates() async {
+    checkForUpdatesCalls += 1;
+    state = state.copyWith(
+      status: AleraUpdateStatus.notAvailable,
+      message: 'Alera is up to date.',
+    );
+  }
+}
+
+class _FakeAppWindowController implements AppWindowController {
+  int closeCalls = 0;
+
+  @override
+  void addListener(AppWindowEventListener listener) {}
+
+  @override
+  Future<void> close() async {
+    closeCalls += 1;
+  }
+
+  @override
+  Future<void> destroy() async {}
+
+  @override
+  Future<Rect> getBounds() async => const Rect.fromLTWH(0, 0, 1280, 720);
+
+  @override
+  Future<bool> isFullScreen() async => false;
+
+  @override
+  Future<bool> isMaximized() async => false;
+
+  @override
+  Future<bool> isMinimized() async => false;
+
+  @override
+  Future<void> maximize() async {}
+
+  @override
+  void removeListener(AppWindowEventListener listener) {}
+
+  @override
+  Future<void> setBounds(Rect bounds) async {}
+
+  @override
+  Future<void> setFullScreen(bool value) async {}
+
+  @override
+  Future<void> setPreventClose(bool value) async {}
+
+  @override
+  Future<void> setTitle(String title) async {}
+}


### PR DESCRIPTION
## Summary

Adds desktop application menus so users can open Settings, check for updates, view About, and exit from the OS menu on macOS, Windows, and Linux (closes #67).

- **macOS:** `PlatformMenuBar` with app menu (About, Settings, Check for Updates, Hide, Quit via window lifecycle), Edit (undo/cut/copy/paste/select all), and Window (minimize/zoom/fullscreen).
- **Windows / Linux:** in-window Material `MenuBar` with the same primary actions and a subtle bottom border.
- Shared actions reuse existing settings dialog and update controller; Exit/Quit call `AppWindowController.close()` so window state still flushes.

## Screenshots

- No new screenshots attached (menu bar chrome). Manual check recommended on each OS.

## Testing

- [x] `dart format --set-exit-if-changed lib test integration_test tool`
- [x] `flutter analyze`
- [x] `flutter test --coverage --exclude-tags golden` (4 unrelated local env flakes: CLI PATH registration, real PTY adapters)
- [x] `dart run tool/quality/coverage_report.dart --input coverage/lcov.info --min-lines 65 --worst 25`
- [ ] Golden tests, if UI changed: `flutter test --tags golden`
- [ ] Desktop E2E, if app-shell flow changed: `flutter test integration_test -d macos`
- [ ] Relevant desktop build: `flutter build macos`, `flutter build windows`, or `flutter build linux`
- [ ] Landing build, if applicable: `cd landing && bun run build`
- [x] Added or updated tests that would catch regressions, or explained why tests were not needed

## AI Review Report

Local review found a missing macOS Edit menu after `PlatformMenuBar` replaces MainMenu.xib (fixed), Quit bypassing lifecycle (fixed via `close()`), hardcoded Settings accelerator display (now derived from keybindings), MenuBar separation (border), and About styling (Alera dialog). Cross-platform menu paths were implemented for macOS / Windows / Linux.

## Security Audit

No new auth, secrets, or process execution beyond existing update check and window close. Menu actions only open existing UI / controllers.

## Notes

- Flutter does not provide native OS menus on Windows/Linux; those platforms use Material `MenuBar`.
- Labels use ASCII ellipsis with a space (`Settings ...`) by product preference.