### PR TITLE
fix: omit null matcher in generated agent hook definitions

### DIFF
--- a/rust/alera-cli/src/agent_status/integration_config.rs
+++ b/rust/alera-cli/src/agent_status/integration_config.rs
@@ -179,10 +179,7 @@ fn prepare_claude(runtime_dir: &Path, script: &Path) -> anyhow::Result<PathBuf> 
     ] {
         let command = managed_command(script, "claude", event);
         let mut definitions = clean_managed_definitions(hooks.remove(event));
-        definitions.push(json!({
-            "matcher": matcher,
-            "hooks": [{ "type": "command", "command": command }],
-        }));
+        definitions.push(managed_hook_definition(matcher, &command));
         hooks.insert(event.to_string(), Value::Array(definitions));
     }
     write_json_object(&runtime_home.join("settings.json"), &settings)?;
@@ -265,7 +262,10 @@ fn install_grok(script: &Path) -> anyhow::Result<()> {
     .map(|(event, matcher)| {
         (
             event.to_string(),
-            json!([{ "matcher": matcher, "hooks": [{ "type": "command", "command": managed_command(script, "grok", event) }] }]),
+            json!([managed_hook_definition(
+                matcher,
+                &managed_command(script, "grok", event)
+            )]),
         )
     })
     .collect::<Map<_, _>>();
@@ -290,6 +290,20 @@ fn install_agy(script: &Path) -> anyhow::Result<()> {
         json!([{ "matcher": "*", "hooks": [{ "type": "command", "command": managed_command(script, "agy", "PostToolUse") }] }]),
     );
     write_json_object(&path, &config)
+}
+
+// Non-tool events have nothing to match on. Their schemas expect the key to be
+// absent rather than null, so emitting `null` trips agent-side validation.
+fn managed_hook_definition(matcher: Option<&str>, command: &str) -> Value {
+    let mut definition = Map::new();
+    if let Some(matcher) = matcher {
+        definition.insert("matcher".to_string(), json!(matcher));
+    }
+    definition.insert(
+        "hooks".to_string(),
+        json!([{ "type": "command", "command": command }]),
+    );
+    Value::Object(definition)
 }
 
 fn managed_command(script: &Path, agent: &str, event: &str) -> String {

--- a/rust/alera-cli/src/agent_status/integration_config_tests.rs
+++ b/rust/alera-cli/src/agent_status/integration_config_tests.rs
@@ -17,6 +17,24 @@ fn removes_current_and_legacy_alera_definitions_only() {
 }
 
 #[test]
+fn omits_the_matcher_key_for_events_without_a_matcher() {
+    let definition = managed_hook_definition(None, "/home/user/hook.sh");
+
+    assert_eq!(
+        definition,
+        json!({ "hooks": [{ "type": "command", "command": "/home/user/hook.sh" }] })
+    );
+    assert!(definition.get("matcher").is_none());
+}
+
+#[test]
+fn keeps_the_matcher_key_for_tool_scoped_events() {
+    let definition = managed_hook_definition(Some("*"), "/home/user/hook.sh");
+
+    assert_eq!(definition["matcher"], json!("*"));
+}
+
+#[test]
 fn managed_scripts_can_derive_the_current_runtime_endpoint() {
     assert!(POSIX_HOOK_SCRIPT.contains("$ALERA_RUNTIME_DIR/agent-hooks/endpoint.env"));
 }

--- a/rust/alera-cli/tests/terminal_host_headless_runtime.rs
+++ b/rust/alera-cli/tests/terminal_host_headless_runtime.rs
@@ -104,6 +104,36 @@ fn spawn_host(runtime_dir: &std::path::Path, token: &str) -> (HostGuard, u16) {
 
 /// Agent integrations are reconciled after the host starts accepting, so the
 /// control file can appear before the hook files are on disk.
+/// Agent hook schemas expect `matcher` to be a string or absent, so a null
+/// value makes the agent print validation warnings on every startup.
+#[cfg(unix)]
+fn assert_no_null_matchers(path: &std::path::Path) {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    let config = loop {
+        let parsed = std::fs::read_to_string(path)
+            .ok()
+            .and_then(|contents| serde_json::from_str::<Value>(&contents).ok());
+        if let Some(config) = parsed {
+            break config;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "integration config never became readable JSON: {}",
+            path.display()
+        );
+        std::thread::sleep(Duration::from_millis(50));
+    };
+    for (event, definitions) in config["hooks"].as_object().expect("hooks object") {
+        for definition in definitions.as_array().expect("definition array") {
+            assert!(
+                !matches!(definition.get("matcher"), Some(Value::Null)),
+                "{} emitted a null matcher for {event}",
+                path.display()
+            );
+        }
+    }
+}
+
 #[cfg(unix)]
 fn wait_for_path(path: &std::path::Path) {
     let deadline = Instant::now() + Duration::from_secs(10);
@@ -356,19 +386,25 @@ fn runtime_hook_receiver_detects_every_enabled_agent() {
     let token = "agent-hook-token";
     let (_guard, port) = spawn_host(dir.path(), token);
     let test_home = dir.path().join("test-home");
+    let claude_settings = dir
+        .path()
+        .join("agent-runtime-homes/claude/home/settings.json");
+    let grok_hooks = test_home.join(".grok/hooks/alera-status.json");
     for integration in [
         dir.path().join("agent-runtime-homes/codex/home/hooks.json"),
-        dir.path()
-            .join("agent-runtime-homes/claude/home/settings.json"),
+        claude_settings.clone(),
         test_home.join(".copilot/hooks/alera.json"),
         test_home.join(".cursor/hooks.json"),
         test_home.join(".gemini/config/hooks.json"),
-        test_home.join(".grok/hooks/alera-status.json"),
+        grok_hooks.clone(),
         test_home.join(".config/opencode/plugins/alera-agent-status.js"),
         test_home.join(".pi/agent/extensions/alera-agent-status.ts"),
         test_home.join(".config/amp/plugins/alera-agent-status.ts"),
     ] {
         wait_for_path(&integration);
+    }
+    for hooks in [&claude_settings, &grok_hooks] {
+        assert_no_null_matchers(hooks);
     }
     let (mut writer, mut reader) = connect(port, token);
     send(


### PR DESCRIPTION
## Summary

Alera wrote `"matcher": null` into the Claude Code `settings.json` it generates for its managed runtime home. Claude Code's schema expects a string or an absent key, so it printed two validation warnings on every startup (`hooks.Stop.0.matcher`, `hooks.UserPromptSubmit.0.matcher`).

`prepare_claude` built every definition with `json!({"matcher": matcher, ...})`, and `Option::None` serializes to `null`. The Dart implementation this Rust code was ported from already omits the key, so this was port drift. A shared `managed_hook_definition` helper now inserts `matcher` only when there is one.

`install_grok` had the identical defect for its six non-tool events (`SessionStart`, `UserPromptSubmit`, `Notification`, `Stop`, `StopFailure`, `SessionEnd`) and is fixed by the same helper.

Existing bad files self-heal: `clean_managed_definitions` matches on the managed-hook marker, not the matcher, so the next reconcile rewrites the entries.

Closes #175.

## Validation

- `make rust-test` (fmt, clippy `-D warnings`, `cargo test --workspace`) passes.
- New unit tests cover both matcher cases.
- `runtime_hook_receiver_detects_every_enabled_agent` now asserts the generated Claude and Grok configs contain no null matcher; verified it fails when the null is reintroduced.
- `dart run tool/quality/check_max_lines.dart` passes (`integration_config.rs` is 496 lines).

## Notes

Behavior-only fix inside an existing generator; no docs, protocol, schema, or FRB binding changes needed. Not verified on Windows hardware, but the generator path is platform-independent.