### PR TITLE
feat: add editable host alias on mobile

### DIFF
--- a/mobile/lib/src/design_system/forms/alera_rename_dialog.dart
+++ b/mobile/lib/src/design_system/forms/alera_rename_dialog.dart
@@ -1,0 +1,79 @@
+import 'package:alera_mobile/src/app/theme/alera_tokens.dart';
+import 'package:flutter/material.dart';
+
+/// Prompts for a new name and pops with the trimmed value. When [allowEmpty]
+/// is true an empty submission pops with an empty string so callers can treat
+/// it as "clear the override"; otherwise empty input keeps the dialog open.
+class AleraRenameDialog extends StatefulWidget {
+  const AleraRenameDialog({
+    super.key,
+    required this.title,
+    required this.labelText,
+    this.initialValue = '',
+    this.helperText,
+    this.allowEmpty = false,
+  });
+
+  final String title;
+  final String labelText;
+  final String initialValue;
+  final String? helperText;
+  final bool allowEmpty;
+
+  @override
+  State<AleraRenameDialog> createState() => _AleraRenameDialogState();
+}
+
+class _AleraRenameDialogState extends State<AleraRenameDialog> {
+  late final TextEditingController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = TextEditingController(text: widget.initialValue);
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void _submit() {
+    final name = _controller.text.trim();
+    if (name.isEmpty && !widget.allowEmpty) {
+      return;
+    }
+    Navigator.of(context).pop(name);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: Text(widget.title),
+      content: TextField(
+        controller: _controller,
+        autofocus: true,
+        onSubmitted: (_) => _submit(),
+        decoration: InputDecoration(
+          labelText: widget.labelText,
+          helperText: widget.helperText,
+          helperMaxLines: 2,
+        ),
+      ),
+      actions: <Widget>[
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(onPressed: _submit, child: const Text('Rename')),
+      ],
+      actionsPadding: const EdgeInsets.fromLTRB(
+        AleraTokens.spaceLg,
+        0,
+        AleraTokens.spaceLg,
+        AleraTokens.spaceLg,
+      ),
+    );
+  }
+}

--- a/mobile/lib/src/design_system/forms/alera_rename_dialog.preview.dart
+++ b/mobile/lib/src/design_system/forms/alera_rename_dialog.preview.dart
@@ -1,0 +1,12 @@
+import 'package:alera_mobile/src/design_system/alera_preview.dart';
+import 'package:alera_mobile/src/design_system/forms/alera_rename_dialog.dart';
+import 'package:flutter/material.dart';
+
+@AleraPreview(name: 'Rename Host', group: 'Rename Dialog')
+Widget aleraRenameDialogPreview() => const AleraRenameDialog(
+  title: 'Rename Host',
+  labelText: 'Host Name',
+  initialValue: 'Alera Workstation',
+  helperText: 'Leave Empty To Use The Advertised Host Name',
+  allowEmpty: true,
+);

--- a/mobile/lib/src/features/hosts/application/host_repository.dart
+++ b/mobile/lib/src/features/hosts/application/host_repository.dart
@@ -5,4 +5,9 @@ abstract interface class HostRepository {
   Future<void> savePairedHost(PairedHostProfile host, String deviceToken);
   Future<void> removeHost(String hostId);
   Future<String?> readDeviceToken(String hostId);
+
+  /// Stores a local display alias for a paired host. A null [alias] clears
+  /// the override so the advertised host name shows again. The device token
+  /// is untouched.
+  Future<void> updateHostAlias(String hostId, String? alias);
 }

--- a/mobile/lib/src/features/hosts/application/paired_hosts_controller.dart
+++ b/mobile/lib/src/features/hosts/application/paired_hosts_controller.dart
@@ -25,4 +25,16 @@ class PairedHostsController extends _$PairedHostsController {
     ref.invalidateSelf();
     await future;
   }
+
+  Future<void> updateHostAlias(String hostId, String? alias) async {
+    final normalized = alias?.trim();
+    await ref
+        .read(hostRepositoryProvider)
+        .updateHostAlias(
+          hostId,
+          normalized == null || normalized.isEmpty ? null : normalized,
+        );
+    ref.invalidateSelf();
+    await future;
+  }
 }

--- a/mobile/lib/src/features/hosts/application/paired_hosts_controller.g.dart
+++ b/mobile/lib/src/features/hosts/application/paired_hosts_controller.g.dart
@@ -35,7 +35,7 @@ final class PairedHostsControllerProvider
 }
 
 String _$pairedHostsControllerHash() =>
