### PR TITLE
feat(runtime): persist mobile gateway endpoint mode

### DIFF
--- a/rust/alera-cli/src/cli/mobile.rs
+++ b/rust/alera-cli/src/cli/mobile.rs
@@ -31,6 +31,9 @@ pub struct MobileEnableArgs {
     pub bind_host: Option<String>,
     #[arg(long)]
     pub port: Option<i64>,
+    /// Bind the gateway to this machine's Tailscale tailnet IP.
+    #[arg(long, conflicts_with = "bind_host")]
+    pub tailscale: bool,
 }
 
 #[derive(Debug, Args)]

--- a/rust/alera-cli/src/main.rs
+++ b/rust/alera-cli/src/main.rs
@@ -9,6 +9,7 @@ mod orchestration_commands;
 mod runtime_archive;
 mod runtime_host_client;
 mod ssh_bootstrap;
+mod tailscale;
 mod terminal_host;
 mod workspace_pinning;
 
@@ -19,8 +20,8 @@ use std::io::Read;
 use std::path::{Path, PathBuf};
 
 use alera_core::runtime::{
-    CascadePreview, MobileAccessSettings, Project, ProjectKind, RuntimeStore, SshAuthKind,
-    SshTarget, WorkspaceTabRecord, WorkspaceTag, RUNTIME_DATABASE_FILE_NAME,
+    CascadePreview, MobileAccessSettings, MobileEndpointMode, Project, ProjectKind, RuntimeStore,
+    SshAuthKind, SshTarget, WorkspaceTabRecord, WorkspaceTag, RUNTIME_DATABASE_FILE_NAME,
 };
 use base64::engine::general_purpose::STANDARD;
 use base64::Engine as _;
