### PR TITLE
docs(mobile): document tailscale remote access

### DIFF
--- a/mobile/README.md
+++ b/mobile/README.md
@@ -36,9 +36,23 @@ alera mobile --json enable --bind-host 127.0.0.1 --port 6768
 alera mobile --json pairing create --endpoint ws://127.0.0.1:6768
 ```
 
-The CLI starts or reuses a mobile-capable runtime host for enable and pairing creation so the gateway is accepting WebSocket connections before it returns a pairing payload. Mobile access defaults to a loopback bind. `ws://` pairing endpoints are accepted only for loopback/local development, and their explicit port must match the local gateway port. For phones over LAN/VPN, publish the loopback gateway through a TLS tunnel or proxy and create the pairing payload with an explicit `wss://<host-or-vpn-name>:<port>` endpoint; that public TLS port can differ from the local gateway port. When the gateway intentionally binds `0.0.0.0`, `pairing create` requires an explicit reachable `--endpoint` because phones cannot connect to a wildcard address. Mobile access is opt-in; use `alera mobile --json disable` to stop publishing the gateway and disconnect active mobile clients.
+The CLI starts or reuses a mobile-capable runtime host for enable and pairing creation so the gateway is accepting WebSocket connections before it returns a pairing payload. Mobile access is opt-in; use `alera mobile --json disable` to stop publishing the gateway and disconnect active mobile clients.
 
-Run `alera mobile --json enable --port <port>` first when changing the local gateway port for loopback `ws://` pairing.
+## Remote Access Modes
+
+The gateway has three endpoint modes, selectable from Settings > Mobile Devices in the desktop app (This Device / Tailscale / Manual) or persisted through the CLI:
+
+- **This Device (default)**: loopback bind. `ws://` pairing endpoints are accepted only for loopback/local development, and their explicit port must match the local gateway port. Run `alera mobile --json enable --port <port>` first when changing the local gateway port for loopback `ws://` pairing.
+- **Tailscale (recommended for remote access)**: run `alera mobile --json enable --tailscale` or pick the Tailscale mode in settings. The runtime verifies Tailscale is installed and running, binds the gateway to this machine's tailnet IPv4 (100.64.0.0/10), and emits pairing offers with `ws://<tailnet-ip>:<port>`. Plaintext `ws://` is acceptable here because traffic between tailnet devices rides Tailscale's WireGuard tunnel; the phone additionally refuses to store credentials when the pairing response's runtime id does not match the offer. The phone must have the Tailscale app installed and be signed in to the same tailnet. Tailscale is detected, never bundled: install it from https://tailscale.com/download on both devices.
+- **Manual (advanced)**: publish the gateway yourself through a TLS tunnel or proxy and create the pairing payload with an explicit `wss://<host-or-vpn-name>:<port>` endpoint; that public TLS port can differ from the local gateway port. When the gateway intentionally binds `0.0.0.0`, `pairing create` requires an explicit reachable `--endpoint` because phones cannot connect to a wildcard address.
+
+### Tailscale Troubleshooting
+
+- `tailscale is not installed`: install Tailscale on the desktop, or use the Manual mode with a `wss://` endpoint.
+- `tailscale is installed but not running`: run `tailscale up` and sign in, then retry.
+- The phone cannot connect on Windows: allow Alera through Windows Firewall for incoming connections on the gateway port (the settings pane shows a hint when the Tailscale mode is active on Windows).
+- The phone cannot connect anywhere: confirm the Tailscale app is connected on the phone, that both devices appear in the same tailnet, and that the tailnet's ACLs allow the connection.
+- After removing the machine from the tailnet, the gateway may fail to bind its stale tailnet IP on restart; re-run `alera mobile --json enable --tailscale` or switch modes in settings to re-resolve.
 
 ## Remaining Work
 

