### PR TITLE
fix: detect pull requests on the live workspace branch

### DIFF
--- a/lib/src/features/pull_requests/application/workspace_pull_request_controller.dart
+++ b/lib/src/features/pull_requests/application/workspace_pull_request_controller.dart
@@ -27,10 +27,13 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'workspace_pull_request_controller.g.dart';
 part 'workspace_pull_request_review_actions.dart';
+part 'workspace_pull_request_review_editing.dart';
 
 @Riverpod(keepAlive: true)
 class WorkspacePullRequestController extends _$WorkspacePullRequestController
-    with _WorkspacePullRequestReviewActions {
+    with
+        _WorkspacePullRequestReviewActions,
+        _WorkspacePullRequestReviewEditing {
   static const Duration _minPollInterval = Duration(seconds: 30);
   static const Duration _maxPollInterval = Duration(seconds: 120);
 
@@ -88,6 +91,42 @@ class WorkspacePullRequestController extends _$WorkspacePullRequestController
           unawaited(_refresh(origin: _RefreshOrigin.resume));
         }
       });
+      return;
+    }
+    // A failed initial load leaves the provider in AsyncError with no timer;
+    // without this recovery an opened panel would stay dead forever.
+    if (state.hasError) {
+      Timer.run(() {
+        unawaited(_recoverFromError());
+      });
+    }
+  }
+
+  Future<void> _recoverFromError() async {
+    if (_disposed || !_visible) {
+      return;
+    }
+    try {
+      final loaded = await _loader.load(scope);
+      if (!_disposed) {
+        state = AsyncData(loaded);
+      }
+    } catch (error, stackTrace) {
+      if (!_disposed) {
+        state = AsyncError<WorkspacePullRequestState>(error, stackTrace);
+      }
+    } finally {
+      if (!_disposed && _visible) {
+        if (state.value != null) {
+          _schedulePoll(scope);
+        } else {
+          // Still failing: keep retrying slowly while the panel stays open.
+          _pollTimer?.cancel();
+          _pollTimer = Timer(_maxPollInterval, () {
+            unawaited(_recoverFromError());
+          });
+        }
+      }
     }
   }
 
@@ -160,122 +199,6 @@ class WorkspacePullRequestController extends _$WorkspacePullRequestController
         );
       },
     );
