### PR TITLE
fix: track antigravity and amp lifecycle status

### DIFF
--- a/lib/src/features/agent_status/application/agent_hook_lifecycle_guard.dart
+++ b/lib/src/features/agent_status/application/agent_hook_lifecycle_guard.dart
@@ -1,0 +1,156 @@
+import 'dart:collection';
+
+import 'package:alera/src/features/agent_status/domain/agent_status.dart';
+import 'package:alera/src/features/agent_status/infra/agent_hook_event_normalizer.dart';
+
+final class AgentHookLifecycleGuard {
+  static const _ampCompletedThreadLimit = 32;
+  static const _legacyAmpThreadKey = '<legacy>';
+
+  final Map<String, _AgyCompletedTurn> _agyCompletedTurns = {};
+  final Map<String, _AmpTerminalLifecycle> _ampTerminals = {};
+  final Map<String, String> _workspaceByTerminal = {};
+
+  bool shouldApply(AgentHookEvent event) {
+    _workspaceByTerminal[event.terminalSessionId] = event.workspaceId;
+    final eventName = agentHookEventName(event);
+    if (eventName == null) {
+      return true;
+    }
+    return switch (event.agentType) {
+      AgentType.agy => _shouldApplyAgy(event, eventName),
+      AgentType.amp => _shouldApplyAmp(event, eventName),
+      AgentType.codex ||
+      AgentType.claude ||
+      AgentType.copilot ||
+      AgentType.cursor ||
+      AgentType.opencode ||
+      AgentType.pi ||
+      AgentType.grok => true,
+    };
+  }
+
+  void clearTerminal(String terminalSessionId) {
+    _agyCompletedTurns.remove(terminalSessionId);
+    _ampTerminals.remove(terminalSessionId);
+    _workspaceByTerminal.remove(terminalSessionId);
+  }
+
+  void clearWorkspace(String workspaceId) {
+    final terminalSessionIds = <String>[
+      for (final entry in _workspaceByTerminal.entries)
+        if (entry.value == workspaceId) entry.key,
+    ];
+    for (final terminalSessionId in terminalSessionIds) {
+      clearTerminal(terminalSessionId);
+    }
+  }
+
+  void reset() {
+    _agyCompletedTurns.clear();
+    _ampTerminals.clear();
+    _workspaceByTerminal.clear();
+  }
+
+  bool _shouldApplyAgy(AgentHookEvent event, String eventName) {
+    final terminalSessionId = event.terminalSessionId;
+    if (eventName == 'PreInvocation') {
+      _agyCompletedTurns.remove(terminalSessionId);
+      return true;
+    }
+
+    final completed = _agyCompletedTurns[terminalSessionId];
+    if (completed != null && eventName != 'Stop') {
+      final transcriptPath = _readString(event.payload, const [
+        'transcriptPath',
+        'transcript_path',
+      ]);
+      if (completed.transcriptPath == null ||
+          transcriptPath == null ||
+          completed.transcriptPath == transcriptPath) {
+        return false;
+      }
+    }
+
+    if (eventName == 'Stop' && !_agyStopStillBusy(event.payload)) {
+      _agyCompletedTurns[terminalSessionId] = _AgyCompletedTurn(
+        _readString(event.payload, const ['transcriptPath', 'transcript_path']),
+      );
+    }
+    return true;
+  }
+
+  bool _shouldApplyAmp(AgentHookEvent event, String eventName) {
+    final terminal = _ampTerminals.putIfAbsent(
+      event.terminalSessionId,
+      _AmpTerminalLifecycle.new,
+    );
+    final threadKey = _ampThreadKey(event.payload);
+    if (eventName == 'session.start') {
+      terminal.completedThreads.remove(threadKey);
+      return false;
+    }
+    if (eventName == 'agent.start') {
+      terminal.completedThreads.remove(threadKey);
+      return true;
+    }
+    if ((eventName == 'tool.call' || eventName == 'tool.result') &&
+        terminal.completedThreads.contains(threadKey)) {
+      return false;
+    }
+    if (eventName == 'agent.end') {
+      terminal.completedThreads
+        ..remove(threadKey)
+        ..add(threadKey);
+      while (terminal.completedThreads.length > _ampCompletedThreadLimit) {
+        terminal.completedThreads.remove(terminal.completedThreads.first);
+      }
+    }
+    return true;
+  }
+
+  String _ampThreadKey(Map<String, Object?> payload) {
+    final direct = _readString(payload, const [
+      'threadId',
+      'threadID',
+      'thread_id',
+    ]);
+    if (direct != null) {
+      return direct;
+    }
+    final thread = payload['thread'];
+    if (thread is Map) {
+      final nested = _readString(Map<String, Object?>.from(thread), const [
+        'id',
+      ]);
+      if (nested != null) {
+        return nested;
+      }
+    }
+    return _legacyAmpThreadKey;
+  }
+
+  String? _readString(Map<String, Object?> payload, List<String> keys) {
+    for (final key in keys) {
+      final value = payload[key];
+      if (value is String && value.trim().isNotEmpty) {
+        return value.trim();
+      }
+    }
+    return null;
+  }
+
+  bool _agyStopStillBusy(Map<String, Object?> payload) {
+    return payload['fullyIdle'] == false || payload['fully_idle'] == false;
+  }
+}
+
+final class _AgyCompletedTurn {
+  const _AgyCompletedTurn(this.transcriptPath);
+
+  final String? transcriptPath;
+}
+
+final class _AmpTerminalLifecycle {
+  final LinkedHashSet<String> completedThreads = LinkedHashSet<String>();
+}

--- a/lib/src/features/agent_status/application/agent_status_controller.dart
+++ b/lib/src/features/agent_status/application/agent_status_controller.dart
@@ -1,3 +1,4 @@
+import 'package:alera/src/features/agent_status/application/agent_hook_lifecycle_guard.dart';
 import 'package:alera/src/features/agent_status/application/agent_status_identity_resolver.dart';
 import 'package:alera/src/features/agent_status/domain/agent_status.dart';
 import 'package:alera/src/features/agent_status/infra/agent_hook_event_normalizer.dart';
