### PR TITLE
fix: stop an RPC timeout from tearing down the shared host connection

### DIFF
--- a/lib/src/features/projects/infra/runtime_project_config_repository.dart
+++ b/lib/src/features/projects/infra/runtime_project_config_repository.dart
@@ -33,7 +33,11 @@ class RuntimeProjectConfigRepository implements ProjectConfigRepository {
   @override
   Future<Map<String, ProjectConfig>> loadAll() async {
     await _ensureReady();
-    final payload = await _client.runtimeRequest('projectConfig.list');
+    final payload = await _client.runtimeRequest(
+      'projectConfig.list',
+      const <String, Object?>{},
+      runtimeSnapshotRequestTimeout,
+    );
     final map = _asMap(payload);
     return <String, ProjectConfig>{
       for (final entry in map.entries)

--- a/lib/src/features/projects/infra/runtime_project_repository.dart
+++ b/lib/src/features/projects/infra/runtime_project_repository.dart
@@ -21,7 +21,11 @@ class RuntimeProjectRepository implements ProjectRepository {
   @override
   Future<List<Project>> listAll() async {
     await _ensureReady();
-    final payload = await _client.runtimeRequest('project.list');
+    final payload = await _client.runtimeRequest(
+      'project.list',
+      const <String, Object?>{},
+      runtimeSnapshotRequestTimeout,
+    );
     return _asList(payload).map(projectFromRuntimeJson).toList(growable: false);
   }
 

--- a/lib/src/features/workbench/infra/runtime_workbench_repository.dart
+++ b/lib/src/features/workbench/infra/runtime_workbench_repository.dart
@@ -25,6 +25,7 @@ class RuntimeWorkbenchRepository implements WorkbenchRepository {
     final payload = await _client.runtimeRequest(
       'workspace.list',
       <String, Object?>{'projectId': projectId},
+      runtimeSnapshotRequestTimeout,
     );
     return _asList(payload).map(_workspaceFromJson).toList(growable: false);
   }
@@ -107,7 +108,7 @@ class RuntimeWorkbenchRepository implements WorkbenchRepository {
     await _ensureReady();
     final payload = await _client.runtimeRequest('tab.list', <String, Object?>{
       'workspaceId': workspaceId,
-    });
+    }, runtimeSnapshotRequestTimeout);
     return _asList(payload).map(_tabFromJson).toList(growable: false);
   }
 

--- a/lib/src/features/workbench/infra/terminal_host/terminal_host_client.dart
+++ b/lib/src/features/workbench/infra/terminal_host/terminal_host_client.dart
@@ -18,20 +18,26 @@ export 'package:alera/src/features/workbench/infra/terminal_host/terminal_host_p
 part 'terminal_host_client_types.dart';
 part 'terminal_host_client_requests.dart';
 part 'terminal_host_client_lifecycle.dart';
+part 'terminal_host_client_heartbeat.dart';
 
 final class SocketTerminalHostClient
+    with _TerminalHostClientHeartbeat
     implements TerminalHostClient, RuntimeHostClient {
   factory SocketTerminalHostClient({
     TerminalHostProcessLauncher? launcher,
     Future<Directory> Function()? applicationSupportDirectory,
     Duration startupTimeout = const Duration(seconds: 8),
     TerminalHostConfig initialConfig = TerminalHostConfig.defaults,
+    Duration heartbeatInterval = _terminalHostHeartbeatInterval,
+    Duration heartbeatTimeout = _terminalHostHeartbeatTimeout,
   }) {
     return SocketTerminalHostClient._(
       launcher ?? DefaultTerminalHostProcessLauncher(),
       applicationSupportDirectory ?? getApplicationSupportDirectory,
       startupTimeout,
       initialConfig,
+      heartbeatInterval,
+      heartbeatTimeout,
     );
   }
 
@@ -40,11 +46,16 @@ final class SocketTerminalHostClient
     this._applicationSupportDirectory,
     this._startupTimeout,
     this._config,
+    this._heartbeatInterval,
+    this._heartbeatTimeout,
   );
 
   final TerminalHostProcessLauncher _launcher;
   final Future<Directory> Function() _applicationSupportDirectory;
   final Duration _startupTimeout;
+  @override
+  final Duration _heartbeatInterval;
+  final Duration _heartbeatTimeout;
   final StreamController<TerminalHostEvent> _events =
       StreamController<TerminalHostEvent>.broadcast();
   final StreamController<RuntimeHostEvent> _runtimeEvents =
@@ -639,6 +650,18 @@ final class SocketTerminalHostClient
     }
   }
 