-  }
-
-  /// Creates a review from [input]: pushes the branch, calls the forge, and
-  /// links the result on success.
-  Future<CreateReviewResult> createReview(CreateReviewInput input) async {
-    final identity = state.value?.identity;
-    final forge = identity == null
-        ? null
-        : _registry.forProvider(identity.provider);
-    if (identity == null || forge == null) {
-      return const CreateReviewFailure(
-        code: CreateReviewErrorCode.blocked,
-        message: 'No hosting provider is configured.',
-      );
-    }
-    _pollTimer?.cancel();
-    state = AsyncData(
-      (state.value ?? const WorkspacePullRequestState()).copyWith(
-        action: PullRequestAction.create,
-        clearError: true,
-      ),
-    );
-    try {
-      await _gitBackend.push(scope.repoPath);
-    } on GitException catch (error) {
-      final result = CreateReviewFailure(
-        code: CreateReviewErrorCode.pushFailed,
-        message: 'Could not push the branch: ${error.context}',
-      );
-      _applyActionOutcome(failureMessage: result.message);
-      return result;
-    }
-    final result = await forge.createReview(
-      identity: identity,
-      repoPath: scope.repoPath,
-      input: input,
-    );
-    if (result is CreateReviewSuccess) {
-      await _linkedReviews.save(
-        LinkedReview.linked(
-          workspaceId: scope.workspaceId,
-          provider: identity.provider,
-          number: result.review.number,
-          url: result.review.url,
-        ),
-      );
-    }
-    _applyActionOutcome(
-      failureMessage: result is CreateReviewFailure ? result.message : null,
-    );
-    if (!_disposed && _visible) {
-      await refresh();
-    }
-    return result;
-  }
-
-  /// Detail metadata for [check] of the linked review; null when nothing is
-  /// linked or the check is gone. Transport/auth failures throw.
-  Future<ReviewCheckDetails?> loadCheckDetails(ReviewCheck check) async {
-    final current = state.value;
-    final identity = current?.identity;
-    final review = current?.review;
-    final forge = identity == null
-        ? null
-        : _registry.forProvider(identity.provider);
-    if (identity == null || review == null || forge == null) {
-      return null;
-    }
-    return forge.getCheckDetails(
-      identity: identity,
-      repoPath: scope.repoPath,
-      number: review.number,
-      check: check,
-    );
-  }
-
-  /// Updates the linked review from [input], then reloads.
-  Future<UpdateReviewResult> updateReview(UpdateReviewInput input) async {
-    final identity = state.value?.identity;
-    final review = state.value?.review;
-    final forge = identity == null
-        ? null
-        : _registry.forProvider(identity.provider);
-    if (identity == null || review == null || forge == null) {
-      return const UpdateReviewFailure(
-        code: UpdateReviewErrorCode.blocked,
-        message: 'No linked pull request to update.',
-      );
-    }
-    if (input.isEmpty) {
-      return const UpdateReviewFailure(
-        code: UpdateReviewErrorCode.blocked,
-        message: 'Nothing to update.',
-      );
-    }
-    _pollTimer?.cancel();
-    state = AsyncData(
-      (state.value ?? const WorkspacePullRequestState()).copyWith(
-        action: PullRequestAction.update,
-        clearError: true,
-      ),
-    );
-    final result = await forge.updateReview(
-      identity: identity,
-      repoPath: scope.repoPath,
-      number: review.number,
-      input: input,
-    );
-    _applyActionOutcome(
-      failureMessage: result is UpdateReviewFailure ? result.message : null,
-    );
-    // Reload only on success; the refresh path would clear the error message.
-    if (!_disposed && _visible && result is UpdateReviewSuccess) {
-      await refresh();
-    }
-    return result;
   }
 
   /// Clears the in-flight action; a non-null [failureMessage] surfaces it.
