### PR TITLE
perf: stop the sidebar from rebuilding and restarting spinners on every change

### DIFF
--- a/lib/src/features/agent_status/application/agent_status_controller.g.dart
+++ b/lib/src/features/agent_status/application/agent_status_controller.g.dart
@@ -184,7 +184,7 @@ final class AgentStatusControllerProvider
 }
 
 String _$agentStatusControllerHash() =>
-    r'f3bfc6d09ab9505fa61907ec93a73c7fd8fabc0b';
+    r'bc43d747e63c722857ed56820689740f12b1ef41';
 
 abstract class _$AgentStatusController
     extends $Notifier<Map<String, AgentStatusEntry>> {

--- a/lib/src/features/agent_status/application/runtime_agent_status_sync.g.dart
+++ b/lib/src/features/agent_status/application/runtime_agent_status_sync.g.dart
@@ -49,4 +49,4 @@ final class RuntimeAgentStatusSyncProvider
 }
 
 String _$runtimeAgentStatusSyncHash() =>
-    r'43b462ed567c1f5f0e004e13c257dc02ac4b23a7';
+    r'ec77ac3b54de7bd33d7f64c5e951c62c43c6bb72';

--- a/lib/src/features/workbench/application/workbench_listing.dart
+++ b/lib/src/features/workbench/application/workbench_listing.dart
@@ -4,8 +4,11 @@ import 'package:alera/src/features/workbench/application/workbench_agent_activit
 import 'package:alera/src/features/workbench/application/workbench_listing_tree.dart';
 import 'package:alera/src/features/workbench/application/workbench_state.dart';
 import 'package:alera/src/features/workbench/application/workbench_workspace_filters.dart';
+import 'package:alera/src/features/workbench/application/workspace_agent_run_groups.dart';
+import 'package:alera/src/features/workbench/application/workspace_agent_status_projection.dart';
 import 'package:alera/src/features/workbench/domain/workbench_view_prefs.dart';
 import 'package:alera/src/features/workbench/domain/workspace.dart';
+import 'package:alera/src/features/workbench/domain/workspace_tab_record.dart';
 
 part 'workbench_sidebar_rows.dart';
 