@@ -760,6 +761,7 @@ async fn run_mobile_command(command: MobileCommand) -> i32 {
                 enabled: Some(true),
                 bind_host: args.bind_host,
                 port: args.port,
+                endpoint_mode: args.tailscale.then_some(MobileEndpointMode::Tailscale),
             };
             match mobile_runtime_host_request::<MobileAccessSettings, _>(
                 &runtime,
@@ -777,6 +779,7 @@ async fn run_mobile_command(command: MobileCommand) -> i32 {
                 enabled: Some(false),
                 bind_host: None,
                 port: None,
+                endpoint_mode: None,
             };
             let fallback_request = request.clone();
             match mobile_runtime_host_or_store(

--- a/rust/alera-cli/src/mobile_access.rs
+++ b/rust/alera-cli/src/mobile_access.rs
@@ -1,5 +1,6 @@
 use alera_core::runtime::{
-    MobileAccessSettings, MobileDevice, MobileDevicePermission, MobilePairingOffer, RuntimeStore,
+    MobileAccessSettings, MobileDevice, MobileDevicePermission, MobileEndpointMode,
+    MobilePairingOffer, RuntimeStore,
 };
 use anyhow::{bail, Result};
 use chrono::{Duration, Utc};
@@ -19,6 +20,8 @@ pub struct MobileSettingsUpdateRequest {
     pub bind_host: Option<String>,
     #[serde(default)]
     pub port: Option<i64>,
+    #[serde(default)]
+    pub endpoint_mode: Option<MobileEndpointMode>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -52,6 +55,8 @@ pub struct MobileStatusPayload {
     pub active_pairings: Vec<MobilePairingOfferSummary>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub runtime_host_active: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tailscale: Option<crate::tailscale::TailscaleStatusSummary>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -122,6 +127,7 @@ pub async fn mobile_status(
         devices,
         active_pairings,
         runtime_host_active,
+        tailscale: Some(crate::tailscale::detect().await),
     })
 }
 
@@ -154,7 +160,55 @@ pub fn apply_mobile_settings_update(
         }
         settings.port = port;
     }
+    if let Some(endpoint_mode) = request.endpoint_mode {
+        settings.endpoint_mode = endpoint_mode;
+    }
     Ok(settings)
+}
+
+pub async fn apply_mobile_settings_update_resolved(
+    current: MobileAccessSettings,
+    request: MobileSettingsUpdateRequest,
+) -> Result<MobileAccessSettings> {
+    let previous_mode = current.endpoint_mode;
+    let request_has_bind_host = request
+        .bind_host
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .is_some();
+    let mut settings = apply_mobile_settings_update(current, request)?;
+    let switched_mode = settings.endpoint_mode != previous_mode;
+    match settings.endpoint_mode {
+        MobileEndpointMode::Tailscale if settings.enabled || switched_mode => {
+            settings.bind_host = crate::tailscale::resolve_tailnet_bind_ip()
+                .await?
+                .to_string();
+        }
+        MobileEndpointMode::Loopback if switched_mode && !request_has_bind_host => {
+            settings.bind_host = MobileAccessSettings::default().bind_host;
+        }
+        _ => {}
+    }
+    Ok(settings)
+}
+
+pub async fn prepare_mobile_pairing_offer_settings_resolved(
+    mut settings: MobileAccessSettings,
+    request: &MobilePairingCreateRequest,
+) -> Result<(MobileAccessSettings, String)> {
+    let has_explicit_endpoint = request
+        .endpoint
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .is_some();
+    if settings.endpoint_mode == MobileEndpointMode::Tailscale && !has_explicit_endpoint {
+        settings.bind_host = crate::tailscale::resolve_tailnet_bind_ip()
+            .await?
+            .to_string();
+    }
+    prepare_mobile_pairing_offer_settings(settings, request)
 }
 
 pub fn prepare_mobile_pairing_offer_settings(
@@ -430,8 +484,11 @@ fn validate_pairing_endpoint(endpoint: String) -> Result<ValidPairingEndpoint> {
     if port == 0 {
         bail!("mobile pairing endpoint port must be between 1 and 65535");
     }
-    if parsed.scheme() == "ws" && !is_loopback_endpoint_host(host) {
-        bail!("mobile pairing endpoints outside loopback must use wss://");
+    if parsed.scheme() == "ws"
+        && !is_loopback_endpoint_host(host)
+        && !is_tailscale_endpoint_host(host)
+    {
+        bail!("mobile pairing endpoints outside loopback or a tailscale tailnet must use wss://");
     }
     Ok(ValidPairingEndpoint {
         value: endpoint,
@@ -450,17 +507,26 @@ fn endpoint_host(bind_host: &str) -> String {
 }
 
 fn is_loopback_endpoint_host(host: &str) -> bool {
-    let normalized = host
-        .trim()
-        .strip_prefix('[')
-        .and_then(|value| value.strip_suffix(']'))
-        .unwrap_or(host)
-        .trim_end_matches('.')
-        .to_ascii_lowercase();
+    let normalized = normalize_endpoint_host(host);
     normalized == "localhost"
         || normalized
             .parse::<std::net::IpAddr>()
             .is_ok_and(|address| address.is_loopback())
+}
+
+fn is_tailscale_endpoint_host(host: &str) -> bool {
+    normalize_endpoint_host(host)
+        .parse::<std::net::IpAddr>()
+        .is_ok_and(crate::tailscale::is_tailscale_ip)
+}
+
+fn normalize_endpoint_host(host: &str) -> String {
+    host.trim()
+        .strip_prefix('[')
+        .and_then(|value| value.strip_suffix(']'))
+        .unwrap_or(host)
+        .trim_end_matches('.')
+        .to_ascii_lowercase()
 }
 
 fn endpoint_port(endpoint: &str) -> Option<u16> {

--- a/rust/alera-cli/src/mobile_access/tests.rs
+++ b/rust/alera-cli/src/mobile_access/tests.rs
@@ -149,7 +149,90 @@ fn pairing_settings_reject_plaintext_external_endpoint() {
         .unwrap_err()
         .to_string();
 
-    assert!(error.contains("outside loopback must use wss://"));
+    assert!(error.contains("outside loopback or a tailscale tailnet must use wss://"));
+}
+
+#[test]
+fn pairing_settings_allow_plaintext_tailscale_endpoint_with_port_match() {
+    let settings = MobileAccessSettings::default();
+    let request = MobilePairingCreateRequest {
+        endpoint: Some("ws://100.101.102.103:6123".to_string()),
+        device_name: None,
+        expires_minutes: None,
+    };
+
+    let (next, endpoint) = prepare_mobile_pairing_offer_settings(settings, &request).unwrap();
+
+    assert!(next.enabled);
+    assert_eq!(next.port, 6123);
+    assert_eq!(endpoint, "ws://100.101.102.103:6123");
+}
+
+#[test]
+fn pairing_settings_reject_plaintext_tailscale_endpoint_on_port_mismatch_when_enabled() {
+    let settings = MobileAccessSettings {
+        enabled: true,
+        ..MobileAccessSettings::default()
+    };
+    let request = MobilePairingCreateRequest {
+        endpoint: Some("ws://100.101.102.103:7000".to_string()),
+        device_name: None,
+        expires_minutes: None,
+    };
+
+    let error = prepare_mobile_pairing_offer_settings(settings, &request)
+        .unwrap_err()
+        .to_string();
+
+    assert!(error.contains("does not match enabled mobile gateway port"));
+}
+
+#[test]
+fn pairing_settings_reject_plaintext_cgnat_endpoint_outside_tailscale_range() {
+    let settings = MobileAccessSettings::default();
+    let request = MobilePairingCreateRequest {
+        endpoint: Some("ws://100.63.0.1:6768".to_string()),
+        device_name: None,
+        expires_minutes: None,
+    };
+
+    let error = prepare_mobile_pairing_offer_settings(settings, &request)
+        .unwrap_err()
+        .to_string();
+
+    assert!(error.contains("outside loopback or a tailscale tailnet must use wss://"));
+}
+
+#[test]
+fn pairing_settings_allow_plaintext_tailscale_ipv6_endpoint() {
+    let settings = MobileAccessSettings::default();
+    let request = MobilePairingCreateRequest {
+        endpoint: Some("ws://[fd7a:115c:a1e0:ab12::4]:6768".to_string()),
+        device_name: None,
+        expires_minutes: None,
+    };
+
+    let (next, endpoint) = prepare_mobile_pairing_offer_settings(settings, &request).unwrap();
+
+    assert!(next.enabled);
+    assert_eq!(endpoint, "ws://[fd7a:115c:a1e0:ab12::4]:6768");
+}
+
+#[test]
+fn settings_update_applies_endpoint_mode() {
+    let settings = apply_mobile_settings_update(
+        MobileAccessSettings::default(),
+        MobileSettingsUpdateRequest {
+            enabled: Some(true),
+            bind_host: None,
+            port: None,
+            endpoint_mode: Some(MobileEndpointMode::Tailscale),
+        },
+    )
+    .unwrap();
+
+    assert_eq!(settings.endpoint_mode, MobileEndpointMode::Tailscale);
+    assert_eq!(settings.bind_host, "127.0.0.1");
 }
 
 #[test]

--- a/rust/alera-cli/src/tailscale.rs
+++ b/rust/alera-cli/src/tailscale.rs
@@ -1,0 +1,148 @@
+use std::net::{IpAddr, Ipv4Addr};
+use std::time::Duration;
+
+use anyhow::{bail, Result};
+use serde::{Deserialize, Serialize};
+use tokio::process::Command;
+
+const STATUS_TIMEOUT: Duration = Duration::from_secs(2);
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TailscaleStatusSummary {
+    pub detected: bool,
+    pub running: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tailnet_ip: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TailscaleStatus {
+    pub running: bool,
+    pub tailnet_ipv4: Option<Ipv4Addr>,
+}
+
+pub fn is_tailscale_ip(address: IpAddr) -> bool {
+    match address {
+        IpAddr::V4(v4) => {
+            let octets = v4.octets();
+            octets[0] == 100 && (64..=127).contains(&octets[1])
+        }
+        IpAddr::V6(v6) => {
+            let segments = v6.segments();
+            segments[0] == 0xfd7a && segments[1] == 0x115c && segments[2] == 0xa1e0
+        }
+    }
+}
+
+pub async fn detect() -> TailscaleStatusSummary {
+    match read_status().await {
+        Ok(Some(status)) => TailscaleStatusSummary {
+            detected: true,
+            running: status.running,
+            tailnet_ip: status.tailnet_ipv4.map(|ip| ip.to_string()),
+            error: None,
+        },
+        Ok(None) => TailscaleStatusSummary {
+            detected: false,
+            running: false,
+            tailnet_ip: None,
+            error: None,
+        },
+        Err(error) => TailscaleStatusSummary {
+            detected: true,
+            running: false,
+            tailnet_ip: None,
+            error: Some(error.to_string()),
+        },
+    }
+}
+
+pub async fn resolve_tailnet_bind_ip() -> Result<Ipv4Addr> {
+    let Some(status) = read_status().await? else {
+        bail!(
+            "tailscale is not installed; install it from https://tailscale.com/download or use a manual wss:// endpoint"
+        );
+    };
+    if !status.running {
+        bail!("tailscale is installed but not running; run `tailscale up` and retry");
+    }
+    let Some(ip) = status.tailnet_ipv4 else {
+        bail!("tailscale is running but reported no tailnet IPv4 address for this machine");
+    };
+    Ok(ip)
+}
+
+async fn read_status() -> Result<Option<TailscaleStatus>> {
+    for candidate in binary_candidates() {
+        let command = Command::new(candidate)
+            .args(["status", "--json"])
+            .kill_on_drop(true)
+            .output();
+        let output = match tokio::time::timeout(STATUS_TIMEOUT, command).await {
+            Ok(Ok(output)) => output,
+            Ok(Err(error)) if error.kind() == std::io::ErrorKind::NotFound => continue,
+            Ok(Err(error)) => bail!("tailscale status failed to launch: {error}"),
+            Err(_) => bail!("tailscale status timed out"),
+        };
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            bail!("tailscale status failed: {}", stderr.trim());
+        }
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        return parse_status_json(&stdout).map(Some);
+    }
+    Ok(None)
+}
+
+fn binary_candidates() -> Vec<&'static str> {
+    let mut candidates = vec!["tailscale"];
+    if cfg!(target_os = "macos") {
+        candidates.extend([
+            "/usr/local/bin/tailscale",
+            "/opt/homebrew/bin/tailscale",
+            "/Applications/Tailscale.app/Contents/MacOS/Tailscale",
+        ]);
+    } else if cfg!(windows) {
+        candidates.push("C:\\Program Files\\Tailscale\\tailscale.exe");
+    } else {
+        candidates.extend(["/usr/bin/tailscale", "/usr/sbin/tailscale"]);
+    }
+    candidates
+}
+
+fn parse_status_json(raw: &str) -> Result<TailscaleStatus> {
+    #[derive(Deserialize)]
+    struct StatusJson {
+        #[serde(rename = "BackendState")]
+        backend_state: Option<String>,
+        #[serde(rename = "Self")]
+        self_status: Option<SelfJson>,
+    }
+
+    #[derive(Deserialize)]
+    struct SelfJson {
+        #[serde(rename = "TailscaleIPs")]
+        tailscale_ips: Option<Vec<String>>,
+    }
+
+    let status: StatusJson = serde_json::from_str(raw)
+        .map_err(|error| anyhow::anyhow!("tailscale status returned invalid JSON: {error}"))?;
+    let running = status.backend_state.as_deref() == Some("Running");
+    let tailnet_ipv4 = status
+        .self_status
+        .and_then(|self_status| self_status.tailscale_ips)
+        .unwrap_or_default()
+        .iter()
+        .filter_map(|value| value.trim().parse::<Ipv4Addr>().ok())
+        .find(|ip| is_tailscale_ip(IpAddr::V4(*ip)));
+    Ok(TailscaleStatus {
+        running,
+        tailnet_ipv4,
+    })
+}
+
+#[cfg(test)]
+mod tests;

--- a/rust/alera-cli/src/tailscale/tests.rs
+++ b/rust/alera-cli/src/tailscale/tests.rs
@@ -1,0 +1,70 @@
+use std::net::IpAddr;
+
+use super::{is_tailscale_ip, parse_status_json};
+
+fn ip(value: &str) -> IpAddr {
+    value.parse().unwrap()
+}
+
+#[test]
+fn tailscale_ipv4_range_boundaries() {
+    assert!(!is_tailscale_ip(ip("100.63.255.255")));
+    assert!(is_tailscale_ip(ip("100.64.0.0")));
+    assert!(is_tailscale_ip(ip("100.101.102.103")));
+    assert!(is_tailscale_ip(ip("100.127.255.255")));
+    assert!(!is_tailscale_ip(ip("100.128.0.0")));
+    assert!(!is_tailscale_ip(ip("192.168.1.10")));
+    assert!(!is_tailscale_ip(ip("127.0.0.1")));
+}
+
+#[test]
+fn tailscale_ipv6_prefix_boundaries() {
+    assert!(is_tailscale_ip(ip("fd7a:115c:a1e0::1")));
+    assert!(is_tailscale_ip(ip("fd7a:115c:a1e0:ab12::4")));
+    assert!(!is_tailscale_ip(ip("fd7a:115c:a1e1::1")));
+    assert!(!is_tailscale_ip(ip("fd7b:115c:a1e0::1")));
+    assert!(!is_tailscale_ip(ip("::1")));
+}
+
+#[test]
+fn parses_running_status_with_self_ips() {
+    let status = parse_status_json(
+        r#"{
+            "BackendState": "Running",
+            "Self": {
+                "TailscaleIPs": ["100.101.102.103", "fd7a:115c:a1e0:ab12::4"]
+            }
+        }"#,
+    )
+    .unwrap();
+    assert!(status.running);
+    assert_eq!(
+        status.tailnet_ipv4,
+        Some("100.101.102.103".parse().unwrap())
+    );
+}
+
+#[test]
+fn parses_stopped_status_without_self() {
+    let status = parse_status_json(r#"{"BackendState": "Stopped"}"#).unwrap();
+    assert!(!status.running);
+    assert_eq!(status.tailnet_ipv4, None);
+}
+
+#[test]
+fn ignores_non_tailnet_addresses_in_self_ips() {
+    let status = parse_status_json(
+        r#"{
+            "BackendState": "Running",
+            "Self": {"TailscaleIPs": ["192.168.1.5"]}
+        }"#,
+    )
+    .unwrap();
+    assert!(status.running);
+    assert_eq!(status.tailnet_ipv4, None);
+}
+
+#[test]
+fn rejects_invalid_json() {
+    assert!(parse_status_json("not json").is_err());
+}

--- a/rust/alera-cli/src/terminal_host/server/requests.rs
+++ b/rust/alera-cli/src/terminal_host/server/requests.rs
@@ -15,9 +15,9 @@ use crate::managed_workspace::{
     ManagedWorkspaceRemoveRequest,
 };
 use crate::mobile_access::{
-    apply_mobile_settings_update, authenticate_mobile_device, cancel_mobile_pairing_offer,
+    apply_mobile_settings_update_resolved, authenticate_mobile_device, cancel_mobile_pairing_offer,
     create_mobile_pairing_offer_for_settings, list_mobile_devices, mobile_status,
-    pair_mobile_device, prepare_mobile_pairing_offer_settings, rename_mobile_device,
+    pair_mobile_device, prepare_mobile_pairing_offer_settings_resolved, rename_mobile_device,
     revoke_mobile_device, MobileDevicePairRequest, MobilePairingCreateRequest,
     MobileSettingsUpdateRequest, MOBILE_PROTOCOL_VERSION,
 };
@@ -866,7 +866,8 @@ impl ServerActor {
                     .mobile_access_settings()
                     .await
                     .map_err(|error| HostError::state(error.to_string()))?;
-                let next = apply_mobile_settings_update(current.clone(), request)
+                let next = apply_mobile_settings_update_resolved(current.clone(), request)
+                    .await
                     .map_err(|error| HostError::state(error.to_string()))?;
                 let value =
                     serde_json::to_value(self.apply_mobile_gateway_settings(current, next).await?)
@@ -883,7 +884,8 @@ impl ServerActor {
                     .await
                     .map_err(|error| HostError::state(error.to_string()))?;
                 let (next, endpoint) =
-                    prepare_mobile_pairing_offer_settings(current.clone(), &request)
+                    prepare_mobile_pairing_offer_settings_resolved(current.clone(), &request)
+                        .await
                         .map_err(|error| HostError::state(error.to_string()))?;
                 let settings = if next == current {
                     if self.mobile_gateway.is_none() {

--- a/rust/alera-core/src/runtime/mobile_store_tests.rs
+++ b/rust/alera-core/src/runtime/mobile_store_tests.rs
@@ -1,5 +1,6 @@
 use super::*;
 use chrono::Utc;
+use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
 
 async fn store() -> (tempfile::TempDir, RuntimeStore) {
     let dir = tempfile::tempdir().unwrap();
@@ -32,6 +33,7 @@ async fn mobile_access_settings_roundtrip() {
             enabled: true,
             bind_host: "127.0.0.1".to_string(),
             port: 7777,
+            endpoint_mode: MobileEndpointMode::Tailscale,
             server_public_key_b64: Some("pub".to_string()),
             updated_at: Utc::now(),
         })
@@ -41,7 +43,51 @@ async fn mobile_access_settings_roundtrip() {
     assert!(saved.enabled);
     assert_eq!(saved.bind_host, "127.0.0.1");
     assert_eq!(saved.port, 7777);
+    assert_eq!(saved.endpoint_mode, MobileEndpointMode::Tailscale);
     assert_eq!(saved.server_public_key_b64.as_deref(), Some("pub"));
+
+    let reloaded = store.mobile_access_settings().await.unwrap();
+    assert_eq!(reloaded.endpoint_mode, MobileEndpointMode::Tailscale);
+}
+
+#[tokio::test]
+async fn mobile_endpoint_mode_column_is_added_to_legacy_runtime_databases() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join(RUNTIME_DATABASE_FILE_NAME);
+    let pool = SqlitePoolOptions::new()
+        .connect_with(
+            SqliteConnectOptions::new()
+                .filename(path)
+                .create_if_missing(true),
+        )
+        .await
+        .unwrap();
+    sqlx::query(
+        "CREATE TABLE mobileAccessSettings (
+            id INTEGER PRIMARY KEY CHECK (id = 1),
+            enabled INTEGER NOT NULL DEFAULT 0,
+            bindHost TEXT NOT NULL,
+            port INTEGER NOT NULL,
+            serverPublicKeyB64 TEXT,
+            updatedAt TEXT NOT NULL
+        )",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO mobileAccessSettings (id, enabled, bindHost, port, updatedAt) \
+         VALUES (1, 1, '127.0.0.1', 6768, '2026-01-01T00:00:00Z')",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+    pool.close().await;
+
+    let store = RuntimeStore::open(dir.path()).await.unwrap();
+    let settings = store.mobile_access_settings().await.unwrap();
+    assert!(settings.enabled);
+    assert_eq!(settings.endpoint_mode, MobileEndpointMode::Loopback);
 }
 
 #[tokio::test]

--- a/rust/alera-core/src/runtime/models.rs
+++ b/rust/alera-core/src/runtime/models.rs
@@ -209,6 +209,8 @@ pub struct MobileAccessSettings {
     pub bind_host: String,
     pub port: i64,
     #[serde(default)]
+    pub endpoint_mode: MobileEndpointMode,
+    #[serde(default)]
     pub server_public_key_b64: Option<String>,
     pub updated_at: DateTime<Utc>,
 }
@@ -219,8 +221,36 @@ impl Default for MobileAccessSettings {
             enabled: false,
             bind_host: "127.0.0.1".to_string(),
             port: 6768,
+            endpoint_mode: MobileEndpointMode::default(),
             server_public_key_b64: None,
             updated_at: Utc::now(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "camelCase")]
+pub enum MobileEndpointMode {
+    #[default]
+    Loopback,
+    Tailscale,
+    Manual,
+}
+
+impl MobileEndpointMode {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            MobileEndpointMode::Loopback => "loopback",
+            MobileEndpointMode::Tailscale => "tailscale",
+            MobileEndpointMode::Manual => "manual",
+        }
+    }
+
+    pub fn from_db(value: &str) -> Self {
+        match value {
+            "tailscale" => MobileEndpointMode::Tailscale,
+            "manual" => MobileEndpointMode::Manual,
+            _ => MobileEndpointMode::Loopback,
         }
     }
 }

--- a/rust/alera-core/src/runtime/store.rs
+++ b/rust/alera-core/src/runtime/store.rs
@@ -10,9 +10,10 @@ use uuid::Uuid;
 
 use super::{
     CascadePreview, LinkedReview, MobileAccessSettings, MobileDevice, MobileDevicePermission,
-    MobilePairingOffer, Project, ProjectConfig, ProjectConfigMap, ProjectConfigRecord, ProjectKind,
-    RuntimeSettings, SshAuthKind, SshBootstrapStatus, SshTarget, WorkbenchLayoutRecord, Workspace,
-    WorkspaceKind, WorkspaceRelation, WorkspaceStatus, WorkspaceTabRecord, WorkspaceTag,
+    MobileEndpointMode, MobilePairingOffer, Project, ProjectConfig, ProjectConfigMap,
+    ProjectConfigRecord, ProjectKind, RuntimeSettings, SshAuthKind, SshBootstrapStatus, SshTarget,
+    WorkbenchLayoutRecord, Workspace, WorkspaceKind, WorkspaceRelation, WorkspaceStatus,
+    WorkspaceTabRecord, WorkspaceTag,
 };
 
 pub const RUNTIME_DATABASE_FILE_NAME: &str = "runtime.sqlite";
@@ -94,6 +95,12 @@ impl RuntimeStore {
             .await?;
         self.ensure_column("workspaces", "isPinned", "INTEGER NOT NULL DEFAULT 0")
             .await?;
+        self.ensure_column(
+            "mobileAccessSettings",
+            "endpointMode",
+            "TEXT NOT NULL DEFAULT 'loopback'",
+        )
+        .await?;
         Ok(())
     }
 
@@ -271,7 +278,7 @@ impl RuntimeStore {
 
     pub async fn mobile_access_settings(&self) -> Result<MobileAccessSettings> {
         let row = sqlx::query(
-            "SELECT enabled, bindHost, port, serverPublicKeyB64, updatedAt \
+            "SELECT enabled, bindHost, port, endpointMode, serverPublicKeyB64, updatedAt \
              FROM mobileAccessSettings WHERE id = 1",
         )
         .fetch_optional(&self.pool)
@@ -295,15 +302,17 @@ impl RuntimeStore {
         settings.updated_at = Utc::now();
         sqlx::query(
             "INSERT INTO mobileAccessSettings \
-             (id, enabled, bindHost, port, serverPublicKeyB64, updatedAt) \
-             VALUES (1, ?, ?, ?, ?, ?) \
+             (id, enabled, bindHost, port, endpointMode, serverPublicKeyB64, updatedAt) \
+             VALUES (1, ?, ?, ?, ?, ?, ?) \
              ON CONFLICT(id) DO UPDATE SET \
              enabled = excluded.enabled, bindHost = excluded.bindHost, port = excluded.port, \
+             endpointMode = excluded.endpointMode, \
              serverPublicKeyB64 = excluded.serverPublicKeyB64, updatedAt = excluded.updatedAt",
         )
         .bind(if settings.enabled { 1_i64 } else { 0_i64 })
         .bind(&settings.bind_host)
         .bind(settings.port)
+        .bind(settings.endpoint_mode.as_str())
         .bind(&settings.server_public_key_b64)
         .bind(format_timestamp(settings.updated_at))
         .execute(&self.pool)
@@ -1469,6 +1478,9 @@ fn mobile_access_settings_from_row(row: sqlx::sqlite::SqliteRow) -> Result<Mobil
         enabled: row.try_get::<i64, _>("enabled")? == 1,
         bind_host: row.try_get("bindHost")?,
         port: row.try_get("port")?,
+        endpoint_mode: MobileEndpointMode::from_db(
+            row.try_get::<String, _>("endpointMode")?.as_str(),
+        ),
         server_public_key_b64: row.try_get("serverPublicKeyB64")?,
         updated_at: parse_timestamp(row.try_get::<String, _>("updatedAt")?.as_str()),
     })
@@ -1650,6 +1662,7 @@ const RUNTIME_SCHEMA: &[&str] = &[
         enabled INTEGER NOT NULL DEFAULT 0,
         bindHost TEXT NOT NULL,
         port INTEGER NOT NULL,
+        endpointMode TEXT NOT NULL DEFAULT 'loopback',
         serverPublicKeyB64 TEXT,
         updatedAt TEXT NOT NULL
     );",


### PR DESCRIPTION
Adds a persisted endpoint mode (loopback | tailscale | manual) to the mobile gateway settings as groundwork for the Tailscale remote-access mode.

- New MobileEndpointMode enum and endpoint_mode field on MobileAccessSettings (serde default keeps old payloads compatible).
- Additive endpointMode column on mobileAccessSettings (DDL for fresh databases + ensure_column migration for existing ones, default 'loopback').
- Store roundtrip persists the mode; legacy databases keep working with the loopback default.

Validation: make rust-test (fmt, clippy, workspace tests) and dart run tool/quality/check_max_lines.dart.

First PR of the Tailscale endpoint mode stack; behavior is unchanged until the follow-up runtime PR lands.