### PR TITLE
feat: add pull request merge actions

### DIFF
--- a/lib/src/design_system/icons/alera_icons.dart
+++ b/lib/src/design_system/icons/alera_icons.dart
@@ -85,7 +85,9 @@ abstract final class AleraIcons {
   static const IconData gitBranch = LucideIcons.gitBranch;
   static const IconData gitGraph = LucideIcons.gitGraph;
   static const IconData gitFork = LucideIcons.gitFork;
+  static const IconData gitMerge = LucideIcons.gitMerge;
   static const IconData gitPullRequest = LucideIcons.gitPullRequest;
+  static const IconData gitPullRequestClosed = LucideIcons.gitPullRequestClosed;
   static const IconData checks = LucideIcons.listChecks;
   static const IconData diff = LucideIcons.gitCompare;
 

--- a/lib/src/design_system/layout/alera_confirm_dialog.dart
+++ b/lib/src/design_system/layout/alera_confirm_dialog.dart
@@ -50,14 +50,15 @@ class AleraConfirmDialog extends StatelessWidget {
               ),
             ),
             const SizedBox(height: AleraTokens.space20),
-            Row(
-              mainAxisAlignment: MainAxisAlignment.end,
+            Wrap(
+              alignment: WrapAlignment.end,
+              spacing: AleraTokens.space8,
+              runSpacing: AleraTokens.space8,
               children: <Widget>[
                 TextButton(
                   onPressed: () => Navigator.of(context).pop(false),
                   child: Text(cancelLabel),
                 ),
-                const SizedBox(width: AleraTokens.space8),
                 FilledButton(
                   onPressed: () => Navigator.of(context).pop(true),
                   style: confirmStyle,

--- a/lib/src/features/pull_requests/application/forge_provider.dart
+++ b/lib/src/features/pull_requests/application/forge_provider.dart
@@ -6,6 +6,7 @@ import 'package:alera/src/features/pull_requests/domain/git_remote_identity.dart
 import 'package:alera/src/features/pull_requests/domain/hosted_review.dart';
 import 'package:alera/src/features/pull_requests/domain/review_check.dart';
 import 'package:alera/src/features/pull_requests/domain/review_check_details.dart';
+import 'package:alera/src/features/pull_requests/domain/review_merge_method.dart';
 import 'package:alera/src/features/pull_requests/domain/update_review_input.dart';
 import 'package:alera/src/features/pull_requests/domain/update_review_result.dart';
 
@@ -23,6 +24,12 @@ abstract interface class ForgeProvider {
 
   /// Whether this provider can create reviews (some are read-only).
   bool get supportsReviewCreation;
+
+  /// Merge strategies this provider can execute.
+  List<ReviewMergeMethod> get supportedMergeMethods;
+
+  /// Whether this provider can close an open review without merging it.
+  bool get supportsReviewClosure;
 
   /// Reports whether the provider's CLI is installed and authenticated for the
   /// host in [identity]. Never throws.
@@ -79,5 +86,21 @@ abstract interface class ForgeProvider {
     required String repoPath,
     required int number,
     required UpdateReviewInput input,
+  });
+
+  /// Merges review [number] using [method]. Expected provider failures throw a
+  /// typed [ForgeException].
+  Future<void> mergeReview({
+    required GitRemoteIdentity identity,
+    required String repoPath,
+    required int number,
+    required ReviewMergeMethod method,
+  });
+
+  /// Closes review [number] without merging it.
+  Future<void> closeReview({
+    required GitRemoteIdentity identity,
+    required String repoPath,
+    required int number,
   });
 }

--- a/lib/src/features/pull_requests/application/workspace_pull_request_controller.dart
+++ b/lib/src/features/pull_requests/application/workspace_pull_request_controller.dart
@@ -1,5 +1,7 @@
 import 'dart:async';
 
+import 'package:alera/src/features/pull_requests/application/forge_exception.dart';
+import 'package:alera/src/features/pull_requests/application/forge_provider.dart';
 import 'package:alera/src/features/pull_requests/application/forge_provider_registry.dart';
 import 'package:alera/src/features/pull_requests/application/linked_review_repository.dart';
 import 'package:alera/src/features/pull_requests/application/pull_request_providers.dart';
@@ -9,9 +11,12 @@ import 'package:alera/src/features/pull_requests/application/workspace_pull_requ
 import 'package:alera/src/features/pull_requests/domain/create_review_input.dart';
 import 'package:alera/src/features/pull_requests/domain/create_review_result.dart';
 import 'package:alera/src/features/pull_requests/domain/forge_auth_status.dart';
+import 'package:alera/src/features/pull_requests/domain/git_remote_identity.dart';
+import 'package:alera/src/features/pull_requests/domain/hosted_review.dart';
 import 'package:alera/src/features/pull_requests/domain/linked_review.dart';
 import 'package:alera/src/features/pull_requests/domain/review_check.dart';
 import 'package:alera/src/features/pull_requests/domain/review_check_details.dart';
+import 'package:alera/src/features/pull_requests/domain/review_merge_method.dart';
 import 'package:alera/src/features/pull_requests/domain/update_review_input.dart';
 import 'package:alera/src/features/pull_requests/domain/update_review_result.dart';
 import 'package:alera/src/features/pull_requests/domain/workspace_pull_request_scope.dart';
@@ -21,9 +26,11 @@ import 'package:alera/src/shared/infra/git/git_providers.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'workspace_pull_request_controller.g.dart';
+part 'workspace_pull_request_review_actions.dart';
 
 @Riverpod(keepAlive: true)
-class WorkspacePullRequestController extends _$WorkspacePullRequestController {
+class WorkspacePullRequestController extends _$WorkspacePullRequestController
+    with _WorkspacePullRequestReviewActions {
   static const Duration _minPollInterval = Duration(seconds: 30);
   static const Duration _maxPollInterval = Duration(seconds: 120);
 
@@ -295,6 +302,15 @@ class WorkspacePullRequestController extends _$WorkspacePullRequestController {
         _resetPollInterval();
       }
     } on _ActionError catch (error) {
+      if (!_disposed) {
+        state = AsyncData(
+          (state.value ?? current).copyWith(
+            clearAction: true,
+            errorMessage: error.message,
+          ),
+        );
+      }
+    } on ForgeException catch (error) {
       if (!_disposed) {
         state = AsyncData(
           (state.value ?? current).copyWith(

--- a/lib/src/features/pull_requests/application/workspace_pull_request_controller.g.dart
+++ b/lib/src/features/pull_requests/application/workspace_pull_request_controller.g.dart
@@ -57,7 +57,7 @@ final class WorkspacePullRequestControllerProvider
 }
 
 String _$workspacePullRequestControllerHash() =>
-    r'5d9806bea7ed91659f0face3ce11f1a87db834de';
+    r'93568278ad55442160f72d7a4178764e2f64ba0d';
 
 final class WorkspacePullRequestControllerFamily extends $Family
     with

--- a/lib/src/features/pull_requests/application/workspace_pull_request_loader.dart
+++ b/lib/src/features/pull_requests/application/workspace_pull_request_loader.dart
@@ -91,6 +91,8 @@ class WorkspacePullRequestLoader {
         currentBranch: branch,
         baseBranches: baseInfo.branches,
         suggestedBaseBranch: baseInfo.suggested,
+        mergeMethods: forge.supportedMergeMethods,
+        canCloseReview: forge.supportsReviewClosure,
       );
     } on ForgeNotAuthenticated {
       return WorkspacePullRequestState(

--- a/lib/src/features/pull_requests/application/workspace_pull_request_review_actions.dart
+++ b/lib/src/features/pull_requests/application/workspace_pull_request_review_actions.dart
@@ -1,0 +1,99 @@
+part of 'workspace_pull_request_controller.dart';
+
+mixin _WorkspacePullRequestReviewActions on _$WorkspacePullRequestController {
+  WorkspacePullRequestController get _controller =>
+      this as WorkspacePullRequestController;
+
+  /// Merges the linked review and keeps it linked so the terminal state remains
+  /// visible after the provider no longer returns it as an open branch review.
+  Future<void> mergeReview(ReviewMergeMethod method) async {
+    final current = state.value;
+    final review = current?.review;
+    if (current == null ||
+        review == null ||
+        review.state != HostedReviewState.open ||
+        !current.mergeMethods.contains(method)) {
+      _surfaceActionError('This Pull Request Cannot Be Merged.');
+      return;
+    }
+    await _runReviewMutation(
+      current: current,
+      action: PullRequestAction.merge,
+      mutate: (forge, identity) => forge.mergeReview(
+        identity: identity,
+        repoPath: _controller.scope.repoPath,
+        number: review.number,
+        method: method,
+      ),
+    );
+  }
+
+  /// Closes the linked review without merging it.
+  Future<void> closeReview() async {
+    final current = state.value;
+    final review = current?.review;
+    if (current == null ||
+        review == null ||
+        !review.isOpen ||
+        !current.canCloseReview) {
+      _surfaceActionError('This Pull Request Cannot Be Closed.');
+      return;
+    }
+    await _runReviewMutation(
+      current: current,
+      action: PullRequestAction.close,
+      mutate: (forge, identity) => forge.closeReview(
+        identity: identity,
+        repoPath: _controller.scope.repoPath,
+        number: review.number,
+      ),
+    );
+  }
+
+  Future<void> _runReviewMutation({
+    required WorkspacePullRequestState current,
+    required PullRequestAction action,
+    required Future<void> Function(ForgeProvider, GitRemoteIdentity) mutate,
+  }) async {
+    final controller = _controller;
+    final identity = current.identity;
+    final review = current.review;
+    final forge = identity == null
+        ? null
+        : controller._registry.forProvider(identity.provider);
+    if (identity == null || review == null || forge == null) {
+      _surfaceActionError('No Linked Pull Request To Update.');
+      return;
+    }
+    await controller._run(
+      scope: controller.scope,
+      action: action,
+      body: () async {
+        await mutate(forge, identity);
+        if (!current.linkedManually) {
+          await controller._linkedReviews.save(
+            LinkedReview.linked(
+              workspaceId: controller.scope.workspaceId,
+              provider: identity.provider,
+              number: review.number,
+              url: review.url,
+            ),
+          );
+        }
+      },
+    );
+  }
+
+  void _surfaceActionError(String message) {
+    final controller = _controller;
+    if (controller._disposed) {
+      return;
+    }
+    state = AsyncData(
+      (state.value ?? const WorkspacePullRequestState()).copyWith(
+        clearAction: true,
+        errorMessage: message,
+      ),
+    );
+  }
+}

--- a/lib/src/features/pull_requests/application/workspace_pull_request_state.dart
+++ b/lib/src/features/pull_requests/application/workspace_pull_request_state.dart
@@ -2,12 +2,13 @@ import 'package:alera/src/features/pull_requests/domain/forge_auth_status.dart';
 import 'package:alera/src/features/pull_requests/domain/git_remote_identity.dart';
 import 'package:alera/src/features/pull_requests/domain/hosted_review.dart';
 import 'package:alera/src/features/pull_requests/domain/review_check.dart';
+import 'package:alera/src/features/pull_requests/domain/review_merge_method.dart';
 
 /// Why the pull-request panel has no provider to work with.
 enum PullRequestUnavailableReason { noRemote, undetectable, unsupported }
 
 /// In-flight action for busy indicators.
-enum PullRequestAction { refresh, link, unlink, create, update }
+enum PullRequestAction { refresh, link, unlink, create, update, merge, close }
 
 /// Immutable state of the pull-request panel for one workspace.
 class WorkspacePullRequestState {
@@ -22,6 +23,8 @@ class WorkspacePullRequestState {
     this.currentBranch,
     this.baseBranches = const <String>[],
     this.suggestedBaseBranch,
+    this.mergeMethods = const <ReviewMergeMethod>[],
+    this.canCloseReview = false,
     this.action,
     this.errorMessage,
   });
@@ -44,6 +47,8 @@ class WorkspacePullRequestState {
   /// Resolved default base branch for the create form.
   final String? suggestedBaseBranch;
 
+  final List<ReviewMergeMethod> mergeMethods;
+  final bool canCloseReview;
   final PullRequestAction? action;
   final String? errorMessage;
 
@@ -71,6 +76,8 @@ class WorkspacePullRequestState {
     String? currentBranch,
     List<String>? baseBranches,
     String? suggestedBaseBranch,
+    List<ReviewMergeMethod>? mergeMethods,
+    bool? canCloseReview,
     PullRequestAction? action,
     bool clearAction = false,
     String? errorMessage,
@@ -87,6 +94,8 @@ class WorkspacePullRequestState {
       currentBranch: currentBranch ?? this.currentBranch,
       baseBranches: baseBranches ?? this.baseBranches,
       suggestedBaseBranch: suggestedBaseBranch ?? this.suggestedBaseBranch,
+      mergeMethods: mergeMethods ?? this.mergeMethods,
+      canCloseReview: canCloseReview ?? this.canCloseReview,
       action: clearAction ? null : (action ?? this.action),
       errorMessage: clearError ? null : (errorMessage ?? this.errorMessage),
     );

--- a/lib/src/features/pull_requests/domain/review_merge_method.dart
+++ b/lib/src/features/pull_requests/domain/review_merge_method.dart
@@ -1,0 +1,12 @@
+/// Merge strategies exposed by hosted-review providers.
+enum ReviewMergeMethod {
+  mergeCommit,
+  squash,
+  rebase;
+
+  String get label => switch (this) {
+    ReviewMergeMethod.mergeCommit => 'Create Merge Commit',
+    ReviewMergeMethod.squash => 'Squash and Merge',
+    ReviewMergeMethod.rebase => 'Rebase and Merge',
+  };
+}

--- a/lib/src/features/pull_requests/infra/azure_devops_forge_provider.dart
+++ b/lib/src/features/pull_requests/infra/azure_devops_forge_provider.dart
@@ -11,6 +11,7 @@ import 'package:alera/src/features/pull_requests/domain/git_remote_identity.dart
 import 'package:alera/src/features/pull_requests/domain/hosted_review.dart';
 import 'package:alera/src/features/pull_requests/domain/review_check.dart';
 import 'package:alera/src/features/pull_requests/domain/review_check_details.dart';
+import 'package:alera/src/features/pull_requests/domain/review_merge_method.dart';
 import 'package:alera/src/features/pull_requests/domain/update_review_input.dart';
 import 'package:alera/src/features/pull_requests/domain/update_review_result.dart';
 import 'package:alera/src/features/pull_requests/infra/azure_devops_cli_failures.dart';
@@ -19,10 +20,14 @@ import 'package:alera/src/shared/infra/process/process_runner.dart';
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
 
+part 'azure_devops_review_actions.dart';
+
 /// [ForgeProvider] for Azure DevOps, wrapping the official `az` CLI (with the
 /// `azure-devops` extension). Authentication relies on `az login`. Checks are
 /// derived from PR policy evaluations.
-class AzureDevOpsForgeProvider implements ForgeProvider {
+class AzureDevOpsForgeProvider
+    with _AzureDevOpsReviewActions
+    implements ForgeProvider {
   const AzureDevOpsForgeProvider(this._processRunner);
 
   final ProcessRunner _processRunner;

--- a/lib/src/features/pull_requests/infra/azure_devops_review_actions.dart
+++ b/lib/src/features/pull_requests/infra/azure_devops_review_actions.dart
@@ -1,0 +1,61 @@
+part of 'azure_devops_forge_provider.dart';
+
+mixin _AzureDevOpsReviewActions {
+  List<ReviewMergeMethod> get supportedMergeMethods =>
+      const <ReviewMergeMethod>[
+        ReviewMergeMethod.mergeCommit,
+        ReviewMergeMethod.squash,
+      ];
+
+  bool get supportsReviewClosure => true;
+
+  Future<void> mergeReview({
+    required GitRemoteIdentity identity,
+    required String repoPath,
+    required int number,
+    required ReviewMergeMethod method,
+  }) async {
+    if (method == ReviewMergeMethod.rebase) {
+      throw const ForgeRequestFailed(
+        'Azure DevOps Does Not Support Rebase and Merge Through Its CLI.',
+      );
+    }
+    final provider = this as AzureDevOpsForgeProvider;
+    await provider._run(<String>[
+      'repos',
+      'pr',
+      'update',
+      '--id',
+      '$number',
+      '--organization',
+      azureOrgUrl(identity),
+      '--status',
+      'completed',
+      '--squash',
+      method == ReviewMergeMethod.squash ? 'true' : 'false',
+      '--output',
+      'none',
+    ], repoPath);
+  }
+
+  Future<void> closeReview({
+    required GitRemoteIdentity identity,
+    required String repoPath,
+    required int number,
+  }) async {
+    final provider = this as AzureDevOpsForgeProvider;
+    await provider._run(<String>[
+      'repos',
+      'pr',
+      'update',
+      '--id',
+      '$number',
+      '--organization',
+      azureOrgUrl(identity),
+      '--status',
+      'abandoned',
+      '--output',
+      'none',
+    ], repoPath);
+  }
+}

--- a/lib/src/features/pull_requests/infra/github_forge_provider.dart
+++ b/lib/src/features/pull_requests/infra/github_forge_provider.dart
@@ -10,17 +10,20 @@ import 'package:alera/src/features/pull_requests/domain/git_remote_identity.dart
 import 'package:alera/src/features/pull_requests/domain/hosted_review.dart';
 import 'package:alera/src/features/pull_requests/domain/review_check.dart';
 import 'package:alera/src/features/pull_requests/domain/review_check_details.dart';
+import 'package:alera/src/features/pull_requests/domain/review_merge_method.dart';
 import 'package:alera/src/features/pull_requests/domain/update_review_input.dart';
 import 'package:alera/src/features/pull_requests/domain/update_review_result.dart';
 import 'package:alera/src/features/pull_requests/infra/github_cli_failures.dart';
 import 'package:alera/src/features/pull_requests/infra/github_review_mappers.dart';
 import 'package:alera/src/shared/infra/process/process_runner.dart';
 
+part 'github_review_actions.dart';
+
 /// [ForgeProvider] for GitHub, wrapping the official `gh` CLI. Authentication
 /// relies on the user being logged in via `gh auth login`. Follows the
 /// `GitHubStarService` pattern: constructor-injected [ProcessRunner], typed
 /// errors instead of leaked stderr.
-class GitHubForgeProvider implements ForgeProvider {
+class GitHubForgeProvider with _GitHubReviewActions implements ForgeProvider {
   const GitHubForgeProvider(this._processRunner);
 
   final ProcessRunner _processRunner;

--- a/lib/src/features/pull_requests/infra/github_review_actions.dart
+++ b/lib/src/features/pull_requests/infra/github_review_actions.dart
@@ -1,0 +1,49 @@
+part of 'github_forge_provider.dart';
+
+mixin _GitHubReviewActions {
+  List<ReviewMergeMethod> get supportedMergeMethods =>
+      const <ReviewMergeMethod>[
+        ReviewMergeMethod.mergeCommit,
+        ReviewMergeMethod.squash,
+        ReviewMergeMethod.rebase,
+      ];
+
+  bool get supportsReviewClosure => true;
+
+  Future<void> mergeReview({
+    required GitRemoteIdentity identity,
+    required String repoPath,
+    required int number,
+    required ReviewMergeMethod method,
+  }) async {
+    final provider = this as GitHubForgeProvider;
+    final flag = switch (method) {
+      ReviewMergeMethod.mergeCommit => '--merge',
+      ReviewMergeMethod.squash => '--squash',
+      ReviewMergeMethod.rebase => '--rebase',
+    };
+    await provider._run(<String>[
+      'pr',
+      'merge',
+      '$number',
+      '--repo',
+      provider._repoSlug(identity),
+      flag,
+    ], repoPath);
+  }
+
+  Future<void> closeReview({
+    required GitRemoteIdentity identity,
+    required String repoPath,
+    required int number,
+  }) async {
+    final provider = this as GitHubForgeProvider;
+    await provider._run(<String>[
+      'pr',
+      'close',
+      '$number',
+      '--repo',
+      provider._repoSlug(identity),
+    ], repoPath);
+  }
+}

--- a/lib/src/features/pull_requests/presentation/pull_request_review_actions.dart
+++ b/lib/src/features/pull_requests/presentation/pull_request_review_actions.dart
@@ -1,0 +1,276 @@
+part of 'pull_request_review_view.dart';
+
+class _PullRequestReviewActions extends StatefulWidget {
+  const _PullRequestReviewActions({
+    required this.review,
+    required this.mergeMethods,
+    required this.canCloseReview,
+    required this.action,
+    required this.onMerge,
+    required this.onClose,
+    required this.onUnlink,
+  });
+
+  final HostedReview review;
+  final List<ReviewMergeMethod> mergeMethods;
+  final bool canCloseReview;
+  final PullRequestAction? action;
+  final Future<void> Function(ReviewMergeMethod method) onMerge;
+  final Future<void> Function() onClose;
+  final VoidCallback onUnlink;
+
+  @override
+  State<_PullRequestReviewActions> createState() =>
+      _PullRequestReviewActionsState();
+}
+
+class _PullRequestReviewActionsState extends State<_PullRequestReviewActions> {
+  ReviewMergeMethod? _selectedMethod;
+
+  ReviewMergeMethod? get _method {
+    final selected = _selectedMethod;
+    if (selected != null && widget.mergeMethods.contains(selected)) {
+      return selected;
+    }
+    return widget.mergeMethods.firstOrNull;
+  }
+
+  bool get _busy => widget.action != null;
+
+  @override
+  Widget build(BuildContext context) {
+    final review = widget.review;
+    final method = _method;
+    final canMerge =
+        review.state == HostedReviewState.open &&
+        review.mergeable != HostedReviewMergeable.conflicting &&
+        method != null;
+    final canClose = review.isOpen && widget.canCloseReview;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: <Widget>[
+        if (review.isOpen) ...<Widget>[
+          if (method != null)
+            _MergePullRequestButton(
+              method: method,
+              methods: widget.mergeMethods,
+              busy: widget.action == PullRequestAction.merge,
+              enabled: canMerge && !_busy,
+              onPressed: () => _confirmMerge(method),
+              onSelected: (selected) {
+                setState(() => _selectedMethod = selected);
+                unawaited(_confirmMerge(selected));
+              },
+            ),
+          if (method != null) const SizedBox(height: AleraTokens.space8),
+          OutlinedButton.icon(
+            onPressed: canClose && !_busy ? _confirmClose : null,
+            icon: widget.action == PullRequestAction.close
+                ? const SizedBox(
+                    width: 14,
+                    height: 14,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  )
+                : const Icon(
+                    AleraIcons.gitPullRequestClosed,
+                    size: 16,
+                    color: AleraTokens.error,
+                  ),
+            label: const Text('Close Pull Request'),
+          ),
+          const SizedBox(height: AleraTokens.space4),
+        ],
+        TextButton.icon(
+          onPressed: _busy ? null : widget.onUnlink,
+          icon: widget.action == PullRequestAction.unlink
+              ? const SizedBox(
+                  width: 14,
+                  height: 14,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                )
+              : const Icon(AleraIcons.unlink, size: 16),
+          label: const Text('Unlink Pull Request'),
+        ),
+      ],
+    );
+  }
+
+  Future<void> _confirmMerge(ReviewMergeMethod method) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (_) => AleraConfirmDialog(
+        title: '${method.label} PR #${widget.review.number}?',
+        message:
+            'This Will Update The Pull Request On '
+            '${widget.review.provider.label}.',
+        confirmLabel: method.label,
+      ),
+    );
+    if (confirmed == true) {
+      await widget.onMerge(method);
+    }
+  }
+
+  Future<void> _confirmClose() async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (_) => AleraConfirmDialog(
+        title: 'Close Pull Request #${widget.review.number}?',
+        message: 'This Will Close The Pull Request Without Merging It.',
+        confirmLabel: 'Close Pull Request',
+        destructive: true,
+      ),
+    );
+    if (confirmed == true) {
+      await widget.onClose();
+    }
+  }
+}
+
+class _MergePullRequestButton extends StatelessWidget {
+  const _MergePullRequestButton({
+    required this.method,
+    required this.methods,
+    required this.busy,
+    required this.enabled,
+    required this.onPressed,
+    required this.onSelected,
+  });
+
+  final ReviewMergeMethod method;
+  final List<ReviewMergeMethod> methods;
+  final bool busy;
+  final bool enabled;
+  final VoidCallback onPressed;
+  final ValueChanged<ReviewMergeMethod> onSelected;
+
+  static const double _height = 34;
+
+  @override
+  Widget build(BuildContext context) {
+    final textStyle = Theme.of(
+      context,
+    ).textTheme.labelLarge?.copyWith(color: AleraTokens.onAccent);
+    final cursor = enabled
+        ? SystemMouseCursors.click
+        : SystemMouseCursors.basic;
+    return MouseRegion(
+      cursor: cursor,
+      child: Opacity(
+        opacity: enabled || busy ? 1 : 0.38,
+        child: ClipRRect(
+          borderRadius: BorderRadius.circular(AleraTokens.radiusLg),
+          child: Material(
+            color: AleraTokens.accent,
+            child: SizedBox(
+              height: _height,
+              child: Row(
+                children: <Widget>[
+                  Expanded(
+                    child: InkWell(
+                      mouseCursor: cursor,
+                      onTap: enabled ? onPressed : null,
+                      child: Center(
+                        child: Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: <Widget>[
+                            if (busy)
+                              const SizedBox(
+                                width: 14,
+                                height: 14,
+                                child: CircularProgressIndicator(
+                                  strokeWidth: 2,
+                                  color: AleraTokens.onAccent,
+                                ),
+                              )
+                            else
+                              const Icon(
+                                AleraIcons.gitMerge,
+                                size: 16,
+                                color: AleraTokens.onAccent,
+                              ),
+                            const SizedBox(width: AleraTokens.space8),
+                            Flexible(
+                              child: Text(
+                                method.label,
+                                maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
+                                style: textStyle,
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                  ),
+                  Container(
+                    width: 0.5,
+                    height: 20,
+                    color: AleraTokens.onAccent.withValues(alpha: 0.18),
+                  ),
+                  Tooltip(
+                    message: 'Merge Options',
+                    child: Builder(
+                      builder: (context) => InkWell(
+                        mouseCursor: cursor,
+                        onTap: enabled
+                            ? () => unawaited(_openMenu(context))
+                            : null,
+                        child: const SizedBox(
+                          width: 34,
+                          height: _height,
+                          child: Icon(
+                            AleraIcons.chevronDown,
+                            size: 17,
+                            color: AleraTokens.onAccent,
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Future<void> _openMenu(BuildContext context) async {
+    final renderBox = context.findRenderObject() as RenderBox?;
+    final overlay = Navigator.of(context).overlay?.context.findRenderObject();
+    if (renderBox == null || overlay is! RenderBox) {
+      return;
+    }
+    final topLeft = renderBox.localToGlobal(Offset.zero, ancestor: overlay);
+    final bottomRight = renderBox.localToGlobal(
+      renderBox.size.bottomRight(Offset.zero),
+      ancestor: overlay,
+    );
+    final selected = await showMenu<ReviewMergeMethod>(
+      context: context,
+      position: RelativeRect.fromRect(
+        Rect.fromPoints(topLeft, bottomRight),
+        Offset.zero & overlay.size,
+      ),
+      color: AleraTokens.surface,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(AleraTokens.radiusMd),
+        side: const BorderSide(color: AleraTokens.border),
+      ),
+      items: <PopupMenuEntry<ReviewMergeMethod>>[
+        for (final option in methods)
+          AleraDropdownEntry<ReviewMergeMethod>(
+            value: option,
+            label: option.label,
+            selected: option == method,
+            leading: const Icon(AleraIcons.gitMerge, size: 16),
+          ),
+      ],
+    );
+    if (selected != null) {
+      onSelected(selected);
+    }
+  }
+}

--- a/lib/src/features/pull_requests/presentation/pull_request_review_view.dart
+++ b/lib/src/features/pull_requests/presentation/pull_request_review_view.dart
@@ -1,16 +1,23 @@
+import 'dart:async';
+
 import 'package:alera/src/app/theme/alera_tokens.dart';
 import 'package:alera/src/design_system/buttons/alera_icon_button.dart';
 import 'package:alera/src/design_system/forms/alera_dropdown_field.dart';
 import 'package:alera/src/design_system/icons/alera_icons.dart';
+import 'package:alera/src/design_system/layout/alera_confirm_dialog.dart';
+import 'package:alera/src/design_system/menus/alera_dropdown_entry.dart';
 import 'package:alera/src/features/pull_requests/application/workspace_pull_request_state.dart';
 import 'package:alera/src/features/pull_requests/domain/hosted_review.dart';
 import 'package:alera/src/features/pull_requests/domain/review_check.dart';
 import 'package:alera/src/features/pull_requests/domain/review_check_details.dart';
+import 'package:alera/src/features/pull_requests/domain/review_merge_method.dart';
 import 'package:alera/src/features/pull_requests/domain/update_review_input.dart';
 import 'package:alera/src/features/pull_requests/domain/update_review_result.dart';
 import 'package:alera/src/features/pull_requests/presentation/pull_request_check_list.dart';
 import 'package:alera/src/features/pull_requests/presentation/pull_request_field_decoration.dart';
 import 'package:flutter/material.dart';
+
+part 'pull_request_review_actions.dart';
 
 /// Presentational body for a linked review: header, inline title/base-branch
 /// editing, expandable checks, and a bottom Unlink button. Pure: data and
@@ -21,9 +28,13 @@ class PullRequestReviewView extends StatefulWidget {
     required this.review,
     required this.checks,
     required this.baseBranches,
+    required this.mergeMethods,
+    required this.canCloseReview,
     required this.action,
     required this.onOpenUrl,
     required this.onUnlink,
+    required this.onMerge,
+    required this.onClose,
     required this.onUpdate,
     required this.onLoadCheckDetails,
   });
@@ -31,9 +42,13 @@ class PullRequestReviewView extends StatefulWidget {
   final HostedReview review;
   final List<ReviewCheck> checks;
   final List<String> baseBranches;
+  final List<ReviewMergeMethod> mergeMethods;
+  final bool canCloseReview;
   final PullRequestAction? action;
   final Future<void> Function(String url) onOpenUrl;
   final VoidCallback onUnlink;
+  final Future<void> Function(ReviewMergeMethod method) onMerge;
+  final Future<void> Function() onClose;
   final Future<UpdateReviewResult> Function(UpdateReviewInput input) onUpdate;
   final Future<ReviewCheckDetails?> Function(ReviewCheck check)
   onLoadCheckDetails;
@@ -49,7 +64,6 @@ class _PullRequestReviewViewState extends State<PullRequestReviewView> {
 
   bool get _busy => widget.action != null;
   bool get _saving => widget.action == PullRequestAction.update;
-  bool get _unlinking => widget.action == PullRequestAction.unlink;
 
   @override
   void dispose() {
@@ -137,16 +151,14 @@ class _PullRequestReviewViewState extends State<PullRequestReviewView> {
             ),
           ),
           const SizedBox(height: AleraTokens.space8),
-          FilledButton.icon(
-            onPressed: _busy ? null : widget.onUnlink,
-            icon: _unlinking
-                ? const SizedBox(
-                    width: 14,
-                    height: 14,
-                    child: CircularProgressIndicator(strokeWidth: 2),
-                  )
-                : const Icon(AleraIcons.unlink, size: 16),
-            label: const Text('Unlink Pull Request'),
+          _PullRequestReviewActions(
+            review: review,
+            mergeMethods: widget.mergeMethods,
+            canCloseReview: widget.canCloseReview,
+            action: widget.action,
+            onMerge: widget.onMerge,
+            onClose: widget.onClose,
+            onUnlink: widget.onUnlink,
           ),
         ],
       ),

--- a/lib/src/features/pull_requests/presentation/workspace_pull_requests_panel.dart
+++ b/lib/src/features/pull_requests/presentation/workspace_pull_requests_panel.dart
@@ -189,9 +189,13 @@ class _PullRequestBody extends StatelessWidget {
         review: review,
         checks: state.checks,
         baseBranches: state.baseBranches,
+        mergeMethods: state.mergeMethods,
+        canCloseReview: state.canCloseReview,
         action: state.action,
         onOpenUrl: onOpenUrl,
         onUnlink: controller.unlink,
+        onMerge: controller.mergeReview,
+        onClose: controller.closeReview,
         onUpdate: controller.updateReview,
         onLoadCheckDetails: controller.loadCheckDetails,
       );

--- a/test/unit/azure_devops_forge_provider_test.dart
+++ b/test/unit/azure_devops_forge_provider_test.dart
@@ -4,6 +4,7 @@ import 'package:alera/src/features/pull_requests/domain/git_hosting_provider.dar
 import 'package:alera/src/features/pull_requests/domain/git_remote_identity.dart';
 import 'package:alera/src/features/pull_requests/domain/hosted_review.dart';
 import 'package:alera/src/features/pull_requests/domain/review_check.dart';
+import 'package:alera/src/features/pull_requests/domain/review_merge_method.dart';
 import 'package:alera/src/features/pull_requests/domain/update_review_input.dart';
 import 'package:alera/src/features/pull_requests/domain/update_review_result.dart';
 import 'package:alera/src/features/pull_requests/infra/azure_devops_forge_provider.dart';
@@ -338,6 +339,62 @@ void main() {
         failure.message,
         contains('the title may already have been updated'),
       );
+    });
+  });
+
+  group('AzureDevOpsForgeProvider review actions', () {
+    for (final entry in <(ReviewMergeMethod, String)>[
+      (ReviewMergeMethod.mergeCommit, 'false'),
+      (ReviewMergeMethod.squash, 'true'),
+    ]) {
+      test('completes with squash=${entry.$2}', () async {
+        final runner = FakeRecordingProcessRunner(<Object>[_ok('')]);
+        final provider = AzureDevOpsForgeProvider(runner);
+
+        await provider.mergeReview(
+          identity: _identity,
+          repoPath: '/repo',
+          number: 42,
+          method: entry.$1,
+        );
+
+        final call = runner.calls.single;
+        expect(call.arguments.sublist(0, 3), <String>['repos', 'pr', 'update']);
+        expect(call.optionValue('status'), 'completed');
+        expect(call.optionValue('squash'), entry.$2);
+        expect(call.optionValue('organization'), 'https://dev.azure.com/myorg');
+      });
+    }
+
+    test('does not expose rebase through the Azure CLI', () async {
+      final runner = FakeRecordingProcessRunner(<Object>[]);
+      final provider = AzureDevOpsForgeProvider(runner);
+
+      expect(
+        () => provider.mergeReview(
+          identity: _identity,
+          repoPath: '/repo',
+          number: 42,
+          method: ReviewMergeMethod.rebase,
+        ),
+        throwsA(isA<Exception>()),
+      );
+      expect(runner.calls, isEmpty);
+    });
+
+    test('abandons the pull request when closing', () async {
+      final runner = FakeRecordingProcessRunner(<Object>[_ok('')]);
+      final provider = AzureDevOpsForgeProvider(runner);
+
+      await provider.closeReview(
+        identity: _identity,
+        repoPath: '/repo',
+        number: 42,
+      );
+
+      final call = runner.calls.single;
+      expect(call.optionValue('status'), 'abandoned');
+      expect(call.optionValue('organization'), 'https://dev.azure.com/myorg');
     });
   });
 

--- a/test/unit/fake_forge_provider.dart
+++ b/test/unit/fake_forge_provider.dart
@@ -9,6 +9,7 @@ import 'package:alera/src/features/pull_requests/domain/hosted_review.dart';
 import 'package:alera/src/features/pull_requests/domain/linked_review.dart';
 import 'package:alera/src/features/pull_requests/domain/review_check.dart';
 import 'package:alera/src/features/pull_requests/domain/review_check_details.dart';
+import 'package:alera/src/features/pull_requests/domain/review_merge_method.dart';
 import 'package:alera/src/features/pull_requests/domain/update_review_input.dart';
 import 'package:alera/src/features/pull_requests/domain/update_review_result.dart';
 
@@ -37,12 +38,29 @@ class FakeForgeProvider implements ForgeProvider {
   );
   UpdateReviewInput? lastUpdateInput;
   int updateCalls = 0;
+  List<ReviewMergeMethod> mergeMethods = const <ReviewMergeMethod>[
+    ReviewMergeMethod.mergeCommit,
+    ReviewMergeMethod.squash,
+    ReviewMergeMethod.rebase,
+  ];
+  bool canCloseReview = true;
+  ReviewMergeMethod? lastMergeMethod;
+  int mergeCalls = 0;
+  Object? mergeError;
+  int closeCalls = 0;
+  Object? closeError;
 
   @override
   GitHostingProvider get id => GitHostingProvider.github;
 
   @override
   bool get supportsReviewCreation => true;
+
+  @override
+  List<ReviewMergeMethod> get supportedMergeMethods => mergeMethods;
+
+  @override
+  bool get supportsReviewClosure => canCloseReview;
 
   @override
   Future<ForgeAuthStatus> checkAuth({
@@ -118,6 +136,50 @@ class FakeForgeProvider implements ForgeProvider {
       }
     }
     return result;
+  }
+
+  @override
+  Future<void> mergeReview({
+    required GitRemoteIdentity identity,
+    required String repoPath,
+    required int number,
+    required ReviewMergeMethod method,
+  }) async {
+    mergeCalls++;
+    lastMergeMethod = method;
+    final error = mergeError;
+    if (error != null) {
+      throw error;
+    }
+    _setReviewState(number, HostedReviewState.merged);
+  }
+
+  @override
+  Future<void> closeReview({
+    required GitRemoteIdentity identity,
+    required String repoPath,
+    required int number,
+  }) async {
+    closeCalls++;
+    final error = closeError;
+    if (error != null) {
+      throw error;
+    }
+    _setReviewState(number, HostedReviewState.closed);
+  }
+
+  void _setReviewState(int number, HostedReviewState state) {
+    final current =
+        byNumber[number] ??
+        (branchReview?.number == number ? branchReview : null);
+    if (current == null) {
+      return;
+    }
+    final updated = current.copyWith(state: state);
+    byNumber[number] = updated;
+    if (branchReview?.number == number) {
+      branchReview = updated;
+    }
   }
 }
 

--- a/test/unit/github_forge_provider_test.dart
+++ b/test/unit/github_forge_provider_test.dart
@@ -5,6 +5,7 @@ import 'package:alera/src/features/pull_requests/domain/git_hosting_provider.dar
 import 'package:alera/src/features/pull_requests/domain/git_remote_identity.dart';
 import 'package:alera/src/features/pull_requests/domain/hosted_review.dart';
 import 'package:alera/src/features/pull_requests/domain/review_check.dart';
+import 'package:alera/src/features/pull_requests/domain/review_merge_method.dart';
 import 'package:alera/src/features/pull_requests/domain/update_review_input.dart';
 import 'package:alera/src/features/pull_requests/domain/update_review_result.dart';
 import 'package:alera/src/features/pull_requests/infra/github_forge_provider.dart';
@@ -298,6 +299,46 @@ void main() {
         (result as UpdateReviewFailure).code,
         UpdateReviewErrorCode.cliMissing,
       );
+    });
+  });
+
+  group('GitHubForgeProvider review actions', () {
+    for (final entry in <(ReviewMergeMethod, String)>[
+      (ReviewMergeMethod.mergeCommit, '--merge'),
+      (ReviewMergeMethod.squash, '--squash'),
+      (ReviewMergeMethod.rebase, '--rebase'),
+    ]) {
+      test('merges with ${entry.$2}', () async {
+        final runner = FakeRecordingProcessRunner(<Object>[_ok('')]);
+        final provider = GitHubForgeProvider(runner);
+
+        await provider.mergeReview(
+          identity: _identity,
+          repoPath: '/repo',
+          number: 123,
+          method: entry.$1,
+        );
+
+        final call = runner.calls.single;
+        expect(call.arguments.sublist(0, 3), <String>['pr', 'merge', '123']);
+        expect(call.optionValue('repo'), 'leynier/alera');
+        expect(call.arguments, contains(entry.$2));
+      });
+    }
+
+    test('closes the pull request through gh', () async {
+      final runner = FakeRecordingProcessRunner(<Object>[_ok('')]);
+      final provider = GitHubForgeProvider(runner);
+
+      await provider.closeReview(
+        identity: _identity,
+        repoPath: '/repo',
+        number: 123,
+      );
+
+      final call = runner.calls.single;
+      expect(call.arguments.sublist(0, 3), <String>['pr', 'close', '123']);
+      expect(call.optionValue('repo'), 'leynier/alera');
     });
   });
 

--- a/test/unit/workspace_pull_request_controller_test.dart
+++ b/test/unit/workspace_pull_request_controller_test.dart
@@ -9,6 +9,7 @@ import 'package:alera/src/features/pull_requests/domain/git_hosting_provider.dar
 import 'package:alera/src/features/pull_requests/domain/hosted_review.dart';
 import 'package:alera/src/features/pull_requests/domain/review_check.dart';
 import 'package:alera/src/features/pull_requests/domain/review_check_details.dart';
+import 'package:alera/src/features/pull_requests/domain/review_merge_method.dart';
 import 'package:alera/src/features/pull_requests/domain/update_review_input.dart';
 import 'package:alera/src/features/pull_requests/domain/update_review_result.dart';
 import 'package:alera/src/features/pull_requests/domain/workspace_pull_request_scope.dart';
@@ -362,6 +363,79 @@ void main() {
     expect(result, isA<UpdateReviewFailure>());
     expect((result as UpdateReviewFailure).code, UpdateReviewErrorCode.blocked);
     expect(forge.updateCalls, 0);
+  });
+
+  test(
+    'merge keeps an auto-detected PR linked and shows its merged state',
+    () async {
+      final forge = FakeForgeProvider()..branchReview = _review(123);
+      final repo = FakeLinkedReviewRepository();
+      final container = _container(forge: forge, repo: repo);
+      addTearDown(container.dispose);
+
+      await container.read(
+        workspacePullRequestControllerProvider(_scope).future,
+      );
+      final controller = container.read(
+        workspacePullRequestControllerProvider(_scope).notifier,
+      );
+
+      await controller.mergeReview(ReviewMergeMethod.squash);
+
+      final state = container
+          .read(workspacePullRequestControllerProvider(_scope))
+          .value!;
+      expect(forge.lastMergeMethod, ReviewMergeMethod.squash);
+      expect(state.review?.state, HostedReviewState.merged);
+      expect(state.linkedManually, isTrue);
+      expect(repo.store['w1']?.number, 123);
+    },
+  );
+
+  test('close keeps the terminal closed state visible', () async {
+    final forge = FakeForgeProvider()..branchReview = _review(123);
+    final repo = FakeLinkedReviewRepository();
+    final container = _container(forge: forge, repo: repo);
+    addTearDown(container.dispose);
+
+    await container.read(workspacePullRequestControllerProvider(_scope).future);
+    final controller = container.read(
+      workspacePullRequestControllerProvider(_scope).notifier,
+    );
+
+    await controller.closeReview();
+
+    final state = container
+        .read(workspacePullRequestControllerProvider(_scope))
+        .value!;
+    expect(forge.closeCalls, 1);
+    expect(state.review?.state, HostedReviewState.closed);
+    expect(state.linkedManually, isTrue);
+  });
+
+  test('blocks a merge method that the provider does not support', () async {
+    final forge = FakeForgeProvider()
+      ..branchReview = _review(123)
+      ..mergeMethods = const <ReviewMergeMethod>[ReviewMergeMethod.mergeCommit];
+    final container = _container(
+      forge: forge,
+      repo: FakeLinkedReviewRepository(),
+    );
+    addTearDown(container.dispose);
+
+    await container.read(workspacePullRequestControllerProvider(_scope).future);
+    final controller = container.read(
+      workspacePullRequestControllerProvider(_scope).notifier,
+    );
+
+    await controller.mergeReview(ReviewMergeMethod.rebase);
+
+    final state = container
+        .read(workspacePullRequestControllerProvider(_scope))
+        .value!;
+    expect(forge.mergeCalls, 0);
+    expect(state.errorMessage, 'This Pull Request Cannot Be Merged.');
+    expect(state.review?.state, HostedReviewState.open);
   });
 
   test('loadCheckDetails queries the linked review number', () async {

--- a/test/widget/pull_request_review_view_test.dart
+++ b/test/widget/pull_request_review_view_test.dart
@@ -3,6 +3,7 @@ import 'package:alera/src/features/pull_requests/domain/git_hosting_provider.dar
 import 'package:alera/src/features/pull_requests/domain/hosted_review.dart';
 import 'package:alera/src/features/pull_requests/domain/review_check.dart';
 import 'package:alera/src/features/pull_requests/domain/review_check_details.dart';
+import 'package:alera/src/features/pull_requests/domain/review_merge_method.dart';
 import 'package:alera/src/features/pull_requests/domain/update_review_input.dart';
 import 'package:alera/src/features/pull_requests/domain/update_review_result.dart';
 import 'package:alera/src/features/pull_requests/presentation/pull_request_review_view.dart';
@@ -22,24 +23,37 @@ const _review = HostedReview(
 
 class _Callbacks {
   int unlinkCalls = 0;
+  int closeCalls = 0;
+  ReviewMergeMethod? mergeMethod;
   UpdateReviewInput? lastInput;
   UpdateReviewResult updateResult = const UpdateReviewSuccess(_review);
 }
 
 Widget _wrap(
   _Callbacks callbacks, {
+  HostedReview review = _review,
   PullRequestAction? action,
   List<ReviewCheck> checks = const <ReviewCheck>[],
+  List<ReviewMergeMethod> mergeMethods = const <ReviewMergeMethod>[
+    ReviewMergeMethod.mergeCommit,
+    ReviewMergeMethod.squash,
+    ReviewMergeMethod.rebase,
+  ],
+  bool canCloseReview = true,
 }) {
   return MaterialApp(
     home: Scaffold(
       body: PullRequestReviewView(
-        review: _review,
+        review: review,
         checks: checks,
         baseBranches: const <String>['develop', 'main'],
+        mergeMethods: mergeMethods,
+        canCloseReview: canCloseReview,
         action: action,
         onOpenUrl: (_) async {},
         onUnlink: () => callbacks.unlinkCalls++,
+        onMerge: (method) async => callbacks.mergeMethod = method,
+        onClose: () async => callbacks.closeCalls++,
         onUpdate: (input) async {
           callbacks.lastInput = input;
           return callbacks.updateResult;
@@ -51,11 +65,18 @@ Widget _wrap(
 }
 
 void main() {
-  testWidgets('shows a labeled Unlink button at the bottom', (tester) async {
+  testWidgets('shows merge, close, and unlink actions for an open PR', (
+    tester,
+  ) async {
     final callbacks = _Callbacks();
     await tester.pumpWidget(_wrap(callbacks));
 
-    final unlink = find.widgetWithText(FilledButton, 'Unlink Pull Request');
+    expect(find.text('Create Merge Commit'), findsOneWidget);
+    expect(
+      find.widgetWithText(OutlinedButton, 'Close Pull Request'),
+      findsOneWidget,
+    );
+    final unlink = find.widgetWithText(TextButton, 'Unlink Pull Request');
     expect(unlink, findsOneWidget);
     await tester.tap(unlink);
     expect(callbacks.unlinkCalls, 1);
@@ -65,10 +86,73 @@ void main() {
     final callbacks = _Callbacks();
     await tester.pumpWidget(_wrap(callbacks, action: PullRequestAction.unlink));
 
-    final button = tester.widget<FilledButton>(
-      find.widgetWithText(FilledButton, 'Unlink Pull Request'),
+    final button = tester.widget<TextButton>(
+      find.widgetWithText(TextButton, 'Unlink Pull Request'),
     );
     expect(button.onPressed, isNull);
+  });
+
+  testWidgets('confirms the primary merge method before invoking it', (
+    tester,
+  ) async {
+    final callbacks = _Callbacks();
+    await tester.pumpWidget(_wrap(callbacks));
+
+    await tester.tap(find.text('Create Merge Commit'));
+    await tester.pumpAndSettle();
+    expect(find.text('Create Merge Commit PR #42?'), findsOneWidget);
+
+    await tester.tap(find.widgetWithText(FilledButton, 'Create Merge Commit'));
+    await tester.pumpAndSettle();
+    expect(callbacks.mergeMethod, ReviewMergeMethod.mergeCommit);
+  });
+
+  testWidgets('offers all provider merge methods in the split menu', (
+    tester,
+  ) async {
+    final callbacks = _Callbacks();
+    await tester.pumpWidget(_wrap(callbacks));
+
+    await tester.tap(find.byTooltip('Merge Options'));
+    await tester.pumpAndSettle();
+    expect(find.text('Create Merge Commit'), findsWidgets);
+    expect(find.text('Squash and Merge'), findsOneWidget);
+    expect(find.text('Rebase and Merge'), findsOneWidget);
+
+    await tester.tap(find.text('Squash and Merge'));
+    await tester.pumpAndSettle();
+    expect(find.text('Squash and Merge PR #42?'), findsOneWidget);
+    await tester.tap(find.widgetWithText(FilledButton, 'Squash and Merge'));
+    await tester.pumpAndSettle();
+    expect(callbacks.mergeMethod, ReviewMergeMethod.squash);
+  });
+
+  testWidgets('confirms closing without merging', (tester) async {
+    final callbacks = _Callbacks();
+    await tester.pumpWidget(_wrap(callbacks));
+
+    await tester.tap(find.widgetWithText(OutlinedButton, 'Close Pull Request'));
+    await tester.pumpAndSettle();
+    expect(find.text('Close Pull Request #42?'), findsOneWidget);
+    await tester.tap(find.widgetWithText(FilledButton, 'Close Pull Request'));
+    await tester.pumpAndSettle();
+    expect(callbacks.closeCalls, 1);
+  });
+
+  testWidgets('hides remote mutation actions after the PR is merged', (
+    tester,
+  ) async {
+    final callbacks = _Callbacks();
+    await tester.pumpWidget(
+      _wrap(
+        callbacks,
+        review: _review.copyWith(state: HostedReviewState.merged),
+      ),
+    );
+
+    expect(find.text('Create Merge Commit'), findsNothing);
+    expect(find.text('Close Pull Request'), findsNothing);
+    expect(find.text('Unlink Pull Request'), findsOneWidget);
   });
 
   testWidgets('edit mode sends only the changed fields on save', (


### PR DESCRIPTION
## Summary

- add a split pull request merge action with merge commit, squash, and rebase options on GitHub
- support merge commit, squash, and close actions on Azure DevOps
- add confirmation, loading, error, and terminal-state refresh behavior
- make confirmation dialog actions responsive to long labels

## Validation

- `dart format --set-exit-if-changed lib test integration_test tool`
- `dart run tool/quality/check_max_lines.dart`
- `flutter analyze`
- `CI=true flutter test --coverage --exclude-tags golden`
- `dart run tool/quality/coverage_report.dart --input coverage/lcov.info --min-lines 65 --worst 25`
- `flutter test --tags golden`
- `cd mobile && dart format --set-exit-if-changed lib test && flutter analyze && flutter test`
- `make rust-test`

## Notes

- Azure DevOps does not expose rebase-and-merge through its CLI, so that provider offers merge commit and squash only.
- No release, updater, security, or documentation behavior changes.
