### PR TITLE
feat: add workspace kind filter to view options

### DIFF
--- a/lib/src/features/pull_requests/application/workspace_pull_request_controller.dart
+++ b/lib/src/features/pull_requests/application/workspace_pull_request_controller.dart
@@ -27,10 +27,13 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'workspace_pull_request_controller.g.dart';
 part 'workspace_pull_request_review_actions.dart';
+part 'workspace_pull_request_review_editing.dart';
 
 @Riverpod(keepAlive: true)
 class WorkspacePullRequestController extends _$WorkspacePullRequestController
-    with _WorkspacePullRequestReviewActions {
+    with
+        _WorkspacePullRequestReviewActions,
+        _WorkspacePullRequestReviewEditing {
   static const Duration _minPollInterval = Duration(seconds: 30);
   static const Duration _maxPollInterval = Duration(seconds: 120);
 
@@ -88,6 +91,42 @@ class WorkspacePullRequestController extends _$WorkspacePullRequestController
           unawaited(_refresh(origin: _RefreshOrigin.resume));
         }
       });
+      return;
+    }
+    // A failed initial load leaves the provider in AsyncError with no timer;
+    // without this recovery an opened panel would stay dead forever.
+    if (state.hasError) {
+      Timer.run(() {
+        unawaited(_recoverFromError());
+      });
+    }
+  }
+
+  Future<void> _recoverFromError() async {
+    if (_disposed || !_visible) {
+      return;
+    }
+    try {
+      final loaded = await _loader.load(scope);
+      if (!_disposed) {
+        state = AsyncData(loaded);
+      }
+    } catch (error, stackTrace) {
+      if (!_disposed) {
+        state = AsyncError<WorkspacePullRequestState>(error, stackTrace);
+      }
+    } finally {
+      if (!_disposed && _visible) {
+        if (state.value != null) {
+          _schedulePoll(scope);
+        } else {
+          // Still failing: keep retrying slowly while the panel stays open.
+          _pollTimer?.cancel();
+          _pollTimer = Timer(_maxPollInterval, () {
+            unawaited(_recoverFromError());
+          });
+        }
+      }
     }
   }
 
@@ -160,122 +199,6 @@ class WorkspacePullRequestController extends _$WorkspacePullRequestController
         );
       },
     );
-  }
-
-  /// Creates a review from [input]: pushes the branch, calls the forge, and
-  /// links the result on success.
-  Future<CreateReviewResult> createReview(CreateReviewInput input) async {
-    final identity = state.value?.identity;
-    final forge = identity == null
-        ? null
-        : _registry.forProvider(identity.provider);
-    if (identity == null || forge == null) {
-      return const CreateReviewFailure(
-        code: CreateReviewErrorCode.blocked,
-        message: 'No hosting provider is configured.',
-      );
-    }
-    _pollTimer?.cancel();
-    state = AsyncData(
-      (state.value ?? const WorkspacePullRequestState()).copyWith(
-        action: PullRequestAction.create,
-        clearError: true,
-      ),
-    );
-    try {
-      await _gitBackend.push(scope.repoPath);
-    } on GitException catch (error) {
-      final result = CreateReviewFailure(
-        code: CreateReviewErrorCode.pushFailed,
-        message: 'Could not push the branch: ${error.context}',
-      );
-      _applyActionOutcome(failureMessage: result.message);
-      return result;
-    }
-    final result = await forge.createReview(
-      identity: identity,
-      repoPath: scope.repoPath,
-      input: input,
-    );
-    if (result is CreateReviewSuccess) {
-      await _linkedReviews.save(
-        LinkedReview.linked(
-          workspaceId: scope.workspaceId,
-          provider: identity.provider,
-          number: result.review.number,
-          url: result.review.url,
-        ),
-      );
-    }
-    _applyActionOutcome(
-      failureMessage: result is CreateReviewFailure ? result.message : null,
-    );
-    if (!_disposed && _visible) {
-      await refresh();
-    }
-    return result;
-  }
-
-  /// Detail metadata for [check] of the linked review; null when nothing is
-  /// linked or the check is gone. Transport/auth failures throw.
-  Future<ReviewCheckDetails?> loadCheckDetails(ReviewCheck check) async {
-    final current = state.value;
-    final identity = current?.identity;
-    final review = current?.review;
-    final forge = identity == null
-        ? null
-        : _registry.forProvider(identity.provider);
-    if (identity == null || review == null || forge == null) {
-      return null;
-    }
-    return forge.getCheckDetails(
-      identity: identity,
-      repoPath: scope.repoPath,
-      number: review.number,
-      check: check,
-    );
-  }
-
-  /// Updates the linked review from [input], then reloads.
-  Future<UpdateReviewResult> updateReview(UpdateReviewInput input) async {
-    final identity = state.value?.identity;
-    final review = state.value?.review;
-    final forge = identity == null
-        ? null
-        : _registry.forProvider(identity.provider);
-    if (identity == null || review == null || forge == null) {
-      return const UpdateReviewFailure(
-        code: UpdateReviewErrorCode.blocked,
-        message: 'No linked pull request to update.',
-      );
-    }
-    if (input.isEmpty) {
-      return const UpdateReviewFailure(
-        code: UpdateReviewErrorCode.blocked,
-        message: 'Nothing to update.',
-      );
-    }
-    _pollTimer?.cancel();
-    state = AsyncData(
-      (state.value ?? const WorkspacePullRequestState()).copyWith(
-        action: PullRequestAction.update,
-        clearError: true,
-      ),
-    );
-    final result = await forge.updateReview(
-      identity: identity,
-      repoPath: scope.repoPath,
-      number: review.number,
-      input: input,
-    );
-    _applyActionOutcome(
-      failureMessage: result is UpdateReviewFailure ? result.message : null,
-    );
-    // Reload only on success; the refresh path would clear the error message.
-    if (!_disposed && _visible && result is UpdateReviewSuccess) {
-      await refresh();
-    }
-    return result;
   }
 
   /// Clears the in-flight action; a non-null [failureMessage] surfaces it.
