### PR TITLE
feat(desktop): mirror tailscale pairing endpoint rules

### DIFF
--- a/lib/src/features/mobile_devices/domain/mobile_access_status.dart
+++ b/lib/src/features/mobile_devices/domain/mobile_access_status.dart
@@ -1,11 +1,30 @@
 import 'package:alera/src/features/mobile_devices/domain/mobile_device.dart';
 import 'package:alera/src/features/mobile_devices/domain/mobile_pairing_offer.dart';
 
+enum MobileEndpointMode {
+  loopback,
+  tailscale,
+  manual;
+
+  /// Defaults to loopback for unknown values so the desktop keeps working
+  /// against runtimes that predate the endpoint mode field.
+  static MobileEndpointMode fromWire(Object? value) {
+    return switch (value) {
+      'tailscale' => MobileEndpointMode.tailscale,
+      'manual' => MobileEndpointMode.manual,
+      _ => MobileEndpointMode.loopback,
+    };
+  }
+
+  String get wireName => name;
+}
+
 class MobileGatewaySettings {
   const MobileGatewaySettings({
     required this.enabled,
     required this.bindHost,
     required this.port,
+    this.endpointMode = MobileEndpointMode.loopback,
     this.serverPublicKeyB64,
   });
 
@@ -23,6 +42,7 @@ class MobileGatewaySettings {
       enabled: enabled,
       bindHost: bindHost,
       port: port.toInt(),
+      endpointMode: MobileEndpointMode.fromWire(json['endpointMode']),
       serverPublicKeyB64: publicKey is String && publicKey.trim().isNotEmpty
           ? publicKey
           : null,
@@ -32,7 +52,35 @@ class MobileGatewaySettings {
   final bool enabled;
   final String bindHost;
   final int port;
+  final MobileEndpointMode endpointMode;
   final String? serverPublicKeyB64;
+}
+
+class MobileTailscaleStatus {
+  const MobileTailscaleStatus({
+    required this.detected,
+    required this.running,
+    this.tailnetIp,
+    this.error,
+  });
+
+  factory MobileTailscaleStatus.fromJson(Map<String, Object?> json) {
+    final tailnetIp = json['tailnetIp'];
+    final error = json['error'];
+    return MobileTailscaleStatus(
+      detected: json['detected'] == true,
+      running: json['running'] == true,
+      tailnetIp: tailnetIp is String && tailnetIp.trim().isNotEmpty
+          ? tailnetIp
+          : null,
+      error: error is String && error.trim().isNotEmpty ? error : null,
+    );
+  }
+
+  final bool detected;
+  final bool running;
+  final String? tailnetIp;
+  final String? error;
 }
 
 class MobileAccessStatus {
@@ -42,6 +90,7 @@ class MobileAccessStatus {
     required this.devices,
     required this.activePairings,
     this.runtimeHostActive,
+    this.tailscale,
   });
 
   factory MobileAccessStatus.fromJson(Map<String, Object?> json) {
@@ -51,6 +100,7 @@ class MobileAccessStatus {
     }
     final version = json['protocolVersion'];
     final runtimeHostActive = json['runtimeHostActive'];
+    final tailscale = json['tailscale'];
     return MobileAccessStatus(
       protocolVersion: version is num ? version.toInt() : 0,
       settings: MobileGatewaySettings.fromJson(
@@ -68,6 +118,9 @@ class MobileAccessStatus {
             MobilePairingOffer.fromJson(Map<String, Object?>.from(offer)),
       ],
       runtimeHostActive: runtimeHostActive is bool ? runtimeHostActive : null,
+      tailscale: tailscale is Map
+          ? MobileTailscaleStatus.fromJson(Map<String, Object?>.from(tailscale))
+          : null,
     );
   }
 
@@ -76,4 +129,5 @@ class MobileAccessStatus {
   final List<MobileDevice> devices;
   final List<MobilePairingOffer> activePairings;
   final bool? runtimeHostActive;
+  final MobileTailscaleStatus? tailscale;
 }

--- a/lib/src/features/mobile_devices/domain/mobile_pairing_endpoint_rules.dart
+++ b/lib/src/features/mobile_devices/domain/mobile_pairing_endpoint_rules.dart
@@ -11,6 +11,38 @@ bool isWildcardBindHost(String value) {
 }
 
 bool isLoopbackEndpointHost(String host) {
+  final normalized = _normalizeEndpointHost(host);
+  if (normalized == 'localhost') {
+    return true;
+  }
+  return _isLoopbackIpLiteral(normalized);
+}
+
+/// True when the host is an IP literal inside the Tailscale tailnet ranges
+/// (IPv4 100.64.0.0/10 or IPv6 fd7a:115c:a1e0::/48). Mirrors the Rust
+/// `is_tailscale_ip`.
+bool isTailscaleEndpointHost(String host) {
+  final normalized = _normalizeEndpointHost(host);
+  try {
+    final bytes = Uri.parseIPv4Address(normalized);
+    return bytes[0] == 100 && bytes[1] >= 64 && bytes[1] <= 127;
+  } on FormatException {
+    // Not an IPv4 literal; fall through to IPv6.
+  }
+  try {
+    final bytes = Uri.parseIPv6Address(normalized);
+    return bytes[0] == 0xfd &&
+        bytes[1] == 0x7a &&
+        bytes[2] == 0x11 &&
+        bytes[3] == 0x5c &&
+        bytes[4] == 0xa1 &&
+        bytes[5] == 0xe0;
+  } on FormatException {
+    return false;
+  }
+}
+
+String _normalizeEndpointHost(String host) {
   var normalized = host.trim();
   if (normalized.startsWith('[') && normalized.endsWith(']')) {
     normalized = normalized.substring(1, normalized.length - 1);
@@ -18,11 +50,7 @@ bool isLoopbackEndpointHost(String host) {
   while (normalized.endsWith('.')) {
     normalized = normalized.substring(0, normalized.length - 1);
   }
-  normalized = normalized.toLowerCase();
-  if (normalized == 'localhost') {
-    return true;
-  }
-  return _isLoopbackIpLiteral(normalized);
+  return normalized.toLowerCase();
 }
 
 bool _isLoopbackIpLiteral(String value) {
@@ -122,8 +150,10 @@ String? validateMobilePairingEndpoint({
   if (parts.port < 1 || parts.port > 65535) {
     return 'Endpoint Port Must Be Between 1 And 65535';
   }
-  if (parts.scheme == 'ws' && !isLoopbackEndpointHost(parts.host)) {
-    return 'Endpoints Outside Loopback Must Use wss://';
+  if (parts.scheme == 'ws' &&
+      !isLoopbackEndpointHost(parts.host) &&
+      !isTailscaleEndpointHost(parts.host)) {
+    return 'Endpoints Outside Loopback Or A Tailscale Tailnet Must Use wss://';
   }
   if (parts.scheme == 'ws' && gatewayEnabled && parts.port != gatewayPort) {
     return 'ws:// Endpoint Port Must Match The Enabled Gateway Port '
@@ -141,6 +171,10 @@ String? mobileGatewayBindHostHint({
   if (isWildcardBindHost(bindHost)) {
     return 'Wildcard Bind Hosts Require An Explicit wss:// Endpoint When '
         'Linking (For Example wss://<host-or-vpn-name>:$port)';
+  }
+  if (isTailscaleEndpointHost(bindHost)) {
+    return 'Devices Connect Over Your Tailnet - Both Devices Must Be Signed '
+        'In To Tailscale';
   }
   if (!isLoopbackEndpointHost(bindHost)) {
     return 'Devices Outside This Machine Must Connect Through wss:// - Use A '

--- a/lib/src/features/mobile_devices/infra/runtime_mobile_access_repository.dart
+++ b/lib/src/features/mobile_devices/infra/runtime_mobile_access_repository.dart
@@ -35,15 +35,15 @@ class RuntimeMobileAccessRepository {
     bool? enabled,
     String? bindHost,
     int? port,
+    MobileEndpointMode? endpointMode,
   }) async {
-    final payload = await _client.runtimeRequest(
-      'mobile.settings.update',
-      <String, Object?>{
-        'enabled': ?enabled,
-        'bindHost': ?bindHost,
-        'port': ?port,
-      },
-    );
+    final payload = await _client
+        .runtimeRequest('mobile.settings.update', <String, Object?>{
+          'enabled': ?enabled,
+          'bindHost': ?bindHost,
+          'port': ?port,
+          'endpointMode': ?endpointMode?.wireName,
+        });
     return MobileGatewaySettings.fromJson(_mapFromPayload(payload));
   }
 

--- a/test/unit/mobile_pairing_endpoint_rules_test.dart
+++ b/test/unit/mobile_pairing_endpoint_rules_test.dart
@@ -29,6 +29,29 @@ void main() {
     });
   });
 
+  group('isTailscaleEndpointHost', () {
+    test('accepts tailnet IPv4 range boundaries', () {
+      expect(isTailscaleEndpointHost('100.64.0.0'), isTrue);
+      expect(isTailscaleEndpointHost('100.101.102.103'), isTrue);
+      expect(isTailscaleEndpointHost('100.127.255.255'), isTrue);
+    });
+
+    test('rejects addresses outside the tailnet IPv4 range', () {
+      expect(isTailscaleEndpointHost('100.63.255.255'), isFalse);
+      expect(isTailscaleEndpointHost('100.128.0.0'), isFalse);
+      expect(isTailscaleEndpointHost('192.168.1.10'), isFalse);
+      expect(isTailscaleEndpointHost('127.0.0.1'), isFalse);
+      expect(isTailscaleEndpointHost('alera.example.test'), isFalse);
+    });
+
+    test('accepts only the tailscale IPv6 prefix', () {
+      expect(isTailscaleEndpointHost('[fd7a:115c:a1e0::1]'), isTrue);
+      expect(isTailscaleEndpointHost('fd7a:115c:a1e0:ab12::4'), isTrue);
+      expect(isTailscaleEndpointHost('[fd7a:115c:a1e1::1]'), isFalse);
+      expect(isTailscaleEndpointHost('[::1]'), isFalse);
+    });
+  });
+
   group('parseMobilePairingEndpoint', () {
     test('parses explicit authority ports', () {
       final parts = parseMobilePairingEndpoint('wss://alera.example.test:443');
@@ -102,6 +125,47 @@ void main() {
       );
     });
 
+    test('accepts plaintext tailscale endpoints', () {
+      expect(
+        validateMobilePairingEndpoint(
+          endpoint: 'ws://100.101.102.103:6768',
+          gatewayEnabled: true,
+          gatewayPort: 6768,
+        ),
+        isNull,
+      );
+      expect(
+        validateMobilePairingEndpoint(
+          endpoint: 'ws://[fd7a:115c:a1e0:ab12::4]:6768',
+          gatewayEnabled: false,
+          gatewayPort: 6768,
+        ),
+        isNull,
+      );
+    });
+
+    test('rejects plaintext cgnat endpoints outside the tailscale range', () {
+      expect(
+        validateMobilePairingEndpoint(
+          endpoint: 'ws://100.63.0.1:6768',
+          gatewayEnabled: false,
+          gatewayPort: 6768,
+        ),
+        contains('wss://'),
+      );
+    });
+
+    test('keeps the port match rule for tailscale ws endpoints', () {
+      expect(
+        validateMobilePairingEndpoint(
+          endpoint: 'ws://100.101.102.103:7000',
+          gatewayEnabled: true,
+          gatewayPort: 6768,
+        ),
+        contains('Match The Enabled Gateway Port 6768'),
+      );
+    });
+
     test('accepts wss endpoints outside loopback', () {
       expect(
         validateMobilePairingEndpoint(
@@ -159,6 +223,15 @@ void main() {
         mobileGatewayBindHostHint(bindHost: '192.168.1.10', port: 6768),
         contains('wss://'),
       );
+    });
+
+    test('hints tailscale binds toward the tailnet instead of wss', () {
+      final hint = mobileGatewayBindHostHint(
+        bindHost: '100.101.102.103',
+        port: 6768,
+      );
+      expect(hint, contains('Tailnet'));
+      expect(hint, isNot(contains('wss://')));
     });
 
     test('returns no hint for loopback binds', () {

--- a/test/unit/runtime_mobile_access_repository_test.dart
+++ b/test/unit/runtime_mobile_access_repository_test.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:alera/src/features/mobile_devices/domain/mobile_access_status.dart';
 import 'package:alera/src/features/mobile_devices/infra/runtime_mobile_access_repository.dart';
 import 'package:alera/src/features/workbench/infra/terminal_host/terminal_host_protocol.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -24,6 +25,43 @@ void main() {
       expect(status.devices.last.isRevoked, isTrue);
       expect(status.activePairings, hasLength(1));
       expect(status.activePairings.first.endpoint, 'ws://127.0.0.1:6768');
+    });
+
+    test(
+      'status tolerates payloads without endpoint mode or tailscale',
+      () async {
+        final client = _FakeRuntimeHostClient();
+        client.responses['mobile.status.get'] = _statusPayload();
+        final repository = RuntimeMobileAccessRepository(client);
+
+        final status = await repository.status();
+
+        expect(status.settings.endpointMode, MobileEndpointMode.loopback);
+        expect(status.tailscale, isNull);
+      },
+    );
+
+    test('status parses endpoint mode and tailscale detection', () async {
+      final client = _FakeRuntimeHostClient();
+      final payload = _statusPayload();
+      (payload['settings']! as Map<String, Object?>)['endpointMode'] =
+          'tailscale';
+      payload['tailscale'] = <String, Object?>{
+        'detected': true,
+        'running': true,
+        'tailnetIp': '100.101.102.103',
+      };
+      client.responses['mobile.status.get'] = payload;
+      final repository = RuntimeMobileAccessRepository(client);
+
+      final status = await repository.status();
+
+      expect(status.settings.endpointMode, MobileEndpointMode.tailscale);
+      expect(status.tailscale, isNotNull);
+      expect(status.tailscale!.detected, isTrue);
+      expect(status.tailscale!.running, isTrue);
+      expect(status.tailscale!.tailnetIp, '100.101.102.103');
+      expect(status.tailscale!.error, isNull);
     });
 
     test('watchStatus refetches on every mobile change event', () async {
@@ -74,6 +112,29 @@ void main() {
       expect(client.payloads['mobile.settings.update']!.single, {
         'enabled': true,
         'port': 7000,
+      });
+    });
+
+    test('updateSettings sends the endpoint mode when provided', () async {
+      final client = _FakeRuntimeHostClient();
+      client.responses['mobile.settings.update'] = <String, Object?>{
+        'enabled': true,
+        'bindHost': '100.101.102.103',
+        'port': 6768,
+        'endpointMode': 'tailscale',
+      };
+      final repository = RuntimeMobileAccessRepository(client);
+
+      final settings = await repository.updateSettings(
+        enabled: true,
+        endpointMode: MobileEndpointMode.tailscale,
+      );
+
+      expect(settings.endpointMode, MobileEndpointMode.tailscale);
+      expect(settings.bindHost, '100.101.102.103');
+      expect(client.payloads['mobile.settings.update']!.single, {
+        'enabled': true,
+        'endpointMode': 'tailscale',
       });
     });
 


### PR DESCRIPTION
Mirrors the runtime's Tailscale endpoint rules on the desktop side so the settings pane pre-validates consistently; the runtime stays the authority.

- `isTailscaleEndpointHost` accepts IP literals in 100.64.0.0/10 and fd7a:115c:a1e0::/48; plaintext ws:// endpoints in those ranges pass validation with the same gateway-port-match rule as loopback.
- Tailscale bind hosts get a tailnet hint instead of the wss:// warning.
- `MobileGatewaySettings` parses `endpointMode` (tolerant default loopback for older runtimes) and `MobileAccessStatus` parses the optional `tailscale` detection summary.
- `updateSettings` forwards `endpointMode` when provided.

Validation: flutter analyze, flutter test (full desktop suite), dart run tool/quality/check_max_lines.dart.

Replaces #145 (auto-closed when its stacked base branch was deleted); original stack base #144 is already merged.
