### PR TITLE
feat: use native app menus on linux and windows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,6 +148,7 @@ When planning is needed, use a spec-driven development flow. Do not jump straigh
 - Use `path` package utilities for filesystem paths.
 - Keep terminal, process, workspace, updater, and release code explicit about platform support.
 - UI shortcut labels must match the actual shortcut behavior for the current platform.
+- The application menu is native on every desktop platform: `PlatformMenuBar` on macOS, a GTK `GtkMenuBar` built in `linux/runner/my_application.cc`, and a Win32 `HMENU` built in `windows/runner/win32_app_menu.cpp`. The Linux/Windows runners forward menu activation to Dart over the `dev.leynier.alera/app_menu` method channel (see `lib/src/features/app_menu/infra/native_app_menu_channel.dart`); menu items must stay in sync across the three implementations. The native menus MUST NOT register keyboard accelerators, so keys like Ctrl+C keep flowing to text fields and the terminal-first shortcut policy.
 
 ## Flutter Performance
 

--- a/lib/src/features/app_menu/infra/native_app_menu_channel.dart
+++ b/lib/src/features/app_menu/infra/native_app_menu_channel.dart
@@ -1,0 +1,77 @@
+import 'dart:async';
+
+import 'package:alera/src/features/app_menu/presentation/app_menu_actions.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Channel the Linux (GTK) and Windows (Win32) runners use to forward native
+/// application-menu activation into Dart. macOS does not use it: the
+/// PlatformMenuBar callbacks already run in Dart.
+const String nativeAppMenuChannelName = 'dev.leynier.alera/app_menu';
+
+const MethodChannel nativeAppMenuChannel = MethodChannel(
+  nativeAppMenuChannelName,
+);
+
+/// Method names invoked by the native runners. Keep in sync with
+/// linux/runner/my_application.cc and windows/runner/win32_app_menu.cpp.
+abstract final class NativeAppMenuMethod {
+  static const String openSettings = 'openSettings';
+  static const String checkForUpdates = 'checkForUpdates';
+  static const String showAbout = 'showAbout';
+  static const String exitApp = 'exitApp';
+  static const String undo = 'undo';
+  static const String redo = 'redo';
+  static const String cut = 'cut';
+  static const String copy = 'copy';
+  static const String paste = 'paste';
+  static const String selectAll = 'selectAll';
+}
+
+/// Dispatches a native menu activation to the shared app-menu actions.
+Future<Object?> handleNativeAppMenuCall(
+  MethodCall call, {
+  required BuildContext context,
+  required WidgetRef ref,
+}) async {
+  switch (call.method) {
+    case NativeAppMenuMethod.openSettings:
+      if (context.mounted) {
+        unawaited(openAppMenuSettings(context));
+      }
+    case NativeAppMenuMethod.checkForUpdates:
+      if (context.mounted) {
+        unawaited(checkForUpdatesFromAppMenu(context, ref));
+      }
+    case NativeAppMenuMethod.showAbout:
+      if (context.mounted) {
+        unawaited(showAppMenuAbout(context));
+      }
+    case NativeAppMenuMethod.exitApp:
+      unawaited(exitAppFromMenu(ref));
+    case NativeAppMenuMethod.undo:
+      invokeFocusedTextIntent(
+        const UndoTextIntent(SelectionChangedCause.keyboard),
+      );
+    case NativeAppMenuMethod.redo:
+      invokeFocusedTextIntent(
+        const RedoTextIntent(SelectionChangedCause.keyboard),
+      );
+    case NativeAppMenuMethod.cut:
+      invokeFocusedTextIntent(
+        const CopySelectionTextIntent.cut(SelectionChangedCause.keyboard),
+      );
+    case NativeAppMenuMethod.copy:
+      invokeFocusedTextIntent(CopySelectionTextIntent.copy);
+    case NativeAppMenuMethod.paste:
+      invokeFocusedTextIntent(
+        const PasteTextIntent(SelectionChangedCause.keyboard),
+      );
+    case NativeAppMenuMethod.selectAll:
+      invokeFocusedTextIntent(
+        const SelectAllTextIntent(SelectionChangedCause.keyboard),
+      );
+  }
+  return null;
+}

--- a/lib/src/features/app_menu/presentation/alera_app_menu_scope.dart
+++ b/lib/src/features/app_menu/presentation/alera_app_menu_scope.dart
@@ -1,8 +1,8 @@
 import 'dart:async';
 
 import 'package:alera/src/app/providers.dart';
-import 'package:alera/src/app/theme/alera_tokens.dart';
 import 'package:alera/src/core/build_flavor.dart';
+import 'package:alera/src/features/app_menu/infra/native_app_menu_channel.dart';
 import 'package:alera/src/features/app_menu/presentation/app_menu_actions.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -12,8 +12,9 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 /// Installs the desktop application menu.
 ///
 /// - **macOS:** [PlatformMenuBar] (system menu bar; replaces MainMenu.xib).