+  @override
+  Future<void> _sendHeartbeatRequest(_TerminalHostConnection connection) async {
+    await _sendTerminalHostRequest(
+      this,
+      connection,
+      'status.get',
+      const <String, Object?>{},
+      timeout: _heartbeatTimeout,
+    );
+  }
+
+  @override
   void _handleConnectionClosed(
     _TerminalHostConnection connection, [
     Object? error,
@@ -646,6 +669,7 @@ final class SocketTerminalHostClient
     if (connection.isClosed) {
       return;
     }
+    _stopHeartbeatFor(connection);
     connection.completeAuthenticationError(
       StateError('Terminal host connection closed: $error'),
     );
@@ -747,6 +771,7 @@ final class SocketTerminalHostClient
       return;
     }
     _disposed = true;
+    _stopHeartbeat();
     final connections = <_TerminalHostConnection>{};
     if (_terminalConnection case final connection?) {
       connections.add(connection);

--- a/lib/src/features/workbench/infra/terminal_host/terminal_host_client_heartbeat.dart
+++ b/lib/src/features/workbench/infra/terminal_host/terminal_host_client_heartbeat.dart
@@ -1,0 +1,85 @@
+part of 'terminal_host_client.dart';
+
+/// How long to wait between liveness probes once a request has timed out.
+const Duration _terminalHostHeartbeatInterval = Duration(seconds: 15);
+
+/// Probe timeout. Short because `status.get` only checks auth and touches no
+/// storage, so a healthy host answers it immediately even while busy.
+const Duration _terminalHostHeartbeatTimeout = Duration(seconds: 5);
+
+/// Consecutive probe failures before the connection is considered dead. More
+/// than one so a single unlucky probe during a burst does not drop every PTY.
+const int _terminalHostHeartbeatFailureLimit = 3;
+
+/// Liveness probing for a connection whose requests started timing out.
+///
+/// Request timeouts no longer tear down the connection, because terminal and
+/// runtime traffic share it and a saturated host is not a dead one. Socket
+/// events still cover a peer that exits or drops. What is left is a host that
+/// is alive but wedged, and that is what these probes detect.
+mixin _TerminalHostClientHeartbeat {
+  /// Overridable so tests can drive the probe cadence without real waits.
+  Duration get _heartbeatInterval;
+
+  Timer? _heartbeatTimer;
+  _TerminalHostConnection? _heartbeatConnection;
+  int _heartbeatFailures = 0;
+
+  void _noteRequestTimedOut(_TerminalHostConnection connection) {
+    if (connection.isClosed || identical(_heartbeatConnection, connection)) {
+      return;
+    }
+    _stopHeartbeat();
+    _heartbeatConnection = connection;
+    _heartbeatFailures = 0;
+    _heartbeatTimer = Timer.periodic(
+      _heartbeatInterval,
+      (_) => unawaited(_sendHeartbeat(connection)),
+    );
+  }
+
+  void _stopHeartbeat() {
+    _heartbeatTimer?.cancel();
+    _heartbeatTimer = null;
+    _heartbeatConnection = null;
+    _heartbeatFailures = 0;
+  }
+
+  void _stopHeartbeatFor(_TerminalHostConnection connection) {
+    if (identical(_heartbeatConnection, connection)) {
+      _stopHeartbeat();
+    }
+  }
+
+  Future<void> _sendHeartbeat(_TerminalHostConnection connection) async {
+    if (!identical(_heartbeatConnection, connection) || connection.isClosed) {
+      _stopHeartbeatFor(connection);
+      return;
+    }
+    try {
+      await _sendHeartbeatRequest(connection);
+      // The host answered, so it was only slow. Stop probing until the next
+      // timeout suggests otherwise.
+      _stopHeartbeatFor(connection);
+    } on Object {
+      if (!identical(_heartbeatConnection, connection)) {
+        return;
+      }
+      _heartbeatFailures += 1;
+      if (_heartbeatFailures >= _terminalHostHeartbeatFailureLimit) {
+        _stopHeartbeat();
+        _handleConnectionClosed(
+          connection,
+          StateError('Terminal host stopped answering liveness probes.'),
+        );
+      }
+    }
+  }
+
+  Future<void> _sendHeartbeatRequest(_TerminalHostConnection connection);
+
+  void _handleConnectionClosed(
+    _TerminalHostConnection connection, [
+    Object? error,
+  ]);
+}

--- a/lib/src/features/workbench/infra/terminal_host/terminal_host_client_requests.dart
+++ b/lib/src/features/workbench/infra/terminal_host/terminal_host_client_requests.dart
@@ -20,9 +20,13 @@ Future<Object?> _sendTerminalHostRequest(
           identical(pending.completer, completer)) {
         client._pending.remove(id);
       }
-      final error = TerminalHostRequestTimeoutException(type, requestTimeout);
-      client._handleConnectionClosed(connection, error);
-      throw error;
+      // A timeout means one request was slow, not that the socket is dead.
+      // Terminal and runtime traffic share this connection, so tearing it
+      // down here would kill every live PTY and every runtime watcher over a
+      // host that is merely saturated. Real death is reported by the socket
+      // itself, and by the heartbeat for a peer that is alive but wedged.
+      client._noteRequestTimedOut(connection);
+      throw TerminalHostRequestTimeoutException(type, requestTimeout);
     },
   );
   try {

--- a/lib/src/shared/infra/runtime/runtime_snapshot_stream.dart
+++ b/lib/src/shared/infra/runtime/runtime_snapshot_stream.dart
@@ -3,6 +3,14 @@ import 'dart:async';
 import 'package:alera/src/features/workbench/infra/terminal_host/terminal_host_protocol.dart';
 import 'package:alera/src/shared/infra/runtime/runtime_change_coalescer.dart';
 
+/// Timeout for the bulk list calls behind a snapshot stream.
+///
+/// The host actor is single-threaded, so a background refresh legitimately
+/// queues behind a coordinator sweep or a burst of PTY flushes. The default
+/// interactive timeout is too tight for that, and a premature timeout only
+/// buys a retry that queues up again.
+const Duration runtimeSnapshotRequestTimeout = Duration(seconds: 30);
+
 /// Matches an event payload that carries no scope, i.e. every watcher refreshes.
 bool _matchesAnyScope(Map<String, Object?> payload) => true;
 

--- a/test/unit/terminal_host_client_resilience_cases.dart
+++ b/test/unit/terminal_host_client_resilience_cases.dart
@@ -103,7 +103,7 @@ void _registerTerminalHostClientResilienceTests() {
   });
 
   test(
-    'request timeout invalidates the connection before reconnecting',
+    'request timeout fails only that request, not the shared connection',
     () async {
       final tempDir = await Directory.systemTemp.createTemp(
         'alera-host-client-request-timeout-',
@@ -154,13 +154,11 @@ void _registerTerminalHostClientResilienceTests() {
         ),
       );
 
+      // Terminal output and every runtime watcher ride this one socket, so a
+      // slow request must not cost a reconnect: only one `hello` is sent.
+      releaseRequest.complete();
       await client.detach('session-1');
-      expect(server.requestTypes, <String>[
-        'hello',
-        'project.list',
-        'hello',
-        'detach',
-      ]);
+      expect(server.requestTypes, <String>['hello', 'project.list', 'detach']);
     },
   );
 

