### PR TITLE
feat: mirror workspace sidebar on mobile with workspace mutations

### DIFF
--- a/mobile/README.md
+++ b/mobile/README.md
@@ -6,7 +6,8 @@ Alera is the Android/iOS companion app for remote Alera work. It is a separate F
 
 - Pair a host with a QR-first flow: scan the pairing QR from the desktop pairing dialog (torch toggle included), or paste the JSON payload from `alera mobile --json pairing create` through the manual entry sheet. A confirmation step shows the host identity, endpoint, and a live offer-expiry countdown, plus an optional device name before pairing. Failures surface as titled states (Invalid Offer, Offer Expired, Runtime Mismatch, Could Not Reach Runtime) with retry and manual-entry actions.
 - Claim the pairing offer over the mobile WebSocket gateway and store the returned device token in platform secure storage.
-- Authenticate with `mobile.hello`, show host status, projects, workspaces, and branch summaries, and start or attach to a terminal session with Flutter `xterm`.
+- Authenticate with `mobile.hello`, then land on a workspace list mirroring the desktop sidebar: a pinned section, group-by-project toggle, and the parent/child workspace tree with collapse state persisted per host. Long-press a workspace for actions: pin/unpin, configure or unlink the parent, and create or delete managed workspaces (with a cascade preview and a delete-branch toggle). Mutations are feature-detected through the `mobileWorkspaceMutations` runtime capability and hidden against older runtimes.
+- Host status, projects, and branch summaries remain available under Host Details, including the embedded terminal preview with Flutter `xterm`.
 
 ## Local Commands
 

--- a/mobile/lib/src/features/hosts/presentation/host_list_screen.dart
+++ b/mobile/lib/src/features/hosts/presentation/host_list_screen.dart
@@ -1,34 +1,11 @@
 import 'package:alera_mobile/src/app/theme/alera_tokens.dart';
-import 'package:alera_mobile/src/design_system/forms/alera_rename_dialog.dart';
 import 'package:alera_mobile/src/features/hosts/application/paired_hosts_controller.dart';
 import 'package:alera_mobile/src/features/hosts/domain/paired_host_profile.dart';
 import 'package:alera_mobile/src/features/hosts/presentation/pair_host_screen.dart';
