### PR TITLE
feat: redesign the about dialog

### DIFF
--- a/lib/src/features/app_menu/infra/native_app_menu_channel.dart
+++ b/lib/src/features/app_menu/infra/native_app_menu_channel.dart
@@ -46,7 +46,7 @@ Future<Object?> handleNativeAppMenuCall(
       }
     case NativeAppMenuMethod.showAbout:
       if (context.mounted) {
-        unawaited(showAppMenuAbout(context));
+        unawaited(showAppMenuAbout(context, ref));
       }
     case NativeAppMenuMethod.exitApp:
       unawaited(exitAppFromMenu(ref));

--- a/lib/src/features/app_menu/presentation/alera_app_menu_scope.dart
+++ b/lib/src/features/app_menu/presentation/alera_app_menu_scope.dart
@@ -205,7 +205,7 @@ class _AleraAppMenuButtonState extends ConsumerState<AleraAppMenuButton> {
           const SelectAllTextIntent(SelectionChangedCause.keyboard),
         );
       case _AppMenuAction.showAbout:
-        await showAppMenuAbout(context);
+        await showAppMenuAbout(context, ref);
       case _AppMenuAction.exitApp:
         await exitAppFromMenu(ref);
     }
@@ -249,7 +249,7 @@ class _MacOsPlatformMenuBar extends ConsumerWidget {
             PlatformMenuItem(
               label: 'About $kAleraAppName',
               onSelected: () {
-                unawaited(showAppMenuAbout(context));
+                unawaited(showAppMenuAbout(context, ref));
               },
             ),
             PlatformMenuItemGroup(

--- a/lib/src/features/app_menu/presentation/app_menu_about_dialog.dart
+++ b/lib/src/features/app_menu/presentation/app_menu_about_dialog.dart
@@ -1,0 +1,105 @@
+import 'package:alera/src/app/theme/alera_tokens.dart';
+import 'package:alera/src/core/build_flavor.dart';
+import 'package:alera/src/design_system/buttons/alera_icon_button.dart';
+import 'package:alera/src/design_system/feedback/alera_toast.dart';
+import 'package:alera/src/design_system/icons/alera_icons.dart';
+import 'package:alera/src/design_system/layout/alera_dialog.dart';
+import 'package:alera/src/design_system/layout/alera_dialog_header.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+
+/// About dialog: app logo, copyable version line, and an update check action.
+class AppMenuAboutDialog extends StatelessWidget {
+  const AppMenuAboutDialog({
+    super.key,
+    required this.info,
+    required this.onCheckForUpdates,
+  });
+
+  final PackageInfo info;
+  final VoidCallback onCheckForUpdates;
+
+  String get _versionLabel => '${info.version} (${info.buildNumber})';
+
+  Future<void> _copyVersion(BuildContext context) async {
+    await Clipboard.setData(ClipboardData(text: _versionLabel));
+    if (context.mounted) {
+      AleraToast.show(context, message: 'Version Copied');
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return AleraDialog(
+      maxWidth: 400,
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(
+          AleraTokens.space16,
+          AleraTokens.space12,
+          AleraTokens.space16,
+          AleraTokens.space16,
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: <Widget>[
+            AleraDialogHeader(
+              title: 'About $kAleraAppName',
+              onClose: () => Navigator.of(context).pop(),
+            ),
+            const SizedBox(height: AleraTokens.space16),
+            Center(
+              child: Image.asset(
+                'assets/logo/alera-logo-white.png',
+                width: 64,
+                height: 64,
+              ),
+            ),
+            const SizedBox(height: AleraTokens.space12),
+            Center(
+              child: Text(kAleraAppName, style: theme.textTheme.titleMedium),
+            ),
+            const SizedBox(height: AleraTokens.space4),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: <Widget>[
+                Text(
+                  'Version $_versionLabel',
+                  style: theme.textTheme.bodyMedium?.copyWith(
+                    color: AleraTokens.foregroundMuted,
+                  ),
+                ),
+                const SizedBox(width: AleraTokens.space4),
+                AleraIconButton(
+                  tooltip: 'Copy Version',
+                  icon: AleraIcons.copy,
+                  iconSize: 14,
+                  minSize: 24,
+                  onPressed: () => _copyVersion(context),
+                ),
+              ],
+            ),
+            const SizedBox(height: AleraTokens.space20),
+            OverflowBar(
+              alignment: MainAxisAlignment.end,
+              spacing: AleraTokens.space8,
+              overflowSpacing: AleraTokens.space8,
+              children: <Widget>[
+                OutlinedButton(
+                  onPressed: onCheckForUpdates,
+                  child: const Text('Check For Updates'),
+                ),
+                FilledButton(
+                  onPressed: () => Navigator.of(context).pop(),
+                  child: const Text('Close'),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/features/app_menu/presentation/app_menu_actions.dart
+++ b/lib/src/features/app_menu/presentation/app_menu_actions.dart
@@ -1,8 +1,8 @@
+import 'dart:async';
+
 import 'package:alera/src/app/providers.dart';
-import 'package:alera/src/app/theme/alera_tokens.dart';
-import 'package:alera/src/core/build_flavor.dart';
 import 'package:alera/src/design_system/feedback/alera_toast.dart';
-import 'package:alera/src/design_system/layout/alera_dialog.dart';
+import 'package:alera/src/features/app_menu/presentation/app_menu_about_dialog.dart';
 import 'package:alera/src/features/app_window/application/app_window_providers.dart';
 import 'package:alera/src/features/updater/domain/alera_update.dart';
 import 'package:alera/src/features/workbench/presentation/workbench_dialog_launchers.dart';
@@ -40,44 +40,25 @@ Future<void> checkForUpdatesFromAppMenu(
 }
 
 Future<void> showAppMenuAbout(
-  BuildContext context, {
+  BuildContext context,
+  WidgetRef ref, {
   AppMenuPackageInfoLoader loadPackageInfo = PackageInfo.fromPlatform,
 }) async {
   final info = await loadPackageInfo();
   if (!context.mounted) {
     return;
   }
-  final theme = Theme.of(context);
   await showDialog<void>(
     context: context,
     builder: (dialogContext) {
-      return AleraDialog(
-        maxWidth: 360,
-        child: Padding(
-          padding: const EdgeInsets.all(AleraTokens.space20),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: <Widget>[
-              Text(kAleraAppName, style: theme.textTheme.titleMedium),
-              const SizedBox(height: AleraTokens.space8),
-              Text(
-                'Version ${info.version} (${info.buildNumber})',
-                style: theme.textTheme.bodyMedium?.copyWith(
-                  color: AleraTokens.foregroundMuted,
-                ),
-              ),
-              const SizedBox(height: AleraTokens.space20),
-              Align(
-                alignment: Alignment.centerRight,
-                child: FilledButton(
-                  onPressed: () => Navigator.of(dialogContext).pop(),
-                  child: const Text('Close'),
-                ),
-              ),
-            ],
-          ),
-        ),
+      return AppMenuAboutDialog(
+        info: info,
+        onCheckForUpdates: () {
+          // Close first: the update result surfaces as a toast under the
+          // launcher context, not the dialog's.
+          Navigator.of(dialogContext).pop();
+          unawaited(checkForUpdatesFromAppMenu(context, ref));
+        },
       );
     },
   );

--- a/lib/src/features/pull_requests/application/workspace_pull_request_controller.dart
+++ b/lib/src/features/pull_requests/application/workspace_pull_request_controller.dart
@@ -27,10 +27,13 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'workspace_pull_request_controller.g.dart';
 part 'workspace_pull_request_review_actions.dart';
+part 'workspace_pull_request_review_editing.dart';
 
 @Riverpod(keepAlive: true)
 class WorkspacePullRequestController extends _$WorkspacePullRequestController
-    with _WorkspacePullRequestReviewActions {
+    with
+        _WorkspacePullRequestReviewActions,
+        _WorkspacePullRequestReviewEditing {
   static const Duration _minPollInterval = Duration(seconds: 30);
   static const Duration _maxPollInterval = Duration(seconds: 120);
 
@@ -88,6 +91,42 @@ class WorkspacePullRequestController extends _$WorkspacePullRequestController
           unawaited(_refresh(origin: _RefreshOrigin.resume));
         }
       });
+      return;
+    }
+    // A failed initial load leaves the provider in AsyncError with no timer;
+    // without this recovery an opened panel would stay dead forever.
+    if (state.hasError) {
+      Timer.run(() {
+        unawaited(_recoverFromError());
+      });
+    }
+  }
+
+  Future<void> _recoverFromError() async {
+    if (_disposed || !_visible) {
+      return;
+    }
+    try {
+      final loaded = await _loader.load(scope);
+      if (!_disposed) {
+        state = AsyncData(loaded);
+      }
+    } catch (error, stackTrace) {
+      if (!_disposed) {
+        state = AsyncError<WorkspacePullRequestState>(error, stackTrace);
+      }
+    } finally {
+      if (!_disposed && _visible) {
+        if (state.value != null) {
+          _schedulePoll(scope);
+        } else {
+          // Still failing: keep retrying slowly while the panel stays open.
+          _pollTimer?.cancel();
+          _pollTimer = Timer(_maxPollInterval, () {
+            unawaited(_recoverFromError());
+          });
+        }
+      }
     }
   }
 
@@ -160,122 +199,6 @@ class WorkspacePullRequestController extends _$WorkspacePullRequestController
         );
       },
     );
-  }
-
-  /// Creates a review from [input]: pushes the branch, calls the forge, and
-  /// links the result on success.
-  Future<CreateReviewResult> createReview(CreateReviewInput input) async {
-    final identity = state.value?.identity;
-    final forge = identity == null
-        ? null
-        : _registry.forProvider(identity.provider);
-    if (identity == null || forge == null) {
-      return const CreateReviewFailure(
-        code: CreateReviewErrorCode.blocked,
-        message: 'No hosting provider is configured.',
-      );
-    }
-    _pollTimer?.cancel();
-    state = AsyncData(
-      (state.value ?? const WorkspacePullRequestState()).copyWith(
-        action: PullRequestAction.create,
-        clearError: true,
-      ),
-    );
-    try {
-      await _gitBackend.push(scope.repoPath);
-    } on GitException catch (error) {
-      final result = CreateReviewFailure(
-        code: CreateReviewErrorCode.pushFailed,
-        message: 'Could not push the branch: ${error.context}',
-      );
-      _applyActionOutcome(failureMessage: result.message);
-      return result;
-    }
-    final result = await forge.createReview(
-      identity: identity,
-      repoPath: scope.repoPath,
-      input: input,
-    );
-    if (result is CreateReviewSuccess) {
-      await _linkedReviews.save(
-        LinkedReview.linked(
-          workspaceId: scope.workspaceId,
-          provider: identity.provider,
-          number: result.review.number,
-          url: result.review.url,
-        ),
-      );
-    }
-    _applyActionOutcome(
-      failureMessage: result is CreateReviewFailure ? result.message : null,
-    );
-    if (!_disposed && _visible) {
-      await refresh();
-    }
-    return result;
-  }
-
-  /// Detail metadata for [check] of the linked review; null when nothing is
-  /// linked or the check is gone. Transport/auth failures throw.
-  Future<ReviewCheckDetails?> loadCheckDetails(ReviewCheck check) async {
-    final current = state.value;
-    final identity = current?.identity;
-    final review = current?.review;
-    final forge = identity == null
-        ? null
-        : _registry.forProvider(identity.provider);
-    if (identity == null || review == null || forge == null) {
-      return null;
-    }
-    return forge.getCheckDetails(
-      identity: identity,
-      repoPath: scope.repoPath,
-      number: review.number,
-      check: check,
-    );
-  }
-
-  /// Updates the linked review from [input], then reloads.
-  Future<UpdateReviewResult> updateReview(UpdateReviewInput input) async {
-    final identity = state.value?.identity;
-    final review = state.value?.review;
-    final forge = identity == null
-        ? null
-        : _registry.forProvider(identity.provider);
-    if (identity == null || review == null || forge == null) {
-      return const UpdateReviewFailure(
-        code: UpdateReviewErrorCode.blocked,
-        message: 'No linked pull request to update.',
-      );
-    }
-    if (input.isEmpty) {
-      return const UpdateReviewFailure(
-        code: UpdateReviewErrorCode.blocked,
-        message: 'Nothing to update.',
-      );
-    }
-    _pollTimer?.cancel();
-    state = AsyncData(
-      (state.value ?? const WorkspacePullRequestState()).copyWith(
-        action: PullRequestAction.update,
-        clearError: true,
-      ),
-    );
-    final result = await forge.updateReview(
-      identity: identity,
-      repoPath: scope.repoPath,
-      number: review.number,
-      input: input,
-    );
-    _applyActionOutcome(
-      failureMessage: result is UpdateReviewFailure ? result.message : null,
-    );
-    // Reload only on success; the refresh path would clear the error message.
-    if (!_disposed && _visible && result is UpdateReviewSuccess) {
-      await refresh();
-    }
-    return result;
   }
 
   /// Clears the in-flight action; a non-null [failureMessage] surfaces it.
@@ -426,15 +349,15 @@ class WorkspacePullRequestController extends _$WorkspacePullRequestController
   }) {
     _pollTimer?.cancel();
     final current = snapshot ?? state.value;
-    if (_disposed ||
-        !_visible ||
-        current == null ||
-        current.isBusy ||
-        current.identity == null ||
-        current.authStatus != ForgeAuthStatus.authenticated) {
+    if (_disposed || !_visible || current == null || current.isBusy) {
       return;
     }
-    _pollTimer = Timer(_pollInterval, () {
+    // Missing identity or auth can heal outside the app (the user signs in,
+    // adds a remote); keep polling slowly instead of never retrying.
+    final degraded =
+        current.identity == null ||
+        current.authStatus != ForgeAuthStatus.authenticated;
+    _pollTimer = Timer(degraded ? _maxPollInterval : _pollInterval, () {
       unawaited(_pollTick(scope));
     });
   }

--- a/lib/src/features/pull_requests/application/workspace_pull_request_controller.g.dart
+++ b/lib/src/features/pull_requests/application/workspace_pull_request_controller.g.dart
@@ -57,7 +57,7 @@ final class WorkspacePullRequestControllerProvider
 }
 
 String _$workspacePullRequestControllerHash() =>
-    r'eac4ab88a727ac219c2c1f79fa6f164c2fc4ce3d';
+    r'c9f788ed5b0933dbfa305d0e98cd19fc5fc91c2d';
 
 final class WorkspacePullRequestControllerFamily extends $Family
     with

--- a/lib/src/features/pull_requests/application/workspace_pull_request_loader.dart
+++ b/lib/src/features/pull_requests/application/workspace_pull_request_loader.dart
@@ -167,16 +167,22 @@ class WorkspacePullRequestLoader {
   }
 
   Future<String?> _resolveBranch(WorkspacePullRequestScope scope) async {
+    // The scope hint is the branch recorded at workspace creation; agents can
+    // switch branches inside the worktree afterwards, so live HEAD wins and
+    // the hint only covers detached HEAD or git failures.
+    try {
+      final current = await _gitBackend.currentBranch(scope.repoPath);
+      if (current.isNotEmpty && current != 'HEAD') {
+        return current;
+      }
+    } on GitException {
+      // Fall back to the scope hint below.
+    }
     final hinted = scope.branch;
     if (hinted != null && hinted.isNotEmpty && hinted != 'HEAD') {
       return hinted;
     }
-    try {
-      final current = await _gitBackend.currentBranch(scope.repoPath);
-      return current.isEmpty || current == 'HEAD' ? null : current;
-    } on GitException {
-      return null;
-    }
+    return null;
   }
 
   Future<HostedReview?> _detectReview(

--- a/lib/src/features/pull_requests/application/workspace_pull_request_review_editing.dart
+++ b/lib/src/features/pull_requests/application/workspace_pull_request_review_editing.dart
@@ -1,0 +1,164 @@
+part of 'workspace_pull_request_controller.dart';
+
+mixin _WorkspacePullRequestReviewEditing on _$WorkspacePullRequestController {
+  WorkspacePullRequestController get _editingController =>
+      this as WorkspacePullRequestController;
+
+  /// Creates a review from [input]: pushes the branch, calls the forge, and
+  /// links the result on success.
+  Future<CreateReviewResult> createReview(CreateReviewInput input) async {
+    final controller = _editingController;
+    final identity = state.value?.identity;
+    final forge = identity == null
+        ? null
+        : controller._registry.forProvider(identity.provider);
+    if (identity == null || forge == null) {
+      return const CreateReviewFailure(
+        code: CreateReviewErrorCode.blocked,
+        message: 'No hosting provider is configured.',
+      );
+    }
+    controller._pollTimer?.cancel();
+    state = AsyncData(
+      (state.value ?? const WorkspacePullRequestState()).copyWith(
+        action: PullRequestAction.create,
+        clearError: true,
+      ),
+    );
+    try {
+      await controller._gitBackend.push(controller.scope.repoPath);
+    } on GitException catch (error) {
+      final result = CreateReviewFailure(
+        code: CreateReviewErrorCode.pushFailed,
+        message: 'Could not push the branch: ${error.context}',
+      );
+      controller._applyActionOutcome(failureMessage: result.message);
+      return result;
+    }
+    // A thrown ForgeException (vs a returned failure) must not skip
+    // _applyActionOutcome, or the action would stay busy and block polling.
+    final CreateReviewResult result;
+    try {
+      result = await forge.createReview(
+        identity: identity,
+        repoPath: controller.scope.repoPath,
+        input: input,
+      );
+    } on ForgeException catch (error) {
+      final failure = CreateReviewFailure(
+        code: CreateReviewErrorCode.unknown,
+        message: error.message,
+      );
+      controller._applyActionOutcome(failureMessage: failure.message);
+      return failure;
+    } catch (error) {
+      final failure = CreateReviewFailure(
+        code: CreateReviewErrorCode.unknown,
+        message: error.toString(),
+      );
+      controller._applyActionOutcome(failureMessage: failure.message);
+      return failure;
+    }
+    if (result is CreateReviewSuccess) {
+      await controller._linkedReviews.save(
+        LinkedReview.linked(
+          workspaceId: controller.scope.workspaceId,
+          provider: identity.provider,
+          number: result.review.number,
+          url: result.review.url,
+        ),
+      );
+    }
+    controller._applyActionOutcome(
+      failureMessage: result is CreateReviewFailure ? result.message : null,
+    );
+    if (!controller._disposed && controller._visible) {
+      await controller.refresh();
+    }
+    return result;
+  }
+
+  /// Detail metadata for [check] of the linked review; null when nothing is
+  /// linked or the check is gone. Transport/auth failures throw.
+  Future<ReviewCheckDetails?> loadCheckDetails(ReviewCheck check) async {
+    final controller = _editingController;
+    final current = state.value;
+    final identity = current?.identity;
+    final review = current?.review;
+    final forge = identity == null
+        ? null
+        : controller._registry.forProvider(identity.provider);
+    if (identity == null || review == null || forge == null) {
+      return null;
+    }
+    return forge.getCheckDetails(
+      identity: identity,
+      repoPath: controller.scope.repoPath,
+      number: review.number,
+      check: check,
+    );
+  }
+
+  /// Updates the linked review from [input], then reloads.
+  Future<UpdateReviewResult> updateReview(UpdateReviewInput input) async {
+    final controller = _editingController;
+    final identity = state.value?.identity;
+    final review = state.value?.review;
+    final forge = identity == null
+        ? null
+        : controller._registry.forProvider(identity.provider);
+    if (identity == null || review == null || forge == null) {
+      return const UpdateReviewFailure(
+        code: UpdateReviewErrorCode.blocked,
+        message: 'No linked pull request to update.',
+      );
+    }
+    if (input.isEmpty) {
+      return const UpdateReviewFailure(
+        code: UpdateReviewErrorCode.blocked,
+        message: 'Nothing to update.',
+      );
+    }
+    controller._pollTimer?.cancel();
+    state = AsyncData(
+      (state.value ?? const WorkspacePullRequestState()).copyWith(
+        action: PullRequestAction.update,
+        clearError: true,
+      ),
+    );
+    // Same containment as createReview: a thrown error must clear the action.
+    final UpdateReviewResult result;
+    try {
+      result = await forge.updateReview(
+        identity: identity,
+        repoPath: controller.scope.repoPath,
+        number: review.number,
+        input: input,
+      );
+    } on ForgeException catch (error) {
+      final failure = UpdateReviewFailure(
+        code: UpdateReviewErrorCode.unknown,
+        message: error.message,
+      );
+      controller._applyActionOutcome(failureMessage: failure.message);
+      return failure;
+    } catch (error) {
+      final failure = UpdateReviewFailure(
+        code: UpdateReviewErrorCode.unknown,
+        message: error.toString(),
+      );
+      controller._applyActionOutcome(failureMessage: failure.message);
+      return failure;
+    }
+    controller._applyActionOutcome(
+      failureMessage: result is UpdateReviewFailure ? result.message : null,
+    );
+    // Reload only on success; the refresh path would clear the error message.
+    if (!controller._disposed &&
+        controller._visible &&
+        result is UpdateReviewSuccess) {
+      await controller.refresh();
+    }
+    return result;
+  }
+}

--- a/lib/src/features/workbench/application/workbench_controller_view_prefs.dart
+++ b/lib/src/features/workbench/application/workbench_controller_view_prefs.dart
@@ -35,6 +35,13 @@ mixin _WorkbenchControllerViewPrefs
     _updateViewPrefs(state.viewPrefs.copyWith(workspaceSort: sort));
   }
 
+  void setWorkspaceKindFilter(WorkspaceKindFilter filter) {
+    if (state.viewPrefs.workspaceKindFilter == filter) {
+      return;
+    }
+    _updateViewPrefs(state.viewPrefs.copyWith(workspaceKindFilter: filter));
+  }
+
   void toggleProjectFilter(String projectId) {
     final next = Set<String>.from(state.viewPrefs.selectedProjectIds);
     if (!next.add(projectId)) {

--- a/lib/src/features/workbench/application/workbench_listing.dart
+++ b/lib/src/features/workbench/application/workbench_listing.dart
@@ -3,6 +3,7 @@ import 'package:alera/src/features/projects/domain/project.dart';
 import 'package:alera/src/features/workbench/application/workbench_agent_activity_sort.dart';
 import 'package:alera/src/features/workbench/application/workbench_listing_tree.dart';
 import 'package:alera/src/features/workbench/application/workbench_state.dart';
+import 'package:alera/src/features/workbench/application/workbench_workspace_filters.dart';
 import 'package:alera/src/features/workbench/domain/workbench_view_prefs.dart';
 import 'package:alera/src/features/workbench/domain/workspace.dart';
 
@@ -344,25 +345,6 @@ List<WorkbenchSidebarRow> buildSidebarRows(
   }
 
   return rows;
-}
-
-/// OR semantics over the selected tag filter: an empty selection shows every
-/// workspace; otherwise a workspace must carry at least one selected tag.
-bool workspaceMatchesTagFilter(WorkbenchViewPrefs prefs, Workspace workspace) {
-  if (prefs.selectedTagIds.isEmpty) {
-    return true;
-  }
-  return workspace.tagIds.any(prefs.selectedTagIds.contains);
-}
-
-/// Whether [workspace] passes the workspace-kind visibility filter: the main
-/// worktree counts as the project's default workspace.
-bool workspaceMatchesKindFilter(WorkbenchViewPrefs prefs, Workspace workspace) {
-  return switch (prefs.workspaceKindFilter) {
-    WorkspaceKindFilter.all => true,
-    WorkspaceKindFilter.defaultOnly => workspace.isMain,
-    WorkspaceKindFilter.nonDefaultOnly => !workspace.isMain,
-  };
 }
 
 WorkbenchSidebarCollapseTargets visibleSidebarCollapseTargets(

--- a/lib/src/features/workbench/application/workbench_listing.dart
+++ b/lib/src/features/workbench/application/workbench_listing.dart
@@ -53,6 +53,9 @@ List<WorkbenchSidebarRow> buildSidebarRows(
   }
 
   bool workspaceVisible(Project project, Workspace workspace) {
+    if (!workspaceMatchesKindFilter(prefs, workspace)) {
+      return false;
+    }
     if (!workspaceMatchesTagFilter(prefs, workspace)) {
       return false;
     }
@@ -208,7 +211,9 @@ List<WorkbenchSidebarRow> buildSidebarRows(
   final rows = <WorkbenchSidebarRow>[];
   final visibleProjects = state.projects.where(projectVisible).toList();
   final filtersHideEmptyProjects =
-      query.isNotEmpty || prefs.selectedTagIds.isNotEmpty;
+      query.isNotEmpty ||
+      prefs.selectedTagIds.isNotEmpty ||
+      prefs.workspaceKindFilter != WorkspaceKindFilter.all;
 
   final pinnedRows = <WorkbenchSidebarRow>[];
   var pinnedWorkspaceCount = 0;
@@ -350,6 +355,16 @@ bool workspaceMatchesTagFilter(WorkbenchViewPrefs prefs, Workspace workspace) {
   return workspace.tagIds.any(prefs.selectedTagIds.contains);
 }
 
+/// Whether [workspace] passes the workspace-kind visibility filter: the main
+/// worktree counts as the project's default workspace.
+bool workspaceMatchesKindFilter(WorkbenchViewPrefs prefs, Workspace workspace) {
+  return switch (prefs.workspaceKindFilter) {
+    WorkspaceKindFilter.all => true,
+    WorkspaceKindFilter.defaultOnly => workspace.isMain,
+    WorkspaceKindFilter.nonDefaultOnly => !workspace.isMain,
+  };
+}
+
 WorkbenchSidebarCollapseTargets visibleSidebarCollapseTargets(
   WorkbenchState state, {
   bool includeCollapsedProjectDescendants = false,
@@ -357,7 +372,9 @@ WorkbenchSidebarCollapseTargets visibleSidebarCollapseTargets(
   final prefs = state.viewPrefs;
   final query = state.searchQuery.trim().toLowerCase();
   final filtersHideEmptyProjects =
-      query.isNotEmpty || prefs.selectedTagIds.isNotEmpty;
+      query.isNotEmpty ||
+      prefs.selectedTagIds.isNotEmpty ||
+      prefs.workspaceKindFilter != WorkspaceKindFilter.all;
   final visibleProjects = state.projects
       .where((project) => _projectVisible(prefs, project))
       .toList(growable: false);
@@ -430,6 +447,9 @@ bool _workspaceVisible(
   Project project,
   Workspace workspace,
 ) {
+  if (!workspaceMatchesKindFilter(prefs, workspace)) {
+    return false;
+  }
   if (!workspaceMatchesTagFilter(prefs, workspace)) {
     return false;
   }

--- a/lib/src/features/workbench/application/workbench_workspace_filters.dart
+++ b/lib/src/features/workbench/application/workbench_workspace_filters.dart
@@ -1,0 +1,21 @@
+import 'package:alera/src/features/workbench/domain/workbench_view_prefs.dart';
+import 'package:alera/src/features/workbench/domain/workspace.dart';
+
+/// OR semantics over the selected tag filter: an empty selection shows every
+/// workspace; otherwise a workspace must carry at least one selected tag.
+bool workspaceMatchesTagFilter(WorkbenchViewPrefs prefs, Workspace workspace) {
+  if (prefs.selectedTagIds.isEmpty) {
+    return true;
+  }
+  return workspace.tagIds.any(prefs.selectedTagIds.contains);
+}
+
+/// Whether [workspace] passes the workspace-kind visibility filter: the main
+/// worktree counts as the project's default workspace.
+bool workspaceMatchesKindFilter(WorkbenchViewPrefs prefs, Workspace workspace) {
+  return switch (prefs.workspaceKindFilter) {
+    WorkspaceKindFilter.all => true,
+    WorkspaceKindFilter.defaultOnly => workspace.isMain,
+    WorkspaceKindFilter.nonDefaultOnly => !workspace.isMain,
+  };
+}

--- a/lib/src/features/workbench/application/workspace_activity_controller.g.dart
+++ b/lib/src/features/workbench/application/workspace_activity_controller.g.dart
@@ -79,7 +79,7 @@ abstract class _$WorkspaceActivityController
 }
 
 /// Feeds [WorkspaceActivityController] from discrete agent status transitions.
-/// Tool-by-tool updates within one state do not count as activity — only a
+/// Tool-by-tool updates within one state do not count as activity - only a
 /// `state`/`stateStartedAt` change marks the workspace as active.
 
 @ProviderFor(workspaceActivityCoordinator)
@@ -87,14 +87,14 @@ final workspaceActivityCoordinatorProvider =
     WorkspaceActivityCoordinatorProvider._();
 
 /// Feeds [WorkspaceActivityController] from discrete agent status transitions.
-/// Tool-by-tool updates within one state do not count as activity — only a
+/// Tool-by-tool updates within one state do not count as activity - only a
 /// `state`/`stateStartedAt` change marks the workspace as active.
 
 final class WorkspaceActivityCoordinatorProvider
     extends $FunctionalProvider<void, void, void>
     with $Provider<void> {
   /// Feeds [WorkspaceActivityController] from discrete agent status transitions.
-  /// Tool-by-tool updates within one state do not count as activity — only a
+  /// Tool-by-tool updates within one state do not count as activity - only a
   /// `state`/`stateStartedAt` change marks the workspace as active.
   WorkspaceActivityCoordinatorProvider._()
     : super(

--- a/lib/src/features/workbench/domain/workbench_view_prefs.dart
+++ b/lib/src/features/workbench/domain/workbench_view_prefs.dart
@@ -22,6 +22,11 @@ enum GitDiffViewMode { tree, flat }
 @MappableEnum()
 enum PullRequestCreateAction { publish, draft }
 
+/// Sidebar visibility filter by workspace kind: the project's main worktree
+/// ("Default Workspace" in the UI) versus linked worktrees.
+@MappableEnum()
+enum WorkspaceKindFilter { all, defaultOnly, nonDefaultOnly }
+
 @MappableClass()
 class WorkbenchViewPrefs with WorkbenchViewPrefsMappable {
   const WorkbenchViewPrefs({
@@ -43,6 +48,7 @@ class WorkbenchViewPrefs with WorkbenchViewPrefsMappable {
     this.explorerMode = WorkspaceExplorerMode.hideIgnored,
     this.gitDiffViewMode = GitDiffViewMode.tree,
     this.pullRequestCreateAction = PullRequestCreateAction.publish,
+    this.workspaceKindFilter = WorkspaceKindFilter.all,
   });
 
   final WorkbenchGroupBy groupBy;
@@ -95,6 +101,10 @@ class WorkbenchViewPrefs with WorkbenchViewPrefsMappable {
   /// persisted with the rest of the workbench view prefs.
   final PullRequestCreateAction pullRequestCreateAction;
 
+  /// Which workspace kinds the sidebar shows. Defaults to [WorkspaceKindFilter.all]
+  /// so previously persisted prefs (missing the key) keep today's behavior.
+  final WorkspaceKindFilter workspaceKindFilter;
+
   static const WorkbenchViewPrefs defaults = WorkbenchViewPrefs(
     groupBy: WorkbenchGroupBy.project,
     projectSort: WorkbenchSortBy.name,
@@ -114,6 +124,7 @@ class WorkbenchViewPrefs with WorkbenchViewPrefsMappable {
     explorerMode: WorkspaceExplorerMode.hideIgnored,
     gitDiffViewMode: GitDiffViewMode.tree,
     pullRequestCreateAction: PullRequestCreateAction.publish,
+    workspaceKindFilter: WorkspaceKindFilter.all,
   );
 
   factory WorkbenchViewPrefs.fromJson(Map<String, Object?> json) =>

--- a/lib/src/features/workbench/domain/workbench_view_prefs.mapper.dart
+++ b/lib/src/features/workbench/domain/workbench_view_prefs.mapper.dart
@@ -305,6 +305,56 @@ extension PullRequestCreateActionMapperExtension on PullRequestCreateAction {
   }
 }
 
+class WorkspaceKindFilterMapper extends EnumMapper<WorkspaceKindFilter> {
+  WorkspaceKindFilterMapper._();
+
+  static WorkspaceKindFilterMapper? _instance;
+  static WorkspaceKindFilterMapper ensureInitialized() {
+    if (_instance == null) {
+      MapperContainer.globals.use(_instance = WorkspaceKindFilterMapper._());
+    }
+    return _instance!;
+  }
+
+  static WorkspaceKindFilter fromValue(dynamic value) {
+    ensureInitialized();
+    return MapperContainer.globals.fromValue(value);
+  }
+
+  @override
+  WorkspaceKindFilter decode(dynamic value) {
+    switch (value) {
+      case r'all':
+        return WorkspaceKindFilter.all;
+      case r'defaultOnly':
+        return WorkspaceKindFilter.defaultOnly;
+      case r'nonDefaultOnly':
+        return WorkspaceKindFilter.nonDefaultOnly;
+      default:
+        throw MapperException.unknownEnumValue(value);
+    }
+  }
+
+  @override
+  dynamic encode(WorkspaceKindFilter self) {
+    switch (self) {
+      case WorkspaceKindFilter.all:
+        return r'all';
+      case WorkspaceKindFilter.defaultOnly:
+        return r'defaultOnly';
+      case WorkspaceKindFilter.nonDefaultOnly:
+        return r'nonDefaultOnly';
+    }
+  }
+}
+
+extension WorkspaceKindFilterMapperExtension on WorkspaceKindFilter {
+  String toValue() {
+    WorkspaceKindFilterMapper.ensureInitialized();
+    return MapperContainer.globals.toValue<WorkspaceKindFilter>(this) as String;
+  }
+}
+
 class WorkbenchViewPrefsMapper extends ClassMapperBase<WorkbenchViewPrefs> {
   WorkbenchViewPrefsMapper._();
 
@@ -318,6 +368,7 @@ class WorkbenchViewPrefsMapper extends ClassMapperBase<WorkbenchViewPrefs> {
       WorkspaceExplorerModeMapper.ensureInitialized();
       GitDiffViewModeMapper.ensureInitialized();
       PullRequestCreateActionMapper.ensureInitialized();
+      WorkspaceKindFilterMapper.ensureInitialized();
     }
     return _instance!;
   }
@@ -453,6 +504,15 @@ class WorkbenchViewPrefsMapper extends ClassMapperBase<WorkbenchViewPrefs> {
     opt: true,
     def: PullRequestCreateAction.publish,
   );
+  static WorkspaceKindFilter _$workspaceKindFilter(WorkbenchViewPrefs v) =>
+      v.workspaceKindFilter;
+  static const Field<WorkbenchViewPrefs, WorkspaceKindFilter>
+  _f$workspaceKindFilter = Field(
+    'workspaceKindFilter',
+    _$workspaceKindFilter,
+    opt: true,
+    def: WorkspaceKindFilter.all,
+  );
 
   @override
   final MappableFields<WorkbenchViewPrefs> fields = const {
@@ -474,6 +534,7 @@ class WorkbenchViewPrefsMapper extends ClassMapperBase<WorkbenchViewPrefs> {
     #explorerMode: _f$explorerMode,
     #gitDiffViewMode: _f$gitDiffViewMode,
     #pullRequestCreateAction: _f$pullRequestCreateAction,
+    #workspaceKindFilter: _f$workspaceKindFilter,
   };
 
   static WorkbenchViewPrefs _instantiate(DecodingData data) {
@@ -498,6 +559,7 @@ class WorkbenchViewPrefsMapper extends ClassMapperBase<WorkbenchViewPrefs> {
       explorerMode: data.dec(_f$explorerMode),
       gitDiffViewMode: data.dec(_f$gitDiffViewMode),
       pullRequestCreateAction: data.dec(_f$pullRequestCreateAction),
+      workspaceKindFilter: data.dec(_f$workspaceKindFilter),
     );
   }
 
@@ -593,6 +655,7 @@ abstract class WorkbenchViewPrefsCopyWith<
     WorkspaceExplorerMode? explorerMode,
     GitDiffViewMode? gitDiffViewMode,
     PullRequestCreateAction? pullRequestCreateAction,
+    WorkspaceKindFilter? workspaceKindFilter,
   });
   WorkbenchViewPrefsCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(
     Then<$Out2, $R2> t,
@@ -634,6 +697,7 @@ class _WorkbenchViewPrefsCopyWithImpl<$R, $Out>
     WorkspaceExplorerMode? explorerMode,
     GitDiffViewMode? gitDiffViewMode,
     PullRequestCreateAction? pullRequestCreateAction,
+    WorkspaceKindFilter? workspaceKindFilter,
   }) => $apply(
     FieldCopyWithData({
       if (groupBy != null) #groupBy: groupBy,
@@ -663,6 +727,8 @@ class _WorkbenchViewPrefsCopyWithImpl<$R, $Out>
       if (gitDiffViewMode != null) #gitDiffViewMode: gitDiffViewMode,
       if (pullRequestCreateAction != null)
         #pullRequestCreateAction: pullRequestCreateAction,
+      if (workspaceKindFilter != null)
+        #workspaceKindFilter: workspaceKindFilter,
     }),
   );
   @override
@@ -717,6 +783,10 @@ class _WorkbenchViewPrefsCopyWithImpl<$R, $Out>
     pullRequestCreateAction: data.get(
       #pullRequestCreateAction,
       or: $value.pullRequestCreateAction,
+    ),
+    workspaceKindFilter: data.get(
+      #workspaceKindFilter,
+      or: $value.workspaceKindFilter,
     ),
   );
 

--- a/lib/src/features/workbench/presentation/widgets/workbench_view_options_controls.dart
+++ b/lib/src/features/workbench/presentation/widgets/workbench_view_options_controls.dart
@@ -81,6 +81,39 @@ class _GroupBySegmented extends StatelessWidget {
   }
 }
 
+class _WorkspaceKindSegmented extends StatelessWidget {
+  const _WorkspaceKindSegmented({required this.value, required this.onChanged});
+
+  final WorkspaceKindFilter value;
+  final ValueChanged<WorkspaceKindFilter> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return AleraSegmentedButton<WorkspaceKindFilter>(
+      dense: true,
+      backgroundColor: AleraTokens.surface,
+      foregroundColor: AleraTokens.foregroundMuted,
+      selectedBackgroundColor: AleraTokens.accentSubtle,
+      selectedForegroundColor: AleraTokens.foreground,
+      borderColor: AleraTokens.borderSubtle,
+      textStyle: Theme.of(context).textTheme.labelSmall,
+      selected: value,
+      onSelectionChanged: onChanged,
+      segments: const <ButtonSegment<WorkspaceKindFilter>>[
+        ButtonSegment(value: WorkspaceKindFilter.all, label: Text('All')),
+        ButtonSegment(
+          value: WorkspaceKindFilter.defaultOnly,
+          label: Text('Default'),
+        ),
+        ButtonSegment(
+          value: WorkspaceKindFilter.nonDefaultOnly,
+          label: Text('Non-Default'),
+        ),
+      ],
+    );
+  }
+}
+
 class _SortRow extends StatelessWidget {
   const _SortRow({
     required this.label,

--- a/lib/src/features/workbench/presentation/widgets/workbench_view_options_menu.dart
+++ b/lib/src/features/workbench/presentation/widgets/workbench_view_options_menu.dart
@@ -33,6 +33,8 @@ class WorkbenchViewOptionsButton extends ConsumerWidget {
     final hasFilters =
         prefs.selectedProjectIds.isNotEmpty ||
         prefs.selectedTagIds.isNotEmpty ||
+        prefs.workspaceKindFilter !=
+            WorkbenchViewPrefs.defaults.workspaceKindFilter ||
         prefs.groupBy != WorkbenchViewPrefs.defaults.groupBy ||
         prefs.projectSort != WorkbenchViewPrefs.defaults.projectSort ||
         prefs.workspaceSort != WorkbenchViewPrefs.defaults.workspaceSort;
@@ -44,7 +46,14 @@ class WorkbenchViewOptionsButton extends ConsumerWidget {
           onPressed: () => _showOptions(context),
           icon: AleraIcons.tune,
         ),
-        if (hasFilters) const Positioned(right: 6, top: 6, child: _ActiveDot()),
+        // Decorative only: without IgnorePointer the dot swallows clicks on
+        // the small icon button underneath it.
+        if (hasFilters)
+          const Positioned(
+            right: 6,
+            top: 6,
+            child: IgnorePointer(child: _ActiveDot()),
+          ),
       ],
     );
   }
@@ -232,91 +241,111 @@ class _WorkbenchViewOptionsPanelState
         children: <Widget>[
           AleraDialogHeader(title: 'View Options', onClose: widget.onDismiss),
           const SizedBox(height: AleraTokens.space12),
-          _SectionLabel(text: 'Group By'),
-          const SizedBox(height: AleraTokens.space6),
-          _GroupBySegmented(
-            value: prefs.groupBy,
-            onChanged: controller.setGroupBy,
-          ),
-          const SizedBox(height: AleraTokens.space12),
-          _SortRow(
-            label: prefs.groupBy == WorkbenchGroupBy.project
-                ? 'Sort Projects By'
-                : 'Sort Workspaces By',
-            value: prefs.groupBy == WorkbenchGroupBy.project
-                ? prefs.projectSort
-                : prefs.workspaceSort,
-            onChanged: prefs.groupBy == WorkbenchGroupBy.project
-                ? controller.setProjectSort
-                : controller.setWorkspaceSort,
-          ),
-          if (prefs.groupBy == WorkbenchGroupBy.project) ...<Widget>[
-            const SizedBox(height: AleraTokens.space8),
-            _SortRow(
-              label: 'Then By',
-              value: prefs.workspaceSort,
-              onChanged: controller.setWorkspaceSort,
-            ),
-          ],
-          const SizedBox(height: AleraTokens.space16),
-          const Divider(height: 1, color: AleraTokens.borderSubtle),
-          const SizedBox(height: AleraTokens.space12),
-          _ProjectsHeader(
-            count: prefs.selectedProjectIds.length,
-            onClear: prefs.selectedProjectIds.isEmpty
-                ? null
-                : controller.clearProjectFilters,
-          ),
-          if (selectedProjects.isNotEmpty) ...<Widget>[
-            const SizedBox(height: AleraTokens.space8),
-            Wrap(
-              spacing: AleraTokens.space6,
-              runSpacing: AleraTokens.space6,
-              children: <Widget>[
-                for (final project in selectedProjects)
-                  AleraChip(
-                    label: project.name,
-                    onRemove: () => controller.removeProjectFilter(project.id),
+          // The option sections can outgrow short windows, so they scroll
+          // under the fixed header.
+          Flexible(
+            child: SingleChildScrollView(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: <Widget>[
+                  _SectionLabel(text: 'Group By'),
+                  const SizedBox(height: AleraTokens.space6),
+                  _GroupBySegmented(
+                    value: prefs.groupBy,
+                    onChanged: controller.setGroupBy,
                   ),
-              ],
+                  const SizedBox(height: AleraTokens.space12),
+                  _SortRow(
+                    label: prefs.groupBy == WorkbenchGroupBy.project
+                        ? 'Sort Projects By'
+                        : 'Sort Workspaces By',
+                    value: prefs.groupBy == WorkbenchGroupBy.project
+                        ? prefs.projectSort
+                        : prefs.workspaceSort,
+                    onChanged: prefs.groupBy == WorkbenchGroupBy.project
+                        ? controller.setProjectSort
+                        : controller.setWorkspaceSort,
+                  ),
+                  if (prefs.groupBy == WorkbenchGroupBy.project) ...<Widget>[
+                    const SizedBox(height: AleraTokens.space8),
+                    _SortRow(
+                      label: 'Then By',
+                      value: prefs.workspaceSort,
+                      onChanged: controller.setWorkspaceSort,
+                    ),
+                  ],
+                  const SizedBox(height: AleraTokens.space12),
+                  _SectionLabel(text: 'Show Workspaces'),
+                  const SizedBox(height: AleraTokens.space6),
+                  _WorkspaceKindSegmented(
+                    value: prefs.workspaceKindFilter,
+                    onChanged: controller.setWorkspaceKindFilter,
+                  ),
+                  const SizedBox(height: AleraTokens.space16),
+                  const Divider(height: 1, color: AleraTokens.borderSubtle),
+                  const SizedBox(height: AleraTokens.space12),
+                  _ProjectsHeader(
+                    count: prefs.selectedProjectIds.length,
+                    onClear: prefs.selectedProjectIds.isEmpty
+                        ? null
+                        : controller.clearProjectFilters,
+                  ),
+                  if (selectedProjects.isNotEmpty) ...<Widget>[
+                    const SizedBox(height: AleraTokens.space8),
+                    Wrap(
+                      spacing: AleraTokens.space6,
+                      runSpacing: AleraTokens.space6,
+                      children: <Widget>[
+                        for (final project in selectedProjects)
+                          AleraChip(
+                            label: project.name,
+                            onRemove: () =>
+                                controller.removeProjectFilter(project.id),
+                          ),
+                      ],
+                    ),
+                  ],
+                  const SizedBox(height: AleraTokens.space8),
+                  AleraTextField(
+                    dense: true,
+                    prefixIcon: AleraIcons.add,
+                    hintText: 'Add Project…',
+                    controller: _searchController,
+                    onSubmitted: (_) => _addFirstMatch(availableProjects),
+                  ),
+                  const SizedBox(height: AleraTokens.space8),
+                  _AvailableProjectsList(
+                    projects: availableProjects,
+                    hasSelection: prefs.selectedProjectIds.isNotEmpty,
+                    query: _projectQuery,
+                    onPick: (project) {
+                      controller.addProjectFilter(project.id);
+                      _searchController.clear();
+                    },
+                    theme: theme,
+                  ),
+                  const SizedBox(height: AleraTokens.space16),
+                  const Divider(height: 1, color: AleraTokens.borderSubtle),
+                  const SizedBox(height: AleraTokens.space12),
+                  _TagsFilterSection(
+                    selectedTags: selectedTags,
+                    availableTags: availableTags,
+                    query: _tagQuery,
+                    searchController: _tagSearchController,
+                    onAdd: (tagId) {
+                      controller.addTagFilter(tagId);
+                      _tagSearchController.clear();
+                    },
+                    onRemove: controller.removeTagFilter,
+                    onClear: prefs.selectedTagIds.isEmpty
+                        ? null
+                        : controller.clearTagFilters,
+                    theme: theme,
+                  ),
+                ],
+              ),
             ),
-          ],
-          const SizedBox(height: AleraTokens.space8),
-          AleraTextField(
-            dense: true,
-            prefixIcon: AleraIcons.add,
-            hintText: 'Add Project…',
-            controller: _searchController,
-            onSubmitted: (_) => _addFirstMatch(availableProjects),
-          ),
-          const SizedBox(height: AleraTokens.space8),
-          _AvailableProjectsList(
-            projects: availableProjects,
-            hasSelection: prefs.selectedProjectIds.isNotEmpty,
-            query: _projectQuery,
-            onPick: (project) {
-              controller.addProjectFilter(project.id);
-              _searchController.clear();
-            },
-            theme: theme,
-          ),
-          const SizedBox(height: AleraTokens.space16),
-          const Divider(height: 1, color: AleraTokens.borderSubtle),
-          const SizedBox(height: AleraTokens.space12),
-          _TagsFilterSection(
-            selectedTags: selectedTags,
-            availableTags: availableTags,
-            query: _tagQuery,
-            searchController: _tagSearchController,
-            onAdd: (tagId) {
-              controller.addTagFilter(tagId);
-              _tagSearchController.clear();
-            },
-            onRemove: controller.removeTagFilter,
-            onClear: prefs.selectedTagIds.isEmpty
-                ? null
-                : controller.clearTagFilters,
-            theme: theme,
           ),
         ],
       ),

--- a/test/unit/fake_forge_provider.dart
+++ b/test/unit/fake_forge_provider.dart
@@ -21,6 +21,7 @@ class FakeForgeProvider implements ForgeProvider {
   HostedReview? branchReview;
   Future<HostedReview?> Function()? branchReviewLoader;
   int branchReviewCalls = 0;
+  String? lastBranchQuery;
   final Map<int, HostedReview> byNumber = <int, HostedReview>{};
   List<ReviewCheck> checks = <ReviewCheck>[];
   Future<List<ReviewCheck>> Function()? checksLoader;
@@ -30,6 +31,7 @@ class FakeForgeProvider implements ForgeProvider {
     message: 'not set',
   );
   int createCalls = 0;
+  Object? createError;
   ReviewCheckDetails? details;
   ReviewCheck? lastDetailsCheck;
   int lastDetailsNumber = -1;
@@ -92,6 +94,7 @@ class FakeForgeProvider implements ForgeProvider {
     required String branch,
   }) async {
     branchReviewCalls++;
+    lastBranchQuery = branch;
     final loader = branchReviewLoader;
     return loader == null ? branchReview : loader();
   }
@@ -169,6 +172,10 @@ class FakeForgeProvider implements ForgeProvider {
     required CreateReviewInput input,
   }) async {
     createCalls++;
+    final error = createError;
+    if (error != null) {
+      throw error;
+    }
     return createResult;
   }
 

--- a/test/unit/workbench_listing_kind_filter_test.dart
+++ b/test/unit/workbench_listing_kind_filter_test.dart
@@ -1,0 +1,145 @@
+import 'package:alera/src/features/projects/domain/project.dart';
+import 'package:alera/src/features/workbench/application/workbench_listing.dart';
+import 'package:alera/src/features/workbench/application/workbench_state.dart';
+import 'package:alera/src/features/workbench/domain/workbench_view_prefs.dart';
+import 'package:alera/src/features/workbench/domain/workspace.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+final DateTime _t0 = DateTime.utc(2026, 5, 1);
+
+Project _project(String id, String name) {
+  return Project(
+    id: id,
+    name: name,
+    repoPath: '/repo/$id',
+    createdAt: _t0,
+    updatedAt: _t0,
+  );
+}
+
+Workspace _workspace(
+  String id,
+  String projectId,
+  String name, {
+  WorkspaceKind kind = WorkspaceKind.linked,
+  List<String> tagIds = const <String>[],
+}) {
+  return Workspace(
+    id: id,
+    projectId: projectId,
+    name: name,
+    branch: name,
+    path: '/repo/$projectId/$id',
+    createdAt: _t0,
+    updatedAt: _t0,
+    kind: kind,
+    status: WorkspaceStatus.active,
+    tagIds: tagIds,
+  );
+}
+
+WorkbenchState _state(WorkbenchViewPrefs prefs, {String searchQuery = ''}) {
+  final alera = _project('p-alera', 'alera');
+  final orca = _project('p-orca', 'orca');
+  return WorkbenchState(
+    projects: <Project>[alera, orca],
+    workspacesByProject: <String, List<Workspace>>{
+      alera.id: <Workspace>[
+        _workspace('w-alera-main', alera.id, 'main', kind: WorkspaceKind.main),
+        _workspace(
+          'w-alera-feature',
+          alera.id,
+          'feature',
+          tagIds: <String>['t1'],
+        ),
+      ],
+      orca.id: <Workspace>[
+        _workspace('w-orca-main', orca.id, 'develop', kind: WorkspaceKind.main),
+      ],
+    },
+    viewPrefs: prefs,
+    activeProjectId: alera.id,
+    searchQuery: searchQuery,
+    bootstrapped: true,
+  );
+}
+
+void main() {
+  group('workspace kind filter', () {
+    test('all shows every workspace', () {
+      final state = _state(WorkbenchViewPrefs.defaults);
+      final rows = buildSidebarRows(state);
+      expect(
+        workspaceOrderOfRows(rows),
+        containsAll(<String>['w-alera-main', 'w-alera-feature', 'w-orca-main']),
+      );
+      expect(countVisibleWorkspaces(state), 3);
+    });
+
+    test('defaultOnly keeps only main worktrees', () {
+      final state = _state(
+        WorkbenchViewPrefs.defaults.copyWith(
+          workspaceKindFilter: WorkspaceKindFilter.defaultOnly,
+        ),
+      );
+      final rows = buildSidebarRows(state);
+      expect(
+        workspaceOrderOfRows(rows),
+        containsAll(<String>['w-alera-main', 'w-orca-main']),
+      );
+      expect(workspaceOrderOfRows(rows), isNot(contains('w-alera-feature')));
+      expect(countVisibleWorkspaces(state), 2);
+    });
+
+    test(
+      'nonDefaultOnly keeps only linked worktrees and hides empty projects',
+      () {
+        final state = _state(
+          WorkbenchViewPrefs.defaults.copyWith(
+            workspaceKindFilter: WorkspaceKindFilter.nonDefaultOnly,
+          ),
+        );
+        final rows = buildSidebarRows(state);
+        expect(workspaceOrderOfRows(rows), <String>['w-alera-feature']);
+        expect(countVisibleWorkspaces(state), 1);
+        // orca has no linked workspaces, so its header disappears while the
+        // filter is active.
+        final headers = rows.whereType<WorkbenchProjectHeaderRow>().toList();
+        expect(headers.any((row) => row.project.id == 'p-orca'), isFalse);
+      },
+    );
+
+    test('combines with the tag filter and search query', () {
+      final tagged = _state(
+        WorkbenchViewPrefs.defaults.copyWith(
+          workspaceKindFilter: WorkspaceKindFilter.defaultOnly,
+          selectedTagIds: <String>{'t1'},
+        ),
+      );
+      // The only tagged workspace is linked, so both filters together match
+      // nothing.
+      expect(countVisibleWorkspaces(tagged), 0);
+
+      final searched = _state(
+        WorkbenchViewPrefs.defaults.copyWith(
+          workspaceKindFilter: WorkspaceKindFilter.nonDefaultOnly,
+        ),
+        searchQuery: 'develop',
+      );
+      // The search matches a default workspace, but the kind filter still
+      // excludes it.
+      expect(countVisibleWorkspaces(searched), 0);
+    });
+
+    test('collapse targets honor the kind filter', () {
+      final state = _state(
+        WorkbenchViewPrefs.defaults.copyWith(
+          workspaceKindFilter: WorkspaceKindFilter.nonDefaultOnly,
+        ),
+      );
+      final targets = visibleSidebarCollapseTargets(state);
+      expect(targets.workspaceIds, <String>{'w-alera-feature'});
+      expect(targets.projectIds, <String>{'p-alera'});
+    });
+  });
+}

--- a/test/unit/workbench_view_prefs_test.dart
+++ b/test/unit/workbench_view_prefs_test.dart
@@ -110,6 +110,17 @@ void main() {
       expect(restored.selectedTagIds, isEmpty);
       expect(restored.collapsedParentWorkspaceIds, isEmpty);
       expect(restored.workspaceSort, WorkbenchSortBy.recent);
+      expect(restored.workspaceKindFilter, WorkspaceKindFilter.all);
+    });
+
+    test('round-trips the workspace kind filter', () {
+      final prefs = WorkbenchViewPrefs.defaults.copyWith(
+        workspaceKindFilter: WorkspaceKindFilter.nonDefaultOnly,
+      );
+      final restored = WorkbenchViewPrefs.fromJson(
+        Map<String, Object?>.from(prefs.toMap()),
+      );
+      expect(restored.workspaceKindFilter, WorkspaceKindFilter.nonDefaultOnly);
     });
 
     test('fromJson decodes the activity sort value', () {

--- a/test/unit/workspace_pull_request_recovery_test.dart
+++ b/test/unit/workspace_pull_request_recovery_test.dart
@@ -1,0 +1,233 @@
+import 'package:alera/src/features/pull_requests/application/forge_exception.dart';
+import 'package:alera/src/features/pull_requests/application/forge_provider.dart';
+import 'package:alera/src/features/pull_requests/application/forge_provider_registry.dart';
+import 'package:alera/src/features/pull_requests/application/pull_request_providers.dart';
+import 'package:alera/src/features/pull_requests/application/workspace_pull_request_controller.dart';
+import 'package:alera/src/features/pull_requests/domain/create_review_input.dart';
+import 'package:alera/src/features/pull_requests/domain/create_review_result.dart';
+import 'package:alera/src/features/pull_requests/domain/forge_auth_status.dart';
+import 'package:alera/src/features/pull_requests/domain/hosted_review.dart';
+import 'package:alera/src/features/pull_requests/domain/linked_review.dart';
+import 'package:alera/src/features/pull_requests/domain/workspace_pull_request_scope.dart';
+import 'package:alera/src/shared/git_hosting/domain/git_hosting_provider.dart';
+import 'package:alera/src/shared/infra/git/git_providers.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'fake_forge_provider.dart';
+import 'fake_git_backend.dart';
+
+HostedReview _review(int number, {String headBranch = 'feature'}) =>
+    HostedReview(
+      provider: GitHostingProvider.github,
+      number: number,
+      title: 'feat: $number',
+      state: HostedReviewState.open,
+      url: 'https://github.com/leynier/alera/pull/$number',
+      headBranch: headBranch,
+    );
+
+const _scope = WorkspacePullRequestScope(
+  workspaceId: 'w1',
+  repoPath: '/repo',
+  branch: 'feature',
+);
+
+/// Fails the first [find] to simulate a broken initial load.
+class _ThrowingLinkedReviewRepository extends FakeLinkedReviewRepository {
+  int findCalls = 0;
+
+  @override
+  Future<LinkedReview?> find(String workspaceId) async {
+    findCalls++;
+    if (findCalls == 1) {
+      throw StateError('linked review storage unavailable');
+    }
+    return super.find(workspaceId);
+  }
+}
+
+ProviderContainer _container({
+  required FakeForgeProvider forge,
+  FakeGitBackend? git,
+  FakeLinkedReviewRepository? linkedReviews,
+  bool attach = true,
+}) {
+  final backend =
+      git ??
+      (FakeGitBackend()
+        ..remotesByName = <String, String?>{
+          'origin': 'https://github.com/leynier/alera.git',
+        });
+  final container = ProviderContainer(
+    overrides: [
+      gitBackendProvider.overrideWithValue(backend),
+      forgeProviderRegistryProvider.overrideWithValue(
+        ForgeProviderRegistry(<ForgeProvider>[forge]),
+      ),
+      linkedReviewRepositoryProvider.overrideWithValue(
+        linkedReviews ?? FakeLinkedReviewRepository(),
+      ),
+    ],
+  );
+  container.listen(workspacePullRequestControllerProvider(_scope), (_, _) {});
+  if (attach) {
+    container
+        .read(workspacePullRequestControllerProvider(_scope).notifier)
+        .attachPanel();
+  }
+  return container;
+}
+
+Future<void> _pumpUntil(WidgetTester tester, bool Function() condition) async {
+  for (var attempt = 0; attempt < 20; attempt++) {
+    if (condition()) {
+      return;
+    }
+    await tester.pump();
+  }
+  fail('Condition was not reached after pumping asynchronous work.');
+}
+
+void main() {
+  test(
+    'detects the review on the live branch over a stale scope hint',
+    () async {
+      // The scope records the branch from workspace creation, but the agent
+      // switched the worktree to another branch and opened the PR from it.
+      final backend = FakeGitBackend()
+        ..headBranch = 'agent-branch'
+        ..remotesByName = <String, String?>{
+          'origin': 'https://github.com/leynier/alera.git',
+        };
+      final forge = FakeForgeProvider()
+        ..branchReview = _review(123, headBranch: 'agent-branch');
+      final container = _container(forge: forge, git: backend);
+      addTearDown(container.dispose);
+
+      final state = await container.read(
+        workspacePullRequestControllerProvider(_scope).future,
+      );
+      expect(state.currentBranch, 'agent-branch');
+      expect(forge.lastBranchQuery, 'agent-branch');
+      expect(state.review?.number, 123);
+    },
+  );
+
+  test('falls back to the scope hint when the repo is detached', () async {
+    final backend = FakeGitBackend()
+      ..headBranch = 'HEAD'
+      ..remotesByName = <String, String?>{
+        'origin': 'https://github.com/leynier/alera.git',
+      };
+    final forge = FakeForgeProvider()..branchReview = _review(123);
+    final container = _container(forge: forge, git: backend);
+    addTearDown(container.dispose);
+
+    final state = await container.read(
+      workspacePullRequestControllerProvider(_scope).future,
+    );
+    expect(state.currentBranch, 'feature');
+    expect(forge.lastBranchQuery, 'feature');
+  });
+
+  testWidgets('keeps polling while not authenticated and picks up sign-in', (
+    tester,
+  ) async {
+    final forge = FakeForgeProvider()..auth = ForgeAuthStatus.notAuthenticated;
+    final container = _container(forge: forge);
+    addTearDown(container.dispose);
+    final provider = workspacePullRequestControllerProvider(_scope);
+
+    await _pumpUntil(tester, () => container.read(provider).hasValue);
+    expect(
+      container.read(provider).value?.authStatus,
+      ForgeAuthStatus.notAuthenticated,
+    );
+
+    forge
+      ..auth = ForgeAuthStatus.authenticated
+      ..branchReview = _review(321);
+    await tester.pump(const Duration(seconds: 121));
+    await _pumpUntil(
+      tester,
+      () => container.read(provider).value?.review?.number == 321,
+    );
+
+    final state = container.read(provider).value!;
+    expect(state.authStatus, ForgeAuthStatus.authenticated);
+    expect(state.review?.number, 321);
+    container.read(provider.notifier).detachPanel();
+    await tester.pump();
+  });
+
+  testWidgets('attachPanel recovers after a failed initial load', (
+    tester,
+  ) async {
+    final forge = FakeForgeProvider()..branchReview = _review(55);
+    final linkedReviews = _ThrowingLinkedReviewRepository();
+    final container = _container(
+      forge: forge,
+      linkedReviews: linkedReviews,
+      attach: false,
+    );
+    addTearDown(container.dispose);
+    final provider = workspacePullRequestControllerProvider(_scope);
+
+    await _pumpUntil(tester, () => container.read(provider).hasError);
+    expect(container.read(provider).hasValue, isFalse);
+
+    container.read(provider.notifier).attachPanel();
+    await tester.pump(const Duration(milliseconds: 1));
+    await _pumpUntil(
+      tester,
+      () => container.read(provider).value?.review?.number == 55,
+    );
+    expect(linkedReviews.findCalls, 2);
+    container.read(provider.notifier).detachPanel();
+    await tester.pump();
+  });
+
+  test(
+    'a throwing forge createReview clears the action and error state',
+    () async {
+      final forge = FakeForgeProvider()..branchReview = _review(123);
+      final container = _container(forge: forge);
+      addTearDown(container.dispose);
+
+      await container.read(
+        workspacePullRequestControllerProvider(_scope).future,
+      );
+      final controller = container.read(
+        workspacePullRequestControllerProvider(_scope).notifier,
+      );
+      forge.createError = const ForgeRequestFailed('boom');
+
+      final result = await controller.createReview(
+        const CreateReviewInput(
+          provider: GitHostingProvider.github,
+          title: 'feat: broken',
+          baseBranch: 'main',
+          headBranch: 'feature',
+        ),
+      );
+
+      expect(result, isA<CreateReviewFailure>());
+      expect((result as CreateReviewFailure).message, 'boom');
+      final wedged = container
+          .read(workspacePullRequestControllerProvider(_scope))
+          .value!;
+      expect(wedged.isBusy, isFalse);
+      expect(wedged.errorMessage, 'boom');
+
+      // The controller must still be able to refresh after the failure.
+      forge.createError = null;
+      await controller.refresh();
+      final refreshed = container
+          .read(workspacePullRequestControllerProvider(_scope))
+          .value!;
+      expect(refreshed.review?.number, 123);
+      expect(refreshed.errorMessage, isNull);
+    },
+  );
+}

--- a/test/widget/app_menu_test.dart
+++ b/test/widget/app_menu_test.dart
@@ -1,29 +1,21 @@
-import 'dart:async';
-
-import 'package:alera/src/app/providers.dart';
-import 'package:alera/src/app/theme/alera_dark_theme.dart';
 import 'package:alera/src/core/build_flavor.dart';
 import 'package:alera/src/design_system/feedback/alera_toast.dart';
 import 'package:alera/src/features/app_menu/infra/native_app_menu_channel.dart';
-import 'package:alera/src/features/app_menu/presentation/alera_app_menu_scope.dart';
 import 'package:alera/src/features/app_menu/presentation/app_menu_actions.dart';
-import 'package:alera/src/features/app_window/application/app_window_controller.dart';
-import 'package:alera/src/features/app_window/application/app_window_providers.dart';
-import 'package:alera/src/features/settings/domain/alera_settings.dart';
 import 'package:alera/src/features/updater/domain/alera_update.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:package_info_plus/package_info_plus.dart';
+
+import 'app_menu_test_support.dart';
 
 void main() {
   group('app menu actions', () {
     testWidgets('openAppMenuSettings opens the settings dialog', (
       tester,
     ) async {
-      await _pumpActionHarness(
+      await pumpActionHarness(
         tester,
         onPressed: (context, _) => openAppMenuSettings(context),
       );
@@ -38,8 +30,11 @@ void main() {
     testWidgets('checkForUpdatesFromAppMenu runs check and shows toast', (
       tester,
     ) async {
-      final updateController = _FakeUpdateController(
-        AleraUpdateState(status: AleraUpdateStatus.idle, config: _config()),
+      final updateController = FakeUpdateController(
+        AleraUpdateState(
+          status: AleraUpdateStatus.idle,
+          config: updateConfig(),
+        ),
       );
       final toastMessages = <String>[];
       final sub = AleraToast.stream.listen((data) {
@@ -47,7 +42,7 @@ void main() {
       });
       addTearDown(sub.cancel);
 
-      await _pumpActionHarness(
+      await pumpActionHarness(
         tester,
         updateController: updateController,
         onPressed: (context, ref) => checkForUpdatesFromAppMenu(context, ref),
@@ -62,7 +57,7 @@ void main() {
     });
 
     testWidgets('showAppMenuAbout opens the about dialog', (tester) async {
-      await _pumpActionHarness(
+      await pumpActionHarness(
         tester,
         onPressed: (context, ref) => showAppMenuAbout(
           context,
@@ -89,14 +84,14 @@ void main() {
     testWidgets('about dialog copies the version to the clipboard', (
       tester,
     ) async {
-      _mockClipboard();
+      mockClipboard();
       final toastMessages = <String>[];
       final sub = AleraToast.stream.listen((data) {
         toastMessages.add(data.message);
       });
       addTearDown(sub.cancel);
 
-      await _pumpActionHarness(
+      await pumpActionHarness(
         tester,
         onPressed: (context, ref) => showAppMenuAbout(
           context,
@@ -123,8 +118,11 @@ void main() {
     testWidgets('about dialog runs the update check and closes', (
       tester,
     ) async {
-      final updateController = _FakeUpdateController(
-        AleraUpdateState(status: AleraUpdateStatus.idle, config: _config()),
+      final updateController = FakeUpdateController(
+        AleraUpdateState(
+          status: AleraUpdateStatus.idle,
+          config: updateConfig(),
+        ),
       );
       final toastMessages = <String>[];
       final sub = AleraToast.stream.listen((data) {
@@ -132,7 +130,7 @@ void main() {
       });
       addTearDown(sub.cancel);
 
-      await _pumpActionHarness(
+      await pumpActionHarness(
         tester,
         updateController: updateController,
         onPressed: (context, ref) => showAppMenuAbout(
@@ -158,8 +156,8 @@ void main() {
     });
 
     testWidgets('exitAppFromMenu closes the app window', (tester) async {
-      final window = _FakeAppWindowController();
-      await _pumpActionHarness(
+      final window = FakeAppWindowController();
+      await pumpActionHarness(
         tester,
         window: window,
         onPressed: (_, ref) => exitAppFromMenu(ref),
@@ -179,8 +177,8 @@ void main() {
     ]) {
       group('on $platform (native bridge compatibility)', () {
         testWidgets('renders no in-window menu bar', (tester) async {
-          await _withPlatform(platform, () async {
-            await _pumpMenuScope(tester);
+          await withPlatform(platform, () async {
+            await pumpMenuScope(tester);
 
             expect(find.byType(MenuBar), findsNothing);
             expect(find.byType(PlatformMenuBar), findsNothing);
@@ -188,10 +186,10 @@ void main() {
         });
 
         testWidgets('native channel opens the settings dialog', (tester) async {
-          await _withPlatform(platform, () async {
-            await _pumpMenuScope(tester);
+          await withPlatform(platform, () async {
+            await pumpMenuScope(tester);
 
-            await _invokeNativeMenuMethod(
+            await invokeNativeMenuMethod(
               tester,
               NativeAppMenuMethod.openSettings,
             );
@@ -203,11 +201,11 @@ void main() {
         });
 
         testWidgets('native channel runs the update check', (tester) async {
-          await _withPlatform(platform, () async {
-            final updateController = _FakeUpdateController(
+          await withPlatform(platform, () async {
+            final updateController = FakeUpdateController(
               AleraUpdateState(
                 status: AleraUpdateStatus.idle,
-                config: _config(),
+                config: updateConfig(),
               ),
             );
             final toastMessages = <String>[];
@@ -216,9 +214,9 @@ void main() {
             });
             addTearDown(sub.cancel);
 
-            await _pumpMenuScope(tester, updateController: updateController);
+            await pumpMenuScope(tester, updateController: updateController);
 
-            await _invokeNativeMenuMethod(
+            await invokeNativeMenuMethod(
               tester,
               NativeAppMenuMethod.checkForUpdates,
             );
@@ -231,15 +229,12 @@ void main() {
         });
 
         testWidgets('native channel shows the about dialog', (tester) async {
-          await _withPlatform(platform, () async {
-            _mockPackageInfo(tester);
+          await withPlatform(platform, () async {
+            mockPackageInfo(tester);
 
-            await _pumpMenuScope(tester);
+            await pumpMenuScope(tester);
 
-            await _invokeNativeMenuMethod(
-              tester,
-              NativeAppMenuMethod.showAbout,
-            );
+            await invokeNativeMenuMethod(tester, NativeAppMenuMethod.showAbout);
             await tester.pumpAndSettle();
 
             expect(find.text(kAleraAppName), findsWidgets);
@@ -248,11 +243,11 @@ void main() {
         });
 
         testWidgets('native channel closes the app window', (tester) async {
-          await _withPlatform(platform, () async {
-            final window = _FakeAppWindowController();
-            await _pumpMenuScope(tester, window: window);
+          await withPlatform(platform, () async {
+            final window = FakeAppWindowController();
+            await pumpMenuScope(tester, window: window);
 
-            await _invokeNativeMenuMethod(tester, NativeAppMenuMethod.exitApp);
+            await invokeNativeMenuMethod(tester, NativeAppMenuMethod.exitApp);
             await tester.pump();
 
             expect(window.closeCalls, 1);
@@ -262,11 +257,11 @@ void main() {
         testWidgets(
           'native channel edit methods act on the focused text field',
           (tester) async {
-            await _withPlatform(platform, () async {
+            await withPlatform(platform, () async {
               final controller = TextEditingController();
               addTearDown(controller.dispose);
-              _mockClipboard();
-              await _pumpMenuScope(
+              mockClipboard();
+              await pumpMenuScope(
                 tester,
                 child: Scaffold(
                   body: Center(child: TextField(controller: controller)),
@@ -278,7 +273,7 @@ void main() {
               await tester.enterText(find.byType(TextField), 'hello');
               await tester.pump();
 
-              await _invokeNativeMenuMethod(
+              await invokeNativeMenuMethod(
                 tester,
                 NativeAppMenuMethod.selectAll,
               );
@@ -288,13 +283,13 @@ void main() {
                 const TextSelection(baseOffset: 0, extentOffset: 5),
               );
 
-              await _invokeNativeMenuMethod(tester, NativeAppMenuMethod.cut);
+              await invokeNativeMenuMethod(tester, NativeAppMenuMethod.cut);
               await tester.pump();
               expect(controller.text, isEmpty);
               final clipboard = await Clipboard.getData(Clipboard.kTextPlain);
               expect(clipboard?.text, 'hello');
 
-              await _invokeNativeMenuMethod(tester, NativeAppMenuMethod.paste);
+              await invokeNativeMenuMethod(tester, NativeAppMenuMethod.paste);
               await tester.pump();
               expect(controller.text, 'hello');
             });
@@ -306,240 +301,12 @@ void main() {
     testWidgets('uses PlatformMenuBar on macOS without in-window MenuBar', (
       tester,
     ) async {
-      await _withPlatform(TargetPlatform.macOS, () async {
-        await _pumpMenuScope(tester);
+      await withPlatform(TargetPlatform.macOS, () async {
+        await pumpMenuScope(tester);
 
         expect(find.byType(PlatformMenuBar), findsOneWidget);
         expect(find.byType(MenuBar), findsNothing);
       });
     });
   });
-}
-
-Future<void> _withPlatform(
-  TargetPlatform platform,
-  Future<void> Function() body,
-) async {
-  final previous = debugDefaultTargetPlatformOverride;
-  debugDefaultTargetPlatformOverride = platform;
-  try {
-    await body();
-  } finally {
-    debugDefaultTargetPlatformOverride = previous;
-  }
-}
-
-Future<void> _pumpActionHarness(
-  WidgetTester tester, {
-  required FutureOr<void> Function(BuildContext context, WidgetRef ref)
-  onPressed,
-  _FakeUpdateController? updateController,
-  _FakeAppWindowController? window,
-}) async {
-  await tester.pumpWidget(
-    ProviderScope(
-      overrides: [
-        aleraUpdateControllerProvider.overrideWith(
-          () =>
-              updateController ??
-              _FakeUpdateController(
-                AleraUpdateState(
-                  status: AleraUpdateStatus.idle,
-                  config: _config(),
-                ),
-              ),
-        ),
-        appWindowControllerProvider.overrideWithValue(
-          window ?? _FakeAppWindowController(),
-        ),
-        settingsControllerProvider.overrideWith(
-          () => _FakeSettingsController(AleraSettings.defaults),
-        ),
-      ],
-      child: MaterialApp(
-        theme: buildAleraDarkTheme(),
-        home: Scaffold(
-          body: Consumer(
-            builder: (context, ref, _) {
-              return TextButton(
-                onPressed: () =>
-                    unawaited(Future<void>.sync(() => onPressed(context, ref))),
-                child: const Text('Run'),
-              );
-            },
-          ),
-        ),
-      ),
-    ),
-  );
-}
-
-Future<void> _pumpMenuScope(
-  WidgetTester tester, {
-  _FakeUpdateController? updateController,
-  _FakeAppWindowController? window,
-  Widget? child,
-}) async {
-  await tester.pumpWidget(
-    ProviderScope(
-      overrides: [
-        aleraUpdateControllerProvider.overrideWith(
-          () =>
-              updateController ??
-              _FakeUpdateController(
-                AleraUpdateState(
-                  status: AleraUpdateStatus.idle,
-                  config: _config(),
-                ),
-              ),
-        ),
-        appWindowControllerProvider.overrideWithValue(
-          window ?? _FakeAppWindowController(),
-        ),
-        settingsControllerProvider.overrideWith(
-          () => _FakeSettingsController(AleraSettings.defaults),
-        ),
-      ],
-      child: MaterialApp(
-        theme: buildAleraDarkTheme(),
-        home: AleraAppMenuScope(
-          child: child ?? const Scaffold(body: SizedBox.expand()),
-        ),
-      ),
-    ),
-  );
-  await tester.pump();
-}
-
-/// Simulates a native (GTK/Win32) menu activation arriving over the app-menu
-/// channel.
-Future<void> _invokeNativeMenuMethod(WidgetTester tester, String method) async {
-  await TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-      .handlePlatformMessage(
-        nativeAppMenuChannelName,
-        const StandardMethodCodec().encodeMethodCall(MethodCall(method)),
-        (_) {},
-      );
-}
-
-void _mockPackageInfo(WidgetTester tester) {
-  const channel = MethodChannel('dev.fluttercommunity.plus/package_info');
-  TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-      .setMockMethodCallHandler(channel, (call) async {
-        return <String, String>{
-          'appName': kAleraAppName,
-          'packageName': 'dev.leynier.alera',
-          'version': '1.2.3',
-          'buildNumber': '45',
-        };
-      });
-  addTearDown(() {
-    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-        .setMockMethodCallHandler(channel, null);
-  });
-}
-
-/// The test binding does not answer clipboard platform messages, so the edit
-/// menu intents would hang without an in-memory mock.
-void _mockClipboard() {
-  String? clipboardText;
-  final messenger =
-      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
-  messenger.setMockMethodCallHandler(SystemChannels.platform, (call) async {
-    switch (call.method) {
-      case 'Clipboard.getData':
-        final text = clipboardText;
-        return text == null ? null : <String, dynamic>{'text': text};
-      case 'Clipboard.setData':
-        clipboardText =
-            (call.arguments as Map<Object?, Object?>)['text'] as String?;
-    }
-    return null;
-  });
-  addTearDown(() {
-    messenger.setMockMethodCallHandler(SystemChannels.platform, null);
-  });
-}
-
-AleraUpdateConfig _config() {
-  return AleraUpdateConfig(
-    archiveUrl: Uri.parse('https://example.com/app-archive.json'),
-    releasePageUrl: Uri.parse('https://example.com/releases'),
-    channel: AleraUpdateChannel.stable,
-    autoInstallEnabled: true,
-    signedRelease: true,
-  );
-}
-
-class _FakeSettingsController extends SettingsController {
-  _FakeSettingsController(this._seed);
-
-  final AleraSettings _seed;
-
-  @override
-  AleraSettings build() => _seed;
-}
-
-class _FakeUpdateController extends AleraUpdateController {
-  _FakeUpdateController(this._seed);
-
-  final AleraUpdateState _seed;
-  int checkForUpdatesCalls = 0;
-
-  @override
-  AleraUpdateState build() => _seed;
-
-  @override
-  Future<void> checkForUpdates() async {
-    checkForUpdatesCalls += 1;
-    state = state.copyWith(
-      status: AleraUpdateStatus.notAvailable,
-      message: 'Alera is up to date.',
-    );
-  }
-}
-
-class _FakeAppWindowController implements AppWindowController {
-  int closeCalls = 0;
-
-  @override
-  void addListener(AppWindowEventListener listener) {}
-
-  @override
-  Future<void> close() async {
-    closeCalls += 1;
-  }
-
-  @override
-  Future<void> destroy() async {}
-
-  @override
-  Future<Rect> getBounds() async => const Rect.fromLTWH(0, 0, 1280, 720);
-
-  @override
-  Future<bool> isFullScreen() async => false;
-
-  @override
-  Future<bool> isMaximized() async => false;
-
-  @override
-  Future<bool> isMinimized() async => false;
-
-  @override
-  Future<void> maximize() async {}
-
-  @override
-  void removeListener(AppWindowEventListener listener) {}
-
-  @override
-  Future<void> setBounds(Rect bounds) async {}
-
-  @override
-  Future<void> setFullScreen(bool value) async {}
-
-  @override
-  Future<void> setPreventClose(bool value) async {}
-
-  @override
-  Future<void> setTitle(String title) async {}
 }

--- a/test/widget/app_menu_test.dart
+++ b/test/widget/app_menu_test.dart
@@ -64,8 +64,9 @@ void main() {
     testWidgets('showAppMenuAbout opens the about dialog', (tester) async {
       await _pumpActionHarness(
         tester,
-        onPressed: (context, _) => showAppMenuAbout(
+        onPressed: (context, ref) => showAppMenuAbout(
           context,
+          ref,
           loadPackageInfo: () async => PackageInfo(
             appName: kAleraAppName,
             packageName: 'dev.leynier.alera',
@@ -81,6 +82,79 @@ void main() {
       expect(find.text(kAleraAppName), findsWidgets);
       expect(find.text('Version 1.2.3 (45)'), findsOneWidget);
       expect(find.text('Close'), findsOneWidget);
+      expect(find.text('Check For Updates'), findsOneWidget);
+      expect(find.byType(Image), findsOneWidget);
+    });
+
+    testWidgets('about dialog copies the version to the clipboard', (
+      tester,
+    ) async {
+      _mockClipboard();
+      final toastMessages = <String>[];
+      final sub = AleraToast.stream.listen((data) {
+        toastMessages.add(data.message);
+      });
+      addTearDown(sub.cancel);
+
+      await _pumpActionHarness(
+        tester,
+        onPressed: (context, ref) => showAppMenuAbout(
+          context,
+          ref,
+          loadPackageInfo: () async => PackageInfo(
+            appName: kAleraAppName,
+            packageName: 'dev.leynier.alera',
+            version: '1.2.3',
+            buildNumber: '45',
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Run'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byTooltip('Copy Version'));
+      await tester.pumpAndSettle();
+
+      final clipboard = await Clipboard.getData(Clipboard.kTextPlain);
+      expect(clipboard?.text, '1.2.3 (45)');
+      expect(toastMessages, <String>['Version Copied']);
+    });
+
+    testWidgets('about dialog runs the update check and closes', (
+      tester,
+    ) async {
+      final updateController = _FakeUpdateController(
+        AleraUpdateState(status: AleraUpdateStatus.idle, config: _config()),
+      );
+      final toastMessages = <String>[];
+      final sub = AleraToast.stream.listen((data) {
+        toastMessages.add(data.message);
+      });
+      addTearDown(sub.cancel);
+
+      await _pumpActionHarness(
+        tester,
+        updateController: updateController,
+        onPressed: (context, ref) => showAppMenuAbout(
+          context,
+          ref,
+          loadPackageInfo: () async => PackageInfo(
+            appName: kAleraAppName,
+            packageName: 'dev.leynier.alera',
+            version: '1.2.3',
+            buildNumber: '45',
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Run'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Check For Updates'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Check For Updates'), findsNothing);
+      expect(updateController.checkForUpdatesCalls, 1);
+      expect(toastMessages, <String>['Alera is up to date.']);
     });
 
     testWidgets('exitAppFromMenu closes the app window', (tester) async {

--- a/test/widget/app_menu_test_support.dart
+++ b/test/widget/app_menu_test_support.dart
@@ -1,0 +1,245 @@
+// Shared harness for the app-menu widget suites.
+import 'dart:async';
+
+import 'package:alera/src/app/providers.dart';
+import 'package:alera/src/app/theme/alera_dark_theme.dart';
+import 'package:alera/src/core/build_flavor.dart';
+import 'package:alera/src/features/app_menu/infra/native_app_menu_channel.dart';
+import 'package:alera/src/features/app_menu/presentation/alera_app_menu_scope.dart';
+import 'package:alera/src/features/app_window/application/app_window_controller.dart';
+import 'package:alera/src/features/app_window/application/app_window_providers.dart';
+import 'package:alera/src/features/settings/domain/alera_settings.dart';
+import 'package:alera/src/features/updater/domain/alera_update.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+Future<void> withPlatform(
+  TargetPlatform platform,
+  Future<void> Function() body,
+) async {
+  final previous = debugDefaultTargetPlatformOverride;
+  debugDefaultTargetPlatformOverride = platform;
+  try {
+    await body();
+  } finally {
+    debugDefaultTargetPlatformOverride = previous;
+  }
+}
+
+Future<void> pumpActionHarness(
+  WidgetTester tester, {
+  required FutureOr<void> Function(BuildContext context, WidgetRef ref)
+  onPressed,
+  FakeUpdateController? updateController,
+  FakeAppWindowController? window,
+}) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        aleraUpdateControllerProvider.overrideWith(
+          () =>
+              updateController ??
+              FakeUpdateController(
+                AleraUpdateState(
+                  status: AleraUpdateStatus.idle,
+                  config: updateConfig(),
+                ),
+              ),
+        ),
+        appWindowControllerProvider.overrideWithValue(
+          window ?? FakeAppWindowController(),
+        ),
+        settingsControllerProvider.overrideWith(
+          () => FakeSettingsController(AleraSettings.defaults),
+        ),
+      ],
+      child: MaterialApp(
+        theme: buildAleraDarkTheme(),
+        home: Scaffold(
+          body: Consumer(
+            builder: (context, ref, _) {
+              return TextButton(
+                onPressed: () =>
+                    unawaited(Future<void>.sync(() => onPressed(context, ref))),
+                child: const Text('Run'),
+              );
+            },
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+Future<void> pumpMenuScope(
+  WidgetTester tester, {
+  FakeUpdateController? updateController,
+  FakeAppWindowController? window,
+  Widget? child,
+}) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        aleraUpdateControllerProvider.overrideWith(
+          () =>
+              updateController ??
+              FakeUpdateController(
+                AleraUpdateState(
+                  status: AleraUpdateStatus.idle,
+                  config: updateConfig(),
+                ),
+              ),
+        ),
+        appWindowControllerProvider.overrideWithValue(
+          window ?? FakeAppWindowController(),
+        ),
+        settingsControllerProvider.overrideWith(
+          () => FakeSettingsController(AleraSettings.defaults),
+        ),
+      ],
+      child: MaterialApp(
+        theme: buildAleraDarkTheme(),
+        home: AleraAppMenuScope(
+          child: child ?? const Scaffold(body: SizedBox.expand()),
+        ),
+      ),
+    ),
+  );
+  await tester.pump();
+}
+
+/// Simulates a native (GTK/Win32) menu activation arriving over the app-menu
+/// channel.
+Future<void> invokeNativeMenuMethod(WidgetTester tester, String method) async {
+  await TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      .handlePlatformMessage(
+        nativeAppMenuChannelName,
+        const StandardMethodCodec().encodeMethodCall(MethodCall(method)),
+        (_) {},
+      );
+}
+
+void mockPackageInfo(WidgetTester tester) {
+  const channel = MethodChannel('dev.fluttercommunity.plus/package_info');
+  TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      .setMockMethodCallHandler(channel, (call) async {
+        return <String, String>{
+          'appName': kAleraAppName,
+          'packageName': 'dev.leynier.alera',
+          'version': '1.2.3',
+          'buildNumber': '45',
+        };
+      });
+  addTearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, null);
+  });
+}
+
+/// The test binding does not answer clipboard platform messages, so the edit
+/// menu intents would hang without an in-memory mock.
+void mockClipboard() {
+  String? clipboardText;
+  final messenger =
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+  messenger.setMockMethodCallHandler(SystemChannels.platform, (call) async {
+    switch (call.method) {
+      case 'Clipboard.getData':
+        final text = clipboardText;
+        return text == null ? null : <String, dynamic>{'text': text};
+      case 'Clipboard.setData':
+        clipboardText =
+            (call.arguments as Map<Object?, Object?>)['text'] as String?;
+    }
+    return null;
+  });
+  addTearDown(() {
+    messenger.setMockMethodCallHandler(SystemChannels.platform, null);
+  });
+}
+
+AleraUpdateConfig updateConfig() {
+  return AleraUpdateConfig(
+    archiveUrl: Uri.parse('https://example.com/app-archive.json'),
+    releasePageUrl: Uri.parse('https://example.com/releases'),
+    channel: AleraUpdateChannel.stable,
+    autoInstallEnabled: true,
+    signedRelease: true,
+  );
+}
+
+class FakeSettingsController extends SettingsController {
+  FakeSettingsController(this._seed);
+
+  final AleraSettings _seed;
+
+  @override
+  AleraSettings build() => _seed;
+}
+
+class FakeUpdateController extends AleraUpdateController {
+  FakeUpdateController(this._seed);
+
+  final AleraUpdateState _seed;
+  int checkForUpdatesCalls = 0;
+
+  @override
+  AleraUpdateState build() => _seed;
+
+  @override
+  Future<void> checkForUpdates() async {
+    checkForUpdatesCalls += 1;
+    state = state.copyWith(
+      status: AleraUpdateStatus.notAvailable,
+      message: 'Alera is up to date.',
+    );
+  }
+}
+
+class FakeAppWindowController implements AppWindowController {
+  int closeCalls = 0;
+
+  @override
+  void addListener(AppWindowEventListener listener) {}
+
+  @override
+  Future<void> close() async {
+    closeCalls += 1;
+  }
+
+  @override
+  Future<void> destroy() async {}
+
+  @override
+  Future<Rect> getBounds() async => const Rect.fromLTWH(0, 0, 1280, 720);
+
+  @override
+  Future<bool> isFullScreen() async => false;
+
+  @override
+  Future<bool> isMaximized() async => false;
+
+  @override
+  Future<bool> isMinimized() async => false;
+
+  @override
+  Future<void> maximize() async {}
+
+  @override
+  void removeListener(AppWindowEventListener listener) {}
+
+  @override
+  Future<void> setBounds(Rect bounds) async {}
+
+  @override
+  Future<void> setFullScreen(bool value) async {}
+
+  @override
+  Future<void> setPreventClose(bool value) async {}
+
+  @override
+  Future<void> setTitle(String title) async {}
+}

--- a/test/widget/workbench_view_options_menu_test.dart
+++ b/test/widget/workbench_view_options_menu_test.dart
@@ -126,6 +126,44 @@ void main() {
       expect(find.text('No Projects Match "missing"'), findsOneWidget);
     });
 
+    testWidgets('updates the workspace kind filter and shows the active dot', (
+      tester,
+    ) async {
+      final controller = _ViewOptionsTestController(
+        WorkbenchState(projects: <Project>[_project('project-1', 'Alera')]),
+      );
+
+      await _pumpButton(tester, controller);
+
+      expect(_activeDot(), findsNothing);
+
+      await tester.tap(_viewOptionsButton());
+      await tester.pumpAndSettle();
+
+      expect(find.text('Show Workspaces'), findsOneWidget);
+      await tester.tap(find.text('Default'));
+      await tester.pumpAndSettle();
+
+      expect(
+        controller.state.viewPrefs.workspaceKindFilter,
+        WorkspaceKindFilter.defaultOnly,
+      );
+
+      await tester.tap(find.byTooltip('Close'));
+      await tester.pumpAndSettle();
+      expect(_activeDot(), findsOneWidget);
+
+      await tester.tap(_viewOptionsButton());
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('All').first);
+      await tester.pumpAndSettle();
+
+      expect(
+        controller.state.viewPrefs.workspaceKindFilter,
+        WorkspaceKindFilter.all,
+      );
+    });
+
     testWidgets('available project rows animate their hover state', (
       tester,
     ) async {
@@ -194,6 +232,16 @@ Finder _projectSearchField() {
 Finder _viewOptionsButton() {
   return find.byWidgetPredicate(
     (widget) => widget is IconButton && widget.tooltip == 'View options',
+  );
+}
+
+Finder _activeDot() {
+  return find.byWidgetPredicate(
+    (widget) =>
+        widget is Container &&
+        widget.decoration is BoxDecoration &&
+        (widget.decoration! as BoxDecoration).shape == BoxShape.circle &&
+        (widget.decoration! as BoxDecoration).color == AleraTokens.accent,
   );
 }
 
@@ -267,6 +315,13 @@ class _ViewOptionsTestController extends WorkbenchController {
   void clearProjectFilters() {
     state = state.copyWith(
       viewPrefs: state.viewPrefs.copyWith(selectedProjectIds: <String>{}),
+    );
+  }
+
+  @override
+  void setWorkspaceKindFilter(WorkspaceKindFilter filter) {
+    state = state.copyWith(
+      viewPrefs: state.viewPrefs.copyWith(workspaceKindFilter: filter),
     );
   }
 }


### PR DESCRIPTION
## Summary
- new AppMenuAboutDialog widget: AleraDialogHeader, app logo, centered name, version line with a copy-to-clipboard icon button (with Version Copied toast), and Check For Updates + Close actions in an OverflowBar
- Check For Updates closes the dialog first and reuses checkForUpdatesFromAppMenu so the result toast surfaces under the launcher context
- showAppMenuAbout gains a WidgetRef parameter; all three call sites updated (native channel, in-window menu, macOS platform menu)

## Validation
- extended test/widget/app_menu_test.dart: dialog contents (logo, version, actions), clipboard copy + toast, update check invocation + dialog close; all 19 tests pass

Stacked on the workspace kind filter PR; after it merges this diff reduces to the about dialog change.