### PR TITLE
perf: read and decode the terminal host socket off the UI isolate

### DIFF
--- a/lib/src/features/workbench/infra/terminal_host/terminal_host_client.dart
+++ b/lib/src/features/workbench/infra/terminal_host/terminal_host_client.dart
@@ -1,12 +1,14 @@
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
+import 'dart:isolate';
 import 'dart:math';
 import 'dart:typed_data';
 
 import 'package:alera/src/features/runtime_host/domain/runtime_host_status.dart';
 import 'package:alera/src/features/workbench/infra/terminal_host/terminal_host_client_models.dart';
 import 'package:alera/src/features/workbench/infra/terminal_host/terminal_host_frame_codec.dart';
+import 'package:alera/src/features/workbench/infra/terminal_host/terminal_host_socket_isolate.dart';
 import 'package:alera/src/features/workbench/infra/terminal_host/terminal_host_process_launcher.dart';
 import 'package:alera/src/features/workbench/infra/terminal_host/terminal_host_protocol.dart';
 import 'package:ghostty_vte_flutter/ghostty_vte_flutter.dart';
@@ -21,6 +23,7 @@ part 'terminal_host_client_requests.dart';
 part 'terminal_host_client_lifecycle.dart';
 part 'terminal_host_client_heartbeat.dart';
 part 'terminal_host_client_session_events.dart';
+part 'terminal_host_client_socket_reader.dart';
 
 final class SocketTerminalHostClient
     with _TerminalHostClientHeartbeat, _TerminalHostClientSessionEvents
