### PR TITLE
fix: correct kimi_apy_key typo to kimi_api_key

### DIFF
--- a/docs/agent-quotas.md
+++ b/docs/agent-quotas.md
@@ -29,7 +29,7 @@ Alera sets `CLAUDE_CONFIG_DIR` only for the hidden quota query. The default Clau
 
 Alera stores only environment variable names, never API key values. Configure the values on every local or remote host where the provider is enabled:
 
-- Kimi Code: `KIMI_APY_KEY` and optionally `KIMI_CODE_BASE_URL`.
+- Kimi Code: `KIMI_API_KEY` and optionally `KIMI_CODE_BASE_URL`.
 - MiniMax: `MINIMAX_API_KEY` and optionally `MINIMAX_API_HOST`.
 - Z.ai: `ZAI_API_KEY` and optionally `ZAI_BASE_URL`.
 
@@ -39,7 +39,7 @@ The Kimi, MiniMax, and Z.ai variable names can be changed per host in settings. 
 
 - Claude and Antigravity use their official interactive usage commands in hidden PTYs.
 - Codex uses the read-only app-server rate-limit method.
-- Kimi calls its usage endpoint with the API key from the configured host environment variable, which defaults to `KIMI_APY_KEY`.
+- Kimi calls its usage endpoint with the API key from the configured host environment variable, which defaults to `KIMI_API_KEY`.
 - Grok reads its existing local login metadata and calls its usage endpoint.
 - MiniMax and Z.ai call their plan usage endpoints with credentials read from the target host environment.
 

--- a/lib/src/features/settings/domain/alera_settings.dart
+++ b/lib/src/features/settings/domain/alera_settings.dart
@@ -280,7 +280,7 @@ class ClaudeQuotaProfileSettings with ClaudeQuotaProfileSettingsMappable {
 @MappableClass()
 class AgentQuotaEnvironmentSettings with AgentQuotaEnvironmentSettingsMappable {
   const AgentQuotaEnvironmentSettings({
-    this.kimiApiKey = 'KIMI_APY_KEY',
+    this.kimiApiKey = 'KIMI_API_KEY',
     this.zaiApiKey = 'ZAI_API_KEY',
     this.zaiBaseUrl = 'ZAI_BASE_URL',
     this.minimaxApiKey = 'MINIMAX_API_KEY',

--- a/lib/src/features/settings/domain/alera_settings.mapper.dart
+++ b/lib/src/features/settings/domain/alera_settings.mapper.dart
@@ -2091,7 +2091,7 @@ class AgentQuotaEnvironmentSettingsMapper
 
   static String _$kimiApiKey(AgentQuotaEnvironmentSettings v) => v.kimiApiKey;
   static const Field<AgentQuotaEnvironmentSettings, String> _f$kimiApiKey =
-      Field('kimiApiKey', _$kimiApiKey, opt: true, def: 'KIMI_APY_KEY');
+      Field('kimiApiKey', _$kimiApiKey, opt: true, def: 'KIMI_API_KEY');
   static String _$zaiApiKey(AgentQuotaEnvironmentSettings v) => v.zaiApiKey;
   static const Field<AgentQuotaEnvironmentSettings, String> _f$zaiApiKey =
       Field('zaiApiKey', _$zaiApiKey, opt: true, def: 'ZAI_API_KEY');

--- a/lib/src/features/settings/presentation/panes/agent_quota_settings_group.dart
+++ b/lib/src/features/settings/presentation/panes/agent_quota_settings_group.dart
@@ -171,7 +171,7 @@ class AgentQuotaSettingsPane extends ConsumerWidget {
                 description:
                     'Environment Variable Read On The Active Host. The Secret Value Is Never Stored By Alera.',
                 value: hostSettings.environment.kimiApiKey,
-                hintText: 'KIMI_APY_KEY',
+                hintText: 'KIMI_API_KEY',
                 onChanged: (value) => _saveEnvironment(
                   controller,
                   hostId,

--- a/lib/src/features/settings/presentation/settings_search_entries.dart
+++ b/lib/src/features/settings/presentation/settings_search_entries.dart
@@ -182,7 +182,7 @@ const List<SettingsSearchEntry> quotaSearchEntries = <SettingsSearchEntry>[
   SettingsSearchEntry(
     title: 'Kimi API Key Variable',
     description: 'Configure The Kimi API Key Environment Variable Name.',
-    keywords: <String>['kimi', 'environment', 'api key', 'KIMI_APY_KEY'],
+    keywords: <String>['kimi', 'environment', 'api key', 'KIMI_API_KEY'],
     groupId: 'credentials',
   ),
   SettingsSearchEntry(

--- a/rust/alera-cli/src/agent_quota/kimi.rs
+++ b/rust/alera-cli/src/agent_quota/kimi.rs
@@ -1,4 +1,4 @@
-const KIMI_API_KEY_ENV: &str = "KIMI_APY_KEY";
+const KIMI_API_KEY_ENV: &str = "KIMI_API_KEY";
 
 async fn fetch_kimi(names: &EnvironmentNames) -> QuotaSnapshot {
     let Some(api_key) = environment_secret(&names.kimi_api_key) else {

--- a/test/unit/agent_quota_settings_test.dart
+++ b/test/unit/agent_quota_settings_test.dart
@@ -11,7 +11,7 @@ void main() {
       expect(local.claudeProfiles, isEmpty);
       expect(local.claudeDefaultEnabled, isTrue);
       expect(local.selectedClaudeProfile, 'default');
-      expect(local.environment.kimiApiKey, 'KIMI_APY_KEY');
+      expect(local.environment.kimiApiKey, 'KIMI_API_KEY');
     });
 
     test('parses host-specific quota configuration', () {

--- a/test/unit/settings_search_entries_test.dart
+++ b/test/unit/settings_search_entries_test.dart
@@ -28,7 +28,7 @@ void main() {
         (candidate) => candidate.title == 'Kimi API Key Variable',
       );
 
-      expect(entry.matches('kimi_apy_key'), isTrue);
+      expect(entry.matches('kimi_api_key'), isTrue);
       expect(entry.groupId, 'credentials');
     },
   );


### PR DESCRIPTION
## Summary

Correct the `KIMI_APY_KEY` environment variable typo to `KIMI_API_KEY` across the codebase, documentation, settings, search keys, and tests.

- Renamed occurrences of the typo in settings (`alera_settings.dart`, `agent_quota_settings_group.dart`, and `settings_search_entries.dart`).
- Regenerated the settings mapper file (`alera_settings.mapper.dart`).
- Fixed the Rust CLI implementation in `rust/alera-cli/src/agent_quota/kimi.rs`.
- Fixed the documentation in `docs/agent-quotas.md`.
- Updated unit tests (`agent_quota_settings_test.dart` and `settings_search_entries_test.dart`) to expect the corrected variable name.

## Validation

- Ran all Dart unit tests successfully: `flutter test test/unit/agent_quota_settings_test.dart test/unit/settings_search_entries_test.dart`.
- Ran all Rust tests successfully: `make rust-test`.

## Notes

No documentation updates needed other than fixing the typo in `docs/agent-quotas.md` itself.