-/// - **Windows / Linux:** Material [MenuBar] at the top of the window (Flutter
-///   engine does not implement native platform menus on these platforms).
+/// - **Windows / Linux:** the runners install a native menu (Win32 `HMENU`,
+///   GTK `GtkMenuBar`) and forward activation over [nativeAppMenuChannel];
+///   this scope only registers the Dart-side handler.
 class AleraAppMenuScope extends ConsumerWidget {
   const AleraAppMenuScope({super.key, required this.child});
 
@@ -27,10 +28,43 @@ class AleraAppMenuScope extends ConsumerWidget {
     return switch (defaultTargetPlatform) {
       TargetPlatform.macOS => _MacOsPlatformMenuBar(child: child),
       TargetPlatform.windows ||
-      TargetPlatform.linux => _DesktopMaterialMenuBar(child: child),
+      TargetPlatform.linux => _NativeAppMenuBridge(child: child),
       _ => child,
     };
   }
+}
+
+/// Linux/Windows install their menu in the native runner; this widget only
+/// wires the channel that receives native menu activation.
+class _NativeAppMenuBridge extends ConsumerStatefulWidget {
+  const _NativeAppMenuBridge({required this.child});
+
+  final Widget child;
+
+  @override
+  ConsumerState<_NativeAppMenuBridge> createState() =>
+      _NativeAppMenuBridgeState();
+}
+
+class _NativeAppMenuBridgeState extends ConsumerState<_NativeAppMenuBridge> {
+  @override
+  void initState() {
+    super.initState();
+    nativeAppMenuChannel.setMethodCallHandler(_handleMenuCall);
+  }
+
+  @override
+  void dispose() {
+    nativeAppMenuChannel.setMethodCallHandler(null);
+    super.dispose();
+  }
+
+  Future<Object?> _handleMenuCall(MethodCall call) {
+    return handleNativeAppMenuCall(call, context: context, ref: ref);
+  }
+
+  @override
+  Widget build(BuildContext context) => widget.child;
 }
 
 class _MacOsPlatformMenuBar extends ConsumerWidget {
@@ -236,86 +270,3 @@ class _MacOsPlatformMenuBar extends ConsumerWidget {
   }
 }
 
-class _DesktopMaterialMenuBar extends ConsumerWidget {
-  const _DesktopMaterialMenuBar({required this.child});
-
-  final Widget child;
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final theme = Theme.of(context);
-    // Rebuild when openSettings binding changes so the display shortcut stays
-    // aligned with KeyboardShortcutsScope.
-    ref.watch(settingsControllerProvider.select((s) => s.keyboard));
-    final settingsShortcut = settingsMenuShortcut(ref);
-
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: <Widget>[
-        Material(
-          color: AleraTokens.surface,
-          child: DecoratedBox(
-            decoration: const BoxDecoration(
-              border: Border(
-                bottom: BorderSide(color: AleraTokens.borderSubtle),
-              ),
-            ),
-            child: MenuBar(
-              style: MenuStyle(
-                backgroundColor: const WidgetStatePropertyAll<Color>(
-                  AleraTokens.surface,
-                ),
-                elevation: const WidgetStatePropertyAll<double>(0),
-                shape: const WidgetStatePropertyAll<OutlinedBorder>(
-                  RoundedRectangleBorder(),
-                ),
-                padding: const WidgetStatePropertyAll<EdgeInsetsGeometry>(
-                  EdgeInsets.symmetric(horizontal: AleraTokens.space4),
-                ),
-              ),
-              children: <Widget>[
-                SubmenuButton(
-                  menuChildren: <Widget>[
-                    MenuItemButton(
-                      onPressed: () {
-                        unawaited(openAppMenuSettings(context));
-                      },
-                      shortcut: settingsShortcut,
-                      child: const Text('Settings ...'),
-                    ),
-                    MenuItemButton(
-                      onPressed: () {
-                        unawaited(checkForUpdatesFromAppMenu(context, ref));
-                      },
-                      child: const Text('Check for Updates ...'),
-                    ),
-                    const Divider(),
-                    MenuItemButton(
-                      onPressed: () {
-                        unawaited(showAppMenuAbout(context));
-                      },
-                      child: Text('About $kAleraAppName'),
-                    ),
-                    MenuItemButton(
-                      onPressed: () {
-                        unawaited(exitAppFromMenu(ref));
-                      },
-                      child: const Text('Exit'),
-                    ),
-                  ],
-                  child: Text(
-                    kAleraAppName,
-                    style: theme.textTheme.labelLarge?.copyWith(
-                      color: AleraTokens.foreground,
-                    ),
-                  ),
-                ),
-              ],
-            ),
-          ),
-        ),
-        Expanded(child: child),
-      ],
-    );
-  }
-}

--- a/lib/src/features/app_menu/presentation/alera_app_menu_scope.dart
+++ b/lib/src/features/app_menu/presentation/alera_app_menu_scope.dart
@@ -269,4 +269,3 @@ class _MacOsPlatformMenuBar extends ConsumerWidget {
     );
   }
 }
-

--- a/lib/src/features/app_menu/presentation/app_menu_actions.dart
+++ b/lib/src/features/app_menu/presentation/app_menu_actions.dart
@@ -4,17 +4,13 @@ import 'package:alera/src/core/build_flavor.dart';
 import 'package:alera/src/design_system/feedback/alera_toast.dart';
 import 'package:alera/src/design_system/layout/alera_dialog.dart';
 import 'package:alera/src/features/app_window/application/app_window_providers.dart';
-import 'package:alera/src/features/keyboard/application/keybinding_resolver.dart';
-import 'package:alera/src/features/keyboard/domain/key_chord.dart';
-import 'package:alera/src/features/keyboard/domain/keyboard_action.dart';
 import 'package:alera/src/features/updater/domain/alera_update.dart';
 import 'package:alera/src/features/workbench/presentation/workbench_dialog_launchers.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 
-/// Shared actions for the desktop application menu (native on macOS,
-/// Material menu bar on Windows/Linux).
+/// Shared actions for the desktop application menu (native on all platforms).
 
 typedef AppMenuPackageInfoLoader = Future<PackageInfo> Function();
 