--- a/mobile/lib/src/models.dart
+++ b/mobile/lib/src/models.dart
@@ -70,9 +70,12 @@ void _validatePairingEndpoint(String endpoint) {
   if (!uri.hasPort || uri.port == 0) {
     throw const FormatException('Pairing Endpoint Must Include A Valid Port');
   }
-  if (uri.scheme == 'ws' && !_isLocalPairingHost(uri.host)) {
+  if (uri.scheme == 'ws' &&
+      !_isLocalPairingHost(uri.host) &&
+      !_isTailscalePairingHost(uri.host)) {
     throw const FormatException(
-      'Plaintext Pairing Endpoint Must Use Localhost Or Loopback',
+      'Plaintext Pairing Endpoint Must Use Localhost, Loopback, Or A '
+      'Tailscale Tailnet Address',
     );
   }
 }
@@ -83,6 +86,27 @@ bool _isLocalPairingHost(String host) {
     return true;
   }
   return InternetAddress.tryParse(host)?.isLoopback ?? false;
+}
+
+/// Tailscale tailnet ranges (IPv4 100.64.0.0/10, IPv6 fd7a:115c:a1e0::/48).
+/// Traffic to these addresses rides the device's WireGuard tunnel, so
+/// plaintext ws:// is acceptable. Mirrors the runtime's `is_tailscale_ip`.
+bool _isTailscalePairingHost(String host) {
+  final address = InternetAddress.tryParse(host);
+  if (address == null) {
+    return false;
+  }
+  final bytes = address.rawAddress;
+  if (address.type == InternetAddressType.IPv4) {
+    return bytes[0] == 100 && bytes[1] >= 64 && bytes[1] <= 127;
+  }
+  return bytes.length >= 6 &&
+      bytes[0] == 0xfd &&
+      bytes[1] == 0x7a &&
+      bytes[2] == 0x11 &&
+      bytes[3] == 0x5c &&
+      bytes[4] == 0xa1 &&
+      bytes[5] == 0xe0;
 }
 
 class PairedHostProfile {
@@ -108,6 +132,14 @@ class PairedHostProfile {
     PairingOffer offer,
     PairedDeviceCredentials credentials,
   ) {
+    // A pair response from a different runtime than the offer promised means
+    // the endpoint reached the wrong host (for example a non-tailnet CGNAT
+    // address); refuse to store credentials for it.
+    if (credentials.runtimeId != offer.runtimeId) {
+      throw const FormatException(
+        'Pairing Response Runtime Id Does Not Match The Offer',
+      );
+    }
     return PairedHostProfile(
       id: offer.runtimeId,
       displayName: offer.hostName,

--- a/mobile/test/models_test.dart
+++ b/mobile/test/models_test.dart
@@ -28,6 +28,35 @@ void main() {
       );
     });
 
+    test('Accepts plaintext tailscale tailnet endpoints', () {
+      final ipv4 = PairingOffer.fromJson(
+        _offer(endpoint: 'ws://100.64.1.5:6768'),
+      );
+      final ipv6 = PairingOffer.fromJson(
+        _offer(endpoint: 'ws://[fd7a:115c:a1e0:ab12::4]:6768'),
+      );
+
+      expect(ipv4.endpoint, 'ws://100.64.1.5:6768');
+      expect(ipv6.endpoint, 'ws://[fd7a:115c:a1e0:ab12::4]:6768');
+    });
+
+    test('Rejects plaintext cgnat endpoints outside the tailscale range', () {
+      expect(
+        () => PairingOffer.fromJson(_offer(endpoint: 'ws://100.63.0.1:6768')),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        () => PairingOffer.fromJson(_offer(endpoint: 'ws://100.128.0.0:6768')),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        () => PairingOffer.fromJson(
+          _offer(endpoint: 'ws://[fd7a:115c:a1e1::1]:6768'),
+        ),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
     test('Rejects endpoints without explicit ports', () {
       expect(
         () => PairingOffer.fromJson(_offer(endpoint: 'wss://alera.example')),
@@ -45,6 +74,44 @@ void main() {
         throwsA(isA<FormatException>()),
       );
     });
+
+    test('Reloads saved tailscale endpoints', () {
+      final profile = PairedHostProfile.fromJson(
+        _profile(endpoint: 'ws://100.64.1.5:6768'),
+      );
+
+      expect(profile.endpoint, 'ws://100.64.1.5:6768');
+    });
+
+    test('Pairing result requires the runtime id promised by the offer', () {
+      final offer = PairingOffer.fromJson(
+        _offer(endpoint: 'ws://100.64.1.5:6768'),
+      );
+
+      expect(
+        () => PairedHostProfile.fromPairingResult(
+          offer,
+          _credentials(runtimeId: 'runtime-other'),
+        ),
+        throwsA(isA<FormatException>()),
+      );
+
+      final profile = PairedHostProfile.fromPairingResult(
+        offer,
+        _credentials(runtimeId: 'runtime-1'),
+      );
+      expect(profile.runtimeId, 'runtime-1');
+      expect(profile.id, 'runtime-1');
+    });
+  });
+}
+
+PairedDeviceCredentials _credentials({required String runtimeId}) {
+  return PairedDeviceCredentials.fromJson(<String, Object?>{
+    'deviceId': 'device-1',
+    'displayName': 'My Phone',
+    'runtimeId': runtimeId,
+    'deviceToken': 'token-1',
   });
 }
 


### PR DESCRIPTION
Documents the three mobile gateway endpoint modes (This Device / Tailscale / Manual) in the mobile README, including `alera mobile --json enable --tailscale`, why plaintext ws:// is acceptable inside a tailnet, the runtime id pinning on the phone, and a Tailscale troubleshooting list (not installed, not running, Windows Firewall, tailnet ACLs, stale tailnet IP after removal).

Docs only; no code changes. Stacked on #147.