### PR TITLE
fix: stop stale host snapshots from resurrecting finished agent runs

### DIFF
--- a/lib/src/features/agent_status/application/agent_status_controller.dart
+++ b/lib/src/features/agent_status/application/agent_status_controller.dart
@@ -2,6 +2,7 @@ import 'package:alera/src/features/agent_status/application/agent_hook_lifecycle
 import 'package:alera/src/features/agent_status/application/agent_status_identity_resolver.dart';
 import 'package:alera/src/features/agent_status/domain/agent_status.dart';
 import 'package:alera/src/features/agent_status/infra/agent_hook_event_normalizer.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -34,9 +35,14 @@ class AgentStatusController extends _$AgentStatusController
   late DateTime Function() _now;
   final AgentHookLifecycleGuard _lifecycleGuard = AgentHookLifecycleGuard();
 
+  /// When a terminal was cleared locally, so a stale host snapshot cannot
+  /// bring its status back.
+  final Map<String, DateTime> _clearedAt = <String, DateTime>{};
+
   @override
   Map<String, AgentStatusEntry> build() {
     _lifecycleGuard.reset();
+    _clearedAt.clear();
     _now = ref.watch(agentStatusClockProvider);
     return const <String, AgentStatusEntry>{};
   }
@@ -155,6 +161,7 @@ class AgentStatusController extends _$AgentStatusController
 
   void clearTerminal(String terminalSessionId) {
     _lifecycleGuard.clearTerminal(terminalSessionId);
+    _clearedAt[terminalSessionId] = _now();
     if (!state.containsKey(terminalSessionId)) {
       return;
     }
@@ -166,19 +173,54 @@ class AgentStatusController extends _$AgentStatusController
   /// Drops every in-memory status entry for a workspace (e.g. after delete).
   void clearWorkspace(String workspaceId) {
     _lifecycleGuard.clearWorkspace(workspaceId);
-    final next = <String, AgentStatusEntry>{
-      for (final entry in state.entries)
-        if (entry.value.workspaceId != workspaceId) entry.key: entry.value,
-    };
+    final clearedAt = _now();
+    final next = <String, AgentStatusEntry>{};
+    for (final entry in state.entries) {
+      if (entry.value.workspaceId == workspaceId) {
+        _clearedAt[entry.key] = clearedAt;
+      } else {
+        next[entry.key] = entry.value;
+      }
+    }
     if (next.length == state.length) {
       return;
     }
     state = next;
   }
 
+  /// Merges the host's presence snapshot over local state.
+  ///
+  /// The host keeps a `working` presence for the life of the PTY when a
+  /// terminating hook never arrives, so a plain replace would resurrect runs
+  /// that [markTerminalExited] or [clearTerminal] already resolved and leave
+  /// them spinning forever. A locally resolved run therefore wins until the
+  /// host reports something genuinely newer.
   void replaceRuntimeSnapshot(Iterable<AgentStatusEntry> entries) {
-    state = <String, AgentStatusEntry>{
-      for (final entry in entries) entry.terminalSessionId: entry,
-    };
+    final next = <String, AgentStatusEntry>{};
+    final reported = <String>{};
+    for (final entry in entries) {
+      reported.add(entry.terminalSessionId);
+      final sessionId = entry.terminalSessionId;
+      if (_clearedAt[sessionId] case final clearedAt?) {
+        if (!entry.updatedAt.isAfter(clearedAt)) {
+          continue;
+        }
+        _clearedAt.remove(sessionId);
+      }
+      final previous = state[sessionId];
+      final resolvedLocally =
+          previous != null &&
+          previous.state == AgentStatusState.done &&
+          entry.state != AgentStatusState.done &&
+          !entry.updatedAt.isAfter(previous.updatedAt);
+      next[sessionId] = resolvedLocally ? previous : entry;
+    }
+    // Only forget a local clear once the host stops reporting that session,
+    // otherwise the very next snapshot would resurrect what was cleared.
+    _clearedAt.removeWhere((sessionId, _) => !reported.contains(sessionId));
+    if (mapEquals(next, state)) {
+      return;
+    }
+    state = next;
   }
 }

--- a/lib/src/features/agent_status/application/runtime_agent_status_sync.dart
+++ b/lib/src/features/agent_status/application/runtime_agent_status_sync.dart
@@ -8,15 +8,22 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'runtime_agent_status_sync.g.dart';
 
