### PR TITLE
feat: redesign mobile pairing flow

### DIFF
--- a/mobile/README.md
+++ b/mobile/README.md
@@ -4,7 +4,7 @@ Alera is the Android/iOS companion app for remote Alera work. It is a separate F
 
 ## Current Surface
 
-- Pair a host by pasting or scanning the JSON payload from `alera mobile --json pairing create`.
+- Pair a host with a QR-first flow: scan the pairing QR from the desktop pairing dialog (torch toggle included), or paste the JSON payload from `alera mobile --json pairing create` through the manual entry sheet. A confirmation step shows the host identity, endpoint, and a live offer-expiry countdown, plus an optional device name before pairing. Failures surface as titled states (Invalid Offer, Offer Expired, Runtime Mismatch, Could Not Reach Runtime) with retry and manual-entry actions.
 - Claim the pairing offer over the mobile WebSocket gateway and store the returned device token in platform secure storage.
 - Authenticate with `mobile.hello`, show host status, projects, workspaces, and branch summaries, and start or attach to a terminal session with Flutter `xterm`.
 

--- a/mobile/lib/src/app/theme/alera_tokens.dart
+++ b/mobile/lib/src/app/theme/alera_tokens.dart
@@ -22,17 +22,26 @@ abstract final class AleraTokens {
   static const double spaceMd = 12;
   static const double spaceLg = 16;
   static const double spaceXl = 24;
+  static const double spaceXxl = 32;
   static const double iconLg = 42;
   static const double emptyIcon = 44;
+  static const double successIcon = 64;
   static const double terminalPreviewHeight = 280;
   static const double keyColumnWidth = 104;
   static const double radiusSm = 8;
+  static const double radiusMd = 12;
   static const double strokeSm = 2;
+  static const double strokeMd = 3;
   static const double emphasisOverlayAlpha = 0.16;
+  static const double scrimAlpha = 0.55;
   static const double squareAspectRatio = 1;
-  static const int pairingInputMinLines = 8;
-  static const int pairingInputMaxLines = 12;
+  static const double pairingViewfinderSize = 260;
+  static const int pairingInputMinLines = 6;
+  static const int pairingInputMaxLines = 10;
   static const int previewRowLimit = 3;
+
+  static const Duration pairingSuccessAutoClose = Duration(milliseconds: 1200);
+  static const Duration expiryTickInterval = Duration(seconds: 1);
 
   static const String fontFamily = 'Inter';
   static const String monoFontFamily = 'JetBrains Mono';

--- a/mobile/lib/src/features/hosts/application/pairing_controller.dart
+++ b/mobile/lib/src/features/hosts/application/pairing_controller.dart
@@ -1,0 +1,103 @@
+import 'package:alera_mobile/src/features/hosts/application/host_providers.dart';
+import 'package:alera_mobile/src/features/hosts/application/paired_hosts_controller.dart';
+import 'package:alera_mobile/src/features/hosts/application/pairing_flow_state.dart';
+import 'package:alera_mobile/src/features/hosts/domain/paired_device_credentials.dart';
+import 'package:alera_mobile/src/features/hosts/domain/paired_host_profile.dart';
+import 'package:alera_mobile/src/features/hosts/domain/pairing_offer.dart';
+import 'package:alera_mobile/src/features/runtime/infra/mobile_runtime_client.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'pairing_controller.g.dart';
+
+typedef PairDeviceFunction =
+    Future<PairedDeviceCredentials> Function(
+      PairingOffer offer, {
+      String? deviceName,
+    });
+
+/// Indirection over the static pairing call so tests can drive the pairing
+/// flow without a live runtime gateway.
+@riverpod
+PairDeviceFunction pairDeviceFunction(Ref ref) {
+  return MobileRuntimeClient.pairDevice;
+}
+
+/// Whether the QR scanner can be offered as the primary pairing input. Tests
+/// (and platforms without camera support) override this to false so the
+/// manual entry path becomes the primary flow.
+@riverpod
+bool pairingScannerEnabled(Ref ref) {
+  return true;
+}
+
+@riverpod
+class PairingController extends _$PairingController {
+  @override
+  PairingFlowState build() {
+    return const PairingScanning();
+  }
+
+  void offerEntered(String rawOffer) {
+    try {
+      state = PairingOfferReady(PairingOffer.parse(rawOffer));
+    } on FormatException catch (error) {
+      state = PairingFailure(_parseFailureReason(error), error.message);
+    } on Object catch (error) {
+      state = PairingFailure(
+        PairingFailureReason.invalidOffer,
+        error.toString(),
+      );
+    }
+  }
+
+  Future<void> confirmPair({String? deviceName}) async {
+    final current = state;
+    if (current is! PairingOfferReady) {
+      return;
+    }
+    final offer = current.offer;
+    if (offer.isExpired) {
+      state = const PairingFailure(
+        PairingFailureReason.offerExpired,
+        'Pairing Offer Expired',
+      );
+      return;
+    }
+    state = PairingInProgress(offer);
+    try {
+      final pair = ref.read(pairDeviceFunctionProvider);
+      final credentials = await pair(offer, deviceName: deviceName);
+      final host = PairedHostProfile.fromPairingResult(offer, credentials);
+      // Persist through the keep-alive repository instead of the auto-dispose
+      // hosts controller: the host list may not be mounted while pairing.
+      await ref
+          .read(hostRepositoryProvider)
+          .savePairedHost(host, credentials.deviceToken);
+      ref.invalidate(pairedHostsControllerProvider);
+      state = PairingSuccess(host);
+    } on FormatException catch (error) {
+      state = PairingFailure(
+        error.message.contains('Runtime Id')
+            ? PairingFailureReason.runtimeMismatch
+            : PairingFailureReason.invalidOffer,
+        error.message,
+      );
+    } on Object catch (error) {
+      state = PairingFailure(
+        PairingFailureReason.unreachable,
+        error.toString(),
+      );
+    }
+  }
+
+  void restart() {
+    state = const PairingScanning();
+  }
+
+  PairingFailureReason _parseFailureReason(FormatException error) {
+    if (error.message.contains('Expired')) {
+      return PairingFailureReason.offerExpired;
+    }
+    return PairingFailureReason.invalidOffer;
+  }
+}

--- a/mobile/lib/src/features/hosts/application/pairing_controller.g.dart
+++ b/mobile/lib/src/features/hosts/application/pairing_controller.g.dart
@@ -1,0 +1,170 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'pairing_controller.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// Indirection over the static pairing call so tests can drive the pairing
+/// flow without a live runtime gateway.
+
+@ProviderFor(pairDeviceFunction)
+final pairDeviceFunctionProvider = PairDeviceFunctionProvider._();
+
+/// Indirection over the static pairing call so tests can drive the pairing
+/// flow without a live runtime gateway.
+
+final class PairDeviceFunctionProvider
+    extends
+        $FunctionalProvider<
+          PairDeviceFunction,
+          PairDeviceFunction,
+          PairDeviceFunction
+        >
+    with $Provider<PairDeviceFunction> {
+  /// Indirection over the static pairing call so tests can drive the pairing
+  /// flow without a live runtime gateway.
+  PairDeviceFunctionProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'pairDeviceFunctionProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$pairDeviceFunctionHash();
+
+  @$internal
+  @override
+  $ProviderElement<PairDeviceFunction> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  PairDeviceFunction create(Ref ref) {
+    return pairDeviceFunction(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(PairDeviceFunction value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<PairDeviceFunction>(value),
+    );
+  }
+}
+
+String _$pairDeviceFunctionHash() =>
+    r'ce96aba4b6e7a4c64015590ec5655e2884619621';
+
+/// Whether the QR scanner can be offered as the primary pairing input. Tests
+/// (and platforms without camera support) override this to false so the
+/// manual entry path becomes the primary flow.
+
+@ProviderFor(pairingScannerEnabled)
+final pairingScannerEnabledProvider = PairingScannerEnabledProvider._();
+
+/// Whether the QR scanner can be offered as the primary pairing input. Tests
+/// (and platforms without camera support) override this to false so the
+/// manual entry path becomes the primary flow.
+
+final class PairingScannerEnabledProvider
+    extends $FunctionalProvider<bool, bool, bool>
+    with $Provider<bool> {
+  /// Whether the QR scanner can be offered as the primary pairing input. Tests
+  /// (and platforms without camera support) override this to false so the
+  /// manual entry path becomes the primary flow.
+  PairingScannerEnabledProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'pairingScannerEnabledProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$pairingScannerEnabledHash();
+
+  @$internal
+  @override
+  $ProviderElement<bool> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  bool create(Ref ref) {
+    return pairingScannerEnabled(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(bool value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<bool>(value),
+    );
+  }
+}
+
+String _$pairingScannerEnabledHash() =>
+    r'2bbba5baa8d0e1ffe0f1eb5e8531be220f530cfb';
+
+@ProviderFor(PairingController)
+final pairingControllerProvider = PairingControllerProvider._();
+
+final class PairingControllerProvider
+    extends $NotifierProvider<PairingController, PairingFlowState> {
+  PairingControllerProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'pairingControllerProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$pairingControllerHash();
+
+  @$internal
+  @override
+  PairingController create() => PairingController();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(PairingFlowState value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<PairingFlowState>(value),
+    );
+  }
+}
+
+String _$pairingControllerHash() => r'6c5e33f27acece862e20214c995806fcd16ad25b';
+
+abstract class _$PairingController extends $Notifier<PairingFlowState> {
+  PairingFlowState build();
+  @$mustCallSuper
+  @override
+  WhenComplete runBuild() {
+    final ref = this.ref as $Ref<PairingFlowState, PairingFlowState>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<PairingFlowState, PairingFlowState>,
+              PairingFlowState,
+              Object?,
+              Object?
+            >;
+    return element.handleCreate(ref, build);
+  }
+}

--- a/mobile/lib/src/features/hosts/application/pairing_flow_state.dart
+++ b/mobile/lib/src/features/hosts/application/pairing_flow_state.dart
@@ -1,0 +1,42 @@
+import 'package:alera_mobile/src/features/hosts/domain/paired_host_profile.dart';
+import 'package:alera_mobile/src/features/hosts/domain/pairing_offer.dart';
+
+sealed class PairingFlowState {
+  const PairingFlowState();
+}
+
+class PairingScanning extends PairingFlowState {
+  const PairingScanning();
+}
+
+class PairingOfferReady extends PairingFlowState {
+  const PairingOfferReady(this.offer);
+
+  final PairingOffer offer;
+}
+
+class PairingInProgress extends PairingFlowState {
+  const PairingInProgress(this.offer);
+
+  final PairingOffer offer;
+}
+
+class PairingSuccess extends PairingFlowState {
+  const PairingSuccess(this.host);
+
+  final PairedHostProfile host;
+}
+
+class PairingFailure extends PairingFlowState {
+  const PairingFailure(this.reason, this.detail);
+
+  final PairingFailureReason reason;
+  final String detail;
+}
+
+enum PairingFailureReason {
+  invalidOffer,
+  offerExpired,
+  runtimeMismatch,
+  unreachable,
+}

--- a/mobile/lib/src/features/hosts/presentation/pair_host_screen.dart
+++ b/mobile/lib/src/features/hosts/presentation/pair_host_screen.dart
@@ -1,154 +1,230 @@
 import 'package:alera_mobile/src/app/theme/alera_tokens.dart';
-import 'package:alera_mobile/src/features/hosts/application/paired_hosts_controller.dart';
-import 'package:alera_mobile/src/features/hosts/domain/paired_host_profile.dart';
-import 'package:alera_mobile/src/features/hosts/domain/pairing_offer.dart';
-import 'package:alera_mobile/src/features/runtime/infra/mobile_runtime_client.dart';
+import 'package:alera_mobile/src/features/hosts/application/pairing_controller.dart';
+import 'package:alera_mobile/src/features/hosts/application/pairing_flow_state.dart';
+import 'package:alera_mobile/src/features/hosts/presentation/pairing/pairing_confirm_card.dart';
+import 'package:alera_mobile/src/features/hosts/presentation/pairing/pairing_manual_entry_sheet.dart';
+import 'package:alera_mobile/src/features/hosts/presentation/pairing/pairing_scanner_view.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:mobile_scanner/mobile_scanner.dart';
 
-class PairHostScreen extends ConsumerStatefulWidget {
+class PairHostScreen extends ConsumerWidget {
   const PairHostScreen({super.key});
 
+  Future<void> _enterManually(BuildContext context, WidgetRef ref) async {
+    final raw = await showPairingManualEntrySheet(context);
+    if (raw == null || raw.trim().isEmpty) {
+      return;
+    }
+    ref.read(pairingControllerProvider.notifier).offerEntered(raw);
+  }
+
   @override
-  ConsumerState<PairHostScreen> createState() => _PairHostScreenState();
+  Widget build(BuildContext context, WidgetRef ref) {
+    final state = ref.watch(pairingControllerProvider);
+    final scannerEnabled = ref.watch(pairingScannerEnabledProvider);
+    ref.listen(pairingControllerProvider, (previous, next) {
+      if (next is PairingSuccess) {
+        Future<void>.delayed(AleraTokens.pairingSuccessAutoClose, () {
+          if (context.mounted) {
+            Navigator.of(context).pop(true);
+          }
+        });
+      }
+    });
+    final notifier = ref.read(pairingControllerProvider.notifier);
+    return Scaffold(
+      appBar: AppBar(title: const Text('Pair Host')),
+      body: SafeArea(
+        child: switch (state) {
+          PairingScanning() when scannerEnabled => PairingScannerView(
+            onOffer: notifier.offerEntered,
+            onEnterManually: () => _enterManually(context, ref),
+          ),
+          PairingScanning() => _ManualFirstEntry(
+            onEnterManually: () => _enterManually(context, ref),
+          ),
+          PairingOfferReady(:final offer) => PairingConfirmCard(
+            offer: offer,
+            pairing: false,
+            onPair: (deviceName) =>
+                notifier.confirmPair(deviceName: deviceName),
+            onScanAgain: notifier.restart,
+          ),
+          PairingInProgress(:final offer) => PairingConfirmCard(
+            offer: offer,
+            pairing: true,
+            onPair: (_) {},
+            onScanAgain: notifier.restart,
+          ),
+          PairingSuccess(:final host) => _PairingSuccessView(
+            hostName: host.displayName,
+          ),
+          PairingFailure(:final reason, :final detail) => _PairingFailureView(
+            reason: reason,
+            detail: detail,
+            onRetry: notifier.restart,
+            onEnterManually: () => _enterManually(context, ref),
+          ),
+        },
+      ),
+    );
+  }
 }
 
-class _PairHostScreenState extends ConsumerState<PairHostScreen> {
-  final TextEditingController _controller = TextEditingController();
-  bool _saving = false;
-  bool _scannerOpen = false;
-  String? _error;
+class _ManualFirstEntry extends StatelessWidget {
+  const _ManualFirstEntry({required this.onEnterManually});
+
+  final VoidCallback onEnterManually;
 
   @override
-  void dispose() {
-    _controller.dispose();
-    super.dispose();
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: AleraTokens.contentPadding,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            Icon(
+              Icons.qr_code_2_outlined,
+              size: AleraTokens.emptyIcon,
+              color: Theme.of(context).colorScheme.onSurfaceVariant,
+            ),
+            const SizedBox(height: AleraTokens.spaceLg),
+            Text(
+              'Pair This Phone',
+              style: Theme.of(context).textTheme.titleLarge,
+            ),
+            const SizedBox(height: AleraTokens.spaceSm),
+            Text(
+              'Paste The Pairing Offer From The Desktop Pairing Dialog.',
+              textAlign: TextAlign.center,
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
+            const SizedBox(height: AleraTokens.spaceLg),
+            FilledButton.icon(
+              onPressed: onEnterManually,
+              icon: const Icon(Icons.keyboard_outlined),
+              label: const Text('Enter Code Manually'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _PairingSuccessView extends StatelessWidget {
+  const _PairingSuccessView({required this.hostName});
+
+  final String hostName;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: AleraTokens.contentPadding,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            const Icon(
+              Icons.check_circle_outline,
+              size: AleraTokens.successIcon,
+              color: AleraTokens.success,
+            ),
+            const SizedBox(height: AleraTokens.spaceLg),
+            Text('Paired', style: Theme.of(context).textTheme.titleLarge),
+            const SizedBox(height: AleraTokens.spaceSm),
+            Text(
+              hostName,
+              textAlign: TextAlign.center,
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _PairingFailureView extends StatelessWidget {
+  const _PairingFailureView({
+    required this.reason,
+    required this.detail,
+    required this.onRetry,
+    required this.onEnterManually,
+  });
+
+  final PairingFailureReason reason;
+  final String detail;
+  final VoidCallback onRetry;
+  final VoidCallback onEnterManually;
+
+  String get _title {
+    return switch (reason) {
+      PairingFailureReason.invalidOffer => 'Invalid Offer',
+      PairingFailureReason.offerExpired => 'Offer Expired',
+      PairingFailureReason.runtimeMismatch => 'Runtime Mismatch',
+      PairingFailureReason.unreachable => 'Could Not Reach Runtime',
+    };
   }
 
-  Future<void> _pairFromInput() async {
-    await _pair(_controller.text);
-  }
-
-  Future<void> _pair(String rawOffer) async {
-    setState(() {
-      _saving = true;
-      _error = null;
-    });
-    try {
-      final offer = PairingOffer.parse(rawOffer);
-      final credentials = await MobileRuntimeClient.pairDevice(offer);
-      final host = PairedHostProfile.fromPairingResult(offer, credentials);
-      await ref
-          .read(pairedHostsControllerProvider.notifier)
-          .savePairedHost(host, credentials.deviceToken);
-      if (mounted) {
-        Navigator.of(context).pop(true);
-      }
-    } on Object catch (error) {
-      if (mounted) {
-        setState(() {
-          _error = error.toString();
-        });
-      }
-    } finally {
-      if (mounted) {
-        setState(() {
-          _saving = false;
-        });
-      }
-    }
-  }
-
-  void _handleBarcode(BarcodeCapture capture) {
-    if (_saving) {
-      return;
-    }
-    String? value;
-    for (final barcode in capture.barcodes) {
-      final rawValue = barcode.rawValue;
-      if (rawValue != null && rawValue.trim().isNotEmpty) {
-        value = rawValue;
-        break;
-      }
-    }
-    if (value == null) {
-      return;
-    }
-    _controller.text = value;
-    setState(() {
-      _scannerOpen = false;
-    });
-    _pair(value);
+  String get _hint {
+    return switch (reason) {
+      PairingFailureReason.invalidOffer =>
+        'The Scanned Code Is Not A Valid Alera Pairing Offer.',
+      PairingFailureReason.offerExpired =>
+        'Generate A Fresh Pairing Offer On The Desktop And Try Again.',
+      PairingFailureReason.runtimeMismatch =>
+        'The Endpoint Answered For A Different Runtime Than The Offer '
+            'Promised. Check The Network And Generate A New Offer.',
+      PairingFailureReason.unreachable =>
+        'Check That The Desktop Runtime Is Running And Reachable From This '
+            'Phone, Then Try Again.',
+    };
   }
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(title: const Text('Pair Host')),
-      body: SafeArea(
-        child: ListView(
-          padding: AleraTokens.pagePadding,
-          children: <Widget>[
-            TextField(
-              controller: _controller,
-              minLines: AleraTokens.pairingInputMinLines,
-              maxLines: AleraTokens.pairingInputMaxLines,
-              decoration: const InputDecoration(
-                labelText: 'Pairing Offer JSON',
-                alignLabelWithHint: true,
-              ),
-            ),
-            const SizedBox(height: AleraTokens.spaceMd),
-            Row(
-              children: <Widget>[
-                Expanded(
-                  child: FilledButton.icon(
-                    onPressed: _saving ? null : _pairFromInput,
-                    icon: _saving
-                        ? const SizedBox.square(
-                            dimension: AleraTokens.spaceLg,
-                            child: CircularProgressIndicator(
-                              strokeWidth: AleraTokens.strokeSm,
-                            ),
-                          )
-                        : const Icon(Icons.link),
-                    label: const Text('Pair'),
-                  ),
-                ),
-                const SizedBox(width: AleraTokens.spaceMd),
-                IconButton.filledTonal(
-                  tooltip: 'Scan QR',
-                  onPressed: _saving
-                      ? null
-                      : () {
-                          setState(() {
-                            _scannerOpen = !_scannerOpen;
-                          });
-                        },
-                  icon: const Icon(Icons.qr_code_scanner),
-                ),
-              ],
-            ),
-            if (_error != null) ...<Widget>[
-              const SizedBox(height: AleraTokens.spaceMd),
-              Text(
-                _error!,
-                style: TextStyle(color: Theme.of(context).colorScheme.error),
-              ),
-            ],
-            if (_scannerOpen) ...<Widget>[
-              const SizedBox(height: AleraTokens.spaceLg),
-              ClipRRect(
-                borderRadius: BorderRadius.circular(AleraTokens.radiusSm),
-                child: AspectRatio(
-                  aspectRatio: AleraTokens.squareAspectRatio,
-                  child: MobileScanner(onDetect: _handleBarcode),
-                ),
-              ),
-            ],
-          ],
-        ),
+    return Center(
+      child: ListView(
+        shrinkWrap: true,
+        padding: AleraTokens.pagePadding,
+        children: <Widget>[
+          Icon(
+            Icons.error_outline,
+            size: AleraTokens.emptyIcon,
+            color: Theme.of(context).colorScheme.error,
+          ),
+          const SizedBox(height: AleraTokens.spaceLg),
+          Text(
+            _title,
+            textAlign: TextAlign.center,
+            style: Theme.of(context).textTheme.titleLarge,
+          ),
+          const SizedBox(height: AleraTokens.spaceSm),
+          Text(
+            _hint,
+            textAlign: TextAlign.center,
+            style: Theme.of(context).textTheme.bodyMedium,
+          ),
+          const SizedBox(height: AleraTokens.spaceSm),
+          Text(
+            detail,
+            textAlign: TextAlign.center,
+            style: Theme.of(context).textTheme.bodySmall,
+          ),
+          const SizedBox(height: AleraTokens.spaceLg),
+          FilledButton.icon(
+            onPressed: onRetry,
+            icon: const Icon(Icons.qr_code_scanner),
+            label: const Text('Try Again'),
+          ),
+          const SizedBox(height: AleraTokens.spaceSm),
+          TextButton(
+            onPressed: onEnterManually,
+            child: const Text('Enter Code Manually'),
+          ),
+        ],
       ),
     );
   }

--- a/mobile/lib/src/features/hosts/presentation/pairing/pairing_confirm_card.dart
+++ b/mobile/lib/src/features/hosts/presentation/pairing/pairing_confirm_card.dart
@@ -1,0 +1,170 @@
+import 'dart:async';
+
+import 'package:alera_mobile/src/app/theme/alera_tokens.dart';
+import 'package:alera_mobile/src/features/hosts/domain/pairing_offer.dart';
+import 'package:flutter/material.dart';
+
+/// Confirmation step shown once an offer parses: host identity, endpoint,
+/// a live expiry countdown, and an optional device name before pairing.
+class PairingConfirmCard extends StatefulWidget {
+  const PairingConfirmCard({
+    super.key,
+    required this.offer,
+    required this.pairing,
+    required this.onPair,
+    required this.onScanAgain,
+  });
+
+  final PairingOffer offer;
+  final bool pairing;
+  final ValueChanged<String?> onPair;
+  final VoidCallback onScanAgain;
+
+  @override
+  State<PairingConfirmCard> createState() => _PairingConfirmCardState();
+}
+
+class _PairingConfirmCardState extends State<PairingConfirmCard> {
+  final TextEditingController _deviceName = TextEditingController();
+  Timer? _ticker;
+
+  @override
+  void initState() {
+    super.initState();
+    _ticker = Timer.periodic(AleraTokens.expiryTickInterval, (_) {
+      setState(() {});
+    });
+  }
+
+  @override
+  void dispose() {
+    _ticker?.cancel();
+    _deviceName.dispose();
+    super.dispose();
+  }
+
+  String get _expiryLabel {
+    final remaining = widget.offer.expiresAt.toUtc().difference(
+      DateTime.now().toUtc(),
+    );
+    if (remaining.isNegative) {
+      return 'Offer Expired';
+    }
+    final minutes = remaining.inMinutes;
+    final seconds = remaining.inSeconds.remainder(60);
+    return 'Expires In $minutes:${seconds.toString().padLeft(2, '0')}';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final expired = widget.offer.isExpired;
+    final endpoint = Uri.parse(widget.offer.endpoint);
+    return ListView(
+      padding: AleraTokens.pagePadding,
+      children: <Widget>[
+        Card(
+          child: Padding(
+            padding: AleraTokens.contentPadding,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Row(
+                  children: <Widget>[
+                    Container(
+                      width: AleraTokens.iconLg,
+                      height: AleraTokens.iconLg,
+                      decoration: BoxDecoration(
+                        color: Theme.of(context).colorScheme.primary.withValues(
+                          alpha: AleraTokens.emphasisOverlayAlpha,
+                        ),
+                        borderRadius: BorderRadius.circular(
+                          AleraTokens.radiusSm,
+                        ),
+                      ),
+                      child: Icon(
+                        Icons.computer,
+                        color: Theme.of(context).colorScheme.primary,
+                      ),
+                    ),
+                    const SizedBox(width: AleraTokens.spaceMd),
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: <Widget>[
+                          Text(
+                            widget.offer.hostName,
+                            style: Theme.of(context).textTheme.titleMedium,
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                          const SizedBox(height: AleraTokens.spaceXs),
+                          Text(
+                            '${endpoint.host}:${endpoint.port}',
+                            style: Theme.of(context).textTheme.bodySmall,
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: AleraTokens.spaceLg),
+                Row(
+                  children: <Widget>[
+                    Icon(
+                      Icons.timer_outlined,
+                      size: AleraTokens.spaceLg,
+                      color: expired
+                          ? Theme.of(context).colorScheme.error
+                          : Theme.of(context).colorScheme.onSurfaceVariant,
+                    ),
+                    const SizedBox(width: AleraTokens.spaceSm),
+                    Text(
+                      _expiryLabel,
+                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        color: expired
+                            ? Theme.of(context).colorScheme.error
+                            : null,
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ),
+        const SizedBox(height: AleraTokens.spaceLg),
+        TextField(
+          controller: _deviceName,
+          enabled: !widget.pairing,
+          decoration: const InputDecoration(
+            labelText: 'Device Name (Optional)',
+            helperText: 'How This Phone Appears On The Desktop',
+          ),
+        ),
+        const SizedBox(height: AleraTokens.spaceLg),
+        FilledButton.icon(
+          onPressed: widget.pairing || expired
+              ? null
+              : () {
+                  final name = _deviceName.text.trim();
+                  widget.onPair(name.isEmpty ? null : name);
+                },
+          icon: widget.pairing
+              ? const SizedBox.square(
+                  dimension: AleraTokens.spaceLg,
+                  child: CircularProgressIndicator(
+                    strokeWidth: AleraTokens.strokeSm,
+                  ),
+                )
+              : const Icon(Icons.link),
+          label: Text(widget.pairing ? 'Pairing' : 'Pair'),
+        ),
+        const SizedBox(height: AleraTokens.spaceSm),
+        TextButton(
+          onPressed: widget.pairing ? null : widget.onScanAgain,
+          child: const Text('Scan Again'),
+        ),
+      ],
+    );
+  }
+}

--- a/mobile/lib/src/features/hosts/presentation/pairing/pairing_manual_entry_sheet.dart
+++ b/mobile/lib/src/features/hosts/presentation/pairing/pairing_manual_entry_sheet.dart
@@ -1,0 +1,91 @@
+import 'package:alera_mobile/src/app/theme/alera_tokens.dart';
+import 'package:flutter/material.dart';
+
+/// Bottom sheet for pasting a pairing offer JSON by hand. Returns the entered
+/// text through [Navigator.pop]; validation happens in the pairing controller
+/// so scanner and manual input share one code path.
+Future<String?> showPairingManualEntrySheet(BuildContext context) {
+  return showModalBottomSheet<String>(
+    context: context,
+    isScrollControlled: true,
+    builder: (context) => const _PairingManualEntrySheet(),
+  );
+}
+
+class _PairingManualEntrySheet extends StatefulWidget {
+  const _PairingManualEntrySheet();
+
+  @override
+  State<_PairingManualEntrySheet> createState() =>
+      _PairingManualEntrySheetState();
+}
+
+class _PairingManualEntrySheetState extends State<_PairingManualEntrySheet> {
+  final TextEditingController _controller = TextEditingController();
+  bool _hasInput = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller.addListener(() {
+      final hasInput = _controller.text.trim().isNotEmpty;
+      if (hasInput != _hasInput) {
+        setState(() {
+          _hasInput = hasInput;
+        });
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: EdgeInsets.only(
+        left: AleraTokens.spaceLg,
+        right: AleraTokens.spaceLg,
+        top: AleraTokens.spaceLg,
+        bottom: MediaQuery.viewInsetsOf(context).bottom + AleraTokens.spaceLg,
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: <Widget>[
+          Text(
+            'Paste Pairing Offer',
+            style: Theme.of(context).textTheme.titleLarge,
+          ),
+          const SizedBox(height: AleraTokens.spaceSm),
+          Text(
+            'Copy The Offer JSON From The Desktop Pairing Dialog.',
+            style: Theme.of(context).textTheme.bodySmall,
+          ),
+          const SizedBox(height: AleraTokens.spaceLg),
+          TextField(
+            controller: _controller,
+            autofocus: true,
+            minLines: AleraTokens.pairingInputMinLines,
+            maxLines: AleraTokens.pairingInputMaxLines,
+            decoration: const InputDecoration(
+              labelText: 'Pairing Offer JSON',
+              alignLabelWithHint: true,
+            ),
+          ),
+          const SizedBox(height: AleraTokens.spaceLg),
+          FilledButton.icon(
+            onPressed: _hasInput
+                ? () => Navigator.of(context).pop(_controller.text)
+                : null,
+            icon: const Icon(Icons.link),
+            label: const Text('Use This Offer'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/mobile/lib/src/features/hosts/presentation/pairing/pairing_scanner_view.dart
+++ b/mobile/lib/src/features/hosts/presentation/pairing/pairing_scanner_view.dart
@@ -1,0 +1,170 @@
+import 'package:alera_mobile/src/app/theme/alera_tokens.dart';
+import 'package:flutter/material.dart';
+import 'package:mobile_scanner/mobile_scanner.dart';
+
+/// Full-bleed QR scanner with a centered viewfinder frame, torch toggle, and
+/// a manual entry escape hatch. Falls back to [onScannerUnavailable] copy when
+/// the camera cannot start (permission denied, no camera, simulator).
+class PairingScannerView extends StatefulWidget {
+  const PairingScannerView({
+    super.key,
+    required this.onOffer,
+    required this.onEnterManually,
+  });
+
+  final ValueChanged<String> onOffer;
+  final VoidCallback onEnterManually;
+
+  @override
+  State<PairingScannerView> createState() => _PairingScannerViewState();
+}
+
+class _PairingScannerViewState extends State<PairingScannerView> {
+  final MobileScannerController _controller = MobileScannerController(
+    torchEnabled: false,
+  );
+  bool _handled = false;
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void _handleBarcode(BarcodeCapture capture) {
+    if (_handled) {
+      return;
+    }
+    for (final barcode in capture.barcodes) {
+      final rawValue = barcode.rawValue;
+      if (rawValue != null && rawValue.trim().isNotEmpty) {
+        _handled = true;
+        widget.onOffer(rawValue);
+        return;
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      fit: StackFit.expand,
+      children: <Widget>[
+        MobileScanner(
+          controller: _controller,
+          onDetect: _handleBarcode,
+          errorBuilder: (context, error) =>
+              _ScannerUnavailable(onEnterManually: widget.onEnterManually),
+        ),
+        IgnorePointer(
+          child: Center(
+            child: Container(
+              width: AleraTokens.pairingViewfinderSize,
+              height: AleraTokens.pairingViewfinderSize,
+              decoration: BoxDecoration(
+                border: Border.all(
+                  color: AleraTokens.foreground,
+                  width: AleraTokens.strokeSm,
+                ),
+                borderRadius: BorderRadius.circular(AleraTokens.radiusMd),
+              ),
+            ),
+          ),
+        ),
+        Align(
+          alignment: Alignment.topCenter,
+          child: SafeArea(
+            child: Padding(
+              padding: const EdgeInsets.only(top: AleraTokens.spaceXl),
+              child: Container(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: AleraTokens.spaceLg,
+                  vertical: AleraTokens.spaceSm,
+                ),
+                decoration: BoxDecoration(
+                  color: AleraTokens.background.withValues(
+                    alpha: AleraTokens.scrimAlpha,
+                  ),
+                  borderRadius: BorderRadius.circular(AleraTokens.radiusSm),
+                ),
+                child: Text(
+                  'Point The Camera At The Pairing QR',
+                  style: Theme.of(context).textTheme.bodyMedium,
+                ),
+              ),
+            ),
+          ),
+        ),
+        Align(
+          alignment: Alignment.bottomCenter,
+          child: SafeArea(
+            child: Padding(
+              padding: const EdgeInsets.only(bottom: AleraTokens.spaceXl),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: <Widget>[
+                  IconButton.filledTonal(
+                    tooltip: 'Toggle Torch',
+                    onPressed: _controller.toggleTorch,
+                    icon: const Icon(Icons.flashlight_on_outlined),
+                  ),
+                  const SizedBox(height: AleraTokens.spaceMd),
+                  FilledButton.tonalIcon(
+                    onPressed: widget.onEnterManually,
+                    icon: const Icon(Icons.keyboard_outlined),
+                    label: const Text('Enter Code Manually'),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _ScannerUnavailable extends StatelessWidget {
+  const _ScannerUnavailable({required this.onEnterManually});
+
+  final VoidCallback onEnterManually;
+
+  @override
+  Widget build(BuildContext context) {
+    return ColoredBox(
+      color: AleraTokens.background,
+      child: Center(
+        child: Padding(
+          padding: AleraTokens.contentPadding,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: <Widget>[
+              Icon(
+                Icons.no_photography_outlined,
+                size: AleraTokens.emptyIcon,
+                color: Theme.of(context).colorScheme.onSurfaceVariant,
+              ),
+              const SizedBox(height: AleraTokens.spaceLg),
+              Text(
+                'Camera Unavailable',
+                style: Theme.of(context).textTheme.titleLarge,
+              ),
+              const SizedBox(height: AleraTokens.spaceSm),
+              Text(
+                'Allow Camera Access Or Paste The Pairing Offer Instead.',
+                textAlign: TextAlign.center,
+                style: Theme.of(context).textTheme.bodyMedium,
+              ),
+              const SizedBox(height: AleraTokens.spaceLg),
+              FilledButton.icon(
+                onPressed: onEnterManually,
+                icon: const Icon(Icons.keyboard_outlined),
+                label: const Text('Enter Code Manually'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/test/pair_host_screen_test.dart
+++ b/mobile/test/pair_host_screen_test.dart
@@ -1,0 +1,114 @@
+import 'dart:convert';
+
+import 'package:alera_mobile/src/core/mobile_protocol.dart';
+import 'package:alera_mobile/src/features/hosts/application/host_providers.dart';
+import 'package:alera_mobile/src/features/hosts/application/pairing_controller.dart';
+import 'package:alera_mobile/src/features/hosts/domain/paired_device_credentials.dart';
+import 'package:alera_mobile/src/features/hosts/presentation/pair_host_screen.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'support/memory_host_repository.dart';
+
+void main() {
+  testWidgets('Pairs a host through the manual entry path', (tester) async {
+    final repository = MemoryHostRepository();
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          hostRepositoryProvider.overrideWithValue(repository),
+          pairingScannerEnabledProvider.overrideWithValue(false),
+          pairDeviceFunctionProvider.overrideWithValue(
+            (offer, {deviceName}) async => const PairedDeviceCredentials(
+              deviceId: 'device-1',
+              displayName: 'My Phone',
+              runtimeId: 'runtime-1',
+              deviceToken: 'token-1',
+            ),
+          ),
+        ],
+        child: MaterialApp(
+          home: Builder(
+            builder: (context) => Scaffold(
+              body: Center(
+                child: TextButton(
+                  onPressed: () {
+                    Navigator.of(context).push(
+                      MaterialPageRoute<bool>(
+                        builder: (_) => const PairHostScreen(),
+                      ),
+                    );
+                  },
+                  child: const Text('Open Pairing'),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('Open Pairing'));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Enter Code Manually'));
+    await tester.pumpAndSettle();
+
+    await tester.enterText(
+      find.byType(TextField),
+      jsonEncode(<String, Object?>{
+        'v': aleraMobileProtocolVersion,
+        'pairingId': 'pairing-1',
+        'endpoint': 'ws://127.0.0.1:6768',
+        'runtimeId': 'runtime-1',
+        'hostName': 'Alera Workstation',
+        'pairingSecret': 'secret-1',
+        'expiresAt': DateTime.now()
+            .toUtc()
+            .add(const Duration(minutes: 5))
+            .toIso8601String(),
+      }),
+    );
+    await tester.pump();
+    await tester.tap(find.text('Use This Offer'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Alera Workstation'), findsOneWidget);
+    expect(find.text('127.0.0.1:6768'), findsOneWidget);
+
+    await tester.tap(find.text('Pair'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Paired'), findsOneWidget);
+    final hosts = await repository.loadHosts();
+    expect(hosts.single.displayName, 'Alera Workstation');
+    expect(await repository.readDeviceToken('runtime-1'), 'token-1');
+
+    await tester.pumpAndSettle(const Duration(seconds: 2));
+    expect(find.text('Open Pairing'), findsOneWidget);
+  });
+
+  testWidgets('Shows a friendly failure for invalid offers', (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          hostRepositoryProvider.overrideWithValue(MemoryHostRepository()),
+          pairingScannerEnabledProvider.overrideWithValue(false),
+        ],
+        child: const MaterialApp(home: PairHostScreen()),
+      ),
+    );
+
+    await tester.tap(find.text('Enter Code Manually'));
+    await tester.pumpAndSettle();
+    await tester.enterText(find.byType(TextField), 'garbage');
+    await tester.pump();
+    await tester.tap(find.text('Use This Offer'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Invalid Offer'), findsOneWidget);
+    expect(find.text('Try Again'), findsOneWidget);
+  });
+}

--- a/mobile/test/pairing_controller_test.dart
+++ b/mobile/test/pairing_controller_test.dart
@@ -1,0 +1,166 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:alera_mobile/src/core/mobile_protocol.dart';
+import 'package:alera_mobile/src/features/hosts/application/host_providers.dart';
+import 'package:alera_mobile/src/features/hosts/application/pairing_controller.dart';
+import 'package:alera_mobile/src/features/hosts/application/pairing_flow_state.dart';
+import 'package:alera_mobile/src/features/hosts/domain/paired_device_credentials.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'support/memory_host_repository.dart';
+
+void main() {
+  test('Pairs and stores the host on the happy path', () async {
+    final repository = MemoryHostRepository();
+    final container = _container(
+      repository,
+      (offer, {deviceName}) async => const PairedDeviceCredentials(
+        deviceId: 'device-1',
+        displayName: 'My Phone',
+        runtimeId: 'runtime-1',
+        deviceToken: 'token-1',
+      ),
+    );
+
+    final notifier = container.read(pairingControllerProvider.notifier);
+    notifier.offerEntered(_rawOffer());
+    expect(container.read(pairingControllerProvider), isA<PairingOfferReady>());
+
+    await notifier.confirmPair(deviceName: 'My Phone');
+    expect(container.read(pairingControllerProvider), isA<PairingSuccess>());
+    final hosts = await repository.loadHosts();
+    expect(hosts.single.runtimeId, 'runtime-1');
+    expect(await repository.readDeviceToken('runtime-1'), 'token-1');
+  });
+
+  test('Reports expired offers distinctly', () {
+    final container = _container(MemoryHostRepository(), _unusedPair);
+
+    container
+        .read(pairingControllerProvider.notifier)
+        .offerEntered(
+          _rawOffer(
+            expiresAt: DateTime.now().toUtc().subtract(
+              const Duration(minutes: 1),
+            ),
+          ),
+        );
+
+    final state = container.read(pairingControllerProvider);
+    expect(
+      state,
+      isA<PairingFailure>().having(
+        (failure) => failure.reason,
+        'reason',
+        PairingFailureReason.offerExpired,
+      ),
+    );
+  });
+
+  test('Reports malformed offers as invalid', () {
+    final container = _container(MemoryHostRepository(), _unusedPair);
+
+    container
+        .read(pairingControllerProvider.notifier)
+        .offerEntered('not json at all');
+
+    final state = container.read(pairingControllerProvider);
+    expect(
+      state,
+      isA<PairingFailure>().having(
+        (failure) => failure.reason,
+        'reason',
+        PairingFailureReason.invalidOffer,
+      ),
+    );
+  });
+
+  test('Reports a runtime mismatch from the pair response', () async {
+    final repository = MemoryHostRepository();
+    final container = _container(
+      repository,
+      (offer, {deviceName}) async => const PairedDeviceCredentials(
+        deviceId: 'device-1',
+        displayName: 'My Phone',
+        runtimeId: 'runtime-other',
+        deviceToken: 'token-1',
+      ),
+    );
+
+    final notifier = container.read(pairingControllerProvider.notifier);
+    notifier.offerEntered(_rawOffer());
+    await notifier.confirmPair();
+
+    final state = container.read(pairingControllerProvider);
+    expect(
+      state,
+      isA<PairingFailure>().having(
+        (failure) => failure.reason,
+        'reason',
+        PairingFailureReason.runtimeMismatch,
+      ),
+    );
+    expect(await repository.loadHosts(), isEmpty);
+  });
+
+  test('Reports network failures as unreachable', () async {
+    final container = _container(
+      MemoryHostRepository(),
+      (offer, {deviceName}) async =>
+          throw const SocketException('Connection Refused'),
+    );
+
+    final notifier = container.read(pairingControllerProvider.notifier);
+    notifier.offerEntered(_rawOffer());
+    await notifier.confirmPair();
+
+    final state = container.read(pairingControllerProvider);
+    expect(
+      state,
+      isA<PairingFailure>().having(
+        (failure) => failure.reason,
+        'reason',
+        PairingFailureReason.unreachable,
+      ),
+    );
+  });
+}
+
+Future<PairedDeviceCredentials> _unusedPair(
+  Object offer, {
+  String? deviceName,
+}) {
+  throw StateError('Pairing Should Not Be Reached');
+}
+
+ProviderContainer _container(
+  MemoryHostRepository repository,
+  PairDeviceFunction pair,
+) {
+  final container = ProviderContainer(
+    overrides: [
+      hostRepositoryProvider.overrideWithValue(repository),
+      pairDeviceFunctionProvider.overrideWithValue(pair),
+    ],
+  );
+  addTearDown(container.dispose);
+  final subscription = container.listen(pairingControllerProvider, (_, _) {});
+  addTearDown(subscription.close);
+  return container;
+}
+
+String _rawOffer({DateTime? expiresAt}) {
+  return jsonEncode(<String, Object?>{
+    'v': aleraMobileProtocolVersion,
+    'pairingId': 'pairing-1',
+    'endpoint': 'ws://127.0.0.1:6768',
+    'runtimeId': 'runtime-1',
+    'hostName': 'Alera Host',
+    'pairingSecret': 'secret-1',
+    'expiresAt':
+        (expiresAt ?? DateTime.now().toUtc().add(const Duration(minutes: 5)))
+            .toIso8601String(),
+  });
+}


### PR DESCRIPTION
QR-first pairing: full-screen scanner with torch and manual-entry fallback, a confirmation step (host identity, endpoint, live expiry countdown, optional device name), success state, and titled failure states with retry. State machine in a Riverpod controller with an injectable pair function.

Validation: controller unit tests (happy path, expired, mismatch, network error) and widget tests of the manual path; `flutter analyze`/`flutter test` in `mobile/`.