-    r'fbdf24cf91a1be0c96dc33add8e17d6ae2c65aed';
+    r'8f4ba28ebd7c4f16bcd75aefbd02669f582e9e8b';
 
 abstract class _$PairedHostsController
     extends $AsyncNotifier<List<PairedHostProfile>> {

--- a/mobile/lib/src/features/hosts/domain/paired_host_profile.dart
+++ b/mobile/lib/src/features/hosts/domain/paired_host_profile.dart
@@ -12,6 +12,7 @@ class PairedHostProfile {
     required this.deviceId,
     required this.pairedAt,
     this.serverPublicKeyB64,
+    this.alias,
   });
 
   final String id;
@@ -21,6 +22,25 @@ class PairedHostProfile {
   final String deviceId;
   final String? serverPublicKeyB64;
   final DateTime pairedAt;
+
+  /// Local, user-chosen name for this host. Never sent to the runtime; the
+  /// desktop keeps advertising its own host name.
+  final String? alias;
+
+  String get effectiveName => alias ?? displayName;
+
+  PairedHostProfile withAlias(String? alias) {
+    return PairedHostProfile(
+      id: id,
+      displayName: displayName,
+      endpoint: endpoint,
+      runtimeId: runtimeId,
+      deviceId: deviceId,
+      pairedAt: pairedAt,
+      serverPublicKeyB64: serverPublicKeyB64,
+      alias: alias,
+    );
+  }
 
   factory PairedHostProfile.fromPairingResult(
     PairingOffer offer,
@@ -56,6 +76,7 @@ class PairedHostProfile {
       deviceId: json.requiredString('deviceId'),
       serverPublicKeyB64: json.optionalString('serverPublicKeyB64'),
       pairedAt: DateTime.parse(json.requiredString('pairedAt')),
+      alias: json.optionalString('alias'),
     );
   }
 
@@ -68,6 +89,7 @@ class PairedHostProfile {
       'deviceId': deviceId,
       'serverPublicKeyB64': serverPublicKeyB64,
       'pairedAt': pairedAt.toUtc().toIso8601String(),
+      if (alias != null) 'alias': alias,
     };
   }
 }

--- a/mobile/lib/src/features/hosts/infra/local_host_repository.dart
+++ b/mobile/lib/src/features/hosts/infra/local_host_repository.dart
@@ -75,6 +75,15 @@ class LocalHostRepository implements HostRepository {
     return _secureStorage.read(key: '$_deviceTokenPrefix$hostId');
   }
 
+  @override
+  Future<void> updateHostAlias(String hostId, String? alias) async {
+    final hosts = await loadHosts();
+    await _writeHosts(<PairedHostProfile>[
+      for (final host in hosts)
+        if (host.id == hostId) host.withAlias(alias) else host,
+    ]);
+  }
+
   Future<void> _writeHosts(List<PairedHostProfile> hosts) {
     return _preferences.setString(
       _hostsKey,

--- a/mobile/lib/src/features/hosts/presentation/host_list_screen.dart
+++ b/mobile/lib/src/features/hosts/presentation/host_list_screen.dart
@@ -1,10 +1,34 @@
 import 'package:alera_mobile/src/app/theme/alera_tokens.dart';
+import 'package:alera_mobile/src/design_system/forms/alera_rename_dialog.dart';
 import 'package:alera_mobile/src/features/hosts/application/paired_hosts_controller.dart';
 import 'package:alera_mobile/src/features/hosts/domain/paired_host_profile.dart';
 import 'package:alera_mobile/src/features/hosts/presentation/pair_host_screen.dart';
 import 'package:alera_mobile/src/features/runtime/presentation/host_dashboard_screen.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+Future<void> showRenameHostDialog(
+  BuildContext context,
+  WidgetRef ref,
+  PairedHostProfile host,
+) async {
+  final name = await showDialog<String>(
+    context: context,
+    builder: (_) => AleraRenameDialog(
+      title: 'Rename Host',
+      labelText: 'Host Name',
+      initialValue: host.alias ?? host.displayName,
+      helperText: 'Leave Empty To Use The Advertised Host Name',
+      allowEmpty: true,
+    ),
+  );
+  if (name == null) {
+    return;
+  }
+  await ref
+      .read(pairedHostsControllerProvider.notifier)
+      .updateHostAlias(host.id, name);
+}
 
 class HostListScreen extends ConsumerWidget {
   const HostListScreen({super.key});
@@ -43,6 +67,44 @@ class HostListScreen extends ConsumerWidget {
     await ref.read(pairedHostsControllerProvider.notifier).removeHost(host.id);
   }
 
+  Future<void> _showHostActions(
+    BuildContext context,
+    WidgetRef ref,
+    PairedHostProfile host,
+  ) async {
+    final action = await showModalBottomSheet<_HostAction>(
+      context: context,
+      builder: (context) => SafeArea(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            ListTile(
+              leading: const Icon(Icons.drive_file_rename_outline),
+              title: const Text('Rename Host'),
+              onTap: () => Navigator.of(context).pop(_HostAction.rename),
+            ),
+            ListTile(
+              leading: const Icon(Icons.delete_outline),
+              title: const Text('Remove Host'),
+              onTap: () => Navigator.of(context).pop(_HostAction.remove),
+            ),
+          ],
+        ),
+      ),
+    );
+    if (!context.mounted) {
+      return;
+    }
+    switch (action) {
+      case _HostAction.rename:
+        await showRenameHostDialog(context, ref, host);
+      case _HostAction.remove:
+        await _removeHost(context, ref, host);
+      case null:
+        break;
+    }
+  }
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final hosts = ref.watch(pairedHostsControllerProvider);
@@ -76,6 +138,7 @@ class HostListScreen extends ConsumerWidget {
                   );
                 },
                 onRemove: () => _removeHost(context, ref, host),