@@ -496,16 +499,7 @@ final class SocketTerminalHostClient
     _TerminalHostControl control,
     _HostConnectionRole role,
   ) async {
-    final socket = await Socket.connect(
-      InternetAddress.loopbackIPv4,
-      control.port,
-      timeout: _terminalHostConnectTimeout,
-    );
-    final connection = _TerminalHostConnection(
-      socket,
-      supportsRuntime: control.supportsRuntime,
-      supportsOrchestration: control.supportsOrchestration,
-    );
+    final connection = await _openHostConnection(control);
     unawaited(
       connection.done.then(
         (_) => _handleConnectionClosed(connection),
@@ -521,6 +515,10 @@ final class SocketTerminalHostClient
         frame.sessionId,
         TerminalHostOutputEvent(frame.sessionId, frame.data),
       ),
+      onError: (Object _) {},
+    );
+    connection.decodedOutput.listen(
+      (event) => _emitHostEvent(event.sessionId, event),
       onError: (Object _) {},
     );
     final lineSub = connection.lines.listen(
@@ -614,9 +612,6 @@ final class SocketTerminalHostClient
         connection.completeAuthenticationError(error);
         _handleConnectionClosed(connection, error);
       } else {
-        if (message['binaryFrames'] == true) {
-          connection.upgradeToBinaryFrames();
-        }
         connection.completeAuthentication();
       }
       return;

--- a/lib/src/features/workbench/infra/terminal_host/terminal_host_client_models.dart
+++ b/lib/src/features/workbench/infra/terminal_host/terminal_host_client_models.dart
@@ -120,6 +120,16 @@ final class TerminalHostOutputEvent extends TerminalHostEvent {
   final Uint8List data;
 }
 
+/// Output that the socket reader isolate already decoded.
+///
+/// The isolate holds one decoder per session, so a code point split across
+/// chunks is reassembled there rather than on the UI isolate.
+final class TerminalHostOutputTextEvent extends TerminalHostEvent {
+  const TerminalHostOutputTextEvent(super.sessionId, this.text);
+
+  final String text;
+}
+
 final class TerminalHostOutputResyncRequiredEvent extends TerminalHostEvent {
   const TerminalHostOutputResyncRequiredEvent(super.sessionId);
 }

--- a/lib/src/features/workbench/infra/terminal_host/terminal_host_client_socket_reader.dart
+++ b/lib/src/features/workbench/infra/terminal_host/terminal_host_client_socket_reader.dart
@@ -1,0 +1,144 @@
+part of 'terminal_host_client.dart';
+
+/// Main-isolate side of the socket reader.
+///
+/// Owns the ports, not the socket: the isolate owns that. Everything this class
+/// hands back is already parsed, so the UI isolate does no framing and no
+/// UTF-8 decoding of terminal output.
+///
+/// Spawning is allowed to fail. Losing terminals over an isolate problem would
+/// be far worse than losing the offload, so the caller falls back to reading
+/// the socket here instead.
+final class _TerminalHostSocketReader {
+  _TerminalHostSocketReader._(this._commands, this._fromIsolate);
+
+  static Future<_TerminalHostSocketReader?> connect({
+    required String host,
+    required int port,
+    required Duration connectTimeout,
+  }) async {
+    final fromIsolate = ReceivePort();
+    final ready = Completer<SendPort?>();
+    final reader = _TerminalHostSocketReader._(null, fromIsolate);
+    reader._attach(fromIsolate, ready);
+    final commands = await spawnTerminalHostSocketIsolate(
+      host: host,
+      port: port,
+      toMain: fromIsolate.sendPort,
+      connectTimeout: connectTimeout,
+      awaitReady: () async {
+        final port = await ready.future.timeout(
+          connectTimeout,
+          onTimeout: () => null,
+        );
+        if (port == null) {
+          throw StateError('Terminal host socket isolate did not start.');
+        }
+        return port;
+      },
+    ).catchError((Object _) => null);
+    if (commands == null) {
+      fromIsolate.close();
+      return null;
+    }
+    reader._commands = commands;
+    return reader;
+  }
+
+  SendPort? _commands;
+  final ReceivePort _fromIsolate;
+  final StreamController<String> _lines = StreamController<String>.broadcast();
+  final StreamController<TerminalHostOutputTextEvent> _output =
+      StreamController<TerminalHostOutputTextEvent>.broadcast();
+  final Completer<void> _done = Completer<void>();
+  bool _closed = false;
+
+  Stream<String> get lines => _lines.stream;
+  Stream<TerminalHostOutputTextEvent> get output => _output.stream;
+  Future<void> get done => _done.future;
+
+  void _attach(ReceivePort port, Completer<SendPort?> ready) {
+    port.listen((Object? message) {
+      if (message is! List || message.isEmpty) {
+        return;
+      }
+      switch (message[0]) {
+        case terminalHostIsolateReady:
+          if (!ready.isCompleted) {
+            ready.complete(message[1] as SendPort);
+          }
+        case terminalHostIsolateLine:
+          if (!_lines.isClosed) {
+            _lines.add(message[1] as String);
+          }
+        case terminalHostIsolateOutput:
+          if (!_output.isClosed) {
+            _output.add(
+              TerminalHostOutputTextEvent(
+                message[1] as String,
+                message[2] as String,
+              ),
+            );
+          }
+        case terminalHostIsolateError:
+          if (!ready.isCompleted) {
+            ready.complete(null);
+          }
+        case terminalHostIsolateClosed:
+          _finish();
+      }
+    });
+  }
+
+  void write(List<int> bytes) {
+    _commands?.send(<Object?>[terminalHostIsolateWrite, bytes]);
+  }
+
+  void dispose() {
+    _commands?.send(const <Object?>[terminalHostIsolateClose]);
+    _finish();
+  }
+
+  void _finish() {
+    if (_closed) {
+      return;
+    }
+    _closed = true;
+    _commands = null;
+    _fromIsolate.close();
+    unawaited(_lines.close());
+    unawaited(_output.close());
+    if (!_done.isCompleted) {
+      _done.complete();
+    }
+  }
+}
+
+/// Opens a connection, preferring a reader isolate and falling back to reading
+/// the socket on this isolate when spawning fails.
+Future<_TerminalHostConnection> _openHostConnection(
+  _TerminalHostControl control,
+) async {
+  final reader = await _TerminalHostSocketReader.connect(
+    host: InternetAddress.loopbackIPv4.address,
+    port: control.port,
+    connectTimeout: _terminalHostConnectTimeout,
+  );
+  if (reader != null) {
+    return _TerminalHostConnection.isolate(
+      reader,
+      supportsRuntime: control.supportsRuntime,
+      supportsOrchestration: control.supportsOrchestration,
+    );
+  }
+  final socket = await Socket.connect(
+    InternetAddress.loopbackIPv4,
+    control.port,
+    timeout: _terminalHostConnectTimeout,
+  );
+  return _TerminalHostConnection(
+    socket,
+    supportsRuntime: control.supportsRuntime,
+    supportsOrchestration: control.supportsOrchestration,
+  );
+}

--- a/lib/src/features/workbench/infra/terminal_host/terminal_host_client_types.dart
+++ b/lib/src/features/workbench/infra/terminal_host/terminal_host_client_types.dart
@@ -1,12 +1,14 @@
 part of 'terminal_host_client.dart';
 
 final class _TerminalHostConnection {
+  /// Socket owned by this isolate. Used when the reader isolate could not be
+  /// spawned, so a terminal never depends on the offload succeeding.
   _TerminalHostConnection(
     this._socket, {
     required this.supportsRuntime,
     required this.supportsOrchestration,
-  }) {
-    _socketSub = _socket.cast<List<int>>().listen(
+  }) : _reader = null {
+    _socketSub = _socket!.cast<List<int>>().listen(
       _consume,
       onError: _lines.addError,
       onDone: () {
@@ -18,14 +20,34 @@ final class _TerminalHostConnection {
     outputFrames = _output.stream.asBroadcastStream();
   }
 
-  final Socket _socket;
+  /// Socket owned by a reader isolate, which also does the framing and decodes
+  /// terminal output, so nothing here touches raw bytes.
+  _TerminalHostConnection.isolate(
+    _TerminalHostSocketReader reader, {
+    required this.supportsRuntime,
+    required this.supportsOrchestration,
+  }) : _reader = reader,
+       _socket = null {
+    lines = reader.lines;
+    outputFrames = const Stream<TerminalHostOutputFrame>.empty();
+    decodedOutput = reader.output;
+    unawaited(
+      reader.done.then((_) {
+        unawaited(_lines.close());
+        unawaited(_output.close());
+      }),
+    );
+  }
+
+  final Socket? _socket;
+  final _TerminalHostSocketReader? _reader;
   final bool supportsRuntime;
   final bool supportsOrchestration;
 
   /// One reader for the whole connection. It starts newline-delimited so the
   /// handshake works against a host without the capability, and switches to
   /// length-prefixed frames once the hello response confirms the upgrade.
-  final TerminalHostFrameReader _reader = TerminalHostFrameReader();
+  final TerminalHostFrameReader _frameReader = TerminalHostFrameReader();
   final StreamController<String> _lines = StreamController<String>();
   final StreamController<TerminalHostOutputFrame> _output =
       StreamController<TerminalHostOutputFrame>();
@@ -34,11 +56,15 @@ final class _TerminalHostConnection {
   /// Control traffic: responses and events, still JSON.
   late final Stream<String> lines;
 
-  /// PTY output, delivered as raw bytes with no base64 or JSON in the way.
+  /// PTY output as raw bytes. Empty on the isolate path, which delivers text.
   late final Stream<TerminalHostOutputFrame> outputFrames;
 
+  /// PTY output already decoded off the UI isolate. Empty on the fallback path.
+  Stream<TerminalHostOutputTextEvent> decodedOutput =
+      const Stream<TerminalHostOutputTextEvent>.empty();
+
   void _consume(List<int> chunk) {
-    for (final frame in _reader.add(chunk)) {
+    for (final frame in _frameReader.add(chunk)) {
       switch (frame) {
         case TerminalHostJsonFrame(:final json):
           if (!_lines.isClosed) {
@@ -52,16 +78,12 @@ final class _TerminalHostConnection {
     }
   }
 
-  /// Switches the reader after the hello response has been consumed. The host
-  /// queues its upgrade marker behind that response on the same lane, so every
-  /// byte from here on is framed.
-  void upgradeToBinaryFrames() => _reader.upgradeToBinary();
   final Completer<void> _authenticated = Completer<void>();
   bool _isClosed = false;
 
   Future<void> get authenticated => _authenticated.future;
 
-  Future<void> get done => _socket.done;
+  Future<void> get done => _reader?.done ?? _socket!.done;
 
   bool get isClosed => _isClosed;
 
@@ -81,7 +103,12 @@ final class _TerminalHostConnection {
     if (_isClosed) {
       throw StateError('Terminal host connection is closed.');
     }
-    _socket.writeln(jsonEncode(message));
+    final reader = _reader;
+    if (reader != null) {
+      reader.write(utf8.encode('${jsonEncode(message)}\n'));
+      return;
+    }
+    _socket!.writeln(jsonEncode(message));
   }
 
   void dispose() {
@@ -90,7 +117,8 @@ final class _TerminalHostConnection {
     _socketSub = null;
     unawaited(_lines.close());
     unawaited(_output.close());
-    _socket.destroy();
+    _reader?.dispose();
+    _socket?.destroy();
   }
 }
 

--- a/lib/src/features/workbench/infra/terminal_host/terminal_host_frame_codec.dart
+++ b/lib/src/features/workbench/infra/terminal_host/terminal_host_frame_codec.dart
@@ -20,6 +20,13 @@ const int terminalHostFrameKindOutput = 2;
 /// Kind byte plus the u32 length.
 const int terminalHostFrameHeaderLength = 5;
 
+/// Last line before the stream switches to frames.
+///
+/// The switch has to be visible in the bytes: the reader can live in another
+/// isolate, so anything that flips it from outside races with the port
+/// round-trip and mis-parses whatever arrived in between.
+const String terminalHostBinaryFramesEnabledLine = 'binaryFramesEnabled';
+
 sealed class TerminalHostFrame {
   const TerminalHostFrame();
 }
@@ -77,6 +84,9 @@ class TerminalHostFrameReader {
     }
     final line = utf8.decode(_buffer.sublist(0, newline), allowMalformed: true);
     _buffer.removeRange(0, newline + 1);
+    if (line.contains(terminalHostBinaryFramesEnabledLine)) {
+      _binary = true;
+    }
     return TerminalHostJsonFrame(line);
   }
 

--- a/lib/src/features/workbench/infra/terminal_host/terminal_host_pty_session.dart
+++ b/lib/src/features/workbench/infra/terminal_host/terminal_host_pty_session.dart
@@ -339,6 +339,8 @@ final class TerminalHostPtySession implements TerminalPtySession {
     switch (event) {
       case TerminalHostOutputEvent(:final data):
         _events.add(TerminalPtyOutputEvent(data));
+      case TerminalHostOutputTextEvent(:final text):
+        _events.add(TerminalPtyOutputTextEvent(text));
       case TerminalHostOutputResyncRequiredEvent():
         _requestOutputResync();
       case TerminalHostExitEvent(:final exitCode):

--- a/lib/src/features/workbench/infra/terminal_host/terminal_host_socket_isolate.dart
+++ b/lib/src/features/workbench/infra/terminal_host/terminal_host_socket_isolate.dart
@@ -1,0 +1,166 @@
+/// Socket reader that runs off the UI isolate.
+///
+/// It owns the TCP socket, does the framing, and decodes PTY output to text so
+/// the main isolate receives something it can hand straight to the emulator.
+/// The per-session decoder has to live here: a multi-byte sequence can be split
+/// across chunks, and this is the only place that sees every chunk in order.
+///
+/// No Flutter imports: this runs in a plain isolate.
+library;
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+import 'dart:isolate';
+import 'dart:typed_data';
+
+import 'package:alera/src/features/workbench/infra/terminal_host/terminal_host_frame_codec.dart';
+
+/// Messages the isolate sends to the main isolate.
+const String terminalHostIsolateReady = 'ready';
+const String terminalHostIsolateLine = 'line';
+const String terminalHostIsolateOutput = 'output';
+const String terminalHostIsolateClosed = 'closed';
+const String terminalHostIsolateError = 'error';
+
+/// Commands the main isolate sends back.
+const String terminalHostIsolateWrite = 'write';
+const String terminalHostIsolateClose = 'close';
+
+class TerminalHostSocketIsolateConfig {
+  const TerminalHostSocketIsolateConfig({
+    required this.host,
+    required this.port,
+    required this.toMain,
+    required this.connectTimeoutMillis,
+  });
+
+  final String host;
+  final int port;
+  final SendPort toMain;
+  final int connectTimeoutMillis;
+}
+
+/// Isolate entry point. Sends [terminalHostIsolateReady] with its command port
+/// once connected, then streams frames until the socket or the owner closes it.
+Future<void> terminalHostSocketIsolateMain(
+  TerminalHostSocketIsolateConfig config,
+) async {
+  final toMain = config.toMain;
+  final Socket socket;
+  try {
+    socket = await Socket.connect(
+      config.host,
+      config.port,
+      timeout: Duration(milliseconds: config.connectTimeoutMillis),
+    );
+  } catch (error) {
+    toMain.send(<Object?>[terminalHostIsolateError, error.toString()]);
+    toMain.send(const <Object?>[terminalHostIsolateClosed]);
+    return;
+  }
+  socket.setOption(SocketOption.tcpNoDelay, true);
+
+  final commands = ReceivePort();
+  final reader = TerminalHostFrameReader();
+  final decoders = <String, ByteConversionSink>{};
+  final decoded = <String, StringBuffer>{};
+  var closed = false;
+
+  void closeSocket() {
+    if (closed) {
+      return;
+    }
+    closed = true;
+    socket.destroy();
+    commands.close();
+  }
+
+  /// One decoder per session, kept across chunks so a split code point is not
+  /// corrupted at a frame boundary.
+  void emitOutput(String sessionId, Uint8List bytes) {
+    final buffer = decoded.putIfAbsent(sessionId, StringBuffer.new);
+    final sink = decoders.putIfAbsent(sessionId, () {
+      // fromStringSink, not withCallback: the latter only delivers on close,
+      // which for a long-lived PTY means never.
+      return const Utf8Decoder(
+        allowMalformed: true,
+      ).startChunkedConversion(StringConversionSink.fromStringSink(buffer));
+    });
+    sink.add(bytes);
+    if (buffer.isEmpty) {
+      return;
+    }
+    final text = buffer.toString();
+    buffer.clear();
+    toMain.send(<Object?>[terminalHostIsolateOutput, sessionId, text]);
+  }
+
+  commands.listen((Object? message) {
+    if (message is! List || message.isEmpty) {
+      return;
+    }
+    switch (message[0]) {
+      case terminalHostIsolateWrite:
+        if (!closed) {
+          socket.add(message[1] as List<int>);
+        }
+      case terminalHostIsolateClose:
+        closeSocket();
+    }
+  });
+
+  socket.listen(
+    (Uint8List chunk) {
+      for (final frame in reader.add(chunk)) {
+        switch (frame) {
+          case TerminalHostJsonFrame(:final json):
+            toMain.send(<Object?>[terminalHostIsolateLine, json]);
+          case TerminalHostOutputFrame(:final sessionId, :final data):
+            emitOutput(sessionId, data);
+        }
+      }
+    },
+    onError: (Object error) {
+      toMain.send(<Object?>[terminalHostIsolateError, error.toString()]);
+      closeSocket();
+      toMain.send(const <Object?>[terminalHostIsolateClosed]);
+    },
+    onDone: () {
+      closeSocket();
+      toMain.send(const <Object?>[terminalHostIsolateClosed]);
+    },
+    cancelOnError: true,
+  );
+
+  toMain.send(<Object?>[terminalHostIsolateReady, commands.sendPort]);
+}
+
+/// Spawns the reader and returns its command port, or null if spawning failed.
+///
+/// A failure is not fatal: the caller falls back to reading the socket on the
+/// main isolate, because losing terminals over an isolate problem would be a
+/// far worse outcome than losing the offload.
+Future<SendPort?> spawnTerminalHostSocketIsolate({
+  required String host,
+  required int port,
+  required SendPort toMain,
+  required Duration connectTimeout,
+  required Future<SendPort> Function() awaitReady,
+}) async {
+  try {
+    await Isolate.spawn<TerminalHostSocketIsolateConfig>(
+      terminalHostSocketIsolateMain,
+      TerminalHostSocketIsolateConfig(
+        host: host,
+        port: port,
+        toMain: toMain,
+        connectTimeoutMillis: connectTimeout.inMilliseconds,
+      ),
+      debugName: 'alera-terminal-host-socket',
+    );
+  } catch (_) {
+    return null;
+  }
+  return awaitReady();
+}

--- a/lib/src/features/workbench/presentation/terminal_runtime.dart
+++ b/lib/src/features/workbench/presentation/terminal_runtime.dart
@@ -227,6 +227,14 @@ final class TerminalPtyOutputEvent extends TerminalPtySessionEvent {
   final Uint8List data;
 }
 
+/// Output already decoded off the UI isolate. Byte-based PTY adapters keep
+/// using [TerminalPtyOutputEvent]; only the socket path produces this.
+final class TerminalPtyOutputTextEvent extends TerminalPtySessionEvent {
+  const TerminalPtyOutputTextEvent(this.text);
+
+  final String text;
+}
+
 final class TerminalPtySnapshotEvent extends TerminalPtySessionEvent {
   const TerminalPtySnapshotEvent(
     this.data, {

--- a/lib/src/features/workbench/presentation/terminal_runtime_session_handle.dart
+++ b/lib/src/features/workbench/presentation/terminal_runtime_session_handle.dart
@@ -456,6 +456,12 @@ class _XtermTerminalSessionHandle extends TerminalSessionHandle {
         if (_visible) {
           _ptyOutputController.add(data);
         }
+      case TerminalPtyOutputTextEvent(:final text):
+        // Already decoded by the reader isolate, so it skips the local
+        // decoder entirely.
+        if (_visible) {
+          _handleTerminalOutput(text);
+        }
       case TerminalPtySnapshotEvent(:final data, :final resetInteractionModes):
         _pendingInteractionModeReset |= resetInteractionModes;
         if (_visible) {

--- a/rust/alera-cli/src/terminal_host/client.rs
+++ b/rust/alera-cli/src/terminal_host/client.rs
@@ -4,6 +4,7 @@ use tokio::net::TcpStream;
 use tokio::sync::mpsc::{Receiver, Sender, UnboundedReceiver, UnboundedSender};
 
 use crate::terminal_host::frame_codec::{encode_json_frame, encode_output_frame};
+use crate::terminal_host::protocol::BINARY_FRAMES_ENABLED_EVENT;
 use crate::terminal_host::server::ServerCommand;
 
 /// One outbound item on a client's lane.
@@ -160,6 +161,17 @@ async fn write_frame(
 ) -> std::io::Result<()> {
     match frame {
         ClientFrame::UpgradeToBinary => {
+            // A sentinel line, not a silent flag flip. The reader may live in
+            // another isolate, so the switch has to be visible in the byte
+            // stream itself: anything else races with the port round-trip.
+            write_json_line(
+                write_half,
+                &crate::terminal_host::protocol::event(
+                    BINARY_FRAMES_ENABLED_EVENT,
+                    serde_json::json!({}),
+                ),
+            )
+            .await?;
             *binary = true;
             Ok(())
         }

--- a/rust/alera-cli/src/terminal_host/protocol.rs
+++ b/rust/alera-cli/src/terminal_host/protocol.rs
@@ -50,6 +50,9 @@ pub const RUNTIME_HOST_TERMINAL_DRIVER_CAPABILITY: &str = "terminalDriverPresenc
 /// length-prefixed binary frames. Negotiated per client, so an older app and
 /// the `alera` CLI keep getting newline-delimited JSON from the same host.
 pub const RUNTIME_HOST_BINARY_FRAMES_CAPABILITY: &str = "binaryFrames";
+/// Last line before the connection switches to frames. Everything after it is
+/// framed, so a reader can flip on seeing it without any out-of-band signal.
+pub const BINARY_FRAMES_ENABLED_EVENT: &str = "binaryFramesEnabled";
 pub const RUNTIME_HOST_LIFECYCLE_CAPABILITY: &str = "runtimeHostLifecycleV1";
 pub const RUNTIME_HOST_AGENT_STATUS_CAPABILITY: &str = "runtimeAgentStatusV1";
 

--- a/test/unit/terminal_host_client_binary_frames_cases.dart
+++ b/test/unit/terminal_host_client_binary_frames_cases.dart
@@ -40,16 +40,16 @@ void _registerTerminalHostClientBinaryFrameTests() {
     );
     expect(server.usingBinaryFrames, isTrue);
 
+    // On the framed path the reader isolate also decodes, so the UI isolate
+    // receives text it can hand straight to the emulator.
     final output = client
         .eventsForSession('session-1')
-        .where((event) => event is TerminalHostOutputEvent)
-        .cast<TerminalHostOutputEvent>()
+        .where((event) => event is TerminalHostOutputTextEvent)
+        .cast<TerminalHostOutputTextEvent>()
         .first;
-    // Bytes that are not valid UTF-8 and would not survive a JSON round-trip
-    // without base64. Here they travel raw.
-    server.sendOutput('session-1', <int>[0x1b, 0x5b, 0x6d, 0xff, 0x00]);
+    server.sendOutput('session-1', utf8.encode('hola ñ'));
 
-    expect((await output).data, <int>[0x1b, 0x5b, 0x6d, 0xff, 0x00]);
+    expect((await output).text, 'hola ñ');
   });
 
   test('control events still arrive once framed', () async {

--- a/test/unit/terminal_host_socket_isolate_test.dart
+++ b/test/unit/terminal_host_socket_isolate_test.dart
@@ -1,0 +1,157 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+import 'dart:isolate';
+
+import 'package:alera/src/features/workbench/infra/terminal_host/terminal_host_frame_codec.dart';
+import 'package:alera/src/features/workbench/infra/terminal_host/terminal_host_socket_isolate.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Drives the isolate against a real loopback socket and collects what it
+/// sends back to the main isolate.
+class _IsolateHarness {
+  _IsolateHarness(this.server, this.messages, this.ready);
+
+  final ServerSocket server;
+  final StreamController<List<Object?>> messages;
+  final Future<Socket> ready;
+}
+
+Future<_IsolateHarness> _startIsolate() async {
+  final server = await ServerSocket.bind(InternetAddress.loopbackIPv4, 0);
+  final accepted = server.first;
+  final messages = StreamController<List<Object?>>.broadcast();
+  final fromIsolate = ReceivePort()
+    ..listen((Object? message) {
+      if (message is List) {
+        messages.add(message);
+      }
+    });
+  await Isolate.spawn<TerminalHostSocketIsolateConfig>(
+    terminalHostSocketIsolateMain,
+    TerminalHostSocketIsolateConfig(
+      host: InternetAddress.loopbackIPv4.address,
+      port: server.port,
+      toMain: fromIsolate.sendPort,
+      connectTimeoutMillis: 2000,
+    ),
+    debugName: 'alera-terminal-host-socket-test',
+  );
+  addTearDown(() async {
+    fromIsolate.close();
+    await messages.close();
+    await server.close();
+  });
+  return _IsolateHarness(server, messages, accepted);
+}
+
+String _sentinelLine() {
+  return '${jsonEncode(<String, Object?>{'event': terminalHostBinaryFramesEnabledLine, 'payload': const <String, Object?>{}})}\n';
+}
+
+void main() {
+  test('delivers control lines before the upgrade', () async {
+    final harness = await _startIsolate();
+    final socket = await harness.ready;
+    final line = harness.messages.stream
+        .where((message) => message.first == terminalHostIsolateLine)
+        .first;
+
+    socket.write('{"id":1,"ok":true}\n');
+
+    expect((await line)[1], '{"id":1,"ok":true}');
+  });
+
+  test('decodes output off the main isolate once framed', () async {
+    final harness = await _startIsolate();
+    final socket = await harness.ready;
+    final output = harness.messages.stream
+        .where((message) => message.first == terminalHostIsolateOutput)
+        .first;
+
+    socket.write(_sentinelLine());
+    socket.add(
+      encodeTerminalHostOutputFrame('session-1', utf8.encode('hola ñ')),
+    );
+
+    final message = await output;
+    expect(message[1], 'session-1');
+    // Text, not bytes: the UI isolate gets something it can hand to xterm.
+    expect(message[2], 'hola ñ');
+  });
+
+  test('reassembles a code point split across frames', () async {
+    // The reason the decoder has to live in the isolate: it is the only place
+    // that sees every chunk of a session in order.
+    final harness = await _startIsolate();
+    final socket = await harness.ready;
+    final collected = StringBuffer();
+    final done = Completer<void>();
+    harness.messages.stream
+        .where((message) => message.first == terminalHostIsolateOutput)
+        .listen((message) {
+          collected.write(message[2] as String);
+          if (collected.toString().endsWith('!') && !done.isCompleted) {
+            done.complete();
+          }
+        });
+
+    socket.write(_sentinelLine());
+    final encoded = utf8.encode('ñ');
+    socket.add(
+      encodeTerminalHostOutputFrame('session-1', <int>[encoded.first]),
+    );
+    socket.add(
+      encodeTerminalHostOutputFrame('session-1', <int>[encoded.last, 0x21]),
+    );
+    await done.future.timeout(const Duration(seconds: 5));
+
+    expect(collected.toString(), 'ñ!');
+  });
+
+  test('reports closure when the peer goes away', () async {
+    final harness = await _startIsolate();
+    final socket = await harness.ready;
+    final closed = harness.messages.stream
+        .where((message) => message.first == terminalHostIsolateClosed)
+        .first;
+
+    await socket.close();
+    socket.destroy();
+
+    await expectLater(closed, completes);
+  });
+
+  test('a refused connection reports an error, not a hang', () async {
+    final probe = await ServerSocket.bind(InternetAddress.loopbackIPv4, 0);
+    final deadPort = probe.port;
+    await probe.close();
+    final messages = StreamController<List<Object?>>.broadcast();
+    final fromIsolate = ReceivePort()
+      ..listen((Object? message) {
+        if (message is List) {
+          messages.add(message);
+        }
+      });
+    addTearDown(() async {
+      fromIsolate.close();
+      await messages.close();
+    });
+    final error = messages.stream
+        .where((message) => message.first == terminalHostIsolateError)
+        .first;
+
+    await Isolate.spawn<TerminalHostSocketIsolateConfig>(
+      terminalHostSocketIsolateMain,
+      TerminalHostSocketIsolateConfig(
+        host: InternetAddress.loopbackIPv4.address,
+        port: deadPort,
+        toMain: fromIsolate.sendPort,
+        connectTimeoutMillis: 1000,
+      ),
+      debugName: 'alera-terminal-host-socket-dead',
+    );
+
+    await expectLater(error, completes);
+  });
+}

--- a/test/unit/terminal_host_test_server.dart
+++ b/test/unit/terminal_host_test_server.dart
@@ -87,6 +87,16 @@ final class _TerminalHostTestServer {
           if (accepted) 'binaryFrames': true,
         }),
       );
+      if (accepted) {
+        // Mirrors the host: a sentinel line, then frames. The reader flips on
+        // seeing it, so nothing has to signal the switch out of band.
+        socket.writeln(
+          jsonEncode(<String, Object?>{
+            'event': terminalHostBinaryFramesEnabledLine,
+            'payload': const <String, Object?>{},
+          }),
+        );
+      }
       _binaryFrames = accepted;
       return;
     }

--- a/test/unit/terminal_runtime_factory_group.dart
+++ b/test/unit/terminal_runtime_factory_group.dart
@@ -191,6 +191,10 @@ void _registerTerminalRuntimeFactoryGroup() {
                   !readyCompleter.isCompleted) {
                 readyCompleter.complete();
               }
+            case TerminalPtyOutputTextEvent():
+              // Only the socket path produces decoded text; the native PTY
+              // adapters under test always emit bytes.
+              break;
             case TerminalPtySnapshotEvent():
               break;
             case TerminalPtyExitEvent():
@@ -254,6 +258,10 @@ void _registerTerminalRuntimeFactoryGroup() {
                   !readyCompleter.isCompleted) {
                 readyCompleter.complete();
               }
+            case TerminalPtyOutputTextEvent():
+              // Only the socket path produces decoded text; the native PTY
+              // adapters under test always emit bytes.
+              break;
             case TerminalPtySnapshotEvent():
               break;
             case TerminalPtyExitEvent():


### PR DESCRIPTION
Stacked on #185.

## Summary

#185 removed base64 and `jsonDecode` from the output path but left the remaining work on the UI isolate: the socket read, the framing, and the per-session UTF-8 decode. A reader isolate now owns the socket and sends back text the emulator can take directly, so the UI isolate handles no raw terminal bytes at all.

## Changes

- New `terminal_host_socket_isolate.dart`: connects, frames, and decodes. No Flutter imports, so it runs in a plain isolate.
- New `terminal_host_client_socket_reader.dart` part: the main-isolate side, owning the ports rather than the socket.
- New `TerminalHostOutputTextEvent` / `TerminalPtyOutputTextEvent`, added alongside the byte events rather than replacing them, so the ghostty and posix PTY adapters are untouched.
- The session handle writes decoded text straight into the frame batcher, skipping its local decoder.

## Two things worth calling out

**The upgrade had to become a sentinel line.** #185 switched the connection when the client saw `binaryFrames: true` in the hello response. With the reader in a different isolate that is a race: the flip travels over a port while the isolate keeps parsing whatever already arrived. The host now writes a `binaryFramesEnabled` line as the last line before switching, and the reader flips on seeing it. The decision is made by the code that owns the bytes, which is the same reasoning that put the upgrade in band on the host side.

**`StringConversionSink.withCallback` only delivers on close.** For a long-lived PTY that means never; the first version of this silently produced no output until I traced it. It uses `fromStringSink` now, and there is a test for a code point split across two frames, which is the case that justifies keeping one decoder per session inside the isolate.

## Fallback

If `Isolate.spawn` fails the client reads the socket inline instead. Losing terminals over an isolate problem would be far worse than losing the offload.

## Validation

- New `terminal_host_socket_isolate_test.dart` against a real loopback socket: control lines before the upgrade, decoded output after it, a code point reassembled across frames, closure reported, and a refused connection reporting an error rather than hanging.
- `terminal_host_client_test.dart` extended to assert decoded text on the framed path, with the line path still asserting bytes.
- `flutter analyze`, `dart run tool/quality/check_max_lines.dart`, `make rust-test`, `flutter test`: green except the two pre-existing native PTY failures.

## Honest caveat

After #185 the remaining main-isolate cost per chunk was already much smaller than when this was planned, so the marginal win here is smaller than the marginal complexity. It is worth confirming with a DevTools timeline under real orchestration load before assuming this pulled its weight; if it did not, the fallback path means reverting it is low risk.