+const String _agentPresenceCoalesceKey = 'agentPresence';
+
 @Riverpod(keepAlive: true)
 void runtimeAgentStatusSync(Ref ref) {
   final client = ref.watch(runtimeHostClientProvider);
+  final coalescer = ref.watch(runtimeChangeCoalescerProvider);
   var disposed = false;
+  var generation = 0;
 
   Future<void> refresh() async {
+    final requested = ++generation;
     try {
       final payload = await client.runtimeRequest('agentPresence.list');
-      if (disposed) {
+      // Concurrent refreshes can land out of order, and an older snapshot
+      // would undo a newer one.
+      if (disposed || requested != generation) {
         return;
       }
       final entries = payload is List
@@ -36,13 +43,21 @@ void runtimeAgentStatusSync(Ref ref) {
   }
 
   final subscription = client.runtimeEvents.listen((event) {
-    if (event.name == 'agentPresenceChanged' ||
-        event.name == aleraRuntimeHostConnectedEvent) {
+    // The host broadcasts one event per hook, so an agent working through a
+    // task emits a steady stream of them. Each one costs a full snapshot RPC
+    // plus a rebuild of every listener, hence the coalescing.
+    if (event.name == 'agentPresenceChanged') {
+      coalescer.schedule(_agentPresenceCoalesceKey, refresh);
+    } else if (event.name == aleraRuntimeHostConnectedEvent) {
+      // Reconnecting means the local snapshot may be stale in either
+      // direction, so resync now instead of waiting out the debounce.
+      coalescer.cancel(_agentPresenceCoalesceKey);
       unawaited(refresh());
     }
   });
   ref.onDispose(() {
     disposed = true;
+    coalescer.cancel(_agentPresenceCoalesceKey);
     unawaited(subscription.cancel());
   });
   unawaited(refresh());

--- a/lib/src/features/agent_status/domain/agent_status.dart
+++ b/lib/src/features/agent_status/domain/agent_status.dart
@@ -1,3 +1,8 @@
+import 'package:dart_mappable/dart_mappable.dart';
+
+part 'agent_status.mapper.dart';
+
+@MappableEnum()
 enum AgentStatusState {
   working('working'),
   waiting('waiting'),
@@ -9,6 +14,7 @@ enum AgentStatusState {
   final String key;
 }
 
+@MappableEnum()
 enum AgentType {
   codex('codex'),
   claude('claude'),
@@ -45,7 +51,11 @@ class AgentHookEvent {
   final String? version;
 }
 
-class AgentStatusEntry {
+/// Value equality matters here: the host snapshot rebuilds these on every
+/// presence event, so without it no Riverpod short-circuit can fire and an
+/// unchanged snapshot still rebuilds the sidebar.
+@MappableClass()
+class AgentStatusEntry with AgentStatusEntryMappable {
   const AgentStatusEntry({
     required this.terminalSessionId,
     required this.workspaceId,
@@ -73,40 +83,4 @@ class AgentStatusEntry {
   final String? toolInput;
   final String? lastAssistantMessage;
   final bool? interrupted;
-
-  AgentStatusEntry copyWith({
-    String? terminalSessionId,
-    String? workspaceId,
-    String? tabId,
-    AgentType? agentType,
-    AgentStatusState? state,
-    String? prompt,
-    DateTime? updatedAt,
-    DateTime? stateStartedAt,
-    Object? toolName = _sentinel,
-    Object? toolInput = _sentinel,
-    Object? lastAssistantMessage = _sentinel,
-    Object? interrupted = _sentinel,
-  }) {
-    return AgentStatusEntry(
-      terminalSessionId: terminalSessionId ?? this.terminalSessionId,
-      workspaceId: workspaceId ?? this.workspaceId,
-      tabId: tabId ?? this.tabId,
-      agentType: agentType ?? this.agentType,
-      state: state ?? this.state,
-      prompt: prompt ?? this.prompt,
-      updatedAt: updatedAt ?? this.updatedAt,
-      stateStartedAt: stateStartedAt ?? this.stateStartedAt,
-      toolName: toolName == _sentinel ? this.toolName : toolName as String?,
-      toolInput: toolInput == _sentinel ? this.toolInput : toolInput as String?,
-      lastAssistantMessage: lastAssistantMessage == _sentinel
-          ? this.lastAssistantMessage
-          : lastAssistantMessage as String?,
-      interrupted: interrupted == _sentinel
-          ? this.interrupted
-          : interrupted as bool?,
-    );
-  }
 }
-
-const Object _sentinel = Object();

--- a/lib/src/features/agent_status/domain/agent_status.mapper.dart
+++ b/lib/src/features/agent_status/domain/agent_status.mapper.dart
@@ -1,0 +1,401 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// dart format off
+// ignore_for_file: type=lint
+// ignore_for_file: invalid_use_of_protected_member
+// ignore_for_file: unused_element, unnecessary_cast, override_on_non_overriding_member
+// ignore_for_file: strict_raw_type, inference_failure_on_untyped_parameter
+
+part of 'agent_status.dart';
+
+class AgentStatusStateMapper extends EnumMapper<AgentStatusState> {
+  AgentStatusStateMapper._();
+
+  static AgentStatusStateMapper? _instance;
+  static AgentStatusStateMapper ensureInitialized() {
+    if (_instance == null) {
+      MapperContainer.globals.use(_instance = AgentStatusStateMapper._());
+    }
+    return _instance!;
+  }
+
+  static AgentStatusState fromValue(dynamic value) {
+    ensureInitialized();
+    return MapperContainer.globals.fromValue(value);
+  }
+
+  @override
+  AgentStatusState decode(dynamic value) {
+    switch (value) {
+      case r'working':
+        return AgentStatusState.working;
+      case r'waiting':
+        return AgentStatusState.waiting;
+      case r'blocked':
+        return AgentStatusState.blocked;
+      case r'done':
+        return AgentStatusState.done;
+      default:
+        throw MapperException.unknownEnumValue(value);
+    }
+  }
+
+  @override
+  dynamic encode(AgentStatusState self) {
+    switch (self) {
+      case AgentStatusState.working:
+        return r'working';
+      case AgentStatusState.waiting:
+        return r'waiting';
+      case AgentStatusState.blocked:
+        return r'blocked';
+      case AgentStatusState.done:
+        return r'done';
+    }
+  }
+}
+
+extension AgentStatusStateMapperExtension on AgentStatusState {
+  String toValue() {
+    AgentStatusStateMapper.ensureInitialized();
+    return MapperContainer.globals.toValue<AgentStatusState>(this) as String;
+  }
+}
+
+class AgentTypeMapper extends EnumMapper<AgentType> {
+  AgentTypeMapper._();
+
+  static AgentTypeMapper? _instance;
+  static AgentTypeMapper ensureInitialized() {
+    if (_instance == null) {
+      MapperContainer.globals.use(_instance = AgentTypeMapper._());
+    }
+    return _instance!;
+  }
+
+  static AgentType fromValue(dynamic value) {
+    ensureInitialized();
+    return MapperContainer.globals.fromValue(value);
+  }
+
+  @override
+  AgentType decode(dynamic value) {
+    switch (value) {
+      case r'codex':
+        return AgentType.codex;
+      case r'claude':
+        return AgentType.claude;
+      case r'copilot':
+        return AgentType.copilot;
+      case r'cursor':
+        return AgentType.cursor;
+      case r'agy':
+        return AgentType.agy;
+      case r'opencode':
+        return AgentType.opencode;
+      case r'pi':
+        return AgentType.pi;
+      case r'amp':
+        return AgentType.amp;
+      case r'grok':
+        return AgentType.grok;
+      default:
+        throw MapperException.unknownEnumValue(value);
+    }
+  }
+
+  @override
+  dynamic encode(AgentType self) {
+    switch (self) {
+      case AgentType.codex:
+        return r'codex';
+      case AgentType.claude:
+        return r'claude';
+      case AgentType.copilot:
+        return r'copilot';
+      case AgentType.cursor:
+        return r'cursor';
+      case AgentType.agy:
+        return r'agy';
+      case AgentType.opencode:
+        return r'opencode';
+      case AgentType.pi:
+        return r'pi';
+      case AgentType.amp:
+        return r'amp';
+      case AgentType.grok:
+        return r'grok';
+    }
+  }
+}
+
+extension AgentTypeMapperExtension on AgentType {
+  String toValue() {
+    AgentTypeMapper.ensureInitialized();
+    return MapperContainer.globals.toValue<AgentType>(this) as String;
+  }
+}
+
+class AgentStatusEntryMapper extends ClassMapperBase<AgentStatusEntry> {
+  AgentStatusEntryMapper._();
+
+  static AgentStatusEntryMapper? _instance;
+  static AgentStatusEntryMapper ensureInitialized() {
+    if (_instance == null) {
+      MapperContainer.globals.use(_instance = AgentStatusEntryMapper._());
+      AgentTypeMapper.ensureInitialized();
+      AgentStatusStateMapper.ensureInitialized();
+    }
+    return _instance!;
+  }
+
+  @override
+  final String id = 'AgentStatusEntry';
+
+  static String _$terminalSessionId(AgentStatusEntry v) => v.terminalSessionId;
+  static const Field<AgentStatusEntry, String> _f$terminalSessionId = Field(
+    'terminalSessionId',
+    _$terminalSessionId,
+  );
+  static String _$workspaceId(AgentStatusEntry v) => v.workspaceId;
+  static const Field<AgentStatusEntry, String> _f$workspaceId = Field(
+    'workspaceId',
+    _$workspaceId,
+  );
+  static String _$tabId(AgentStatusEntry v) => v.tabId;
+  static const Field<AgentStatusEntry, String> _f$tabId = Field(
+    'tabId',
+    _$tabId,
+  );
+  static AgentType _$agentType(AgentStatusEntry v) => v.agentType;
+  static const Field<AgentStatusEntry, AgentType> _f$agentType = Field(
+    'agentType',
+    _$agentType,
+  );
+  static AgentStatusState _$state(AgentStatusEntry v) => v.state;
+  static const Field<AgentStatusEntry, AgentStatusState> _f$state = Field(
+    'state',
+    _$state,
+  );
+  static String _$prompt(AgentStatusEntry v) => v.prompt;
+  static const Field<AgentStatusEntry, String> _f$prompt = Field(
+    'prompt',
+    _$prompt,
+  );
+  static DateTime _$updatedAt(AgentStatusEntry v) => v.updatedAt;
+  static const Field<AgentStatusEntry, DateTime> _f$updatedAt = Field(
+    'updatedAt',
+    _$updatedAt,
+  );
+  static DateTime _$stateStartedAt(AgentStatusEntry v) => v.stateStartedAt;
+  static const Field<AgentStatusEntry, DateTime> _f$stateStartedAt = Field(
+    'stateStartedAt',
+    _$stateStartedAt,
+  );
+  static String? _$toolName(AgentStatusEntry v) => v.toolName;
+  static const Field<AgentStatusEntry, String> _f$toolName = Field(
+    'toolName',
+    _$toolName,
+    opt: true,
+  );
+  static String? _$toolInput(AgentStatusEntry v) => v.toolInput;
+  static const Field<AgentStatusEntry, String> _f$toolInput = Field(
+    'toolInput',
+    _$toolInput,
+    opt: true,
+  );
+  static String? _$lastAssistantMessage(AgentStatusEntry v) =>
+      v.lastAssistantMessage;
+  static const Field<AgentStatusEntry, String> _f$lastAssistantMessage = Field(
+    'lastAssistantMessage',
+    _$lastAssistantMessage,
+    opt: true,
+  );
+  static bool? _$interrupted(AgentStatusEntry v) => v.interrupted;
+  static const Field<AgentStatusEntry, bool> _f$interrupted = Field(
+    'interrupted',
+    _$interrupted,
+    opt: true,
+  );
+
+  @override
+  final MappableFields<AgentStatusEntry> fields = const {
+    #terminalSessionId: _f$terminalSessionId,
+    #workspaceId: _f$workspaceId,
+    #tabId: _f$tabId,
+    #agentType: _f$agentType,
+    #state: _f$state,
+    #prompt: _f$prompt,
+    #updatedAt: _f$updatedAt,
+    #stateStartedAt: _f$stateStartedAt,
+    #toolName: _f$toolName,
+    #toolInput: _f$toolInput,
+    #lastAssistantMessage: _f$lastAssistantMessage,
+    #interrupted: _f$interrupted,
+  };
+
+  static AgentStatusEntry _instantiate(DecodingData data) {
+    return AgentStatusEntry(
+      terminalSessionId: data.dec(_f$terminalSessionId),
+      workspaceId: data.dec(_f$workspaceId),
+      tabId: data.dec(_f$tabId),
+      agentType: data.dec(_f$agentType),
+      state: data.dec(_f$state),
+      prompt: data.dec(_f$prompt),
+      updatedAt: data.dec(_f$updatedAt),
+      stateStartedAt: data.dec(_f$stateStartedAt),
+      toolName: data.dec(_f$toolName),
+      toolInput: data.dec(_f$toolInput),
+      lastAssistantMessage: data.dec(_f$lastAssistantMessage),
+      interrupted: data.dec(_f$interrupted),
+    );
+  }
+
+  @override
+  final Function instantiate = _instantiate;
+
+  static AgentStatusEntry fromMap(Map<String, dynamic> map) {
+    return ensureInitialized().decodeMap<AgentStatusEntry>(map);
+  }
+
+  static AgentStatusEntry fromJson(String json) {
+    return ensureInitialized().decodeJson<AgentStatusEntry>(json);
+  }
+}
+
+mixin AgentStatusEntryMappable {
+  String toJson() {
+    return AgentStatusEntryMapper.ensureInitialized()
+        .encodeJson<AgentStatusEntry>(this as AgentStatusEntry);
+  }
+
+  Map<String, dynamic> toMap() {
+    return AgentStatusEntryMapper.ensureInitialized()
+        .encodeMap<AgentStatusEntry>(this as AgentStatusEntry);
+  }
+
+  AgentStatusEntryCopyWith<AgentStatusEntry, AgentStatusEntry, AgentStatusEntry>
+  get copyWith =>
+      _AgentStatusEntryCopyWithImpl<AgentStatusEntry, AgentStatusEntry>(
+        this as AgentStatusEntry,
+        $identity,
+        $identity,
+      );
+  @override
+  String toString() {
+    return AgentStatusEntryMapper.ensureInitialized().stringifyValue(
+      this as AgentStatusEntry,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return AgentStatusEntryMapper.ensureInitialized().equalsValue(
+      this as AgentStatusEntry,
+      other,
+    );
+  }
+
+  @override
+  int get hashCode {
+    return AgentStatusEntryMapper.ensureInitialized().hashValue(
+      this as AgentStatusEntry,
+    );
+  }
+}
+
+extension AgentStatusEntryValueCopy<$R, $Out>
+    on ObjectCopyWith<$R, AgentStatusEntry, $Out> {
+  AgentStatusEntryCopyWith<$R, AgentStatusEntry, $Out>
+  get $asAgentStatusEntry =>
+      $base.as((v, t, t2) => _AgentStatusEntryCopyWithImpl<$R, $Out>(v, t, t2));
+}
+
+abstract class AgentStatusEntryCopyWith<$R, $In extends AgentStatusEntry, $Out>
+    implements ClassCopyWith<$R, $In, $Out> {
+  $R call({
+    String? terminalSessionId,
+    String? workspaceId,
+    String? tabId,
+    AgentType? agentType,
+    AgentStatusState? state,
+    String? prompt,
+    DateTime? updatedAt,
+    DateTime? stateStartedAt,
+    String? toolName,
+    String? toolInput,
+    String? lastAssistantMessage,
+    bool? interrupted,
+  });
+  AgentStatusEntryCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(
+    Then<$Out2, $R2> t,
+  );
+}
+
+class _AgentStatusEntryCopyWithImpl<$R, $Out>
+    extends ClassCopyWithBase<$R, AgentStatusEntry, $Out>
+    implements AgentStatusEntryCopyWith<$R, AgentStatusEntry, $Out> {
+  _AgentStatusEntryCopyWithImpl(super.value, super.then, super.then2);
+
+  @override
+  late final ClassMapperBase<AgentStatusEntry> $mapper =
+      AgentStatusEntryMapper.ensureInitialized();
+  @override
+  $R call({
+    String? terminalSessionId,
+    String? workspaceId,
+    String? tabId,
+    AgentType? agentType,
+    AgentStatusState? state,
+    String? prompt,
+    DateTime? updatedAt,
+    DateTime? stateStartedAt,
+    Object? toolName = $none,
+    Object? toolInput = $none,
+    Object? lastAssistantMessage = $none,
+    Object? interrupted = $none,
+  }) => $apply(
+    FieldCopyWithData({
+      if (terminalSessionId != null) #terminalSessionId: terminalSessionId,
+      if (workspaceId != null) #workspaceId: workspaceId,
+      if (tabId != null) #tabId: tabId,
+      if (agentType != null) #agentType: agentType,
+      if (state != null) #state: state,
+      if (prompt != null) #prompt: prompt,
+      if (updatedAt != null) #updatedAt: updatedAt,
+      if (stateStartedAt != null) #stateStartedAt: stateStartedAt,
+      if (toolName != $none) #toolName: toolName,
+      if (toolInput != $none) #toolInput: toolInput,
+      if (lastAssistantMessage != $none)
+        #lastAssistantMessage: lastAssistantMessage,
+      if (interrupted != $none) #interrupted: interrupted,
+    }),
+  );
+  @override
+  AgentStatusEntry $make(CopyWithData data) => AgentStatusEntry(
+    terminalSessionId: data.get(
+      #terminalSessionId,
+      or: $value.terminalSessionId,
+    ),
+    workspaceId: data.get(#workspaceId, or: $value.workspaceId),
+    tabId: data.get(#tabId, or: $value.tabId),
+    agentType: data.get(#agentType, or: $value.agentType),
+    state: data.get(#state, or: $value.state),
+    prompt: data.get(#prompt, or: $value.prompt),
+    updatedAt: data.get(#updatedAt, or: $value.updatedAt),
+    stateStartedAt: data.get(#stateStartedAt, or: $value.stateStartedAt),
+    toolName: data.get(#toolName, or: $value.toolName),
+    toolInput: data.get(#toolInput, or: $value.toolInput),
+    lastAssistantMessage: data.get(
+      #lastAssistantMessage,
+      or: $value.lastAssistantMessage,
+    ),
+    interrupted: data.get(#interrupted, or: $value.interrupted),
+  );
+
+  @override
+  AgentStatusEntryCopyWith<$R2, AgentStatusEntry, $Out2> $chain<$R2, $Out2>(
+    Then<$Out2, $R2> t,
+  ) => _AgentStatusEntryCopyWithImpl<$R2, $Out2>($value, $cast, t);
+}
+

--- a/test/unit/agent_status_controller_test.dart
+++ b/test/unit/agent_status_controller_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 part 'grok_agent_status_controller_test_cases.dart';
 part 'agy_agent_status_controller_test_cases.dart';
+part 'agent_status_snapshot_test_cases.dart';
 part 'agent_status_controller_test_harness.dart';
 
 void main() {
@@ -38,6 +39,7 @@ void main() {
 
     _registerGrokAgentStatusControllerTests(() => container);
     _registerAgyAgentStatusControllerTests(() => container);
+    _registerAgentStatusSnapshotTests(() => container);
 
     test('normalizes Codex events and preserves state start time', () {
       final controller = container.read(agentStatusControllerProvider.notifier);

--- a/test/unit/agent_status_snapshot_test_cases.dart
+++ b/test/unit/agent_status_snapshot_test_cases.dart
@@ -1,0 +1,128 @@
+part of 'agent_status_controller_test.dart';
+
+AgentStatusEntry _snapshotEntry({
+  String terminalSessionId = 'session-1',
+  AgentStatusState state = AgentStatusState.working,
+  required DateTime updatedAt,
+}) {
+  return AgentStatusEntry(
+    terminalSessionId: terminalSessionId,
+    workspaceId: 'workspace-1',
+    tabId: 'tab-1',
+    agentType: AgentType.codex,
+    state: state,
+    prompt: 'Run tests',
+    updatedAt: updatedAt,
+    stateStartedAt: updatedAt,
+  );
+}
+
+void _registerAgentStatusSnapshotTests(ProviderContainer Function() container) {
+  test('an identical snapshot does not replace the state', () {
+    final controller = container().read(agentStatusControllerProvider.notifier);
+    final at = DateTime.utc(2026, 5, 26, 2);
+
+    controller.replaceRuntimeSnapshot(<AgentStatusEntry>[
+      _snapshotEntry(updatedAt: at),
+    ]);
+    final first = controller.state;
+    controller.replaceRuntimeSnapshot(<AgentStatusEntry>[
+      _snapshotEntry(updatedAt: at),
+    ]);
+
+    // Identity, not just equality: a new map would rebuild every listener.
+    expect(identical(controller.state, first), isTrue);
+  });
+
+  test('a stale snapshot does not resurrect a terminal that exited', () {
+    // The host keeps a working presence for the life of the PTY when a
+    // terminating hook never arrives, which is what left runs spinning
+    // forever under orchestration load. The harness clock starts at 01:00,
+    // so this snapshot predates the local resolution.
+    final controller = container().read(agentStatusControllerProvider.notifier);
+    final at = DateTime.utc(2026, 5, 26, 0, 30);
+    controller.replaceRuntimeSnapshot(<AgentStatusEntry>[
+      _snapshotEntry(updatedAt: at),
+    ]);
+
+    controller.markTerminalExited(
+      workspaceId: 'workspace-1',
+      tabId: 'tab-1',
+      exitCode: 0,
+    );
+    expect(controller.state['session-1']!.state, AgentStatusState.done);
+
+    controller.replaceRuntimeSnapshot(<AgentStatusEntry>[
+      _snapshotEntry(updatedAt: at),
+    ]);
+
+    expect(controller.state['session-1']!.state, AgentStatusState.done);
+  });
+
+  test('a genuinely newer snapshot wins over the local resolution', () {
+    final controller = container().read(agentStatusControllerProvider.notifier);
+    controller.replaceRuntimeSnapshot(<AgentStatusEntry>[
+      _snapshotEntry(updatedAt: DateTime.utc(2026, 5, 26, 0, 30)),
+    ]);
+    controller.markTerminalExited(
+      workspaceId: 'workspace-1',
+      tabId: 'tab-1',
+      exitCode: 0,
+    );
+
+    controller.replaceRuntimeSnapshot(<AgentStatusEntry>[
+      _snapshotEntry(updatedAt: DateTime.utc(2026, 5, 26, 9)),
+    ]);
+
+    expect(controller.state['session-1']!.state, AgentStatusState.working);
+  });
+
+  test('a snapshot does not un-clear a locally cleared terminal', () {
+    final controller = container().read(agentStatusControllerProvider.notifier);
+    final at = DateTime.utc(2026, 5, 26, 0, 30);
+    controller.replaceRuntimeSnapshot(<AgentStatusEntry>[
+      _snapshotEntry(updatedAt: at),
+    ]);
+
+    controller.clearTerminal('session-1');
+    expect(controller.state, isEmpty);
+
+    controller.replaceRuntimeSnapshot(<AgentStatusEntry>[
+      _snapshotEntry(updatedAt: at),
+    ]);
+
+    expect(controller.state, isEmpty);
+  });
+
+  test('a clear is forgotten once the host stops reporting the session', () {
+    final controller = container().read(agentStatusControllerProvider.notifier);
+    controller.replaceRuntimeSnapshot(<AgentStatusEntry>[
+      _snapshotEntry(updatedAt: DateTime.utc(2026, 5, 26, 0, 30)),
+    ]);
+    controller.clearTerminal('session-1');
+
+    controller.replaceRuntimeSnapshot(const <AgentStatusEntry>[]);
+    controller.replaceRuntimeSnapshot(<AgentStatusEntry>[
+      _snapshotEntry(updatedAt: DateTime.utc(2026, 5, 26, 0, 30)),
+    ]);
+
+    expect(controller.state['session-1'], isNotNull);
+  });
+
+  test('unrelated sessions in the snapshot are kept', () {
+    final controller = container().read(agentStatusControllerProvider.notifier);
+    final at = DateTime.utc(2026, 5, 26, 0, 30);
+
+    controller.replaceRuntimeSnapshot(<AgentStatusEntry>[
+      _snapshotEntry(updatedAt: at),
+      _snapshotEntry(terminalSessionId: 'session-2', updatedAt: at),
+    ]);
+    controller.clearTerminal('session-1');
+    controller.replaceRuntimeSnapshot(<AgentStatusEntry>[
+      _snapshotEntry(updatedAt: at),
+      _snapshotEntry(terminalSessionId: 'session-2', updatedAt: at),
+    ]);
+
+    expect(controller.state.keys, <String>['session-2']);
+  });
+}

--- a/test/unit/agent_status_test.dart
+++ b/test/unit/agent_status_test.dart
@@ -1,7 +1,52 @@
 import 'package:alera/src/features/agent_status/domain/agent_status.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+AgentStatusEntry _entry({
+  AgentStatusState state = AgentStatusState.working,
+  String prompt = 'Run tests',
+  String? toolName = 'bash',
+  bool? interrupted,
+}) {
+  final updatedAt = DateTime.utc(2026, 5, 28);
+  return AgentStatusEntry(
+    terminalSessionId: 'session-1',
+    workspaceId: 'workspace-1',
+    tabId: 'tab-1',
+    agentType: AgentType.codex,
+    state: state,
+    prompt: prompt,
+    updatedAt: updatedAt,
+    stateStartedAt: updatedAt,
+    toolName: toolName,
+    interrupted: interrupted,
+  );
+}
+
 void main() {
+  test('AgentStatusEntry compares by value', () {
+    // Without this every host snapshot builds fresh objects, so no Riverpod
+    // short-circuit can fire and an unchanged snapshot rebuilds the sidebar.
+    expect(_entry(), _entry());
+    expect(_entry().hashCode, _entry().hashCode);
+  });
+
+  test('AgentStatusEntry differs when any field differs', () {
+    expect(_entry(), isNot(_entry(state: AgentStatusState.done)));
+    expect(_entry(), isNot(_entry(prompt: 'Other')));
+    expect(_entry(), isNot(_entry(toolName: 'grep')));
+    expect(_entry(), isNot(_entry(interrupted: true)));
+  });
+
+  test('AgentStatusEntry copyWith can null a field explicitly', () {
+    // Guards the migration from the hand-written sentinel to the generated
+    // one: passing null must mean "clear", not "keep".
+    expect(_entry().copyWith(toolName: null).toolName, isNull);
+    expect(
+      _entry(interrupted: true).copyWith(interrupted: null).interrupted,
+      isNull,
+    );
+  });
+
   test('AgentStatusEntry copyWith preserves nullable fields by default', () {
     final updatedAt = DateTime.utc(2026, 5, 28);
     final entry = AgentStatusEntry(


### PR DESCRIPTION
Stacked on #180. This is the fix for "finished agents stayed loading forever".

## Summary

`replaceRuntimeSnapshot` assigned the host snapshot unconditionally, bypassing the lifecycle guard and clobbering the results of `markTerminalExited` and `clearTerminal`. The host's `AgentPresenceRegistry` only drops a presence on PTY exit or respawn, so a `working` presence whose terminating hook never arrived stays `working` for the life of the PTY, and the app could no longer resolve it locally. That is the permanent spinner.

Separately, `AgentStatusEntry` had no `==`/`hashCode` and every snapshot built fresh instances, so no Riverpod equality short-circuit could ever fire: an identical snapshot still rebuilt the sidebar and the workbench view.

## Changes

- `replaceRuntimeSnapshot` merges instead of replacing. A locally resolved (`done`) run wins until the host reports a genuinely newer `updatedAt`, and a locally cleared terminal stays cleared until the host stops reporting that session. It also skips the assignment entirely when the resulting map is equal, so the state object identity is preserved.
- `AgentStatusEntry` and its two enums move to `dart_mappable`, consistent with the other domain models. The generated `copyWith` uses the same sentinel semantics as the hand-written one (`$none` vs the old `_sentinel`), so `copyWith(interrupted: null)` still means "clear"; there is a test pinning that.
- `runtime_agent_status_sync.dart` routes `agentPresenceChanged` through the shared coalescer and adds a monotonic generation guard, since concurrent refreshes could previously land out of order. `runtimeHostConnected` still resyncs immediately.

## Validation

- New `agent_status_snapshot_test_cases.dart`: identical snapshot keeps state identity; a stale snapshot does not resurrect an exited terminal; a genuinely newer one does win; a snapshot does not un-clear a cleared terminal; the clear is forgotten once the host stops reporting the session; unrelated sessions are untouched.
- New equality and explicit-null `copyWith` cases in `agent_status_test.dart`.
- `flutter test`: green except the two pre-existing `terminal_runtime_native_test.dart` native PTY failures.
- `flutter analyze lib test`, `dart run tool/quality/check_max_lines.dart`: clean. `build_runner build -d` run once for the mapper.