### PR TITLE
feat: rename pull requests tab to checks

### DIFF
--- a/lib/src/design_system/icons/alera_icons.dart
+++ b/lib/src/design_system/icons/alera_icons.dart
@@ -85,6 +85,7 @@ abstract final class AleraIcons {
   static const IconData gitGraph = LucideIcons.gitGraph;
   static const IconData gitFork = LucideIcons.gitFork;
   static const IconData gitPullRequest = LucideIcons.gitPullRequest;
+  static const IconData checks = LucideIcons.listChecks;
   static const IconData diff = LucideIcons.gitCompare;
 
   // Download / upload

--- a/lib/src/features/pull_requests/presentation/workspace_pull_requests_panel.dart
+++ b/lib/src/features/pull_requests/presentation/workspace_pull_requests_panel.dart
@@ -216,7 +216,7 @@ class _Header extends StatelessWidget {
           child: Row(
             children: <Widget>[
               Text(
-                'Pull Requests',
+                'Checks',
                 style: theme.textTheme.labelLarge?.copyWith(
                   color: AleraTokens.foreground,
                 ),

--- a/lib/src/features/workbench/presentation/workspace_context_sidebar.dart
+++ b/lib/src/features/workbench/presentation/workspace_context_sidebar.dart
@@ -212,8 +212,8 @@ class _CollapsedContextRail extends StatelessWidget {
             _ContextTabButton(
               tab: WorkbenchContextPanelTab.pullRequests,
               activeTab: activeTab,
-              tooltip: 'Pull Requests',
-              icon: AleraIcons.gitPullRequest,
+              tooltip: 'Checks',
+              icon: AleraIcons.checks,
               onPressed: () => onOpenTab(WorkbenchContextPanelTab.pullRequests),
             ),
           ],
@@ -289,8 +289,8 @@ class _ContextTabHeader extends StatelessWidget {
                 _ContextTabButton(
                   tab: WorkbenchContextPanelTab.pullRequests,
                   activeTab: activeTab,
-                  tooltip: 'Pull Requests',
-                  icon: AleraIcons.gitPullRequest,
+                  tooltip: 'Checks',
+                  icon: AleraIcons.checks,
                   onPressed: () =>
                       onSetActiveTab(WorkbenchContextPanelTab.pullRequests),
                 ),


### PR DESCRIPTION
## Summary

Visual-only rename of the right-panel "Pull Requests" tab to "Checks":

- new semantic icon `AleraIcons.checks` (Lucide `listChecks`) in the design-system icon registry
- tab tooltip and icon updated in both the collapsed rail and the expanded header of the workspace context sidebar
- panel header title changed from "Pull Requests" to "Checks"

No functional changes: the `WorkbenchContextPanelTab.pullRequests` enum, the panel logic, and the refresh action are untouched.

## Validation

- `flutter analyze` clean on the three edited files
- no tests referenced the previous tooltip or header text