### PR TITLE
feat: enlarge settings modal and add hand cursor on projects

### DIFF
--- a/lib/src/features/settings/presentation/panes/projects_pane.dart
+++ b/lib/src/features/settings/presentation/panes/projects_pane.dart
@@ -447,6 +447,7 @@ class _ProjectConfigProjectList extends StatelessWidget {
         for (final project in projects)
           InkWell(
             onTap: () => onSelect(project),
+            mouseCursor: SystemMouseCursors.click,
             child: Container(
               padding: const EdgeInsets.all(AleraTokens.space12),
               color: project.id == selectedProjectId

--- a/lib/src/features/settings/presentation/settings_dialog.dart
+++ b/lib/src/features/settings/presentation/settings_dialog.dart
@@ -18,14 +18,14 @@ import 'package:alera/src/features/settings/presentation/settings_sections.dart'
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-// The dialog tracks the screen so settings stay comfortable on small laptops
-// while using the extra room of large desktop displays.
-const double _kDialogWidthFraction = 0.75;
-const double _kDialogHeightFraction = 0.82;
+// The dialog fills most of the screen so the settings surface feels like a
+// full window while still leaving a small breathing margin on large displays.
+const double _kDialogWidthFraction = 0.92;
+const double _kDialogHeightFraction = 0.92;
 const double _kDialogMinWidth = 760;
-const double _kDialogMaxWidth = 1240;
+const double _kDialogMaxWidth = 1800;
 const double _kDialogMinHeight = 560;
-const double _kDialogMaxHeight = 920;
+const double _kDialogMaxHeight = 1280;
 
 class SettingsDialog extends ConsumerStatefulWidget {
   const SettingsDialog({super.key});


### PR DESCRIPTION
## Summary
- Bump the settings dialog to nearly fullscreen (92% width/height, raised max caps to 1800×1280) so it reads like a full window.
- Force `SystemMouseCursors.click` on each project list item in Settings → Projects so the hand cursor activates on hover.

## Validation
- `flutter analyze` on both edited files: no issues.