@@ -194,6 +197,11 @@ List<WorkbenchSidebarRow> buildSidebarRows(
     );
     for (final entry in tree) {
       final indent = baseIndent + entry.depth;
+      final tabs = state.tabsFor(entry.workspace.id);
+      final agentRuns = visibleWorkspaceAgentRuns(
+        tabs: tabs,
+        agentStatuses: agentStatuses,
+      );
       rows.add(
         WorkbenchWorkspaceRow(
           project: projectOf(entry.workspace),
@@ -201,6 +209,11 @@ List<WorkbenchSidebarRow> buildSidebarRows(
           showProjectChip: showProjectChip,
           indent: indent,
           expanded: prefs.expandedWorkspaceIds.contains(entry.workspace.id),
+          agentRuns: agentRuns,
+          agentRunGroups: groupWorkspaceAgentRuns(agentRuns),
+          hasTerminalTabs: tabs.any(
+            (tab) => tab.kind == WorkspaceTabKind.terminal,
+          ),
           visibleChildCount: entry.visibleChildCount,
           childrenCollapsed: entry.childrenCollapsed,
           isPinnedCopy: isPinnedCopy,

--- a/lib/src/features/workbench/application/workbench_providers.dart
+++ b/lib/src/features/workbench/application/workbench_providers.dart
@@ -9,6 +9,7 @@ import 'package:alera/src/features/projects/domain/project.dart';
 import 'package:alera/src/features/settings/application/settings_controller.dart';
 import 'package:alera/src/features/settings/domain/alera_settings.dart';
 import 'package:alera/src/features/workbench/application/workbench_controller.dart';
+import 'package:alera/src/features/workbench/application/workbench_listing.dart';
 import 'package:alera/src/features/workbench/application/workbench_repository.dart';
 import 'package:alera/src/features/workbench/application/workbench_state.dart';
 import 'package:alera/src/features/workbench/application/workbench_view_prefs_repository.dart';
@@ -79,6 +80,44 @@ WorkbenchViewPrefsRepository workbenchViewPrefsRepository(Ref ref) {
 @Riverpod(keepAlive: true)
 SidebarOrderMemory sidebarOrderMemory(Ref ref) {
   return SidebarOrderMemory();
+}
+
+/// The sidebar row list, recomputed once per state change instead of once per
+/// widget rebuild.
+///
+/// `buildSidebarRows` filters and multi-key sorts every workspace, and the
+/// sidebar used to run it inline on every rebuild while also mutating the
+/// order memory during build.
+@Riverpod(keepAlive: true)
+List<WorkbenchSidebarRow> workbenchSidebarRows(Ref ref) {
+  final state = ref.watch(
+    workbenchControllerProvider.select(
+      (state) => (
+        activeWorkspaceId: state.activeWorkspaceId,
+        projects: state.projects,
+        searchQuery: state.searchQuery,
+        tabsByWorkspace: state.tabsByWorkspace,
+        viewPrefs: state.viewPrefs,
+        workspacesByProject: state.workspacesByProject,
+      ),
+    ),
+  );
+  final orderMemory = ref.read(sidebarOrderMemoryProvider);
+  final rows = buildSidebarRows(
+    WorkbenchState(
+      projects: state.projects,
+      workspacesByProject: state.workspacesByProject,
+      tabsByWorkspace: state.tabsByWorkspace,
+      viewPrefs: state.viewPrefs,
+      activeWorkspaceId: state.activeWorkspaceId,
+      searchQuery: state.searchQuery,
+    ),
+    agentStatuses: ref.watch(agentStatusControllerProvider),
+    lastActivityByWorkspaceId: ref.watch(workspaceActivityControllerProvider),
+    previousWorkspaceOrder: orderMemory.order,
+  );
+  orderMemory.order = workspaceOrderOfRows(rows);
+  return rows;
 }
 
 @Riverpod(keepAlive: true)

--- a/lib/src/features/workbench/application/workbench_providers.g.dart
+++ b/lib/src/features/workbench/application/workbench_providers.g.dart
@@ -202,6 +202,74 @@ final class SidebarOrderMemoryProvider
 String _$sidebarOrderMemoryHash() =>
     r'63af5266267a090aad55563c87262c6ea27d6a5b';
 
+/// The sidebar row list, recomputed once per state change instead of once per
+/// widget rebuild.
+///
+/// `buildSidebarRows` filters and multi-key sorts every workspace, and the
+/// sidebar used to run it inline on every rebuild while also mutating the
+/// order memory during build.
+
+@ProviderFor(workbenchSidebarRows)
+final workbenchSidebarRowsProvider = WorkbenchSidebarRowsProvider._();
+
+/// The sidebar row list, recomputed once per state change instead of once per
+/// widget rebuild.
+///
+/// `buildSidebarRows` filters and multi-key sorts every workspace, and the
+/// sidebar used to run it inline on every rebuild while also mutating the
+/// order memory during build.
+
+final class WorkbenchSidebarRowsProvider
+    extends
+        $FunctionalProvider<
+          List<WorkbenchSidebarRow>,
+          List<WorkbenchSidebarRow>,
+          List<WorkbenchSidebarRow>
+        >
+    with $Provider<List<WorkbenchSidebarRow>> {
+  /// The sidebar row list, recomputed once per state change instead of once per
+  /// widget rebuild.
+  ///
+  /// `buildSidebarRows` filters and multi-key sorts every workspace, and the
+  /// sidebar used to run it inline on every rebuild while also mutating the
+  /// order memory during build.
+  WorkbenchSidebarRowsProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'workbenchSidebarRowsProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$workbenchSidebarRowsHash();
+
+  @$internal
+  @override
+  $ProviderElement<List<WorkbenchSidebarRow>> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  List<WorkbenchSidebarRow> create(Ref ref) {
+    return workbenchSidebarRows(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(List<WorkbenchSidebarRow> value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<List<WorkbenchSidebarRow>>(value),
+    );
+  }
+}
+
+String _$workbenchSidebarRowsHash() =>
+    r'f549c71cd45c77050faa6ce3d2908407e9911a01';
+
 @ProviderFor(workspaceActivityRepository)
 final workspaceActivityRepositoryProvider =
     WorkspaceActivityRepositoryProvider._();

--- a/lib/src/features/workbench/application/workbench_sidebar_rows.dart
+++ b/lib/src/features/workbench/application/workbench_sidebar_rows.dart
@@ -4,6 +4,13 @@ part of 'workbench_listing.dart';
 /// [buildSidebarRows] is flat and self-describing.
 sealed class WorkbenchSidebarRow {
   const WorkbenchSidebarRow();
+
+  /// Stable identity for the list element that renders this row.
+  ///
+  /// Rows reorder live as agents change state, so without a key the list
+  /// re-matches elements by index and row content slides between them, which
+  /// restarts in-flight animations and scrambles per-element state.
+  String get key;
 }
 
 class WorkbenchSidebarCollapseTargets {
@@ -44,6 +51,9 @@ class WorkbenchProjectHeaderRow extends WorkbenchSidebarRow {
   final Project project;
   final int workspaceCount;
   final bool collapsed;
+
+  @override
+  String get key => 'project:${project.id}';
 }
 
 class WorkbenchPinnedHeaderRow extends WorkbenchSidebarRow {
@@ -54,6 +64,9 @@ class WorkbenchPinnedHeaderRow extends WorkbenchSidebarRow {
 
   final int workspaceCount;
   final bool collapsed;
+
+  @override
+  String get key => 'pinned-header';
 }
 
 /// Header for the flat "All" section that follows the pinned section when the
@@ -67,6 +80,9 @@ class WorkbenchAllHeaderRow extends WorkbenchSidebarRow {
 
   final int workspaceCount;
   final bool collapsed;
+
+  @override
+  String get key => 'all-header';
 }
 
 class WorkbenchWorkspaceRow extends WorkbenchSidebarRow {
@@ -76,10 +92,22 @@ class WorkbenchWorkspaceRow extends WorkbenchSidebarRow {
     required this.showProjectChip,
     required this.indent,
     required this.expanded,
+    this.agentRuns = const <WorkspaceAgentRun>[],
+    this.agentRunGroups = const <WorkspaceAgentRunGroup>[],
+    this.hasTerminalTabs = false,
     this.visibleChildCount = 0,
     this.childrenCollapsed = false,
     this.isPinnedCopy = false,
   });
+
+  /// Computed here rather than per rebuild in the widget: the row build
+  /// already walks this workspace's tabs and statuses.
+  final List<WorkspaceAgentRun> agentRuns;
+  final List<WorkspaceAgentRunGroup> agentRunGroups;
+  final bool hasTerminalTabs;
+
+  AgentStatusEntry? get aggregateStatus =>
+      agentRuns.isEmpty ? null : agentRuns.first.status;
 
   final Project project;
   final Workspace workspace;
@@ -89,6 +117,12 @@ class WorkbenchWorkspaceRow extends WorkbenchSidebarRow {
   final bool childrenCollapsed;
   final bool isPinnedCopy;
   final int indent;
+
+  // A pinned workspace also appears in the list below, so the section has to
+  // be part of the key or the two copies would share one element.
+  @override
+  String get key =>
+      'workspace:${isPinnedCopy ? 'pinned' : 'all'}:${workspace.id}';
 
   bool get hasVisibleChildren => visibleChildCount > 0;
 }

--- a/lib/src/features/workbench/presentation/project_workbench_sidebar.dart
+++ b/lib/src/features/workbench/presentation/project_workbench_sidebar.dart
@@ -8,7 +8,6 @@ import 'package:alera/src/features/projects/presentation/widgets/sidebar_brand_r
 import 'package:alera/src/features/projects/presentation/widgets/sidebar_collapsed_rail.dart';
 import 'package:alera/src/design_system/buttons/alera_icon_button.dart';
 import 'package:alera/src/design_system/feedback/alera_empty_state.dart';
-import 'package:alera/src/design_system/feedback/alera_status_dot.dart';
 import 'package:alera/src/design_system/feedback/alera_toast.dart';
 import 'package:alera/src/design_system/layout/alera_confirm_dialog.dart';
 import 'package:alera/src/design_system/menus/alera_dropdown_entry.dart';
@@ -16,7 +15,6 @@ import 'package:alera/src/features/agent_status/domain/agent_status.dart';
 import 'package:alera/src/features/agent_status/presentation/agent_identity_icon.dart';
 import 'package:alera/src/features/projects/presentation/widgets/sidebar_resize_handle.dart';
 import 'package:alera/src/features/projects/presentation/widgets/sidebar_search_bar.dart';
-import 'package:alera/src/features/workbench/application/workbench_agent_activity_sort.dart';
 import 'package:alera/src/features/workbench/application/workbench_listing.dart';
 import 'package:alera/src/features/workbench/application/workbench_state.dart';
 import 'package:alera/src/features/workbench/application/workspace_agent_run_groups.dart';
@@ -32,6 +30,7 @@ import 'package:alera/src/features/workbench/presentation/widgets/workspace_agen
 import 'package:alera/src/features/workbench/presentation/workbench_dialog_launchers.dart';
 import 'package:alera/src/features/workbench/presentation/workspace_graph_dialogs.dart';
 import 'package:alera/src/features/workbench/presentation/workspace_graph_indicators.dart';
+import 'package:alera/src/features/workbench/presentation/widgets/agent_run_spinner_scope.dart';
 import 'package:alera/src/features/workbench/presentation/widgets/workbench_sidebar_toolbar.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';

--- a/lib/src/features/workbench/presentation/project_workbench_sidebar_body.dart
+++ b/lib/src/features/workbench/presentation/project_workbench_sidebar_body.dart
@@ -4,9 +4,7 @@ class _SidebarBody extends StatelessWidget {
   const _SidebarBody({
     required this.state,
     required this.controller,
-    required this.agentStatuses,
-    required this.lastActivityByWorkspaceId,
-    required this.orderMemory,
+    required this.rows,
     required this.onOpenWorkspace,
     required this.onOpenWorkspaceFolder,
     required this.onCopyWorkspacePath,
@@ -28,9 +26,7 @@ class _SidebarBody extends StatelessWidget {
 
   final WorkbenchState state;
   final WorkbenchController controller;
-  final Map<String, AgentStatusEntry> agentStatuses;
-  final Map<String, DateTime> lastActivityByWorkspaceId;
-  final SidebarOrderMemory orderMemory;
+  final List<WorkbenchSidebarRow> rows;
   final Future<void> Function(Project project, Workspace workspace)
   onOpenWorkspace;
   final Future<void> Function(Workspace workspace) onOpenWorkspaceFolder;
@@ -54,13 +50,6 @@ class _SidebarBody extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final rows = buildSidebarRows(
-      state,
-      agentStatuses: agentStatuses,
-      lastActivityByWorkspaceId: lastActivityByWorkspaceId,
-      previousWorkspaceOrder: orderMemory.order,
-    );
-    orderMemory.order = workspaceOrderOfRows(rows);
     if (rows.isEmpty) {
       return _EmptyResultsView(query: state.searchQuery);
     }
@@ -71,7 +60,10 @@ class _SidebarBody extends StatelessWidget {
       ),
       itemCount: rows.length,
       itemBuilder: (context, index) {
-        return _buildRow(rows, index);
+        return KeyedSubtree(
+          key: ValueKey<String>(rows[index].key),
+          child: _buildRow(rows, index),
+        );
       },
     );
   }
@@ -119,23 +111,15 @@ class _SidebarBody extends StatelessWidget {
     }
     if (row is WorkbenchWorkspaceRow) {
       final leftPadding = _indentPadding(row.indent);
-      final tabs = state.tabsFor(row.workspace.id);
-      final agentRuns = visibleWorkspaceAgentRuns(
-        tabs: tabs,
-        agentStatuses: agentStatuses,
-      );
-      final hasTerminalTabs = tabs.any(
-        (tab) => tab.kind == WorkspaceTabKind.terminal,
-      );
       return Padding(
         padding: EdgeInsets.only(left: leftPadding, right: AleraTokens.space8),
         child: _WorkspaceRow(
           project: row.project,
           workspace: row.workspace,
-          agentRuns: agentRuns,
-          agentRunGroups: groupWorkspaceAgentRuns(agentRuns),
-          status: agentRuns.isEmpty ? null : agentRuns.first.status,
-          hasTerminalTabs: hasTerminalTabs,
+          agentRuns: row.agentRuns,
+          agentRunGroups: row.agentRunGroups,
+          status: row.aggregateStatus,
+          hasTerminalTabs: row.hasTerminalTabs,
           isActive: row.workspace.id == state.activeWorkspaceId,
           activeTabId: state.activeTabIdByWorkspace[row.workspace.id],
           showProject: row.showProjectChip,

--- a/lib/src/features/workbench/presentation/project_workbench_sidebar_shell.dart
+++ b/lib/src/features/workbench/presentation/project_workbench_sidebar_shell.dart
@@ -48,7 +48,6 @@ class _ProjectWorkbenchSidebarState
       searchQuery: sidebar.searchQuery,
       collapsed: sidebar.collapsed,
     );
-    final orderMemory = ref.read(sidebarOrderMemoryProvider);
     final controller = ref.read(workbenchControllerProvider.notifier);
     final workspaceFolderOpener = ref.read(workspaceFolderOpenerProvider);
     if (state.collapsed) {
@@ -91,43 +90,44 @@ class _ProjectWorkbenchSidebarState
                 ),
                 const Divider(height: 1, color: AleraTokens.borderSubtle),
                 Expanded(
-                  child: state.projects.isEmpty
-                      ? _EmptyProjectsView(onAddProject: _addProject)
-                      : Consumer(
-                          builder: (context, ref, _) {
-                            final agentStatuses = ref.watch(
-                              agentStatusControllerProvider,
-                            );
-                            final lastActivity = ref.watch(
-                              workspaceActivityControllerProvider,
-                            );
-                            return _SidebarBody(
-                              state: state,
-                              controller: controller,
-                              agentStatuses: agentStatuses,
-                              lastActivityByWorkspaceId: lastActivity,
-                              orderMemory: orderMemory,
-                              onOpenWorkspace: _openWorkspace,
-                              onOpenWorkspaceFolder: openWorkspaceFolder,
-                              onCopyWorkspacePath: copyWorkspacePath,
-                              onOpenWorkspaceInBrowser: openWorkspaceInBrowser,
-                              onSleepWorkspace: sleepWorkspace,
-                              onCreateWorkspace: _createWorkspace,
-                              onDeleteWorkspace: _deleteWorkspace,
-                              onRenameProject: _renameProject,
-                              onRemoveProject: _removeProject,
-                              onRenameWorkspace: _renameWorkspace,
-                              onSetWorkspacePinned: _setWorkspacePinned,
-                              onManageWorkspaceTags: _manageWorkspaceTags,
-                              onSetWorkspaceParent: _setWorkspaceParent,
-                              onClearWorkspaceParent: _clearWorkspaceParent,
-                              fileManagerLabel:
-                                  workspaceFolderOpener.fileManagerLabel,
-                              onSelectTerminal: _selectTerminal,
-                              onCloseTerminal: _closeTerminal,
-                            );
-                          },
-                        ),
+                  // One ticker for every agent spinner in the list.
+                  child: AgentRunSpinnerScope(
+                    child: state.projects.isEmpty
+                        ? _EmptyProjectsView(onAddProject: _addProject)
+                        : Consumer(
+                            builder: (context, ref, _) {
+                              // The rows are memoized in a provider, so this only
+                              // rebuilds when the computed list actually changes.
+                              final rows = ref.watch(
+                                workbenchSidebarRowsProvider,
+                              );
+                              return _SidebarBody(
+                                state: state,
+                                controller: controller,
+                                rows: rows,
+                                onOpenWorkspace: _openWorkspace,
+                                onOpenWorkspaceFolder: openWorkspaceFolder,
+                                onCopyWorkspacePath: copyWorkspacePath,
+                                onOpenWorkspaceInBrowser:
+                                    openWorkspaceInBrowser,
+                                onSleepWorkspace: sleepWorkspace,
+                                onCreateWorkspace: _createWorkspace,
+                                onDeleteWorkspace: _deleteWorkspace,
+                                onRenameProject: _renameProject,
+                                onRemoveProject: _removeProject,
+                                onRenameWorkspace: _renameWorkspace,
+                                onSetWorkspacePinned: _setWorkspacePinned,
+                                onManageWorkspaceTags: _manageWorkspaceTags,
+                                onSetWorkspaceParent: _setWorkspaceParent,
+                                onClearWorkspaceParent: _clearWorkspaceParent,
+                                fileManagerLabel:
+                                    workspaceFolderOpener.fileManagerLabel,
+                                onSelectTerminal: _selectTerminal,
+                                onCloseTerminal: _closeTerminal,
+                              );
+                            },
+                          ),
+                  ),
                 ),
                 const Divider(height: 1, color: AleraTokens.borderSubtle),
                 _SidebarFooter(

--- a/lib/src/features/workbench/presentation/project_workbench_workspace_rows.dart
+++ b/lib/src/features/workbench/presentation/project_workbench_workspace_rows.dart
@@ -195,14 +195,18 @@ class _WorkspaceRowState extends State<_WorkspaceRow> {
                         SizedBox.square(
                           dimension: _statusSlotSize,
                           child: Center(
-                            child: widget.status == null
-                                ? AleraStatusDot(
-                                    active: isActive || widget.hasTerminalTabs,
-                                  )
-                                : AgentRunStateIndicator(
-                                    status: widget.status!,
-                                    size: _statusSlotSize - 1,
-                                  ),
+                            // One widget type in this slot regardless of state:
+                            // swapping types here destroyed the element and
+                            // restarted the spinner whenever an agent started
+                            // or finished.
+                            child: AgentRunStateIndicator(
+                              key: const ValueKey<String>(
+                                'workspace-status-glyph',
+                              ),
+                              status: widget.status,
+                              size: _statusSlotSize - 1,
+                              idleDotActive: isActive || widget.hasTerminalTabs,
+                            ),
                           ),
                         ),
                         const SizedBox(width: AleraTokens.space8),

--- a/lib/src/features/workbench/presentation/widgets/agent_run_spinner_scope.dart
+++ b/lib/src/features/workbench/presentation/widgets/agent_run_spinner_scope.dart
@@ -1,0 +1,190 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+
+/// One ticker for every agent spinner under this scope.
+///
+/// A `CircularProgressIndicator` owns a private `AnimationController` and
+/// rebuilds itself every frame, so a sidebar with twenty working agents ran
+/// twenty tickers and twenty per-frame rebuilds. Sharing one animation and
+/// painting it keeps the cost to one ticker and N paints, with no build or
+/// layout work in the list.
+///
+/// The ticker is reference counted by the mounted spinners, so an idle sidebar
+/// schedules no frames at all.
+class AgentRunSpinnerScope extends StatefulWidget {
+  const AgentRunSpinnerScope({super.key, required this.child});
+
+  final Widget child;
+
+  static _AgentRunSpinnerScopeState? _maybeStateOf(BuildContext context) {
+    return context
+        .dependOnInheritedWidgetOfExactType<_AgentRunSpinnerAnimation>()
+        ?.scope;
+  }
+
+  @override
+  State<AgentRunSpinnerScope> createState() => _AgentRunSpinnerScopeState();
+}
+
+class _AgentRunSpinnerScopeState extends State<AgentRunSpinnerScope>
+    with SingleTickerProviderStateMixin {
+  // Built eagerly, never lazily: a `late final` would construct a ticker
+  // inside dispose() when no spinner ever mounted, which is unsafe.
+  late final AnimationController _controller;
+  int _spinners = 0;
+
+  Animation<double> get animation => _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      duration: const Duration(milliseconds: 1400),
+      vsync: this,
+    );
+  }
+
+  void _acquire() {
+    _spinners += 1;
+    if (_spinners == 1 && !_controller.isAnimating) {
+      _controller.repeat();
+    }
+  }
+
+  void _release() {
+    _spinners -= 1;
+    if (_spinners <= 0) {
+      _spinners = 0;
+      _controller.stop();
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return _AgentRunSpinnerAnimation(scope: this, child: widget.child);
+  }
+}
+
+/// A plain [InheritedWidget], deliberately not an `InheritedNotifier`: the
+/// latter rebuilds every dependent on each tick, which is the cost this scope
+/// exists to remove. The scope identity is stable, so dependents never rebuild
+/// and repaint off the shared ticker instead.
+class _AgentRunSpinnerAnimation extends InheritedWidget {
+  const _AgentRunSpinnerAnimation({required this.scope, required super.child});
+
+  final _AgentRunSpinnerScopeState scope;
+
+  @override
+  bool updateShouldNotify(_AgentRunSpinnerAnimation oldWidget) {
+    return !identical(scope, oldWidget.scope);
+  }
+}
+
+/// Indeterminate spinner painted off the nearest [AgentRunSpinnerScope].
+class AgentRunSharedSpinner extends StatefulWidget {
+  const AgentRunSharedSpinner({
+    super.key,
+    required this.size,
+    required this.color,
+    required this.strokeWidth,
+  });
+
+  final double size;
+  final Color color;
+  final double strokeWidth;
+
+  /// Whether a scope is available, so callers outside the sidebar can fall
+  /// back to their own indicator.
+  static bool isAvailable(BuildContext context) {
+    return AgentRunSpinnerScope._maybeStateOf(context) != null;
+  }
+
+  @override
+  State<AgentRunSharedSpinner> createState() => _AgentRunSharedSpinnerState();
+}
+
+class _AgentRunSharedSpinnerState extends State<AgentRunSharedSpinner> {
+  _AgentRunSpinnerScopeState? _scope;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final scope = AgentRunSpinnerScope._maybeStateOf(context);
+    if (identical(scope, _scope)) {
+      return;
+    }
+    _scope?._release();
+    _scope = scope?.._acquire();
+  }
+
+  @override
+  void dispose() {
+    _scope?._release();
+    _scope = null;
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final scope = _scope;
+    if (scope == null) {
+      return SizedBox.square(dimension: widget.size);
+    }
+    return RepaintBoundary(
+      child: CustomPaint(
+        size: Size.square(widget.size),
+        painter: AgentRunSpinnerPainter(
+          progress: scope.animation,
+          color: widget.color,
+          strokeWidth: widget.strokeWidth,
+        ),
+      ),
+    );
+  }
+}
+
+/// Draws the indeterminate arc for one agent run off a shared ticker.
+class AgentRunSpinnerPainter extends CustomPainter {
+  AgentRunSpinnerPainter({
+    required this.progress,
+    required this.color,
+    required this.strokeWidth,
+  }) : super(repaint: progress);
+
+  final Animation<double> progress;
+  final Color color;
+  final double strokeWidth;
+
+  static const double _sweep = 4.7;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final paint = Paint()
+      ..style = PaintingStyle.stroke
+      ..strokeCap = StrokeCap.round
+      ..strokeWidth = strokeWidth
+      ..color = color;
+    final inset = strokeWidth / 2;
+    final rect = Rect.fromLTWH(
+      inset,
+      inset,
+      size.width - strokeWidth,
+      size.height - strokeWidth,
+    );
+    canvas.drawArc(rect, progress.value * 2 * math.pi, _sweep, false, paint);
+  }
+
+  @override
+  bool shouldRepaint(AgentRunSpinnerPainter oldDelegate) {
+    return oldDelegate.color != color ||
+        oldDelegate.strokeWidth != strokeWidth ||
+        !identical(oldDelegate.progress, progress);
+  }
+}

--- a/lib/src/features/workbench/presentation/widgets/agent_run_state_indicator.dart
+++ b/lib/src/features/workbench/presentation/widgets/agent_run_state_indicator.dart
@@ -1,22 +1,39 @@
 import 'package:alera/src/app/theme/alera_tokens.dart';
 import 'package:alera/src/design_system/icons/alera_icons.dart';
 import 'package:alera/src/features/agent_status/domain/agent_status.dart';
+import 'package:alera/src/features/workbench/presentation/widgets/agent_run_spinner_scope.dart';
+import 'package:alera/src/design_system/feedback/alera_status_dot.dart';
 import 'package:flutter/material.dart';
 
 /// Visual state glyph for one agent run: spinner while working, state-colored
 /// icon otherwise. Shared by the sidebar agent rows and the compact summary.
+///
+/// A null [status] renders the idle dot rather than leaving the caller to pick
+/// a different widget. Swapping widget types in a slot destroys the element,
+/// which restarts the spinner from zero every time an agent starts or stops.
 class AgentRunStateIndicator extends StatelessWidget {
   const AgentRunStateIndicator({
     super.key,
     required this.status,
     this.size = 13,
+    this.idleDotActive = false,
   });
 
-  final AgentStatusEntry status;
+  final AgentStatusEntry? status;
   final double size;
+
+  /// Whether the idle dot shown for a null [status] reads as active.
+  final bool idleDotActive;
 
   @override
   Widget build(BuildContext context) {
+    final status = this.status;
+    if (status == null) {
+      return SizedBox.square(
+        dimension: size,
+        child: Center(child: AleraStatusDot(active: idleDotActive)),
+      );
+    }
     final label = agentRunStateLabel(status);
     final color = agentRunStateColor(status);
     return Tooltip(
@@ -25,17 +42,28 @@ class AgentRunStateIndicator extends StatelessWidget {
         label: label,
         child: SizedBox.square(
           dimension: size,
-          child: Center(child: _buildIndicator(color)),
+          child: Center(child: _buildIndicator(context, status, color)),
         ),
       ),
     );
   }
 
-  Widget _buildIndicator(Color color) {
+  Widget _buildIndicator(
+    BuildContext context,
+    AgentStatusEntry status,
+    Color color,
+  ) {
     if (status.state == AgentStatusState.working) {
+      if (AgentRunSharedSpinner.isAvailable(context)) {
+        return AgentRunSharedSpinner(
+          size: size - 2,
+          color: AleraTokens.warning,
+          strokeWidth: 1.7,
+        );
+      }
       return SizedBox.square(
         dimension: size - 2,
-        child: CircularProgressIndicator(
+        child: const CircularProgressIndicator(
           strokeWidth: 1.7,
           color: AleraTokens.warning,
         ),

--- a/test/widget/alera_shell_page_runtime_test_harness.dart
+++ b/test/widget/alera_shell_page_runtime_test_harness.dart
@@ -10,10 +10,15 @@ class _ShellSettingsController extends SettingsController {
 }
 
 class _ShellPumpHarness {
-  const _ShellPumpHarness({required this.controller, required this.runtime});
+  const _ShellPumpHarness({
+    required this.controller,
+    required this.runtime,
+    required this.agentStatus,
+  });
 
   final _ShellTestWorkbenchController controller;
   final _FakeTerminalRuntime runtime;
+  final _ShellTestAgentStatusController agentStatus;
 }
 
 class _FakeTerminalRuntime implements TerminalRuntime {

--- a/test/widget/alera_shell_page_sidebar_identity_test_cases.dart
+++ b/test/widget/alera_shell_page_sidebar_identity_test_cases.dart
@@ -1,0 +1,84 @@
+part of 'alera_shell_page_test.dart';
+
+const Key _statusGlyphKey = ValueKey<String>('workspace-status-glyph');
+
+void _registerAleraShellSidebarIdentityTests() {
+  testWidgets('a workspace row keeps its element when rows reorder', (
+    tester,
+  ) async {
+    // Rows sort by live agent activity, so without stable keys the list
+    // re-matches elements by index and row content slides between them.
+    final state = _stackedWorkbenchState();
+    final harness = await _pumpShell(tester, state: state);
+    final rowKey = ValueKey<String>(
+      'workspace:all:${_firstWorkspaceId(state)}',
+    );
+    final before = tester.element(find.byKey(rowKey));
+
+    harness.agentStatus.setEntries(<String, AgentStatusEntry>{
+      'tab-2': _agentStatusEntry(
+        terminalSessionId: 'tab-2',
+        workspaceId: 'workspace-2',
+        tabId: 'tab-2',
+        state: AgentStatusState.waiting,
+      ),
+    });
+    await tester.pump();
+
+    expect(identical(tester.element(find.byKey(rowKey)), before), isTrue);
+  });
+
+  testWidgets('the status slot keeps its element when an agent starts', (
+    tester,
+  ) async {
+    // Swapping widget types in this slot destroyed the element and restarted
+    // the spinner from zero, which is the stutter under orchestration load.
+    final state = _stackedWorkbenchState();
+    final harness = await _pumpShell(tester, state: state);
+    final before = tester.element(find.byKey(_statusGlyphKey).first);
+
+    harness.agentStatus.setEntries(<String, AgentStatusEntry>{
+      'tab-1': _agentStatusEntry(
+        terminalSessionId: 'tab-1',
+        workspaceId: 'workspace-1',
+        tabId: 'tab-1',
+        state: AgentStatusState.working,
+      ),
+    });
+    await tester.pump();
+
+    expect(
+      identical(tester.element(find.byKey(_statusGlyphKey).first), before),
+      isTrue,
+    );
+  });
+
+  testWidgets('working agents share a single spinner ticker', (tester) async {
+    final state = _stackedWorkbenchState();
+    await _pumpShell(
+      tester,
+      state: state,
+      agentStatuses: <String, AgentStatusEntry>{
+        'tab-1': _agentStatusEntry(
+          terminalSessionId: 'tab-1',
+          workspaceId: 'workspace-1',
+          tabId: 'tab-1',
+          state: AgentStatusState.working,
+        ),
+        'tab-2': _agentStatusEntry(
+          terminalSessionId: 'tab-2',
+          workspaceId: 'workspace-2',
+          tabId: 'tab-2',
+          state: AgentStatusState.working,
+        ),
+      },
+    );
+
+    expect(find.byType(AgentRunSharedSpinner), findsWidgets);
+    expect(find.byType(CircularProgressIndicator), findsNothing);
+  });
+}
+
+String _firstWorkspaceId(WorkbenchState state) {
+  return state.workspacesByProject.values.first.first.id;
+}

--- a/test/widget/alera_shell_page_test.dart
+++ b/test/widget/alera_shell_page_test.dart
@@ -19,6 +19,7 @@ import 'package:alera/src/features/workbench/domain/workbench_layout.dart';
 import 'package:alera/src/features/workbench/domain/workbench_view_prefs.dart';
 import 'package:alera/src/features/workbench/domain/workspace.dart';
 import 'package:alera/src/features/workbench/presentation/terminal_runtime.dart';
+import 'package:alera/src/features/workbench/presentation/widgets/agent_run_spinner_scope.dart';
 import 'package:alera/src/features/workbench/presentation/project_workbench_sidebar.dart';
 import 'package:alera/src/features/workbench/presentation/widgets/workspace_agent_compact_summary.dart';
 import 'package:alera/src/features/workbench/presentation/workspace_workbench_view.dart';
@@ -37,6 +38,7 @@ part 'alera_shell_page_workbench_test_cases.dart';
 part 'alera_shell_page_sidebar_actions_test_cases.dart';
 part 'alera_shell_page_sidebar_states_test_cases.dart';
 part 'alera_shell_page_pinning_test_cases.dart';
+part 'alera_shell_page_sidebar_identity_test_cases.dart';
 
 Future<AleraDatabase> _openMemoryDb() async {
   return AleraDatabase(executor: NativeDatabase.memory());
@@ -58,6 +60,7 @@ Future<_ShellPumpHarness> _pumpShell(
   final settingsController = _ShellSettingsController(
     settings ?? AleraSettings.defaults,
   );
+  final agentStatusController = _ShellTestAgentStatusController(agentStatuses);
   final db = await _openMemoryDb();
   addTearDown(db.close);
 
@@ -66,9 +69,7 @@ Future<_ShellPumpHarness> _pumpShell(
       overrides: [
         aleraDatabaseProvider.overrideWith((ref) async => db),
         workbenchControllerProvider.overrideWith(() => shellController),
-        agentStatusControllerProvider.overrideWith(
-          () => _ShellTestAgentStatusController(agentStatuses),
-        ),
+        agentStatusControllerProvider.overrideWith(() => agentStatusController),
         agentQuotaStateProvider.overrideWith(
           (ref) async =>
               AgentQuotaState.empty(state.activeWorkspace?.hostId ?? 'local'),
@@ -92,7 +93,11 @@ Future<_ShellPumpHarness> _pumpShell(
   );
   await tester.pump();
   await tester.pump(const Duration(milliseconds: 200));
-  return _ShellPumpHarness(controller: shellController, runtime: runtime);
+  return _ShellPumpHarness(
+    controller: shellController,
+    runtime: runtime,
+    agentStatus: agentStatusController,
+  );
 }
 
 void main() {
@@ -100,6 +105,7 @@ void main() {
   _registerAleraShellSidebarActionTests();
   _registerAleraShellSidebarStateTests();
   _registerAleraShellPinningTests();
+  _registerAleraShellSidebarIdentityTests();
 }
 
 WorkbenchState _stackedWorkbenchState() {

--- a/test/widget/alera_shell_page_test_harness.dart
+++ b/test/widget/alera_shell_page_test_harness.dart
@@ -7,6 +7,11 @@ class _ShellTestAgentStatusController extends AgentStatusController {
 
   @override
   Map<String, AgentStatusEntry> build() => _entries;
+
+  /// Drives a live status change after the shell is pumped.
+  void setEntries(Map<String, AgentStatusEntry> entries) {
+    state = entries;
+  }
 }
 
 class _ShellTestWorkbenchController extends WorkbenchController {


### PR DESCRIPTION
Stacked on #181. This is the fix for "the loading spinners stuttered instead of animating".

## Summary

Four separate costs compounded on every agent status change:

1. `project_workbench_sidebar_shell.dart` watched the entire `agentStatusControllerProvider` and `workspaceActivityControllerProvider` maps with no `.select`, and each rebuild re-ran `buildSidebarRows` (filter plus multi-key sort over every workspace) while mutating `orderMemory.order` during build.
2. Each row then recomputed `visibleWorkspaceAgentRuns` and `groupWorkspaceAgentRuns`, a second walk over data `buildSidebarRows` had already visited.
3. The `ListView.builder` had no item keys while `workbench_agent_activity_sort.dart` reorders rows by live activity, so elements were re-matched by index and row content slid between them.
4. The status slot swapped between `AleraStatusDot` and `AgentRunStateIndicator`, changing widget type. That destroys the element and recreates the `CircularProgressIndicator`, restarting its animation at t=0 — and with (3) it happened to many rows at once. Each working run also owned its own repeating ticker.

## Changes

- New `workbenchSidebarRowsProvider`: computes the row list once per state change rather than once per rebuild, and updates the order memory outside build. `WorkbenchWorkspaceRow` now carries its `agentRuns`, `agentRunGroups` and `hasTerminalTabs`, computed in `buildSidebarRows` where the tabs are already being walked.
- `WorkbenchSidebarRow.key` on the sealed hierarchy, applied via `KeyedSubtree` in the item builder. Pinned copies are namespaced separately since a pinned workspace also appears in the list below.
- `AgentRunStateIndicator.status` is nullable and renders the idle dot itself, so the slot holds one widget type in every state.
- New `AgentRunSpinnerScope`: one `AnimationController` shared by every spinner, exposed through a plain `InheritedWidget` (not `InheritedNotifier`, which would rebuild all dependents per tick). Spinners paint via `CustomPaint(repaint: animation)` inside a `RepaintBoundary`, so a tick costs N paints and zero builds. The ticker is reference counted by mounted spinners, so an idle sidebar schedules no frames at all. Callers outside a scope fall back to `CircularProgressIndicator`.

## Validation

- New `alera_shell_page_sidebar_identity_test_cases.dart` asserts element identity, and I verified both cases fail without their fix: removing the `KeyedSubtree` fails the reorder test, and reintroducing the type swap fails the status-slot test.
- `flutter test`: green except the two pre-existing `terminal_runtime_native_test.dart` native PTY failures.
- `flutter analyze lib test`, `dart run tool/quality/check_max_lines.dart`: clean. `build_runner build -d` run once for the new provider.

## Note

An earlier revision ran the shared ticker unconditionally, which hung `pumpAndSettle` across ~45 widget tests. Reference counting fixes that and is also the better runtime behavior.