--- a/test/unit/terminal_host_client_test.dart
+++ b/test/unit/terminal_host_client_test.dart
@@ -9,9 +9,11 @@ import 'package:ghostty_vte_flutter/ghostty_vte_flutter.dart';
 import 'package:path/path.dart' as p;
 
 part 'terminal_host_client_resilience_cases.dart';
+part 'terminal_host_client_timeout_cases.dart';
 
 void main() {
   _registerTerminalHostClientResilienceTests();
+  _registerTerminalHostClientTimeoutTests();
 
   test('connects through launcher and sends lifecycle requests', () async {
     final tempDir = await Directory.systemTemp.createTemp('alera-host-client-');
@@ -1132,6 +1134,7 @@ final class _TerminalHostTestServer {
   StreamSubscription<Socket>? _sub;
   Socket? _client;
   String token = 'existing-token';
+  int acceptedConnections = 0;
 
   int get port => _server.port;
 
@@ -1147,6 +1150,7 @@ final class _TerminalHostTestServer {
   }
 
   void _accept(Socket socket) {
+    acceptedConnections += 1;
     _client = socket;
     socket
         .cast<List<int>>()

--- a/test/unit/terminal_host_client_timeout_cases.dart
+++ b/test/unit/terminal_host_client_timeout_cases.dart
@@ -1,0 +1,122 @@
+part of 'terminal_host_client_test.dart';
+
+Future<SocketTerminalHostClient> _connectedClient(
+  _TerminalHostTestServer server, {
+  Duration heartbeatInterval = const Duration(seconds: 15),
+  Duration heartbeatTimeout = const Duration(seconds: 5),
+}) async {
+  final tempDir = await Directory.systemTemp.createTemp('alera-host-timeout-');
+  addTearDown(() async {
+    if (await tempDir.exists()) {
+      await tempDir.delete(recursive: true);
+    }
+  });
+  await _writeControlFile(
+    tempDir: tempDir,
+    port: server.port,
+    token: 'existing-token',
+  );
+  final client = SocketTerminalHostClient(
+    launcher: _NoopTerminalHostLauncher(),
+    applicationSupportDirectory: () async => tempDir,
+    heartbeatInterval: heartbeatInterval,
+    heartbeatTimeout: heartbeatTimeout,
+  );
+  addTearDown(client.dispose);
+  return client;
+}
+
+void _registerTerminalHostClientTimeoutTests() {
+  test('a sibling request still completes while another times out', () async {
+    final server = await _TerminalHostTestServer.start(
+      beforeResponse: (type) async {
+        if (type == 'slow.request') {
+          await Future<void>.delayed(const Duration(milliseconds: 300));
+        }
+      },
+    );
+    addTearDown(server.dispose);
+    final client = await _connectedClient(server);
+
+    final slow = client.runtimeRequest(
+      'slow.request',
+      const <String, Object?>{},
+      const Duration(milliseconds: 50),
+    );
+    final fast = client.runtimeRequest('status.get');
+
+    await expectLater(
+      slow,
+      throwsA(isA<TerminalHostRequestTimeoutException>()),
+    );
+    await expectLater(fast, completes);
+  });
+
+  test('the connection survives fewer failures than the probe limit', () async {
+    final server = await _TerminalHostTestServer.start(
+      beforeResponse: (type) async {
+        if (type == 'slow.request' || type == 'status.get') {
+          await Future<void>.delayed(const Duration(milliseconds: 200));
+        }
+      },
+    );
+    addTearDown(server.dispose);
+    final client = await _connectedClient(
+      server,
+      heartbeatInterval: const Duration(milliseconds: 30),
+      heartbeatTimeout: const Duration(milliseconds: 20),
+    );
+
+    await expectLater(
+      client.runtimeRequest(
+        'slow.request',
+        const <String, Object?>{},
+        const Duration(milliseconds: 20),
+      ),
+      throwsA(isA<TerminalHostRequestTimeoutException>()),
+    );
+    // Two probe intervals: below the three-failure limit, so no teardown.
+    await Future<void>.delayed(const Duration(milliseconds: 75));
+
+    expect(server.acceptedConnections, 1);
+  });
+
+  test('a wedged host is torn down after the probe limit', () async {
+    // Sockets cannot report a peer that is alive but stuck, so this is the
+    // one case the heartbeat exists for.
+    final server = await _TerminalHostTestServer.start(
+      beforeResponse: (type) async {
+        if (type != 'hello') {
+          await Future<void>.delayed(const Duration(seconds: 5));
+        }
+      },
+    );
+    addTearDown(server.dispose);
+    final client = await _connectedClient(
+      server,
+      heartbeatInterval: const Duration(milliseconds: 20),
+      heartbeatTimeout: const Duration(milliseconds: 15),
+    );
+
+    await expectLater(
+      client.runtimeRequest(
+        'slow.request',
+        const <String, Object?>{},
+        const Duration(milliseconds: 20),
+      ),
+      throwsA(isA<TerminalHostRequestTimeoutException>()),
+    );
+    await Future<void>.delayed(const Duration(milliseconds: 200));
+
+    // The dead connection was dropped, so the next request reconnects.
+    await expectLater(
+      client.runtimeRequest(
+        'status.get',
+        const <String, Object?>{},
+        const Duration(milliseconds: 50),
+      ),
+      throwsA(anything),
+    );
+    expect(server.acceptedConnections, greaterThan(1));
+  });
+}


### PR DESCRIPTION
Stacked on #179.

## Summary

`terminal_host_client_requests.dart` called `_handleConnectionClosed` from its `onTimeout` closure. Terminal output and every runtime watcher share one `_TerminalHostConnection` and one `LineSplitter` (`terminal_host_client.dart:255-276, 532-551`), so a single slow request dropped every live PTY and every watcher. Under orchestration load the host actor is single-threaded and legitimately takes seconds behind a coordinator sweep, so 10s is reachable without anything actually being wrong. This is the trigger for the permanent freeze that #177 makes survivable.

## Changes

- A timeout now fails only its own request. The `TerminalHostRequestTimeoutException` and the pending-entry cleanup are unchanged; the connection teardown is gone. The write-failure path still tears down, since a failed `writeln` is real evidence.
- New `terminal_host_client_heartbeat.dart` part: once a request times out, probe with `status.get` (auth-only, no storage) every 15s with a 5s timeout, and tear the connection down only after 3 consecutive failures. A successful probe stops the probing. This covers the one case sockets cannot report: a peer that is alive but wedged.
- Bulk snapshot reads (`workspace.list`, `tab.list`, `project.list`, `projectConfig.list`) use a 30s `runtimeSnapshotRequestTimeout`. A premature timeout on a background refresh only buys a retry that queues up again.
- `heartbeatInterval` / `heartbeatTimeout` constructor params so tests drive the cadence without real waits.

The model is: **timeouts fail requests, only liveness evidence kills connections.** An adaptive timeout was considered and rejected as harder to test deterministically and as treating the symptom.

## Validation

- `flutter test`: green except the two pre-existing `terminal_runtime_native_test.dart` native PTY failures.
- The existing `request timeout invalidates the connection before reconnecting` test asserted the old behavior (two `hello` frames); it is rewritten to assert the new contract and keeps its exception-shape assertions.
- New cases: a sibling request completes while another times out; two probe failures do not tear down; three do, and the next request reconnects.
- `flutter analyze lib test` and `dart run tool/quality/check_max_lines.dart`: clean. `terminal_host_client.dart` was kept under its 819 baseline by moving the teardown call into the mixin.