### PR TITLE
fix: tolerate unchanged mobile pubspec when cutting a mobile release

### DIFF
--- a/.github/workflows/mobile-release-cut.yml
+++ b/.github/workflows/mobile-release-cut.yml
@@ -256,7 +256,11 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           dart tool/release/update_mobile_pubspec_version.dart "$ARTIFACT_VERSION" "$BUILD_NUMBER"
           git add mobile/pubspec.yaml
-          git commit -m "release: $TAG"
+          if git diff --cached --quiet; then
+            echo "::notice::mobile/pubspec.yaml already at $ARTIFACT_VERSION+$BUILD_NUMBER; skipping release commit."
+          else
+            git commit -m "release: $TAG"
+          fi
           git tag -a "$TAG" -m "$TAG"
           echo "release_sha=$(git rev-parse HEAD)" >>"$GITHUB_OUTPUT"
 
@@ -275,9 +279,11 @@ jobs:
             fi
           }
           trap cleanup_failed_push ERR
-          current_sha="$(git rev-parse HEAD~1)"
+          head_sha="$(git rev-parse HEAD)"
           main_sha="$(git rev-parse origin/main)"
-          if [[ "$current_sha" == "$main_sha" ]]; then
+          if [[ "$head_sha" == "$main_sha" ]]; then
+            echo "::notice::No release commit was needed; only the mobile tag will be pushed."
+          elif [[ "$(git rev-parse HEAD~1)" == "$main_sha" ]]; then
             git push origin "HEAD:refs/heads/main"
             pushed_main=true
           else


### PR DESCRIPTION
## Summary

The first Cut Mobile Release run (29654253699) failed in the publish job because the computed version `0.0.1+1` matched the version already committed in `mobile/pubspec.yaml`, so `git commit` exited 1 with nothing staged.

- Skip the release commit when `mobile/pubspec.yaml` is already at the target version; the tag then points at the current `origin/main` HEAD, which is the intended content.
- Adjust the push step so it no longer assumes a release commit exists: when `HEAD == origin/main` it pushes only the tag, and the `HEAD~1` comparison is evaluated only when a commit was created.

## Validation

- `dart run tool/quality/check_max_lines.dart` passes.
- Reviewed the failure-cleanup trap: `pushed_main` can only be true when a release commit exists, so the `HEAD~1` force-with-lease rollback remains correct.

## Notes

No documentation updates needed; behavior change is internal to the release workflow.