@@ -90,35 +86,6 @@ Future<void> showAppMenuAbout(
 /// Closes through the app-window lifecycle (flush state, then destroy).
 Future<void> exitAppFromMenu(WidgetRef ref) {
   return ref.read(appWindowControllerProvider).close();
-}
-
-/// Display-only menu shortcut for Settings, from the effective openSettings
-/// binding. Returns null when the action is disabled or has no binding.
-MenuSerializableShortcut? settingsMenuShortcut(WidgetRef ref) {
-  final keyboard = ref.read(settingsControllerProvider).keyboard;
-  final resolver = KeybindingResolver(settings: keyboard);
-  final chords = resolver.effectiveChords(KeyboardActionId.openSettings);
-  if (chords.isEmpty) {
-    return null;
-  }
-  return keyChordToMenuShortcut(
-    chords.first,
-    isMacOS: resolver.platform.isMacOS,
-  );
-}
-
-/// Converts a [KeyChord] into a [SingleActivator] for menu display.
-MenuSerializableShortcut keyChordToMenuShortcut(
-  KeyChord chord, {
-  required bool isMacOS,
-}) {
-  return SingleActivator(
-    chord.trigger,
-    control: chord.control || (!isMacOS && chord.useMod),
-    meta: chord.meta || (isMacOS && chord.useMod),
-    alt: chord.alt,
-    shift: chord.shift,
-  );
 }
 
 /// Invokes a text-editing intent on the primary focus, if any action handles it.

--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -8,9 +8,11 @@ project(runner LANGUAGES CXX)
 # https://wiki.gnome.org/HowDoI/ChooseApplicationID
 set(BINARY_NAME "alera-dev")
 set(APPLICATION_ID "dev.leynier.alera.dev")
+set(ALERA_APP_NAME "Alera Dev")
 if("$ENV{ALERA_FLAVOR}" STREQUAL "release")
   set(BINARY_NAME "alera")
   set(APPLICATION_ID "dev.leynier.alera")
+  set(ALERA_APP_NAME "Alera")
 endif()
 
 # Explicitly opt in to modern CMake behaviors to avoid warnings with recent

--- a/linux/runner/CMakeLists.txt
+++ b/linux/runner/CMakeLists.txt
@@ -16,8 +16,9 @@ add_executable(${BINARY_NAME}
 # that need different build settings.
 apply_standard_settings(${BINARY_NAME})
 
-# Add preprocessor definitions for the application ID.
+# Add preprocessor definitions for the application ID and display name.
 add_definitions(-DAPPLICATION_ID="${APPLICATION_ID}")
+target_compile_definitions(${BINARY_NAME} PRIVATE ALERA_APP_NAME="${ALERA_APP_NAME}")
 
 # Add dependency libraries. Add any application-specific dependencies here.
 target_link_libraries(${BINARY_NAME} PRIVATE flutter)

--- a/linux/runner/my_application.cc
+++ b/linux/runner/my_application.cc
@@ -14,6 +14,7 @@ struct _MyApplication {
   GtkApplication parent_instance;
   char** dart_entrypoint_arguments;
   FlMethodChannel* clipboard_channel;
+  FlMethodChannel* app_menu_channel;
 };
 
 G_DEFINE_TYPE(MyApplication, my_application, GTK_TYPE_APPLICATION)
@@ -27,6 +28,76 @@ constexpr char kClipboardImageSuffix[] = ".png";
 constexpr gint64 kClipboardImageMaxPixels = 32LL * 1024LL * 1024LL;
 constexpr goffset kClipboardImageMaxPngBytes = 18LL * 1024LL * 1024LL;
 constexpr time_t kClipboardImageMaxAgeSeconds = 24 * 60 * 60;
+
+constexpr char kAppMenuChannel[] = "dev.leynier.alera/app_menu";
+
+// Forwards native GTK menu activation to Dart over the app-menu channel. The
+// action name doubles as the channel method name (see NativeAppMenuMethod in
+// lib/src/features/app_menu/infra/native_app_menu_channel.dart).
+void app_menu_action_cb(GSimpleAction* action, GVariant*,
+                        gpointer user_data) {
+  auto* self = MY_APPLICATION(user_data);
+  if (self->app_menu_channel == nullptr) {
+    return;
+  }
+  fl_method_channel_invoke_method(self->app_menu_channel,
+                                  g_action_get_name(G_ACTION(action)), nullptr,
+                                  nullptr, nullptr, nullptr);
+}
+
+const GActionEntry kAppMenuActionEntries[] = {
+    {"openSettings", app_menu_action_cb, nullptr, nullptr, nullptr},
+    {"checkForUpdates", app_menu_action_cb, nullptr, nullptr, nullptr},
+    {"showAbout", app_menu_action_cb, nullptr, nullptr, nullptr},
+    {"exitApp", app_menu_action_cb, nullptr, nullptr, nullptr},
+    {"undo", app_menu_action_cb, nullptr, nullptr, nullptr},
+    {"redo", app_menu_action_cb, nullptr, nullptr, nullptr},
+    {"cut", app_menu_action_cb, nullptr, nullptr, nullptr},
+    {"copy", app_menu_action_cb, nullptr, nullptr, nullptr},
+    {"paste", app_menu_action_cb, nullptr, nullptr, nullptr},
+    {"selectAll", app_menu_action_cb, nullptr, nullptr, nullptr},
+};
+
+// Builds the classic GTK menu bar shown above the Flutter view. No keyboard
+// accelerators are registered: global accelerators would swallow keys like
+// Ctrl+C before text fields and the terminal-first shortcut policy see them.
+GtkWidget* build_app_menu_bar() {
+  g_autoptr(GMenu) app_actions_section = g_menu_new();
+  g_menu_append(app_actions_section, "Settings ...", "app.openSettings");
+  g_menu_append(app_actions_section, "Check for Updates ...",
+                "app.checkForUpdates");
+  g_autoptr(GMenu) app_about_section = g_menu_new();
+  g_autofree gchar* about_label =
+      g_strdup_printf("About %s", ALERA_APP_NAME);
+  g_menu_append(app_about_section, about_label, "app.showAbout");
+  g_autoptr(GMenu) app_exit_section = g_menu_new();
+  g_menu_append(app_exit_section, "Exit", "app.exitApp");
+  g_autoptr(GMenu) app_submenu = g_menu_new();
+  g_menu_append_section(app_submenu, nullptr,
+                        G_MENU_MODEL(app_actions_section));
+  g_menu_append_section(app_submenu, nullptr, G_MENU_MODEL(app_about_section));
+  g_menu_append_section(app_submenu, nullptr, G_MENU_MODEL(app_exit_section));
+
+  g_autoptr(GMenu) edit_history_section = g_menu_new();
+  g_menu_append(edit_history_section, "Undo", "app.undo");
+  g_menu_append(edit_history_section, "Redo", "app.redo");
+  g_autoptr(GMenu) edit_clipboard_section = g_menu_new();
+  g_menu_append(edit_clipboard_section, "Cut", "app.cut");
+  g_menu_append(edit_clipboard_section, "Copy", "app.copy");
+  g_menu_append(edit_clipboard_section, "Paste", "app.paste");
+  g_menu_append(edit_clipboard_section, "Select All", "app.selectAll");
+  g_autoptr(GMenu) edit_submenu = g_menu_new();
+  g_menu_append_section(edit_submenu, nullptr,
+                        G_MENU_MODEL(edit_history_section));
+  g_menu_append_section(edit_submenu, nullptr,
+                        G_MENU_MODEL(edit_clipboard_section));
+
+  g_autoptr(GMenu) menu_model = g_menu_new();
+  g_menu_append_submenu(menu_model, ALERA_APP_NAME, G_MENU_MODEL(app_submenu));
+  g_menu_append_submenu(menu_model, "Edit", G_MENU_MODEL(edit_submenu));
+
+  return gtk_menu_bar_new_from_model(G_MENU_MODEL(menu_model));
+}
 
 struct ClipboardImageRequest {
   FlMethodCall* method_call;
@@ -217,14 +288,30 @@ static void my_application_activate(GApplication* application) {
   if (use_header_bar) {
     GtkHeaderBar* header_bar = GTK_HEADER_BAR(gtk_header_bar_new());
     gtk_widget_show(GTK_WIDGET(header_bar));
-    gtk_header_bar_set_title(header_bar, "Alera");
+    gtk_header_bar_set_title(header_bar, ALERA_APP_NAME);
     gtk_header_bar_set_show_close_button(header_bar, TRUE);
     gtk_window_set_titlebar(window, GTK_WIDGET(header_bar));
   } else {
-    gtk_window_set_title(window, "Alera");
+    gtk_window_set_title(window, ALERA_APP_NAME);
   }
 
   gtk_window_set_default_size(window, 1280, 720);
+
+  // The app is dark-only; keep native GTK menus on the dark system theme too.
+  g_object_set(gtk_settings_get_default(), "gtk-application-prefer-dark-theme",
+               TRUE, nullptr);
+
+  g_action_map_add_action_entries(G_ACTION_MAP(application),
+                                  kAppMenuActionEntries,
+                                  G_N_ELEMENTS(kAppMenuActionEntries), self);
+
+  GtkWidget* box = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
+  gtk_widget_show(box);
+  gtk_container_add(GTK_CONTAINER(window), box);
+
+  GtkWidget* menu_bar = build_app_menu_bar();
+  gtk_widget_show(menu_bar);
+  gtk_box_pack_start(GTK_BOX(box), menu_bar, FALSE, FALSE, 0);
 
   g_autoptr(FlDartProject) project = fl_dart_project_new();
   fl_dart_project_set_dart_entrypoint_arguments(
@@ -237,7 +324,7 @@ static void my_application_activate(GApplication* application) {
   gdk_rgba_parse(&background_color, "#000000");
   fl_view_set_background_color(view, &background_color);
   gtk_widget_show(GTK_WIDGET(view));
-  gtk_container_add(GTK_CONTAINER(window), GTK_WIDGET(view));
+  gtk_box_pack_start(GTK_BOX(box), GTK_WIDGET(view), TRUE, TRUE, 0);
 
   // Show the window when Flutter renders.
   // Requires the view to be realized so we can start rendering.
@@ -253,6 +340,12 @@ static void my_application_activate(GApplication* application) {
       FL_METHOD_CODEC(clipboard_codec));
   fl_method_channel_set_method_call_handler(
       self->clipboard_channel, clipboard_channel_method_cb, self, nullptr);
+
+  g_autoptr(FlStandardMethodCodec) app_menu_codec =
+      fl_standard_method_codec_new();
+  self->app_menu_channel = fl_method_channel_new(
+      fl_engine_get_binary_messenger(engine), kAppMenuChannel,
+      FL_METHOD_CODEC(app_menu_codec));
 
   fl_register_plugins(FL_PLUGIN_REGISTRY(view));
 
@@ -303,6 +396,7 @@ static void my_application_dispose(GObject* object) {
   MyApplication* self = MY_APPLICATION(object);
   g_clear_pointer(&self->dart_entrypoint_arguments, g_strfreev);
   g_clear_object(&self->clipboard_channel);
+  g_clear_object(&self->app_menu_channel);
   G_OBJECT_CLASS(my_application_parent_class)->dispose(object);
 }
 

--- a/test/widget/app_menu_test.dart
+++ b/test/widget/app_menu_test.dart
@@ -4,6 +4,7 @@ import 'package:alera/src/app/providers.dart';
 import 'package:alera/src/app/theme/alera_dark_theme.dart';
 import 'package:alera/src/core/build_flavor.dart';
 import 'package:alera/src/design_system/feedback/alera_toast.dart';
+import 'package:alera/src/features/app_menu/infra/native_app_menu_channel.dart';
 import 'package:alera/src/features/app_menu/presentation/alera_app_menu_scope.dart';
 import 'package:alera/src/features/app_menu/presentation/app_menu_actions.dart';
 import 'package:alera/src/features/app_window/application/app_window_controller.dart';
@@ -12,6 +13,7 @@ import 'package:alera/src/features/settings/domain/alera_settings.dart';
 import 'package:alera/src/features/updater/domain/alera_update.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:package_info_plus/package_info_plus.dart';
@@ -97,37 +99,128 @@ void main() {
   });
 
   group('AleraAppMenuScope', () {
-    testWidgets('shows Material menu bar items on Linux', (tester) async {
-      await _withPlatform(TargetPlatform.linux, () async {
-        await _pumpMenuScope(tester);
+    for (final platform in <TargetPlatform>[
+      TargetPlatform.linux,
+      TargetPlatform.windows,
+    ]) {
+      group('on $platform (native runner menu)', () {
+        testWidgets('renders no in-window menu bar', (tester) async {
+          await _withPlatform(platform, () async {
+            await _pumpMenuScope(tester);
 
-        expect(find.byType(MenuBar), findsOneWidget);
-        expect(find.text(kAleraAppName), findsOneWidget);
+            expect(find.byType(MenuBar), findsNothing);
+            expect(find.byType(PlatformMenuBar), findsNothing);
+          });
+        });
 
-        await tester.tap(find.text(kAleraAppName));
-        await tester.pumpAndSettle();
-        expect(find.text('Settings ...'), findsOneWidget);
-        expect(find.text('Check for Updates ...'), findsOneWidget);
-        expect(find.text('About $kAleraAppName'), findsOneWidget);
-        expect(find.text('Exit'), findsOneWidget);
+        testWidgets('native channel opens the settings dialog', (tester) async {
+          await _withPlatform(platform, () async {
+            await _pumpMenuScope(tester);
+
+            await _invokeNativeMenuMethod(
+              tester,
+              NativeAppMenuMethod.openSettings,
+            );
+            await tester.pump();
+            await tester.pump(const Duration(milliseconds: 300));
+
+            expect(find.text('Application'), findsWidgets);
+          });
+        });
+
+        testWidgets('native channel runs the update check', (tester) async {
+          await _withPlatform(platform, () async {
+            final updateController = _FakeUpdateController(
+              AleraUpdateState(status: AleraUpdateStatus.idle, config: _config()),
+            );
+            final toastMessages = <String>[];
+            final sub = AleraToast.stream.listen((data) {
+              toastMessages.add(data.message);
+            });
+            addTearDown(sub.cancel);
+
+            await _pumpMenuScope(tester, updateController: updateController);
+
+            await _invokeNativeMenuMethod(
+              tester,
+              NativeAppMenuMethod.checkForUpdates,
+            );
+            await tester.pump();
+            await tester.pump();
+
+            expect(updateController.checkForUpdatesCalls, 1);
+            expect(toastMessages, <String>['Alera is up to date.']);
+          });
+        });
+
+        testWidgets('native channel shows the about dialog', (tester) async {
+          await _withPlatform(platform, () async {
+            _mockPackageInfo(tester);
+
+            await _pumpMenuScope(tester);
+
+            await _invokeNativeMenuMethod(tester, NativeAppMenuMethod.showAbout);
+            await tester.pumpAndSettle();
+
+            expect(find.text(kAleraAppName), findsWidgets);
+            expect(find.text('Version 1.2.3 (45)'), findsOneWidget);
+          });
+        });
+
+        testWidgets('native channel closes the app window', (tester) async {
+          await _withPlatform(platform, () async {
+            final window = _FakeAppWindowController();
+            await _pumpMenuScope(tester, window: window);
+
+            await _invokeNativeMenuMethod(tester, NativeAppMenuMethod.exitApp);
+            await tester.pump();
+
+            expect(window.closeCalls, 1);
+          });
+        });
+
+        testWidgets('native channel edit methods act on the focused text field', (
+          tester,
+        ) async {
+          await _withPlatform(platform, () async {
+            final controller = TextEditingController();
+            addTearDown(controller.dispose);
+            _mockClipboard();
+            await _pumpMenuScope(
+              tester,
+              child: Scaffold(
+                body: Center(child: TextField(controller: controller)),
+              ),
+            );
+
+            await tester.tap(find.byType(TextField));
+            await tester.pump();
+            await tester.enterText(find.byType(TextField), 'hello');
+            await tester.pump();
+
+            await _invokeNativeMenuMethod(
+              tester,
+              NativeAppMenuMethod.selectAll,
+            );
+            await tester.pump();
+            expect(
+              controller.selection,
+              const TextSelection(baseOffset: 0, extentOffset: 5),
+            );
+
+            await _invokeNativeMenuMethod(tester, NativeAppMenuMethod.cut);
+            await tester.pump();
+            expect(controller.text, isEmpty);
+            final clipboard = await Clipboard.getData(Clipboard.kTextPlain);
+            expect(clipboard?.text, 'hello');
+
+            await _invokeNativeMenuMethod(tester, NativeAppMenuMethod.paste);
+            await tester.pump();
+            expect(controller.text, 'hello');
+          });
+        });
       });
-    });
-
-    testWidgets('shows Material menu bar items on Windows', (tester) async {
-      await _withPlatform(TargetPlatform.windows, () async {
-        await _pumpMenuScope(tester);
-
-        expect(find.byType(MenuBar), findsOneWidget);
-        expect(find.text('Check for Updates ...'), findsNothing);
-
-        await tester.tap(find.text(kAleraAppName));
-        await tester.pumpAndSettle();
-        expect(find.text('Settings ...'), findsOneWidget);
-        expect(find.text('Check for Updates ...'), findsOneWidget);
-        expect(find.text('About $kAleraAppName'), findsOneWidget);
-        expect(find.text('Exit'), findsOneWidget);
-      });
-    });
+    }
 
     testWidgets('uses PlatformMenuBar on macOS without in-window MenuBar', (
       tester,
@@ -200,17 +293,27 @@ Future<void> _pumpActionHarness(
   );
 }
 
-Future<void> _pumpMenuScope(WidgetTester tester) async {
+Future<void> _pumpMenuScope(
+  WidgetTester tester, {
+  _FakeUpdateController? updateController,
+  _FakeAppWindowController? window,
+  Widget? child,
+}) async {
   await tester.pumpWidget(
     ProviderScope(
       overrides: [
         aleraUpdateControllerProvider.overrideWith(
-          () => _FakeUpdateController(
-            AleraUpdateState(status: AleraUpdateStatus.idle, config: _config()),
-          ),
+          () =>
+              updateController ??
+              _FakeUpdateController(
+                AleraUpdateState(
+                  status: AleraUpdateStatus.idle,
+                  config: _config(),
+                ),
+              ),
         ),
         appWindowControllerProvider.overrideWithValue(
-          _FakeAppWindowController(),
+          window ?? _FakeAppWindowController(),
         ),
         settingsControllerProvider.overrideWith(
           () => _FakeSettingsController(AleraSettings.defaults),
@@ -218,11 +321,63 @@ Future<void> _pumpMenuScope(WidgetTester tester) async {
       ],
       child: MaterialApp(
         theme: buildAleraDarkTheme(),
-        home: const AleraAppMenuScope(child: Scaffold(body: SizedBox.expand())),
+        home: AleraAppMenuScope(
+          child: child ?? const Scaffold(body: SizedBox.expand()),
+        ),
       ),
     ),
   );
   await tester.pump();
+}
+
+/// Simulates a native (GTK/Win32) menu activation arriving over the app-menu
+/// channel.
+Future<void> _invokeNativeMenuMethod(WidgetTester tester, String method) async {
+  await TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      .handlePlatformMessage(
+        nativeAppMenuChannelName,
+        const StandardMethodCodec().encodeMethodCall(MethodCall(method)),
+        (_) {},
+      );
+}
+
+void _mockPackageInfo(WidgetTester tester) {
+  const channel = MethodChannel('dev.fluttercommunity.plus/package_info');
+  TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      .setMockMethodCallHandler(channel, (call) async {
+        return <String, String>{
+          'appName': kAleraAppName,
+          'packageName': 'dev.leynier.alera',
+          'version': '1.2.3',
+          'buildNumber': '45',
+        };
+      });
+  addTearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, null);
+  });
+}
+
+/// The test binding does not answer clipboard platform messages, so the edit
+/// menu intents would hang without an in-memory mock.
+void _mockClipboard() {
+  String? clipboardText;
+  final messenger =
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+  messenger.setMockMethodCallHandler(SystemChannels.platform, (call) async {
+    switch (call.method) {
+      case 'Clipboard.getData':
+        final text = clipboardText;
+        return text == null ? null : <String, dynamic>{'text': text};
+      case 'Clipboard.setData':
+        clipboardText =
+            (call.arguments as Map<Object?, Object?>)['text'] as String?;
+    }
+    return null;
+  });
+  addTearDown(() {
+    messenger.setMockMethodCallHandler(SystemChannels.platform, null);
+  });
 }
 
 AleraUpdateConfig _config() {

--- a/test/widget/app_menu_test.dart
+++ b/test/widget/app_menu_test.dart
@@ -131,7 +131,10 @@ void main() {
         testWidgets('native channel runs the update check', (tester) async {
           await _withPlatform(platform, () async {
             final updateController = _FakeUpdateController(
-              AleraUpdateState(status: AleraUpdateStatus.idle, config: _config()),
+              AleraUpdateState(
+                status: AleraUpdateStatus.idle,
+                config: _config(),
+              ),
             );
             final toastMessages = <String>[];
             final sub = AleraToast.stream.listen((data) {
@@ -159,7 +162,10 @@ void main() {
 
             await _pumpMenuScope(tester);
 
-            await _invokeNativeMenuMethod(tester, NativeAppMenuMethod.showAbout);
+            await _invokeNativeMenuMethod(
+              tester,
+              NativeAppMenuMethod.showAbout,
+            );
             await tester.pumpAndSettle();
 
             expect(find.text(kAleraAppName), findsWidgets);
@@ -179,46 +185,47 @@ void main() {
           });
         });
 
-        testWidgets('native channel edit methods act on the focused text field', (
-          tester,
-        ) async {
-          await _withPlatform(platform, () async {
-            final controller = TextEditingController();
-            addTearDown(controller.dispose);
-            _mockClipboard();
-            await _pumpMenuScope(
-              tester,
-              child: Scaffold(
-                body: Center(child: TextField(controller: controller)),
-              ),
-            );
+        testWidgets(
+          'native channel edit methods act on the focused text field',
+          (tester) async {
+            await _withPlatform(platform, () async {
+              final controller = TextEditingController();
+              addTearDown(controller.dispose);
+              _mockClipboard();
+              await _pumpMenuScope(
+                tester,
+                child: Scaffold(
+                  body: Center(child: TextField(controller: controller)),
+                ),
+              );
 
-            await tester.tap(find.byType(TextField));
-            await tester.pump();
-            await tester.enterText(find.byType(TextField), 'hello');
-            await tester.pump();
+              await tester.tap(find.byType(TextField));
+              await tester.pump();
+              await tester.enterText(find.byType(TextField), 'hello');
+              await tester.pump();
 
-            await _invokeNativeMenuMethod(
-              tester,
-              NativeAppMenuMethod.selectAll,
-            );
-            await tester.pump();
-            expect(
-              controller.selection,
-              const TextSelection(baseOffset: 0, extentOffset: 5),
-            );
+              await _invokeNativeMenuMethod(
+                tester,
+                NativeAppMenuMethod.selectAll,
+              );
+              await tester.pump();
+              expect(
+                controller.selection,
+                const TextSelection(baseOffset: 0, extentOffset: 5),
+              );
 
-            await _invokeNativeMenuMethod(tester, NativeAppMenuMethod.cut);
-            await tester.pump();
-            expect(controller.text, isEmpty);
-            final clipboard = await Clipboard.getData(Clipboard.kTextPlain);
-            expect(clipboard?.text, 'hello');
+              await _invokeNativeMenuMethod(tester, NativeAppMenuMethod.cut);
+              await tester.pump();
+              expect(controller.text, isEmpty);
+              final clipboard = await Clipboard.getData(Clipboard.kTextPlain);
+              expect(clipboard?.text, 'hello');
 
-            await _invokeNativeMenuMethod(tester, NativeAppMenuMethod.paste);
-            await tester.pump();
-            expect(controller.text, 'hello');
-          });
-        });
+              await _invokeNativeMenuMethod(tester, NativeAppMenuMethod.paste);
+              await tester.pump();
+              expect(controller.text, 'hello');
+            });
+          },
+        );
       });
     }
 

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -5,8 +5,10 @@ project(alera LANGUAGES CXX)
 # The on-disk name of the executable. Driven by ALERA_FLAVOR so that a dev
 # build coexists with an installed release build.
 set(BINARY_NAME "alera-dev")
+set(ALERA_APP_NAME "Alera Dev")
 if("$ENV{ALERA_FLAVOR}" STREQUAL "release")
   set(BINARY_NAME "Alera")
+  set(ALERA_APP_NAME "Alera")
 endif()
 
 # Explicitly opt in to modern CMake behaviors to avoid warnings with recent

--- a/windows/runner/CMakeLists.txt
+++ b/windows/runner/CMakeLists.txt
@@ -10,6 +10,7 @@ add_executable(${BINARY_NAME} WIN32
   "flutter_window.cpp"
   "main.cpp"
   "utils.cpp"
+  "win32_app_menu.cpp"
   "win32_window.cpp"
   "${FLUTTER_MANAGED_DIR}/generated_plugin_registrant.cc"
   "Runner.rc"
@@ -29,6 +30,9 @@ target_compile_definitions(${BINARY_NAME} PRIVATE "FLUTTER_VERSION_BUILD=${FLUTT
 
 # Disable Windows macros that collide with C++ standard library functions.
 target_compile_definitions(${BINARY_NAME} PRIVATE "NOMINMAX")
+
+# Flavor-aware display name (wide literal) for the window title and app menu.
+target_compile_definitions(${BINARY_NAME} PRIVATE ALERA_APP_NAME=L"${ALERA_APP_NAME}")
 
 # Add dependency libraries and include directories. Add any application-specific
 # dependencies here.

--- a/windows/runner/flutter_window.cpp
+++ b/windows/runner/flutter_window.cpp
@@ -2,7 +2,10 @@
 
 #include <optional>
 
+#include <flutter/standard_method_codec.h>
+
 #include "flutter/generated_plugin_registrant.h"
+#include "win32_app_menu.h"
 
 FlutterWindow::FlutterWindow(const flutter::DartProject& project)
     : project_(project) {}
@@ -12,6 +15,12 @@ FlutterWindow::~FlutterWindow() {}
 bool FlutterWindow::OnCreate() {
   if (!Win32Window::OnCreate()) {
     return false;
+  }
+
+  // Attach the native menu before sizing the Flutter view so the initial
+  // client area already excludes the menu height.
+  if (HMENU app_menu = CreateWin32AppMenu()) {
+    ::SetMenu(GetHandle(), app_menu);
   }
 
   RECT frame = GetClientArea();
@@ -26,6 +35,12 @@ bool FlutterWindow::OnCreate() {
   }
   RegisterPlugins(flutter_controller_->engine());
   SetChildContent(flutter_controller_->view()->GetNativeWindow());
+
+  app_menu_channel_ =
+      std::make_unique<flutter::MethodChannel<flutter::EncodableValue>>(
+          flutter_controller_->engine()->messenger(),
+          "dev.leynier.alera/app_menu",
+          &flutter::StandardMethodCodec::GetInstance());
 
   flutter_controller_->engine()->SetNextFrameCallback([&]() {
     this->Show();
@@ -62,6 +77,15 @@ FlutterWindow::MessageHandler(HWND hwnd, UINT const message,
   }
 
   switch (message) {
+    case WM_COMMAND:
+      if (const char* method =
+              Win32AppMenuMethodForCommand(LOWORD(wparam))) {
+        if (app_menu_channel_) {
+          app_menu_channel_->InvokeMethod(method, nullptr);
+        }
+        return 0;
+      }
+      break;
     case WM_FONTCHANGE:
       flutter_controller_->engine()->ReloadSystemFonts();
       break;

--- a/windows/runner/flutter_window.h
+++ b/windows/runner/flutter_window.h
@@ -2,7 +2,9 @@
 #define RUNNER_FLUTTER_WINDOW_H_
 
 #include <flutter/dart_project.h>
+#include <flutter/encodable_value.h>
 #include <flutter/flutter_view_controller.h>
+#include <flutter/method_channel.h>
 
 #include <memory>
 
@@ -28,6 +30,10 @@ class FlutterWindow : public Win32Window {
 
   // The Flutter instance hosted by this window.
   std::unique_ptr<flutter::FlutterViewController> flutter_controller_;
+
+  // Channel used to forward native app-menu activation into Dart.
+  std::unique_ptr<flutter::MethodChannel<flutter::EncodableValue>>
+      app_menu_channel_;
 };
 
 #endif  // RUNNER_FLUTTER_WINDOW_H_

--- a/windows/runner/main.cpp
+++ b/windows/runner/main.cpp
@@ -27,7 +27,7 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
   FlutterWindow window(project);
   Win32Window::Point origin(10, 10);
   Win32Window::Size size(1280, 720);
-  if (!window.Create(L"Alera", origin, size)) {
+  if (!window.Create(ALERA_APP_NAME, origin, size)) {
     return EXIT_FAILURE;
   }
   window.SetQuitOnClose(true);

--- a/windows/runner/win32_app_menu.cpp
+++ b/windows/runner/win32_app_menu.cpp
@@ -1,0 +1,68 @@
+#include "win32_app_menu.h"
+
+HMENU CreateWin32AppMenu() {
+  HMENU menu_bar = ::CreateMenu();
+  if (menu_bar == nullptr) {
+    return nullptr;
+  }
+
+  HMENU app_menu = ::CreatePopupMenu();
+  if (app_menu == nullptr) {
+    ::DestroyMenu(menu_bar);
+    return nullptr;
+  }
+  ::AppendMenuW(app_menu, MF_STRING, kWin32AppMenuOpenSettings,
+                L"Settings ...");
+  ::AppendMenuW(app_menu, MF_STRING, kWin32AppMenuCheckForUpdates,
+                L"Check for Updates ...");
+  ::AppendMenuW(app_menu, MF_SEPARATOR, 0, nullptr);
+  ::AppendMenuW(app_menu, MF_STRING, kWin32AppMenuShowAbout,
+                L"About " ALERA_APP_NAME);
+  ::AppendMenuW(app_menu, MF_STRING, kWin32AppMenuExitApp, L"Exit");
+  ::AppendMenuW(menu_bar, MF_POPUP, reinterpret_cast<UINT_PTR>(app_menu),
+                ALERA_APP_NAME);
+
+  HMENU edit_menu = ::CreatePopupMenu();
+  if (edit_menu == nullptr) {
+    ::DestroyMenu(menu_bar);
+    return nullptr;
+  }
+  ::AppendMenuW(edit_menu, MF_STRING, kWin32AppMenuUndo, L"Undo");
+  ::AppendMenuW(edit_menu, MF_STRING, kWin32AppMenuRedo, L"Redo");
+  ::AppendMenuW(edit_menu, MF_SEPARATOR, 0, nullptr);
+  ::AppendMenuW(edit_menu, MF_STRING, kWin32AppMenuCut, L"Cut");
+  ::AppendMenuW(edit_menu, MF_STRING, kWin32AppMenuCopy, L"Copy");
+  ::AppendMenuW(edit_menu, MF_STRING, kWin32AppMenuPaste, L"Paste");
+  ::AppendMenuW(edit_menu, MF_STRING, kWin32AppMenuSelectAll, L"Select All");
+  ::AppendMenuW(menu_bar, MF_POPUP, reinterpret_cast<UINT_PTR>(edit_menu),
+                L"Edit");
+
+  return menu_bar;
+}
+
+const char* Win32AppMenuMethodForCommand(UINT command_id) {
+  switch (command_id) {
+    case kWin32AppMenuOpenSettings:
+      return "openSettings";
+    case kWin32AppMenuCheckForUpdates:
+      return "checkForUpdates";
+    case kWin32AppMenuShowAbout:
+      return "showAbout";
+    case kWin32AppMenuExitApp:
+      return "exitApp";
+    case kWin32AppMenuUndo:
+      return "undo";
+    case kWin32AppMenuRedo:
+      return "redo";
+    case kWin32AppMenuCut:
+      return "cut";
+    case kWin32AppMenuCopy:
+      return "copy";
+    case kWin32AppMenuPaste:
+      return "paste";
+    case kWin32AppMenuSelectAll:
+      return "selectAll";
+    default:
+      return nullptr;
+  }
+}

--- a/windows/runner/win32_app_menu.h
+++ b/windows/runner/win32_app_menu.h
@@ -1,0 +1,31 @@
+#ifndef RUNNER_WIN32_APP_MENU_H_
+#define RUNNER_WIN32_APP_MENU_H_
+
+#include <windows.h>
+
+// Command ids for the native application menu.
+enum Win32AppMenuCommandId : UINT {
+  kWin32AppMenuOpenSettings = 1001,
+  kWin32AppMenuCheckForUpdates,
+  kWin32AppMenuShowAbout,
+  kWin32AppMenuExitApp,
+  kWin32AppMenuUndo,
+  kWin32AppMenuRedo,
+  kWin32AppMenuCut,
+  kWin32AppMenuCopy,
+  kWin32AppMenuPaste,
+  kWin32AppMenuSelectAll,
+};
+
+// Builds the native application menu bar. Returns nullptr on failure.
+// No keyboard accelerators are registered: global accelerators would swallow
+// keys like Ctrl+C before text fields and the terminal-first shortcut policy
+// see them.
+HMENU CreateWin32AppMenu();
+
+// Maps a WM_COMMAND id to the app-menu channel method, or nullptr when the
+// command does not belong to the app menu. Method names stay in sync with
+// lib/src/features/app_menu/infra/native_app_menu_channel.dart.
+const char* Win32AppMenuMethodForCommand(UINT command_id);
+
+#endif  // RUNNER_WIN32_APP_MENU_H_


### PR DESCRIPTION
## Summary

Replaces the in-app Material `MenuBar` on Linux and Windows with real OS-native menus, so the application menu is native on all three desktop platforms (macOS already used `PlatformMenuBar`).

- **Linux:** GTK `GtkMenuBar` built in `linux/runner/my_application.cc` (app + Edit menus), with `GSimpleAction`s forwarding activation to Dart.
- **Windows:** Win32 `HMENU` built in `windows/runner/win32_app_menu.cpp`, attached before the Flutter view is sized; `WM_COMMAND` forwards activation to Dart.
- **Dart:** new `dev.leynier.alera/app_menu` method channel (`lib/src/features/app_menu/infra/native_app_menu_channel.dart`) dispatching to the existing shared actions, including the Edit menu intents (Undo/Redo/Cut/Copy/Paste/Select All) that previously only existed on macOS.
- Menu labels are flavor-aware (`ALERA_APP_NAME` CMake define: "Alera Dev" / "Alera") and the GTK menu follows the dark system theme.
- Native menus intentionally register no keyboard accelerators so keys like Ctrl+C keep flowing to text fields and the terminal-first shortcut policy.

## Validation

- `flutter analyze`: clean.
- `test/widget/app_menu_test.dart`: 17/17 (channel dispatch per platform, edit actions verified on a focused `TextField`). Full suite: only 2 pre-existing environment-dependent PTY failures, also failing on a clean tree.
- `flutter build linux --debug`: OK (-Wall -Werror).
- `flutter build windows --debug` on a Windows machine (VS2022, /W4 /WX): OK.

## Notes

- Edit menu items act on the focused `TextField` only (same limitation as macOS); the terminal handles copy/paste through its own key path.
- `AGENTS.md` documents the native menu + channel contract for future menu changes.