@@ -426,15 +349,15 @@ class WorkspacePullRequestController extends _$WorkspacePullRequestController
   }) {
     _pollTimer?.cancel();
     final current = snapshot ?? state.value;
-    if (_disposed ||
-        !_visible ||
-        current == null ||
-        current.isBusy ||
-        current.identity == null ||
-        current.authStatus != ForgeAuthStatus.authenticated) {
+    if (_disposed || !_visible || current == null || current.isBusy) {
       return;
     }
-    _pollTimer = Timer(_pollInterval, () {
+    // Missing identity or auth can heal outside the app (the user signs in,
+    // adds a remote); keep polling slowly instead of never retrying.
+    final degraded =
+        current.identity == null ||
+        current.authStatus != ForgeAuthStatus.authenticated;
+    _pollTimer = Timer(degraded ? _maxPollInterval : _pollInterval, () {
       unawaited(_pollTick(scope));
     });
   }

--- a/lib/src/features/pull_requests/application/workspace_pull_request_controller.g.dart
+++ b/lib/src/features/pull_requests/application/workspace_pull_request_controller.g.dart
@@ -57,7 +57,7 @@ final class WorkspacePullRequestControllerProvider
 }
 
 String _$workspacePullRequestControllerHash() =>
-    r'eac4ab88a727ac219c2c1f79fa6f164c2fc4ce3d';
+    r'c9f788ed5b0933dbfa305d0e98cd19fc5fc91c2d';
 
 final class WorkspacePullRequestControllerFamily extends $Family
     with

--- a/lib/src/features/pull_requests/application/workspace_pull_request_loader.dart
+++ b/lib/src/features/pull_requests/application/workspace_pull_request_loader.dart
@@ -167,16 +167,22 @@ class WorkspacePullRequestLoader {
   }
 
   Future<String?> _resolveBranch(WorkspacePullRequestScope scope) async {
+    // The scope hint is the branch recorded at workspace creation; agents can
+    // switch branches inside the worktree afterwards, so live HEAD wins and
+    // the hint only covers detached HEAD or git failures.
+    try {
+      final current = await _gitBackend.currentBranch(scope.repoPath);
+      if (current.isNotEmpty && current != 'HEAD') {
+        return current;
+      }
+    } on GitException {
+      // Fall back to the scope hint below.
+    }
     final hinted = scope.branch;
     if (hinted != null && hinted.isNotEmpty && hinted != 'HEAD') {
       return hinted;
     }
-    try {
-      final current = await _gitBackend.currentBranch(scope.repoPath);
-      return current.isEmpty || current == 'HEAD' ? null : current;
-    } on GitException {
-      return null;
-    }
+    return null;
   }
 
   Future<HostedReview?> _detectReview(

--- a/lib/src/features/pull_requests/application/workspace_pull_request_review_editing.dart
+++ b/lib/src/features/pull_requests/application/workspace_pull_request_review_editing.dart
@@ -1,0 +1,164 @@
+part of 'workspace_pull_request_controller.dart';
+
+mixin _WorkspacePullRequestReviewEditing on _$WorkspacePullRequestController {
+  WorkspacePullRequestController get _editingController =>
+      this as WorkspacePullRequestController;
+
+  /// Creates a review from [input]: pushes the branch, calls the forge, and
+  /// links the result on success.
+  Future<CreateReviewResult> createReview(CreateReviewInput input) async {
+    final controller = _editingController;
+    final identity = state.value?.identity;
+    final forge = identity == null
+        ? null
+        : controller._registry.forProvider(identity.provider);
+    if (identity == null || forge == null) {
+      return const CreateReviewFailure(
+        code: CreateReviewErrorCode.blocked,
+        message: 'No hosting provider is configured.',
+      );
+    }
+    controller._pollTimer?.cancel();
+    state = AsyncData(
+      (state.value ?? const WorkspacePullRequestState()).copyWith(
+        action: PullRequestAction.create,
+        clearError: true,
+      ),
+    );
+    try {
+      await controller._gitBackend.push(controller.scope.repoPath);
+    } on GitException catch (error) {
+      final result = CreateReviewFailure(
+        code: CreateReviewErrorCode.pushFailed,
+        message: 'Could not push the branch: ${error.context}',
+      );
+      controller._applyActionOutcome(failureMessage: result.message);
+      return result;
+    }
+    // A thrown ForgeException (vs a returned failure) must not skip
+    // _applyActionOutcome, or the action would stay busy and block polling.
+    final CreateReviewResult result;
+    try {
+      result = await forge.createReview(
+        identity: identity,
+        repoPath: controller.scope.repoPath,
+        input: input,
+      );
+    } on ForgeException catch (error) {
+      final failure = CreateReviewFailure(
+        code: CreateReviewErrorCode.unknown,
+        message: error.message,
+      );
+      controller._applyActionOutcome(failureMessage: failure.message);
+      return failure;
+    } catch (error) {
+      final failure = CreateReviewFailure(
+        code: CreateReviewErrorCode.unknown,
+        message: error.toString(),
+      );
+      controller._applyActionOutcome(failureMessage: failure.message);
+      return failure;
+    }
+    if (result is CreateReviewSuccess) {
+      await controller._linkedReviews.save(
+        LinkedReview.linked(
+          workspaceId: controller.scope.workspaceId,
+          provider: identity.provider,
+          number: result.review.number,
+          url: result.review.url,
+        ),
+      );
+    }
+    controller._applyActionOutcome(
+      failureMessage: result is CreateReviewFailure ? result.message : null,
+    );
+    if (!controller._disposed && controller._visible) {
+      await controller.refresh();
+    }
+    return result;
+  }
+
+  /// Detail metadata for [check] of the linked review; null when nothing is
+  /// linked or the check is gone. Transport/auth failures throw.
+  Future<ReviewCheckDetails?> loadCheckDetails(ReviewCheck check) async {
+    final controller = _editingController;
+    final current = state.value;
+    final identity = current?.identity;
+    final review = current?.review;
+    final forge = identity == null
+        ? null
+        : controller._registry.forProvider(identity.provider);
+    if (identity == null || review == null || forge == null) {
+      return null;
+    }
+    return forge.getCheckDetails(
+      identity: identity,
+      repoPath: controller.scope.repoPath,
+      number: review.number,
+      check: check,
+    );
+  }
+
+  /// Updates the linked review from [input], then reloads.
+  Future<UpdateReviewResult> updateReview(UpdateReviewInput input) async {
+    final controller = _editingController;
+    final identity = state.value?.identity;
+    final review = state.value?.review;
+    final forge = identity == null
+        ? null
+        : controller._registry.forProvider(identity.provider);
+    if (identity == null || review == null || forge == null) {
+      return const UpdateReviewFailure(
+        code: UpdateReviewErrorCode.blocked,
+        message: 'No linked pull request to update.',
+      );
+    }
+    if (input.isEmpty) {
+      return const UpdateReviewFailure(
+        code: UpdateReviewErrorCode.blocked,
+        message: 'Nothing to update.',
+      );
+    }
+    controller._pollTimer?.cancel();
+    state = AsyncData(
+      (state.value ?? const WorkspacePullRequestState()).copyWith(
+        action: PullRequestAction.update,
+        clearError: true,
+      ),
+    );
+    // Same containment as createReview: a thrown error must clear the action.
+    final UpdateReviewResult result;
+    try {
+      result = await forge.updateReview(
+        identity: identity,
+        repoPath: controller.scope.repoPath,
+        number: review.number,
+        input: input,
+      );
+    } on ForgeException catch (error) {
+      final failure = UpdateReviewFailure(
+        code: UpdateReviewErrorCode.unknown,
+        message: error.message,
+      );
+      controller._applyActionOutcome(failureMessage: failure.message);
+      return failure;
+    } catch (error) {
+      final failure = UpdateReviewFailure(
+        code: UpdateReviewErrorCode.unknown,
+        message: error.toString(),
+      );
+      controller._applyActionOutcome(failureMessage: failure.message);
+      return failure;
+    }
+    controller._applyActionOutcome(
+      failureMessage: result is UpdateReviewFailure ? result.message : null,
+    );
+    // Reload only on success; the refresh path would clear the error message.
+    if (!controller._disposed &&
+        controller._visible &&
+        result is UpdateReviewSuccess) {
+      await controller.refresh();
+    }
+    return result;
+  }
+}

--- a/lib/src/features/workbench/application/workbench_controller_view_prefs.dart
+++ b/lib/src/features/workbench/application/workbench_controller_view_prefs.dart
@@ -35,6 +35,13 @@ mixin _WorkbenchControllerViewPrefs
     _updateViewPrefs(state.viewPrefs.copyWith(workspaceSort: sort));
   }
 
+  void setWorkspaceKindFilter(WorkspaceKindFilter filter) {
+    if (state.viewPrefs.workspaceKindFilter == filter) {
+      return;
+    }
+    _updateViewPrefs(state.viewPrefs.copyWith(workspaceKindFilter: filter));
+  }
+
   void toggleProjectFilter(String projectId) {
     final next = Set<String>.from(state.viewPrefs.selectedProjectIds);
     if (!next.add(projectId)) {

--- a/lib/src/features/workbench/application/workbench_listing.dart
+++ b/lib/src/features/workbench/application/workbench_listing.dart
@@ -3,6 +3,7 @@ import 'package:alera/src/features/projects/domain/project.dart';
 import 'package:alera/src/features/workbench/application/workbench_agent_activity_sort.dart';
 import 'package:alera/src/features/workbench/application/workbench_listing_tree.dart';
 import 'package:alera/src/features/workbench/application/workbench_state.dart';
+import 'package:alera/src/features/workbench/application/workbench_workspace_filters.dart';
 import 'package:alera/src/features/workbench/domain/workbench_view_prefs.dart';
 import 'package:alera/src/features/workbench/domain/workspace.dart';
 
@@ -344,25 +345,6 @@ List<WorkbenchSidebarRow> buildSidebarRows(
   }
 
   return rows;
-}
-
-/// OR semantics over the selected tag filter: an empty selection shows every
-/// workspace; otherwise a workspace must carry at least one selected tag.
-bool workspaceMatchesTagFilter(WorkbenchViewPrefs prefs, Workspace workspace) {
-  if (prefs.selectedTagIds.isEmpty) {
-    return true;
-  }
-  return workspace.tagIds.any(prefs.selectedTagIds.contains);
-}
-
-/// Whether [workspace] passes the workspace-kind visibility filter: the main
-/// worktree counts as the project's default workspace.
-bool workspaceMatchesKindFilter(WorkbenchViewPrefs prefs, Workspace workspace) {
-  return switch (prefs.workspaceKindFilter) {
-    WorkspaceKindFilter.all => true,
-    WorkspaceKindFilter.defaultOnly => workspace.isMain,
-    WorkspaceKindFilter.nonDefaultOnly => !workspace.isMain,
-  };
 }
 
 WorkbenchSidebarCollapseTargets visibleSidebarCollapseTargets(

--- a/lib/src/features/workbench/application/workbench_listing.dart
+++ b/lib/src/features/workbench/application/workbench_listing.dart
@@ -53,6 +53,9 @@ List<WorkbenchSidebarRow> buildSidebarRows(
   }
 
   bool workspaceVisible(Project project, Workspace workspace) {
+    if (!workspaceMatchesKindFilter(prefs, workspace)) {
+      return false;
+    }
     if (!workspaceMatchesTagFilter(prefs, workspace)) {
       return false;
     }
@@ -208,7 +211,9 @@ List<WorkbenchSidebarRow> buildSidebarRows(
   final rows = <WorkbenchSidebarRow>[];
   final visibleProjects = state.projects.where(projectVisible).toList();
   final filtersHideEmptyProjects =
-      query.isNotEmpty || prefs.selectedTagIds.isNotEmpty;
+      query.isNotEmpty ||
+      prefs.selectedTagIds.isNotEmpty ||
+      prefs.workspaceKindFilter != WorkspaceKindFilter.all;
 
   final pinnedRows = <WorkbenchSidebarRow>[];
   var pinnedWorkspaceCount = 0;
@@ -350,6 +355,16 @@ bool workspaceMatchesTagFilter(WorkbenchViewPrefs prefs, Workspace workspace) {
   return workspace.tagIds.any(prefs.selectedTagIds.contains);
 }
 
+/// Whether [workspace] passes the workspace-kind visibility filter: the main
+/// worktree counts as the project's default workspace.
+bool workspaceMatchesKindFilter(WorkbenchViewPrefs prefs, Workspace workspace) {
+  return switch (prefs.workspaceKindFilter) {
+    WorkspaceKindFilter.all => true,
+    WorkspaceKindFilter.defaultOnly => workspace.isMain,
+    WorkspaceKindFilter.nonDefaultOnly => !workspace.isMain,
+  };
+}
+
 WorkbenchSidebarCollapseTargets visibleSidebarCollapseTargets(
   WorkbenchState state, {
   bool includeCollapsedProjectDescendants = false,
@@ -357,7 +372,9 @@ WorkbenchSidebarCollapseTargets visibleSidebarCollapseTargets(
   final prefs = state.viewPrefs;
   final query = state.searchQuery.trim().toLowerCase();
   final filtersHideEmptyProjects =
-      query.isNotEmpty || prefs.selectedTagIds.isNotEmpty;
+      query.isNotEmpty ||
+      prefs.selectedTagIds.isNotEmpty ||
+      prefs.workspaceKindFilter != WorkspaceKindFilter.all;
   final visibleProjects = state.projects
       .where((project) => _projectVisible(prefs, project))
       .toList(growable: false);
@@ -430,6 +447,9 @@ bool _workspaceVisible(
   Project project,
   Workspace workspace,
 ) {
+  if (!workspaceMatchesKindFilter(prefs, workspace)) {
+    return false;
+  }
   if (!workspaceMatchesTagFilter(prefs, workspace)) {
     return false;
   }

--- a/lib/src/features/workbench/application/workbench_workspace_filters.dart
+++ b/lib/src/features/workbench/application/workbench_workspace_filters.dart
@@ -1,0 +1,21 @@
+import 'package:alera/src/features/workbench/domain/workbench_view_prefs.dart';
+import 'package:alera/src/features/workbench/domain/workspace.dart';
+
+/// OR semantics over the selected tag filter: an empty selection shows every
+/// workspace; otherwise a workspace must carry at least one selected tag.
+bool workspaceMatchesTagFilter(WorkbenchViewPrefs prefs, Workspace workspace) {
+  if (prefs.selectedTagIds.isEmpty) {
+    return true;
+  }
+  return workspace.tagIds.any(prefs.selectedTagIds.contains);
+}
+
+/// Whether [workspace] passes the workspace-kind visibility filter: the main
+/// worktree counts as the project's default workspace.
+bool workspaceMatchesKindFilter(WorkbenchViewPrefs prefs, Workspace workspace) {
+  return switch (prefs.workspaceKindFilter) {
+    WorkspaceKindFilter.all => true,
+    WorkspaceKindFilter.defaultOnly => workspace.isMain,
+    WorkspaceKindFilter.nonDefaultOnly => !workspace.isMain,
+  };
+}

--- a/lib/src/features/workbench/application/workspace_activity_controller.g.dart
+++ b/lib/src/features/workbench/application/workspace_activity_controller.g.dart
@@ -79,7 +79,7 @@ abstract class _$WorkspaceActivityController
 }
 
 /// Feeds [WorkspaceActivityController] from discrete agent status transitions.
-/// Tool-by-tool updates within one state do not count as activity — only a
+/// Tool-by-tool updates within one state do not count as activity - only a
 /// `state`/`stateStartedAt` change marks the workspace as active.
 
 @ProviderFor(workspaceActivityCoordinator)
@@ -87,14 +87,14 @@ final workspaceActivityCoordinatorProvider =
     WorkspaceActivityCoordinatorProvider._();
 
 /// Feeds [WorkspaceActivityController] from discrete agent status transitions.
-/// Tool-by-tool updates within one state do not count as activity — only a
+/// Tool-by-tool updates within one state do not count as activity - only a
 /// `state`/`stateStartedAt` change marks the workspace as active.
 
 final class WorkspaceActivityCoordinatorProvider
     extends $FunctionalProvider<void, void, void>
     with $Provider<void> {
   /// Feeds [WorkspaceActivityController] from discrete agent status transitions.
-  /// Tool-by-tool updates within one state do not count as activity — only a
+  /// Tool-by-tool updates within one state do not count as activity - only a
   /// `state`/`stateStartedAt` change marks the workspace as active.
   WorkspaceActivityCoordinatorProvider._()
     : super(

--- a/lib/src/features/workbench/domain/workbench_view_prefs.dart
+++ b/lib/src/features/workbench/domain/workbench_view_prefs.dart
@@ -22,6 +22,11 @@ enum GitDiffViewMode { tree, flat }
 @MappableEnum()
 enum PullRequestCreateAction { publish, draft }
 
+/// Sidebar visibility filter by workspace kind: the project's main worktree
+/// ("Default Workspace" in the UI) versus linked worktrees.
+@MappableEnum()
+enum WorkspaceKindFilter { all, defaultOnly, nonDefaultOnly }
+
 @MappableClass()
 class WorkbenchViewPrefs with WorkbenchViewPrefsMappable {
   const WorkbenchViewPrefs({
@@ -43,6 +48,7 @@ class WorkbenchViewPrefs with WorkbenchViewPrefsMappable {
     this.explorerMode = WorkspaceExplorerMode.hideIgnored,
     this.gitDiffViewMode = GitDiffViewMode.tree,
     this.pullRequestCreateAction = PullRequestCreateAction.publish,
+    this.workspaceKindFilter = WorkspaceKindFilter.all,
   });
 
   final WorkbenchGroupBy groupBy;
@@ -95,6 +101,10 @@ class WorkbenchViewPrefs with WorkbenchViewPrefsMappable {
   /// persisted with the rest of the workbench view prefs.
   final PullRequestCreateAction pullRequestCreateAction;
 
+  /// Which workspace kinds the sidebar shows. Defaults to [WorkspaceKindFilter.all]
+  /// so previously persisted prefs (missing the key) keep today's behavior.
+  final WorkspaceKindFilter workspaceKindFilter;
+
   static const WorkbenchViewPrefs defaults = WorkbenchViewPrefs(
     groupBy: WorkbenchGroupBy.project,
     projectSort: WorkbenchSortBy.name,
@@ -114,6 +124,7 @@ class WorkbenchViewPrefs with WorkbenchViewPrefsMappable {
     explorerMode: WorkspaceExplorerMode.hideIgnored,
     gitDiffViewMode: GitDiffViewMode.tree,
     pullRequestCreateAction: PullRequestCreateAction.publish,
+    workspaceKindFilter: WorkspaceKindFilter.all,
   );
 
   factory WorkbenchViewPrefs.fromJson(Map<String, Object?> json) =>

--- a/lib/src/features/workbench/domain/workbench_view_prefs.mapper.dart
+++ b/lib/src/features/workbench/domain/workbench_view_prefs.mapper.dart
@@ -305,6 +305,56 @@ extension PullRequestCreateActionMapperExtension on PullRequestCreateAction {
   }
 }
 
+class WorkspaceKindFilterMapper extends EnumMapper<WorkspaceKindFilter> {
+  WorkspaceKindFilterMapper._();
+
+  static WorkspaceKindFilterMapper? _instance;
+  static WorkspaceKindFilterMapper ensureInitialized() {
+    if (_instance == null) {
+      MapperContainer.globals.use(_instance = WorkspaceKindFilterMapper._());
+    }
+    return _instance!;
+  }
+
+  static WorkspaceKindFilter fromValue(dynamic value) {
+    ensureInitialized();
+    return MapperContainer.globals.fromValue(value);
+  }
+
+  @override
+  WorkspaceKindFilter decode(dynamic value) {
+    switch (value) {
+      case r'all':
+        return WorkspaceKindFilter.all;
+      case r'defaultOnly':
+        return WorkspaceKindFilter.defaultOnly;
+      case r'nonDefaultOnly':
+        return WorkspaceKindFilter.nonDefaultOnly;
+      default:
+        throw MapperException.unknownEnumValue(value);
+    }
+  }
+
+  @override
+  dynamic encode(WorkspaceKindFilter self) {
+    switch (self) {
+      case WorkspaceKindFilter.all:
+        return r'all';
+      case WorkspaceKindFilter.defaultOnly:
+        return r'defaultOnly';
+      case WorkspaceKindFilter.nonDefaultOnly:
+        return r'nonDefaultOnly';
+    }
+  }
+}
+
+extension WorkspaceKindFilterMapperExtension on WorkspaceKindFilter {
+  String toValue() {
+    WorkspaceKindFilterMapper.ensureInitialized();
+    return MapperContainer.globals.toValue<WorkspaceKindFilter>(this) as String;
+  }
+}
+
 class WorkbenchViewPrefsMapper extends ClassMapperBase<WorkbenchViewPrefs> {
   WorkbenchViewPrefsMapper._();
 
@@ -318,6 +368,7 @@ class WorkbenchViewPrefsMapper extends ClassMapperBase<WorkbenchViewPrefs> {
       WorkspaceExplorerModeMapper.ensureInitialized();
       GitDiffViewModeMapper.ensureInitialized();
       PullRequestCreateActionMapper.ensureInitialized();
+      WorkspaceKindFilterMapper.ensureInitialized();
     }
     return _instance!;
   }
@@ -453,6 +504,15 @@ class WorkbenchViewPrefsMapper extends ClassMapperBase<WorkbenchViewPrefs> {
     opt: true,
     def: PullRequestCreateAction.publish,
   );
+  static WorkspaceKindFilter _$workspaceKindFilter(WorkbenchViewPrefs v) =>
+      v.workspaceKindFilter;
+  static const Field<WorkbenchViewPrefs, WorkspaceKindFilter>
+  _f$workspaceKindFilter = Field(
+    'workspaceKindFilter',
+    _$workspaceKindFilter,
+    opt: true,
+    def: WorkspaceKindFilter.all,
+  );
 
   @override
   final MappableFields<WorkbenchViewPrefs> fields = const {
@@ -474,6 +534,7 @@ class WorkbenchViewPrefsMapper extends ClassMapperBase<WorkbenchViewPrefs> {
     #explorerMode: _f$explorerMode,
     #gitDiffViewMode: _f$gitDiffViewMode,
     #pullRequestCreateAction: _f$pullRequestCreateAction,
+    #workspaceKindFilter: _f$workspaceKindFilter,
   };
 
   static WorkbenchViewPrefs _instantiate(DecodingData data) {
@@ -498,6 +559,7 @@ class WorkbenchViewPrefsMapper extends ClassMapperBase<WorkbenchViewPrefs> {
       explorerMode: data.dec(_f$explorerMode),
       gitDiffViewMode: data.dec(_f$gitDiffViewMode),
       pullRequestCreateAction: data.dec(_f$pullRequestCreateAction),
+      workspaceKindFilter: data.dec(_f$workspaceKindFilter),
     );
   }
 
@@ -593,6 +655,7 @@ abstract class WorkbenchViewPrefsCopyWith<
     WorkspaceExplorerMode? explorerMode,
     GitDiffViewMode? gitDiffViewMode,
     PullRequestCreateAction? pullRequestCreateAction,
+    WorkspaceKindFilter? workspaceKindFilter,
   });
   WorkbenchViewPrefsCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(
     Then<$Out2, $R2> t,
@@ -634,6 +697,7 @@ class _WorkbenchViewPrefsCopyWithImpl<$R, $Out>
     WorkspaceExplorerMode? explorerMode,
     GitDiffViewMode? gitDiffViewMode,
     PullRequestCreateAction? pullRequestCreateAction,
+    WorkspaceKindFilter? workspaceKindFilter,
   }) => $apply(
     FieldCopyWithData({
       if (groupBy != null) #groupBy: groupBy,
@@ -663,6 +727,8 @@ class _WorkbenchViewPrefsCopyWithImpl<$R, $Out>
       if (gitDiffViewMode != null) #gitDiffViewMode: gitDiffViewMode,
       if (pullRequestCreateAction != null)
         #pullRequestCreateAction: pullRequestCreateAction,
+      if (workspaceKindFilter != null)
+        #workspaceKindFilter: workspaceKindFilter,
     }),
   );
   @override
@@ -717,6 +783,10 @@ class _WorkbenchViewPrefsCopyWithImpl<$R, $Out>
     pullRequestCreateAction: data.get(
       #pullRequestCreateAction,
       or: $value.pullRequestCreateAction,
+    ),
+    workspaceKindFilter: data.get(
+      #workspaceKindFilter,
+      or: $value.workspaceKindFilter,
     ),
   );
 

--- a/lib/src/features/workbench/presentation/widgets/workbench_view_options_controls.dart
+++ b/lib/src/features/workbench/presentation/widgets/workbench_view_options_controls.dart
@@ -81,6 +81,39 @@ class _GroupBySegmented extends StatelessWidget {
   }
 }
 
+class _WorkspaceKindSegmented extends StatelessWidget {
+  const _WorkspaceKindSegmented({required this.value, required this.onChanged});
+
+  final WorkspaceKindFilter value;
+  final ValueChanged<WorkspaceKindFilter> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return AleraSegmentedButton<WorkspaceKindFilter>(
+      dense: true,
+      backgroundColor: AleraTokens.surface,
+      foregroundColor: AleraTokens.foregroundMuted,
+      selectedBackgroundColor: AleraTokens.accentSubtle,
+      selectedForegroundColor: AleraTokens.foreground,
+      borderColor: AleraTokens.borderSubtle,
+      textStyle: Theme.of(context).textTheme.labelSmall,
+      selected: value,
+      onSelectionChanged: onChanged,
+      segments: const <ButtonSegment<WorkspaceKindFilter>>[
+        ButtonSegment(value: WorkspaceKindFilter.all, label: Text('All')),
+        ButtonSegment(
+          value: WorkspaceKindFilter.defaultOnly,
+          label: Text('Default'),
+        ),
+        ButtonSegment(
+          value: WorkspaceKindFilter.nonDefaultOnly,
+          label: Text('Non-Default'),
+        ),
+      ],
+    );
+  }
+}
+
 class _SortRow extends StatelessWidget {
   const _SortRow({
     required this.label,

--- a/lib/src/features/workbench/presentation/widgets/workbench_view_options_menu.dart
+++ b/lib/src/features/workbench/presentation/widgets/workbench_view_options_menu.dart
@@ -33,6 +33,8 @@ class WorkbenchViewOptionsButton extends ConsumerWidget {
     final hasFilters =
         prefs.selectedProjectIds.isNotEmpty ||
         prefs.selectedTagIds.isNotEmpty ||
+        prefs.workspaceKindFilter !=
+            WorkbenchViewPrefs.defaults.workspaceKindFilter ||
         prefs.groupBy != WorkbenchViewPrefs.defaults.groupBy ||
         prefs.projectSort != WorkbenchViewPrefs.defaults.projectSort ||
         prefs.workspaceSort != WorkbenchViewPrefs.defaults.workspaceSort;
@@ -44,7 +46,14 @@ class WorkbenchViewOptionsButton extends ConsumerWidget {
           onPressed: () => _showOptions(context),
           icon: AleraIcons.tune,
         ),
-        if (hasFilters) const Positioned(right: 6, top: 6, child: _ActiveDot()),
+        // Decorative only: without IgnorePointer the dot swallows clicks on
+        // the small icon button underneath it.
+        if (hasFilters)
+          const Positioned(
+            right: 6,
+            top: 6,
+            child: IgnorePointer(child: _ActiveDot()),
+          ),
       ],
     );
   }
@@ -232,91 +241,111 @@ class _WorkbenchViewOptionsPanelState
         children: <Widget>[
           AleraDialogHeader(title: 'View Options', onClose: widget.onDismiss),
           const SizedBox(height: AleraTokens.space12),
-          _SectionLabel(text: 'Group By'),
-          const SizedBox(height: AleraTokens.space6),
-          _GroupBySegmented(
-            value: prefs.groupBy,
-            onChanged: controller.setGroupBy,
-          ),
-          const SizedBox(height: AleraTokens.space12),
-          _SortRow(
-            label: prefs.groupBy == WorkbenchGroupBy.project
-                ? 'Sort Projects By'
-                : 'Sort Workspaces By',
-            value: prefs.groupBy == WorkbenchGroupBy.project
-                ? prefs.projectSort
-                : prefs.workspaceSort,
-            onChanged: prefs.groupBy == WorkbenchGroupBy.project
-                ? controller.setProjectSort
-                : controller.setWorkspaceSort,
-          ),
-          if (prefs.groupBy == WorkbenchGroupBy.project) ...<Widget>[
-            const SizedBox(height: AleraTokens.space8),
-            _SortRow(
-              label: 'Then By',
-              value: prefs.workspaceSort,
-              onChanged: controller.setWorkspaceSort,
-            ),
-          ],
-          const SizedBox(height: AleraTokens.space16),
-          const Divider(height: 1, color: AleraTokens.borderSubtle),
-          const SizedBox(height: AleraTokens.space12),
-          _ProjectsHeader(
-            count: prefs.selectedProjectIds.length,
-            onClear: prefs.selectedProjectIds.isEmpty
-                ? null
-                : controller.clearProjectFilters,
-          ),
-          if (selectedProjects.isNotEmpty) ...<Widget>[
-            const SizedBox(height: AleraTokens.space8),
-            Wrap(
-              spacing: AleraTokens.space6,
-              runSpacing: AleraTokens.space6,
-              children: <Widget>[
-                for (final project in selectedProjects)
-                  AleraChip(
-                    label: project.name,
-                    onRemove: () => controller.removeProjectFilter(project.id),
+          // The option sections can outgrow short windows, so they scroll
+          // under the fixed header.
+          Flexible(
+            child: SingleChildScrollView(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: <Widget>[
+                  _SectionLabel(text: 'Group By'),
+                  const SizedBox(height: AleraTokens.space6),
+                  _GroupBySegmented(
+                    value: prefs.groupBy,
+                    onChanged: controller.setGroupBy,
                   ),
-              ],
+                  const SizedBox(height: AleraTokens.space12),
+                  _SortRow(
+                    label: prefs.groupBy == WorkbenchGroupBy.project
+                        ? 'Sort Projects By'
+                        : 'Sort Workspaces By',
+                    value: prefs.groupBy == WorkbenchGroupBy.project
+                        ? prefs.projectSort
+                        : prefs.workspaceSort,
+                    onChanged: prefs.groupBy == WorkbenchGroupBy.project
+                        ? controller.setProjectSort
+                        : controller.setWorkspaceSort,
+                  ),
+                  if (prefs.groupBy == WorkbenchGroupBy.project) ...<Widget>[
+                    const SizedBox(height: AleraTokens.space8),
+                    _SortRow(
+                      label: 'Then By',
+                      value: prefs.workspaceSort,
+                      onChanged: controller.setWorkspaceSort,
+                    ),
+                  ],
+                  const SizedBox(height: AleraTokens.space12),
+                  _SectionLabel(text: 'Show Workspaces'),
+                  const SizedBox(height: AleraTokens.space6),
+                  _WorkspaceKindSegmented(
+                    value: prefs.workspaceKindFilter,
+                    onChanged: controller.setWorkspaceKindFilter,
+                  ),
+                  const SizedBox(height: AleraTokens.space16),
+                  const Divider(height: 1, color: AleraTokens.borderSubtle),
+                  const SizedBox(height: AleraTokens.space12),
+                  _ProjectsHeader(
+                    count: prefs.selectedProjectIds.length,
+                    onClear: prefs.selectedProjectIds.isEmpty
+                        ? null
+                        : controller.clearProjectFilters,
+                  ),
+                  if (selectedProjects.isNotEmpty) ...<Widget>[
+                    const SizedBox(height: AleraTokens.space8),
+                    Wrap(
+                      spacing: AleraTokens.space6,
+                      runSpacing: AleraTokens.space6,
+                      children: <Widget>[
+                        for (final project in selectedProjects)
+                          AleraChip(
+                            label: project.name,
+                            onRemove: () =>
+                                controller.removeProjectFilter(project.id),
+                          ),
+                      ],
+                    ),
+                  ],
+                  const SizedBox(height: AleraTokens.space8),
+                  AleraTextField(
+                    dense: true,
+                    prefixIcon: AleraIcons.add,
+                    hintText: 'Add Project…',
+                    controller: _searchController,
+                    onSubmitted: (_) => _addFirstMatch(availableProjects),
+                  ),
+                  const SizedBox(height: AleraTokens.space8),
+                  _AvailableProjectsList(
+                    projects: availableProjects,
+                    hasSelection: prefs.selectedProjectIds.isNotEmpty,
+                    query: _projectQuery,
+                    onPick: (project) {
+                      controller.addProjectFilter(project.id);
+                      _searchController.clear();
+                    },
+                    theme: theme,
+                  ),
+                  const SizedBox(height: AleraTokens.space16),
+                  const Divider(height: 1, color: AleraTokens.borderSubtle),
+                  const SizedBox(height: AleraTokens.space12),
+                  _TagsFilterSection(
+                    selectedTags: selectedTags,
+                    availableTags: availableTags,
+                    query: _tagQuery,
+                    searchController: _tagSearchController,
+                    onAdd: (tagId) {
+                      controller.addTagFilter(tagId);
+                      _tagSearchController.clear();
+                    },
+                    onRemove: controller.removeTagFilter,
+                    onClear: prefs.selectedTagIds.isEmpty
+                        ? null
+                        : controller.clearTagFilters,
+                    theme: theme,
+                  ),
+                ],
+              ),
             ),
-          ],
-          const SizedBox(height: AleraTokens.space8),
-          AleraTextField(
-            dense: true,
-            prefixIcon: AleraIcons.add,
-            hintText: 'Add Project…',
-            controller: _searchController,
-            onSubmitted: (_) => _addFirstMatch(availableProjects),
-          ),
-          const SizedBox(height: AleraTokens.space8),
-          _AvailableProjectsList(
-            projects: availableProjects,
-            hasSelection: prefs.selectedProjectIds.isNotEmpty,
-            query: _projectQuery,
-            onPick: (project) {
-              controller.addProjectFilter(project.id);
-              _searchController.clear();
-            },
-            theme: theme,
-          ),
-          const SizedBox(height: AleraTokens.space16),
-          const Divider(height: 1, color: AleraTokens.borderSubtle),
-          const SizedBox(height: AleraTokens.space12),
-          _TagsFilterSection(
-            selectedTags: selectedTags,
-            availableTags: availableTags,
-            query: _tagQuery,
-            searchController: _tagSearchController,
-            onAdd: (tagId) {
-              controller.addTagFilter(tagId);
-              _tagSearchController.clear();
-            },
-            onRemove: controller.removeTagFilter,
-            onClear: prefs.selectedTagIds.isEmpty
-                ? null
-                : controller.clearTagFilters,
-            theme: theme,
           ),
         ],
       ),

--- a/test/unit/fake_forge_provider.dart
+++ b/test/unit/fake_forge_provider.dart
@@ -21,6 +21,7 @@ class FakeForgeProvider implements ForgeProvider {
   HostedReview? branchReview;
   Future<HostedReview?> Function()? branchReviewLoader;
   int branchReviewCalls = 0;
+  String? lastBranchQuery;
   final Map<int, HostedReview> byNumber = <int, HostedReview>{};
   List<ReviewCheck> checks = <ReviewCheck>[];
   Future<List<ReviewCheck>> Function()? checksLoader;
@@ -30,6 +31,7 @@ class FakeForgeProvider implements ForgeProvider {
     message: 'not set',
   );
   int createCalls = 0;
+  Object? createError;
   ReviewCheckDetails? details;
   ReviewCheck? lastDetailsCheck;
   int lastDetailsNumber = -1;
@@ -92,6 +94,7 @@ class FakeForgeProvider implements ForgeProvider {
     required String branch,
   }) async {
     branchReviewCalls++;
+    lastBranchQuery = branch;
     final loader = branchReviewLoader;
     return loader == null ? branchReview : loader();
   }
@@ -169,6 +172,10 @@ class FakeForgeProvider implements ForgeProvider {
     required CreateReviewInput input,
   }) async {
     createCalls++;
+    final error = createError;
+    if (error != null) {
+      throw error;
+    }
     return createResult;
   }
 

--- a/test/unit/workbench_listing_kind_filter_test.dart
+++ b/test/unit/workbench_listing_kind_filter_test.dart
@@ -1,0 +1,145 @@
+import 'package:alera/src/features/projects/domain/project.dart';
+import 'package:alera/src/features/workbench/application/workbench_listing.dart';
+import 'package:alera/src/features/workbench/application/workbench_state.dart';
+import 'package:alera/src/features/workbench/domain/workbench_view_prefs.dart';
+import 'package:alera/src/features/workbench/domain/workspace.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+final DateTime _t0 = DateTime.utc(2026, 5, 1);
+
+Project _project(String id, String name) {
+  return Project(
+    id: id,
+    name: name,
+    repoPath: '/repo/$id',
+    createdAt: _t0,
+    updatedAt: _t0,
+  );
+}
+
+Workspace _workspace(
+  String id,
+  String projectId,
+  String name, {
+  WorkspaceKind kind = WorkspaceKind.linked,
+  List<String> tagIds = const <String>[],
+}) {
+  return Workspace(
+    id: id,
+    projectId: projectId,
+    name: name,
+    branch: name,
+    path: '/repo/$projectId/$id',
+    createdAt: _t0,
+    updatedAt: _t0,
+    kind: kind,
+    status: WorkspaceStatus.active,
+    tagIds: tagIds,
+  );
+}
+
+WorkbenchState _state(WorkbenchViewPrefs prefs, {String searchQuery = ''}) {
+  final alera = _project('p-alera', 'alera');
+  final orca = _project('p-orca', 'orca');
+  return WorkbenchState(
+    projects: <Project>[alera, orca],
+    workspacesByProject: <String, List<Workspace>>{
+      alera.id: <Workspace>[
+        _workspace('w-alera-main', alera.id, 'main', kind: WorkspaceKind.main),
+        _workspace(
+          'w-alera-feature',
+          alera.id,
+          'feature',
+          tagIds: <String>['t1'],
+        ),
+      ],
+      orca.id: <Workspace>[
+        _workspace('w-orca-main', orca.id, 'develop', kind: WorkspaceKind.main),
+      ],
+    },
+    viewPrefs: prefs,
+    activeProjectId: alera.id,
+    searchQuery: searchQuery,
+    bootstrapped: true,
+  );
+}
+
+void main() {
+  group('workspace kind filter', () {
+    test('all shows every workspace', () {
+      final state = _state(WorkbenchViewPrefs.defaults);
+      final rows = buildSidebarRows(state);
+      expect(
+        workspaceOrderOfRows(rows),
+        containsAll(<String>['w-alera-main', 'w-alera-feature', 'w-orca-main']),
+      );
+      expect(countVisibleWorkspaces(state), 3);
+    });
+
+    test('defaultOnly keeps only main worktrees', () {
+      final state = _state(
+        WorkbenchViewPrefs.defaults.copyWith(
+          workspaceKindFilter: WorkspaceKindFilter.defaultOnly,
+        ),
+      );
+      final rows = buildSidebarRows(state);
+      expect(
+        workspaceOrderOfRows(rows),
+        containsAll(<String>['w-alera-main', 'w-orca-main']),
+      );
+      expect(workspaceOrderOfRows(rows), isNot(contains('w-alera-feature')));
+      expect(countVisibleWorkspaces(state), 2);
+    });
+
+    test(
+      'nonDefaultOnly keeps only linked worktrees and hides empty projects',
+      () {
+        final state = _state(
+          WorkbenchViewPrefs.defaults.copyWith(
+            workspaceKindFilter: WorkspaceKindFilter.nonDefaultOnly,
+          ),
+        );
+        final rows = buildSidebarRows(state);
+        expect(workspaceOrderOfRows(rows), <String>['w-alera-feature']);
+        expect(countVisibleWorkspaces(state), 1);
+        // orca has no linked workspaces, so its header disappears while the
+        // filter is active.
+        final headers = rows.whereType<WorkbenchProjectHeaderRow>().toList();
+        expect(headers.any((row) => row.project.id == 'p-orca'), isFalse);
+      },
+    );
+
+    test('combines with the tag filter and search query', () {
+      final tagged = _state(
+        WorkbenchViewPrefs.defaults.copyWith(
+          workspaceKindFilter: WorkspaceKindFilter.defaultOnly,
+          selectedTagIds: <String>{'t1'},
+        ),
+      );
+      // The only tagged workspace is linked, so both filters together match
+      // nothing.
+      expect(countVisibleWorkspaces(tagged), 0);
+
+      final searched = _state(
+        WorkbenchViewPrefs.defaults.copyWith(
+          workspaceKindFilter: WorkspaceKindFilter.nonDefaultOnly,
+        ),
+        searchQuery: 'develop',
+      );
+      // The search matches a default workspace, but the kind filter still
+      // excludes it.
+      expect(countVisibleWorkspaces(searched), 0);
+    });
+
+    test('collapse targets honor the kind filter', () {
+      final state = _state(
+        WorkbenchViewPrefs.defaults.copyWith(
+          workspaceKindFilter: WorkspaceKindFilter.nonDefaultOnly,
+        ),
+      );
+      final targets = visibleSidebarCollapseTargets(state);
+      expect(targets.workspaceIds, <String>{'w-alera-feature'});
+      expect(targets.projectIds, <String>{'p-alera'});
+    });
+  });
+}

--- a/test/unit/workbench_view_prefs_test.dart
+++ b/test/unit/workbench_view_prefs_test.dart
@@ -110,6 +110,17 @@ void main() {
       expect(restored.selectedTagIds, isEmpty);
       expect(restored.collapsedParentWorkspaceIds, isEmpty);
       expect(restored.workspaceSort, WorkbenchSortBy.recent);
+      expect(restored.workspaceKindFilter, WorkspaceKindFilter.all);
+    });
+
+    test('round-trips the workspace kind filter', () {
+      final prefs = WorkbenchViewPrefs.defaults.copyWith(
+        workspaceKindFilter: WorkspaceKindFilter.nonDefaultOnly,
+      );
+      final restored = WorkbenchViewPrefs.fromJson(
+        Map<String, Object?>.from(prefs.toMap()),
+      );
+      expect(restored.workspaceKindFilter, WorkspaceKindFilter.nonDefaultOnly);
     });
 
     test('fromJson decodes the activity sort value', () {

--- a/test/unit/workspace_pull_request_recovery_test.dart
+++ b/test/unit/workspace_pull_request_recovery_test.dart
@@ -1,0 +1,233 @@
+import 'package:alera/src/features/pull_requests/application/forge_exception.dart';
+import 'package:alera/src/features/pull_requests/application/forge_provider.dart';
+import 'package:alera/src/features/pull_requests/application/forge_provider_registry.dart';
+import 'package:alera/src/features/pull_requests/application/pull_request_providers.dart';
+import 'package:alera/src/features/pull_requests/application/workspace_pull_request_controller.dart';
+import 'package:alera/src/features/pull_requests/domain/create_review_input.dart';
+import 'package:alera/src/features/pull_requests/domain/create_review_result.dart';
+import 'package:alera/src/features/pull_requests/domain/forge_auth_status.dart';
+import 'package:alera/src/features/pull_requests/domain/hosted_review.dart';
+import 'package:alera/src/features/pull_requests/domain/linked_review.dart';
+import 'package:alera/src/features/pull_requests/domain/workspace_pull_request_scope.dart';
+import 'package:alera/src/shared/git_hosting/domain/git_hosting_provider.dart';
+import 'package:alera/src/shared/infra/git/git_providers.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'fake_forge_provider.dart';
+import 'fake_git_backend.dart';
+
+HostedReview _review(int number, {String headBranch = 'feature'}) =>
+    HostedReview(
+      provider: GitHostingProvider.github,
+      number: number,
+      title: 'feat: $number',
+      state: HostedReviewState.open,
+      url: 'https://github.com/leynier/alera/pull/$number',
+      headBranch: headBranch,
+    );
+
+const _scope = WorkspacePullRequestScope(
+  workspaceId: 'w1',
+  repoPath: '/repo',
+  branch: 'feature',
+);
+
+/// Fails the first [find] to simulate a broken initial load.
+class _ThrowingLinkedReviewRepository extends FakeLinkedReviewRepository {
+  int findCalls = 0;
+
+  @override
+  Future<LinkedReview?> find(String workspaceId) async {
+    findCalls++;
+    if (findCalls == 1) {
+      throw StateError('linked review storage unavailable');
+    }
+    return super.find(workspaceId);
+  }
+}
+
+ProviderContainer _container({
+  required FakeForgeProvider forge,
+  FakeGitBackend? git,
+  FakeLinkedReviewRepository? linkedReviews,
+  bool attach = true,
+}) {
+  final backend =
+      git ??
+      (FakeGitBackend()
+        ..remotesByName = <String, String?>{
+          'origin': 'https://github.com/leynier/alera.git',
+        });
+  final container = ProviderContainer(
+    overrides: [
+      gitBackendProvider.overrideWithValue(backend),
+      forgeProviderRegistryProvider.overrideWithValue(
+        ForgeProviderRegistry(<ForgeProvider>[forge]),
+      ),
+      linkedReviewRepositoryProvider.overrideWithValue(
+        linkedReviews ?? FakeLinkedReviewRepository(),
+      ),
+    ],
+  );
+  container.listen(workspacePullRequestControllerProvider(_scope), (_, _) {});
+  if (attach) {
+    container
+        .read(workspacePullRequestControllerProvider(_scope).notifier)
+        .attachPanel();
+  }
+  return container;
+}
+
+Future<void> _pumpUntil(WidgetTester tester, bool Function() condition) async {
+  for (var attempt = 0; attempt < 20; attempt++) {
+    if (condition()) {
+      return;
+    }
+    await tester.pump();
+  }
+  fail('Condition was not reached after pumping asynchronous work.');
+}
+
+void main() {
+  test(
+    'detects the review on the live branch over a stale scope hint',
+    () async {
+      // The scope records the branch from workspace creation, but the agent
+      // switched the worktree to another branch and opened the PR from it.
+      final backend = FakeGitBackend()
+        ..headBranch = 'agent-branch'
+        ..remotesByName = <String, String?>{
+          'origin': 'https://github.com/leynier/alera.git',
+        };
+      final forge = FakeForgeProvider()
+        ..branchReview = _review(123, headBranch: 'agent-branch');
+      final container = _container(forge: forge, git: backend);
+      addTearDown(container.dispose);
+
+      final state = await container.read(
+        workspacePullRequestControllerProvider(_scope).future,
+      );
+      expect(state.currentBranch, 'agent-branch');
+      expect(forge.lastBranchQuery, 'agent-branch');
+      expect(state.review?.number, 123);
+    },
+  );
+
+  test('falls back to the scope hint when the repo is detached', () async {
+    final backend = FakeGitBackend()
+      ..headBranch = 'HEAD'
+      ..remotesByName = <String, String?>{
+        'origin': 'https://github.com/leynier/alera.git',
+      };
+    final forge = FakeForgeProvider()..branchReview = _review(123);
+    final container = _container(forge: forge, git: backend);
+    addTearDown(container.dispose);
+
+    final state = await container.read(
+      workspacePullRequestControllerProvider(_scope).future,
+    );
+    expect(state.currentBranch, 'feature');
+    expect(forge.lastBranchQuery, 'feature');
+  });
+
+  testWidgets('keeps polling while not authenticated and picks up sign-in', (
+    tester,
+  ) async {
+    final forge = FakeForgeProvider()..auth = ForgeAuthStatus.notAuthenticated;
+    final container = _container(forge: forge);
+    addTearDown(container.dispose);
+    final provider = workspacePullRequestControllerProvider(_scope);
+
+    await _pumpUntil(tester, () => container.read(provider).hasValue);
+    expect(
+      container.read(provider).value?.authStatus,
+      ForgeAuthStatus.notAuthenticated,
+    );
+
+    forge
+      ..auth = ForgeAuthStatus.authenticated
+      ..branchReview = _review(321);
+    await tester.pump(const Duration(seconds: 121));
+    await _pumpUntil(
+      tester,
+      () => container.read(provider).value?.review?.number == 321,
+    );
+
+    final state = container.read(provider).value!;
+    expect(state.authStatus, ForgeAuthStatus.authenticated);
+    expect(state.review?.number, 321);
+    container.read(provider.notifier).detachPanel();
+    await tester.pump();
+  });
+
+  testWidgets('attachPanel recovers after a failed initial load', (
+    tester,
+  ) async {
+    final forge = FakeForgeProvider()..branchReview = _review(55);
+    final linkedReviews = _ThrowingLinkedReviewRepository();
+    final container = _container(
+      forge: forge,
+      linkedReviews: linkedReviews,
+      attach: false,
+    );
+    addTearDown(container.dispose);
+    final provider = workspacePullRequestControllerProvider(_scope);
+
+    await _pumpUntil(tester, () => container.read(provider).hasError);
+    expect(container.read(provider).hasValue, isFalse);
+
+    container.read(provider.notifier).attachPanel();
+    await tester.pump(const Duration(milliseconds: 1));
+    await _pumpUntil(
+      tester,
+      () => container.read(provider).value?.review?.number == 55,
+    );
+    expect(linkedReviews.findCalls, 2);
+    container.read(provider.notifier).detachPanel();
+    await tester.pump();
+  });
+
+  test(
+    'a throwing forge createReview clears the action and error state',
+    () async {
+      final forge = FakeForgeProvider()..branchReview = _review(123);
+      final container = _container(forge: forge);
+      addTearDown(container.dispose);
+
+      await container.read(
+        workspacePullRequestControllerProvider(_scope).future,
+      );
+      final controller = container.read(
+        workspacePullRequestControllerProvider(_scope).notifier,
+      );
+      forge.createError = const ForgeRequestFailed('boom');
+
+      final result = await controller.createReview(
+        const CreateReviewInput(
+          provider: GitHostingProvider.github,
+          title: 'feat: broken',
+          baseBranch: 'main',
+          headBranch: 'feature',
+        ),
+      );
+
+      expect(result, isA<CreateReviewFailure>());
+      expect((result as CreateReviewFailure).message, 'boom');
+      final wedged = container
+          .read(workspacePullRequestControllerProvider(_scope))
+          .value!;
+      expect(wedged.isBusy, isFalse);
+      expect(wedged.errorMessage, 'boom');
+
+      // The controller must still be able to refresh after the failure.
+      forge.createError = null;
+      await controller.refresh();
+      final refreshed = container
+          .read(workspacePullRequestControllerProvider(_scope))
+          .value!;
+      expect(refreshed.review?.number, 123);
+      expect(refreshed.errorMessage, isNull);
+    },
+  );
+}

--- a/test/widget/workbench_view_options_menu_test.dart
+++ b/test/widget/workbench_view_options_menu_test.dart
@@ -126,6 +126,44 @@ void main() {
       expect(find.text('No Projects Match "missing"'), findsOneWidget);
     });
 
+    testWidgets('updates the workspace kind filter and shows the active dot', (
+      tester,
+    ) async {
+      final controller = _ViewOptionsTestController(
+        WorkbenchState(projects: <Project>[_project('project-1', 'Alera')]),
+      );
+
+      await _pumpButton(tester, controller);
+
+      expect(_activeDot(), findsNothing);
+
+      await tester.tap(_viewOptionsButton());
+      await tester.pumpAndSettle();
+
+      expect(find.text('Show Workspaces'), findsOneWidget);
+      await tester.tap(find.text('Default'));
+      await tester.pumpAndSettle();
+
+      expect(
+        controller.state.viewPrefs.workspaceKindFilter,
+        WorkspaceKindFilter.defaultOnly,
+      );
+
+      await tester.tap(find.byTooltip('Close'));
+      await tester.pumpAndSettle();
+      expect(_activeDot(), findsOneWidget);
+
+      await tester.tap(_viewOptionsButton());
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('All').first);
+      await tester.pumpAndSettle();
+
+      expect(
+        controller.state.viewPrefs.workspaceKindFilter,
+        WorkspaceKindFilter.all,
+      );
+    });
+
     testWidgets('available project rows animate their hover state', (
       tester,
     ) async {
@@ -194,6 +232,16 @@ Finder _projectSearchField() {
 Finder _viewOptionsButton() {
   return find.byWidgetPredicate(
     (widget) => widget is IconButton && widget.tooltip == 'View options',
+  );
+}
+
+Finder _activeDot() {
+  return find.byWidgetPredicate(
+    (widget) =>
+        widget is Container &&
+        widget.decoration is BoxDecoration &&
+        (widget.decoration! as BoxDecoration).shape == BoxShape.circle &&
+        (widget.decoration! as BoxDecoration).color == AleraTokens.accent,
   );
 }
 
@@ -267,6 +315,13 @@ class _ViewOptionsTestController extends WorkbenchController {
   void clearProjectFilters() {
     state = state.copyWith(
       viewPrefs: state.viewPrefs.copyWith(selectedProjectIds: <String>{}),
+    );
+  }
+
+  @override
+  void setWorkspaceKindFilter(WorkspaceKindFilter filter) {
+    state = state.copyWith(
+      viewPrefs: state.viewPrefs.copyWith(workspaceKindFilter: filter),
     );
   }
 }


### PR DESCRIPTION
## Summary
- new persisted WorkspaceKindFilter (All / Default / Non-Default) on WorkbenchViewPrefs, defaulting to All so existing persisted prefs keep decoding
- AleraSegmentedButton section "Show Workspaces" in the view options panel, wired through setWorkspaceKindFilter and included in the active-filters dot
- filter applied in both sidebar visibility paths and in empty-project hiding so counts and collapse targets stay consistent
- fixes: view options panel body scrolls on short windows (it overflowed after the new section), and the active-filters dot no longer swallows clicks on the options button

## Validation
- new test/unit/workbench_listing_kind_filter_test.dart (per-value visibility, tag/search interaction, collapse targets, empty project hiding)
- extended view prefs round-trip/legacy-json tests and view options menu widget tests; workbench suites pass (120 tests)

Stacked on the pull request detection fix; merge that one first and this diff reduces to the filter change.