### PR TITLE
fix: prevent orphaned linux sleep inhibitors

### DIFF
--- a/lib/src/features/agent_status/application/agent_awake_service.dart
+++ b/lib/src/features/agent_status/application/agent_awake_service.dart
@@ -36,6 +36,8 @@ class AgentAwakeService {
   bool _enabled = false;
   bool _displayLockEnabled = false;
   bool _disposed = false;
+  Future<void> _operationTail = Future<void>.value();
+  Future<void>? _disposeFuture;
   AgentStatusHookSettings _hookSettings = AgentStatusHookSettings.defaults;
   Map<String, AgentStatusEntry> _statuses = const <String, AgentStatusEntry>{};
   Timer? _staleTimer;
@@ -62,18 +64,30 @@ class AgentAwakeService {
   }
 
   Future<void> dispose() async {
-    if (_disposed) {
-      return;
+    final existingDispose = _disposeFuture;
+    if (existingDispose != null) {
+      return existingDispose;
     }
     _disposed = true;
     _clearStaleTimer();
-    await _setDisplayLock(false, 'dispose');
-    for (final assertion in _assertions) {
-      await _tryAssertion('dispose assertion', () => assertion.dispose());
-    }
+    final disposeFuture = _enqueue(() async {
+      await _setDisplayLock(false, 'dispose');
+      for (final assertion in _assertions) {
+        await _tryAssertion('dispose assertion', () => assertion.dispose());
+      }
+    });
+    _disposeFuture = disposeFuture;
+    await disposeFuture;
   }
 
-  Future<void> _refresh(String reason) async {
+  Future<void> _refresh(String reason) {
+    if (_disposed) {
+      return Future<void>.value();
+    }
+    return _enqueue(() => _performRefresh(reason));
+  }
+
+  Future<void> _performRefresh(String reason) async {
     if (_disposed) {
       return;
     }
@@ -182,5 +196,14 @@ class AgentAwakeService {
         stackTrace,
       );
     }
+  }
+
+  Future<void> _enqueue(Future<void> Function() operation) {
+    final result = _operationTail.then((_) => operation());
+    _operationTail = result.then<void>(
+      (_) {},
+      onError: (Object _, StackTrace _) {},
+    );
+    return result;
   }
 }

--- a/lib/src/features/agent_status/infra/agent_awake_assertions.dart
+++ b/lib/src/features/agent_status/infra/agent_awake_assertions.dart
@@ -50,19 +50,22 @@ class MacosSystemSleepAssertion extends _ProcessBackedAwakeAssertion {
 class LinuxLidSleepAssertion extends _ProcessBackedAwakeAssertion {
   LinuxLidSleepAssertion({
     required super.processRunner,
+    int? processId,
     super.now,
     super.logger,
     super.platform,
     super.retryDelay = linuxLidSleepAssertionRetryDelay,
   }) : super(
          executable: 'systemd-inhibit',
-         arguments: const <String>[
+         arguments: <String>[
            '--what=sleep:handle-lid-switch',
            '--who=Alera',
            '--why=Agents are working',
            '--mode=block',
-           'sleep',
-           'infinity',
+           'tail',
+           '--pid=${processId ?? pid}',
+           '-f',
+           '/dev/null',
          ],
          supportedPlatform: 'linux',
          label: 'Linux lid sleep assertion',
@@ -164,14 +167,25 @@ class _ProcessBackedAwakeAssertion implements AgentAwakeAssertion {
   DateTime? _retryNotBefore;
   Timer? _retryTimer;
   bool _unavailable = false;
+  bool _desiredActive = false;
+  bool _disposed = false;
+  Future<void> _operationTail = Future<void>.value();
   String? _lastFailureKey;
   bool _warnedForLastFailure = false;
   final Set<StartedProcess> _intentionalStops = <StartedProcess>{};
   final Set<StartedProcess> _reportedFailures = <StartedProcess>{};
 
   @override
-  Future<void> start(String reason) async {
-    if (_platform != supportedPlatform || _child != null || _unavailable) {
+  Future<void> start(String reason) {
+    if (_platform != supportedPlatform || _disposed) {
+      return Future<void>.value();
+    }
+    _desiredActive = true;
+    return _enqueue(() => _startNow(reason));
+  }
+
+  Future<void> _startNow(String reason) async {
+    if (!_desiredActive || _disposed || _child != null || _unavailable) {
       return;
     }
     final retryNotBefore = _retryNotBefore;
@@ -188,7 +202,6 @@ class _ProcessBackedAwakeAssertion implements AgentAwakeAssertion {
       return;
     }
 
-    _child = child;
     unawaited(child.stdout.drain<void>());
     unawaited(child.stderr.drain<void>());
     unawaited(
@@ -206,20 +219,35 @@ class _ProcessBackedAwakeAssertion implements AgentAwakeAssertion {
             );
           }),
     );
+    if (!_desiredActive || _disposed) {
+      _intentionalStops.add(child);
+      _killChild(child, reason);
+      return;
+    }
+    _child = child;
     _resetRetrySuppression();
     _resetFailureStreak();
   }
 
   @override
-  Future<void> stop(String reason) async {
+  Future<void> stop(String reason) {
+    _desiredActive = false;
     _resetRetrySuppression();
     _resetFailureStreak();
+    return _enqueue(() async => _stopNow(reason));
+  }
+
+  void _stopNow(String reason) {
     final child = _child;
     if (child == null) {
       return;
     }
     _child = null;
     _intentionalStops.add(child);
+    _killChild(child, reason);
+  }
+
+  void _killChild(StartedProcess child, String reason) {
     try {
       child.kill();
     } catch (error, stackTrace) {
@@ -233,7 +261,14 @@ class _ProcessBackedAwakeAssertion implements AgentAwakeAssertion {
 
   @override
   Future<void> dispose() {
-    return stop('dispose');
+    if (_disposed) {
+      return _operationTail;
+    }
+    _disposed = true;
+    _desiredActive = false;
+    _resetRetrySuppression();
+    _resetFailureStreak();
+    return _enqueue(() async => _stopNow('dispose'));
   }
 
   void _handleChildExit(StartedProcess child, int exitCode, String reason) {
@@ -287,6 +322,9 @@ class _ProcessBackedAwakeAssertion implements AgentAwakeAssertion {
       return;
     }
     _logFailure(failureKey, reason, details, failureType);
+    if (!_desiredActive || _disposed) {
+      return;
+    }
     _retryNotBefore = _now().add(retryDelay);
     _scheduleRetry();
   }
@@ -315,7 +353,10 @@ class _ProcessBackedAwakeAssertion implements AgentAwakeAssertion {
 
   void _scheduleRetry() {
     final retryNotBefore = _retryNotBefore;
-    if (retryNotBefore == null || _retryTimer != null) {
+    if (!_desiredActive ||
+        _disposed ||
+        retryNotBefore == null ||
+        _retryTimer != null) {
       return;
     }
     final delay = retryNotBefore.difference(_now());
@@ -334,6 +375,15 @@ class _ProcessBackedAwakeAssertion implements AgentAwakeAssertion {
   void _resetFailureStreak() {
     _lastFailureKey = null;
     _warnedForLastFailure = false;
+  }
+
+  Future<void> _enqueue(Future<void> Function() operation) {
+    final result = _operationTail.then((_) => operation());
+    _operationTail = result.then<void>(
+      (_) {},
+      onError: (Object _, StackTrace _) {},
+    );
+    return result;
   }
 }
 

--- a/test/unit/agent_awake_assertions_test.dart
+++ b/test/unit/agent_awake_assertions_test.dart
@@ -51,6 +51,25 @@ void main() {
       expect(runner.calls, hasLength(1));
     });
 
+    test('stops a process that finishes spawning after stop', () async {
+      final child = _FakeStartedProcess();
+      final pending = Completer<StartedProcess>();
+      final runner = _FakeProcessRunner()..queuedStarts.add(pending.future);
+      final assertion = MacosSystemSleepAssertion(
+        processRunner: runner,
+        platform: 'macos',
+      );
+
+      final start = assertion.start('status-change');
+      await _waitForStartCalls(runner, 1);
+      final stop = assertion.stop('status-change');
+      pending.complete(child.startedProcess);
+      await Future.wait<void>(<Future<void>>[start, stop]);
+
+      expect(runner.calls, hasLength(1));
+      expect(child.killCalls, 1);
+    });
+
     test('retries after an unexpected process exit', () async {
       final first = _FakeStartedProcess();
       final second = _FakeStartedProcess();
@@ -168,69 +187,6 @@ void main() {
         expect(runner.calls, hasLength(3));
       },
     );
-  });
-
-  group('LinuxLidSleepAssertion', () {
-    test(
-      'spawns systemd-inhibit with sleep and lid-switch inhibitors',
-      () async {
-        final runner = _FakeProcessRunner()
-          ..queuedStarts.add(_FakeStartedProcess());
-        final assertion = LinuxLidSleepAssertion(
-          processRunner: runner,
-          platform: 'linux',
-        );
-
-        await assertion.start('status-change');
-
-        expect(runner.calls, hasLength(1));
-        expect(runner.calls.single.executable, 'systemd-inhibit');
-        expect(runner.calls.single.arguments, <String>[
-          '--what=sleep:handle-lid-switch',
-          '--who=Alera',
-          '--why=Agents are working',
-          '--mode=block',
-          'sleep',
-          'infinity',
-        ]);
-      },
-    );
-
-    test('degrades to no-op when systemd-inhibit is missing', () async {
-      final runner = _FakeProcessRunner()
-        ..queuedStarts.add(
-          const ProcessException('systemd-inhibit', <String>[], 'not found', 2),
-        );
-      final assertion = LinuxLidSleepAssertion(
-        processRunner: runner,
-        platform: 'linux',
-        retryDelay: const Duration(milliseconds: 5),
-      );
-
-      await assertion.start('status-change');
-      await Future<void>.delayed(const Duration(milliseconds: 10));
-      await assertion.start('power-resume');
-
-      expect(runner.calls, hasLength(1));
-    });
-
-    test('treats shell command-not-found exits as unavailable', () async {
-      final first = _FakeStartedProcess();
-      final runner = _FakeProcessRunner()
-        ..queuedStarts.addAll(<Object>[first, _FakeStartedProcess()]);
-      final assertion = LinuxLidSleepAssertion(
-        processRunner: runner,
-        platform: 'linux',
-        retryDelay: const Duration(milliseconds: 5),
-      );
-
-      await assertion.start('status-change');
-      first.completeExit(127);
-      await Future<void>.delayed(const Duration(milliseconds: 10));
-      await assertion.start('power-resume');
-
-      expect(runner.calls, hasLength(1));
-    });
   });
 
   group('WindowsSystemSleepAssertion', () {
@@ -373,8 +329,11 @@ class _FakeProcessRunner implements ProcessRunner {
     final next = queuedStarts.isEmpty
         ? _FakeStartedProcess()
         : queuedStarts.removeAt(0);
-    if (next is ProcessException) {
+    if (next is Exception) {
       throw next;
+    }
+    if (next is Future<StartedProcess>) {
+      return next;
     }
     return (next as _FakeStartedProcess).startedProcess;
   }

--- a/test/unit/agent_awake_service_test.dart
+++ b/test/unit/agent_awake_service_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:alera/src/features/agent_status/application/agent_awake_service.dart';
 import 'package:alera/src/features/agent_status/domain/agent_status.dart';
 import 'package:alera/src/features/settings/domain/alera_settings.dart';
@@ -77,7 +79,7 @@ void main() {
       });
 
       now = base.add(staleAfter).add(const Duration(milliseconds: 1));
-      await Future<void>.delayed(const Duration(milliseconds: 10));
+      await _waitForAssertionStop(assertion, 'stale-expiry');
 
       expect(displayLock.states, <bool>[true, false]);
       expect(assertion.stops, contains('stale-expiry'));
@@ -99,6 +101,35 @@ void main() {
       expect(displayLock.states, <bool>[true, false]);
       expect(assertion.stops, contains('settings-change'));
     });
+
+    test(
+      'serializes a working to idle transition while start is pending',
+      () async {
+        final displayLock = _FakeDisplayLock();
+        final assertion = _FakeAssertion()..startGate = Completer<void>();
+        final service = _service(
+          displayLock: displayLock,
+          assertion: assertion,
+        );
+
+        await service.setHookSettings(
+          const AgentStatusHookSettings(codex: true),
+        );
+        await service.setEnabled(true);
+        final working = service.setStatuses(<String, AgentStatusEntry>{
+          'session-1': _entry(state: AgentStatusState.working),
+        });
+        await _waitForAssertionStarts(assertion, 1);
+        final idle = service.setStatuses(const <String, AgentStatusEntry>{});
+        assertion.startGate!.complete();
+        await Future.wait<void>(<Future<void>>[working, idle]);
+
+        expect(assertion.maxActiveCount, 1);
+        expect(assertion.activeCount, 0);
+        expect(assertion.stops, contains('status-change'));
+        await service.dispose();
+      },
+    );
 
     test('treats every enabled agent hook as wake eligible', () async {
       for (final agentType in AgentType.values) {
@@ -247,6 +278,36 @@ class _FakeDisplayLock implements AgentAwakeDisplayLock {
   }
 }
 
+Future<void> _waitForAssertionStarts(
+  _FakeAssertion assertion,
+  int count, {
+  Duration timeout = const Duration(seconds: 1),
+}) async {
+  final deadline = DateTime.now().add(timeout);
+  while (DateTime.now().isBefore(deadline)) {
+    if (assertion.starts.length >= count) {
+      return;
+    }
+    await Future<void>.delayed(const Duration(milliseconds: 5));
+  }
+  fail('Expected at least $count assertion starts.');
+}
+
+Future<void> _waitForAssertionStop(
+  _FakeAssertion assertion,
+  String reason, {
+  Duration timeout = const Duration(seconds: 1),
+}) async {
+  final deadline = DateTime.now().add(timeout);
+  while (DateTime.now().isBefore(deadline)) {
+    if (assertion.stops.contains(reason)) {
+      return;
+    }
+    await Future<void>.delayed(const Duration(milliseconds: 5));
+  }
+  fail('Expected an assertion stop for $reason.');
+}
+
 class _FakeAssertion implements AgentAwakeAssertion {
   final List<String> starts = <String>[];
   final List<String> stops = <String>[];
@@ -254,10 +315,18 @@ class _FakeAssertion implements AgentAwakeAssertion {
   var throwOnStart = false;
   var throwOnStop = false;
   var throwOnDispose = false;
+  Completer<void>? startGate;
+  var activeCount = 0;
+  var maxActiveCount = 0;
 
   @override
   Future<void> start(String reason) async {
     starts.add(reason);
+    activeCount++;
+    if (activeCount > maxActiveCount) {
+      maxActiveCount = activeCount;
+    }
+    await startGate?.future;
     if (throwOnStart) {
       throw StateError('start failed');
     }
@@ -266,6 +335,9 @@ class _FakeAssertion implements AgentAwakeAssertion {
   @override
   Future<void> stop(String reason) async {
     stops.add(reason);
+    if (activeCount > 0) {
+      activeCount--;
+    }
     if (throwOnStop) {
       throw StateError('stop failed');
     }

--- a/test/unit/linux_lid_sleep_assertion_test.dart
+++ b/test/unit/linux_lid_sleep_assertion_test.dart
@@ -1,0 +1,201 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:alera/src/features/agent_status/infra/agent_awake_assertions.dart';
+import 'package:alera/src/shared/infra/process/process_runner.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('LinuxLidSleepAssertion', () {
+    test('runs a parent-bound inhibitor without sleep infinity', () async {
+      final runner = _FakeProcessRunner();
+      final assertion = LinuxLidSleepAssertion(
+        processRunner: runner,
+        processId: 4242,
+        platform: 'linux',
+      );
+
+      await assertion.start('status-change');
+
+      expect(runner.calls, <_StartCall>[
+        const _StartCall('systemd-inhibit', <String>[
+          '--what=sleep:handle-lid-switch',
+          '--who=Alera',
+          '--why=Agents are working',
+          '--mode=block',
+          'tail',
+          '--pid=4242',
+          '-f',
+          '/dev/null',
+        ]),
+      ]);
+    });
+
+    test('is a no-op off Linux', () async {
+      final runner = _FakeProcessRunner();
+      final assertion = LinuxLidSleepAssertion(
+        processRunner: runner,
+        platform: 'macos',
+      );
+
+      await assertion.start('status-change');
+
+      expect(runner.calls, isEmpty);
+    });
+
+    test('coalesces concurrent starts into one helper', () async {
+      final runner = _FakeProcessRunner();
+      final assertion = LinuxLidSleepAssertion(
+        processRunner: runner,
+        platform: 'linux',
+      );
+
+      await Future.wait<void>(<Future<void>>[
+        assertion.start('status-change'),
+        assertion.start('status-change'),
+        assertion.start('status-change'),
+      ]);
+
+      expect(runner.calls, hasLength(1));
+    });
+
+    test('retries with a fresh helper after an unexpected exit', () async {
+      final first = _FakeStartedProcess();
+      final second = _FakeStartedProcess();
+      final runner = _FakeProcessRunner()
+        ..queuedStarts.addAll(<Object>[first, second]);
+      final assertion = LinuxLidSleepAssertion(
+        processRunner: runner,
+        platform: 'linux',
+        retryDelay: const Duration(milliseconds: 5),
+      );
+
+      await assertion.start('status-change');
+      first.completeExit(1);
+      await _waitForStartCalls(runner, 2);
+
+      expect(runner.calls, hasLength(2));
+      await assertion.dispose();
+    });
+
+    test('does not retry when systemd-inhibit is unavailable', () async {
+      final runner = _FakeProcessRunner()
+        ..queuedStarts.add(
+          const ProcessException('systemd-inhibit', <String>[], 'not found', 2),
+        );
+      final assertion = LinuxLidSleepAssertion(
+        processRunner: runner,
+        platform: 'linux',
+        retryDelay: const Duration(milliseconds: 5),
+      );
+
+      await assertion.start('status-change');
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+      await assertion.start('power-resume');
+
+      expect(runner.calls, hasLength(1));
+    });
+  });
+}
+
+Future<void> _waitForStartCalls(
+  _FakeProcessRunner runner,
+  int count, {
+  Duration timeout = const Duration(seconds: 1),
+}) async {
+  final deadline = DateTime.now().add(timeout);
+  while (DateTime.now().isBefore(deadline)) {
+    if (runner.calls.length >= count) {
+      return;
+    }
+    await Future<void>.delayed(const Duration(milliseconds: 5));
+  }
+}
+
+class _FakeProcessRunner implements ProcessRunner {
+  final List<_StartCall> calls = <_StartCall>[];
+  final List<Object> queuedStarts = <Object>[];
+
+  @override
+  Future<ProcessRunOutput> run(
+    String executable,
+    List<String> arguments, {
+    String? workingDirectory,
+    Map<String, String>? environment,
+  }) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<StartedProcess> start(
+    String executable,
+    List<String> arguments, {
+    String? workingDirectory,
+    Map<String, String>? environment,
+  }) async {
+    calls.add(_StartCall(executable, List<String>.from(arguments)));
+    final next = queuedStarts.isEmpty
+        ? _FakeStartedProcess()
+        : queuedStarts.removeAt(0);
+    if (next is ProcessException) {
+      throw next;
+    }
+    return (next as _FakeStartedProcess).startedProcess;
+  }
+}
+
+class _FakeStartedProcess {
+  _FakeStartedProcess() {
+    startedProcess = StartedProcess(
+      stdinWrite: (_) {},
+      stdout: const Stream<List<int>>.empty(),
+      stderr: const Stream<List<int>>.empty(),
+      pid: 123,
+      exitCode: _exitCode.future,
+      kill: ([dynamic signal]) {
+        killCalls++;
+        completeExit(143);
+        return true;
+      },
+    );
+  }
+
+  final Completer<int> _exitCode = Completer<int>();
+  late final StartedProcess startedProcess;
+  int killCalls = 0;
+
+  void completeExit(int exitCode) {
+    if (!_exitCode.isCompleted) {
+      _exitCode.complete(exitCode);
+    }
+  }
+}
+
+class _StartCall {
+  const _StartCall(this.executable, this.arguments);
+
+  final String executable;
+  final List<String> arguments;
+
+  @override
+  bool operator ==(Object other) {
+    return other is _StartCall &&
+        other.executable == executable &&
+        _listEquals(other.arguments, arguments);
+  }
+
+  @override
+  int get hashCode => Object.hash(executable, Object.hashAll(arguments));
+}
+
+bool _listEquals(List<String> left, List<String> right) {
+  if (left.length != right.length) {
+    return false;
+  }
+  for (var index = 0; index < left.length; index++) {
+    if (left[index] != right[index]) {
+      return false;
+    }
+  }
+  return true;
+}


### PR DESCRIPTION
## Summary

- replace unbounded Linux `sleep infinity` inhibitors with a parent-bound `systemd-inhibit` helper
- serialize awake assertion and service lifecycle transitions to avoid late-start and stop races
- add focused coverage for retries, disposal, stale status expiry, and Linux command construction

## Root cause

Alera launched `sleep infinity` as the inhibition payload. Those helpers had no parent-lifecycle binding, so abnormal app exits could leave them running indefinitely and repeated launches accumulated background processes.

## Validation

- Flutter format, analyze, max-lines, full tests, golden tests, and coverage gate
- mobile analyze and tests
- Rust fmt, clippy with warnings denied, and workspace tests
- Linux desktop E2E
- release desktop builds on Linux, macOS, and Windows