@@ -426,15 +349,15 @@ class WorkspacePullRequestController extends _$WorkspacePullRequestController
   }) {
     _pollTimer?.cancel();
     final current = snapshot ?? state.value;
-    if (_disposed ||
-        !_visible ||
-        current == null ||
-        current.isBusy ||
-        current.identity == null ||
-        current.authStatus != ForgeAuthStatus.authenticated) {
+    if (_disposed || !_visible || current == null || current.isBusy) {
       return;
     }
-    _pollTimer = Timer(_pollInterval, () {
+    // Missing identity or auth can heal outside the app (the user signs in,
+    // adds a remote); keep polling slowly instead of never retrying.
+    final degraded =
+        current.identity == null ||
+        current.authStatus != ForgeAuthStatus.authenticated;
+    _pollTimer = Timer(degraded ? _maxPollInterval : _pollInterval, () {
       unawaited(_pollTick(scope));
     });
   }

--- a/lib/src/features/pull_requests/application/workspace_pull_request_loader.dart
+++ b/lib/src/features/pull_requests/application/workspace_pull_request_loader.dart
@@ -167,16 +167,22 @@ class WorkspacePullRequestLoader {
   }
 
   Future<String?> _resolveBranch(WorkspacePullRequestScope scope) async {
+    // The scope hint is the branch recorded at workspace creation; agents can
+    // switch branches inside the worktree afterwards, so live HEAD wins and
+    // the hint only covers detached HEAD or git failures.
+    try {
+      final current = await _gitBackend.currentBranch(scope.repoPath);
+      if (current.isNotEmpty && current != 'HEAD') {
+        return current;
+      }
+    } on GitException {
+      // Fall back to the scope hint below.
+    }
     final hinted = scope.branch;
     if (hinted != null && hinted.isNotEmpty && hinted != 'HEAD') {
       return hinted;
     }
-    try {
-      final current = await _gitBackend.currentBranch(scope.repoPath);
-      return current.isEmpty || current == 'HEAD' ? null : current;
-    } on GitException {
-      return null;
-    }
+    return null;
   }
 
   Future<HostedReview?> _detectReview(

--- a/lib/src/features/pull_requests/application/workspace_pull_request_review_editing.dart
+++ b/lib/src/features/pull_requests/application/workspace_pull_request_review_editing.dart
@@ -1,0 +1,164 @@
+part of 'workspace_pull_request_controller.dart';
+
+mixin _WorkspacePullRequestReviewEditing on _$WorkspacePullRequestController {
+  WorkspacePullRequestController get _editingController =>
+      this as WorkspacePullRequestController;
+
+  /// Creates a review from [input]: pushes the branch, calls the forge, and
+  /// links the result on success.
+  Future<CreateReviewResult> createReview(CreateReviewInput input) async {
+    final controller = _editingController;
+    final identity = state.value?.identity;
+    final forge = identity == null
+        ? null
+        : controller._registry.forProvider(identity.provider);
+    if (identity == null || forge == null) {
+      return const CreateReviewFailure(
+        code: CreateReviewErrorCode.blocked,
+        message: 'No hosting provider is configured.',
+      );
+    }
+    controller._pollTimer?.cancel();
+    state = AsyncData(
+      (state.value ?? const WorkspacePullRequestState()).copyWith(
+        action: PullRequestAction.create,
+        clearError: true,
+      ),
+    );
+    try {
+      await controller._gitBackend.push(controller.scope.repoPath);
+    } on GitException catch (error) {
+      final result = CreateReviewFailure(
+        code: CreateReviewErrorCode.pushFailed,
+        message: 'Could not push the branch: ${error.context}',
+      );
+      controller._applyActionOutcome(failureMessage: result.message);
+      return result;
+    }
+    // A thrown ForgeException (vs a returned failure) must not skip
+    // _applyActionOutcome, or the action would stay busy and block polling.
+    final CreateReviewResult result;
+    try {
+      result = await forge.createReview(
+        identity: identity,
+        repoPath: controller.scope.repoPath,
+        input: input,
+      );
+    } on ForgeException catch (error) {
+      final failure = CreateReviewFailure(
+        code: CreateReviewErrorCode.unknown,
+        message: error.message,
+      );
+      controller._applyActionOutcome(failureMessage: failure.message);
+      return failure;
+    } catch (error) {
+      final failure = CreateReviewFailure(
+        code: CreateReviewErrorCode.unknown,
+        message: error.toString(),
+      );
+      controller._applyActionOutcome(failureMessage: failure.message);
+      return failure;
+    }
+    if (result is CreateReviewSuccess) {
+      await controller._linkedReviews.save(
+        LinkedReview.linked(
+          workspaceId: controller.scope.workspaceId,
+          provider: identity.provider,
+          number: result.review.number,
+          url: result.review.url,
+        ),
+      );
+    }
+    controller._applyActionOutcome(
+      failureMessage: result is CreateReviewFailure ? result.message : null,
+    );
+    if (!controller._disposed && controller._visible) {
+      await controller.refresh();
+    }
+    return result;
+  }
+
+  /// Detail metadata for [check] of the linked review; null when nothing is
+  /// linked or the check is gone. Transport/auth failures throw.
+  Future<ReviewCheckDetails?> loadCheckDetails(ReviewCheck check) async {
+    final controller = _editingController;
+    final current = state.value;
+    final identity = current?.identity;
+    final review = current?.review;
+    final forge = identity == null
+        ? null
+        : controller._registry.forProvider(identity.provider);
+    if (identity == null || review == null || forge == null) {
+      return null;
+    }
+    return forge.getCheckDetails(
+      identity: identity,
+      repoPath: controller.scope.repoPath,
+      number: review.number,
+      check: check,
+    );
+  }
+
+  /// Updates the linked review from [input], then reloads.
+  Future<UpdateReviewResult> updateReview(UpdateReviewInput input) async {
+    final controller = _editingController;
+    final identity = state.value?.identity;
+    final review = state.value?.review;
+    final forge = identity == null
+        ? null
+        : controller._registry.forProvider(identity.provider);
+    if (identity == null || review == null || forge == null) {
+      return const UpdateReviewFailure(
+        code: UpdateReviewErrorCode.blocked,
+        message: 'No linked pull request to update.',
+      );
+    }
+    if (input.isEmpty) {
+      return const UpdateReviewFailure(
+        code: UpdateReviewErrorCode.blocked,
+        message: 'Nothing to update.',
+      );
+    }
+    controller._pollTimer?.cancel();
+    state = AsyncData(
+      (state.value ?? const WorkspacePullRequestState()).copyWith(
+        action: PullRequestAction.update,
+        clearError: true,
+      ),
+    );
+    // Same containment as createReview: a thrown error must clear the action.
+    final UpdateReviewResult result;
+    try {
+      result = await forge.updateReview(
+        identity: identity,
+        repoPath: controller.scope.repoPath,
+        number: review.number,
+        input: input,
+      );
+    } on ForgeException catch (error) {
+      final failure = UpdateReviewFailure(
+        code: UpdateReviewErrorCode.unknown,
+        message: error.message,
+      );
+      controller._applyActionOutcome(failureMessage: failure.message);
+      return failure;
+    } catch (error) {
+      final failure = UpdateReviewFailure(
+        code: UpdateReviewErrorCode.unknown,
+        message: error.toString(),
+      );
+      controller._applyActionOutcome(failureMessage: failure.message);
+      return failure;
+    }
+    controller._applyActionOutcome(
+      failureMessage: result is UpdateReviewFailure ? result.message : null,
+    );
+    // Reload only on success; the refresh path would clear the error message.
+    if (!controller._disposed &&
+        controller._visible &&
+        result is UpdateReviewSuccess) {
+      await controller.refresh();
+    }
+    return result;
+  }
+}

--- a/test/unit/fake_forge_provider.dart
+++ b/test/unit/fake_forge_provider.dart
@@ -21,6 +21,7 @@ class FakeForgeProvider implements ForgeProvider {
   HostedReview? branchReview;
   Future<HostedReview?> Function()? branchReviewLoader;
   int branchReviewCalls = 0;
+  String? lastBranchQuery;
   final Map<int, HostedReview> byNumber = <int, HostedReview>{};
   List<ReviewCheck> checks = <ReviewCheck>[];
   Future<List<ReviewCheck>> Function()? checksLoader;
@@ -30,6 +31,7 @@ class FakeForgeProvider implements ForgeProvider {
     message: 'not set',
   );
   int createCalls = 0;
+  Object? createError;
   ReviewCheckDetails? details;
   ReviewCheck? lastDetailsCheck;
   int lastDetailsNumber = -1;
@@ -92,6 +94,7 @@ class FakeForgeProvider implements ForgeProvider {
     required String branch,
   }) async {
     branchReviewCalls++;
+    lastBranchQuery = branch;
     final loader = branchReviewLoader;
     return loader == null ? branchReview : loader();
   }
@@ -169,6 +172,10 @@ class FakeForgeProvider implements ForgeProvider {
     required CreateReviewInput input,
   }) async {
     createCalls++;
+    final error = createError;
+    if (error != null) {
+      throw error;
+    }
     return createResult;
   }
 

--- a/test/unit/workspace_pull_request_recovery_test.dart
+++ b/test/unit/workspace_pull_request_recovery_test.dart
@@ -1,0 +1,233 @@
+import 'package:alera/src/features/pull_requests/application/forge_exception.dart';
+import 'package:alera/src/features/pull_requests/application/forge_provider.dart';
+import 'package:alera/src/features/pull_requests/application/forge_provider_registry.dart';
+import 'package:alera/src/features/pull_requests/application/pull_request_providers.dart';
+import 'package:alera/src/features/pull_requests/application/workspace_pull_request_controller.dart';
+import 'package:alera/src/features/pull_requests/domain/create_review_input.dart';
+import 'package:alera/src/features/pull_requests/domain/create_review_result.dart';
+import 'package:alera/src/features/pull_requests/domain/forge_auth_status.dart';
+import 'package:alera/src/features/pull_requests/domain/hosted_review.dart';
+import 'package:alera/src/features/pull_requests/domain/linked_review.dart';
+import 'package:alera/src/features/pull_requests/domain/workspace_pull_request_scope.dart';
+import 'package:alera/src/shared/git_hosting/domain/git_hosting_provider.dart';
+import 'package:alera/src/shared/infra/git/git_providers.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'fake_forge_provider.dart';
+import 'fake_git_backend.dart';
+
+HostedReview _review(int number, {String headBranch = 'feature'}) =>
+    HostedReview(
+      provider: GitHostingProvider.github,
+      number: number,
+      title: 'feat: $number',
+      state: HostedReviewState.open,
+      url: 'https://github.com/leynier/alera/pull/$number',
+      headBranch: headBranch,
+    );
+
+const _scope = WorkspacePullRequestScope(
+  workspaceId: 'w1',
+  repoPath: '/repo',
+  branch: 'feature',
+);
+
+/// Fails the first [find] to simulate a broken initial load.
+class _ThrowingLinkedReviewRepository extends FakeLinkedReviewRepository {
+  int findCalls = 0;
+
+  @override
+  Future<LinkedReview?> find(String workspaceId) async {
+    findCalls++;
+    if (findCalls == 1) {
+      throw StateError('linked review storage unavailable');
+    }
+    return super.find(workspaceId);
+  }
+}
+
+ProviderContainer _container({
+  required FakeForgeProvider forge,
+  FakeGitBackend? git,
+  FakeLinkedReviewRepository? linkedReviews,
+  bool attach = true,
+}) {
+  final backend =
+      git ??
+      (FakeGitBackend()
+        ..remotesByName = <String, String?>{
+          'origin': 'https://github.com/leynier/alera.git',
+        });
+  final container = ProviderContainer(
+    overrides: [
+      gitBackendProvider.overrideWithValue(backend),
+      forgeProviderRegistryProvider.overrideWithValue(
+        ForgeProviderRegistry(<ForgeProvider>[forge]),
+      ),
+      linkedReviewRepositoryProvider.overrideWithValue(
+        linkedReviews ?? FakeLinkedReviewRepository(),
+      ),
+    ],
+  );
+  container.listen(workspacePullRequestControllerProvider(_scope), (_, _) {});
+  if (attach) {
+    container
+        .read(workspacePullRequestControllerProvider(_scope).notifier)
+        .attachPanel();
+  }
+  return container;
+}
+
+Future<void> _pumpUntil(WidgetTester tester, bool Function() condition) async {
+  for (var attempt = 0; attempt < 20; attempt++) {
+    if (condition()) {
+      return;
+    }
+    await tester.pump();
+  }
+  fail('Condition was not reached after pumping asynchronous work.');
+}
+
+void main() {
+  test(
+    'detects the review on the live branch over a stale scope hint',
+    () async {
+      // The scope records the branch from workspace creation, but the agent
+      // switched the worktree to another branch and opened the PR from it.
+      final backend = FakeGitBackend()
+        ..headBranch = 'agent-branch'
+        ..remotesByName = <String, String?>{
+          'origin': 'https://github.com/leynier/alera.git',
+        };
+      final forge = FakeForgeProvider()
+        ..branchReview = _review(123, headBranch: 'agent-branch');
+      final container = _container(forge: forge, git: backend);
+      addTearDown(container.dispose);
+
+      final state = await container.read(
+        workspacePullRequestControllerProvider(_scope).future,
+      );
+      expect(state.currentBranch, 'agent-branch');
+      expect(forge.lastBranchQuery, 'agent-branch');
+      expect(state.review?.number, 123);
+    },
+  );
+
+  test('falls back to the scope hint when the repo is detached', () async {
+    final backend = FakeGitBackend()
+      ..headBranch = 'HEAD'
+      ..remotesByName = <String, String?>{
+        'origin': 'https://github.com/leynier/alera.git',
+      };
+    final forge = FakeForgeProvider()..branchReview = _review(123);
+    final container = _container(forge: forge, git: backend);
+    addTearDown(container.dispose);
+
+    final state = await container.read(
+      workspacePullRequestControllerProvider(_scope).future,
+    );
+    expect(state.currentBranch, 'feature');
+    expect(forge.lastBranchQuery, 'feature');
+  });
+
+  testWidgets('keeps polling while not authenticated and picks up sign-in', (
+    tester,
+  ) async {
+    final forge = FakeForgeProvider()..auth = ForgeAuthStatus.notAuthenticated;
+    final container = _container(forge: forge);
+    addTearDown(container.dispose);
+    final provider = workspacePullRequestControllerProvider(_scope);
+
+    await _pumpUntil(tester, () => container.read(provider).hasValue);
+    expect(
+      container.read(provider).value?.authStatus,
+      ForgeAuthStatus.notAuthenticated,
+    );
+
+    forge
+      ..auth = ForgeAuthStatus.authenticated
+      ..branchReview = _review(321);
+    await tester.pump(const Duration(seconds: 121));
+    await _pumpUntil(
+      tester,
+      () => container.read(provider).value?.review?.number == 321,
+    );
+
+    final state = container.read(provider).value!;
+    expect(state.authStatus, ForgeAuthStatus.authenticated);
+    expect(state.review?.number, 321);
+    container.read(provider.notifier).detachPanel();
+    await tester.pump();
+  });
+
+  testWidgets('attachPanel recovers after a failed initial load', (
+    tester,
+  ) async {
+    final forge = FakeForgeProvider()..branchReview = _review(55);
+    final linkedReviews = _ThrowingLinkedReviewRepository();
+    final container = _container(
+      forge: forge,
+      linkedReviews: linkedReviews,
+      attach: false,
+    );
+    addTearDown(container.dispose);
+    final provider = workspacePullRequestControllerProvider(_scope);
+
+    await _pumpUntil(tester, () => container.read(provider).hasError);
+    expect(container.read(provider).hasValue, isFalse);
+
+    container.read(provider.notifier).attachPanel();
+    await tester.pump(const Duration(milliseconds: 1));
+    await _pumpUntil(
+      tester,
+      () => container.read(provider).value?.review?.number == 55,
+    );
+    expect(linkedReviews.findCalls, 2);
+    container.read(provider.notifier).detachPanel();
+    await tester.pump();
+  });
+
+  test(
+    'a throwing forge createReview clears the action and error state',
+    () async {
+      final forge = FakeForgeProvider()..branchReview = _review(123);
+      final container = _container(forge: forge);
+      addTearDown(container.dispose);
+
+      await container.read(
+        workspacePullRequestControllerProvider(_scope).future,
+      );
+      final controller = container.read(
+        workspacePullRequestControllerProvider(_scope).notifier,
+      );
+      forge.createError = const ForgeRequestFailed('boom');
+
+      final result = await controller.createReview(
+        const CreateReviewInput(
+          provider: GitHostingProvider.github,
+          title: 'feat: broken',
+          baseBranch: 'main',
+          headBranch: 'feature',
+        ),
+      );
+
+      expect(result, isA<CreateReviewFailure>());
+      expect((result as CreateReviewFailure).message, 'boom');
+      final wedged = container
+          .read(workspacePullRequestControllerProvider(_scope))
+          .value!;
+      expect(wedged.isBusy, isFalse);
+      expect(wedged.errorMessage, 'boom');
+
+      // The controller must still be able to refresh after the failure.
+      forge.createError = null;
+      await controller.refresh();
+      final refreshed = container
+          .read(workspacePullRequestControllerProvider(_scope))
+          .value!;
+      expect(refreshed.review?.number, 123);
+      expect(refreshed.errorMessage, isNull);
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- resolve the pull request head from live HEAD instead of the branch recorded at workspace creation, falling back to the scope hint only on detached HEAD or git errors
- recover the panel after a failed initial load and keep a slow retry while identity or auth is unresolved, so opening the panel and waiting always picks up an agent-created PR
- contain thrown forge errors in createReview/updateReview so a stuck busy action can no longer block refresh and polling
- split review editing into a part file to keep the controller under the file size limit

## Validation
- new unit suite test/unit/workspace_pull_request_recovery_test.dart (stale hint vs live branch, detached fallback, sign-in pickup via slow poll, attach recovery, throwing forge)
- full test/unit and pull request widget suites pass (terminal_runtime_native_test failures are pre-existing on main, environment-dependent)

## Notes
- degraded states now poll at the max interval (120s), which adds a periodic gh auth status call while the panel is open and unauthenticated