### PR TITLE
chore: update github actions to node 24 runtimes

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 
@@ -52,7 +52,7 @@ jobs:
           version: 0.15.2
 
       - name: Cache native assets
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             .dart_tool/hooks_runner

--- a/.github/workflows/issue-os-labeler.yml
+++ b/.github/workflows/issue-os-labeler.yml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Apply OS label from issue form
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/landing.yml
+++ b/.github/workflows/landing.yml
@@ -21,7 +21,7 @@ jobs:
         working-directory: landing
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2

--- a/.github/workflows/mobile-release-cut.yml
+++ b/.github/workflows/mobile-release-cut.yml
@@ -47,7 +47,7 @@ jobs:
       release_base_ref: ${{ steps.version.outputs.release_base_ref }}
     steps:
       - name: Checkout ref
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           ref: ${{ inputs.ref }}
           fetch-depth: 0
@@ -131,7 +131,7 @@ jobs:
     timeout-minutes: 35
     steps:
       - name: Checkout release ref
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           ref: ${{ needs.cut.outputs.release_base_ref }}
           submodules: recursive
@@ -184,7 +184,7 @@ jobs:
           (cd release-assets && sha256sum -c ./*.sha256)
 
       - name: Upload Android release assets
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: mobile-android-release-assets
           path: release-assets
@@ -200,7 +200,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout release ref
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           ref: ${{ needs.cut.outputs.release_base_ref }}
           fetch-depth: 0
@@ -210,7 +210,7 @@ jobs:
         uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
 
       - name: Download Android release assets
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: mobile-android-release-assets
           path: release-assets

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 
@@ -36,7 +36,7 @@ jobs:
           version: 0.15.2
 
       - name: Cache native assets
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             .dart_tool/hooks_runner
@@ -79,7 +79,7 @@ jobs:
 
       - name: Upload coverage
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: flutter-coverage
           path: coverage/lcov.info
@@ -93,7 +93,7 @@ jobs:
         working-directory: mobile
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 
@@ -120,7 +120,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 
@@ -142,7 +142,7 @@ jobs:
           version: 0.15.2
 
       - name: Cache native assets
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             .dart_tool/hooks_runner
@@ -176,7 +176,7 @@ jobs:
     timeout-minutes: 35
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 
@@ -201,7 +201,7 @@ jobs:
           version: 0.15.2
 
       - name: Cache native assets
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             .dart_tool/hooks_runner
@@ -248,7 +248,7 @@ jobs:
 
       - name: Upload Linux startup performance report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: linux-startup-performance
           path: .dart_tool/performance-ci/startup_linux.json
@@ -259,7 +259,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@master

--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -52,7 +52,7 @@ jobs:
       release_base_ref: ${{ steps.version.outputs.release_base_ref }}
     steps:
       - name: Checkout ref
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           ref: ${{ inputs.ref }}
           fetch-depth: 0
@@ -141,7 +141,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout release ref
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           ref: ${{ needs.cut.outputs.release_base_ref }}
           submodules: recursive
@@ -165,7 +165,7 @@ jobs:
           version: 0.15.2
 
       - name: Cache native assets
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             .dart_tool/hooks_runner
@@ -447,7 +447,7 @@ jobs:
           done
 
       - name: Upload updater artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: updater-${{ matrix.platform }}
           path: pages/
@@ -455,7 +455,7 @@ jobs:
           if-no-files-found: error
 
       - name: Upload release asset artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: release-${{ matrix.platform }}
           path: release-assets/
@@ -475,7 +475,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           ref: ${{ needs.cut.outputs.release_base_ref }}
           fetch-depth: 0
@@ -499,14 +499,14 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: Download updater artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           pattern: updater-*
           path: public
           merge-multiple: true
 
       - name: Download release assets
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           pattern: release-*
           path: release-assets


### PR DESCRIPTION
## Summary

GitHub deprecated Node.js 20 on Actions runners, so runs were printing "Node.js 20 is deprecated" warnings. This bumps every affected action to its current Node 24 release, preserving each file's pin style (SHA pins stay SHA pins, tag pins stay tags):

- `actions/checkout` v4 -> v7.0.0 (`9c091bb2`) in release-cut, mobile-release-cut; `@v4` -> `@v7` in pr, desktop-build, landing.
- `actions/upload-artifact` v4.6.2 -> v7.0.1 (`043fb46d`) in release-cut, mobile-release-cut; `@v4` -> `@v7` in pr.
- `actions/download-artifact` v4 -> v8.0.1 (`3e5f45b2`) in release-cut, mobile-release-cut.
- `actions/cache` `@v4` -> `@v6` in pr, desktop-build, release-cut.
- `actions/github-script` `@v7` -> `@v8` in issue-os-labeler.

Breaking-change review: checkout v7 only restricts fork-PR checkout under `pull_request_target`/`workflow_run`, which this repo does not use; upload v7 + download v8 are the current pair and existing zipped-artifact flows are unchanged; cache v5/v6 is Node 24 + ESM only. All jobs run on GitHub-hosted runners, which meet the required runner version.

## Validation

- `dart run tool/quality/check_max_lines.dart` passes.
- This PR's own checks exercise the bumped checkout, cache, and upload-artifact versions.
- After merge, a `dry_run=true` dispatch of Cut Mobile Release will confirm the warnings are gone from run annotations.

## Notes

`mlugg/setup-zig@v2` (pr.yml, desktop-build.yml) still targets Node 20 and has no Node 24 release yet (latest is v2.2.1), so its warning remains until upstream ships one. No documentation updates needed.