### PR TITLE
feat: render markdown in pull request comments

### DIFF
--- a/lib/src/features/pull_requests/presentation/pull_request_comment_markdown.dart
+++ b/lib/src/features/pull_requests/presentation/pull_request_comment_markdown.dart
@@ -1,0 +1,196 @@
+import 'dart:async';
+
+import 'package:alera/src/app/theme/alera_tokens.dart';
+import 'package:alera/src/design_system/icons/alera_icons.dart';
+import 'package:flutter/material.dart';
+import 'package:gpt_markdown/gpt_markdown.dart';
+
+class PullRequestCommentMarkdown extends StatelessWidget {
+  const PullRequestCommentMarkdown({
+    super.key,
+    required this.body,
+    required this.onOpenUrl,
+  });
+
+  final String body;
+  final Future<void> Function(String url) onOpenUrl;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final bodyStyle =
+        theme.textTheme.bodySmall?.copyWith(
+          color: AleraTokens.foreground,
+          height: 1.4,
+        ) ??
+        const TextStyle(color: AleraTokens.foreground, height: 1.4);
+    return SelectionArea(
+      child: GptMarkdownTheme(
+        gptThemeData: GptMarkdownThemeData(
+          brightness: Brightness.dark,
+          h1: theme.textTheme.titleMedium,
+          h2: theme.textTheme.titleSmall,
+          h3: theme.textTheme.labelLarge,
+          h4: theme.textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.w600),
+          h5: bodyStyle.copyWith(fontWeight: FontWeight.w600),
+          h6: bodyStyle.copyWith(
+            color: AleraTokens.foregroundMuted,
+            fontWeight: FontWeight.w600,
+          ),
+          hrLineColor: AleraTokens.borderSubtle,
+          hrLinePadding: const EdgeInsets.symmetric(
+            vertical: AleraTokens.space4,
+          ),
+          linkColor: AleraTokens.info,
+          linkHoverColor: AleraTokens.foreground,
+          highlightColor: AleraTokens.accentSubtle,
+          autoAddDividerLineAfterH1: false,
+        ),
+        child: DefaultTextStyle(
+          style: bodyStyle,
+          child: GptMarkdown(
+            body,
+            style: bodyStyle,
+            codeBuilder: _buildCodeBlock,
+            imageBuilder: buildPullRequestCommentImage,
+            onLinkTap: (url, _) {
+              if (isSupportedPullRequestCommentLinkUri(Uri.tryParse(url))) {
+                unawaited(onOpenUrl(url));
+              }
+            },
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildCodeBlock(
+    BuildContext context,
+    String language,
+    String code,
+    bool closed,
+  ) {
+    final theme = Theme.of(context);
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: AleraTokens.bg,
+        border: Border.all(color: AleraTokens.borderSubtle),
+        borderRadius: BorderRadius.circular(AleraTokens.radiusMd),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: <Widget>[
+          if (language.trim().isNotEmpty) ...<Widget>[
+            Padding(
+              padding: const EdgeInsets.symmetric(
+                horizontal: AleraTokens.space8,
+                vertical: AleraTokens.space6,
+              ),
+              child: Text(
+                language.trim(),
+                style: theme.textTheme.labelSmall?.copyWith(
+                  color: AleraTokens.foregroundMuted,
+                ),
+              ),
+            ),
+            const Divider(height: 1, color: AleraTokens.borderSubtle),
+          ],
+          SingleChildScrollView(
+            scrollDirection: Axis.horizontal,
+            padding: const EdgeInsets.all(AleraTokens.space8),
+            child: Text(
+              code,
+              style: AleraTokens.monoStyle.copyWith(
+                color: AleraTokens.foreground,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+bool isSupportedPullRequestCommentLinkUri(Uri? uri) {
+  if (uri == null || uri.host.trim().isEmpty) {
+    return false;
+  }
+  return switch (uri.scheme.toLowerCase()) {
+    'http' || 'https' => true,
+    _ => false,
+  };
+}
+
+bool isSupportedPullRequestCommentImageUri(Uri? uri) {
+  return uri != null &&
+      uri.scheme.toLowerCase() == 'https' &&
+      uri.host.trim().isNotEmpty;
+}
+
+Widget buildPullRequestCommentImage(
+  BuildContext context,
+  String imageUrl,
+  double? width,
+  double? height,
+) {
+  final safeWidth = _limitImageDimension(width, AleraTokens.imageMaxWidth);
+  final safeHeight = _limitImageDimension(height, AleraTokens.imageMaxHeight);
+  if (!isSupportedPullRequestCommentImageUri(Uri.tryParse(imageUrl))) {
+    return _PullRequestCommentImagePlaceholder(
+      width: safeWidth,
+      height: safeHeight,
+    );
+  }
+  return ConstrainedBox(
+    constraints: const BoxConstraints(
+      maxWidth: AleraTokens.imageMaxWidth,
+      maxHeight: AleraTokens.imageMaxHeight,
+    ),
+    child: ClipRRect(
+      borderRadius: BorderRadius.circular(AleraTokens.radiusMd),
+      child: Image.network(
+        imageUrl,
+        width: safeWidth,
+        height: safeHeight,
+        fit: BoxFit.contain,
+        errorBuilder: (_, _, _) => _PullRequestCommentImagePlaceholder(
+          width: safeWidth,
+          height: safeHeight,
+        ),
+      ),
+    ),
+  );
+}
+
+double? _limitImageDimension(double? value, double maximum) {
+  if (value == null || value <= 0) {
+    return null;
+  }
+  return value > maximum ? maximum : value;
+}
+
+class _PullRequestCommentImagePlaceholder extends StatelessWidget {
+  const _PullRequestCommentImagePlaceholder({this.width, this.height});
+
+  final double? width;
+  final double? height;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: width ?? AleraTokens.space48,
+      height: height ?? AleraTokens.space48,
+      alignment: Alignment.center,
+      decoration: BoxDecoration(
+        color: AleraTokens.surface,
+        border: Border.all(color: AleraTokens.borderSubtle),
+        borderRadius: BorderRadius.circular(AleraTokens.radiusMd),
+      ),
+      child: const Icon(
+        AleraIcons.imageError,
+        color: AleraTokens.foregroundMuted,
+        size: 20,
+      ),
+    );
+  }
+}

--- a/lib/src/features/pull_requests/presentation/pull_request_review_comments.dart
+++ b/lib/src/features/pull_requests/presentation/pull_request_review_comments.dart
@@ -228,11 +228,9 @@ class _ReviewCommentCard extends StatelessWidget {
               ),
             ],
             const SizedBox(height: AleraTokens.space8),
-            SelectableText(
-              comment.body,
-              style: theme.textTheme.bodySmall?.copyWith(
-                color: AleraTokens.foreground,
-              ),
+            PullRequestCommentMarkdown(
+              body: comment.body,
+              onOpenUrl: onOpenUrl,
             ),
           ],
         ),

--- a/lib/src/features/pull_requests/presentation/pull_request_review_view.dart
+++ b/lib/src/features/pull_requests/presentation/pull_request_review_view.dart
@@ -15,6 +15,7 @@ import 'package:alera/src/features/pull_requests/domain/review_merge_method.dart
 import 'package:alera/src/features/pull_requests/domain/update_review_input.dart';
 import 'package:alera/src/features/pull_requests/domain/update_review_result.dart';
 import 'package:alera/src/features/pull_requests/presentation/pull_request_check_list.dart';
+import 'package:alera/src/features/pull_requests/presentation/pull_request_comment_markdown.dart';
 import 'package:alera/src/features/pull_requests/presentation/pull_request_field_decoration.dart';
 import 'package:flutter/material.dart';
 

--- a/test/widget/pull_request_comment_markdown_test.dart
+++ b/test/widget/pull_request_comment_markdown_test.dart
@@ -1,0 +1,167 @@
+import 'package:alera/src/design_system/icons/alera_icons.dart';
+import 'package:alera/src/features/pull_requests/presentation/pull_request_comment_markdown.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('comment links only allow web URLs with hosts', () {
+    expect(
+      isSupportedPullRequestCommentLinkUri(
+        Uri.parse('https://example.com/docs'),
+      ),
+      isTrue,
+    );
+    expect(
+      isSupportedPullRequestCommentLinkUri(Uri.parse('http://example.com')),
+      isTrue,
+    );
+    expect(
+      isSupportedPullRequestCommentLinkUri(Uri.parse('file:///tmp/readme.md')),
+      isFalse,
+    );
+    expect(
+      isSupportedPullRequestCommentLinkUri(
+        Uri.parse('mailto:test@example.com'),
+      ),
+      isFalse,
+    );
+    expect(
+      isSupportedPullRequestCommentLinkUri(Uri.tryParse('docs/readme.md')),
+      isFalse,
+    );
+  });
+
+  test('comment images only allow HTTPS URLs with hosts', () {
+    expect(
+      isSupportedPullRequestCommentImageUri(
+        Uri.parse('https://example.com/diagram.png'),
+      ),
+      isTrue,
+    );
+    expect(
+      isSupportedPullRequestCommentImageUri(
+        Uri.parse('http://example.com/diagram.png'),
+      ),
+      isFalse,
+    );
+    expect(
+      isSupportedPullRequestCommentImageUri(
+        Uri.parse('file:///tmp/diagram.png'),
+      ),
+      isFalse,
+    );
+    expect(
+      isSupportedPullRequestCommentImageUri(
+        Uri.parse('data:image/png;base64,AA=='),
+      ),
+      isFalse,
+    );
+  });
+
+  testWidgets('renders formatted text, lists, and fenced code', (tester) async {
+    await tester.pumpWidget(
+      _surface('''
+**Important**
+
+- First item
+- Second item
+
+```dart
+final value = 1;
+```
+'''),
+    );
+
+    expect(find.byType(SelectionArea), findsOneWidget);
+    expect(find.textContaining('Important'), findsOneWidget);
+    expect(find.textContaining('**Important**'), findsNothing);
+    expect(find.textContaining('First item'), findsOneWidget);
+    expect(find.text('dart'), findsOneWidget);
+    expect(find.textContaining('final value = 1;'), findsOneWidget);
+  });
+
+  testWidgets('opens supported links and ignores unsupported links', (
+    tester,
+  ) async {
+    final opened = <String>[];
+    await tester.pumpWidget(
+      _surface(
+        '[Docs](https://example.com/docs)\n\n'
+        '[Local](file:///tmp/readme.md)',
+        onOpenUrl: (url) async => opened.add(url),
+      ),
+    );
+
+    await tester.tap(find.text('Docs'));
+    await tester.pump();
+    await tester.tap(find.text('Local'));
+    await tester.pump();
+
+    expect(opened, <String>['https://example.com/docs']);
+  });
+
+  testWidgets('loads HTTPS images and marks blocked or failed images', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Builder(
+            builder: (context) => Column(
+              children: <Widget>[
+                buildPullRequestCommentImage(
+                  context,
+                  'https://example.com/diagram.png',
+                  999,
+                  999,
+                ),
+                buildPullRequestCommentImage(
+                  context,
+                  'http://example.com/blocked.png',
+                  null,
+                  null,
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final imageFinder = find.byType(Image);
+    expect(imageFinder, findsOneWidget);
+    final image = tester.widget<Image>(imageFinder);
+    expect(image.image, isA<NetworkImage>());
+    expect(
+      (image.image as NetworkImage).url,
+      'https://example.com/diagram.png',
+    );
+    expect(image.width, 400);
+    expect(image.height, 300);
+    expect(find.byIcon(AleraIcons.imageError), findsOneWidget);
+
+    final errorWidget = image.errorBuilder!(
+      tester.element(imageFinder),
+      StateError('network failed'),
+      StackTrace.empty,
+    );
+    await tester.pumpWidget(MaterialApp(home: Scaffold(body: errorWidget)));
+
+    expect(find.byType(Image), findsNothing);
+    expect(find.byIcon(AleraIcons.imageError), findsOneWidget);
+  });
+}
+
+Widget _surface(String body, {Future<void> Function(String url)? onOpenUrl}) {
+  return MaterialApp(
+    home: Scaffold(
+      body: SizedBox(
+        width: 420,
+        child: PullRequestCommentMarkdown(
+          body: body,
+          onOpenUrl: onOpenUrl ?? (_) async {},
+        ),
+      ),
+    ),
+  );
+}

--- a/test/widget/pull_request_review_view_test.dart
+++ b/test/widget/pull_request_review_view_test.dart
@@ -8,6 +8,7 @@ import 'package:alera/src/features/pull_requests/domain/review_comment.dart';
 import 'package:alera/src/features/pull_requests/domain/review_merge_method.dart';
 import 'package:alera/src/features/pull_requests/domain/update_review_input.dart';
 import 'package:alera/src/features/pull_requests/domain/update_review_result.dart';
+import 'package:alera/src/features/pull_requests/presentation/pull_request_comment_markdown.dart';
 import 'package:alera/src/features/pull_requests/presentation/pull_request_review_view.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -378,6 +379,7 @@ void main() {
     );
 
     expect(find.text('Comments (2)'), findsOneWidget);
+    expect(find.byType(PullRequestCommentMarkdown), findsNWidgets(2));
     expect(find.text('General feedback'), findsOneWidget);
     expect(find.text('Please cover this branch'), findsOneWidget);
     expect(find.text('lib/src/example.dart:42'), findsOneWidget);


### PR DESCRIPTION
## Summary

- render published pull request comments as selectable Markdown
- restrict links to web URLs and remote images to HTTPS
- add compact code blocks, safe image fallbacks, and widget coverage

## Validation

- native asset preflight
- dart format --set-exit-if-changed lib test integration_test tool
- dart run tool/quality/check_max_lines.dart
- flutter analyze
- CI=true flutter test --coverage --exclude-tags golden
- dart run tool/quality/coverage_report.dart --input coverage/lcov.info --min-lines 100 --worst 25

## Notes

- the comment composer remains plain text without a preview
- no generated code or documentation changes are required