### PR TITLE
perf: bound terminal scrollback memory with an evicting budget

### DIFF
--- a/integration_test/alera_smoke_flow_test.dart
+++ b/integration_test/alera_smoke_flow_test.dart
@@ -194,6 +194,12 @@ class _E2eTerminalRuntime implements TerminalRuntime {
       .map((session) => session.displayTitle);
 
   @override
+  TerminalSessionHandle? peekSession(String tabId) => _sessions[tabId];
+
+  @override
+  void setActiveWorkspace(String? workspaceId) {}
+
+  @override
   TerminalSessionHandle sessionFor({
     required Workspace workspace,
     required WorkspaceTabRecord tab,

--- a/lib/src/features/settings/domain/alera_settings.dart
+++ b/lib/src/features/settings/domain/alera_settings.dart
@@ -72,6 +72,7 @@ class TerminalSettings with TerminalSettingsMappable {
     this.hostEmptyShutdownDelaySeconds = 30,
     this.hostDetachedSessionShutdownDelaySeconds = 60 * 60,
     this.hostScrollbackBytes = 10 * 1000 * 1000,
+    this.bufferBudgetMegabytes = 256,
     this.keepRuntimeOpenOnAppQuit = false,
     this.loginShell,
   });
@@ -96,6 +97,9 @@ class TerminalSettings with TerminalSettingsMappable {
   final int hostEmptyShutdownDelaySeconds;
   final int hostDetachedSessionShutdownDelaySeconds;
   final int hostScrollbackBytes;
+
+  /// Terminal buffer ceiling; 0 is unbounded. See `TerminalBufferBudget`.
+  final int bufferBudgetMegabytes;
   final bool keepRuntimeOpenOnAppQuit;
 
   /// `null` keeps the platform default resolved by [resolvedLoginShell].

--- a/lib/src/features/settings/domain/alera_settings.mapper.dart
+++ b/lib/src/features/settings/domain/alera_settings.mapper.dart
@@ -455,6 +455,14 @@ class TerminalSettingsMapper extends ClassMapperBase<TerminalSettings> {
     opt: true,
     def: 10 * 1000 * 1000,
   );
+  static int _$bufferBudgetMegabytes(TerminalSettings v) =>
+      v.bufferBudgetMegabytes;
+  static const Field<TerminalSettings, int> _f$bufferBudgetMegabytes = Field(
+    'bufferBudgetMegabytes',
+    _$bufferBudgetMegabytes,
+    opt: true,
+    def: 256,
+  );
   static bool _$keepRuntimeOpenOnAppQuit(TerminalSettings v) =>
       v.keepRuntimeOpenOnAppQuit;
   static const Field<TerminalSettings, bool> _f$keepRuntimeOpenOnAppQuit =
@@ -494,6 +502,7 @@ class TerminalSettingsMapper extends ClassMapperBase<TerminalSettings> {
     #hostDetachedSessionShutdownDelaySeconds:
         _f$hostDetachedSessionShutdownDelaySeconds,
     #hostScrollbackBytes: _f$hostScrollbackBytes,
+    #bufferBudgetMegabytes: _f$bufferBudgetMegabytes,
     #keepRuntimeOpenOnAppQuit: _f$keepRuntimeOpenOnAppQuit,
     #loginShell: _f$loginShell,
   };
@@ -524,6 +533,7 @@ class TerminalSettingsMapper extends ClassMapperBase<TerminalSettings> {
         _f$hostDetachedSessionShutdownDelaySeconds,
       ),
       hostScrollbackBytes: data.dec(_f$hostScrollbackBytes),
+      bufferBudgetMegabytes: data.dec(_f$bufferBudgetMegabytes),
       keepRuntimeOpenOnAppQuit: data.dec(_f$keepRuntimeOpenOnAppQuit),
       loginShell: data.dec(_f$loginShell),
     );
@@ -618,6 +628,7 @@ abstract class TerminalSettingsCopyWith<$R, $In extends TerminalSettings, $Out>
     int? hostEmptyShutdownDelaySeconds,
     int? hostDetachedSessionShutdownDelaySeconds,
     int? hostScrollbackBytes,
+    int? bufferBudgetMegabytes,
     bool? keepRuntimeOpenOnAppQuit,
     bool? loginShell,
   });
@@ -664,6 +675,7 @@ class _TerminalSettingsCopyWithImpl<$R, $Out>
     int? hostEmptyShutdownDelaySeconds,
     int? hostDetachedSessionShutdownDelaySeconds,
     int? hostScrollbackBytes,