-import 'package:alera_mobile/src/features/runtime/presentation/host_dashboard_screen.dart';
+import 'package:alera_mobile/src/features/hosts/presentation/rename_host_dialog.dart';
+import 'package:alera_mobile/src/features/workbench/presentation/runtime_workspaces_screen.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-
-Future<void> showRenameHostDialog(
-  BuildContext context,
-  WidgetRef ref,
-  PairedHostProfile host,
-) async {
-  final name = await showDialog<String>(
-    context: context,
-    builder: (_) => AleraRenameDialog(
-      title: 'Rename Host',
-      labelText: 'Host Name',
-      initialValue: host.alias ?? host.displayName,
-      helperText: 'Leave Empty To Use The Advertised Host Name',
-      allowEmpty: true,
-    ),
-  );
-  if (name == null) {
-    return;
-  }
-  await ref
-      .read(pairedHostsControllerProvider.notifier)
-      .updateHostAlias(host.id, name);
-}
 
 class HostListScreen extends ConsumerWidget {
   const HostListScreen({super.key});
@@ -133,7 +110,7 @@ class HostListScreen extends ConsumerWidget {
                 onOpen: () {
                   Navigator.of(context).push(
                     MaterialPageRoute<void>(
-                      builder: (_) => HostDashboardScreen(host: host),
+                      builder: (_) => RuntimeWorkspacesScreen(host: host),
                     ),
                   );
                 },

--- a/mobile/lib/src/features/hosts/presentation/rename_host_dialog.dart
+++ b/mobile/lib/src/features/hosts/presentation/rename_host_dialog.dart
@@ -1,0 +1,28 @@
+import 'package:alera_mobile/src/design_system/forms/alera_rename_dialog.dart';
+import 'package:alera_mobile/src/features/hosts/application/paired_hosts_controller.dart';
+import 'package:alera_mobile/src/features/hosts/domain/paired_host_profile.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+Future<void> showRenameHostDialog(
+  BuildContext context,
+  WidgetRef ref,
+  PairedHostProfile host,
+) async {
+  final name = await showDialog<String>(
+    context: context,
+    builder: (_) => AleraRenameDialog(
+      title: 'Rename Host',
+      labelText: 'Host Name',
+      initialValue: host.alias ?? host.displayName,
+      helperText: 'Leave Empty To Use The Advertised Host Name',
+      allowEmpty: true,
+    ),
+  );
+  if (name == null) {
+    return;
+  }
+  await ref
+      .read(pairedHostsControllerProvider.notifier)
+      .updateHostAlias(host.id, name);
+}

--- a/mobile/lib/src/features/runtime/domain/workspace_creation_result.dart
+++ b/mobile/lib/src/features/runtime/domain/workspace_creation_result.dart
@@ -1,0 +1,45 @@
+import 'package:alera_mobile/src/core/json_payload_fields.dart';
+import 'package:alera_mobile/src/features/runtime/domain/workspace_summary.dart';
+
+class WorkspaceSetupStep {
+  const WorkspaceSetupStep({
+    required this.kind,
+    required this.label,
+    required this.succeeded,
+    this.message,
+    this.exitCode,
+  });
+
+  final String kind;
+  final String label;
+  final bool succeeded;
+  final String? message;
+  final int? exitCode;
+
+  factory WorkspaceSetupStep.fromJson(Map<String, Object?> json) {
+    return WorkspaceSetupStep(
+      kind: json.optionalString('kind') ?? 'config',
+      label: json.requiredString('label'),
+      succeeded: json['succeeded'] == true,
+      message: json.optionalString('message'),
+      exitCode: (json['exitCode'] as num?)?.toInt(),
+    );
+  }
+}
+
+class WorkspaceCreationResult {
+  const WorkspaceCreationResult({required this.workspace, required this.steps});
+
+  final WorkspaceSummary workspace;
+  final List<WorkspaceSetupStep> steps;
+
+  factory WorkspaceCreationResult.fromJson(Map<String, Object?> json) {
+    return WorkspaceCreationResult(
+      workspace: WorkspaceSummary.fromJson(json.mapValue('workspace')),
+      steps: <WorkspaceSetupStep>[
+        for (final item in json.mapValue('setupReport').objectList('steps'))
+          if (item is Map) WorkspaceSetupStep.fromJson(asJsonMap(item)),
+      ],
+    );
+  }
+}

--- a/mobile/lib/src/features/runtime/domain/workspace_summary.dart
+++ b/mobile/lib/src/features/runtime/domain/workspace_summary.dart
@@ -1,5 +1,7 @@
 import 'package:alera_mobile/src/core/json_payload_fields.dart';
 
+/// Field casing mirrors the desktop runtime parsers in
+/// `lib/src/features/workbench/infra/runtime_workbench_repository.dart`.
 class WorkspaceSummary {
   const WorkspaceSummary({
     required this.id,
@@ -7,6 +9,13 @@ class WorkspaceSummary {
     required this.name,
     required this.path,
     this.branch,
+    this.kind = 'linked',
+    this.status = 'active',
+    this.isPinned = false,
+    this.parentWorkspaceId,
+    this.childCount = 0,
+    this.tagIds = const <String>[],
+    this.updatedAt,
   });
 
   final String id;
@@ -14,6 +23,16 @@ class WorkspaceSummary {
   final String name;
   final String path;
   final String? branch;
+  final String kind;
+  final String status;
+  final bool isPinned;
+  final String? parentWorkspaceId;
+  final int childCount;
+  final List<String> tagIds;
+  final DateTime? updatedAt;
+
+  bool get isMain => kind == 'main';
+  bool get hasParent => parentWorkspaceId != null;
 
   factory WorkspaceSummary.fromJson(Map<String, Object?> json) {
     return WorkspaceSummary(
@@ -22,6 +41,13 @@ class WorkspaceSummary {
       name: json.requiredString('name'),
       path: json.requiredString('path'),
       branch: json.optionalString('branch'),
+      kind: json.optionalString('kind') ?? 'linked',
+      status: json.optionalString('status') ?? 'active',
+      isPinned: json['isPinned'] == true,
+      parentWorkspaceId: json.optionalString('parentWorkspaceId'),
+      childCount: (json['childCount'] as num?)?.toInt() ?? 0,
+      tagIds: json.stringList('tagIds'),
+      updatedAt: json.optionalDateTime('updatedAt'),
     );
   }
 }

--- a/mobile/lib/src/features/runtime/infra/mobile_runtime_client.dart
+++ b/mobile/lib/src/features/runtime/infra/mobile_runtime_client.dart
@@ -8,11 +8,20 @@ import 'package:alera_mobile/src/features/hosts/domain/paired_device_credentials
 import 'package:alera_mobile/src/features/hosts/domain/pairing_offer.dart';
 import 'package:alera_mobile/src/features/runtime/domain/mobile_runtime_status.dart';
 import 'package:alera_mobile/src/features/runtime/domain/project_summary.dart';
+import 'package:alera_mobile/src/features/runtime/domain/workspace_creation_result.dart';
 import 'package:alera_mobile/src/features/runtime/domain/workspace_summary.dart';
 import 'package:alera_mobile/src/features/runtime/domain/workspace_tab_summary.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
 
 const Duration _defaultRequestTimeout = Duration(seconds: 20);
+// Managed workspace lifecycle mirrors the desktop client timeouts
+// (lib/src/features/workbench/infra/runtime_managed_workspace_client.dart).
+const Duration _managedWorkspaceCreateTimeout = Duration(minutes: 30);
+const Duration _managedWorkspaceRemoveTimeout = Duration(minutes: 10);
+
+/// Capability advertised by runtimes whose mobile gateway accepts workspace
+/// mutations (pin, link/unlink, create/remove managed, tab removal).
+const String mobileWorkspaceMutationsCapability = 'mobileWorkspaceMutations';
 
 class MobileRuntimeEvent {
   const MobileRuntimeEvent(this.name, this.payload);
@@ -37,7 +46,38 @@ abstract interface class MobileTerminalClient {
   Future<void> detachTerminal(String sessionId);
 }
 
-class MobileRuntimeClient implements MobileTerminalClient {
+/// Workspace listing and mutation surface consumed by the workbench
+/// controllers; kept as an interface so tests can fake the runtime.
+abstract interface class MobileWorkspaceClient {
+  Stream<MobileRuntimeEvent> get events;
+  bool get supportsWorkspaceMutations;
+  Future<List<ProjectSummary>> listProjects();
+  Future<ProjectBranches> listBranches(String projectId);
+  Future<List<WorkspaceSummary>> listWorkspaces();
+  Future<void> setWorkspacePinned(String workspaceId, bool isPinned);
+  Future<void> linkWorkspaces({
+    required String parentWorkspaceId,
+    required String childWorkspaceId,
+  });
+  Future<void> unlinkWorkspaces({
+    required String parentWorkspaceId,
+    required String childWorkspaceId,
+  });
+  Future<WorkspaceCreationResult> createManagedWorkspace({
+    required String projectId,
+    required String branch,
+    String? sourceBranch,
+    bool reuseExistingBranch = false,
+    String? name,
+    String? parentWorkspaceId,
+  });
+  Future<void> removeManagedWorkspace(String workspaceId, {bool? deleteBranch});
+  Future<List<String>> cascadePreview(String workspaceId);
+  Future<void> removeTab(String tabId);
+}
+
+class MobileRuntimeClient
+    implements MobileTerminalClient, MobileWorkspaceClient {
   MobileRuntimeClient._(
     this._channel, {
     this._requestTimeout = _defaultRequestTimeout,
@@ -104,21 +144,34 @@ class MobileRuntimeClient implements MobileTerminalClient {
   Object? _closedError;
   StackTrace? _closedStackTrace;
 
+  Set<String> _runtimeCapabilities = const <String>{};
+
+  @override
   Stream<MobileRuntimeEvent> get events => _events.stream;
   @override
   Stream<MobileTerminalOutputEvent> get terminalOutput =>
       _terminalOutput.stream;
   int get debugPendingRequestCount => _pending.length;
 
+  /// Capabilities advertised by the runtime in the `mobile.hello` response.
+  /// Empty until [authenticate] completes.
+  Set<String> get runtimeCapabilities => _runtimeCapabilities;
+
+  @override
+  bool get supportsWorkspaceMutations =>
+      _runtimeCapabilities.contains(mobileWorkspaceMutationsCapability);
+
   Future<Map<String, Object?>> authenticate({
     required String deviceId,
     required String deviceToken,
-  }) {
-    return requestMap('mobile.hello', <String, Object?>{
+  }) async {
+    final payload = await requestMap('mobile.hello', <String, Object?>{
       'protocolVersion': aleraMobileProtocolVersion,
       'deviceId': deviceId,
       'deviceToken': deviceToken,
     });
+    _runtimeCapabilities = payload.stringList('runtimeCapabilities').toSet();
+    return payload;
   }
 
   Future<MobileRuntimeStatus> mobileStatus() async {
@@ -126,6 +179,87 @@ class MobileRuntimeClient implements MobileTerminalClient {
     return MobileRuntimeStatus.fromJson(payload);
   }
 
+  @override
+  Future<void> setWorkspacePinned(String workspaceId, bool isPinned) async {
+    await request('workspace.setPinned', <String, Object?>{
+      'id': workspaceId,
+      'isPinned': isPinned,
+    });
+  }
+
+  @override
+  Future<void> linkWorkspaces({
+    required String parentWorkspaceId,
+    required String childWorkspaceId,
+  }) async {
+    await request('workspaceRelation.link', <String, Object?>{
+      'parentWorkspaceId': parentWorkspaceId,
+      'childWorkspaceId': childWorkspaceId,
+    });
+  }
+
+  @override
+  Future<void> unlinkWorkspaces({
+    required String parentWorkspaceId,
+    required String childWorkspaceId,
+  }) async {
+    await request('workspaceRelation.unlink', <String, Object?>{
+      'parentWorkspaceId': parentWorkspaceId,
+      'childWorkspaceId': childWorkspaceId,
+    });
+  }
+
+  @override
+  Future<WorkspaceCreationResult> createManagedWorkspace({
+    required String projectId,
+    required String branch,
+    String? sourceBranch,
+    bool reuseExistingBranch = false,
+    String? name,
+    String? parentWorkspaceId,
+  }) async {
+    final payload =
+        await requestMap('workspace.createManaged', <String, Object?>{
+          'projectId': projectId,
+          'branch': branch,
+          'reuseExistingBranch': reuseExistingBranch,
+          if (!reuseExistingBranch && sourceBranch != null)
+            'sourceBranch': sourceBranch,
+          'name': ?name,
+          'parentWorkspaceId': ?parentWorkspaceId,
+        }, _managedWorkspaceCreateTimeout);
+    return WorkspaceCreationResult.fromJson(payload);
+  }
+
+  @override
+  Future<void> removeManagedWorkspace(
+    String workspaceId, {
+    bool? deleteBranch,
+  }) async {
+    await request('workspace.removeManaged', <String, Object?>{
+      'id': workspaceId,
+      'deleteBranch': ?deleteBranch,
+    }, _managedWorkspaceRemoveTimeout);
+  }
+
+  @override
+  Future<List<String>> cascadePreview(String workspaceId) async {
+    final payload = await requestMap(
+      'workspaceCascade.preview',
+      <String, Object?>{
+        'workspaceIds': <String>[workspaceId],
+        'includeDescendants': true,
+      },
+    );
+    return payload.stringList('workspaceIds');
+  }
+
+  @override
+  Future<void> removeTab(String tabId) async {
+    await request('tab.remove', <String, Object?>{'id': tabId});
+  }
+
+  @override
   Future<List<ProjectSummary>> listProjects() async {
     final payload = await requestList('project.list');
     return <ProjectSummary>[
@@ -135,6 +269,7 @@ class MobileRuntimeClient implements MobileTerminalClient {
     ];
   }
 
+  @override
   Future<ProjectBranches> listBranches(String projectId) async {
     final payload = await requestMap('project.branches.list', <String, Object?>{
       'projectId': projectId,
@@ -142,6 +277,7 @@ class MobileRuntimeClient implements MobileTerminalClient {
     return ProjectBranches.fromJson(payload);
   }
 
+  @override
   Future<List<WorkspaceSummary>> listWorkspaces() async {
     final payload = await requestList('workspace.listAll');
     return <WorkspaceSummary>[
@@ -203,6 +339,7 @@ class MobileRuntimeClient implements MobileTerminalClient {
   Future<Object?> request(
     String type, [
     Map<String, Object?> payload = const <String, Object?>{},
+    Duration? timeout,
   ]) {
     if (_disposed) {
       throw StateError('Mobile Runtime Client Is Disposed.');
@@ -227,13 +364,14 @@ class MobileRuntimeClient implements MobileTerminalClient {
       _handleSocketError(error, stackTrace);
       return Future<Object?>.error(error, stackTrace);
     }
+    final effectiveTimeout = timeout ?? _requestTimeout;
     return completer.future.timeout(
-      _requestTimeout,
+      effectiveTimeout,
       onTimeout: () {
         _pending.remove(id);
         throw TimeoutException(
           'Mobile Runtime Request Timed Out.',
-          _requestTimeout,
+          effectiveTimeout,
         );
       },
     );
@@ -242,8 +380,9 @@ class MobileRuntimeClient implements MobileTerminalClient {
   Future<Map<String, Object?>> requestMap(
     String type, [
     Map<String, Object?> payload = const <String, Object?>{},
+    Duration? timeout,
   ]) async {
-    final value = await request(type, payload);
+    final value = await request(type, payload, timeout);
     return asJsonMap(value);
   }
 

--- a/mobile/lib/src/features/runtime/presentation/host_dashboard_screen.dart
+++ b/mobile/lib/src/features/runtime/presentation/host_dashboard_screen.dart
@@ -1,7 +1,7 @@
 import 'package:alera_mobile/src/app/theme/alera_tokens.dart';
 import 'package:alera_mobile/src/features/hosts/application/paired_hosts_controller.dart';
 import 'package:alera_mobile/src/features/hosts/domain/paired_host_profile.dart';
-import 'package:alera_mobile/src/features/hosts/presentation/host_list_screen.dart';
+import 'package:alera_mobile/src/features/hosts/presentation/rename_host_dialog.dart';
 import 'package:alera_mobile/src/features/runtime/application/host_connection_controller.dart';
 import 'package:alera_mobile/src/features/runtime/application/host_dashboard_controller.dart';
 import 'package:alera_mobile/src/features/runtime/domain/mobile_runtime_status.dart';

--- a/mobile/lib/src/features/workbench/application/mobile_view_prefs_controller.dart
+++ b/mobile/lib/src/features/workbench/application/mobile_view_prefs_controller.dart
@@ -1,0 +1,60 @@
+import 'package:alera_mobile/src/features/workbench/application/workbench_providers.dart';
+import 'package:alera_mobile/src/features/workbench/domain/mobile_view_prefs.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'mobile_view_prefs_controller.g.dart';
+
+@riverpod
+class MobileViewPrefsController extends _$MobileViewPrefsController {
+  @override
+  Future<MobileViewPrefs> build(String hostId) {
+    return ref.watch(viewPrefsRepositoryProvider).load(hostId);
+  }
+
+  Future<void> setGroupBy(MobileWorkspaceGroupBy groupBy) {
+    return _update((prefs) => prefs.copyWith(groupBy: groupBy));
+  }
+
+  Future<void> togglePinnedSection() {
+    return _update(
+      (prefs) =>
+          prefs.copyWith(pinnedSectionCollapsed: !prefs.pinnedSectionCollapsed),
+    );
+  }
+
+  Future<void> toggleProjectCollapsed(String projectId) {
+    return _update(
+      (prefs) => prefs.copyWith(
+        collapsedProjectIds: _toggled(prefs.collapsedProjectIds, projectId),
+      ),
+    );
+  }
+
+  Future<void> toggleParentCollapsed(String workspaceId) {
+    return _update(
+      (prefs) => prefs.copyWith(
+        collapsedParentWorkspaceIds: _toggled(
+          prefs.collapsedParentWorkspaceIds,
+          workspaceId,
+        ),
+      ),
+    );
+  }
+
+  Future<void> _update(
+    MobileViewPrefs Function(MobileViewPrefs) transform,
+  ) async {
+    final current = await future;
+    final next = transform(current);
+    state = AsyncData(next);
+    await ref.read(viewPrefsRepositoryProvider).save(hostId, next);
+  }
+
+  Set<String> _toggled(Set<String> ids, String id) {
+    final next = <String>{...ids};
+    if (!next.remove(id)) {
+      next.add(id);
+    }
+    return next;
+  }
+}

--- a/mobile/lib/src/features/workbench/application/mobile_view_prefs_controller.g.dart
+++ b/mobile/lib/src/features/workbench/application/mobile_view_prefs_controller.g.dart
@@ -1,0 +1,102 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'mobile_view_prefs_controller.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(MobileViewPrefsController)
+final mobileViewPrefsControllerProvider = MobileViewPrefsControllerFamily._();
+
+final class MobileViewPrefsControllerProvider
+    extends $AsyncNotifierProvider<MobileViewPrefsController, MobileViewPrefs> {
+  MobileViewPrefsControllerProvider._({
+    required MobileViewPrefsControllerFamily super.from,
+    required String super.argument,
+  }) : super(
+         retry: null,
+         name: r'mobileViewPrefsControllerProvider',
+         isAutoDispose: true,
+         dependencies: null,
+         $allTransitiveDependencies: null,
+       );
+
+  @override
+  String debugGetCreateSourceHash() => _$mobileViewPrefsControllerHash();
+
+  @override
+  String toString() {
+    return r'mobileViewPrefsControllerProvider'
+        ''
+        '($argument)';
+  }
+
+  @$internal
+  @override
+  MobileViewPrefsController create() => MobileViewPrefsController();
+
+  @override
+  bool operator ==(Object other) {
+    return other is MobileViewPrefsControllerProvider &&
+        other.argument == argument;
+  }
+
+  @override
+  int get hashCode {
+    return argument.hashCode;
+  }
+}
+
+String _$mobileViewPrefsControllerHash() =>
+    r'eac39d3bba03dc6e742bff7a38da5d857498bfd6';
+
+final class MobileViewPrefsControllerFamily extends $Family
+    with
+        $ClassFamilyOverride<
+          MobileViewPrefsController,
+          AsyncValue<MobileViewPrefs>,
+          MobileViewPrefs,
+          FutureOr<MobileViewPrefs>,
+          String
+        > {
+  MobileViewPrefsControllerFamily._()
+    : super(
+        retry: null,
+        name: r'mobileViewPrefsControllerProvider',
+        dependencies: null,
+        $allTransitiveDependencies: null,
+        isAutoDispose: true,
+      );
+
+  MobileViewPrefsControllerProvider call(String hostId) =>
+      MobileViewPrefsControllerProvider._(argument: hostId, from: this);
+
+  @override
+  String toString() => r'mobileViewPrefsControllerProvider';
+}
+
+abstract class _$MobileViewPrefsController
+    extends $AsyncNotifier<MobileViewPrefs> {
+  late final _$args = ref.$arg as String;
+  String get hostId => _$args;
+
+  FutureOr<MobileViewPrefs> build(String hostId);
+  @$mustCallSuper
+  @override
+  WhenComplete runBuild() {
+    final ref = this.ref as $Ref<AsyncValue<MobileViewPrefs>, MobileViewPrefs>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<AsyncValue<MobileViewPrefs>, MobileViewPrefs>,
+              AsyncValue<MobileViewPrefs>,
+              Object?,
+              Object?
+            >;
+    return element.handleCreate(ref, () => build(_$args));
+  }
+}

--- a/mobile/lib/src/features/workbench/application/mobile_workspace_rows.dart
+++ b/mobile/lib/src/features/workbench/application/mobile_workspace_rows.dart
@@ -1,0 +1,129 @@
+import 'package:alera_mobile/src/features/runtime/domain/project_summary.dart';
+import 'package:alera_mobile/src/features/runtime/domain/workspace_summary.dart';
+import 'package:alera_mobile/src/features/workbench/application/workspace_listing_tree.dart';
+import 'package:alera_mobile/src/features/workbench/domain/mobile_view_prefs.dart';
+
+/// Flattened list model for the mobile workspace list, mirroring the desktop
+/// sidebar sections: an optional pinned section on top, then either project
+/// groups or one flat tree.
+sealed class MobileWorkspaceRow {
+  const MobileWorkspaceRow();
+}
+
+class MobilePinnedHeaderRow extends MobileWorkspaceRow {
+  const MobilePinnedHeaderRow({required this.count, required this.collapsed});
+
+  final int count;
+  final bool collapsed;
+}
+
+class MobileProjectHeaderRow extends MobileWorkspaceRow {
+  const MobileProjectHeaderRow({
+    required this.projectId,
+    required this.projectName,
+    required this.count,
+    required this.collapsed,
+  });
+
+  final String projectId;
+  final String projectName;
+  final int count;
+  final bool collapsed;
+}
+
+class MobileWorkspaceEntryRow extends MobileWorkspaceRow {
+  const MobileWorkspaceEntryRow({
+    required this.entry,
+    this.isPinnedCopy = false,
+  });
+
+  final WorkspaceTreeEntry entry;
+
+  /// True for the flat duplicate rendered inside the pinned section; the same
+  /// workspace still appears in its tree position below.
+  final bool isPinnedCopy;
+}
+
+List<MobileWorkspaceRow> buildMobileWorkspaceRows({
+  required List<WorkspaceSummary> workspaces,
+  required List<ProjectSummary> projects,
+  required MobileViewPrefs prefs,
+}) {
+  final rows = <MobileWorkspaceRow>[];
+
+  final pinned = <WorkspaceSummary>[
+    for (final workspace in workspaces)
+      if (workspace.isPinned) workspace,
+  ];
+  if (pinned.isNotEmpty) {
+    rows.add(
+      MobilePinnedHeaderRow(
+        count: pinned.length,
+        collapsed: prefs.pinnedSectionCollapsed,
+      ),
+    );
+    if (!prefs.pinnedSectionCollapsed) {
+      for (final workspace in pinned) {
+        rows.add(
+          MobileWorkspaceEntryRow(
+            entry: WorkspaceTreeEntry(
+              workspace: workspace,
+              depth: 0,
+              visibleChildCount: 0,
+              childrenCollapsed: false,
+            ),
+            isPinnedCopy: true,
+          ),
+        );
+      }
+    }
+  }
+
+  if (prefs.groupBy == MobileWorkspaceGroupBy.project) {
+    final projectNames = <String, String>{
+      for (final project in projects) project.id: project.name,
+    };
+    final byProject = <String, List<WorkspaceSummary>>{};
+    for (final workspace in workspaces) {
+      byProject
+          .putIfAbsent(workspace.projectId, () => <WorkspaceSummary>[])
+          .add(workspace);
+    }
+    final orderedProjectIds = <String>[
+      for (final project in projects)
+        if (byProject.containsKey(project.id)) project.id,
+      for (final projectId in byProject.keys)
+        if (!projectNames.containsKey(projectId)) projectId,
+    ];
+    for (final projectId in orderedProjectIds) {
+      final group = byProject[projectId]!;
+      final collapsed = prefs.collapsedProjectIds.contains(projectId);
+      rows.add(
+        MobileProjectHeaderRow(
+          projectId: projectId,
+          projectName: projectNames[projectId] ?? projectId,
+          count: group.length,
+          collapsed: collapsed,
+        ),
+      );
+      if (collapsed) {
+        continue;
+      }
+      for (final entry in buildWorkspaceTree(
+        entries: group,
+        collapsedParentIds: prefs.collapsedParentWorkspaceIds,
+      )) {
+        rows.add(MobileWorkspaceEntryRow(entry: entry));
+      }
+    }
+  } else {
+    for (final entry in buildWorkspaceTree(
+      entries: workspaces,
+      collapsedParentIds: prefs.collapsedParentWorkspaceIds,
+    )) {
+      rows.add(MobileWorkspaceEntryRow(entry: entry));
+    }
+  }
+
+  return rows;
+}

--- a/mobile/lib/src/features/workbench/application/view_prefs_repository.dart
+++ b/mobile/lib/src/features/workbench/application/view_prefs_repository.dart
@@ -1,0 +1,6 @@
+import 'package:alera_mobile/src/features/workbench/domain/mobile_view_prefs.dart';
+
+abstract interface class ViewPrefsRepository {
+  Future<MobileViewPrefs> load(String hostId);
+  Future<void> save(String hostId, MobileViewPrefs prefs);
+}

--- a/mobile/lib/src/features/workbench/application/workbench_providers.dart
+++ b/mobile/lib/src/features/workbench/application/workbench_providers.dart
@@ -1,0 +1,19 @@
+import 'package:alera_mobile/src/features/runtime/application/host_connection_controller.dart';
+import 'package:alera_mobile/src/features/runtime/infra/mobile_runtime_client.dart';
+import 'package:alera_mobile/src/features/workbench/application/view_prefs_repository.dart';
+import 'package:alera_mobile/src/features/workbench/infra/local_view_prefs_repository.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'workbench_providers.g.dart';
+
+@Riverpod(keepAlive: true)
+ViewPrefsRepository viewPrefsRepository(Ref ref) {
+  return LocalViewPrefsRepository();
+}
+
+/// The workspace surface of the host connection. Tests override this with a
+/// fake so workbench controllers can run without a live gateway.
+@riverpod
+Future<MobileWorkspaceClient> workspaceClient(Ref ref, String hostId) {
+  return ref.watch(hostConnectionControllerProvider(hostId).future);
+}

--- a/mobile/lib/src/features/workbench/application/workbench_providers.g.dart
+++ b/mobile/lib/src/features/workbench/application/workbench_providers.g.dart
@@ -1,0 +1,149 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'workbench_providers.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(viewPrefsRepository)
+final viewPrefsRepositoryProvider = ViewPrefsRepositoryProvider._();
+
+final class ViewPrefsRepositoryProvider
+    extends
+        $FunctionalProvider<
+          ViewPrefsRepository,
+          ViewPrefsRepository,
+          ViewPrefsRepository
+        >
+    with $Provider<ViewPrefsRepository> {
+  ViewPrefsRepositoryProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'viewPrefsRepositoryProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$viewPrefsRepositoryHash();
+
+  @$internal
+  @override
+  $ProviderElement<ViewPrefsRepository> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  ViewPrefsRepository create(Ref ref) {
+    return viewPrefsRepository(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(ViewPrefsRepository value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<ViewPrefsRepository>(value),
+    );
+  }
+}
+
+String _$viewPrefsRepositoryHash() =>
+    r'7e6e618b2f430c6bcb25d5cb73536701d35abf42';
+
+/// The workspace surface of the host connection. Tests override this with a
+/// fake so workbench controllers can run without a live gateway.
+
+@ProviderFor(workspaceClient)
+final workspaceClientProvider = WorkspaceClientFamily._();
+
+/// The workspace surface of the host connection. Tests override this with a
+/// fake so workbench controllers can run without a live gateway.
+
+final class WorkspaceClientProvider
+    extends
+        $FunctionalProvider<
+          AsyncValue<MobileWorkspaceClient>,
+          MobileWorkspaceClient,
+          FutureOr<MobileWorkspaceClient>
+        >
+    with
+        $FutureModifier<MobileWorkspaceClient>,
+        $FutureProvider<MobileWorkspaceClient> {
+  /// The workspace surface of the host connection. Tests override this with a
+  /// fake so workbench controllers can run without a live gateway.
+  WorkspaceClientProvider._({
+    required WorkspaceClientFamily super.from,
+    required String super.argument,
+  }) : super(
+         retry: null,
+         name: r'workspaceClientProvider',
+         isAutoDispose: true,
+         dependencies: null,
+         $allTransitiveDependencies: null,
+       );
+
+  @override
+  String debugGetCreateSourceHash() => _$workspaceClientHash();
+
+  @override
+  String toString() {
+    return r'workspaceClientProvider'
+        ''
+        '($argument)';
+  }
+
+  @$internal
+  @override
+  $FutureProviderElement<MobileWorkspaceClient> $createElement(
+    $ProviderPointer pointer,
+  ) => $FutureProviderElement(pointer);
+
+  @override
+  FutureOr<MobileWorkspaceClient> create(Ref ref) {
+    final argument = this.argument as String;
+    return workspaceClient(ref, argument);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is WorkspaceClientProvider && other.argument == argument;
+  }
+
+  @override
+  int get hashCode {
+    return argument.hashCode;
+  }
+}
+
+String _$workspaceClientHash() => r'9090961936ae5bfb9c5391dde4f850b5fbcb396e';
+
+/// The workspace surface of the host connection. Tests override this with a
+/// fake so workbench controllers can run without a live gateway.
+
+final class WorkspaceClientFamily extends $Family
+    with $FunctionalFamilyOverride<FutureOr<MobileWorkspaceClient>, String> {
+  WorkspaceClientFamily._()
+    : super(
+        retry: null,
+        name: r'workspaceClientProvider',
+        dependencies: null,
+        $allTransitiveDependencies: null,
+        isAutoDispose: true,
+      );
+
+  /// The workspace surface of the host connection. Tests override this with a
+  /// fake so workbench controllers can run without a live gateway.
+
+  WorkspaceClientProvider call(String hostId) =>
+      WorkspaceClientProvider._(argument: hostId, from: this);
+
+  @override
+  String toString() => r'workspaceClientProvider';
+}

--- a/mobile/lib/src/features/workbench/application/workspace_list_controller.dart
+++ b/mobile/lib/src/features/workbench/application/workspace_list_controller.dart
@@ -1,0 +1,127 @@
+import 'dart:async';
+
+import 'package:alera_mobile/src/features/runtime/domain/project_summary.dart';
+import 'package:alera_mobile/src/features/runtime/domain/workspace_creation_result.dart';
+import 'package:alera_mobile/src/features/runtime/domain/workspace_summary.dart';
+import 'package:alera_mobile/src/features/workbench/application/workbench_providers.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'workspace_list_controller.g.dart';
+
+const Set<String> _refreshEvents = <String>{
+  'workspacesChanged',
+  'workspaceRelationsChanged',
+  'workspaceTabsChanged',
+  'projectsChanged',
+};
+
+class WorkspaceListData {
+  const WorkspaceListData({
+    required this.workspaces,
+    required this.projects,
+    required this.supportsMutations,
+  });
+
+  final List<WorkspaceSummary> workspaces;
+  final List<ProjectSummary> projects;
+
+  /// False against runtimes that predate the mobile mutation allowlist; the
+  /// UI hides mutating actions in that case.
+  final bool supportsMutations;
+
+  WorkspaceSummary? workspaceById(String id) {
+    for (final workspace in workspaces) {
+      if (workspace.id == id) {
+        return workspace;
+      }
+    }
+    return null;
+  }
+}
+
+@riverpod
+class WorkspaceListController extends _$WorkspaceListController {
+  @override
+  Future<WorkspaceListData> build(String hostId) async {
+    final client = await ref.watch(workspaceClientProvider(hostId).future);
+    final subscription = client.events.listen((event) {
+      if (_refreshEvents.contains(event.name)) {
+        ref.invalidateSelf();
+      }
+    });
+    ref.onDispose(subscription.cancel);
+    final results = await Future.wait(<Future<Object?>>[
+      client.listWorkspaces(),
+      client.listProjects(),
+    ]);
+    return WorkspaceListData(
+      workspaces: results[0]! as List<WorkspaceSummary>,
+      projects: results[1]! as List<ProjectSummary>,
+      supportsMutations: client.supportsWorkspaceMutations,
+    );
+  }
+
+  Future<void> setPinned(String workspaceId, bool isPinned) async {
+    final client = await ref.read(workspaceClientProvider(hostId).future);
+    await client.setWorkspacePinned(workspaceId, isPinned);
+    ref.invalidateSelf();
+  }
+
+  Future<void> linkParent({
+    required String childWorkspaceId,
+    required String parentWorkspaceId,
+  }) async {
+    final client = await ref.read(workspaceClientProvider(hostId).future);
+    await client.linkWorkspaces(
+      parentWorkspaceId: parentWorkspaceId,
+      childWorkspaceId: childWorkspaceId,
+    );
+    ref.invalidateSelf();
+  }
+
+  Future<void> unlinkParent(WorkspaceSummary workspace) async {
+    final parentId = workspace.parentWorkspaceId;
+    if (parentId == null) {
+      return;
+    }
+    final client = await ref.read(workspaceClientProvider(hostId).future);
+    await client.unlinkWorkspaces(
+      parentWorkspaceId: parentId,
+      childWorkspaceId: workspace.id,
+    );
+    ref.invalidateSelf();
+  }
+
+  Future<WorkspaceCreationResult> createWorkspace({
+    required String projectId,
+    required String branch,
+    String? sourceBranch,
+    bool reuseExistingBranch = false,
+    String? name,
+  }) async {
+    final client = await ref.read(workspaceClientProvider(hostId).future);
+    final result = await client.createManagedWorkspace(
+      projectId: projectId,
+      branch: branch,
+      sourceBranch: sourceBranch,
+      reuseExistingBranch: reuseExistingBranch,
+      name: name,
+    );
+    ref.invalidateSelf();
+    return result;
+  }
+
+  Future<void> deleteWorkspace(String workspaceId, {bool? deleteBranch}) async {
+    final client = await ref.read(workspaceClientProvider(hostId).future);
+    await client.removeManagedWorkspace(
+      workspaceId,
+      deleteBranch: deleteBranch,
+    );
+    ref.invalidateSelf();
+  }
+
+  Future<List<String>> cascadePreview(String workspaceId) async {
+    final client = await ref.read(workspaceClientProvider(hostId).future);
+    return client.cascadePreview(workspaceId);
+  }
+}

--- a/mobile/lib/src/features/workbench/application/workspace_list_controller.g.dart
+++ b/mobile/lib/src/features/workbench/application/workspace_list_controller.g.dart
@@ -1,0 +1,103 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'workspace_list_controller.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(WorkspaceListController)
+final workspaceListControllerProvider = WorkspaceListControllerFamily._();
+
+final class WorkspaceListControllerProvider
+    extends $AsyncNotifierProvider<WorkspaceListController, WorkspaceListData> {
+  WorkspaceListControllerProvider._({
+    required WorkspaceListControllerFamily super.from,
+    required String super.argument,
+  }) : super(
+         retry: null,
+         name: r'workspaceListControllerProvider',
+         isAutoDispose: true,
+         dependencies: null,
+         $allTransitiveDependencies: null,
+       );
+
+  @override
+  String debugGetCreateSourceHash() => _$workspaceListControllerHash();
+
+  @override
+  String toString() {
+    return r'workspaceListControllerProvider'
+        ''
+        '($argument)';
+  }
+
+  @$internal
+  @override
+  WorkspaceListController create() => WorkspaceListController();
+
+  @override
+  bool operator ==(Object other) {
+    return other is WorkspaceListControllerProvider &&
+        other.argument == argument;
+  }
+
+  @override
+  int get hashCode {
+    return argument.hashCode;
+  }
+}
+
+String _$workspaceListControllerHash() =>
+    r'ab1b4d6cbe5dc8c2c3b6a4bb0f73a33e2c7805cb';
+
+final class WorkspaceListControllerFamily extends $Family
+    with
+        $ClassFamilyOverride<
+          WorkspaceListController,
+          AsyncValue<WorkspaceListData>,
+          WorkspaceListData,
+          FutureOr<WorkspaceListData>,
+          String
+        > {
+  WorkspaceListControllerFamily._()
+    : super(
+        retry: null,
+        name: r'workspaceListControllerProvider',
+        dependencies: null,
+        $allTransitiveDependencies: null,
+        isAutoDispose: true,
+      );
+
+  WorkspaceListControllerProvider call(String hostId) =>
+      WorkspaceListControllerProvider._(argument: hostId, from: this);
+
+  @override
+  String toString() => r'workspaceListControllerProvider';
+}
+
+abstract class _$WorkspaceListController
+    extends $AsyncNotifier<WorkspaceListData> {
+  late final _$args = ref.$arg as String;
+  String get hostId => _$args;
+
+  FutureOr<WorkspaceListData> build(String hostId);
+  @$mustCallSuper
+  @override
+  WhenComplete runBuild() {
+    final ref =
+        this.ref as $Ref<AsyncValue<WorkspaceListData>, WorkspaceListData>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<AsyncValue<WorkspaceListData>, WorkspaceListData>,
+              AsyncValue<WorkspaceListData>,
+              Object?,
+              Object?
+            >;
+    return element.handleCreate(ref, () => build(_$args));
+  }
+}

--- a/mobile/lib/src/features/workbench/application/workspace_listing_tree.dart
+++ b/mobile/lib/src/features/workbench/application/workspace_listing_tree.dart
@@ -1,0 +1,140 @@
+import 'package:alera_mobile/src/features/runtime/domain/workspace_summary.dart';
+
+// Adapted from the desktop tree builder at
+// lib/src/features/workbench/application/workbench_listing_tree.dart,
+// retargeted to the mobile WorkspaceSummary model. Keep the algorithms in
+// sync when the desktop version changes.
+
+/// One workspace positioned in the sidebar tree.
+class WorkspaceTreeEntry {
+  const WorkspaceTreeEntry({
+    required this.workspace,
+    required this.depth,
+    required this.visibleChildCount,
+    required this.childrenCollapsed,
+  });
+
+  final WorkspaceSummary workspace;
+
+  /// Nesting depth relative to the sibling group root (0 = root level).
+  final int depth;
+
+  /// How many children this workspace has in the current filtered/sibling
+  /// group (including when those children are collapsed and not rendered).
+  final int visibleChildCount;
+
+  /// Whether this workspace has children rendered (or collapsed) beneath it in
+  /// the current group.
+  bool get hasVisibleChildren => visibleChildCount > 0;
+
+  /// Whether this workspace's children are currently hidden by the user.
+  final bool childrenCollapsed;
+}
+
+/// Deeper nesting reuses the max indent so rows stay readable on a phone.
+const int maxWorkspaceTreeDepth = 4;
+
+/// Orders one sibling group's already-filtered, already-sorted workspaces into
+/// a depth-first tree. A workspace whose parent is not part of [entries]
+/// (filtered out, in another group, or absent) is promoted to the root level,
+/// so filters never hide a child.
+List<WorkspaceTreeEntry> buildWorkspaceTree({
+  required List<WorkspaceSummary> entries,
+  required Set<String> collapsedParentIds,
+}) {
+  final ids = <String>{for (final workspace in entries) workspace.id};
+  final childrenOf = <String, List<WorkspaceSummary>>{};
+  final roots = <WorkspaceSummary>[];
+  for (final workspace in entries) {
+    final parentId = workspace.parentWorkspaceId;
+    if (parentId != null &&
+        parentId != workspace.id &&
+        ids.contains(parentId)) {
+      childrenOf
+          .putIfAbsent(parentId, () => <WorkspaceSummary>[])
+          .add(workspace);
+    } else {
+      roots.add(workspace);
+    }
+  }
+
+  final out = <WorkspaceTreeEntry>[];
+  // Guards against stale relation cycles so the walk always terminates.
+  final visited = <String>{};
+
+  void markSubtreeVisited(WorkspaceSummary workspace) {
+    if (!visited.add(workspace.id)) {
+      return;
+    }
+    for (final child
+        in childrenOf[workspace.id] ?? const <WorkspaceSummary>[]) {
+      markSubtreeVisited(child);
+    }
+  }
+
+  void visit(WorkspaceSummary workspace, int depth) {
+    if (!visited.add(workspace.id)) {
+      return;
+    }
+    final children = childrenOf[workspace.id] ?? const <WorkspaceSummary>[];
+    final collapsed = collapsedParentIds.contains(workspace.id);
+    out.add(
+      WorkspaceTreeEntry(
+        workspace: workspace,
+        depth: depth,
+        visibleChildCount: children.length,
+        childrenCollapsed: collapsed,
+      ),
+    );
+    if (collapsed) {
+      for (final child in children) {
+        markSubtreeVisited(child);
+      }
+      return;
+    }
+    final childDepth = depth >= maxWorkspaceTreeDepth
+        ? maxWorkspaceTreeDepth
+        : depth + 1;
+    for (final child in children) {
+      visit(child, childDepth);
+    }
+  }
+
+  for (final root in roots) {
+    visit(root, 0);
+  }
+  // A cycle among non-root workspaces leaves them unvisited; append them at
+  // the root level rather than dropping them.
+  for (final workspace in entries) {
+    if (!visited.contains(workspace.id)) {
+      visit(workspace, 0);
+    }
+  }
+  return out;
+}
+
+/// Ids of every descendant of [workspaceId] given the current workspace set.
+/// Used to keep parent selection acyclic on the phone.
+Set<String> workspaceDescendantIds(
+  List<WorkspaceSummary> workspaces,
+  String workspaceId,
+) {
+  final childrenOf = <String, List<String>>{};
+  for (final workspace in workspaces) {
+    final parentId = workspace.parentWorkspaceId;
+    if (parentId != null && parentId != workspace.id) {
+      childrenOf.putIfAbsent(parentId, () => <String>[]).add(workspace.id);
+    }
+  }
+  final out = <String>{};
+  void visit(String id) {
+    for (final childId in childrenOf[id] ?? const <String>[]) {
+      if (out.add(childId)) {
+        visit(childId);
+      }
+    }
+  }
+
+  visit(workspaceId);
+  return out;
+}

--- a/mobile/lib/src/features/workbench/domain/mobile_view_prefs.dart
+++ b/mobile/lib/src/features/workbench/domain/mobile_view_prefs.dart
@@ -1,0 +1,58 @@
+import 'package:alera_mobile/src/core/json_payload_fields.dart';
+
+enum MobileWorkspaceGroupBy { none, project }
+
+/// Per-host sidebar view state persisted on the phone. Mirrors the desktop
+/// `WorkbenchViewPrefs` surface that matters on a small screen.
+class MobileViewPrefs {
+  const MobileViewPrefs({
+    this.groupBy = MobileWorkspaceGroupBy.project,
+    this.pinnedSectionCollapsed = false,
+    this.collapsedProjectIds = const <String>{},
+    this.collapsedParentWorkspaceIds = const <String>{},
+  });
+
+  final MobileWorkspaceGroupBy groupBy;
+  final bool pinnedSectionCollapsed;
+  final Set<String> collapsedProjectIds;
+  final Set<String> collapsedParentWorkspaceIds;
+
+  MobileViewPrefs copyWith({
+    MobileWorkspaceGroupBy? groupBy,
+    bool? pinnedSectionCollapsed,
+    Set<String>? collapsedProjectIds,
+    Set<String>? collapsedParentWorkspaceIds,
+  }) {
+    return MobileViewPrefs(
+      groupBy: groupBy ?? this.groupBy,
+      pinnedSectionCollapsed:
+          pinnedSectionCollapsed ?? this.pinnedSectionCollapsed,
+      collapsedProjectIds: collapsedProjectIds ?? this.collapsedProjectIds,
+      collapsedParentWorkspaceIds:
+          collapsedParentWorkspaceIds ?? this.collapsedParentWorkspaceIds,
+    );
+  }
+
+  factory MobileViewPrefs.fromJson(Map<String, Object?> json) {
+    return MobileViewPrefs(
+      groupBy:
+          json.optionalString('groupBy') == MobileWorkspaceGroupBy.none.name
+          ? MobileWorkspaceGroupBy.none
+          : MobileWorkspaceGroupBy.project,
+      pinnedSectionCollapsed: json['pinnedSectionCollapsed'] == true,
+      collapsedProjectIds: json.stringList('collapsedProjectIds').toSet(),
+      collapsedParentWorkspaceIds: json
+          .stringList('collapsedParentWorkspaceIds')
+          .toSet(),
+    );
+  }
+
+  Map<String, Object?> toJson() {
+    return <String, Object?>{
+      'groupBy': groupBy.name,
+      'pinnedSectionCollapsed': pinnedSectionCollapsed,
+      'collapsedProjectIds': collapsedProjectIds.toList(),
+      'collapsedParentWorkspaceIds': collapsedParentWorkspaceIds.toList(),
+    };
+  }
+}

--- a/mobile/lib/src/features/workbench/infra/local_view_prefs_repository.dart
+++ b/mobile/lib/src/features/workbench/infra/local_view_prefs_repository.dart
@@ -1,0 +1,36 @@
+import 'dart:convert';
+
+import 'package:alera_mobile/src/core/json_payload_fields.dart';
+import 'package:alera_mobile/src/features/workbench/application/view_prefs_repository.dart';
+import 'package:alera_mobile/src/features/workbench/domain/mobile_view_prefs.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class LocalViewPrefsRepository implements ViewPrefsRepository {
+  LocalViewPrefsRepository({SharedPreferencesAsync? preferences})
+    : _preferences = preferences ?? SharedPreferencesAsync();
+
+  static const String _keyPrefix = 'alera.mobile.viewPrefs.';
+
+  final SharedPreferencesAsync _preferences;
+
+  @override
+  Future<MobileViewPrefs> load(String hostId) async {
+    final encoded = await _preferences.getString('$_keyPrefix$hostId');
+    if (encoded == null || encoded.trim().isEmpty) {
+      return const MobileViewPrefs();
+    }
+    try {
+      return MobileViewPrefs.fromJson(asJsonMap(jsonDecode(encoded)));
+    } on FormatException {
+      return const MobileViewPrefs();
+    }
+  }
+
+  @override
+  Future<void> save(String hostId, MobileViewPrefs prefs) {
+    return _preferences.setString(
+      '$_keyPrefix$hostId',
+      jsonEncode(prefs.toJson()),
+    );
+  }
+}

--- a/mobile/lib/src/features/workbench/presentation/create_workspace_screen.dart
+++ b/mobile/lib/src/features/workbench/presentation/create_workspace_screen.dart
@@ -1,0 +1,292 @@
+import 'package:alera_mobile/src/app/theme/alera_tokens.dart';
+import 'package:alera_mobile/src/features/runtime/domain/project_summary.dart';
+import 'package:alera_mobile/src/features/runtime/domain/workspace_creation_result.dart';
+import 'package:alera_mobile/src/features/workbench/application/workbench_providers.dart';
+import 'package:alera_mobile/src/features/workbench/application/workspace_list_controller.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class CreateWorkspaceScreen extends ConsumerStatefulWidget {
+  const CreateWorkspaceScreen({
+    super.key,
+    required this.hostId,
+    required this.projects,
+  });
+
+  final String hostId;
+  final List<ProjectSummary> projects;
+
+  @override
+  ConsumerState<CreateWorkspaceScreen> createState() =>
+      _CreateWorkspaceScreenState();
+}
+
+class _CreateWorkspaceScreenState extends ConsumerState<CreateWorkspaceScreen> {
+  final TextEditingController _branch = TextEditingController();
+  final TextEditingController _name = TextEditingController();
+  String? _projectId;
+  List<String> _branches = const <String>[];
+  String? _sourceBranch;
+  bool _reuseExistingBranch = false;
+  bool _loadingBranches = false;
+  bool _creating = false;
+  String? _error;
+  WorkspaceCreationResult? _result;
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.projects.length == 1) {
+      _selectProject(widget.projects.single.id);
+    }
+  }
+
+  @override
+  void dispose() {
+    _branch.dispose();
+    _name.dispose();
+    super.dispose();
+  }
+
+  Future<void> _selectProject(String projectId) async {
+    setState(() {
+      _projectId = projectId;
+      _branches = const <String>[];
+      _sourceBranch = null;
+      _loadingBranches = true;
+    });
+    try {
+      final client = await ref.read(
+        workspaceClientProvider(widget.hostId).future,
+      );
+      final branches = await client.listBranches(projectId);
+      if (!mounted || _projectId != projectId) {
+        return;
+      }
+      setState(() {
+        _branches = branches.branches;
+        _sourceBranch = branches.branches.isEmpty
+            ? null
+            : branches.branches.first;
+      });
+    } on Object catch (error) {
+      if (mounted && _projectId == projectId) {
+        setState(() {
+          _error = 'Could Not Load Branches: $error';
+        });
+      }
+    } finally {
+      if (mounted && _projectId == projectId) {
+        setState(() {
+          _loadingBranches = false;
+        });
+      }
+    }
+  }
+
+  bool get _canSubmit {
+    if (_creating || _projectId == null || _branch.text.trim().isEmpty) {
+      return false;
+    }
+    return _reuseExistingBranch || _sourceBranch != null;
+  }
+
+  Future<void> _create() async {
+    setState(() {
+      _creating = true;
+      _error = null;
+    });
+    try {
+      final name = _name.text.trim();
+      final result = await ref
+          .read(workspaceListControllerProvider(widget.hostId).notifier)
+          .createWorkspace(
+            projectId: _projectId!,
+            branch: _branch.text.trim(),
+            sourceBranch: _reuseExistingBranch ? null : _sourceBranch,
+            reuseExistingBranch: _reuseExistingBranch,
+            name: name.isEmpty ? null : name,
+          );
+      if (mounted) {
+        setState(() {
+          _result = result;
+        });
+      }
+    } on Object catch (error) {
+      if (mounted) {
+        setState(() {
+          _error = error.toString();
+        });
+      }
+    } finally {
+      if (mounted) {
+        setState(() {
+          _creating = false;
+        });
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final result = _result;
+    return Scaffold(
+      appBar: AppBar(title: const Text('New Workspace')),
+      body: SafeArea(
+        child: result != null
+            ? _SetupReportView(
+                result: result,
+                onDone: () => Navigator.of(context).pop(true),
+              )
+            : _buildForm(context),
+      ),
+    );
+  }
+
+  Widget _buildForm(BuildContext context) {
+    return ListView(
+      padding: AleraTokens.pagePadding,
+      children: <Widget>[
+        DropdownButtonFormField<String>(
+          initialValue: _projectId,
+          decoration: const InputDecoration(labelText: 'Project'),
+          items: <DropdownMenuItem<String>>[
+            for (final project in widget.projects)
+              DropdownMenuItem<String>(
+                value: project.id,
+                child: Text(project.name, overflow: TextOverflow.ellipsis),
+              ),
+          ],
+          onChanged: _creating
+              ? null
+              : (value) {
+                  if (value != null) {
+                    _selectProject(value);
+                  }
+                },
+        ),
+        const SizedBox(height: AleraTokens.spaceLg),
+        TextField(
+          controller: _branch,
+          enabled: !_creating,
+          onChanged: (_) => setState(() {}),
+          decoration: const InputDecoration(
+            labelText: 'Branch Name',
+            helperText: 'The Worktree Branch For This Workspace',
+          ),
+        ),
+        const SizedBox(height: AleraTokens.spaceLg),
+        SwitchListTile(
+          contentPadding: EdgeInsets.zero,
+          value: _reuseExistingBranch,
+          onChanged: _creating
+              ? null
+              : (value) {
+                  setState(() {
+                    _reuseExistingBranch = value;
+                  });
+                },
+          title: const Text('Reuse Existing Branch'),
+        ),
+        if (!_reuseExistingBranch) ...<Widget>[
+          const SizedBox(height: AleraTokens.spaceSm),
+          if (_loadingBranches)
+            const Center(child: CircularProgressIndicator())
+          else
+            DropdownButtonFormField<String>(
+              initialValue: _sourceBranch,
+              decoration: const InputDecoration(labelText: 'Source Branch'),
+              items: <DropdownMenuItem<String>>[
+                for (final branch in _branches)
+                  DropdownMenuItem<String>(
+                    value: branch,
+                    child: Text(branch, overflow: TextOverflow.ellipsis),
+                  ),
+              ],
+              onChanged: _creating
+                  ? null
+                  : (value) {
+                      setState(() {
+                        _sourceBranch = value;
+                      });
+                    },
+            ),
+        ],
+        const SizedBox(height: AleraTokens.spaceLg),
+        TextField(
+          controller: _name,
+          enabled: !_creating,
+          decoration: const InputDecoration(
+            labelText: 'Display Name (Optional)',
+          ),
+        ),
+        if (_error != null) ...<Widget>[
+          const SizedBox(height: AleraTokens.spaceMd),
+          Text(
+            _error!,
+            style: TextStyle(color: Theme.of(context).colorScheme.error),
+          ),
+        ],
+        const SizedBox(height: AleraTokens.spaceXl),
+        FilledButton.icon(
+          onPressed: _canSubmit ? _create : null,
+          icon: _creating
+              ? const SizedBox.square(
+                  dimension: AleraTokens.spaceLg,
+                  child: CircularProgressIndicator(
+                    strokeWidth: AleraTokens.strokeSm,
+                  ),
+                )
+              : const Icon(Icons.add),
+          label: Text(_creating ? 'Creating' : 'Create Workspace'),
+        ),
+      ],
+    );
+  }
+}
+
+class _SetupReportView extends StatelessWidget {
+  const _SetupReportView({required this.result, required this.onDone});
+
+  final WorkspaceCreationResult result;
+  final VoidCallback onDone;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return ListView(
+      padding: AleraTokens.pagePadding,
+      children: <Widget>[
+        Row(
+          children: <Widget>[
+            const Icon(Icons.check_circle_outline, color: AleraTokens.success),
+            const SizedBox(width: AleraTokens.spaceSm),
+            Expanded(
+              child: Text(
+                result.workspace.name,
+                style: theme.textTheme.titleLarge,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: AleraTokens.spaceLg),
+        for (final step in result.steps)
+          ListTile(
+            contentPadding: EdgeInsets.zero,
+            dense: true,
+            leading: Icon(
+              step.succeeded ? Icons.check : Icons.close,
+              color: step.succeeded ? AleraTokens.success : AleraTokens.error,
+            ),
+            title: Text(step.label, overflow: TextOverflow.ellipsis),
+            subtitle: step.message == null
+                ? null
+                : Text(step.message!, overflow: TextOverflow.ellipsis),
+          ),
+        const SizedBox(height: AleraTokens.spaceXl),
+        FilledButton(onPressed: onDone, child: const Text('Done')),
+      ],
+    );
+  }
+}

--- a/mobile/lib/src/features/workbench/presentation/delete_workspace_dialog.dart
+++ b/mobile/lib/src/features/workbench/presentation/delete_workspace_dialog.dart
@@ -1,0 +1,105 @@
+import 'package:alera_mobile/src/app/theme/alera_tokens.dart';
+import 'package:alera_mobile/src/features/runtime/domain/workspace_summary.dart';
+import 'package:flutter/material.dart';
+
+class DeleteWorkspaceDecision {
+  const DeleteWorkspaceDecision({required this.deleteBranch});
+
+  final bool deleteBranch;
+}
+
+/// Destructive confirmation for removing a managed workspace. [cascadeCount]
+/// is the subtree size from `workspaceCascade.preview` (1 = no descendants).
+Future<DeleteWorkspaceDecision?> showDeleteWorkspaceDialog(
+  BuildContext context, {
+  required WorkspaceSummary workspace,
+  required int cascadeCount,
+}) {
+  return showDialog<DeleteWorkspaceDecision>(
+    context: context,
+    builder: (context) => _DeleteWorkspaceDialog(
+      workspace: workspace,
+      cascadeCount: cascadeCount,
+    ),
+  );
+}
+
+class _DeleteWorkspaceDialog extends StatefulWidget {
+  const _DeleteWorkspaceDialog({
+    required this.workspace,
+    required this.cascadeCount,
+  });
+
+  final WorkspaceSummary workspace;
+  final int cascadeCount;
+
+  @override
+  State<_DeleteWorkspaceDialog> createState() => _DeleteWorkspaceDialogState();
+}
+
+class _DeleteWorkspaceDialogState extends State<_DeleteWorkspaceDialog> {
+  bool _deleteBranch = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final descendants = widget.cascadeCount - 1;
+    return AlertDialog(
+      title: const Text('Delete Workspace'),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Text(widget.workspace.name, style: theme.textTheme.titleSmall),
+          if (widget.workspace.branch != null) ...<Widget>[
+            const SizedBox(height: AleraTokens.spaceXs),
+            Text(
+              widget.workspace.branch!,
+              style: theme.textTheme.bodySmall?.copyWith(
+                fontFamily: AleraTokens.monoFontFamily,
+              ),
+            ),
+          ],
+          if (descendants > 0) ...<Widget>[
+            const SizedBox(height: AleraTokens.spaceMd),
+            Text(
+              'This Workspace Has $descendants Linked '
+              '${descendants == 1 ? 'Descendant' : 'Descendants'}. They Will '
+              'Be Unlinked, Not Deleted.',
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: AleraTokens.warning,
+              ),
+            ),
+          ],
+          const SizedBox(height: AleraTokens.spaceMd),
+          SwitchListTile(
+            contentPadding: EdgeInsets.zero,
+            value: _deleteBranch,
+            onChanged: (value) {
+              setState(() {
+                _deleteBranch = value;
+              });
+            },
+            title: const Text('Delete Branch'),
+          ),
+        ],
+      ),
+      actions: <Widget>[
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(
+          style: FilledButton.styleFrom(
+            backgroundColor: theme.colorScheme.error,
+            foregroundColor: theme.colorScheme.onError,
+          ),
+          onPressed: () => Navigator.of(
+            context,
+          ).pop(DeleteWorkspaceDecision(deleteBranch: _deleteBranch)),
+          child: const Text('Delete'),
+        ),
+      ],
+    );
+  }
+}

--- a/mobile/lib/src/features/workbench/presentation/parent_picker_sheet.dart
+++ b/mobile/lib/src/features/workbench/presentation/parent_picker_sheet.dart
@@ -1,0 +1,71 @@
+import 'package:alera_mobile/src/app/theme/alera_tokens.dart';
+import 'package:alera_mobile/src/features/runtime/domain/workspace_summary.dart';
+import 'package:alera_mobile/src/features/workbench/application/workspace_listing_tree.dart';
+import 'package:flutter/material.dart';
+
+/// Picks a parent workspace for [child]. Pops with the chosen workspace id.
+/// Candidates exclude the child itself and its descendants so relations stay
+/// acyclic; the runtime enforces the same rule server-side.
+Future<String?> showParentPickerSheet(
+  BuildContext context, {
+  required WorkspaceSummary child,
+  required List<WorkspaceSummary> workspaces,
+}) {
+  final excluded = workspaceDescendantIds(workspaces, child.id)..add(child.id);
+  final candidates = <WorkspaceSummary>[
+    for (final workspace in workspaces)
+      if (!excluded.contains(workspace.id)) workspace,
+  ];
+  return showModalBottomSheet<String>(
+    context: context,
+    builder: (context) => SafeArea(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: <Widget>[
+          Padding(
+            padding: AleraTokens.contentPadding,
+            child: Text(
+              'Select Parent Workspace',
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+          ),
+          if (candidates.isEmpty)
+            Padding(
+              padding: AleraTokens.contentPadding,
+              child: Text(
+                'No Eligible Parents',
+                style: Theme.of(context).textTheme.bodyMedium,
+              ),
+            )
+          else
+            Flexible(
+              child: ListView.builder(
+                shrinkWrap: true,
+                itemCount: candidates.length,
+                itemBuilder: (context, index) {
+                  final workspace = candidates[index];
+                  return ListTile(
+                    leading: Icon(
+                      workspace.isMain
+                          ? Icons.home_outlined
+                          : Icons.account_tree_outlined,
+                    ),
+                    title: Text(
+                      workspace.name,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                    subtitle: Text(
+                      workspace.branch ?? workspace.path,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                    onTap: () => Navigator.of(context).pop(workspace.id),
+                  );
+                },
+              ),
+            ),
+        ],
+      ),
+    ),
+  );
+}

--- a/mobile/lib/src/features/workbench/presentation/runtime_workspaces_screen.dart
+++ b/mobile/lib/src/features/workbench/presentation/runtime_workspaces_screen.dart
@@ -1,0 +1,313 @@
+import 'package:alera_mobile/src/app/theme/alera_tokens.dart';
+import 'package:alera_mobile/src/features/hosts/application/paired_hosts_controller.dart';
+import 'package:alera_mobile/src/features/hosts/domain/paired_host_profile.dart';
+import 'package:alera_mobile/src/features/hosts/presentation/rename_host_dialog.dart';
+import 'package:alera_mobile/src/features/runtime/application/host_connection_controller.dart';
+import 'package:alera_mobile/src/features/runtime/presentation/host_dashboard_screen.dart';
+import 'package:alera_mobile/src/features/workbench/application/mobile_view_prefs_controller.dart';
+import 'package:alera_mobile/src/features/workbench/application/mobile_workspace_rows.dart';
+import 'package:alera_mobile/src/features/workbench/application/workspace_list_controller.dart';
+import 'package:alera_mobile/src/features/workbench/domain/mobile_view_prefs.dart';
+import 'package:alera_mobile/src/features/workbench/presentation/create_workspace_screen.dart';
+import 'package:alera_mobile/src/features/workbench/presentation/workspace_actions_sheet.dart';
+import 'package:alera_mobile/src/features/workbench/presentation/workspace_row_widgets.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+enum _ScreenMenuAction { groupByProject, hostDetails, renameHost }
+
+/// Host detail screen: the workspace list mirroring the desktop sidebar,
+/// with pinning, project grouping, and the parent/child tree.
+class RuntimeWorkspacesScreen extends ConsumerWidget {
+  const RuntimeWorkspacesScreen({super.key, required this.host});
+
+  final PairedHostProfile host;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final data = ref.watch(workspaceListControllerProvider(host.id));
+    final prefs = ref.watch(mobileViewPrefsControllerProvider(host.id));
+    final connection = ref.watch(hostConnectionControllerProvider(host.id));
+    final currentHost =
+        ref
+            .watch(pairedHostsControllerProvider)
+            .value
+            ?.where((profile) => profile.id == host.id)
+            .firstOrNull ??
+        host;
+    return Scaffold(
+      appBar: AppBar(
+        title: Row(
+          children: <Widget>[
+            _ConnectionDot(connected: connection.hasValue),
+            const SizedBox(width: AleraTokens.spaceSm),
+            Expanded(
+              child: Text(
+                currentHost.effectiveName,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ),
+          ],
+        ),
+        actions: <Widget>[
+          PopupMenuButton<_ScreenMenuAction>(
+            onSelected: (action) =>
+                _handleMenu(context, ref, action, currentHost, prefs.value),
+            itemBuilder: (context) => <PopupMenuEntry<_ScreenMenuAction>>[
+              CheckedPopupMenuItem<_ScreenMenuAction>(
+                value: _ScreenMenuAction.groupByProject,
+                checked: prefs.value?.groupBy == MobileWorkspaceGroupBy.project,
+                child: const Text('Group By Project'),
+              ),
+              const PopupMenuItem<_ScreenMenuAction>(
+                value: _ScreenMenuAction.hostDetails,
+                child: Text('Host Details'),
+              ),
+              const PopupMenuItem<_ScreenMenuAction>(
+                value: _ScreenMenuAction.renameHost,
+                child: Text('Rename Host'),
+              ),
+            ],
+          ),
+        ],
+      ),
+      body: SafeArea(
+        child: switch ((data, prefs)) {
+          (AsyncData(value: final listData), AsyncData())
+              when listData.workspaces.isEmpty =>
+            const _EmptyWorkspaces(),
+          (
+            AsyncData(value: final listData),
+            AsyncData(value: final viewPrefs),
+          ) =>
+            _WorkspaceListBody(
+              hostId: host.id,
+              data: listData,
+              prefs: viewPrefs,
+            ),
+          (AsyncError(:final error), _) => _ConnectionError(
+            error: error,
+            onRetry: () {
+              ref.invalidate(hostConnectionControllerProvider(host.id));
+            },
+          ),
+          _ => const Center(child: CircularProgressIndicator()),
+        },
+      ),
+      floatingActionButton: data.value?.supportsMutations == true
+          ? FloatingActionButton.extended(
+              onPressed: () {
+                Navigator.of(context).push(
+                  MaterialPageRoute<bool>(
+                    builder: (_) => CreateWorkspaceScreen(
+                      hostId: host.id,
+                      projects: data.value!.projects,
+                    ),
+                  ),
+                );
+              },
+              icon: const Icon(Icons.add),
+              label: const Text('New Workspace'),
+            )
+          : null,
+    );
+  }
+
+  Future<void> _handleMenu(
+    BuildContext context,
+    WidgetRef ref,
+    _ScreenMenuAction action,
+    PairedHostProfile currentHost,
+    MobileViewPrefs? prefs,
+  ) async {
+    switch (action) {
+      case _ScreenMenuAction.groupByProject:
+        await ref
+            .read(mobileViewPrefsControllerProvider(host.id).notifier)
+            .setGroupBy(
+              prefs?.groupBy == MobileWorkspaceGroupBy.project
+                  ? MobileWorkspaceGroupBy.none
+                  : MobileWorkspaceGroupBy.project,
+            );
+      case _ScreenMenuAction.hostDetails:
+        if (context.mounted) {
+          Navigator.of(context).push(
+            MaterialPageRoute<void>(
+              builder: (_) => HostDashboardScreen(host: currentHost),
+            ),
+          );
+        }
+      case _ScreenMenuAction.renameHost:
+        if (context.mounted) {
+          await showRenameHostDialog(context, ref, currentHost);
+        }
+    }
+  }
+}
+
+class _WorkspaceListBody extends ConsumerWidget {
+  const _WorkspaceListBody({
+    required this.hostId,
+    required this.data,
+    required this.prefs,
+  });
+
+  final String hostId;
+  final WorkspaceListData data;
+  final MobileViewPrefs prefs;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final rows = buildMobileWorkspaceRows(
+      workspaces: data.workspaces,
+      projects: data.projects,
+      prefs: prefs,
+    );
+    final prefsController = ref.read(
+      mobileViewPrefsControllerProvider(hostId).notifier,
+    );
+    return ListView.builder(
+      padding: const EdgeInsets.only(bottom: AleraTokens.spaceXxl * 2),
+      itemCount: rows.length,
+      itemBuilder: (context, index) {
+        final row = rows[index];
+        return switch (row) {
+          MobilePinnedHeaderRow(:final count, :final collapsed) =>
+            MobileSectionHeader(
+              label: 'Pinned',
+              icon: Icons.push_pin,
+              count: count,
+              collapsed: collapsed,
+              onToggle: prefsController.togglePinnedSection,
+            ),
+          MobileProjectHeaderRow(
+            :final projectId,
+            :final projectName,
+            :final count,
+            :final collapsed,
+          ) =>
+            MobileSectionHeader(
+              label: projectName,
+              icon: Icons.folder_outlined,
+              count: count,
+              collapsed: collapsed,
+              onToggle: () => prefsController.toggleProjectCollapsed(projectId),
+            ),
+          MobileWorkspaceEntryRow() => MobileWorkspaceListRow(
+            row: row,
+            onTap: () => showWorkspaceActionsSheet(
+              context,
+              ref,
+              hostId: hostId,
+              workspace: row.entry.workspace,
+              data: data,
+            ),
+            onLongPress: () => showWorkspaceActionsSheet(
+              context,
+              ref,
+              hostId: hostId,
+              workspace: row.entry.workspace,
+              data: data,
+            ),
+            onToggleChildren: () =>
+                prefsController.toggleParentCollapsed(row.entry.workspace.id),
+          ),
+        };
+      },
+    );
+  }
+}
+
+class _ConnectionDot extends StatelessWidget {
+  const _ConnectionDot({required this.connected});
+
+  final bool connected;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: AleraTokens.spaceSm,
+      height: AleraTokens.spaceSm,
+      decoration: BoxDecoration(
+        shape: BoxShape.circle,
+        color: connected ? AleraTokens.success : AleraTokens.foregroundMuted,
+      ),
+    );
+  }
+}
+
+class _EmptyWorkspaces extends StatelessWidget {
+  const _EmptyWorkspaces();
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: AleraTokens.contentPadding,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            Icon(
+              Icons.workspaces_outline,
+              size: AleraTokens.emptyIcon,
+              color: Theme.of(context).colorScheme.onSurfaceVariant,
+            ),
+            const SizedBox(height: AleraTokens.spaceLg),
+            Text(
+              'No Workspaces',
+              style: Theme.of(context).textTheme.titleLarge,
+            ),
+            const SizedBox(height: AleraTokens.spaceSm),
+            Text(
+              'Create A Workspace To Get Started.',
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ConnectionError extends StatelessWidget {
+  const _ConnectionError({required this.error, required this.onRetry});
+
+  final Object error;
+  final VoidCallback onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: AleraTokens.contentPadding,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            Icon(
+              Icons.cloud_off_outlined,
+              size: AleraTokens.emptyIcon,
+              color: Theme.of(context).colorScheme.error,
+            ),
+            const SizedBox(height: AleraTokens.spaceLg),
+            Text(
+              'Connection Failed',
+              style: Theme.of(context).textTheme.titleLarge,
+            ),
+            const SizedBox(height: AleraTokens.spaceSm),
+            Text(
+              error.toString(),
+              textAlign: TextAlign.center,
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
+            const SizedBox(height: AleraTokens.spaceLg),
+            FilledButton.icon(
+              onPressed: onRetry,
+              icon: const Icon(Icons.refresh),
+              label: const Text('Retry'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/src/features/workbench/presentation/workspace_actions_sheet.dart
+++ b/mobile/lib/src/features/workbench/presentation/workspace_actions_sheet.dart
@@ -1,0 +1,145 @@
+import 'package:alera_mobile/src/features/runtime/domain/workspace_summary.dart';
+import 'package:alera_mobile/src/features/workbench/application/workspace_list_controller.dart';
+import 'package:alera_mobile/src/features/workbench/presentation/delete_workspace_dialog.dart';
+import 'package:alera_mobile/src/features/workbench/presentation/parent_picker_sheet.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+enum _WorkspaceAction { pin, unpin, configureParent, unlinkParent, delete }
+
+/// Long-press actions for one workspace row. Mutating entries only appear
+/// when the runtime advertises the mobile mutations capability.
+Future<void> showWorkspaceActionsSheet(
+  BuildContext context,
+  WidgetRef ref, {
+  required String hostId,
+  required WorkspaceSummary workspace,
+  required WorkspaceListData data,
+}) async {
+  if (!data.supportsMutations) {
+    return;
+  }
+  final action = await showModalBottomSheet<_WorkspaceAction>(
+    context: context,
+    builder: (context) => SafeArea(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: <Widget>[
+          ListTile(
+            title: Text(
+              workspace.name,
+              style: Theme.of(context).textTheme.titleMedium,
+              overflow: TextOverflow.ellipsis,
+            ),
+            subtitle: Text(
+              workspace.branch ?? workspace.path,
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+          const Divider(height: 1),
+          ListTile(
+            leading: Icon(
+              workspace.isPinned ? Icons.push_pin_outlined : Icons.push_pin,
+            ),
+            title: Text(workspace.isPinned ? 'Unpin' : 'Pin'),
+            onTap: () => Navigator.of(context).pop(
+              workspace.isPinned
+                  ? _WorkspaceAction.unpin
+                  : _WorkspaceAction.pin,
+            ),
+          ),
+          ListTile(
+            leading: const Icon(Icons.account_tree_outlined),
+            title: const Text('Configure Parent'),
+            onTap: () =>
+                Navigator.of(context).pop(_WorkspaceAction.configureParent),
+          ),
+          if (workspace.hasParent)
+            ListTile(
+              leading: const Icon(Icons.link_off),
+              title: const Text('Unlink Parent'),
+              onTap: () =>
+                  Navigator.of(context).pop(_WorkspaceAction.unlinkParent),
+            ),
+          if (!workspace.isMain)
+            ListTile(
+              leading: Icon(
+                Icons.delete_outline,
+                color: Theme.of(context).colorScheme.error,
+              ),
+              title: Text(
+                'Delete Workspace',
+                style: TextStyle(color: Theme.of(context).colorScheme.error),
+              ),
+              onTap: () => Navigator.of(context).pop(_WorkspaceAction.delete),
+            ),
+        ],
+      ),
+    ),
+  );
+  if (action == null || !context.mounted) {
+    return;
+  }
+  final controller = ref.read(workspaceListControllerProvider(hostId).notifier);
+  try {
+    switch (action) {
+      case _WorkspaceAction.pin:
+        await controller.setPinned(workspace.id, true);
+      case _WorkspaceAction.unpin:
+        await controller.setPinned(workspace.id, false);
+      case _WorkspaceAction.configureParent:
+        final parentId = await showParentPickerSheet(
+          context,
+          child: workspace,
+          workspaces: data.workspaces,
+        );
+        if (parentId != null) {
+          await controller.linkParent(
+            childWorkspaceId: workspace.id,
+            parentWorkspaceId: parentId,
+          );
+        }
+      case _WorkspaceAction.unlinkParent:
+        await controller.unlinkParent(workspace);
+      case _WorkspaceAction.delete:
+        await _confirmAndDelete(context, controller, workspace);
+    }
+  } on Object catch (error) {
+    if (context.mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Workspace Action Failed: $error')),
+      );
+    }
+  }
+}
+
+Future<void> _confirmAndDelete(
+  BuildContext context,
+  WorkspaceListController controller,
+  WorkspaceSummary workspace,
+) async {
+  var cascadeCount = 1;
+  try {
+    cascadeCount = (await controller.cascadePreview(workspace.id)).length;
+  } on Object {
+    // The preview is advisory; deletion still confirms explicitly.
+  }
+  if (!context.mounted) {
+    return;
+  }
+  final decision = await showDeleteWorkspaceDialog(
+    context,
+    workspace: workspace,
+    cascadeCount: cascadeCount,
+  );
+  if (decision == null || !context.mounted) {
+    return;
+  }
+  final messenger = ScaffoldMessenger.of(context);
+  messenger.showSnackBar(SnackBar(content: Text('Removing ${workspace.name}')));
+  await controller.deleteWorkspace(
+    workspace.id,
+    deleteBranch: decision.deleteBranch,
+  );
+  messenger.showSnackBar(SnackBar(content: Text('Removed ${workspace.name}')));
+}

--- a/mobile/lib/src/features/workbench/presentation/workspace_row_widgets.dart
+++ b/mobile/lib/src/features/workbench/presentation/workspace_row_widgets.dart
@@ -1,0 +1,168 @@
+import 'package:alera_mobile/src/app/theme/alera_tokens.dart';
+import 'package:alera_mobile/src/features/workbench/application/mobile_workspace_rows.dart';
+import 'package:flutter/material.dart';
+
+const double _treeIndentStep = 16;
+
+class MobileSectionHeader extends StatelessWidget {
+  const MobileSectionHeader({
+    super.key,
+    required this.label,
+    required this.count,
+    required this.collapsed,
+    required this.onToggle,
+    this.icon,
+  });
+
+  final String label;
+  final int count;
+  final bool collapsed;
+  final VoidCallback onToggle;
+  final IconData? icon;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return InkWell(
+      onTap: onToggle,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(
+          horizontal: AleraTokens.spaceLg,
+          vertical: AleraTokens.spaceSm,
+        ),
+        child: Row(
+          children: <Widget>[
+            Icon(
+              collapsed ? Icons.chevron_right : Icons.expand_more,
+              size: AleraTokens.spaceLg,
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+            const SizedBox(width: AleraTokens.spaceSm),
+            if (icon != null) ...<Widget>[
+              Icon(
+                icon,
+                size: AleraTokens.spaceLg,
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+              const SizedBox(width: AleraTokens.spaceSm),
+            ],
+            Expanded(
+              child: Text(
+                label,
+                style: theme.textTheme.labelLarge?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+                overflow: TextOverflow.ellipsis,
+              ),
+            ),
+            Text(
+              count.toString(),
+              style: theme.textTheme.labelSmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class MobileWorkspaceListRow extends StatelessWidget {
+  const MobileWorkspaceListRow({
+    super.key,
+    required this.row,
+    required this.onTap,
+    required this.onLongPress,
+    required this.onToggleChildren,
+  });
+
+  final MobileWorkspaceEntryRow row;
+  final VoidCallback onTap;
+  final VoidCallback onLongPress;
+  final VoidCallback onToggleChildren;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final entry = row.entry;
+    final workspace = entry.workspace;
+    final subtitle = workspace.branch ?? workspace.path;
+    return InkWell(
+      onTap: onTap,
+      onLongPress: onLongPress,
+      child: Padding(
+        padding: EdgeInsets.only(
+          left:
+              AleraTokens.spaceLg +
+              (row.isPinnedCopy ? 0 : entry.depth) * _treeIndentStep,
+          right: AleraTokens.spaceSm,
+          top: AleraTokens.spaceSm,
+          bottom: AleraTokens.spaceSm,
+        ),
+        child: Row(
+          children: <Widget>[
+            Icon(
+              workspace.isMain
+                  ? Icons.home_outlined
+                  : Icons.account_tree_outlined,
+              size: AleraTokens.spaceXl,
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+            const SizedBox(width: AleraTokens.spaceMd),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: <Widget>[
+                  Row(
+                    children: <Widget>[
+                      Flexible(
+                        child: Text(
+                          workspace.name,
+                          style: theme.textTheme.bodyLarge,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ),
+                      if (workspace.isPinned && !row.isPinnedCopy) ...<Widget>[
+                        const SizedBox(width: AleraTokens.spaceSm),
+                        Icon(
+                          Icons.push_pin,
+                          size: AleraTokens.spaceMd,
+                          color: theme.colorScheme.onSurfaceVariant,
+                        ),
+                      ],
+                    ],
+                  ),
+                  const SizedBox(height: AleraTokens.spaceXs),
+                  Text(
+                    subtitle,
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      fontFamily: workspace.branch != null
+                          ? AleraTokens.monoFontFamily
+                          : null,
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ],
+              ),
+            ),
+            if (!row.isPinnedCopy && entry.hasVisibleChildren)
+              IconButton(
+                tooltip: entry.childrenCollapsed
+                    ? 'Expand Children'
+                    : 'Collapse Children',
+                onPressed: onToggleChildren,
+                icon: entry.childrenCollapsed
+                    ? Badge.count(
+                        count: entry.visibleChildCount,
+                        child: const Icon(Icons.chevron_right),
+                      )
+                    : const Icon(Icons.expand_more),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/test/workspace_list_controller_test.dart
+++ b/mobile/test/workspace_list_controller_test.dart
@@ -1,0 +1,194 @@
+import 'dart:async';
+
+import 'package:alera_mobile/src/features/runtime/domain/project_summary.dart';
+import 'package:alera_mobile/src/features/runtime/domain/workspace_creation_result.dart';
+import 'package:alera_mobile/src/features/runtime/domain/workspace_summary.dart';
+import 'package:alera_mobile/src/features/runtime/infra/mobile_runtime_client.dart';
+import 'package:alera_mobile/src/features/workbench/application/workbench_providers.dart';
+import 'package:alera_mobile/src/features/workbench/application/workspace_list_controller.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('Loads workspaces and refreshes on runtime events', () async {
+    final client = _FakeWorkspaceClient();
+    final container = _container(client);
+
+    final data = await container.read(
+      workspaceListControllerProvider('host-1').future,
+    );
+    expect(data.workspaces.map((workspace) => workspace.id), <String>['a']);
+    expect(data.supportsMutations, isTrue);
+
+    client.workspaces = <WorkspaceSummary>[_workspace('a'), _workspace('b')];
+    client.emit('workspacesChanged');
+    await Future<void>.delayed(Duration.zero);
+
+    final refreshed = await container.read(
+      workspaceListControllerProvider('host-1').future,
+    );
+    expect(refreshed.workspaces, hasLength(2));
+  });
+
+  test('Mutations call the runtime and refresh the list', () async {
+    final client = _FakeWorkspaceClient();
+    final container = _container(client);
+    final notifier = container.read(
+      workspaceListControllerProvider('host-1').notifier,
+    );
+    await container.read(workspaceListControllerProvider('host-1').future);
+
+    await notifier.setPinned('a', true);
+    expect(client.calls, contains('setPinned a true'));
+
+    await notifier.linkParent(childWorkspaceId: 'a', parentWorkspaceId: 'b');
+    expect(client.calls, contains('link b a'));
+
+    await notifier.unlinkParent(_workspace('a', parent: 'b'));
+    expect(client.calls, contains('unlink b a'));
+
+    await notifier.deleteWorkspace('a', deleteBranch: true);
+    expect(client.calls, contains('remove a true'));
+
+    final result = await notifier.createWorkspace(
+      projectId: 'p1',
+      branch: 'feature/x',
+      sourceBranch: 'main',
+    );
+    expect(result.workspace.id, 'created');
+    expect(client.calls, contains('create p1 feature/x main'));
+  });
+
+  test('Cascade preview returns the subtree ids', () async {
+    final client = _FakeWorkspaceClient()..cascadeIds = <String>['a', 'child'];
+    final container = _container(client);
+    final notifier = container.read(
+      workspaceListControllerProvider('host-1').notifier,
+    );
+    await container.read(workspaceListControllerProvider('host-1').future);
+
+    expect(await notifier.cascadePreview('a'), <String>['a', 'child']);
+  });
+}
+
+ProviderContainer _container(_FakeWorkspaceClient client) {
+  final container = ProviderContainer(
+    overrides: [
+      workspaceClientProvider('host-1').overrideWith((ref) async => client),
+    ],
+  );
+  addTearDown(container.dispose);
+  addTearDown(client.dispose);
+  final subscription = container.listen(
+    workspaceListControllerProvider('host-1'),
+    (_, _) {},
+  );
+  addTearDown(subscription.close);
+  return container;
+}
+
+WorkspaceSummary _workspace(String id, {String? parent}) {
+  return WorkspaceSummary(
+    id: id,
+    projectId: 'p1',
+    name: id,
+    path: '/tmp/$id',
+    parentWorkspaceId: parent,
+  );
+}
+
+class _FakeWorkspaceClient implements MobileWorkspaceClient {
+  final StreamController<MobileRuntimeEvent> _events =
+      StreamController<MobileRuntimeEvent>.broadcast();
+  final List<String> calls = <String>[];
+  List<WorkspaceSummary> workspaces = <WorkspaceSummary>[_workspace('a')];
+  List<String> cascadeIds = <String>['a'];
+
+  void emit(String name) {
+    _events.add(MobileRuntimeEvent(name, const <String, Object?>{}));
+  }
+
+  Future<void> dispose() => _events.close();
+
+  @override
+  Stream<MobileRuntimeEvent> get events => _events.stream;
+
+  @override
+  bool get supportsWorkspaceMutations => true;
+
+  @override
+  Future<List<ProjectSummary>> listProjects() async {
+    return <ProjectSummary>[
+      const ProjectSummary(id: 'p1', name: 'Project', repoPath: '/repo'),
+    ];
+  }
+
+  @override
+  Future<ProjectBranches> listBranches(String projectId) async {
+    return ProjectBranches(
+      projectId: projectId,
+      branches: const <String>['main'],
+      localBranches: const <String>['main'],
+    );
+  }
+
+  @override
+  Future<List<WorkspaceSummary>> listWorkspaces() async {
+    return workspaces;
+  }
+
+  @override
+  Future<void> setWorkspacePinned(String workspaceId, bool isPinned) async {
+    calls.add('setPinned $workspaceId $isPinned');
+  }
+
+  @override
+  Future<void> linkWorkspaces({
+    required String parentWorkspaceId,
+    required String childWorkspaceId,
+  }) async {
+    calls.add('link $parentWorkspaceId $childWorkspaceId');
+  }
+
+  @override
+  Future<void> unlinkWorkspaces({
+    required String parentWorkspaceId,
+    required String childWorkspaceId,
+  }) async {
+    calls.add('unlink $parentWorkspaceId $childWorkspaceId');
+  }
+
+  @override
+  Future<WorkspaceCreationResult> createManagedWorkspace({
+    required String projectId,
+    required String branch,
+    String? sourceBranch,
+    bool reuseExistingBranch = false,
+    String? name,
+    String? parentWorkspaceId,
+  }) async {
+    calls.add('create $projectId $branch $sourceBranch');
+    return WorkspaceCreationResult(
+      workspace: _workspace('created'),
+      steps: const <WorkspaceSetupStep>[],
+    );
+  }
+
+  @override
+  Future<void> removeManagedWorkspace(
+    String workspaceId, {
+    bool? deleteBranch,
+  }) async {
+    calls.add('remove $workspaceId $deleteBranch');
+  }
+
+  @override
+  Future<List<String>> cascadePreview(String workspaceId) async {
+    return cascadeIds;
+  }
+
+  @override
+  Future<void> removeTab(String tabId) async {
+    calls.add('removeTab $tabId');
+  }
+}

--- a/mobile/test/workspace_rows_test.dart
+++ b/mobile/test/workspace_rows_test.dart
@@ -1,0 +1,182 @@
+import 'package:alera_mobile/src/features/runtime/domain/project_summary.dart';
+import 'package:alera_mobile/src/features/runtime/domain/workspace_summary.dart';
+import 'package:alera_mobile/src/features/workbench/application/mobile_workspace_rows.dart';
+import 'package:alera_mobile/src/features/workbench/application/workspace_listing_tree.dart';
+import 'package:alera_mobile/src/features/workbench/domain/mobile_view_prefs.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('buildWorkspaceTree', () {
+    test('Orders children depth-first under their parents', () {
+      final tree = buildWorkspaceTree(
+        entries: <WorkspaceSummary>[
+          _workspace('root'),
+          _workspace('child-a', parent: 'root'),
+          _workspace('grandchild', parent: 'child-a'),
+          _workspace('child-b', parent: 'root'),
+        ],
+        collapsedParentIds: const <String>{},
+      );
+
+      expect(tree.map((entry) => entry.workspace.id).toList(), <String>[
+        'root',
+        'child-a',
+        'grandchild',
+        'child-b',
+      ]);
+      expect(tree[0].depth, 0);
+      expect(tree[1].depth, 1);
+      expect(tree[2].depth, 2);
+      expect(tree[0].visibleChildCount, 2);
+    });
+
+    test('Collapsing a parent hides its subtree but keeps the count', () {
+      final tree = buildWorkspaceTree(
+        entries: <WorkspaceSummary>[
+          _workspace('root'),
+          _workspace('child-a', parent: 'root'),
+          _workspace('grandchild', parent: 'child-a'),
+        ],
+        collapsedParentIds: const <String>{'root'},
+      );
+
+      expect(tree.map((entry) => entry.workspace.id).toList(), <String>[
+        'root',
+      ]);
+      expect(tree.single.childrenCollapsed, isTrue);
+      expect(tree.single.visibleChildCount, 1);
+    });
+
+    test('Promotes orphans and cycles to the root level', () {
+      final tree = buildWorkspaceTree(
+        entries: <WorkspaceSummary>[
+          _workspace('orphan', parent: 'missing'),
+          _workspace('cycle-a', parent: 'cycle-b'),
+          _workspace('cycle-b', parent: 'cycle-a'),
+        ],
+        collapsedParentIds: const <String>{},
+      );
+
+      expect(tree, hasLength(3));
+      expect(tree.first.workspace.id, 'orphan');
+      expect(tree.first.depth, 0);
+    });
+
+    test('Caps indentation at the max tree depth', () {
+      final entries = <WorkspaceSummary>[_workspace('w0')];
+      for (var i = 1; i < 8; i++) {
+        entries.add(_workspace('w$i', parent: 'w${i - 1}'));
+      }
+      final tree = buildWorkspaceTree(
+        entries: entries,
+        collapsedParentIds: const <String>{},
+      );
+
+      expect(tree.last.depth, maxWorkspaceTreeDepth);
+    });
+
+    test('Computes descendants transitively', () {
+      final workspaces = <WorkspaceSummary>[
+        _workspace('root'),
+        _workspace('child', parent: 'root'),
+        _workspace('grandchild', parent: 'child'),
+        _workspace('other'),
+      ];
+
+      expect(workspaceDescendantIds(workspaces, 'root'), <String>{
+        'child',
+        'grandchild',
+      });
+      expect(workspaceDescendantIds(workspaces, 'other'), isEmpty);
+    });
+  });
+
+  group('buildMobileWorkspaceRows', () {
+    test('Renders the pinned section first with flat copies', () {
+      final rows = buildMobileWorkspaceRows(
+        workspaces: <WorkspaceSummary>[
+          _workspace('a', project: 'p1'),
+          _workspace('b', project: 'p1', pinned: true),
+        ],
+        projects: <ProjectSummary>[_project('p1')],
+        prefs: const MobileViewPrefs(groupBy: MobileWorkspaceGroupBy.none),
+      );
+
+      expect(rows.first, isA<MobilePinnedHeaderRow>());
+      final pinnedCopy = rows[1] as MobileWorkspaceEntryRow;
+      expect(pinnedCopy.isPinnedCopy, isTrue);
+      expect(pinnedCopy.entry.workspace.id, 'b');
+      final treeIds = rows
+          .skip(2)
+          .whereType<MobileWorkspaceEntryRow>()
+          .map((row) => row.entry.workspace.id)
+          .toList();
+      expect(treeIds, <String>['a', 'b']);
+    });
+
+    test('Collapsed pinned section hides copies but keeps the header', () {
+      final rows = buildMobileWorkspaceRows(
+        workspaces: <WorkspaceSummary>[
+          _workspace('b', project: 'p1', pinned: true),
+        ],
+        projects: <ProjectSummary>[_project('p1')],
+        prefs: const MobileViewPrefs(
+          groupBy: MobileWorkspaceGroupBy.none,
+          pinnedSectionCollapsed: true,
+        ),
+      );
+
+      expect(rows.first, isA<MobilePinnedHeaderRow>());
+      expect((rows.first as MobilePinnedHeaderRow).collapsed, isTrue);
+      final copies = rows.whereType<MobileWorkspaceEntryRow>().where(
+        (row) => row.isPinnedCopy,
+      );
+      expect(copies, isEmpty);
+    });
+
+    test('Groups by project in project order with collapse', () {
+      final rows = buildMobileWorkspaceRows(
+        workspaces: <WorkspaceSummary>[
+          _workspace('w2', project: 'p2'),
+          _workspace('w1', project: 'p1'),
+          _workspace('w1-child', project: 'p1', parent: 'w1'),
+        ],
+        projects: <ProjectSummary>[_project('p1'), _project('p2')],
+        prefs: const MobileViewPrefs(collapsedProjectIds: <String>{'p2'}),
+      );
+
+      final headers = rows.whereType<MobileProjectHeaderRow>().toList();
+      expect(headers.map((header) => header.projectId).toList(), <String>[
+        'p1',
+        'p2',
+      ]);
+      expect(headers.last.collapsed, isTrue);
+      final entryIds = rows
+          .whereType<MobileWorkspaceEntryRow>()
+          .map((row) => row.entry.workspace.id)
+          .toList();
+      expect(entryIds, <String>['w1', 'w1-child']);
+    });
+  });
+}
+
+WorkspaceSummary _workspace(
+  String id, {
+  String project = 'p1',
+  String? parent,
+  bool pinned = false,
+}) {
+  return WorkspaceSummary(
+    id: id,
+    projectId: project,
+    name: id,
+    path: '/tmp/$id',
+    branch: 'branch/$id',
+    isPinned: pinned,
+    parentWorkspaceId: parent,
+  );
+}
+
+ProjectSummary _project(String id) {
+  return ProjectSummary(id: id, name: 'Project $id', repoPath: '/repo/$id');
+}

--- a/rust/alera-cli/src/terminal_host/protocol.rs
+++ b/rust/alera-cli/src/terminal_host/protocol.rs
@@ -16,6 +16,10 @@ pub const RUNTIME_HOST_CAPABILITY: &str = "runtimeStore";
 pub const RUNTIME_HOST_BOOTSTRAP_CAPABILITY: &str = "sshTargetBootstrap";
 pub const RUNTIME_HOST_MANAGED_WORKSPACE_CAPABILITY: &str = "managedWorkspaceLifecycle";
 pub const RUNTIME_HOST_MOBILE_CAPABILITY: &str = "mobileCompanionAccess";
+// Advertised once mobile clients may call workspace mutations (pin, link,
+// create/remove managed, tab removal). Mobile apps feature-check this instead
+// of the strict-equality mobile protocol version.
+pub const RUNTIME_HOST_MOBILE_MUTATIONS_CAPABILITY: &str = "mobileWorkspaceMutations";
 // Advertised additively: older hosts stay usable for non-orchestration verbs,
 // so clients must feature-check this capability instead of the protocol version.
 pub const RUNTIME_HOST_ORCHESTRATION_CAPABILITY: &str = "orchestration";

--- a/rust/alera-cli/src/terminal_host/server/requests.rs
+++ b/rust/alera-cli/src/terminal_host/server/requests.rs
@@ -27,7 +27,8 @@ use crate::terminal_host::protocol::{
     error_response, event, int_or, ok_response, require_object, TerminalHostConfig,
     TerminalHostLaunch, PROTOCOL_VERSION, RUNTIME_HOST_BOOTSTRAP_CAPABILITY,
     RUNTIME_HOST_CAPABILITY, RUNTIME_HOST_MANAGED_WORKSPACE_CAPABILITY,
-    RUNTIME_HOST_MOBILE_CAPABILITY, RUNTIME_HOST_ORCHESTRATION_CAPABILITY,
+    RUNTIME_HOST_MOBILE_CAPABILITY, RUNTIME_HOST_MOBILE_MUTATIONS_CAPABILITY,
+    RUNTIME_HOST_ORCHESTRATION_CAPABILITY,
 };
 use crate::terminal_host::session::Session;
 use uuid::Uuid;
@@ -295,6 +296,7 @@ impl ServerActor {
                         RUNTIME_HOST_CAPABILITY,
                         RUNTIME_HOST_MANAGED_WORKSPACE_CAPABILITY,
                         RUNTIME_HOST_MOBILE_CAPABILITY,
+                        RUNTIME_HOST_MOBILE_MUTATIONS_CAPABILITY,
                     ],
                     "authenticated": true,
                     "device": device,
@@ -447,6 +449,7 @@ impl ServerActor {
                         RUNTIME_HOST_BOOTSTRAP_CAPABILITY,
                         RUNTIME_HOST_MANAGED_WORKSPACE_CAPABILITY,
                         RUNTIME_HOST_MOBILE_CAPABILITY,
+                        RUNTIME_HOST_MOBILE_MUTATIONS_CAPABILITY,
                         RUNTIME_HOST_ORCHESTRATION_CAPABILITY,
                     ],
                     "authenticated": true,
@@ -1273,12 +1276,18 @@ fn mobile_request_allowed(request_type: &str) -> bool {
             | "workspace.list"
             | "workspace.listAll"
             | "workspace.find"
+            | "workspace.setPinned"
+            | "workspace.createManaged"
+            | "workspace.removeManaged"
             | "tab.list"
             | "tab.find"
+            | "tab.remove"
             | "linkedReview.find"
             | "layout.find"
             | "workspaceTag.list"
             | "workspaceRelation.list"
+            | "workspaceRelation.link"
+            | "workspaceRelation.unlink"
             | "workspaceCascade.preview"
             | "terminal.create"
             | "terminal.attach"

--- a/rust/alera-cli/src/terminal_host/server/requests/tests.rs
+++ b/rust/alera-cli/src/terminal_host/server/requests/tests.rs
@@ -1,9 +1,25 @@
 use super::*;
 
 #[test]
-fn mobile_allowlist_excludes_managed_workspace_mutations() {
-    assert!(!mobile_request_allowed("workspace.createManaged"));
-    assert!(!mobile_request_allowed("workspace.removeManaged"));
+fn mobile_allowlist_includes_workspace_mutations() {
+    assert!(mobile_request_allowed("workspace.setPinned"));
+    assert!(mobile_request_allowed("workspace.createManaged"));
+    assert!(mobile_request_allowed("workspace.removeManaged"));
+    assert!(mobile_request_allowed("workspaceRelation.link"));
+    assert!(mobile_request_allowed("workspaceRelation.unlink"));
+    assert!(mobile_request_allowed("tab.remove"));
+}
+
+#[test]
+fn mobile_allowlist_still_excludes_raw_and_admin_mutations() {
+    assert!(!mobile_request_allowed("workspace.upsert"));
+    assert!(!mobile_request_allowed("workspace.remove"));
+    assert!(!mobile_request_allowed("tab.upsert"));
+    assert!(!mobile_request_allowed("tab.removeForWorkspace"));
+    assert!(!mobile_request_allowed("project.upsert"));
+    assert!(!mobile_request_allowed("sshTarget.upsert"));
+    assert!(!mobile_request_allowed("mobile.settings.update"));
+    assert!(!mobile_request_allowed("runtimeMetadata.set"));
 }
 
 #[test]


### PR DESCRIPTION
The host screen becomes a workspace list mirroring the desktop sidebar: pinned section, group-by-project toggle, parent/child tree with per-host persisted collapse state, and long-press actions (pin/unpin, configure/unlink parent, create and delete managed workspaces with cascade preview and delete-branch toggle).

Runtime side: the mobile gateway allowlist gains `workspace.setPinned`, `workspaceRelation.link/unlink`, `workspace.createManaged/removeManaged`, and `tab.remove`, advertised through the new `mobileWorkspaceMutations` capability so the app hides mutations against older runtimes. The mobile client gains per-request timeouts (managed create/remove reuse the desktop 30/10 minute limits).

Validation: `make rust-test` (allowlist tests), tree/rows builder and controller tests with a fake client; `flutter analyze`/`flutter test` in `mobile/` (40 tests).