### PR TITLE
fix: open detected update release for manual download

### DIFF
--- a/lib/src/features/updater/domain/alera_update.dart
+++ b/lib/src/features/updater/domain/alera_update.dart
@@ -96,6 +96,21 @@ class AleraUpdateConfig with AleraUpdateConfigMappable {
             channel == AleraUpdateChannel.rc);
   }
 
+  /// Resolves the manual-download page for an available update.
+  ///
+  /// Release builds bake [releasePageUrl] to the *installed* version's GitHub
+  /// tag page (`.../releases/tag/vX.Y.Z`). When a newer update is detected,
+  /// open that update's tag page instead of the baked current-version URL.
+  Uri downloadPageUrlFor(AleraUpdateInfo? update) {
+    if (update == null) {
+      return releasePageUrl;
+    }
+    return resolveAleraReleaseTagPageUrl(
+      releasePageUrl: releasePageUrl,
+      version: update.version,
+    );
+  }
+
   factory AleraUpdateConfig.fromEnvironment() {
     final archiveUrl = Uri.tryParse(
       const String.fromEnvironment(
@@ -135,6 +150,38 @@ class AleraUpdateConfig with AleraUpdateConfigMappable {
 @visibleForTesting
 Uri resolveUpdateConfigUriForTesting(Uri? value, Uri fallback) =>
     value ?? fallback;
+
+/// Builds a GitHub-style release tag URL for [version] under [releasePageUrl].
+///
+/// Accepts either the releases list (`.../releases`) or a baked tag page
+/// (`.../releases/tag/v0.9.0`) and returns `.../releases/tag/v{version}`.
+@visibleForTesting
+Uri resolveAleraReleaseTagPageUrl({
+  required Uri releasePageUrl,
+  required String version,
+}) {
+  final trimmed = version.trim();
+  if (trimmed.isEmpty) {
+    return releasePageUrl;
+  }
+  final tag = trimmed.startsWith('v') ? trimmed : 'v$trimmed';
+  final segments = releasePageUrl.pathSegments
+      .where((segment) => segment.isNotEmpty)
+      .toList();
+  final releasesIndex = segments.indexOf('releases');
+  if (releasesIndex < 0) {
+    return releasePageUrl.replace(
+      pathSegments: <String>[...segments, 'tag', tag],
+    );
+  }
+  return releasePageUrl.replace(
+    pathSegments: <String>[
+      ...segments.sublist(0, releasesIndex + 1),
+      'tag',
+      tag,
+    ],
+  );
+}
 
 @MappableEnum()
 enum AleraUpdateStatus {

--- a/lib/src/features/updater/infra/desktop_update_service.dart
+++ b/lib/src/features/updater/infra/desktop_update_service.dart
@@ -153,7 +153,7 @@ class DesktopAleraUpdateService implements AleraUpdateService {
 
   @override
   Future<void> openDownloadPage(AleraUpdateInfo? update) async {
-    await _launchUrl(config.releasePageUrl);
+    await _launchUrl(config.downloadPageUrlFor(update));
   }
 
   @override

--- a/test/unit/alera_update_test.dart
+++ b/test/unit/alera_update_test.dart
@@ -61,6 +61,63 @@ void main() {
         AleraUpdateConfig.defaultReleasePageUrl,
       );
     });
+
+    test(
+      'downloadPageUrlFor maps a detected update to its release tag page',
+      () {
+        final listRoot = AleraUpdateConfig(
+          archiveUrl: Uri.parse('https://example.com/app-archive.json'),
+          releasePageUrl: Uri.parse(
+            'https://github.com/leynier/alera/releases',
+          ),
+          channel: AleraUpdateChannel.stable,
+          autoInstallEnabled: false,
+          signedRelease: false,
+        );
+        final bakedCurrent = listRoot.copyWith(
+          releasePageUrl: Uri.parse(
+            'https://github.com/leynier/alera/releases/tag/v0.9.0',
+          ),
+        );
+
+        expect(listRoot.downloadPageUrlFor(null), listRoot.releasePageUrl);
+        expect(
+          listRoot.downloadPageUrlFor(_update),
+          Uri.parse('https://github.com/leynier/alera/releases/tag/v0.1.2'),
+        );
+        expect(
+          bakedCurrent.downloadPageUrlFor(_update),
+          Uri.parse('https://github.com/leynier/alera/releases/tag/v0.1.2'),
+        );
+        expect(
+          bakedCurrent.downloadPageUrlFor(
+            _update.copyWith(version: 'v0.10.0-rc.1'),
+          ),
+          Uri.parse(
+            'https://github.com/leynier/alera/releases/tag/v0.10.0-rc.1',
+          ),
+        );
+      },
+    );
+
+    test('resolveAleraReleaseTagPageUrl falls back without a releases segment', () {
+      expect(
+        resolveAleraReleaseTagPageUrl(
+          releasePageUrl: Uri.parse('https://example.com/downloads'),
+          version: '1.2.3',
+        ),
+        Uri.parse('https://example.com/downloads/tag/v1.2.3'),
+      );
+      expect(
+        resolveAleraReleaseTagPageUrl(
+          releasePageUrl: Uri.parse(
+            'https://github.com/leynier/alera/releases/tag/v0.9.0',
+          ),
+          version: '  ',
+        ),
+        Uri.parse('https://github.com/leynier/alera/releases/tag/v0.9.0'),
+      );
+    });
   });
 
   group('AleraUpdateState', () {

--- a/test/unit/alera_update_test.dart
+++ b/test/unit/alera_update_test.dart
@@ -100,24 +100,27 @@ void main() {
       },
     );
 
-    test('resolveAleraReleaseTagPageUrl falls back without a releases segment', () {
-      expect(
-        resolveAleraReleaseTagPageUrl(
-          releasePageUrl: Uri.parse('https://example.com/downloads'),
-          version: '1.2.3',
-        ),
-        Uri.parse('https://example.com/downloads/tag/v1.2.3'),
-      );
-      expect(
-        resolveAleraReleaseTagPageUrl(
-          releasePageUrl: Uri.parse(
-            'https://github.com/leynier/alera/releases/tag/v0.9.0',
+    test(
+      'resolveAleraReleaseTagPageUrl falls back without a releases segment',
+      () {
+        expect(
+          resolveAleraReleaseTagPageUrl(
+            releasePageUrl: Uri.parse('https://example.com/downloads'),
+            version: '1.2.3',
           ),
-          version: '  ',
-        ),
-        Uri.parse('https://github.com/leynier/alera/releases/tag/v0.9.0'),
-      );
-    });
+          Uri.parse('https://example.com/downloads/tag/v1.2.3'),
+        );
+        expect(
+          resolveAleraReleaseTagPageUrl(
+            releasePageUrl: Uri.parse(
+              'https://github.com/leynier/alera/releases/tag/v0.9.0',
+            ),
+            version: '  ',
+          ),
+          Uri.parse('https://github.com/leynier/alera/releases/tag/v0.9.0'),
+        );
+      },
+    );
   });
 
   group('AleraUpdateState', () {

--- a/test/unit/desktop_update_service_test.dart
+++ b/test/unit/desktop_update_service_test.dart
@@ -359,7 +359,9 @@ void main() {
         final service = DesktopAleraUpdateService(
           config: AleraUpdateConfig(
             archiveUrl: Uri.parse('https://example.com/archive.json'),
-            releasePageUrl: Uri.parse('https://example.com/releases'),
+            releasePageUrl: Uri.parse(
+              'https://github.com/leynier/alera/releases/tag/v0.9.0',
+            ),
             channel: AleraUpdateChannel.stable,
             autoInstallEnabled: false,
             signedRelease: false,
@@ -373,9 +375,25 @@ void main() {
         );
 
         await service.openDownloadPage(null);
+        await service.openDownloadPage(
+          AleraUpdateInfo(
+            version: '0.10.0',
+            shortVersion: 23,
+            date: '2026-07-10',
+            mandatory: false,
+            url: Uri.parse(
+              'https://updates.alera.build/updates/stable/0.10.0+23-linux/alera.deb',
+            ),
+            platform: 'linux',
+            changes: const <String>['Release 0.10.0.'],
+          ),
+        );
         await service.restartApp();
 
-        expect(launched, <Uri>[Uri.parse('https://example.com/releases')]);
+        expect(launched, <Uri>[
+          Uri.parse('https://github.com/leynier/alera/releases/tag/v0.9.0'),
+          Uri.parse('https://github.com/leynier/alera/releases/tag/v0.10.0'),
+        ]);
         expect(updater.restartCalls, 1);
       },
     );

--- a/test/unit/desktop_update_service_test.dart
+++ b/test/unit/desktop_update_service_test.dart
@@ -34,12 +34,9 @@ void main() {
           platform: 'macos',
         );
       final service = DesktopAleraUpdateService(
-        config: AleraUpdateConfig(
-          archiveUrl: Uri.parse('https://example.com/archive.json'),
-          releasePageUrl: Uri.parse('https://example.com/releases'),
+        config: _config(
           channel: AleraUpdateChannel.rc,
           autoInstallEnabled: true,
-          signedRelease: false,
         ),
         desktopUpdater: updater,
         platform: 'macos',
@@ -59,13 +56,7 @@ void main() {
       'checks the published archive manually when auto-install is blocked',
       () async {
         final service = DesktopAleraUpdateService(
-          config: AleraUpdateConfig(
-            archiveUrl: Uri.parse('https://example.com/archive.json'),
-            releasePageUrl: Uri.parse('https://example.com/releases'),
-            channel: AleraUpdateChannel.stable,
-            autoInstallEnabled: true,
-            signedRelease: false,
-          ),
+          config: _config(autoInstallEnabled: true),
           client: MockClient((request) async {
             expect(request.url.toString(), 'https://example.com/archive.json');
             return http.Response(_archiveJson, 200);
@@ -88,13 +79,7 @@ void main() {
       'manual checks describe downloadable updates when auto-install is off',
       () async {
         final service = DesktopAleraUpdateService(
-          config: AleraUpdateConfig(
-            archiveUrl: Uri.parse('https://example.com/archive.json'),
-            releasePageUrl: Uri.parse('https://example.com/releases'),
-            channel: AleraUpdateChannel.stable,
-            autoInstallEnabled: false,
-            signedRelease: false,
-          ),
+          config: _config(),
           client: MockClient((_) async => http.Response(_archiveJson, 200)),
           loadPackageInfo: () async => _packageInfo(buildNumber: '1'),
           platform: 'macos',
@@ -199,13 +184,7 @@ void main() {
       'throws when the archive download fails with a non-404 status',
       () async {
         final service = DesktopAleraUpdateService(
-          config: AleraUpdateConfig(
-            archiveUrl: Uri.parse('https://example.com/archive.json'),
-            releasePageUrl: Uri.parse('https://example.com/releases'),
-            channel: AleraUpdateChannel.stable,
-            autoInstallEnabled: false,
-            signedRelease: false,
-          ),
+          config: _config(),
           client: MockClient((_) async => http.Response('boom', 500)),
           platform: 'macos',
         );
@@ -251,12 +230,9 @@ void main() {
             ),
           ]);
         final service = DesktopAleraUpdateService(
-          config: AleraUpdateConfig(
-            archiveUrl: Uri.parse('https://example.com/archive.json'),
-            releasePageUrl: Uri.parse('https://example.com/releases'),
+          config: _config(
             channel: AleraUpdateChannel.rc,
             autoInstallEnabled: true,
-            signedRelease: false,
           ),
           desktopUpdater: updater,
           platform: 'macos',
@@ -264,14 +240,10 @@ void main() {
         final progress = <double>[];
 
         await service.installUpdate(
-          AleraUpdateInfo(
+          _updateInfo(
             version: '0.1.4-rc.0',
             shortVersion: 4,
-            date: '2026-05-25',
-            mandatory: false,
-            url: Uri.parse('https://example.com/updates/0.1.4+4-macos'),
-            platform: 'macos',
-            changes: <String>['Preview'],
+            url: 'https://example.com/updates/0.1.4+4-macos',
           ),
           onProgress: progress.add,
         );
@@ -286,27 +258,13 @@ void main() {
 
     test('rejects installation when automatic updates are disabled', () async {
       final service = DesktopAleraUpdateService(
-        config: AleraUpdateConfig(
-          archiveUrl: Uri.parse('https://example.com/archive.json'),
-          releasePageUrl: Uri.parse('https://example.com/releases'),
-          channel: AleraUpdateChannel.stable,
-          autoInstallEnabled: false,
-          signedRelease: false,
-        ),
+        config: _config(),
         platform: 'macos',
       );
 
       await expectLater(
         service.installUpdate(
-          AleraUpdateInfo(
-            version: '0.1.2',
-            shortVersion: 3,
-            date: '2026-05-25',
-            mandatory: false,
-            url: Uri.parse('https://example.com/updates/0.1.2+3-macos'),
-            platform: 'macos',
-            changes: <String>['Fix'],
-          ),
+          _updateInfo(url: 'https://example.com/updates/0.1.2+3-macos'),
         ),
         throwsA(isA<StateError>()),
       );
@@ -316,12 +274,9 @@ void main() {
       'installUpdate throws when the updater has no available item',
       () async {
         final service = DesktopAleraUpdateService(
-          config: AleraUpdateConfig(
-            archiveUrl: Uri.parse('https://example.com/archive.json'),
-            releasePageUrl: Uri.parse('https://example.com/releases'),
+          config: _config(
             channel: AleraUpdateChannel.rc,
             autoInstallEnabled: true,
-            signedRelease: false,
           ),
           desktopUpdater: _FakeDesktopUpdater(),
           platform: 'macos',
@@ -329,14 +284,10 @@ void main() {
 
         await expectLater(
           service.installUpdate(
-            AleraUpdateInfo(
+            _updateInfo(
               version: '0.1.4-rc.0',
               shortVersion: 4,
-              date: '2026-05-25',
-              mandatory: false,
-              url: Uri.parse('https://example.com/updates/0.1.4+4-macos'),
-              platform: 'macos',
-              changes: <String>['Preview'],
+              url: 'https://example.com/updates/0.1.4+4-macos',
             ),
           ),
           throwsStateError,
@@ -352,19 +303,15 @@ void main() {
     });
 
     test(
-      'opens the release page and restarts through injected delegates',
+      'opens the detected update release page and restarts via delegates',
       () async {
         final launched = <Uri>[];
         final updater = _FakeDesktopUpdater();
         final service = DesktopAleraUpdateService(
-          config: AleraUpdateConfig(
-            archiveUrl: Uri.parse('https://example.com/archive.json'),
+          config: _config(
             releasePageUrl: Uri.parse(
               'https://github.com/leynier/alera/releases/tag/v0.9.0',
             ),
-            channel: AleraUpdateChannel.stable,
-            autoInstallEnabled: false,
-            signedRelease: false,
           ),
           desktopUpdater: updater,
           launchUrl: (uri) async {
@@ -376,17 +323,7 @@ void main() {
 
         await service.openDownloadPage(null);
         await service.openDownloadPage(
-          AleraUpdateInfo(
-            version: '0.10.0',
-            shortVersion: 23,
-            date: '2026-07-10',
-            mandatory: false,
-            url: Uri.parse(
-              'https://updates.alera.build/updates/stable/0.10.0+23-linux/alera.deb',
-            ),
-            platform: 'linux',
-            changes: const <String>['Release 0.10.0.'],
-          ),
+          _updateInfo(version: '0.10.0', shortVersion: 23, platform: 'linux'),
         );
         await service.restartApp();
 
@@ -404,13 +341,7 @@ void main() {
       UrlLauncherPlatform.instance = fakePlatform;
       addTearDown(() => UrlLauncherPlatform.instance = previousPlatform);
       final service = DesktopAleraUpdateService(
-        config: AleraUpdateConfig(
-          archiveUrl: Uri.parse('https://example.com/archive.json'),
-          releasePageUrl: Uri.parse('https://example.com/releases'),
-          channel: AleraUpdateChannel.stable,
-          autoInstallEnabled: false,
-          signedRelease: false,
-        ),
+        config: _config(),
         platform: 'macos',
       );
       addTearDown(service.dispose);
@@ -422,6 +353,41 @@ void main() {
       ]);
     });
   });
+}
+
+AleraUpdateConfig _config({
+  Uri? releasePageUrl,
+  AleraUpdateChannel channel = AleraUpdateChannel.stable,
+  bool autoInstallEnabled = false,
+  bool signedRelease = false,
+  String manifestPublicKey = '',
+}) {
+  return AleraUpdateConfig(
+    archiveUrl: Uri.parse('https://example.com/archive.json'),
+    releasePageUrl: releasePageUrl ?? Uri.parse('https://example.com/releases'),
+    channel: channel,
+    autoInstallEnabled: autoInstallEnabled,
+    signedRelease: signedRelease,
+    manifestPublicKey: manifestPublicKey,
+  );
+}
+
+AleraUpdateInfo _updateInfo({
+  String version = '0.1.2',
+  int shortVersion = 3,
+  String url = 'https://example.com/updates/0.1.2+3-macos',
+  String platform = 'macos',
+  List<String> changes = const <String>['Preview'],
+}) {
+  return AleraUpdateInfo(
+    version: version,
+    shortVersion: shortVersion,
+    date: '2026-05-25',
+    mandatory: false,
+    url: Uri.parse(url),
+    platform: platform,
+    changes: changes,
+  );
 }
 
 PackageInfo _packageInfo({required String buildNumber}) {


### PR DESCRIPTION
## Summary
- Manual Download was opening the release baked into the installed build (`ALERA_RELEASE_PAGE_URL` points at the current version tag) instead of the detected update version.
- Resolve a version-specific GitHub release tag page from the detected `AleraUpdateInfo` when opening the manual download page.
- Keep the baked release URL as the fallback when no update is selected.

## Validation
- `flutter test test/unit/alera_update_test.dart test/unit/desktop_update_service_test.dart test/unit/update_controller_test.dart`

## Risks / notes
- Existing release binaries still bake a current-version release URL; this runtime fix corrects Download Manually without requiring a CI define change.