+    int? bufferBudgetMegabytes,
     bool? keepRuntimeOpenOnAppQuit,
     Object? loginShell = $none,
   }) => $apply(
@@ -694,6 +706,8 @@ class _TerminalSettingsCopyWithImpl<$R, $Out>
             hostDetachedSessionShutdownDelaySeconds,
       if (hostScrollbackBytes != null)
         #hostScrollbackBytes: hostScrollbackBytes,
+      if (bufferBudgetMegabytes != null)
+        #bufferBudgetMegabytes: bufferBudgetMegabytes,
       if (keepRuntimeOpenOnAppQuit != null)
         #keepRuntimeOpenOnAppQuit: keepRuntimeOpenOnAppQuit,
       if (loginShell != $none) #loginShell: loginShell,
@@ -741,6 +755,10 @@ class _TerminalSettingsCopyWithImpl<$R, $Out>
     hostScrollbackBytes: data.get(
       #hostScrollbackBytes,
       or: $value.hostScrollbackBytes,
+    ),
+    bufferBudgetMegabytes: data.get(
+      #bufferBudgetMegabytes,
+      or: $value.bufferBudgetMegabytes,
     ),
     keepRuntimeOpenOnAppQuit: data.get(
       #keepRuntimeOpenOnAppQuit,

--- a/lib/src/features/settings/presentation/panes/terminal_pane.dart
+++ b/lib/src/features/settings/presentation/panes/terminal_pane.dart
@@ -274,6 +274,21 @@ class TerminalSettingsPane extends StatelessWidget {
                   settings.copyWith(hostScrollbackBytes: value * 1000 * 1000),
                 ),
               ),
+              SettingsIntegerRow(
+                title: 'Terminal Memory Budget',
+                description:
+                    'Ceiling for terminal scrollback held in the app. Over it, '
+                    'terminals you have not looked at recently are unloaded '
+                    'and restored when you return. Their agents keep running. '
+                    'Use 0 for no limit.',
+                value: settings.bufferBudgetMegabytes,
+                min: 0,
+                max: 4096,
+                step: 64,
+                suffix: 'MB',
+                onChanged: (value) =>
+                    onChanged(settings.copyWith(bufferBudgetMegabytes: value)),
+              ),
               SettingsTextRow(
                 title: 'Word Separators',
                 description:

--- a/lib/src/features/shell/presentation/alera_shell_page_body.dart
+++ b/lib/src/features/shell/presentation/alera_shell_page_body.dart
@@ -21,6 +21,7 @@ class _AleraShellPageBodyState extends ConsumerState<_AleraShellPageBody> {
     ref.watch(agentAwakeCoordinatorProvider);
     ref.watch(terminalRuntimeExitCoordinatorProvider);
     ref.watch(workspaceActivityCoordinatorProvider);
+    ref.watch(terminalRuntimeActiveWorkspaceCoordinatorProvider);
     ref.watch(workspaceActivityPersistenceCoordinatorProvider);
     final shell = ref.watch(
       workbenchControllerProvider.select((state) {

--- a/lib/src/features/workbench/application/workbench_providers.dart
+++ b/lib/src/features/workbench/application/workbench_providers.dart
@@ -120,6 +120,19 @@ List<WorkbenchSidebarRow> workbenchSidebarRows(Ref ref) {
   return rows;
 }
 
+/// Keeps the terminal runtime's pinned workspace in sync with the active one,
+/// so the memory budget never evicts a terminal in the workspace being worked
+/// in.
+@Riverpod(keepAlive: true)
+void terminalRuntimeActiveWorkspaceCoordinator(Ref ref) {
+  final runtime = ref.watch(terminalRuntimeProvider);
+  ref.listen<String?>(
+    workbenchControllerProvider.select((state) => state.activeWorkspaceId),
+    (previous, next) => runtime.setActiveWorkspace(next),
+    fireImmediately: true,
+  );
+}
+
 @Riverpod(keepAlive: true)
 WorkspaceActivityRepository workspaceActivityRepository(Ref ref) {
   final dbAsync = ref.watch(aleraDatabaseProvider);

--- a/lib/src/features/workbench/application/workbench_providers.g.dart
+++ b/lib/src/features/workbench/application/workbench_providers.g.dart
@@ -270,6 +270,61 @@ final class WorkbenchSidebarRowsProvider
 String _$workbenchSidebarRowsHash() =>
     r'f549c71cd45c77050faa6ce3d2908407e9911a01';
 
+/// Keeps the terminal runtime's pinned workspace in sync with the active one,
+/// so the memory budget never evicts a terminal in the workspace being worked
+/// in.
+
+@ProviderFor(terminalRuntimeActiveWorkspaceCoordinator)
+final terminalRuntimeActiveWorkspaceCoordinatorProvider =
+    TerminalRuntimeActiveWorkspaceCoordinatorProvider._();
+
+/// Keeps the terminal runtime's pinned workspace in sync with the active one,
+/// so the memory budget never evicts a terminal in the workspace being worked
+/// in.
+
+final class TerminalRuntimeActiveWorkspaceCoordinatorProvider
+    extends $FunctionalProvider<void, void, void>
+    with $Provider<void> {
+  /// Keeps the terminal runtime's pinned workspace in sync with the active one,
+  /// so the memory budget never evicts a terminal in the workspace being worked
+  /// in.
+  TerminalRuntimeActiveWorkspaceCoordinatorProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'terminalRuntimeActiveWorkspaceCoordinatorProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() =>
+      _$terminalRuntimeActiveWorkspaceCoordinatorHash();
+
+  @$internal
+  @override
+  $ProviderElement<void> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  void create(Ref ref) {
+    return terminalRuntimeActiveWorkspaceCoordinator(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(void value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<void>(value),
+    );
+  }
+}
+
+String _$terminalRuntimeActiveWorkspaceCoordinatorHash() =>
+    r'e01d17c5ce70a9aaa04ee477b661703888484b84';
+
 @ProviderFor(workspaceActivityRepository)
 final workspaceActivityRepositoryProvider =
     WorkspaceActivityRepositoryProvider._();

--- a/lib/src/features/workbench/presentation/terminal_buffer_budget.dart
+++ b/lib/src/features/workbench/presentation/terminal_buffer_budget.dart
@@ -1,0 +1,97 @@
+/// Bytes an xterm buffer holds for a given size.
+///
+/// xterm stores 4 `Uint32` per cell (16 bytes), so a fully scrolled 10000-line
+/// terminal at 120 columns is around 19 MB. This is an estimate, not a
+/// measurement: it ignores the capacity rounding in `BufferLine` and any
+/// extended text. That is fine for ordering eviction candidates and holding a
+/// ceiling, and it errs low, which the budget accounts for by evicting until
+/// the estimate is under the limit rather than at it.
+int estimateTerminalBufferBytes({required int lines, required int columns}) {
+  if (lines <= 0 || columns <= 0) {
+    return 0;
+  }
+  return lines * columns * _bytesPerCell;
+}
+
+const int _bytesPerCell = 16;
+
+/// What one live terminal costs and when it was last on screen.
+class TerminalBufferUsage {
+  const TerminalBufferUsage({
+    required this.tabId,
+    required this.bytes,
+    required this.lastVisibleAt,
+  });
+
+  final String tabId;
+  final int bytes;
+
+  /// Null for a handle that has never been visible, which makes it the first
+  /// candidate: nobody is looking at it and nobody was.
+  final DateTime? lastVisibleAt;
+}
+
+/// Picks which terminal buffers to drop so total memory stays under a ceiling.
+///
+/// Eviction detaches a session but never terminates its PTY, so the agent in
+/// that terminal keeps running on the host and its scrollback is restored from
+/// the host snapshot on return. That is what makes a memory ceiling affordable
+/// at all.
+class TerminalBufferBudget {
+  const TerminalBufferBudget({required this.budgetBytes});
+
+  /// Zero or negative means unbounded, matching the "no limit" setting.
+  final int budgetBytes;
+
+  bool get isUnbounded => budgetBytes <= 0;
+
+  /// Least-recently-visible first, stopping as soon as the remaining total
+  /// fits. Pinned tabs are never returned, so the real ceiling is this budget
+  /// plus whatever the active workspace holds.
+  List<String> selectEvictions({
+    required Iterable<TerminalBufferUsage> live,
+    required Set<String> pinnedTabIds,
+  }) {
+    if (isUnbounded) {
+      return const <String>[];
+    }
+    var total = 0;
+    final candidates = <TerminalBufferUsage>[];
+    for (final usage in live) {
+      total += usage.bytes;
+      if (!pinnedTabIds.contains(usage.tabId)) {
+        candidates.add(usage);
+      }
+    }
+    if (total <= budgetBytes || candidates.isEmpty) {
+      return const <String>[];
+    }
+    candidates.sort(_byLeastRecentlyVisible);
+    final evicted = <String>[];
+    for (final usage in candidates) {
+      if (total <= budgetBytes) {
+        break;
+      }
+      evicted.add(usage.tabId);
+      total -= usage.bytes;
+    }
+    return evicted;
+  }
+}
+
+int _byLeastRecentlyVisible(TerminalBufferUsage a, TerminalBufferUsage b) {
+  final left = a.lastVisibleAt;
+  final right = b.lastVisibleAt;
+  if (left == null && right == null) {
+    return a.tabId.compareTo(b.tabId);
+  }
+  // Never visible sorts first: nobody is looking at it and nobody was.
+  if (left == null) {
+    return -1;
+  }
+  if (right == null) {
+    return 1;
+  }
+  final byTime = left.compareTo(right);
+  return byTime != 0 ? byTime : a.tabId.compareTo(b.tabId);
+}

--- a/lib/src/features/workbench/presentation/terminal_runtime.dart
+++ b/lib/src/features/workbench/presentation/terminal_runtime.dart
@@ -6,6 +6,7 @@ import 'dart:io' show File, Platform;
 import 'dart:isolate';
 
 import 'package:alera/src/features/settings/domain/alera_settings.dart';
+import 'package:alera/src/features/workbench/presentation/terminal_buffer_budget.dart';
 import 'package:alera/src/features/workbench/presentation/terminal_link_resolver.dart';
 import 'package:alera/src/features/settings/domain/terminal_theme_catalog.dart';
 import 'package:alera/src/features/workbench/domain/terminal_agent_prompt_injection.dart';
@@ -37,6 +38,8 @@ part 'terminal_runtime_interactive_view.dart';
 part 'terminal_runtime_shell_launches.dart';
 part 'terminal_login_shell_launch.dart';
 part 'terminal_runtime_posix_io.dart';
+part 'terminal_runtime_buffer_accounting.dart';
+part 'terminal_runtime_restore_progress.dart';
 part 'terminal_runtime_testing.dart';
 
 abstract class TerminalSessionHandle extends ChangeNotifier {
@@ -52,6 +55,25 @@ abstract class TerminalSessionHandle extends ChangeNotifier {
   /// own notifier rebuilt the whole terminal view and every tab chip, so the
   /// tab strip listens here instead.
   ValueListenable<String> get titleListenable;
+
+  /// Whether a visibility lease is currently held for this terminal.
+  ///
+  /// Defaulted so the many test doubles of this class do not each have to
+  /// restate budget bookkeeping they have no buffer for.
+  bool get isVisible => false;
+
+  /// Estimated buffer cost and last-visible time, used by the memory budget.
+  TerminalBufferUsage get bufferUsage =>
+      TerminalBufferUsage(tabId: tabId, bytes: 0, lastVisibleAt: null);
+
+  /// Non-null while a restored scrollback snapshot is still being drained.
+  ///
+  /// Returning to an evicted terminal re-fetches its scrollback from the host
+  /// and replays it through the frame batcher, which can take several frames.
+  /// The surface shows a skeleton rather than an empty terminal so the wait
+  /// does not read as lost history.
+  ValueListenable<TerminalRestoreProgress?> get restoreProgress =>
+      _neverRestoring;
 
   bool get isRunning;
 
@@ -95,11 +117,45 @@ abstract interface class TerminalRuntime {
     required WorkspaceTabRecord tab,
   });
 
+  /// The live handle for [tabId], or null. Never creates one.
+  ///
+  /// The tab strip renders a chip for every tab of the active workspace, and
+  /// calling [sessionFor] there built a full handle, with its own xterm
+  /// buffer, for tabs the user never opened.
+  TerminalSessionHandle? peekSession(String tabId);
+
+  /// Pins the active workspace so switching tabs inside the workspace being
+  /// worked in never pays a restore.
+  void setActiveWorkspace(String? workspaceId);
+
   void closeTab(String tabId);
 
   void closeWorkspace(String workspaceId);
 
   void dispose();
+}
+
+/// Shared empty progress for handles that never restore a snapshot.
+final ValueNotifier<TerminalRestoreProgress?> _neverRestoring =
+    ValueNotifier<TerminalRestoreProgress?>(null);
+
+/// How much of a restored snapshot has reached the emulator.
+class TerminalRestoreProgress {
+  const TerminalRestoreProgress({
+    required this.writtenChars,
+    required this.totalChars,
+  });
+
+  final int writtenChars;
+  final int totalChars;
+
+  double get fraction {
+    if (totalChars <= 0) {
+      return 1;
+    }
+    final value = writtenChars / totalChars;
+    return value < 0 ? 0 : (value > 1 ? 1 : value);
+  }
 }
 
 typedef TerminalLaunchEnvironmentBuilder =

--- a/lib/src/features/workbench/presentation/terminal_runtime_buffer_accounting.dart
+++ b/lib/src/features/workbench/presentation/terminal_runtime_buffer_accounting.dart
@@ -1,0 +1,31 @@
+part of 'terminal_runtime.dart';
+
+/// Visibility tracking and buffer-cost estimation for a session handle.
+///
+/// Both feed the memory budget: visibility is what makes a terminal an
+/// eviction candidate, and the estimate is what decides whether it has to go.
+extension _TerminalBufferAccounting on _XtermTerminalSessionHandle {
+  void _syncVisibilityFromLeases() {
+    final visible = _visibilityLeases.isNotEmpty;
+    if (_visible == visible) {
+      return;
+    }
+    _visible = visible;
+    if (visible) {
+      _lastVisibleAt = DateTime.now();
+    }
+    _syncPtyOutputVisibility();
+    _onVisibilityChanged(this);
+  }
+
+  TerminalBufferUsage _estimateBufferUsage() {
+    return TerminalBufferUsage(
+      tabId: tabId,
+      bytes: estimateTerminalBufferBytes(
+        lines: _terminal.buffer.lines.length,
+        columns: _terminal.viewWidth,
+      ),
+      lastVisibleAt: _lastVisibleAt,
+    );
+  }
+}

--- a/lib/src/features/workbench/presentation/terminal_runtime_output_batching.dart
+++ b/lib/src/features/workbench/presentation/terminal_runtime_output_batching.dart
@@ -100,6 +100,7 @@ void _drainSessionTerminalOutputChunk(_XtermTerminalSessionHandle handle) {
     return;
   }
   handle._writeToTerminal(frame.toString());
+  handle._advanceRestore(written);
 }
 
 void _flushSessionTerminalOutputNow(_XtermTerminalSessionHandle handle) {

--- a/lib/src/features/workbench/presentation/terminal_runtime_restore_progress.dart
+++ b/lib/src/features/workbench/presentation/terminal_runtime_restore_progress.dart
@@ -1,0 +1,63 @@
+part of 'terminal_runtime.dart';
+
+/// Restore-progress bookkeeping for a session handle.
+///
+/// A restored snapshot is drained over several frames, so the surface needs
+/// to know how far along it is to show something better than an empty
+/// terminal.
+extension _TerminalRestoreProgressTracking on _XtermTerminalSessionHandle {
+  void _beginRestore(int totalChars) {
+    _restoreTotalChars = totalChars;
+    _restoreWrittenChars = 0;
+    _restoreProgress.value = totalChars <= 0
+        ? null
+        : TerminalRestoreProgress(writtenChars: 0, totalChars: totalChars);
+  }
+
+  void _advanceRestore(int chars) {
+    if (_restoreTotalChars <= 0) {
+      return;
+    }
+    _restoreWrittenChars += chars;
+    if (_restoreWrittenChars >= _restoreTotalChars) {
+      _restoreTotalChars = 0;
+      _restoreWrittenChars = 0;
+      _restoreProgress.value = null;
+      return;
+    }
+    _restoreProgress.value = TerminalRestoreProgress(
+      writtenChars: _restoreWrittenChars,
+      totalChars: _restoreTotalChars,
+    );
+  }
+
+  void _rebuildTerminalFromSnapshot(
+    List<int> data, {
+    required bool resetInteractionModes,
+  }) {
+    if (_disposed) {
+      return;
+    }
+    _clearPendingTerminalOutput();
+    _terminalController.clearSelection();
+    final previousTerminal = _terminal;
+    final viewWidth = previousTerminal.viewWidth;
+    final viewHeight = previousTerminal.viewHeight;
+    _detachTerminal(previousTerminal);
+    _osc8LinkTracker.dispose();
+
+    final nextTerminal = _createTerminal()..resize(viewWidth, viewHeight);
+    _terminal = nextTerminal;
+    _osc8LinkTracker = Osc8TerminalLinkTracker(terminal: nextTerminal);
+    _attachTerminal(nextTerminal);
+    // Scrollback can reach the host's 10 MB cap, and parsing all of it in one
+    // synchronous write blocked the frame that showed the terminal. Go through
+    // the same per-frame batcher as live output instead.
+    final restored = const Utf8Decoder(allowMalformed: true).convert(data);
+    _beginRestore(restored.length);
+    _queueTerminalOutput(restored, bounded: false);
+    if (resetInteractionModes) {
+      _queueTerminalOutput(terminalInteractionModeReset, bounded: false);
+    }
+  }
+}

--- a/lib/src/features/workbench/presentation/terminal_runtime_session_handle.dart
+++ b/lib/src/features/workbench/presentation/terminal_runtime_session_handle.dart
@@ -15,6 +15,7 @@ class _XtermTerminalSessionHandle extends TerminalSessionHandle {
     this._interactionNotice,
     this._osc52Blocked,
     this._onExit,
+    this._onVisibilityChanged,
   ) {
     _terminal = _createTerminal();
     _osc8LinkTracker = Osc8TerminalLinkTracker(terminal: _terminal);
@@ -37,6 +38,10 @@ class _XtermTerminalSessionHandle extends TerminalSessionHandle {
   final void Function(String message, {bool error})? _interactionNotice;
   final VoidCallback _osc52Blocked;
   final void Function(TerminalRuntimeExitEvent event) _onExit;
+
+  /// Lets the runtime re-run the memory budget when a terminal stops being
+  /// visible, which is the only moment a new eviction candidate appears.
+  final void Function(_XtermTerminalSessionHandle handle) _onVisibilityChanged;
   TerminalSettings _settings;
   late xterm.Terminal _terminal;
   late Osc8TerminalLinkTracker _osc8LinkTracker;
@@ -81,6 +86,10 @@ class _XtermTerminalSessionHandle extends TerminalSessionHandle {
   );
   String? _errorMessage;
   bool _visible = false;
+  DateTime? _lastVisibleAt;
+  final ValueNotifier<TerminalRestoreProgress?> _restoreProgress =
+      ValueNotifier<TerminalRestoreProgress?>(null);
+  int _restoreTotalChars = 0, _restoreWrittenChars = 0;
   bool _pendingInteractionModeReset = false;
   bool _disposed = false;
 
@@ -95,6 +104,16 @@ class _XtermTerminalSessionHandle extends TerminalSessionHandle {
   @override
   @override
   ValueListenable<String> get titleListenable => _titleNotifier;
+
+  @override
+  bool get isVisible => _visible;
+
+  @override
+  ValueListenable<TerminalRestoreProgress?> get restoreProgress =>
+      _restoreProgress;
+
+  @override
+  TerminalBufferUsage get bufferUsage => _estimateBufferUsage();
 
   @override
   String get displayTitle {
@@ -522,41 +541,20 @@ class _XtermTerminalSessionHandle extends TerminalSessionHandle {
 
   void _flushPendingTerminalOutputNow() => _flushSessionTerminalOutputNow(this);
 
-  void _clearPendingTerminalOutput() {
-    _pendingTerminalOutput.clear();
-    _pendingTerminalOutputLength = 0;
-  }
-
   void _replaceTerminalWithSnapshot(
     List<int> data, {
     required bool resetInteractionModes,
   }) {
-    if (_disposed) {
-      return;
-    }
-    _clearPendingTerminalOutput();
-    _terminalController.clearSelection();
-    final previousTerminal = _terminal;
-    final viewWidth = previousTerminal.viewWidth;
-    final viewHeight = previousTerminal.viewHeight;
-    _detachTerminal(previousTerminal);
-    _osc8LinkTracker.dispose();
-
-    final nextTerminal = _createTerminal()..resize(viewWidth, viewHeight);
-    _terminal = nextTerminal;
-    _osc8LinkTracker = Osc8TerminalLinkTracker(terminal: nextTerminal);
-    _attachTerminal(nextTerminal);
-    // Scrollback can reach the host's 10 MB cap, and parsing all of it in one
-    // synchronous write blocked the frame that showed the terminal. Go through
-    // the same per-frame batcher as live output instead.
-    _queueTerminalOutput(
-      const Utf8Decoder(allowMalformed: true).convert(data),
-      bounded: false,
+    _rebuildTerminalFromSnapshot(
+      data,
+      resetInteractionModes: resetInteractionModes,
     );
-    if (resetInteractionModes) {
-      _queueTerminalOutput(terminalInteractionModeReset, bounded: false);
-    }
     notifyListeners();
+  }
+
+  void _clearPendingTerminalOutput() {
+    _pendingTerminalOutput.clear();
+    _pendingTerminalOutputLength = 0;
   }
 
   void _syncPtyOutputVisibility() {
@@ -582,15 +580,6 @@ class _XtermTerminalSessionHandle extends TerminalSessionHandle {
     _errorMessage = message;
     _running = false;
     notifyListeners();
-  }
-
-  void _syncVisibilityFromLeases() {
-    final visible = _visibilityLeases.isNotEmpty;
-    if (_visible == visible) {
-      return;
-    }
-    _visible = visible;
-    _syncPtyOutputVisibility();
   }
 
   Future<void> _stopPtySession({required bool suppressExit}) async {
@@ -660,6 +649,7 @@ class _XtermTerminalSessionHandle extends TerminalSessionHandle {
     _scrollController.dispose();
     _focusNode.dispose();
     _titleNotifier.dispose();
+    _restoreProgress.dispose();
     super.dispose();
   }
 

--- a/lib/src/features/workbench/presentation/terminal_runtime_xterm_runtime.dart
+++ b/lib/src/features/workbench/presentation/terminal_runtime_xterm_runtime.dart
@@ -50,6 +50,7 @@ class XtermTerminalRuntime implements TerminalRuntime {
   final TerminalClipboard _terminalClipboard;
   final void Function(String message, {bool error})? _interactionNotice;
   TerminalSettings _settings;
+  String? _activeWorkspaceId;
   final StreamController<TerminalRuntimeExitEvent> _exitController =
       StreamController<TerminalRuntimeExitEvent>.broadcast();
   final Map<String, _XtermTerminalSessionHandle> _sessions =
@@ -64,6 +65,9 @@ class XtermTerminalRuntime implements TerminalRuntime {
     for (final session in _sessions.values) {
       session.applySettings(settings);
     }
+    // Lowering the budget in settings has to take effect now, not at the next
+    // workspace switch.
+    _enforceBufferBudget();
   }
 
   @override
@@ -87,9 +91,63 @@ class XtermTerminalRuntime implements TerminalRuntime {
             _interactionNotice,
             _notifyOsc52Blocked,
             _handleSessionExit,
+            _handleVisibilityChanged,
           );
         })
         .sync(workspace: workspace, tab: tab);
+  }
+
+  @override
+  TerminalSessionHandle? peekSession(String tabId) => _sessions[tabId];
+
+  @override
+  void setActiveWorkspace(String? workspaceId) {
+    if (_activeWorkspaceId == workspaceId) {
+      return;
+    }
+    _activeWorkspaceId = workspaceId;
+    _enforceBufferBudget();
+  }
+
+  void _handleVisibilityChanged(_XtermTerminalSessionHandle handle) {
+    if (handle.isVisible) {
+      return;
+    }
+    // A terminal going off screen is the only moment a new eviction candidate
+    // appears, so this is the sweep trigger rather than a timer.
+    _enforceBufferBudget();
+  }
+
+  /// Detaches the coldest terminals until the estimated buffer total fits.
+  ///
+  /// Eviction never terminates the PTY, so the agent keeps running on the host
+  /// and the scrollback is restored from the host snapshot on return.
+  void _enforceBufferBudget() {
+    final budget = TerminalBufferBudget(
+      budgetBytes: _settings.bufferBudgetMegabytes * 1024 * 1024,
+    );
+    if (budget.isUnbounded || _sessions.isEmpty) {
+      return;
+    }
+    final pinned = <String>{
+      for (final entry in _sessions.entries)
+        if (entry.value.isVisible ||
+            (_activeWorkspaceId != null &&
+                entry.value.workspaceId == _activeWorkspaceId))
+          entry.key,
+    };
+    final evictions = budget.selectEvictions(
+      live: <TerminalBufferUsage>[
+        for (final session in _sessions.values) session.bufferUsage,
+      ],
+      pinnedTabIds: pinned,
+    );
+    for (final tabId in evictions) {
+      final session = _sessions.remove(tabId);
+      if (session != null) {
+        _disposeSession(session, terminatePty: false);
+      }
+    }
   }
 
   void _notifyOsc52Blocked() {

--- a/lib/src/features/workbench/presentation/terminal_surface.dart
+++ b/lib/src/features/workbench/presentation/terminal_surface.dart
@@ -117,9 +117,52 @@ class _TerminalSurfaceState extends ConsumerState<TerminalSurface> {
                   child: CircularProgressIndicator(strokeWidth: 1.5),
                 ),
               ),
+            // Restoring an evicted terminal replays its whole scrollback over
+            // several frames. The corner spinner does not read as a wait that
+            // long, so cover the area until the history is back.
+            Positioned.fill(
+              child: ValueListenableBuilder<TerminalRestoreProgress?>(
+                valueListenable: widget.session.restoreProgress,
+                builder: (context, progress, _) {
+                  if (progress == null) {
+                    return const SizedBox.shrink();
+                  }
+                  return _TerminalRestoreState(progress: progress);
+                },
+              ),
+            ),
           ],
         );
       },
+    );
+  }
+}
+
+class _TerminalRestoreState extends StatelessWidget {
+  const _TerminalRestoreState({required this.progress});
+
+  final TerminalRestoreProgress progress;
+
+  @override
+  Widget build(BuildContext context) {
+    return DecoratedBox(
+      decoration: const BoxDecoration(color: AleraTokens.bg),
+      child: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            Text(
+              'Restoring Terminal',
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
+            const SizedBox(height: AleraTokens.space12),
+            SizedBox(
+              width: 180,
+              child: LinearProgressIndicator(value: progress.fraction),
+            ),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/lib/src/features/workbench/presentation/workspace_workbench_tab_chips.dart
+++ b/lib/src/features/workbench/presentation/workspace_workbench_tab_chips.dart
@@ -33,12 +33,18 @@ class _DraggableWorkspaceTabChip extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    // peek, not sessionFor: building a handle here allocated a full xterm
+    // buffer for every tab of the active workspace, including ones the user
+    // never opened. Selecting the tab is what actually needs a session.
     final session = tab.kind == WorkspaceTabKind.terminal
-        ? terminalRuntime.sessionFor(workspace: workspace, tab: tab)
+        ? terminalRuntime.peekSession(tab.id)
         : null;
     void selectAndFocus() {
       onSelect();
-      session?.requestFocus();
+      if (tab.kind != WorkspaceTabKind.terminal) {
+        return;
+      }
+      terminalRuntime.sessionFor(workspace: workspace, tab: tab).requestFocus();
     }
 
     return Padding(

--- a/test/unit/app_providers_terminal_fakes.dart
+++ b/test/unit/app_providers_terminal_fakes.dart
@@ -32,6 +32,12 @@ class _FakeTerminalRuntime implements TerminalRuntime {
   }) {
     throw UnimplementedError();
   }
+
+  @override
+  TerminalSessionHandle? peekSession(String tabId) => null;
+
+  @override
+  void setActiveWorkspace(String? workspaceId) {}
 }
 
 class _FocusableTerminalRuntime implements TerminalRuntime {
@@ -52,6 +58,12 @@ class _FocusableTerminalRuntime implements TerminalRuntime {
   void dispose() {
     _events.close();
   }
+
+  @override
+  TerminalSessionHandle? peekSession(String tabId) => null;
+
+  @override
+  void setActiveWorkspace(String? workspaceId) {}
 
   @override
   TerminalSessionHandle sessionFor({

--- a/test/unit/terminal_buffer_budget_test.dart
+++ b/test/unit/terminal_buffer_budget_test.dart
@@ -1,0 +1,168 @@
+import 'package:alera/src/features/workbench/presentation/terminal_buffer_budget.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+const int _mb = 1024 * 1024;
+
+TerminalBufferUsage _usage(
+  String tabId, {
+  required int megabytes,
+  DateTime? lastVisibleAt,
+}) {
+  return TerminalBufferUsage(
+    tabId: tabId,
+    bytes: megabytes * _mb,
+    lastVisibleAt: lastVisibleAt,
+  );
+}
+
+void main() {
+  group('estimateTerminalBufferBytes', () {
+    test('scales with lines and columns at 16 bytes per cell', () {
+      expect(estimateTerminalBufferBytes(lines: 10, columns: 4), 640);
+      expect(estimateTerminalBufferBytes(lines: 20, columns: 4), 1280);
+      expect(estimateTerminalBufferBytes(lines: 10, columns: 8), 1280);
+    });
+
+    test('a default terminal lands in the tens of megabytes', () {
+      // The number that motivates the whole budget: 10000 lines at 120
+      // columns is ~19 MB for a single terminal.
+      final bytes = estimateTerminalBufferBytes(lines: 10000, columns: 120);
+      expect(bytes ~/ _mb, inInclusiveRange(15, 25));
+    });
+
+    test('degenerate sizes cost nothing', () {
+      expect(estimateTerminalBufferBytes(lines: 0, columns: 120), 0);
+      expect(estimateTerminalBufferBytes(lines: 100, columns: 0), 0);
+      expect(estimateTerminalBufferBytes(lines: -1, columns: -1), 0);
+    });
+  });
+
+  group('TerminalBufferBudget', () {
+    final now = DateTime.utc(2026, 7, 25, 12);
+
+    test('evicts nothing while the total fits', () {
+      const budget = TerminalBufferBudget(budgetBytes: 100 * _mb);
+
+      expect(
+        budget.selectEvictions(
+          live: <TerminalBufferUsage>[
+            _usage('a', megabytes: 20, lastVisibleAt: now),
+            _usage('b', megabytes: 20, lastVisibleAt: now),
+          ],
+          pinnedTabIds: const <String>{},
+        ),
+        isEmpty,
+      );
+    });
+
+    test('evicts least recently visible first, and only enough to fit', () {
+      const budget = TerminalBufferBudget(budgetBytes: 50 * _mb);
+
+      final evicted = budget.selectEvictions(
+        live: <TerminalBufferUsage>[
+          _usage('newest', megabytes: 20, lastVisibleAt: now),
+          _usage(
+            'oldest',
+            megabytes: 20,
+            lastVisibleAt: now.subtract(const Duration(hours: 2)),
+          ),
+          _usage(
+            'middle',
+            megabytes: 20,
+            lastVisibleAt: now.subtract(const Duration(hours: 1)),
+          ),
+        ],
+        pinnedTabIds: const <String>{},
+      );
+
+      // 60 MB over a 50 MB budget: dropping the oldest alone gets under it.
+      expect(evicted, <String>['oldest']);
+    });
+
+    test('a handle that was never visible is the first candidate', () {
+      const budget = TerminalBufferBudget(budgetBytes: 30 * _mb);
+
+      final evicted = budget.selectEvictions(
+        live: <TerminalBufferUsage>[
+          _usage(
+            'seen-long-ago',
+            megabytes: 20,
+            lastVisibleAt: now.subtract(const Duration(days: 1)),
+          ),
+          _usage('never-seen', megabytes: 20),
+        ],
+        pinnedTabIds: const <String>{},
+      );
+
+      expect(evicted, <String>['never-seen']);
+    });
+
+    test('never evicts a pinned tab, even when that leaves it over', () {
+      // The active workspace is pinned, so the real ceiling is the budget plus
+      // whatever it holds. This test states that tradeoff explicitly.
+      const budget = TerminalBufferBudget(budgetBytes: 10 * _mb);
+
+      final evicted = budget.selectEvictions(
+        live: <TerminalBufferUsage>[
+          _usage(
+            'pinned',
+            megabytes: 40,
+            lastVisibleAt: now.subtract(const Duration(days: 1)),
+          ),
+          _usage('cold', megabytes: 5, lastVisibleAt: now),
+        ],
+        pinnedTabIds: const <String>{'pinned'},
+      );
+
+      expect(evicted, <String>['cold']);
+    });
+
+    test('evicts several when one is not enough', () {
+      const budget = TerminalBufferBudget(budgetBytes: 25 * _mb);
+
+      final evicted = budget.selectEvictions(
+        live: <TerminalBufferUsage>[
+          _usage(
+            'a',
+            megabytes: 20,
+            lastVisibleAt: now.subtract(const Duration(hours: 3)),
+          ),
+          _usage(
+            'b',
+            megabytes: 20,
+            lastVisibleAt: now.subtract(const Duration(hours: 2)),
+          ),
+          _usage('c', megabytes: 20, lastVisibleAt: now),
+        ],
+        pinnedTabIds: const <String>{},
+      );
+
+      expect(evicted, <String>['a', 'b']);
+    });
+
+    test('a zero budget means unbounded, not evict everything', () {
+      const budget = TerminalBufferBudget(budgetBytes: 0);
+
+      expect(budget.isUnbounded, isTrue);
+      expect(
+        budget.selectEvictions(
+          live: <TerminalBufferUsage>[_usage('a', megabytes: 500)],
+          pinnedTabIds: const <String>{},
+        ),
+        isEmpty,
+      );
+    });
+
+    test('everything pinned means nothing to evict', () {
+      const budget = TerminalBufferBudget(budgetBytes: 1);
+
+      expect(
+        budget.selectEvictions(
+          live: <TerminalBufferUsage>[_usage('a', megabytes: 40)],
+          pinnedTabIds: const <String>{'a'},
+        ),
+        isEmpty,
+      );
+    });
+  });
+}

--- a/test/unit/terminal_buffer_eviction_cases.dart
+++ b/test/unit/terminal_buffer_eviction_cases.dart
@@ -1,0 +1,193 @@
+part of 'terminal_runtime_native_test.dart';
+
+/// Grows a terminal's scrollback so the budget has something to weigh.
+void _fillScrollback(TerminalSessionHandle session, {int lines = 4000}) {
+  queueTerminalOutputForTesting(session, '\n' * lines);
+  flushTerminalOutputForTesting(session);
+}
+
+/// PTY teardown runs off the event loop, so poll rather than guess a delay.
+Future<void> _settleUntil(bool Function() condition) async {
+  for (var attempt = 0; attempt < 50; attempt += 1) {
+    if (condition()) {
+      return;
+    }
+    await Future<void>.delayed(Duration.zero);
+  }
+}
+
+/// Starts a terminal the way the app does, fills its scrollback, and then
+/// takes it off screen, which is what makes it an eviction candidate.
+///
+/// Starting needs a desktop platform, since `ensureStarted` refuses to build a
+/// PTY anywhere else. Tests that only care about handle bookkeeping use
+/// [_fillAndHide] instead and skip the PTY entirely.
+Future<void> _startFillAndHide(TerminalSessionHandle session) async {
+  final visibility = acquireTerminalVisibilityForTesting(session);
+  await session.ensureStarted();
+  _fillScrollback(session);
+  visibility.dispose();
+}
+
+void _fillAndHide(TerminalSessionHandle session) {
+  final visibility = acquireTerminalVisibilityForTesting(session);
+  _fillScrollback(session);
+  visibility.dispose();
+}
+
+void _registerTerminalBufferEvictionTests() {
+  test('a cold terminal is evicted without terminating its PTY', () async {
+    // The property the whole policy rests on: eviction detaches, so the agent
+    // in that terminal keeps running on the host and its scrollback comes back
+    // from the host snapshot on return.
+    debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+    addTearDown(() => debugDefaultTargetPlatformOverride = null);
+    final cold = _FakeTerminalPtySession();
+    final warm = _FakeTerminalPtySession();
+    final runtime = XtermTerminalRuntime(
+      ptySessionFactory: _FakeTerminalPtySessionFactory(
+        sessions: <_FakeTerminalPtySession>[cold, warm],
+      ),
+      shellLaunchesBuilder: () => <GhosttyTerminalShellLaunch>[
+        _launch('shell', shell: '/bin/sh'),
+      ],
+    );
+    addTearDown(runtime.dispose);
+
+    final coldSession = runtime.sessionFor(
+      workspace: _workspace(id: 'workspace-1'),
+      tab: _tab(id: 'tab-1', workspaceId: 'workspace-1'),
+    );
+    await _startFillAndHide(coldSession);
+
+    final warmSession = runtime.sessionFor(
+      workspace: _workspace(id: 'workspace-2'),
+      tab: _tab(id: 'tab-2', workspaceId: 'workspace-2'),
+    );
+    await _startFillAndHide(warmSession);
+
+    runtime.setActiveWorkspace('workspace-2');
+    final oneTerminal = coldSession.bufferUsage.bytes;
+    expect(oneTerminal, greaterThan(0), reason: 'scrollback should have grown');
+
+    // A budget that fits one terminal but not both.
+    runtime.updateSettings(
+      TerminalSettings.defaults.copyWith(
+        bufferBudgetMegabytes: (oneTerminal * 1.5) ~/ (1024 * 1024) + 1,
+      ),
+    );
+
+    expect(runtime.peekSession('tab-1'), isNull, reason: 'cold tab evicted');
+    expect(runtime.peekSession('tab-2'), isNotNull, reason: 'active workspace');
+    await _settleUntil(() => cold.disposed);
+    expect(cold.disposed, isTrue, reason: 'the client detaches');
+    expect(cold.terminated, isFalse, reason: 'the agent must keep running');
+  });
+
+  test('the active workspace is never evicted', () {
+    final first = _FakeTerminalPtySession();
+    final second = _FakeTerminalPtySession();
+    final runtime = XtermTerminalRuntime(
+      ptySessionFactory: _FakeTerminalPtySessionFactory(
+        sessions: <_FakeTerminalPtySession>[first, second],
+      ),
+      shellLaunchesBuilder: () => <GhosttyTerminalShellLaunch>[
+        _launch('shell', shell: '/bin/sh'),
+      ],
+    );
+    addTearDown(runtime.dispose);
+
+    for (final id in <String>['tab-1', 'tab-2']) {
+      final session = runtime.sessionFor(
+        workspace: _workspace(id: 'workspace-1'),
+        tab: _tab(id: id, workspaceId: 'workspace-1'),
+      );
+      _fillAndHide(session);
+    }
+
+    runtime.setActiveWorkspace('workspace-1');
+    // A budget far under what the two terminals need. Both survive anyway
+    // because they belong to the workspace being worked in, which is the
+    // honest cost of pinning: the ceiling is budget plus the active workspace.
+    runtime.updateSettings(
+      TerminalSettings.defaults.copyWith(bufferBudgetMegabytes: 1),
+    );
+
+    expect(runtime.peekSession('tab-1'), isNotNull);
+    expect(runtime.peekSession('tab-2'), isNotNull);
+  });
+
+  test('a zero budget keeps every terminal alive', () {
+    final pty = _FakeTerminalPtySession();
+    final runtime = XtermTerminalRuntime(
+      ptySessionFactory: _FakeTerminalPtySessionFactory(
+        sessions: <_FakeTerminalPtySession>[pty],
+      ),
+      shellLaunchesBuilder: () => <GhosttyTerminalShellLaunch>[
+        _launch('shell', shell: '/bin/sh'),
+      ],
+    );
+    addTearDown(runtime.dispose);
+
+    final session = runtime.sessionFor(
+      workspace: _workspace(id: 'workspace-1'),
+      tab: _tab(id: 'tab-1', workspaceId: 'workspace-1'),
+    );
+    _fillAndHide(session);
+
+    runtime.setActiveWorkspace('workspace-2');
+    runtime.updateSettings(
+      TerminalSettings.defaults.copyWith(bufferBudgetMegabytes: 0),
+    );
+
+    expect(runtime.peekSession('tab-1'), isNotNull);
+  });
+
+  test('returning to an evicted tab builds a fresh handle', () {
+    final original = _FakeTerminalPtySession();
+    final replacement = _FakeTerminalPtySession();
+    final runtime = XtermTerminalRuntime(
+      ptySessionFactory: _FakeTerminalPtySessionFactory(
+        sessions: <_FakeTerminalPtySession>[original, replacement],
+      ),
+      shellLaunchesBuilder: () => <GhosttyTerminalShellLaunch>[
+        _launch('shell', shell: '/bin/sh'),
+      ],
+    );
+    addTearDown(runtime.dispose);
+
+    final tab = _tab(id: 'tab-1', workspaceId: 'workspace-1');
+    final session = runtime.sessionFor(
+      workspace: _workspace(id: 'workspace-1'),
+      tab: tab,
+    );
+    _fillAndHide(session);
+
+    runtime.setActiveWorkspace('workspace-2');
+    runtime.updateSettings(
+      TerminalSettings.defaults.copyWith(bufferBudgetMegabytes: 1),
+    );
+    expect(runtime.peekSession('tab-1'), isNull);
+
+    final restored = runtime.sessionFor(
+      workspace: _workspace(id: 'workspace-1'),
+      tab: tab,
+    );
+
+    expect(identical(restored, session), isFalse);
+    expect(runtime.peekSession('tab-1'), isNotNull);
+  });
+
+  test('peekSession never creates a handle', () {
+    final runtime = XtermTerminalRuntime(
+      ptySessionFactory: _FakeTerminalPtySessionFactory(),
+      shellLaunchesBuilder: () => <GhosttyTerminalShellLaunch>[
+        _launch('shell', shell: '/bin/sh'),
+      ],
+    );
+    addTearDown(runtime.dispose);
+
+    expect(runtime.peekSession('never-opened'), isNull);
+    expect(runtime.peekSession('never-opened'), isNull);
+  });
+}

--- a/test/unit/terminal_runtime_native_test.dart
+++ b/test/unit/terminal_runtime_native_test.dart
@@ -27,6 +27,7 @@ part 'terminal_runtime_factory_group.dart';
 part 'terminal_runtime_clipboard_cases.dart';
 part 'terminal_runtime_xterm_session_cases.dart';
 part 'terminal_runtime_snapshot_cases.dart';
+part 'terminal_buffer_eviction_cases.dart';
 part 'terminal_runtime_output_backpressure_cases.dart';
 part 'terminal_runtime_remint_cases.dart';
 part 'terminal_runtime_xterm_widget_cases.dart';
@@ -40,6 +41,7 @@ void main() {
     _registerXtermRuntimeClipboardTests();
     _registerXtermRuntimeSessionTests();
     _registerTerminalRuntimeSnapshotTests();
+    _registerTerminalBufferEvictionTests();
     _registerTerminalRuntimeOutputBackpressureTests();
     _registerXtermRuntimeRemintTests();
     _registerXtermRuntimeWidgetTests();

--- a/test/unit/workbench_controller_test_harness.dart
+++ b/test/unit/workbench_controller_test_harness.dart
@@ -136,6 +136,12 @@ class _FakeTerminalRuntime implements TerminalRuntime {
   @override
   Stream<TerminalRuntimeExitEvent> get exits => _exits.stream;
   @override
+  TerminalSessionHandle? peekSession(String tabId) => sessions[tabId];
+
+  @override
+  void setActiveWorkspace(String? workspaceId) {}
+
+  @override
   TerminalSessionHandle sessionFor({
     required Workspace workspace,
     required WorkspaceTabRecord tab,

--- a/test/widget/alera_shell_page_runtime_test_harness.dart
+++ b/test/widget/alera_shell_page_runtime_test_harness.dart
@@ -33,6 +33,12 @@ class _FakeTerminalRuntime implements TerminalRuntime {
   Stream<TerminalRuntimeExitEvent> get exits => _exitController.stream;
 
   @override
+  TerminalSessionHandle? peekSession(String tabId) => _sessions[tabId];
+
+  @override
+  void setActiveWorkspace(String? workspaceId) {}
+
+  @override
   TerminalSessionHandle sessionFor({
     required Workspace workspace,
     required WorkspaceTabRecord tab,

--- a/test/widget/keyboard_command_dispatcher_test_harness.dart
+++ b/test/widget/keyboard_command_dispatcher_test_harness.dart
@@ -175,6 +175,12 @@ class _FakeTerminalRuntime implements TerminalRuntime {
       .map((entry) => entry.key);
 
   @override
+  TerminalSessionHandle? peekSession(String tabId) => _sessions[tabId];
+
+  @override
+  void setActiveWorkspace(String? workspaceId) {}
+
+  @override
   TerminalSessionHandle sessionFor({
     required Workspace workspace,
     required WorkspaceTabRecord tab,

--- a/test/widget/workspace_workbench_view_pane_test_cases.dart
+++ b/test/widget/workspace_workbench_view_pane_test_cases.dart
@@ -131,10 +131,10 @@ void _registerWorkspaceWorkbenchViewPaneTests() {
       mergedGroups: mergedGroups,
       updatedRatios: updatedRatios,
     );
-    expect(terminalRuntime.visibilityByTab, <String, bool>{
-      'tab-1': true,
-      'tab-2': false,
-    });
+    // Only the rendered tab gets a session at all. The inactive tab used to
+    // appear here with visibility false because the tab strip built a handle,
+    // and its xterm buffer, for every chip.
+    expect(terminalRuntime.visibilityByTab, <String, bool>{'tab-1': true});
 
     await _pumpWorkbenchView(
       tester,
@@ -156,6 +156,11 @@ void _registerWorkspaceWorkbenchViewPaneTests() {
       'tab-1': false,
       'tab-2': true,
     });
+    expect(
+      terminalRuntime.requestedTabIds,
+      <String>['tab-1', 'tab-2'],
+      reason: 'a handle is created only when a tab is actually rendered',
+    );
   });
 
   testWidgets('dragging the split handle updates the split ratio', (

--- a/test/widget/workspace_workbench_view_test_harness.dart
+++ b/test/widget/workspace_workbench_view_test_harness.dart
@@ -219,6 +219,12 @@ class _FakeTerminalRuntime implements TerminalRuntime {
       const Stream<TerminalRuntimeExitEvent>.empty();
 
   @override
+  TerminalSessionHandle? peekSession(String tabId) => _sessions[tabId];
+
+  @override
+  void setActiveWorkspace(String? workspaceId) {}
+
+  @override
   TerminalSessionHandle sessionFor({
     required Workspace workspace,
     required WorkspaceTabRecord tab,


### PR DESCRIPTION
Stacked on #183, which is now fully green.

## Summary

RAM grew with the number of workspaces the orchestrator touched and never came back down. `_sessions` retained a handle for every tab ever opened, released only on an explicit `closeTab`/`closeWorkspace`, and `workspace_workbench_tab_chips.dart` called `sessionFor` during the build of every chip, so handles existed for tabs the user never opened. Each handle holds an `xterm.Terminal` sized `scrollbackLines` by `viewWidth` at 4 `Uint32` per cell (`third_party/xterm/lib/src/core/buffer/line.dart:10,24`), around 19 MB for a scrolled default terminal.

## Changes

- `TerminalRuntime.peekSession(tabId)` never creates. The tab strip uses it and renders `tab.title` when there is no handle, which the `titleListenable` from #183 made possible. `sessionFor` now runs only when a tab is actually selected or rendered.
- New `terminal_buffer_budget.dart`: `estimateTerminalBufferBytes` plus `TerminalBufferBudget.selectEvictions`, a pure LRU-by-megabytes selector.
- `XtermTerminalRuntime` sweeps when a terminal goes off screen, when the active workspace changes, and when the budget setting changes. Visible terminals and the active workspace are pinned.
- `terminalBufferBudgetMegabytes` setting, default 256, `0` for unbounded, with a row in the terminal pane.
- The surface shows a "Restoring Terminal" skeleton with progress while a restored snapshot drains, since the corner spinner did not read as a multi-frame wait.

## Why eviction is safe

`dispose(terminatePty: false)` reaches `TerminalHostPtySession.dispose()`, which calls `_client.detach`. On the Rust side `Session::detach` (`session.rs:263-267`) only removes the client from the session's set: **it does not reap the PTY**. And `detached_session_shutdown_delay_seconds` is not a per-session reaper, it is how long the host process lingers after the last client leaves, and `schedule_shutdown_if_idle` (`lifecycle.rs:39-51`) returns early while any client is authenticated. So an agent in an evicted terminal keeps running, and its scrollback is restored from the host snapshot.

There is a test asserting exactly this (`detach` yes, `terminate` no), because the whole policy rests on it.

## Honest limits

- The estimate ignores `BufferLine`'s capacity rounding and extended text, so it errs low. It is good enough to order candidates and hold a ceiling; if measurement shows the real heap sitting consistently above the budget, the factor should be corrected with the measured number rather than guessed.
- The active workspace is pinned, so the real ceiling is the budget **plus** whatever that workspace holds. One test states that tradeoff explicitly rather than hiding it.
- 256 MB is a starting point, not a measured value.

## Validation

- New `terminal_buffer_budget_test.dart` (10 cases) and `terminal_buffer_eviction_cases.dart` (5 cases) covering the runtime integration.
- `workspace_workbench_view_pane_test_cases.dart` changed: an unopened tab no longer appears in `visibilityByTab` at all, which is the intended improvement rather than a regression.
- `flutter analyze` (whole package, including `integration_test/`), `dart run tool/quality/check_max_lines.dart`, and `flutter test`: green except the two pre-existing native PTY failures.
- `terminal_runtime_session_handle.dart` was kept under baseline by splitting restore progress and buffer accounting into their own parts.