+                onLongPress: () => _showHostActions(context, ref, host),
               );
             },
             separatorBuilder: (_, _) =>
@@ -131,16 +194,20 @@ class _EmptyHosts extends StatelessWidget {
   }
 }
 
+enum _HostAction { rename, remove }
+
 class _HostCard extends StatelessWidget {
   const _HostCard({
     required this.host,
     required this.onOpen,
     required this.onRemove,
+    required this.onLongPress,
   });
 
   final PairedHostProfile host;
   final VoidCallback onOpen;
   final VoidCallback onRemove;
+  final VoidCallback onLongPress;
 
   @override
   Widget build(BuildContext context) {
@@ -148,6 +215,7 @@ class _HostCard extends StatelessWidget {
       child: InkWell(
         borderRadius: BorderRadius.circular(AleraTokens.radiusSm),
         onTap: onOpen,
+        onLongPress: onLongPress,
         child: Padding(
           padding: AleraTokens.contentPadding,
           child: Row(
@@ -172,10 +240,18 @@ class _HostCard extends StatelessWidget {
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: <Widget>[
                     Text(
-                      host.displayName,
+                      host.effectiveName,
                       style: Theme.of(context).textTheme.titleMedium,
                       overflow: TextOverflow.ellipsis,
                     ),
+                    if (host.alias != null) ...<Widget>[
+                      const SizedBox(height: AleraTokens.spaceXs),
+                      Text(
+                        host.displayName,
+                        style: Theme.of(context).textTheme.bodySmall,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ],
                     const SizedBox(height: AleraTokens.spaceXs),
                     Text(
                       host.endpoint,

--- a/mobile/lib/src/features/runtime/presentation/host_dashboard_screen.dart
+++ b/mobile/lib/src/features/runtime/presentation/host_dashboard_screen.dart
@@ -1,5 +1,7 @@
 import 'package:alera_mobile/src/app/theme/alera_tokens.dart';
+import 'package:alera_mobile/src/features/hosts/application/paired_hosts_controller.dart';
 import 'package:alera_mobile/src/features/hosts/domain/paired_host_profile.dart';
+import 'package:alera_mobile/src/features/hosts/presentation/host_list_screen.dart';
 import 'package:alera_mobile/src/features/runtime/application/host_connection_controller.dart';
 import 'package:alera_mobile/src/features/runtime/application/host_dashboard_controller.dart';
 import 'package:alera_mobile/src/features/runtime/domain/mobile_runtime_status.dart';
@@ -18,8 +20,34 @@ class HostDashboardScreen extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final data = ref.watch(hostDashboardDataProvider(host.id));
     final connection = ref.watch(hostConnectionControllerProvider(host.id));
+    // Resolve the freshest profile so a rename reflects while this screen is
+    // open; the constructor argument is the fallback before the list loads.
+    final currentHost =
+        ref
+            .watch(pairedHostsControllerProvider)
+            .value
+            ?.where((profile) => profile.id == host.id)
+            .firstOrNull ??
+        host;
     return Scaffold(
-      appBar: AppBar(title: Text(host.displayName)),
+      appBar: AppBar(
+        title: Text(currentHost.effectiveName),
+        actions: <Widget>[
+          PopupMenuButton<String>(
+            onSelected: (value) {
+              if (value == 'rename') {
+                showRenameHostDialog(context, ref, currentHost);
+              }
+            },
+            itemBuilder: (context) => <PopupMenuEntry<String>>[
+              const PopupMenuItem<String>(
+                value: 'rename',
+                child: Text('Rename Host'),
+              ),
+            ],
+          ),
+        ],
+      ),
       body: SafeArea(
         child: switch (data) {
           AsyncData(value: final dashboard) => ListView(

--- a/mobile/test/host_alias_test.dart
+++ b/mobile/test/host_alias_test.dart
@@ -1,0 +1,111 @@
+import 'package:alera_mobile/src/design_system/forms/alera_rename_dialog.dart';
+import 'package:alera_mobile/src/features/hosts/application/host_providers.dart';
+import 'package:alera_mobile/src/features/hosts/application/paired_hosts_controller.dart';
+import 'package:alera_mobile/src/features/hosts/domain/paired_host_profile.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'support/memory_host_repository.dart';
+
+void main() {
+  group('PairedHostProfile alias', () {
+    test('Round-trips through json and prefers the alias for display', () {
+      final host = _profile().withAlias('Home Desk');
+      final restored = PairedHostProfile.fromJson(host.toJson());
+
+      expect(restored.alias, 'Home Desk');
+      expect(restored.effectiveName, 'Home Desk');
+      expect(restored.displayName, 'Alera Host');
+    });
+
+    test('Parses records stored before the alias existed', () {
+      final json = _profile().toJson()..remove('alias');
+      final restored = PairedHostProfile.fromJson(json);
+
+      expect(restored.alias, isNull);
+      expect(restored.effectiveName, 'Alera Host');
+    });
+  });
+
+  test(
+    'Controller updates and clears the alias without touching the token',
+    () async {
+      final repository = MemoryHostRepository();
+      await repository.savePairedHost(_profile(), 'token-1');
+      final container = ProviderContainer(
+        overrides: [hostRepositoryProvider.overrideWithValue(repository)],
+      );
+      addTearDown(container.dispose);
+      final subscription = container.listen(
+        pairedHostsControllerProvider,
+        (_, _) {},
+      );
+      addTearDown(subscription.close);
+
+      final notifier = container.read(pairedHostsControllerProvider.notifier);
+      await notifier.updateHostAlias('runtime-1', 'Home Desk');
+      var hosts = await container.read(pairedHostsControllerProvider.future);
+      expect(hosts.single.effectiveName, 'Home Desk');
+      expect(await repository.readDeviceToken('runtime-1'), 'token-1');
+
+      await notifier.updateHostAlias('runtime-1', '   ');
+      hosts = await container.read(pairedHostsControllerProvider.future);
+      expect(hosts.single.alias, isNull);
+      expect(hosts.single.effectiveName, 'Alera Host');
+    },
+  );
+
+  testWidgets('Rename dialog pops with the entered name', (tester) async {
+    String? result;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Builder(
+          builder: (context) => Scaffold(
+            body: Center(
+              child: TextButton(
+                onPressed: () async {
+                  result = await showDialog<String>(
+                    context: context,
+                    builder: (_) => const AleraRenameDialog(
+                      title: 'Rename Host',
+                      labelText: 'Host Name',
+                      initialValue: 'Alera Host',
+                      allowEmpty: true,
+                    ),
+                  );
+                },
+                child: const Text('Open'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('Open'));
+    await tester.pumpAndSettle();
+    await tester.enterText(find.byType(TextField), 'Home Desk');
+    await tester.tap(find.text('Rename'));
+    await tester.pumpAndSettle();
+    expect(result, 'Home Desk');
+
+    await tester.tap(find.text('Open'));
+    await tester.pumpAndSettle();
+    await tester.enterText(find.byType(TextField), '');
+    await tester.tap(find.text('Rename'));
+    await tester.pumpAndSettle();
+    expect(result, isEmpty);
+  });
+}
+
+PairedHostProfile _profile() {
+  return PairedHostProfile(
+    id: 'runtime-1',
+    displayName: 'Alera Host',
+    endpoint: 'ws://127.0.0.1:6768',
+    runtimeId: 'runtime-1',
+    deviceId: 'device-1',
+    pairedAt: DateTime.now().toUtc(),
+  );
+}

--- a/mobile/test/support/memory_host_repository.dart
+++ b/mobile/test/support/memory_host_repository.dart
@@ -29,4 +29,12 @@ class MemoryHostRepository implements HostRepository {
   Future<String?> readDeviceToken(String hostId) async {
     return _secrets[hostId];
   }
+
+  @override
+  Future<void> updateHostAlias(String hostId, String? alias) async {
+    final host = _hosts[hostId];
+    if (host != null) {
+      _hosts[hostId] = host.withAlias(alias);
+    }
+  }
 }


### PR DESCRIPTION
Adds a local, user-chosen alias per paired host (never sent to the runtime): rename from the host list long-press sheet or the host screen menu, shown everywhere via `effectiveName`, cleared with an empty input. Includes a reusable `AleraRenameDialog` in the mobile design system.

Validation: json round-trip and back-compat tests, controller alias update test, rename dialog widget test.