### PR TITLE
fix: keep runtime watchers alive across host connection loss

### DIFF
--- a/lib/src/features/mobile_devices/infra/runtime_mobile_access_repository.dart
+++ b/lib/src/features/mobile_devices/infra/runtime_mobile_access_repository.dart
@@ -4,6 +4,8 @@ import 'package:alera/src/features/mobile_devices/domain/mobile_access_status.da
 import 'package:alera/src/features/mobile_devices/domain/mobile_device.dart';
 import 'package:alera/src/features/mobile_devices/domain/mobile_pairing_offer.dart';
 import 'package:alera/src/features/workbench/infra/terminal_host/terminal_host_protocol.dart';
+import 'package:alera/src/shared/infra/runtime/runtime_change_coalescer.dart';
+import 'package:alera/src/shared/infra/runtime/runtime_snapshot_stream.dart';
 
 const Set<String> _mobileChangeEventNames = <String>{
   'mobileSettingsChanged',
@@ -13,22 +15,27 @@ const Set<String> _mobileChangeEventNames = <String>{
 };
 
 class RuntimeMobileAccessRepository {
-  RuntimeMobileAccessRepository(this._client);
+  RuntimeMobileAccessRepository(
+    this._client, {
+    RuntimeChangeCoalescer? coalescer,
+  }) : _coalescer = coalescer ?? RuntimeChangeCoalescer();
 
   final RuntimeHostClient _client;
+  final RuntimeChangeCoalescer _coalescer;
 
   Future<MobileAccessStatus> status() async {
     final payload = await _client.runtimeRequest('mobile.status.get');
     return MobileAccessStatus.fromJson(_mapFromPayload(payload));
   }
 
-  Stream<MobileAccessStatus> watchStatus() async* {
-    yield await status();
-    await for (final event in _client.runtimeEvents) {
-      if (_mobileChangeEventNames.contains(event.name)) {
-        yield await status();
-      }
-    }
+  Stream<MobileAccessStatus> watchStatus() {
+    return runtimeSnapshotStream(
+      client: _client,
+      eventNames: _mobileChangeEventNames,
+      readSnapshot: status,
+      coalesceKey: 'mobileStatus',
+      coalescer: _coalescer,
+    );
   }
 
   Future<MobileGatewaySettings> updateSettings({

--- a/lib/src/features/projects/infra/runtime_project_config_repository.dart
+++ b/lib/src/features/projects/infra/runtime_project_config_repository.dart
@@ -3,12 +3,19 @@ import 'dart:async';
 import 'package:alera/src/features/projects/application/project_config_repository.dart';
 import 'package:alera/src/features/projects/domain/project_config.dart';
 import 'package:alera/src/features/workbench/infra/terminal_host/terminal_host_protocol.dart';
+import 'package:alera/src/shared/infra/runtime/runtime_change_coalescer.dart';
+import 'package:alera/src/shared/infra/runtime/runtime_snapshot_stream.dart';
 
 class RuntimeProjectConfigRepository implements ProjectConfigRepository {
-  RuntimeProjectConfigRepository(this._client, {this.beforeAccess});
+  RuntimeProjectConfigRepository(
+    this._client, {
+    this.beforeAccess,
+    RuntimeChangeCoalescer? coalescer,
+  }) : _coalescer = coalescer ?? RuntimeChangeCoalescer();
 
   final RuntimeHostClient _client;
   final Future<void> Function()? beforeAccess;
+  final RuntimeChangeCoalescer _coalescer;
 
   @override
   Future<ProjectConfig?> findByProjectId(String projectId) async {
@@ -35,13 +42,14 @@ class RuntimeProjectConfigRepository implements ProjectConfigRepository {
   }
 
   @override
-  Stream<Map<String, ProjectConfig>> watchAll() async* {
-    yield await loadAll();
-    await for (final event in _client.runtimeEvents) {
-      if (event.name == 'projectConfigsChanged') {
-        yield await loadAll();
-      }
-    }
+  Stream<Map<String, ProjectConfig>> watchAll() {
+    return runtimeSnapshotStream(
+      client: _client,
+      eventNames: const <String>{'projectConfigsChanged'},
+      readSnapshot: loadAll,
+      coalesceKey: 'projectConfigs',
+      coalescer: _coalescer,
+    );
   }
 
   @override

--- a/lib/src/features/projects/infra/runtime_project_repository.dart
+++ b/lib/src/features/projects/infra/runtime_project_repository.dart
@@ -4,12 +4,19 @@ import 'package:alera/src/features/projects/application/project_repository.dart'
 import 'package:alera/src/features/projects/domain/project.dart';
 import 'package:alera/src/features/projects/infra/runtime_project_management_client.dart';
 import 'package:alera/src/features/workbench/infra/terminal_host/terminal_host_protocol.dart';
+import 'package:alera/src/shared/infra/runtime/runtime_change_coalescer.dart';
+import 'package:alera/src/shared/infra/runtime/runtime_snapshot_stream.dart';
 
 class RuntimeProjectRepository implements ProjectRepository {
-  RuntimeProjectRepository(this._client, {this.beforeAccess});
+  RuntimeProjectRepository(
+    this._client, {
+    this.beforeAccess,
+    RuntimeChangeCoalescer? coalescer,
+  }) : _coalescer = coalescer ?? RuntimeChangeCoalescer();
 
   final RuntimeHostClient _client;
   final Future<void> Function()? beforeAccess;
+  final RuntimeChangeCoalescer _coalescer;
 
   @override
   Future<List<Project>> listAll() async {
@@ -19,13 +26,14 @@ class RuntimeProjectRepository implements ProjectRepository {
   }
 
   @override
-  Stream<List<Project>> watchAll() async* {
-    yield await listAll();
-    await for (final event in _client.runtimeEvents) {
-      if (event.name == 'projectsChanged') {
-        yield await listAll();
-      }
-    }
+  Stream<List<Project>> watchAll() {
+    return runtimeSnapshotStream(
+      client: _client,
+      eventNames: const <String>{'projectsChanged'},
+      readSnapshot: listAll,
+      coalesceKey: 'projects',
+      coalescer: _coalescer,
+    );
   }
 
   @override

--- a/lib/src/features/pull_requests/infra/runtime_linked_review_repository.dart
+++ b/lib/src/features/pull_requests/infra/runtime_linked_review_repository.dart
@@ -3,15 +3,22 @@ import 'dart:async';
 import 'package:alera/src/features/pull_requests/application/linked_review_repository.dart';
 import 'package:alera/src/features/pull_requests/domain/linked_review.dart';
 import 'package:alera/src/features/workbench/infra/terminal_host/terminal_host_protocol.dart';
+import 'package:alera/src/shared/infra/runtime/runtime_change_coalescer.dart';
+import 'package:alera/src/shared/infra/runtime/runtime_snapshot_stream.dart';
 
 /// [LinkedReviewRepository] over the runtime host RPC. Mirrors
 /// `RuntimeProjectConfigRepository`: the host owns the `linkedReviews` table and
 /// broadcasts `linkedReviewsChanged` on every mutation.
 class RuntimeLinkedReviewRepository implements LinkedReviewRepository {
-  RuntimeLinkedReviewRepository(this._client, {this.beforeAccess});
+  RuntimeLinkedReviewRepository(
+    this._client, {
+    this.beforeAccess,
+    RuntimeChangeCoalescer? coalescer,
+  }) : _coalescer = coalescer ?? RuntimeChangeCoalescer();
 
   final RuntimeHostClient _client;
   final Future<void> Function()? beforeAccess;
+  final RuntimeChangeCoalescer _coalescer;
 
   @override
   Future<LinkedReview?> find(String workspaceId) async {
@@ -27,13 +34,15 @@ class RuntimeLinkedReviewRepository implements LinkedReviewRepository {
   }
 
   @override
-  Stream<LinkedReview?> watch(String workspaceId) async* {
-    yield await find(workspaceId);
-    await for (final event in _client.runtimeEvents) {
-      if (event.name == 'linkedReviewsChanged') {
-        yield await find(workspaceId);
-      }
-    }
+  Stream<LinkedReview?> watch(String workspaceId) {
+    return runtimeSnapshotStream(
+      client: _client,
+      eventNames: const <String>{'linkedReviewsChanged'},
+      readSnapshot: () => find(workspaceId),
+      coalesceKey: 'linkedReview:$workspaceId',
+      coalescer: _coalescer,
+      matchesScope: runtimeScopeMatcher('workspaceId', workspaceId),
+    );
   }
 
   @override

--- a/lib/src/features/remote_hosts/infra/runtime_ssh_target_repository.dart
+++ b/lib/src/features/remote_hosts/infra/runtime_ssh_target_repository.dart
@@ -2,6 +2,8 @@ import 'dart:async';
 
 import 'package:alera/src/features/remote_hosts/domain/ssh_target.dart';
 import 'package:alera/src/features/workbench/infra/terminal_host/terminal_host_protocol.dart';
+import 'package:alera/src/shared/infra/runtime/runtime_change_coalescer.dart';
+import 'package:alera/src/shared/infra/runtime/runtime_snapshot_stream.dart';
 
 class RuntimeSshTargetRepository {
   RuntimeSshTargetRepository(
@@ -9,11 +11,13 @@ class RuntimeSshTargetRepository {
     this.beforeAccess,
     this.bootstrapDefaults =
         const RuntimeSshBootstrapDefaults.fromEnvironment(),
-  });
+    RuntimeChangeCoalescer? coalescer,
+  }) : _coalescer = coalescer ?? RuntimeChangeCoalescer();
 
   final RuntimeHostClient _client;
   final Future<void> Function()? beforeAccess;
   final RuntimeSshBootstrapDefaults bootstrapDefaults;
+  final RuntimeChangeCoalescer _coalescer;
 
   Future<List<SshTarget>> list() async {
     await beforeAccess?.call();
@@ -21,13 +25,14 @@ class RuntimeSshTargetRepository {
     return _targetListFromPayload(payload);
   }
 
-  Stream<List<SshTarget>> watchAll() async* {
-    yield await list();
-    await for (final event in _client.runtimeEvents) {
-      if (event.name == 'sshTargetsChanged') {
-        yield await list();
-      }
-    }
+  Stream<List<SshTarget>> watchAll() {
+    return runtimeSnapshotStream(
+      client: _client,
+      eventNames: const <String>{'sshTargetsChanged'},
+      readSnapshot: list,
+      coalesceKey: 'sshTargets',
+      coalescer: _coalescer,
+    );
   }
 
   Stream<SshTargetBootstrapProgress> watchBootstrapProgress() async* {

--- a/lib/src/features/workbench/application/workbench_controller.dart
+++ b/lib/src/features/workbench/application/workbench_controller.dart
@@ -81,6 +81,11 @@ class WorkbenchController extends _$WorkbenchController
       }
       _projectsSub = _projectsService.projectRepository.watchAll().listen(
         _onProjectsChanged,
+        // A dead watcher is never re-created, so a stream that errors or
+        // completes must not leave a stale subscription behind.
+        onError: (Object _) {},
+        onDone: () => _projectsSub = null,
+        cancelOnError: false,
       );
       final initialProjects = await _projectsService.projectRepository
           .listAll();

--- a/lib/src/features/workbench/application/workbench_controller_sync.dart
+++ b/lib/src/features/workbench/application/workbench_controller_sync.dart
@@ -103,7 +103,15 @@ mixin _WorkbenchControllerSync
       }
       _workspaceSubs[project.id] = _repository
           .watchWorkspaces(project.id)
-          .listen((workspaces) => _onWorkspacesChanged(project, workspaces));
+          .listen(
+            (workspaces) => _onWorkspacesChanged(project, workspaces),
+            // Re-subscription is guarded by `containsKey`, so a subscription
+            // that dies must drop out of the map or the project stops syncing
+            // for the rest of the session.
+            onError: (Object _) {},
+            onDone: () => _workspaceSubs.remove(project.id),
+            cancelOnError: false,
+          );
       unawaited(_ensureMainWorkspaceForProject(project));
     }
 
@@ -157,7 +165,15 @@ mixin _WorkbenchControllerSync
       unawaited(_loadLayoutForWorkspace(workspace.id));
       _tabSubs[workspace.id] = _repository
           .watchWorkspaceTabs(workspace.id)
-          .listen((tabs) => _onTabsChanged(workspace.id, tabs));
+          .listen(
+            (tabs) => _onTabsChanged(workspace.id, tabs),
+            onError: (Object _) {},
+            onDone: () {
+              _tabSubs.remove(workspace.id);
+              _tabSubProjectIds.remove(workspace.id);
+            },
+            cancelOnError: false,
+          );
     }
     // Preserve the active project while it is still valid; never silently jump
     // to a different project just because this project's workspaces changed.

--- a/lib/src/features/workbench/infra/runtime_workbench_repository.dart
+++ b/lib/src/features/workbench/infra/runtime_workbench_repository.dart
@@ -5,12 +5,19 @@ import 'package:alera/src/features/workbench/domain/workbench_layout.dart';
 import 'package:alera/src/features/workbench/domain/workspace.dart';
 import 'package:alera/src/features/workbench/domain/workspace_tab_record.dart';
 import 'package:alera/src/features/workbench/infra/terminal_host/terminal_host_protocol.dart';
+import 'package:alera/src/shared/infra/runtime/runtime_change_coalescer.dart';
+import 'package:alera/src/shared/infra/runtime/runtime_snapshot_stream.dart';
 
 class RuntimeWorkbenchRepository implements WorkbenchRepository {
-  RuntimeWorkbenchRepository(this._client, {this.beforeAccess});
+  RuntimeWorkbenchRepository(
+    this._client, {
+    this.beforeAccess,
+    RuntimeChangeCoalescer? coalescer,
+  }) : _coalescer = coalescer ?? RuntimeChangeCoalescer();
 
   final RuntimeHostClient _client;
   final Future<void> Function()? beforeAccess;
+  final RuntimeChangeCoalescer _coalescer;
 
   @override
   Future<List<Workspace>> listWorkspaces(String projectId) async {
@@ -23,15 +30,19 @@ class RuntimeWorkbenchRepository implements WorkbenchRepository {
   }
 
   @override
-  Stream<List<Workspace>> watchWorkspaces(String projectId) async* {
-    yield await listWorkspaces(projectId);
-    await for (final event in _client.runtimeEvents) {
-      if (event.name == 'workspacesChanged' ||
-          event.name == 'workspaceTagsChanged' ||
-          event.name == 'workspaceRelationsChanged') {
-        yield await listWorkspaces(projectId);
-      }
-    }
+  Stream<List<Workspace>> watchWorkspaces(String projectId) {
+    return runtimeSnapshotStream(
+      client: _client,
+      eventNames: const <String>{
+        'workspacesChanged',
+        'workspaceTagsChanged',
+        'workspaceRelationsChanged',
+      },
+      readSnapshot: () => listWorkspaces(projectId),
+      coalesceKey: 'workspaces:$projectId',
+      coalescer: _coalescer,
+      matchesScope: runtimeScopeMatcher('projectId', projectId),
+    );
   }
 
   @override
@@ -101,15 +112,15 @@ class RuntimeWorkbenchRepository implements WorkbenchRepository {
   }
 
   @override
-  Stream<List<WorkspaceTabRecord>> watchWorkspaceTabs(
-    String workspaceId,
-  ) async* {
-    yield await listWorkspaceTabs(workspaceId);
-    await for (final event in _client.runtimeEvents) {
-      if (event.name == 'workspaceTabsChanged') {
-        yield await listWorkspaceTabs(workspaceId);
-      }
-    }
+  Stream<List<WorkspaceTabRecord>> watchWorkspaceTabs(String workspaceId) {
+    return runtimeSnapshotStream(
+      client: _client,
+      eventNames: const <String>{'workspaceTabsChanged'},
+      readSnapshot: () => listWorkspaceTabs(workspaceId),
+      coalesceKey: 'tabs:$workspaceId',
+      coalescer: _coalescer,
+      matchesScope: runtimeScopeMatcher('workspaceId', workspaceId),
+    );
   }
 
   @override

--- a/lib/src/shared/infra/runtime/runtime_change_coalescer.dart
+++ b/lib/src/shared/infra/runtime/runtime_change_coalescer.dart
@@ -1,0 +1,124 @@
+import 'dart:async';
+
+/// Collapses bursts of runtime host change events into at most one refresh per
+/// key.
+///
+/// The host broadcasts one change event per mutation, so orchestration spawning
+/// many terminals emits one event per terminal. Without coalescing every one of
+/// those costs a socket round-trip per watcher, which is what saturates the
+/// single-threaded host actor under load.
+class RuntimeChangeCoalescer {
+  RuntimeChangeCoalescer({
+    this.debounce = const Duration(milliseconds: 120),
+    this.maxDelay = const Duration(milliseconds: 600),
+  });
+
+  /// Quiet period a key waits for before running.
+  final Duration debounce;
+
+  /// Ceiling on how long continuous churn may keep postponing a run. Without
+  /// it a trailing debounce would never fire while orchestration keeps
+  /// mutating state.
+  final Duration maxDelay;
+
+  final Map<String, _CoalescedKey> _keys = <String, _CoalescedKey>{};
+  bool _disposed = false;
+
+  /// Schedules [run] for [key], collapsing repeat calls inside the debounce
+  /// window into a single run. A call arriving while a run is in flight marks
+  /// the key dirty and re-runs exactly once after it settles.
+  void schedule(String key, Future<void> Function() run) {
+    if (_disposed) {
+      return;
+    }
+    final entry = _keys.putIfAbsent(key, _CoalescedKey.new)..run = run;
+    if (entry.inFlight != null) {
+      entry.dirty = true;
+      return;
+    }
+    entry.firstScheduledAt ??= DateTime.now();
+    final elapsed = DateTime.now().difference(entry.firstScheduledAt!);
+    if (elapsed >= maxDelay) {
+      entry.timer?.cancel();
+      entry.timer = null;
+      unawaited(_start(key, entry));
+      return;
+    }
+    final remaining = maxDelay - elapsed;
+    final delay = debounce < remaining ? debounce : remaining;
+    entry.timer?.cancel();
+    entry.timer = Timer(delay, () => unawaited(_start(key, entry)));
+  }
+
+  /// Runs [key] now, skipping the debounce but keeping in-flight
+  /// de-duplication. Returns once the resulting run settles.
+  Future<void> flush(String key) async {
+    final entry = _keys[key];
+    if (entry == null || entry.run == null) {
+      return;
+    }
+    entry.timer?.cancel();
+    entry.timer = null;
+    final inFlight = entry.inFlight;
+    if (inFlight != null) {
+      entry.dirty = true;
+      await inFlight;
+      if (!identical(_keys[key], entry) || entry.inFlight != null) {
+        return;
+      }
+      // The settled run re-scheduled itself through the debounce; a flush is
+      // explicit, so run it now instead of waiting out that window.
+      entry.timer?.cancel();
+      entry.timer = null;
+    }
+    await _start(key, entry);
+  }
+
+  void cancel(String key) {
+    final entry = _keys.remove(key);
+    entry?.timer?.cancel();
+    entry?.dirty = false;
+  }
+
+  void dispose() {
+    _disposed = true;
+    for (final entry in _keys.values) {
+      entry.timer?.cancel();
+    }
+    _keys.clear();
+  }
+
+  Future<void> _start(String key, _CoalescedKey entry) async {
+    final run = entry.run;
+    if (run == null || !identical(_keys[key], entry)) {
+      return;
+    }
+    entry.timer = null;
+    entry.firstScheduledAt = null;
+    entry.dirty = false;
+    final future = run();
+    entry.inFlight = future;
+    try {
+      await future;
+    } finally {
+      if (identical(entry.inFlight, future)) {
+        entry.inFlight = null;
+      }
+    }
+    if (entry.dirty && identical(_keys[key], entry) && !_disposed) {
+      entry.dirty = false;
+      // Go back through the debounce rather than re-running straight away.
+      // Events that keep landing during a run would otherwise chain into one
+      // run per event, which is the fan-out this class exists to prevent.
+      schedule(key, run);
+    }
+  }
+}
+
+class _CoalescedKey {
+  Timer? timer;
+  Future<void>? inFlight;
+  bool dirty = false;
+  DateTime? firstScheduledAt;
+  Future<void> Function()? run;
+}

--- a/lib/src/shared/infra/runtime/runtime_snapshot_stream.dart
+++ b/lib/src/shared/infra/runtime/runtime_snapshot_stream.dart
@@ -1,0 +1,103 @@
+import 'dart:async';
+
+import 'package:alera/src/features/workbench/infra/terminal_host/terminal_host_protocol.dart';
+import 'package:alera/src/shared/infra/runtime/runtime_change_coalescer.dart';
+
+/// Matches an event payload that carries no scope, i.e. every watcher refreshes.
+bool _matchesAnyScope(Map<String, Object?> payload) => true;
+
+/// Builds a scope predicate that accepts an event when it targets [ownId] or
+/// when it carries no scope at all.
+///
+/// A missing or empty scope means wildcard on purpose: an older host broadcasts
+/// change events with an empty payload, so the wildcard keeps a new app correct
+/// against a host that is already running.
+bool Function(Map<String, Object?>) runtimeScopeMatcher(
+  String field,
+  String ownId,
+) {
+  return (payload) {
+    final scope = payload[field];
+    return scope is! String || scope.isEmpty || scope == ownId;
+  };
+}
+
+/// A stream of snapshots that survives terminal host connection loss.
+///
+/// The stream never emits an error and never completes on its own. That is the
+/// whole point: an `async*` body that throws while reading a snapshot is dead
+/// for good, and its listener has no way to tell recoverable IPC failure from
+/// intentional completion. Here a failed read schedules a retry instead.
+///
+/// The retry loop doubles as the reconnect driver. Reading a snapshot goes
+/// through [RuntimeHostClient.runtimeRequest], which lazily reopens the socket,
+/// so a retry is what brings the connection back. Reconnecting then emits
+/// [aleraRuntimeHostConnectedEvent], which force-refreshes every other watcher.
+/// One watcher recovering heals the whole tree, so this coupling is deliberate.
+Stream<T> runtimeSnapshotStream<T>({
+  required RuntimeHostClient client,
+  required Set<String> eventNames,
+  required Future<T> Function() readSnapshot,
+  required String coalesceKey,
+  required RuntimeChangeCoalescer coalescer,
+  bool Function(Map<String, Object?> payload) matchesScope = _matchesAnyScope,
+  Duration retryDelay = const Duration(seconds: 1),
+  Duration maxRetryDelay = const Duration(seconds: 15),
+}) {
+  late final StreamController<T> controller;
+  StreamSubscription<RuntimeHostEvent>? eventSub;
+  Timer? retryTimer;
+  var backoff = retryDelay;
+
+  Future<void> refresh() async {
+    if (controller.isClosed) {
+      return;
+    }
+    try {
+      final value = await readSnapshot();
+      if (controller.isClosed) {
+        return;
+      }
+      controller.add(value);
+      backoff = retryDelay;
+    } on Object {
+      if (controller.isClosed) {
+        return;
+      }
+      retryTimer?.cancel();
+      retryTimer = Timer(backoff, () => unawaited(refresh()));
+      final next = backoff * 2;
+      backoff = next > maxRetryDelay ? maxRetryDelay : next;
+    }
+  }
+
+  controller = StreamController<T>(
+    onListen: () {
+      eventSub = client.runtimeEvents.listen(
+        (event) {
+          if (event.name == aleraRuntimeHostConnectedEvent) {
+            retryTimer?.cancel();
+            backoff = retryDelay;
+            coalescer.schedule(coalesceKey, refresh);
+            return;
+          }
+          if (eventNames.contains(event.name) && matchesScope(event.payload)) {
+            coalescer.schedule(coalesceKey, refresh);
+          }
+        },
+        onError: (Object _) {},
+        cancelOnError: false,
+      );
+      unawaited(refresh());
+    },
+    onCancel: () {
+      retryTimer?.cancel();
+      retryTimer = null;
+      coalescer.cancel(coalesceKey);
+      final sub = eventSub;
+      eventSub = null;
+      return sub?.cancel();
+    },
+  );
+  return controller.stream;
+}

--- a/test/unit/runtime_change_coalescer_test.dart
+++ b/test/unit/runtime_change_coalescer_test.dart
@@ -1,0 +1,119 @@
+import 'dart:async';
+
+import 'package:alera/src/shared/infra/runtime/runtime_change_coalescer.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('collapses repeat schedules inside the debounce window', () async {
+    final coalescer = RuntimeChangeCoalescer(
+      debounce: const Duration(milliseconds: 20),
+      maxDelay: const Duration(milliseconds: 200),
+    );
+    addTearDown(coalescer.dispose);
+    var runs = 0;
+
+    for (var i = 0; i < 10; i++) {
+      coalescer.schedule('key', () async => runs += 1);
+      await Future<void>.delayed(const Duration(milliseconds: 5));
+    }
+    expect(runs, 0, reason: 'still inside the debounce window');
+
+    await Future<void>.delayed(const Duration(milliseconds: 60));
+    expect(runs, 1);
+  });
+
+  test('maxDelay stops continuous churn from starving a run', () async {
+    final coalescer = RuntimeChangeCoalescer(
+      debounce: const Duration(milliseconds: 30),
+      maxDelay: const Duration(milliseconds: 50),
+    );
+    addTearDown(coalescer.dispose);
+    var runs = 0;
+
+    final ticker = Timer.periodic(
+      const Duration(milliseconds: 10),
+      (_) => coalescer.schedule('key', () async => runs += 1),
+    );
+    await Future<void>.delayed(const Duration(milliseconds: 200));
+    ticker.cancel();
+
+    expect(
+      runs,
+      greaterThanOrEqualTo(2),
+      reason: 'a pure trailing debounce would never fire here',
+    );
+  });
+
+  test('keys are independent', () async {
+    final coalescer = RuntimeChangeCoalescer(
+      debounce: const Duration(milliseconds: 10),
+      maxDelay: const Duration(milliseconds: 100),
+    );
+    addTearDown(coalescer.dispose);
+    final ran = <String>[];
+
+    coalescer.schedule('a', () async => ran.add('a'));
+    coalescer.schedule('b', () async => ran.add('b'));
+    await Future<void>.delayed(const Duration(milliseconds: 40));
+
+    expect(ran..sort(), <String>['a', 'b']);
+  });
+
+  test('flush skips the debounce', () async {
+    final coalescer = RuntimeChangeCoalescer(
+      debounce: const Duration(seconds: 30),
+      maxDelay: const Duration(seconds: 60),
+    );
+    addTearDown(coalescer.dispose);
+    var runs = 0;
+
+    coalescer.schedule('key', () async => runs += 1);
+    expect(runs, 0);
+
+    await coalescer.flush('key');
+    expect(runs, 1);
+  });
+
+  test('flush re-runs once when a run is already in flight', () async {
+    final coalescer = RuntimeChangeCoalescer(
+      debounce: const Duration(milliseconds: 5),
+      maxDelay: const Duration(milliseconds: 50),
+    );
+    addTearDown(coalescer.dispose);
+    var runs = 0;
+    final gate = Completer<void>();
+
+    coalescer.schedule('key', () async {
+      runs += 1;
+      if (runs == 1) {
+        await gate.future;
+      }
+    });
+    await Future<void>.delayed(const Duration(milliseconds: 20));
+    expect(runs, 1);
+
+    final flushed = coalescer.flush('key');
+    gate.complete();
+    await flushed;
+
+    expect(runs, 2);
+  });
+
+  test('cancel and dispose leave no pending run', () async {
+    final coalescer = RuntimeChangeCoalescer(
+      debounce: const Duration(milliseconds: 10),
+      maxDelay: const Duration(milliseconds: 100),
+    );
+    var runs = 0;
+
+    coalescer.schedule('key', () async => runs += 1);
+    coalescer.cancel('key');
+    await Future<void>.delayed(const Duration(milliseconds: 40));
+    expect(runs, 0);
+
+    coalescer.schedule('other', () async => runs += 1);
+    coalescer.dispose();
+    await Future<void>.delayed(const Duration(milliseconds: 40));
+    expect(runs, 0);
+  });
+}

--- a/test/unit/runtime_mobile_access_repository_test.dart
+++ b/test/unit/runtime_mobile_access_repository_test.dart
@@ -64,13 +64,17 @@ void main() {
       expect(status.tailscale!.error, isNull);
     });
 
-    test('watchStatus refetches on every mobile change event', () async {
+    test('watchStatus coalesces a burst of mobile change events', () async {
       final client = _FakeRuntimeHostClient();
       client.responses['mobile.status.get'] = _statusPayload();
       final repository = RuntimeMobileAccessRepository(client);
 
-      final statuses = repository.watchStatus().take(5).toList();
-      await Future<void>.delayed(Duration.zero);
+      final received = <MobileAccessStatus>[];
+      final subscription = repository.watchStatus().listen(received.add);
+      addTearDown(subscription.cancel);
+      await Future<void>.delayed(const Duration(milliseconds: 250));
+      expect(received, hasLength(1), reason: 'initial fetch');
+
       for (final name in <String>[
         'mobileSettingsChanged',
         'mobilePairingsChanged',
@@ -79,17 +83,15 @@ void main() {
         'projectsChanged',
       ]) {
         client.emit(RuntimeHostEvent(name, const <String, Object?>{}));
-        await Future<void>.delayed(Duration.zero);
       }
-      client.close();
+      await Future<void>.delayed(const Duration(milliseconds: 250));
 
-      final received = await statuses;
-      // Initial fetch plus one refetch per mobile event; the non-mobile
-      // event must not trigger a fetch.
-      expect(received, hasLength(5));
+      // The four mobile events collapse into a single refetch; the non-mobile
+      // event must not trigger one at all.
+      expect(received, hasLength(2));
       expect(
         client.requests.where((type) => type == 'mobile.status.get'),
-        hasLength(5),
+        hasLength(2),
       );
     });
 

--- a/test/unit/runtime_snapshot_stream_test.dart
+++ b/test/unit/runtime_snapshot_stream_test.dart
@@ -1,0 +1,273 @@
+import 'dart:async';
+
+import 'package:alera/src/features/workbench/domain/workspace_tab_record.dart';
+import 'package:alera/src/features/workbench/infra/runtime_workbench_repository.dart';
+import 'package:alera/src/features/workbench/infra/terminal_host/terminal_host_protocol.dart';
+import 'package:alera/src/shared/infra/runtime/runtime_change_coalescer.dart';
+import 'package:alera/src/shared/infra/runtime/runtime_snapshot_stream.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+const Duration _fastDebounce = Duration(milliseconds: 5);
+const Duration _fastMaxDelay = Duration(milliseconds: 20);
+const Duration _fastRetry = Duration(milliseconds: 10);
+
+RuntimeChangeCoalescer _coalescer() =>
+    RuntimeChangeCoalescer(debounce: _fastDebounce, maxDelay: _fastMaxDelay);
+
+void main() {
+  test(
+    'survives a failed snapshot read and recovers on host reconnect',
+    () async {
+      // Regression for the permanent freeze: an RPC timeout used to tear down
+      // the shared connection, which killed the async* watcher for good and
+      // left the workbench unable to see new workspaces or tabs.
+      final client = _FakeRuntimeHostClient();
+      final coalescer = _coalescer();
+      var value = 'first';
+      var failNext = false;
+      final emitted = <String>[];
+      var errored = false;
+      var closed = false;
+
+      final subscription =
+          runtimeSnapshotStream<String>(
+            client: client,
+            eventNames: const <String>{'changed'},
+            readSnapshot: () async {
+              if (failNext) {
+                throw StateError('connection closed');
+              }
+              return value;
+            },
+            coalesceKey: 'key',
+            coalescer: coalescer,
+            retryDelay: const Duration(seconds: 30),
+          ).listen(
+            emitted.add,
+            onError: (Object _) => errored = true,
+            onDone: () => closed = true,
+          );
+      addTearDown(subscription.cancel);
+
+      await _settle();
+      expect(emitted, <String>['first']);
+
+      failNext = true;
+      client.emit(const RuntimeHostEvent('changed', <String, Object?>{}));
+      await _settle();
+
+      expect(errored, isFalse, reason: 'the stream must never surface errors');
+      expect(closed, isFalse, reason: 'the stream must never complete');
+      expect(emitted, <String>['first']);
+
+      failNext = false;
+      value = 'second';
+      client.emit(
+        const RuntimeHostEvent(
+          aleraRuntimeHostConnectedEvent,
+          <String, Object?>{},
+        ),
+      );
+      await _settle();
+
+      expect(emitted, <String>['first', 'second']);
+    },
+  );
+
+  test('retries a failed read on its own, which drives reconnection', () async {
+    final client = _FakeRuntimeHostClient();
+    final coalescer = _coalescer();
+    var failures = 2;
+    final emitted = <String>[];
+
+    final subscription = runtimeSnapshotStream<String>(
+      client: client,
+      eventNames: const <String>{'changed'},
+      readSnapshot: () async {
+        if (failures > 0) {
+          failures -= 1;
+          throw StateError('host unavailable');
+        }
+        return 'ready';
+      },
+      coalesceKey: 'key',
+      coalescer: coalescer,
+      retryDelay: _fastRetry,
+    ).listen(emitted.add);
+    addTearDown(subscription.cancel);
+
+    await _settle(const Duration(milliseconds: 120));
+    expect(emitted, <String>['ready']);
+    expect(failures, 0);
+  });
+
+  test('coalesces a burst of events into a single read', () async {
+    final client = _FakeRuntimeHostClient();
+    final coalescer = _coalescer();
+    var reads = 0;
+
+    final subscription = runtimeSnapshotStream<int>(
+      client: client,
+      eventNames: const <String>{'changed'},
+      readSnapshot: () async => ++reads,
+      coalesceKey: 'key',
+      coalescer: coalescer,
+    ).listen((_) {});
+    addTearDown(subscription.cancel);
+
+    await _settle();
+    expect(reads, 1, reason: 'initial read');
+
+    for (var i = 0; i < 10; i++) {
+      client.emit(const RuntimeHostEvent('changed', <String, Object?>{}));
+    }
+    await _settle();
+
+    expect(reads, 2, reason: '10 events must collapse into one read');
+  });
+
+  test('de-duplicates an event arriving while a read is in flight', () async {
+    final client = _FakeRuntimeHostClient();
+    final coalescer = _coalescer();
+    var reads = 0;
+    final gate = Completer<void>();
+
+    final subscription = runtimeSnapshotStream<int>(
+      client: client,
+      eventNames: const <String>{'changed'},
+      readSnapshot: () async {
+        reads += 1;
+        if (reads == 2) {
+          await gate.future;
+        }
+        return reads;
+      },
+      coalesceKey: 'key',
+      coalescer: coalescer,
+    ).listen((_) {});
+    addTearDown(subscription.cancel);
+
+    await _settle();
+    expect(reads, 1);
+
+    client.emit(const RuntimeHostEvent('changed', <String, Object?>{}));
+    await _settle();
+    expect(reads, 2, reason: 'the second read is now in flight');
+
+    for (var i = 0; i < 10; i++) {
+      client.emit(const RuntimeHostEvent('changed', <String, Object?>{}));
+    }
+    gate.complete();
+    await _settle();
+
+    expect(reads, 3, reason: '10 events during a read must add one re-run');
+  });
+
+  test('RuntimeWorkbenchRepository keeps its tab stream alive after a failed '
+      'list', () async {
+    // Repository-level statement of the same contract: a torn-down connection
+    // must not end the watcher that feeds new terminals into the workbench.
+    final client = _FakeRuntimeHostClient()..failNextRequests = 1;
+    final repository = RuntimeWorkbenchRepository(
+      client,
+      coalescer: _coalescer(),
+    );
+    client.responses['tab.list'] = <Object?>[];
+    var errored = false;
+    var closed = false;
+    final emitted = <List<WorkspaceTabRecord>>[];
+
+    final subscription = repository
+        .watchWorkspaceTabs('workspace-1')
+        .listen(
+          emitted.add,
+          onError: (Object _) => errored = true,
+          onDone: () => closed = true,
+        );
+    addTearDown(subscription.cancel);
+
+    await _settle();
+    expect(errored, isFalse);
+    expect(closed, isFalse);
+    expect(emitted, isEmpty);
+
+    client.emit(
+      const RuntimeHostEvent(
+        aleraRuntimeHostConnectedEvent,
+        <String, Object?>{},
+      ),
+    );
+    await _settle();
+
+    expect(emitted, hasLength(1));
+  });
+
+  group('scope filtering', () {
+    // Backward compatibility contract: an older host broadcasts change events
+    // with an empty payload, so an absent or empty scope means wildcard and a
+    // new app stays correct against a host that is already running.
+    Future<int> readsFor(Map<String, Object?> payload) async {
+      final client = _FakeRuntimeHostClient();
+      final coalescer = _coalescer();
+      var reads = 0;
+      final subscription = runtimeSnapshotStream<int>(
+        client: client,
+        eventNames: const <String>{'changed'},
+        readSnapshot: () async => ++reads,
+        coalesceKey: 'key',
+        coalescer: coalescer,
+        matchesScope: runtimeScopeMatcher('workspaceId', 'mine'),
+      ).listen((_) {});
+      addTearDown(subscription.cancel);
+      await _settle();
+      reads = 0;
+      client.emit(RuntimeHostEvent('changed', payload));
+      await _settle();
+      return reads;
+    }
+
+    test('ignores an event scoped to another workspace', () async {
+      expect(await readsFor(<String, Object?>{'workspaceId': 'other'}), 0);
+    });
+
+    test('accepts an unscoped event from an older host', () async {
+      expect(await readsFor(const <String, Object?>{}), 1);
+    });
+
+    test('accepts an event scoped to this workspace', () async {
+      expect(await readsFor(<String, Object?>{'workspaceId': 'mine'}), 1);
+    });
+  });
+}
+
+Future<void> _settle([
+  Duration duration = const Duration(milliseconds: 60),
+]) async {
+  await Future<void>.delayed(duration);
+}
+
+final class _FakeRuntimeHostClient implements RuntimeHostClient {
+  final _events = StreamController<RuntimeHostEvent>.broadcast();
+  final responses = <String, Object?>{};
+
+  /// Number of upcoming requests that fail, modelling a torn-down connection.
+  int failNextRequests = 0;
+
+  @override
+  Stream<RuntimeHostEvent> get runtimeEvents => _events.stream;
+
+  @override
+  Future<Object?> runtimeRequest(
+    String type, [
+    Map<String, Object?> payload = const <String, Object?>{},
+    Duration? timeout,
+  ]) async {
+    if (failNextRequests > 0) {
+      failNextRequests -= 1;
+      throw StateError('terminal host connection closed');
+    }
+    return responses[type];
+  }
+
+  void emit(RuntimeHostEvent event) => _events.add(event);
+}

--- a/test/unit/workbench_controller_test.dart
+++ b/test/unit/workbench_controller_test.dart
@@ -42,6 +42,7 @@ part 'workbench_controller_failure_test_cases.dart';
 part 'workbench_controller_create_workspace_test_cases.dart';
 part 'workbench_controller_workspace_graph_test_cases.dart';
 part 'workbench_controller_pinning_test_cases.dart';
+part 'workbench_controller_watcher_recovery_test_cases.dart';
 part 'workbench_controller_view_prefs_test_repository.dart';
 part 'workbench_controller_test_harness.dart';
 
@@ -67,5 +68,6 @@ void main() {
     _registerWorkbenchControllerCreateWorkspaceTests();
     _registerWorkbenchControllerWorkspaceGraphTests();
     _registerWorkbenchControllerPinningTests();
+    _registerWorkbenchControllerWatcherRecoveryTests();
   });
 }

--- a/test/unit/workbench_controller_test_harness.dart
+++ b/test/unit/workbench_controller_test_harness.dart
@@ -606,6 +606,17 @@ class _FakeWorkbenchRepository implements WorkbenchRepository {
     return _tabControllers.containsKey(workspaceId);
   }
 
+  /// Models a runtime watcher dying on a connection error: the stream errors
+  /// and completes, and the next `watchWorkspaceTabs` hands back a fresh one.
+  void killTabWatcher(String workspaceId) {
+    final controller = _tabControllers.remove(workspaceId);
+    if (controller == null) {
+      return;
+    }
+    controller.addError(StateError('terminal host connection closed'));
+    unawaited(controller.close());
+  }
+
   void emitTabs(String workspaceId) {
     _tabControllers[workspaceId]?.add(
       List<WorkspaceTabRecord>.from(

--- a/test/unit/workbench_controller_watcher_recovery_test_cases.dart
+++ b/test/unit/workbench_controller_watcher_recovery_test_cases.dart
@@ -1,0 +1,50 @@
+part of 'workbench_controller_test.dart';
+
+void _registerWorkbenchControllerWatcherRecoveryTests() {
+  test(
+    're-subscribes tabs after a watcher dies on a connection error',
+    () async {
+      // Regression for the permanent freeze reported under orchestration load:
+      // a dead tab watcher used to stay in the subscription map forever, so new
+      // terminals spawned into the workspace were never detected again.
+      await _controller.bootstrap();
+      await _flushUntil(
+        () => _controller.state.workspacesFor(_harness.project.id).isNotEmpty,
+      );
+      final workspace = _controller.state
+          .workspacesFor(_harness.project.id)
+          .single;
+      expect(_harness.workbenchRepository.hasTabWatcher(workspace.id), isTrue);
+
+      _harness.workbenchRepository.killTabWatcher(workspace.id);
+      await _flush();
+
+      // Any workspace change re-runs the subscription pass; without the onDone
+      // cleanup the `containsKey` guard would skip this workspace for good.
+      await _harness.workbenchRepository.upsertWorkspace(workspace);
+      await _flushUntil(
+        () => _harness.workbenchRepository.hasTabWatcher(workspace.id),
+      );
+
+      await _harness.workbenchRepository.upsertWorkspaceTab(
+        WorkspaceTabRecord(
+          id: 'tab-after-recovery',
+          workspaceId: workspace.id,
+          title: 'Terminal 1',
+          createdAt: DateTime.utc(2026, 5, 22),
+          updatedAt: DateTime.utc(2026, 5, 22),
+        ),
+      );
+      await _flushUntil(
+        () => _controller.state
+            .tabsFor(workspace.id)
+            .any((tab) => tab.id == 'tab-after-recovery'),
+      );
+
+      expect(
+        _controller.state.tabsFor(workspace.id).map((tab) => tab.id),
+        contains('tab-after-recovery'),
+      );
+    },
+  );
+}

--- a/test/widget/settings_dialog_interaction_test_cases.dart
+++ b/test/widget/settings_dialog_interaction_test_cases.dart
@@ -424,7 +424,10 @@ void _registerSettingsDialogAdvancedTests() {
       starController: _FakeGitHubStarController(GitHubStarState.hidden),
       extraOverrides: <dynamic>[
         sshTargetRepositoryProvider.overrideWithValue(
-          RuntimeSshTargetRepository(runtimeClient),
+          RuntimeSshTargetRepository(
+            runtimeClient,
+            coalescer: _immediateCoalescer(),
+          ),
         ),
       ],
     );
@@ -503,7 +506,10 @@ void _registerSettingsDialogAdvancedTests() {
       starController: _FakeGitHubStarController(GitHubStarState.hidden),
       extraOverrides: <dynamic>[
         sshTargetRepositoryProvider.overrideWithValue(
-          RuntimeSshTargetRepository(runtimeClient),
+          RuntimeSshTargetRepository(
+            runtimeClient,
+            coalescer: _immediateCoalescer(),
+          ),
         ),
       ],
     );
@@ -558,7 +564,10 @@ void _registerSettingsDialogAdvancedTests() {
       starController: _FakeGitHubStarController(GitHubStarState.hidden),
       extraOverrides: <dynamic>[
         sshTargetRepositoryProvider.overrideWithValue(
-          RuntimeSshTargetRepository(runtimeClient),
+          RuntimeSshTargetRepository(
+            runtimeClient,
+            coalescer: _immediateCoalescer(),
+          ),
         ),
       ],
     );
@@ -614,7 +623,10 @@ void _registerSettingsDialogAdvancedTests() {
       starController: _FakeGitHubStarController(GitHubStarState.hidden),
       extraOverrides: <dynamic>[
         sshTargetRepositoryProvider.overrideWithValue(
-          RuntimeSshTargetRepository(runtimeClient),
+          RuntimeSshTargetRepository(
+            runtimeClient,
+            coalescer: _immediateCoalescer(),
+          ),
         ),
       ],
     );
@@ -668,7 +680,10 @@ void _registerSettingsDialogAdvancedTests() {
       starController: _FakeGitHubStarController(GitHubStarState.hidden),
       extraOverrides: <dynamic>[
         sshTargetRepositoryProvider.overrideWithValue(
-          RuntimeSshTargetRepository(runtimeClient),
+          RuntimeSshTargetRepository(
+            runtimeClient,
+            coalescer: _immediateCoalescer(),
+          ),
         ),
       ],
     );
@@ -722,7 +737,10 @@ void _registerSettingsDialogAdvancedTests() {
       starController: _FakeGitHubStarController(GitHubStarState.hidden),
       extraOverrides: <dynamic>[
         sshTargetRepositoryProvider.overrideWithValue(
-          RuntimeSshTargetRepository(runtimeClient),
+          RuntimeSshTargetRepository(
+            runtimeClient,
+            coalescer: _immediateCoalescer(),
+          ),
         ),
       ],
     );
@@ -752,7 +770,10 @@ void _registerSettingsDialogAdvancedTests() {
       starController: _FakeGitHubStarController(GitHubStarState.hidden),
       extraOverrides: <dynamic>[
         sshTargetRepositoryProvider.overrideWithValue(
-          RuntimeSshTargetRepository(runtimeClient),
+          RuntimeSshTargetRepository(
+            runtimeClient,
+            coalescer: _immediateCoalescer(),
+          ),
         ),
       ],
     );
@@ -781,7 +802,10 @@ void _registerSettingsDialogAdvancedTests() {
       starController: _FakeGitHubStarController(GitHubStarState.hidden),
       extraOverrides: <dynamic>[
         sshTargetRepositoryProvider.overrideWithValue(
-          RuntimeSshTargetRepository(runtimeClient),
+          RuntimeSshTargetRepository(
+            runtimeClient,
+            coalescer: _immediateCoalescer(),
+          ),
         ),
       ],
     );
@@ -831,7 +855,10 @@ void _registerSettingsDialogAdvancedTests() {
       starController: _FakeGitHubStarController(GitHubStarState.hidden),
       extraOverrides: <dynamic>[
         sshTargetRepositoryProvider.overrideWithValue(
-          RuntimeSshTargetRepository(runtimeClient),
+          RuntimeSshTargetRepository(
+            runtimeClient,
+            coalescer: _immediateCoalescer(),
+          ),
         ),
       ],
     );
@@ -880,7 +907,10 @@ void _registerSettingsDialogAdvancedTests() {
       starController: _FakeGitHubStarController(GitHubStarState.hidden),
       extraOverrides: <dynamic>[
         sshTargetRepositoryProvider.overrideWithValue(
-          RuntimeSshTargetRepository(runtimeClient),
+          RuntimeSshTargetRepository(
+            runtimeClient,
+            coalescer: _immediateCoalescer(),
+          ),
         ),
       ],
     );

--- a/test/widget/settings_dialog_test.dart
+++ b/test/widget/settings_dialog_test.dart
@@ -27,6 +27,7 @@ import 'package:alera/src/features/settings/presentation/settings_dialog.dart';
 import 'package:alera/src/features/updater/application/update_service.dart';
 import 'package:alera/src/features/updater/domain/alera_update.dart';
 import 'package:alera/src/features/workbench/infra/terminal_host/terminal_host_protocol.dart';
+import 'package:alera/src/shared/infra/runtime/runtime_change_coalescer.dart';
 import 'package:alera/src/design_system/feedback/alera_color_swatch.dart';
 import 'package:alera/src/design_system/forms/alera_checkbox.dart';
 import 'package:alera/src/design_system/forms/alera_number_field.dart';

--- a/test/widget/settings_dialog_test_harness.dart
+++ b/test/widget/settings_dialog_test_harness.dart
@@ -305,3 +305,12 @@ class _RuntimeRequest {
   final String type;
   final Map<String, Object?> payload;
 }
+
+/// These dialog tests assert UI behavior, not event coalescing, so they drive
+/// the runtime watchers without a debounce window to wait out.
+RuntimeChangeCoalescer _immediateCoalescer() {
+  return RuntimeChangeCoalescer(
+    debounce: Duration.zero,
+    maxDelay: Duration.zero,
+  );
+}


### PR DESCRIPTION
## Summary

Under orchestration load the UI stopped receiving agent updates entirely: finished agents stayed loading and newly spawned agents were never detected in their workspace. The cause is not throughput, it is that the runtime watchers die permanently on the first connection error.

`watchWorkspaces`, `watchWorkspaceTabs`, `watchAll` and three sibling repositories were `async*` generators doing `yield await listX()` inside `await for (event in runtimeEvents)`. When an RPC exceeds the 10s timeout the client tears down the shared socket, that `await` throws, the generator ends and the stream closes. The listeners in `workbench_controller_sync.dart` had no `onError`, and re-subscription is guarded by `containsKey`, so the dead subscription stayed in the map for the rest of the session. Nothing reconnects proactively either (`_connectRuntime` is lazy), so once every watcher died nobody reopened the socket.

## Changes

- New `runtimeSnapshotStream` (`lib/src/shared/infra/runtime/runtime_snapshot_stream.dart`): backed by a `StreamController`, never surfaces an error, never completes on its own, and retries a failed read with exponential backoff. The retry loop doubles as the reconnect driver, and the resulting `runtimeHostConnected` event force-refreshes every other watcher, so one watcher recovering heals the whole tree.
- New `RuntimeChangeCoalescer`: trailing debounce with a `maxDelay` ceiling and in-flight de-duplication, so a burst of change events collapses into one read per key.
- Migrated all six runtime repositories (workbench, projects, ssh targets, linked reviews, project configs, mobile access).
- `onError`/`onDone` guards in `workbench_controller.dart` and `workbench_controller_sync.dart` as a secondary safety net, so a future regression degrades to "re-subscribes on the next project change" instead of "frozen forever".

Scope predicates are already in place (`runtimeScopeMatcher`) and treat an absent or empty scope as wildcard, which is what an older host broadcasts today. The follow-up PR adds the scoped payloads on the Rust side.

## Validation

- `flutter test`: full suite green except the two pre-existing `terminal_runtime_native_test.dart` native PTY failures, confirmed failing on a clean `main` checkout as well.
- `flutter analyze lib test`: no issues.
- `dart run tool/quality/check_max_lines.dart`: ok.
- The controller regression test was verified to fail without the fix (`Bad state: condition was not met`) and pass with it.

## Notes

- `runtime_mobile_access_repository_test.dart` changed from asserting one refetch per event to asserting that a burst coalesces into one; that is the intended behavior change.
- The remote-host dialog widget tests inject a zero-debounce coalescer since they assert UI behavior, not coalescing.