@@ -31,9 +32,11 @@ AgentStatusEntry? agentStatusByTerminalSession(
 class AgentStatusController extends _$AgentStatusController
     implements AgentStatusSink {
   late DateTime Function() _now;
+  final AgentHookLifecycleGuard _lifecycleGuard = AgentHookLifecycleGuard();
 
   @override
   Map<String, AgentStatusEntry> build() {
+    _lifecycleGuard.reset();
     _now = ref.watch(agentStatusClockProvider);
     return const <String, AgentStatusEntry>{};
   }
@@ -51,6 +54,9 @@ class AgentStatusController extends _$AgentStatusController
     var changed = false;
     final receivedAt = _now();
     for (final event in events) {
+      if (!_lifecycleGuard.shouldApply(event)) {
+        continue;
+      }
       final previous = next[event.terminalSessionId];
       if (isAgentSessionResetHookEvent(event)) {
         if (previous == null) {
@@ -148,6 +154,7 @@ class AgentStatusController extends _$AgentStatusController
   }
 
   void clearTerminal(String terminalSessionId) {
+    _lifecycleGuard.clearTerminal(terminalSessionId);
     if (!state.containsKey(terminalSessionId)) {
       return;
     }
@@ -158,6 +165,7 @@ class AgentStatusController extends _$AgentStatusController
 
   /// Drops every in-memory status entry for a workspace (e.g. after delete).
   void clearWorkspace(String workspaceId) {
+    _lifecycleGuard.clearWorkspace(workspaceId);
     final next = <String, AgentStatusEntry>{
       for (final entry in state.entries)
         if (entry.value.workspaceId != workspaceId) entry.key: entry.value,

--- a/lib/src/features/agent_status/application/agent_status_controller.g.dart
+++ b/lib/src/features/agent_status/application/agent_status_controller.g.dart
@@ -184,7 +184,7 @@ final class AgentStatusControllerProvider
 }
 
 String _$agentStatusControllerHash() =>
-    r'cd4c61c5c2341f1d4f1510f54305737a99d549fe';
+    r'061462342c3a36a40d11a6c244f349ae46d35c8c';
 
 abstract class _$AgentStatusController
     extends $Notifier<Map<String, AgentStatusEntry>> {

--- a/lib/src/features/agent_status/infra/agent_hook_event_normalizer.dart
+++ b/lib/src/features/agent_status/infra/agent_hook_event_normalizer.dart
@@ -39,7 +39,7 @@ NormalizedAgentStatus? normalizeAgentHookEvent(
   AgentHookEvent event, {
   AgentStatusEntry? previous,
 }) {
-  final eventName = _hookEventName(event);
+  final eventName = agentHookEventName(event);
   if (eventName == null) {
     return null;
   }
@@ -53,7 +53,11 @@ NormalizedAgentStatus? normalizeAgentHookEvent(
       toolSnapshot.toolName,
     ),
     AgentType.cursor => _normalizeCursorState(eventName, previous),
-    AgentType.agy => _normalizeAgyState(eventName, toolSnapshot.toolName),
+    AgentType.agy => _normalizeAgyState(
+      eventName,
+      toolSnapshot.toolName,
+      event.payload,
+    ),
     AgentType.opencode => _normalizeOpenCodeState(eventName),
     AgentType.pi => _normalizePiState(eventName),
     AgentType.amp => _normalizeAmpState(eventName),
@@ -89,7 +93,7 @@ NormalizedAgentStatus? normalizeAgentHookEvent(
 }
 
 bool isAgentSessionCloseHookEvent(AgentHookEvent event) {
-  final eventName = _hookEventName(event);
+  final eventName = agentHookEventName(event);
   if (eventName == null) {
     return false;
   }
@@ -107,11 +111,11 @@ bool isAgentSessionCloseHookEvent(AgentHookEvent event) {
 }
 
 bool isAgentSessionResetHookEvent(AgentHookEvent event) {
-  final eventName = _hookEventName(event);
+  final eventName = agentHookEventName(event);
   return event.agentType == AgentType.grok && eventName == 'SessionStart';
 }
 
-String? _hookEventName(AgentHookEvent event) {
+String? agentHookEventName(AgentHookEvent event) {
   final explicit = _readFirstString(
     <String, Object?>{'hookEventName': event.hookEventName},
     const <String>['hookEventName'],

--- a/lib/src/features/agent_status/infra/managed_hooks/amp_managed_agent_hook.dart
+++ b/lib/src/features/agent_status/infra/managed_hooks/amp_managed_agent_hook.dart
@@ -133,36 +133,77 @@ async function post(hookEventName: string, extra: Record<string, unknown> = {}) 
   } catch {}
 }
 
-export default function (amp: any) {
-  amp.on('session.start', async (event: any) => {
-    await post('session.start', event || {})
-  })
+const MAX_PENDING_POSTS = 50
+type QueuedPost = { hookEventName: string; payload: Record<string, unknown> }
+let postQueue: QueuedPost[] = []
+let postDraining = false
 
-  amp.on('agent.start', async (event: any) => {
-    await post('agent.start', {
-      message: event?.message ?? '',
-      thread: event?.thread,
+async function drainPostQueue() {
+  if (postDraining) return
+  postDraining = true
+  try {
+    while (postQueue.length > 0) {
+      const next = postQueue.shift()
+      if (!next) continue
+      await post(next.hookEventName, next.payload)
+    }
+  } finally {
+    postDraining = false
+    if (postQueue.length > 0) {
+      void drainPostQueue()
+    }
+  }
+}
+
+function enqueuePost(hookEventName: string, payload: Record<string, unknown> = {}) {
+  if (postQueue.length >= MAX_PENDING_POSTS) {
+    postQueue.shift()
+  }
+  postQueue.push({ hookEventName, payload })
+  void drainPostQueue()
+}
+
+export default function (amp: any) {
+  amp.on('session.start', (event: any) => {
+    enqueuePost('session.start', {
+      threadId: event?.thread?.id,
     })
   })
 
-  amp.on('tool.call', async (event: any) => {
-    await post('tool.call', {
+  amp.on('agent.start', (event: any) => {
+    enqueuePost('agent.start', {
+      threadId: event?.thread?.id,
+      id: event?.id,
+      message: event?.message ?? '',
+    })
+  })
+
+  amp.on('tool.call', (event: any) => {
+    enqueuePost('tool.call', {
+      threadId: event?.thread?.id,
+      toolUseId: event?.toolUseID,
       tool: event?.tool,
       input: event?.input,
     })
     return { action: 'allow' }
   })
 
-  amp.on('tool.result', async (event: any) => {
-    await post('tool.result', {
+  amp.on('tool.result', (event: any) => {
+    enqueuePost('tool.result', {
+      threadId: event?.thread?.id,
+      toolUseId: event?.toolUseID,
       tool: event?.tool,
+      input: event?.input,
       status: event?.status,
-      result: event?.result ?? event?.output,
+      error: event?.error,
+      output: event?.output ?? event?.result,
     })
   })
 
-  amp.on('agent.end', async (event: any) => {
-    await post('agent.end', {
+  amp.on('agent.end', (event: any) => {
+    enqueuePost('agent.end', {
+      threadId: event?.thread?.id,
+      id: event?.id,
       status: event?.status,
       messages: event?.messages,
       message: event?.message,

--- a/lib/src/features/agent_status/infra/normalizers/agy_agent_hook_normalizer.dart
+++ b/lib/src/features/agent_status/infra/normalizers/agy_agent_hook_normalizer.dart
@@ -1,8 +1,15 @@
 part of '../agent_hook_event_normalizer.dart';
 
-AgentStatusState? _normalizeAgyState(String eventName, String? toolName) {
+AgentStatusState? _normalizeAgyState(
+  String eventName,
+  String? toolName,
+  Map<String, Object?> payload,
+) {
   if (eventName == 'PreToolUse' && _isAgyFeedbackTool(toolName)) {
     return AgentStatusState.waiting;
+  }
+  if (eventName == 'Stop' && _agyStopStillBusy(payload)) {
+    return AgentStatusState.working;
   }
   return switch (eventName) {
     'PreInvocation' ||
@@ -12,6 +19,10 @@ AgentStatusState? _normalizeAgyState(String eventName, String? toolName) {
     'Stop' => AgentStatusState.done,
     _ => null,
   };
+}
+
+bool _agyStopStillBusy(Map<String, Object?> payload) {
+  return payload['fullyIdle'] == false || payload['fully_idle'] == false;
 }
 
 bool _isAgyNewTurn(String eventName) {

--- a/lib/src/features/agent_status/infra/normalizers/amp_agent_hook_normalizer.dart
+++ b/lib/src/features/agent_status/infra/normalizers/amp_agent_hook_normalizer.dart
@@ -2,10 +2,7 @@ part of '../agent_hook_event_normalizer.dart';
 
 AgentStatusState? _normalizeAmpState(String eventName) {
   return switch (eventName) {
-    'session.start' ||
-    'agent.start' ||
-    'tool.call' ||
-    'tool.result' => AgentStatusState.working,
+    'agent.start' || 'tool.call' || 'tool.result' => AgentStatusState.working,
     'agent.end' => AgentStatusState.done,
     _ => null,
   };

--- a/test/unit/agent_hook_event_normalizer_test.dart
+++ b/test/unit/agent_hook_event_normalizer_test.dart
@@ -6,11 +6,13 @@ import 'package:alera/src/features/agent_status/infra/agent_hook_event_normalize
 import 'package:flutter_test/flutter_test.dart';
 
 part 'grok_agent_hook_event_normalizer_test_cases.dart';
+part 'agy_agent_hook_event_normalizer_test_cases.dart';
 part 'agent_hook_event_normalizer_test_harness.dart';
 
 void main() {
   group('agent hook event normalizer', () {
     _registerGrokAgentHookEventNormalizerTests();
+    _registerAgyAgentHookEventNormalizerTests();
 
     test('reads assistant messages from Codex transcript formats', () {
       expect(
@@ -613,49 +615,6 @@ void main() {
           ),
         ),
         isNull,
-      );
-    });
-
-    test('keeps AGY working until Stop reports fully idle', () {
-      expect(
-        normalizeAgentHookEvent(
-          _event(
-            agentType: AgentType.agy,
-            hookEventName: 'Stop',
-            payload: const <String, Object?>{'fullyIdle': false},
-          ),
-        )?.state,
-        AgentStatusState.working,
-      );
-      expect(
-        normalizeAgentHookEvent(
-          _event(
-            agentType: AgentType.agy,
-            hookEventName: 'Stop',
-            payload: const <String, Object?>{'fully_idle': false},
-          ),
-        )?.state,
-        AgentStatusState.working,
-      );
-      expect(
-        normalizeAgentHookEvent(
-          _event(
-            agentType: AgentType.agy,
-            hookEventName: 'Stop',
-            payload: const <String, Object?>{'fullyIdle': true},
-          ),
-        )?.state,
-        AgentStatusState.done,
-      );
-      expect(
-        normalizeAgentHookEvent(
-          _event(
-            agentType: AgentType.agy,
-            hookEventName: 'Stop',
-            payload: const <String, Object?>{},
-          ),
-        )?.state,
-        AgentStatusState.done,
       );
     });
   });

--- a/test/unit/agent_hook_event_normalizer_test.dart
+++ b/test/unit/agent_hook_event_normalizer_test.dart
@@ -604,6 +604,59 @@ void main() {
       );
       expect(normalized?.state, AgentStatusState.working);
       expect(normalized?.prompt, 'Ship the feature');
+      expect(
+        normalizeAgentHookEvent(
+          _event(
+            agentType: AgentType.amp,
+            hookEventName: 'session.start',
+            payload: const <String, Object?>{'threadId': 'thread-1'},
+          ),
+        ),
+        isNull,
+      );
+    });
+
+    test('keeps AGY working until Stop reports fully idle', () {
+      expect(
+        normalizeAgentHookEvent(
+          _event(
+            agentType: AgentType.agy,
+            hookEventName: 'Stop',
+            payload: const <String, Object?>{'fullyIdle': false},
+          ),
+        )?.state,
+        AgentStatusState.working,
+      );
+      expect(
+        normalizeAgentHookEvent(
+          _event(
+            agentType: AgentType.agy,
+            hookEventName: 'Stop',
+            payload: const <String, Object?>{'fully_idle': false},
+          ),
+        )?.state,
+        AgentStatusState.working,
+      );
+      expect(
+        normalizeAgentHookEvent(
+          _event(
+            agentType: AgentType.agy,
+            hookEventName: 'Stop',
+            payload: const <String, Object?>{'fullyIdle': true},
+          ),
+        )?.state,
+        AgentStatusState.done,
+      );
+      expect(
+        normalizeAgentHookEvent(
+          _event(
+            agentType: AgentType.agy,
+            hookEventName: 'Stop',
+            payload: const <String, Object?>{},
+          ),
+        )?.state,
+        AgentStatusState.done,
+      );
     });
   });
 }

--- a/test/unit/agent_hook_lifecycle_guard_test.dart
+++ b/test/unit/agent_hook_lifecycle_guard_test.dart
@@ -1,0 +1,65 @@
+import 'package:alera/src/features/agent_status/application/agent_hook_lifecycle_guard.dart';
+import 'package:alera/src/features/agent_status/domain/agent_status.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('AgentHookLifecycleGuard', () {
+    test('bounds completed Amp threads and clears workspace state', () {
+      final guard = AgentHookLifecycleGuard();
+
+      expect(
+        guard.shouldApply(_ampEvent('session.start', threadId: 'thread-0')),
+        isFalse,
+      );
+      expect(
+        guard.shouldApply(_ampEvent('agent.start', threadId: 'thread-0')),
+        isTrue,
+      );
+      for (var index = 0; index < 33; index++) {
+        expect(
+          guard.shouldApply(_ampEvent('agent.end', threadId: 'thread-$index')),
+          isTrue,
+        );
+      }
+
+      expect(
+        guard.shouldApply(_ampEvent('tool.result', threadId: 'thread-0')),
+        isTrue,
+      );
+      expect(
+        guard.shouldApply(_ampEvent('tool.result', threadId: 'thread-32')),
+        isFalse,
+      );
+
+      guard.clearWorkspace('workspace-1');
+
+      expect(
+        guard.shouldApply(_ampEvent('tool.result', threadId: 'thread-32')),
+        isTrue,
+      );
+    });
+
+    test('supports legacy Amp payloads without a thread id', () {
+      final guard = AgentHookLifecycleGuard();
+
+      expect(guard.shouldApply(_ampEvent('agent.start')), isTrue);
+      expect(guard.shouldApply(_ampEvent('agent.end')), isTrue);
+      expect(guard.shouldApply(_ampEvent('tool.call')), isFalse);
+
+      guard.clearTerminal('session-1');
+
+      expect(guard.shouldApply(_ampEvent('tool.call')), isTrue);
+    });
+  });
+}
+
+AgentHookEvent _ampEvent(String eventName, {String? threadId}) {
+  return AgentHookEvent(
+    terminalSessionId: 'session-1',
+    workspaceId: 'workspace-1',
+    tabId: 'tab-1',
+    agentType: AgentType.amp,
+    hookEventName: eventName,
+    payload: <String, Object?>{'threadId': ?threadId},
+  );
+}

--- a/test/unit/agent_runtime_overlay_amp_test_cases.dart
+++ b/test/unit/agent_runtime_overlay_amp_test_cases.dart
@@ -1,0 +1,54 @@
+part of 'agent_runtime_overlay_service_test.dart';
+
+void _registerAmpRuntimeOverlayTests(
+  Directory Function() readHome,
+  AgentRuntimeOverlayService Function() readService,
+) {
+  test('creates an Amp overlay and wrapper', () async {
+    final home = readHome();
+    final ampConfig = Directory(p.join(home.path, '.config', 'amp'))
+      ..createSync(recursive: true);
+    File(
+      p.join(ampConfig.path, 'settings.json'),
+    ).writeAsStringSync('{"theme":"dark"}\n');
+    final plugins = Directory(p.join(ampConfig.path, 'plugins'))..createSync();
+    File(
+      p.join(plugins.path, 'user-plugin.ts'),
+    ).writeAsStringSync('export default function userPlugin() {}\n');
+    File(
+      p.join(plugins.path, 'alera-agent-status.ts'),
+    ).writeAsStringSync('USER OWNED PLUGIN\n');
+
+    final preparation = await readService().prepareAmpForTerminalLaunch(
+      terminalSessionId: 'session-amp',
+    );
+
+    final ampOverlay = preparation.environment['ALERA_AMP_CONFIG_DIR']!;
+    final wrapperPath = preparation.environment['ALERA_AGENT_WRAPPER_PATH']!;
+    expect(preparation.sourcePath, ampConfig.path);
+    expect(
+      File(p.join(ampOverlay, 'settings.json')).readAsStringSync(),
+      '{"theme":"dark"}\n',
+    );
+    expect(
+      File(p.join(ampOverlay, 'plugins', 'user-plugin.ts')).readAsStringSync(),
+      'export default function userPlugin() {}\n',
+    );
+    final statusPlugin = File(
+      p.join(ampOverlay, 'plugins', 'alera-agent-status.ts'),
+    ).readAsStringSync();
+    expect(statusPlugin, contains('ALERA_AGENT_STATUS_MANAGED_FILE'));
+    expect(statusPlugin, contains('/hook/amp'));
+    expect(statusPlugin, contains('const MAX_PENDING_POSTS = 50'));
+    expect(statusPlugin, contains("enqueuePost('agent.start'"));
+    expect(
+      File(p.join(plugins.path, 'alera-agent-status.ts')).readAsStringSync(),
+      'USER OWNED PLUGIN\n',
+    );
+    final wrapper = File(p.join(wrapperPath, 'amp')).readAsStringSync();
+    expect(wrapper, startsWith('#!/bin/sh'));
+    expect(wrapper, contains('XDG_CONFIG_HOME'));
+    expect(wrapper, contains('AMP_SETTINGS_FILE'));
+    expect(wrapper, contains('command -v amp'));
+  });
+}

--- a/test/unit/agent_runtime_overlay_service_test.dart
+++ b/test/unit/agent_runtime_overlay_service_test.dart
@@ -6,6 +6,8 @@ import 'package:alera/src/features/agent_status/infra/managed_agent_hook_install
 import 'package:flutter_test/flutter_test.dart';
 import 'package:path/path.dart' as p;
 
+part 'agent_runtime_overlay_amp_test_cases.dart';
+
 void main() {
   group('AgentRuntimeOverlayService', () {
     late Directory home;
@@ -45,6 +47,8 @@ void main() {
         resourceLinkCreator: resourceLinkCreator,
       );
     }
+
+    _registerAmpRuntimeOverlayTests(() => home, () => service());
 
     test('creates an OpenCode overlay with only the Alera plugin', () async {
       final preparation = await service().prepareOpenCodeForTerminalLaunch(
@@ -520,56 +524,6 @@ void main() {
       expect(wrapper, startsWith('#!/bin/sh'));
       expect(wrapper, contains('--plugin-dir'));
       expect(wrapper, contains(pluginDir));
-    });
-
-    test('creates an Amp overlay and wrapper', () async {
-      final ampConfig = Directory(p.join(home.path, '.config', 'amp'))
-        ..createSync(recursive: true);
-      File(
-        p.join(ampConfig.path, 'settings.json'),
-      ).writeAsStringSync('{"theme":"dark"}\n');
-      final plugins = Directory(p.join(ampConfig.path, 'plugins'))
-        ..createSync();
-      File(
-        p.join(plugins.path, 'user-plugin.ts'),
-      ).writeAsStringSync('export default function userPlugin() {}\n');
-      File(
-        p.join(plugins.path, 'alera-agent-status.ts'),
-      ).writeAsStringSync('USER OWNED PLUGIN\n');
-
-      final preparation = await service().prepareAmpForTerminalLaunch(
-        terminalSessionId: 'session-amp',
-      );
-
-      final ampOverlay = preparation.environment['ALERA_AMP_CONFIG_DIR']!;
-      final wrapperPath = preparation.environment['ALERA_AGENT_WRAPPER_PATH']!;
-      expect(preparation.sourcePath, ampConfig.path);
-      expect(
-        File(p.join(ampOverlay, 'settings.json')).readAsStringSync(),
-        '{"theme":"dark"}\n',
-      );
-      expect(
-        File(
-          p.join(ampOverlay, 'plugins', 'user-plugin.ts'),
-        ).readAsStringSync(),
-        'export default function userPlugin() {}\n',
-      );
-      final statusPlugin = File(
-        p.join(ampOverlay, 'plugins', 'alera-agent-status.ts'),
-      ).readAsStringSync();
-      expect(statusPlugin, contains('ALERA_AGENT_STATUS_MANAGED_FILE'));
-      expect(statusPlugin, contains('/hook/amp'));
-      expect(statusPlugin, contains('const MAX_PENDING_POSTS = 50'));
-      expect(statusPlugin, contains("enqueuePost('agent.start'"));
-      expect(
-        File(p.join(plugins.path, 'alera-agent-status.ts')).readAsStringSync(),
-        'USER OWNED PLUGIN\n',
-      );
-      final wrapper = File(p.join(wrapperPath, 'amp')).readAsStringSync();
-      expect(wrapper, startsWith('#!/bin/sh'));
-      expect(wrapper, contains('XDG_CONFIG_HOME'));
-      expect(wrapper, contains('AMP_SETTINGS_FILE'));
-      expect(wrapper, contains('command -v amp'));
     });
 
     test(

--- a/test/unit/agent_runtime_overlay_service_test.dart
+++ b/test/unit/agent_runtime_overlay_service_test.dart
@@ -559,6 +559,8 @@ void main() {
       ).readAsStringSync();
       expect(statusPlugin, contains('ALERA_AGENT_STATUS_MANAGED_FILE'));
       expect(statusPlugin, contains('/hook/amp'));
+      expect(statusPlugin, contains('const MAX_PENDING_POSTS = 50'));
+      expect(statusPlugin, contains("enqueuePost('agent.start'"));
       expect(
         File(p.join(plugins.path, 'alera-agent-status.ts')).readAsStringSync(),
         'USER OWNED PLUGIN\n',

--- a/test/unit/agent_status_controller_completion_test.dart
+++ b/test/unit/agent_status_controller_completion_test.dart
@@ -15,6 +15,9 @@ void main() {
         DateTime.utc(2026, 5, 26, 1, 2),
         DateTime.utc(2026, 5, 26, 1, 3),
         DateTime.utc(2026, 5, 26, 1, 4),
+        DateTime.utc(2026, 5, 26, 1, 5),
+        DateTime.utc(2026, 5, 26, 1, 6),
+        DateTime.utc(2026, 5, 26, 1, 7),
       ];
       var index = 0;
       container = ProviderContainer(
@@ -70,6 +73,73 @@ void main() {
       expect(entry.toolInput, 'dart format .');
       expect(entry.lastAssistantMessage, 'All set.');
       expect(entry.interrupted, isTrue);
+    });
+
+    test('keeps Amp lifecycle scoped to each completed thread', () {
+      final controller = container.read(agentStatusControllerProvider.notifier);
+
+      controller.applyHookEvent(
+        _event(
+          agentType: AgentType.amp,
+          hookEventName: 'session.start',
+          payload: <String, Object?>{'threadId': 'thread-1'},
+        ),
+      );
+      expect(container.read(agentStatusControllerProvider), isEmpty);
+
+      controller.applyHookEvent(
+        _event(
+          agentType: AgentType.amp,
+          hookEventName: 'agent.start',
+          payload: <String, Object?>{
+            'threadId': 'thread-1',
+            'message': 'first turn',
+          },
+        ),
+      );
+      controller.applyHookEvent(
+        _event(
+          agentType: AgentType.amp,
+          hookEventName: 'agent.end',
+          payload: <String, Object?>{'threadId': 'thread-1', 'status': 'done'},
+        ),
+      );
+      final completed = container.read(
+        agentStatusControllerProvider,
+      )['session-1']!;
+      expect(completed.state, AgentStatusState.done);
+
+      controller.applyHookEvent(
+        _event(
+          agentType: AgentType.amp,
+          hookEventName: 'tool.result',
+          payload: <String, Object?>{
+            'threadId': 'thread-1',
+            'tool': 'bash',
+            'input': <String, Object?>{'command': 'late command'},
+          },
+        ),
+      );
+      expect(
+        container.read(agentStatusControllerProvider)['session-1'],
+        same(completed),
+      );
+
+      controller.applyHookEvent(
+        _event(
+          agentType: AgentType.amp,
+          hookEventName: 'agent.start',
+          payload: <String, Object?>{
+            'threadId': 'thread-2',
+            'message': 'second turn',
+          },
+        ),
+      );
+      final nextTurn = container.read(
+        agentStatusControllerProvider,
+      )['session-1']!;
+      expect(nextTurn.state, AgentStatusState.working);
+      expect(nextTurn.prompt, 'second turn');
     });
 
     test('marks active terminal exits as inferred done', () {

--- a/test/unit/agent_status_controller_test.dart
+++ b/test/unit/agent_status_controller_test.dart
@@ -20,6 +20,11 @@ void main() {
         DateTime.utc(2026, 5, 26, 1, 4),
         DateTime.utc(2026, 5, 26, 1, 5),
         DateTime.utc(2026, 5, 26, 1, 6),
+        DateTime.utc(2026, 5, 26, 1, 7),
+        DateTime.utc(2026, 5, 26, 1, 8),
+        DateTime.utc(2026, 5, 26, 1, 9),
+        DateTime.utc(2026, 5, 26, 1, 10),
+        DateTime.utc(2026, 5, 26, 1, 11),
       ];
       var index = 0;
       container = ProviderContainer(
@@ -328,15 +333,83 @@ void main() {
         _event(
           agentType: AgentType.agy,
           hookEventName: 'Stop',
-          payload: <String, Object?>{},
+          payload: <String, Object?>{
+            'fullyIdle': false,
+            'transcriptPath': '/tmp/agy-turn.jsonl',
+          },
         ),
       );
 
-      final stoppedEntry = container.read(
+      var stoppedEntry = container.read(
+        agentStatusControllerProvider,
+      )['session-1']!;
+      expect(stoppedEntry.state, AgentStatusState.working);
+
+      controller.applyHookEvent(
+        _event(
+          agentType: AgentType.agy,
+          hookEventName: 'PostToolUse',
+          payload: <String, Object?>{
+            'transcriptPath': '/tmp/agy-turn.jsonl',
+            'toolCall': <String, Object?>{
+              'name': 'run_command',
+              'args': <String, Object?>{'CommandLine': 'flutter test'},
+            },
+          },
+        ),
+      );
+      expect(
+        container.read(agentStatusControllerProvider)['session-1']!.toolName,
+        'run_command',
+      );
+
+      controller.applyHookEvent(
+        _event(
+          agentType: AgentType.agy,
+          hookEventName: 'Stop',
+          payload: <String, Object?>{
+            'fullyIdle': true,
+            'transcriptPath': '/tmp/agy-turn.jsonl',
+          },
+        ),
+      );
+      stoppedEntry = container.read(
         agentStatusControllerProvider,
       )['session-1']!;
       expect(stoppedEntry.state, AgentStatusState.done);
       expect(stoppedEntry.prompt, 'fix test');
+
+      controller.applyHookEvent(
+        _event(
+          agentType: AgentType.agy,
+          hookEventName: 'PostToolUse',
+          payload: <String, Object?>{
+            'transcriptPath': '/tmp/agy-turn.jsonl',
+            'toolCall': <String, Object?>{
+              'name': 'run_command',
+              'args': <String, Object?>{'CommandLine': 'late command'},
+            },
+          },
+        ),
+      );
+      expect(
+        container.read(agentStatusControllerProvider)['session-1'],
+        same(stoppedEntry),
+      );
+
+      controller.applyHookEvent(
+        _event(
+          agentType: AgentType.agy,
+          hookEventName: 'PreInvocation',
+          payload: <String, Object?>{'prompt': 'next turn'},
+        ),
+      );
+      final nextTurn = container.read(
+        agentStatusControllerProvider,
+      )['session-1']!;
+      expect(nextTurn.state, AgentStatusState.working);
+      expect(nextTurn.prompt, 'next turn');
+      expect(nextTurn.toolName, isNull);
     });
 
     test('normalizes Cursor tool, waiting, done, and response states', () {

--- a/test/unit/agent_status_controller_test.dart
+++ b/test/unit/agent_status_controller_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 part 'grok_agent_status_controller_test_cases.dart';
+part 'agy_agent_status_controller_test_cases.dart';
 part 'agent_status_controller_test_harness.dart';
 
 void main() {
@@ -36,6 +37,7 @@ void main() {
     });
 
     _registerGrokAgentStatusControllerTests(() => container);
+    _registerAgyAgentStatusControllerTests(() => container);
 
     test('normalizes Codex events and preserves state start time', () {
       final controller = container.read(agentStatusControllerProvider.notifier);
@@ -284,132 +286,6 @@ void main() {
         container.read(agentStatusControllerProvider).containsKey('session-1'),
         isFalse,
       );
-    });
-
-    test('normalizes AGY invocation and feedback tool states', () {
-      final controller = container.read(agentStatusControllerProvider.notifier);
-
-      controller.applyHookEvent(
-        _event(
-          agentType: AgentType.agy,
-          hookEventName: 'PreInvocation',
-          payload: <String, Object?>{'prompt': 'fix test'},
-        ),
-      );
-      controller.applyHookEvent(
-        _event(
-          agentType: AgentType.agy,
-          hookEventName: 'PreToolUse',
-          payload: <String, Object?>{
-            'toolCall': <String, Object?>{
-              'name': 'ask_question',
-              'args': <String, Object?>{'Prompt': 'Which file?'},
-            },
-          },
-        ),
-      );
-
-      final entry = container.read(agentStatusControllerProvider)['session-1']!;
-      expect(entry.state, AgentStatusState.waiting);
-      expect(entry.prompt, 'fix test');
-      expect(entry.toolName, 'ask_question');
-      expect(entry.toolInput, 'Which file?');
-
-      controller.applyHookEvent(
-        _event(
-          agentType: AgentType.agy,
-          hookEventName: 'PostInvocation',
-          payload: <String, Object?>{},
-        ),
-      );
-
-      final postInvocationEntry = container.read(
-        agentStatusControllerProvider,
-      )['session-1']!;
-      expect(postInvocationEntry.state, AgentStatusState.working);
-      expect(postInvocationEntry.prompt, 'fix test');
-
-      controller.applyHookEvent(
-        _event(
-          agentType: AgentType.agy,
-          hookEventName: 'Stop',
-          payload: <String, Object?>{
-            'fullyIdle': false,
-            'transcriptPath': '/tmp/agy-turn.jsonl',
-          },
-        ),
-      );
-
-      var stoppedEntry = container.read(
-        agentStatusControllerProvider,
-      )['session-1']!;
-      expect(stoppedEntry.state, AgentStatusState.working);
-
-      controller.applyHookEvent(
-        _event(
-          agentType: AgentType.agy,
-          hookEventName: 'PostToolUse',
-          payload: <String, Object?>{
-            'transcriptPath': '/tmp/agy-turn.jsonl',
-            'toolCall': <String, Object?>{
-              'name': 'run_command',
-              'args': <String, Object?>{'CommandLine': 'flutter test'},
-            },
-          },
-        ),
-      );
-      expect(
-        container.read(agentStatusControllerProvider)['session-1']!.toolName,
-        'run_command',
-      );
-
-      controller.applyHookEvent(
-        _event(
-          agentType: AgentType.agy,
-          hookEventName: 'Stop',
-          payload: <String, Object?>{
-            'fullyIdle': true,
-            'transcriptPath': '/tmp/agy-turn.jsonl',
-          },
-        ),
-      );
-      stoppedEntry = container.read(
-        agentStatusControllerProvider,
-      )['session-1']!;
-      expect(stoppedEntry.state, AgentStatusState.done);
-      expect(stoppedEntry.prompt, 'fix test');
-
-      controller.applyHookEvent(
-        _event(
-          agentType: AgentType.agy,
-          hookEventName: 'PostToolUse',
-          payload: <String, Object?>{
-            'transcriptPath': '/tmp/agy-turn.jsonl',
-            'toolCall': <String, Object?>{
-              'name': 'run_command',
-              'args': <String, Object?>{'CommandLine': 'late command'},
-            },
-          },
-        ),
-      );
-      expect(
-        container.read(agentStatusControllerProvider)['session-1'],
-        same(stoppedEntry),
-      );
-
-      controller.applyHookEvent(
-        _event(
-          agentType: AgentType.agy,
-          hookEventName: 'PreInvocation',
-          payload: <String, Object?>{'prompt': 'next turn'},
-        ),
-      );
-      final nextTurn = container.read(
-        agentStatusControllerProvider,
-      )['session-1']!;
-      expect(nextTurn.state, AgentStatusState.working);
-      expect(nextTurn.prompt, 'next turn');
-      expect(nextTurn.toolName, isNull);
     });
 
     test('normalizes Cursor tool, waiting, done, and response states', () {

--- a/test/unit/agy_agent_hook_event_normalizer_test_cases.dart
+++ b/test/unit/agy_agent_hook_event_normalizer_test_cases.dart
@@ -1,0 +1,46 @@
+part of 'agent_hook_event_normalizer_test.dart';
+
+void _registerAgyAgentHookEventNormalizerTests() {
+  test('keeps AGY working until Stop reports fully idle', () {
+    expect(
+      normalizeAgentHookEvent(
+        _event(
+          agentType: AgentType.agy,
+          hookEventName: 'Stop',
+          payload: const <String, Object?>{'fullyIdle': false},
+        ),
+      )?.state,
+      AgentStatusState.working,
+    );
+    expect(
+      normalizeAgentHookEvent(
+        _event(
+          agentType: AgentType.agy,
+          hookEventName: 'Stop',
+          payload: const <String, Object?>{'fully_idle': false},
+        ),
+      )?.state,
+      AgentStatusState.working,
+    );
+    expect(
+      normalizeAgentHookEvent(
+        _event(
+          agentType: AgentType.agy,
+          hookEventName: 'Stop',
+          payload: const <String, Object?>{'fullyIdle': true},
+        ),
+      )?.state,
+      AgentStatusState.done,
+    );
+    expect(
+      normalizeAgentHookEvent(
+        _event(
+          agentType: AgentType.agy,
+          hookEventName: 'Stop',
+          payload: const <String, Object?>{},
+        ),
+      )?.state,
+      AgentStatusState.done,
+    );
+  });
+}

--- a/test/unit/agy_agent_status_controller_test_cases.dart
+++ b/test/unit/agy_agent_status_controller_test_cases.dart
@@ -1,0 +1,130 @@
+part of 'agent_status_controller_test.dart';
+
+void _registerAgyAgentStatusControllerTests(
+  ProviderContainer Function() readContainer,
+) {
+  test('normalizes AGY invocation and feedback tool states', () {
+    final container = readContainer();
+    final controller = container.read(agentStatusControllerProvider.notifier);
+
+    controller.applyHookEvent(
+      _event(
+        agentType: AgentType.agy,
+        hookEventName: 'PreInvocation',
+        payload: <String, Object?>{'prompt': 'fix test'},
+      ),
+    );
+    controller.applyHookEvent(
+      _event(
+        agentType: AgentType.agy,
+        hookEventName: 'PreToolUse',
+        payload: <String, Object?>{
+          'toolCall': <String, Object?>{
+            'name': 'ask_question',
+            'args': <String, Object?>{'Prompt': 'Which file?'},
+          },
+        },
+      ),
+    );
+
+    final entry = container.read(agentStatusControllerProvider)['session-1']!;
+    expect(entry.state, AgentStatusState.waiting);
+    expect(entry.prompt, 'fix test');
+    expect(entry.toolName, 'ask_question');
+    expect(entry.toolInput, 'Which file?');
+
+    controller.applyHookEvent(
+      _event(
+        agentType: AgentType.agy,
+        hookEventName: 'PostInvocation',
+        payload: <String, Object?>{},
+      ),
+    );
+
+    final postInvocationEntry = container.read(
+      agentStatusControllerProvider,
+    )['session-1']!;
+    expect(postInvocationEntry.state, AgentStatusState.working);
+    expect(postInvocationEntry.prompt, 'fix test');
+
+    controller.applyHookEvent(
+      _event(
+        agentType: AgentType.agy,
+        hookEventName: 'Stop',
+        payload: <String, Object?>{
+          'fullyIdle': false,
+          'transcriptPath': '/tmp/agy-turn.jsonl',
+        },
+      ),
+    );
+
+    var stoppedEntry = container.read(
+      agentStatusControllerProvider,
+    )['session-1']!;
+    expect(stoppedEntry.state, AgentStatusState.working);
+
+    controller.applyHookEvent(
+      _event(
+        agentType: AgentType.agy,
+        hookEventName: 'PostToolUse',
+        payload: <String, Object?>{
+          'transcriptPath': '/tmp/agy-turn.jsonl',
+          'toolCall': <String, Object?>{
+            'name': 'run_command',
+            'args': <String, Object?>{'CommandLine': 'flutter test'},
+          },
+        },
+      ),
+    );
+    expect(
+      container.read(agentStatusControllerProvider)['session-1']!.toolName,
+      'run_command',
+    );
+
+    controller.applyHookEvent(
+      _event(
+        agentType: AgentType.agy,
+        hookEventName: 'Stop',
+        payload: <String, Object?>{
+          'fullyIdle': true,
+          'transcriptPath': '/tmp/agy-turn.jsonl',
+        },
+      ),
+    );
+    stoppedEntry = container.read(agentStatusControllerProvider)['session-1']!;
+    expect(stoppedEntry.state, AgentStatusState.done);
+    expect(stoppedEntry.prompt, 'fix test');
+
+    controller.applyHookEvent(
+      _event(
+        agentType: AgentType.agy,
+        hookEventName: 'PostToolUse',
+        payload: <String, Object?>{
+          'transcriptPath': '/tmp/agy-turn.jsonl',
+          'toolCall': <String, Object?>{
+            'name': 'run_command',
+            'args': <String, Object?>{'CommandLine': 'late command'},
+          },
+        },
+      ),
+    );
+    expect(
+      container.read(agentStatusControllerProvider)['session-1'],
+      same(stoppedEntry),
+    );
+
+    controller.applyHookEvent(
+      _event(
+        agentType: AgentType.agy,
+        hookEventName: 'PreInvocation',
+        payload: <String, Object?>{'prompt': 'next turn'},
+      ),
+    );
+    final nextTurn = container.read(
+      agentStatusControllerProvider,
+    )['session-1']!;
+    expect(nextTurn.state, AgentStatusState.working);
+    expect(nextTurn.prompt, 'next turn');
+    expect(nextTurn.toolName, isNull);
+  });
+}

--- a/test/unit/managed_agent_hook_installer_amp_test_cases.dart
+++ b/test/unit/managed_agent_hook_installer_amp_test_cases.dart
@@ -1,0 +1,57 @@
+part of 'managed_agent_hook_installer_test.dart';
+
+void _registerAmpHookInstallerTests(
+  Directory Function() readHome,
+  ManagedAgentHookInstallService Function() readService,
+) {
+  test('installs and removes the managed Amp system plugin', () {
+    final home = readHome();
+    final service = readService();
+    final pluginPath = p.join(
+      home.path,
+      '.config',
+      'amp',
+      'plugins',
+      'alera-agent-status.ts',
+    );
+
+    expect(
+      service.status(AgentType.amp).state,
+      ManagedAgentHookInstallState.notInstalled,
+    );
+    expect(
+      service.install(AgentType.amp).state,
+      ManagedAgentHookInstallState.installed,
+    );
+
+    final source = File(pluginPath).readAsStringSync();
+    expect(source, contains('ALERA_AGENT_STATUS_MANAGED_FILE'));
+    expect(source, contains("amp.on('agent.start'"));
+    expect(source, contains("amp.on('tool.call'"));
+    expect(source, contains("return { action: 'allow' }"));
+    expect(source, contains('const MAX_PENDING_POSTS = 50'));
+    expect(source, contains('function enqueuePost'));
+    expect(source, contains("enqueuePost('agent.start'"));
+    expect(source, contains('threadId: event?.thread?.id'));
+    expect(source, isNot(contains("await post('agent.start'")));
+    expect(source, contains('/hook/amp'));
+    expect(source, contains('ALERA_AGENT_HOOK_ENDPOINT'));
+
+    File(pluginPath).writeAsStringSync(
+      '// ALERA_AGENT_STATUS_MANAGED_FILE\n'
+      'export default function staleAmpPlugin() {}\n',
+    );
+    expect(
+      service.status(AgentType.amp).state,
+      ManagedAgentHookInstallState.partial,
+    );
+    expect(
+      service.install(AgentType.amp).state,
+      ManagedAgentHookInstallState.installed,
+    );
+
+    final removed = service.remove(AgentType.amp);
+    expect(removed.state, ManagedAgentHookInstallState.notInstalled);
+    expect(File(pluginPath).existsSync(), isFalse);
+  });
+}

--- a/test/unit/managed_agent_hook_installer_test.dart
+++ b/test/unit/managed_agent_hook_installer_test.dart
@@ -8,6 +8,7 @@ import 'package:path/path.dart' as p;
 
 part 'managed_agent_hook_installer_test_harness.dart';
 part 'managed_agent_hook_installer_grok_test_cases.dart';
+part 'managed_agent_hook_installer_amp_test_cases.dart';
 
 void main() {
   group('ManagedAgentHookInstallService', () {
@@ -29,6 +30,7 @@ void main() {
       }
     });
     _registerGrokHookInstallerTests(() => home, () => service);
+    _registerAmpHookInstallerTests(() => home, () => service);
     test('does not install Codex hooks into the user config', () {
       final configPath = p.join(home.path, '.codex', 'hooks.json');
       _writeJson(configPath, <String, Object?>{
@@ -617,55 +619,6 @@ void main() {
       expect(source, contains("pi.on('before_agent_start'"));
       expect(source, contains('/hook/pi'));
       expect(source, contains('ALERA_AGENT_HOOK_ENDPOINT'));
-    });
-
-    test('installs and removes the managed Amp system plugin', () {
-      final pluginPath = p.join(
-        home.path,
-        '.config',
-        'amp',
-        'plugins',
-        'alera-agent-status.ts',
-      );
-
-      expect(
-        service.status(AgentType.amp).state,
-        ManagedAgentHookInstallState.notInstalled,
-      );
-      expect(
-        service.install(AgentType.amp).state,
-        ManagedAgentHookInstallState.installed,
-      );
-
-      final source = File(pluginPath).readAsStringSync();
-      expect(source, contains('ALERA_AGENT_STATUS_MANAGED_FILE'));
-      expect(source, contains("amp.on('agent.start'"));
-      expect(source, contains("amp.on('tool.call'"));
-      expect(source, contains("return { action: 'allow' }"));
-      expect(source, contains('const MAX_PENDING_POSTS = 50'));
-      expect(source, contains('function enqueuePost'));
-      expect(source, contains("enqueuePost('agent.start'"));
-      expect(source, contains('threadId: event?.thread?.id'));
-      expect(source, isNot(contains("await post('agent.start'")));
-      expect(source, contains('/hook/amp'));
-      expect(source, contains('ALERA_AGENT_HOOK_ENDPOINT'));
-
-      File(pluginPath).writeAsStringSync(
-        '// ALERA_AGENT_STATUS_MANAGED_FILE\n'
-        'export default function staleAmpPlugin() {}\n',
-      );
-      expect(
-        service.status(AgentType.amp).state,
-        ManagedAgentHookInstallState.partial,
-      );
-      expect(
-        service.install(AgentType.amp).state,
-        ManagedAgentHookInstallState.installed,
-      );
-
-      final removed = service.remove(AgentType.amp);
-      expect(removed.state, ManagedAgentHookInstallState.notInstalled);
-      expect(File(pluginPath).existsSync(), isFalse);
     });
 
     test('resolves Amp artifact paths from env and Windows defaults', () {

--- a/test/unit/managed_agent_hook_installer_test.dart
+++ b/test/unit/managed_agent_hook_installer_test.dart
@@ -642,8 +642,26 @@ void main() {
       expect(source, contains("amp.on('agent.start'"));
       expect(source, contains("amp.on('tool.call'"));
       expect(source, contains("return { action: 'allow' }"));
+      expect(source, contains('const MAX_PENDING_POSTS = 50'));
+      expect(source, contains('function enqueuePost'));
+      expect(source, contains("enqueuePost('agent.start'"));
+      expect(source, contains('threadId: event?.thread?.id'));
+      expect(source, isNot(contains("await post('agent.start'")));
       expect(source, contains('/hook/amp'));
       expect(source, contains('ALERA_AGENT_HOOK_ENDPOINT'));
+
+      File(pluginPath).writeAsStringSync(
+        '// ALERA_AGENT_STATUS_MANAGED_FILE\n'
+        'export default function staleAmpPlugin() {}\n',
+      );
+      expect(
+        service.status(AgentType.amp).state,
+        ManagedAgentHookInstallState.partial,
+      );
+      expect(
+        service.install(AgentType.amp).state,
+        ManagedAgentHookInstallState.installed,
+      );
 
       final removed = service.remove(AgentType.amp);
       expect(removed.state, ManagedAgentHookInstallState.notInstalled);


### PR DESCRIPTION
## Summary

- keep Antigravity active until its Stop hook reports a fully idle session
- correlate Amp lifecycle events by thread and prevent late tool events from reopening completed runs
- make Amp hook delivery non-blocking while preserving event order

## Root cause

Antigravity emits intermediate Stop events before becoming fully idle, while Amp emits session and tool events whose ordering and thread identity require lifecycle-aware handling. The previous normalization treated those events as independent status updates.

## Validation

- 84 focused Flutter unit tests
- flutter analyze
- git diff --check
- codex review loop with no actionable findings