### PR TITLE
perf: batch terminal output and carry it binary in the mobile app

### DIFF
--- a/mobile/AGENTS.md
+++ b/mobile/AGENTS.md
@@ -24,4 +24,5 @@ This file applies under `mobile/`. The root `AGENTS.md` also applies; this file 
 ## Protocol
 
 - The runtime gateway protocol version is `aleraMobileProtocolVersion` in `lib/src/core/mobile_protocol.dart`. The runtime enforces strict equality during `mobile.hello`, so never bump it for additive changes; feature-detect through the `runtimeCapabilities` array returned by the handshake instead.
+- Terminal output may arrive as a binary WebSocket message (`[u16be idLength][sessionId][raw bytes]`) instead of base64 inside JSON. The app asks for it with `binaryFrames: true` in `mobile.hello` and the runtime answers with what it granted; feature-detect through that response and `runtimeCapabilities`, never through `aleraMobileProtocolVersion`. The WebSocket already delimits messages, so there is no length-prefixed framing here, unlike the desktop socket.
 - Requests the gateway accepts from mobile clients are allowlisted in `rust/alera-cli/src/terminal_host/server/requests.rs` (`mobile_request_allowed`). Adding a new request type to the mobile app requires allowlisting it there first.

--- a/mobile/lib/src/features/runtime/domain/runtime_client_surfaces.dart
+++ b/mobile/lib/src/features/runtime/domain/runtime_client_surfaces.dart
@@ -14,6 +14,12 @@ const String mobileWorkspaceSidebarParityCapability =
     'mobileWorkspaceSidebarParityV1';
 const String mobileProjectManagementCapability = 'mobileProjectManagementV1';
 const String mobileTabRenameCapability = 'mobileTabRenameV1';
+
+/// The runtime can send terminal output as a binary WebSocket message instead
+/// of base64 inside JSON. Feature-detected, never version-gated: the runtime
+/// requires an exact `aleraMobileProtocolVersion` match, so bumping it would
+/// lock out every device that has not updated at the same moment.
+const String mobileBinaryFramesCapability = 'binaryFrames';
 const String mobileTerminalTitlesCapability = 'mobileTerminalTitlesV1';
 const String mobilePortableSettingsCapability = 'mobilePortableSettingsV1';
 const String mobileAgentQuotaCapability = 'mobileAgentQuotaV1';

--- a/mobile/lib/src/features/runtime/infra/mobile_binary_output_payload.dart
+++ b/mobile/lib/src/features/runtime/infra/mobile_binary_output_payload.dart
@@ -1,0 +1,30 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:alera_mobile/src/features/runtime/domain/runtime_client_surfaces.dart';
+
+/// Decodes `[u16be idLength][sessionId][raw bytes]`.
+///
+/// The same payload the desktop socket carries inside a length-prefixed frame,
+/// minus the length prefix: the WebSocket already delimits messages.
+///
+/// Returns null for anything malformed rather than throwing. A bad message
+/// must not take down the output stream for a session that is otherwise fine.
+MobileTerminalOutputEvent? decodeMobileBinaryOutput(List<int> raw) {
+  if (raw.length < 2) {
+    return null;
+  }
+  final idLength = (raw[0] << 8) | raw[1];
+  final idEnd = 2 + idLength;
+  if (raw.length < idEnd) {
+    return null;
+  }
+  final sessionId = utf8.decode(raw.sublist(2, idEnd), allowMalformed: true);
+  if (sessionId.isEmpty) {
+    return null;
+  }
+  return MobileTerminalOutputEvent(
+    sessionId,
+    Uint8List.fromList(raw.sublist(idEnd)),
+  );
+}

--- a/mobile/lib/src/features/runtime/infra/mobile_runtime_client.dart
+++ b/mobile/lib/src/features/runtime/infra/mobile_runtime_client.dart
@@ -4,6 +4,7 @@ import 'dart:convert';
 import 'package:alera_mobile/src/core/json_payload_fields.dart';
 import 'package:alera_mobile/src/core/mobile_protocol.dart';
 import 'package:alera_mobile/src/features/hosts/domain/paired_device_credentials.dart';
+import 'package:alera_mobile/src/features/runtime/infra/mobile_binary_output_payload.dart';
 import 'package:alera_mobile/src/features/hosts/domain/pairing_offer.dart';
 import 'package:alera_mobile/src/features/runtime/domain/mobile_runtime_status.dart';
 import 'package:alera_mobile/src/features/runtime/domain/project_summary.dart';
@@ -100,6 +101,7 @@ class MobileRuntimeClient
   StackTrace? _closedStackTrace;
 
   Set<String> _runtimeCapabilities = const <String>{};
+  bool _binaryFrames = false;
 
   @override
   Stream<MobileRuntimeEvent> get events => _events.stream;
@@ -140,8 +142,12 @@ class MobileRuntimeClient
       'protocolVersion': aleraMobileProtocolVersion,
       'deviceId': deviceId,
       'deviceToken': deviceToken,
+      'binaryFrames': true,
     });
     _runtimeCapabilities = payload.stringList('runtimeCapabilities').toSet();
+    // The response decides, not the request: an older runtime simply omits it
+    // and keeps sending base64 inside JSON.
+    _binaryFrames = payload['binaryFrames'] == true;
     return payload;
   }
 
@@ -424,6 +430,15 @@ class MobileRuntimeClient
   }
 
   void _handleMessage(Object? raw) {
+    // Once negotiated, a binary message is terminal output and never JSON, so
+    // it skips jsonDecode and base64Decode entirely.
+    if (_binaryFrames && raw is List<int>) {
+      final output = decodeMobileBinaryOutput(raw);
+      if (output != null && !_terminalOutput.isClosed) {
+        _terminalOutput.add(output);
+      }
+      return;
+    }
     final decoded = switch (raw) {
       String text => jsonDecode(text),
       List<int> bytes => jsonDecode(utf8.decode(bytes)),

--- a/mobile/lib/src/features/terminal/domain/terminal_output_batcher.dart
+++ b/mobile/lib/src/features/terminal/domain/terminal_output_batcher.dart
@@ -1,0 +1,146 @@
+import 'dart:collection';
+
+import 'package:flutter/scheduler.dart';
+
+/// Coalesces terminal output into one write per frame.
+///
+/// Without this every PTY chunk hits the emulator immediately, so a noisy
+/// build parses and repaints many times inside a single frame. That is the
+/// cost the desktop app removed; on a phone there is even less headroom.
+///
+/// Chunks are kept whole in a queue rather than concatenated into one growing
+/// buffer: a single buffer forces a full copy plus a substring on every drain,
+/// which makes draining a backlog quadratic in its size.
+class TerminalOutputBatcher {
+  TerminalOutputBatcher({
+    required this.write,
+    this.maxCharsPerFrame = _defaultMaxCharsPerFrame,
+    this.maxPendingChars = _defaultMaxPendingChars,
+    this.scheduler,
+  });
+
+  static const int _defaultMaxCharsPerFrame = 64 * 1024;
+  static const int _defaultMaxPendingChars = 512 * 1024;
+
+  final void Function(String text) write;
+  final int maxCharsPerFrame;
+  final int maxPendingChars;
+
+  /// Injected only by tests, which drive frames by hand.
+  final SchedulerBinding? scheduler;
+
+  final Queue<String> _pending = Queue<String>();
+  int _pendingChars = 0;
+  bool _flushScheduled = false;
+  bool _disposed = false;
+
+  int get pendingChars => _pendingChars;
+
+  /// Queues live output. Oldest output is dropped past the backlog cap, since
+  /// a runaway process must not grow memory without bound and what the user is
+  /// looking at is the newest output.
+  void add(String text) => _enqueue(text, bounded: true);
+
+  /// Queues a restored snapshot, which is a bounded one-shot payload and so is
+  /// exempt from the cap that exists to contain a live process.
+  void addSnapshot(String text) => _enqueue(text, bounded: false);
+
+  void _enqueue(String text, {required bool bounded}) {
+    if (_disposed || text.isEmpty) {
+      return;
+    }
+    _pending.add(text);
+    _pendingChars += text.length;
+    if (bounded) {
+      while (_pendingChars > maxPendingChars && _pending.length > 1) {
+        _pendingChars -= _pending.removeFirst().length;
+      }
+      if (_pendingChars > maxPendingChars) {
+        final chunk = _pending.removeFirst();
+        final start = _headTrimStart(chunk, chunk.length - maxPendingChars);
+        _pending.addFirst(chunk.substring(start));
+        _pendingChars = chunk.length - start;
+      }
+    }
+    _schedule();
+  }
+
+  void _schedule() {
+    if (_flushScheduled || _disposed) {
+      return;
+    }
+    _flushScheduled = true;
+    final binding = scheduler ?? SchedulerBinding.instance;
+    binding.scheduleFrameCallback((_) => flushFrame());
+    binding.ensureVisualUpdate();
+  }
+
+  /// Writes at most one frame's worth, splitting only the chunk that straddles
+  /// the budget so the rest stays untouched.
+  void flushFrame() {
+    _flushScheduled = false;
+    if (_disposed || _pending.isEmpty) {
+      return;
+    }
+    final frame = StringBuffer();
+    var written = 0;
+    while (_pending.isNotEmpty && written < maxCharsPerFrame) {
+      final chunk = _pending.first;
+      final remaining = maxCharsPerFrame - written;
+      if (chunk.length <= remaining) {
+        _pending.removeFirst();
+        _pendingChars -= chunk.length;
+        frame.write(chunk);
+        written += chunk.length;
+        continue;
+      }
+      final cutoff = _chunkCutoff(chunk, remaining);
+      if (cutoff == 0) {
+        break;
+      }
+      _pending.removeFirst();
+      _pending.addFirst(chunk.substring(cutoff));
+      _pendingChars -= cutoff;
+      frame.write(chunk.substring(0, cutoff));
+      written += cutoff;
+    }
+    if (written > 0) {
+      write(frame.toString());
+    }
+    if (_pending.isNotEmpty) {
+      _schedule();
+    }
+  }
+
+  void dispose() {
+    _disposed = true;
+    _pending.clear();
+    _pendingChars = 0;
+  }
+}
+
+/// Never cuts between a surrogate pair, which would corrupt the code point.
+int _chunkCutoff(String value, int limit) {
+  if (value.length <= limit) {
+    return value.length;
+  }
+  final codeUnit = value.codeUnitAt(limit);
+  if (codeUnit >= 0xDC00 && codeUnit <= 0xDFFF) {
+    return limit - 1;
+  }
+  return limit;
+}
+
+int _headTrimStart(String value, int start) {
+  if (start <= 0) {
+    return 0;
+  }
+  if (start >= value.length) {
+    return value.length;
+  }
+  final codeUnit = value.codeUnitAt(start);
+  if (codeUnit >= 0xDC00 && codeUnit <= 0xDFFF) {
+    return start + 1;
+  }
+  return start;
+}

--- a/mobile/lib/src/features/terminal/presentation/terminal_tab_view.dart
+++ b/mobile/lib/src/features/terminal/presentation/terminal_tab_view.dart
@@ -12,6 +12,7 @@ import 'package:alera_mobile/src/features/terminal/presentation/terminal_accesso
 import 'package:alera_mobile/src/features/terminal/presentation/terminal_compose_bar.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:alera_mobile/src/features/terminal/domain/terminal_output_batcher.dart';
 import 'package:xterm/xterm.dart';
 
 /// One terminal tab filling the available space, with the quick-key bar and
@@ -96,6 +97,7 @@ class _TerminalSurface extends StatefulWidget {
 class _TerminalSurfaceState extends State<_TerminalSurface> {
   late final Terminal _terminal;
   late final TerminalController _controller;
+  late final TerminalOutputBatcher _batcher;
   StreamSubscription<Uint8List>? _outputSub;
 
   @override
@@ -107,19 +109,23 @@ class _TerminalSurfaceState extends State<_TerminalSurface> {
       onResize: (width, height, _, _) => widget.onViewportResize(width, height),
     );
     _controller = TerminalController();
+    // One write per frame. Writing every chunk straight through made a noisy
+    // build parse and repaint many times inside a single frame.
+    _batcher = TerminalOutputBatcher(write: _terminal.write);
     if (widget.session.snapshot.isNotEmpty) {
-      _terminal.write(
+      _batcher.addSnapshot(
         utf8.decode(widget.session.snapshot, allowMalformed: true),
       );
     }
     _outputSub = widget.session.output.listen((data) {
-      _terminal.write(utf8.decode(data, allowMalformed: true));
+      _batcher.add(utf8.decode(data, allowMalformed: true));
     });
   }
 
   @override
   void dispose() {
     unawaited(_outputSub?.cancel());
+    _batcher.dispose();
     super.dispose();
   }
 

--- a/mobile/test/mobile_runtime_binary_output_test.dart
+++ b/mobile/test/mobile_runtime_binary_output_test.dart
@@ -1,0 +1,137 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:alera_mobile/src/features/runtime/infra/mobile_runtime_client.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Runtime stand-in that can accept or decline the binary upgrade.
+Future<({HttpServer server, List<Map<String, Object?>> requests})> _runtime({
+  required bool grantBinaryFrames,
+  required void Function(WebSocket socket) onAuthenticated,
+}) async {
+  final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+  final requests = <Map<String, Object?>>[];
+  final sockets = <WebSocket>[];
+  addTearDown(() async {
+    for (final socket in sockets) {
+      await socket.close();
+    }
+    await server.close(force: true);
+  });
+  final subscription = server.listen((request) async {
+    final socket = await WebSocketTransformer.upgrade(request);
+    sockets.add(socket);
+    socket.listen((raw) {
+      final message = jsonDecode(raw as String) as Map<String, Object?>;
+      requests.add(message);
+      socket.add(
+        jsonEncode(<String, Object?>{
+          'id': message['id'],
+          'ok': true,
+          'payload': <String, Object?>{
+            'runtimeCapabilities': <String>[
+              if (grantBinaryFrames) mobileBinaryFramesCapability,
+            ],
+            if (grantBinaryFrames) 'binaryFrames': true,
+          },
+        }),
+      );
+      if (message['type'] == 'mobile.hello') {
+        onAuthenticated(socket);
+      }
+    });
+  });
+  addTearDown(subscription.cancel);
+  return (server: server, requests: requests);
+}
+
+Uint8List _outputMessage(String sessionId, List<int> data) {
+  final id = utf8.encode(sessionId);
+  return Uint8List.fromList(<int>[
+    (id.length >> 8) & 0xff,
+    id.length & 0xff,
+    ...id,
+    ...data,
+  ]);
+}
+
+void main() {
+  test('asks for binary frames and receives raw output', () async {
+    late WebSocket runtimeSocket;
+    final runtime = await _runtime(
+      grantBinaryFrames: true,
+      onAuthenticated: (socket) => runtimeSocket = socket,
+    );
+    final client = await MobileRuntimeClient.connect(
+      'ws://${runtime.server.address.address}:${runtime.server.port}',
+    );
+    addTearDown(client.dispose);
+
+    await client.authenticate(deviceId: 'device-1', deviceToken: 'token-1');
+    expect(
+      (runtime.requests.single['payload']! as Map)['binaryFrames'],
+      isTrue,
+    );
+
+    final output = client.terminalOutput.first;
+    // Bytes that are not valid UTF-8, so a JSON round-trip without base64
+    // would have destroyed them.
+    runtimeSocket.add(_outputMessage('session-1', <int>[0x1b, 0xff, 0x00]));
+
+    final event = await output;
+    expect(event.sessionId, 'session-1');
+    expect(event.data, <int>[0x1b, 0xff, 0x00]);
+  });
+
+  test('a runtime that declines keeps sending base64 in JSON', () async {
+    // The compatibility case that is easiest to break, because the phone
+    // updates on its own schedule and mobile.hello demands an exact version.
+    late WebSocket runtimeSocket;
+    final runtime = await _runtime(
+      grantBinaryFrames: false,
+      onAuthenticated: (socket) => runtimeSocket = socket,
+    );
+    final client = await MobileRuntimeClient.connect(
+      'ws://${runtime.server.address.address}:${runtime.server.port}',
+    );
+    addTearDown(client.dispose);
+
+    await client.authenticate(deviceId: 'device-1', deviceToken: 'token-1');
+
+    final output = client.terminalOutput.first;
+    runtimeSocket.add(
+      jsonEncode(<String, Object?>{
+        'event': 'output',
+        'payload': <String, Object?>{
+          'sessionId': 'session-1',
+          'dataBase64': base64Encode(<int>[1, 2, 3]),
+        },
+      }),
+    );
+
+    final event = await output;
+    expect(event.data, <int>[1, 2, 3]);
+  });
+
+  test('a truncated binary message is ignored, not fatal', () async {
+    late WebSocket runtimeSocket;
+    final runtime = await _runtime(
+      grantBinaryFrames: true,
+      onAuthenticated: (socket) => runtimeSocket = socket,
+    );
+    final client = await MobileRuntimeClient.connect(
+      'ws://${runtime.server.address.address}:${runtime.server.port}',
+    );
+    addTearDown(client.dispose);
+    await client.authenticate(deviceId: 'device-1', deviceToken: 'token-1');
+
+    final output = client.terminalOutput.first;
+    // Claims a 90-byte session id it does not carry.
+    runtimeSocket.add(Uint8List.fromList(<int>[0, 90, 0x61]));
+    runtimeSocket.add(_outputMessage('session-1', <int>[9]));
+
+    final event = await output.timeout(const Duration(seconds: 5));
+    expect(event.data, <int>[9], reason: 'the stream must keep working');
+  });
+}

--- a/mobile/test/terminal_output_batcher_test.dart
+++ b/mobile/test/terminal_output_batcher_test.dart
@@ -1,0 +1,118 @@
+import 'package:alera_mobile/src/features/terminal/domain/terminal_output_batcher.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  // The batcher schedules frame callbacks, so the binding has to exist even
+  // though these tests drive flushes by hand.
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late List<String> writes;
+
+  TerminalOutputBatcher batcher({int maxCharsPerFrame = 1024}) {
+    return TerminalOutputBatcher(
+      write: writes.add,
+      maxCharsPerFrame: maxCharsPerFrame,
+      maxPendingChars: 4096,
+    );
+  }
+
+  setUp(() => writes = <String>[]);
+
+  test('a burst of chunks becomes one write per frame', () {
+    // The behaviour that matters: without this each chunk parsed and repainted
+    // on its own inside the same frame.
+    final subject = batcher();
+
+    for (var i = 0; i < 20; i++) {
+      subject.add('chunk-$i ');
+    }
+    subject.flushFrame();
+
+    expect(writes, hasLength(1));
+    expect(writes.single, startsWith('chunk-0 '));
+    expect(writes.single, endsWith('chunk-19 '));
+  });
+
+  test('output past the frame budget carries into the next frame', () {
+    final subject = batcher(maxCharsPerFrame: 10);
+
+    subject.add('a' * 25);
+    subject.flushFrame();
+    expect(writes, hasLength(1));
+    expect(writes.single.length, 10);
+
+    subject.flushFrame();
+    subject.flushFrame();
+
+    expect(writes.map((write) => write.length), <int>[10, 10, 5]);
+    expect(writes.join(), 'a' * 25);
+  });
+
+  test('a runaway process cannot grow the backlog without bound', () {
+    final subject = TerminalOutputBatcher(
+      write: writes.add,
+      maxCharsPerFrame: 100,
+      maxPendingChars: 50,
+    );
+
+    for (var i = 0; i < 10; i++) {
+      subject.add('x' * 30);
+    }
+
+    expect(subject.pendingChars, lessThanOrEqualTo(50));
+  });
+
+  test('a snapshot is exempt from the backlog cap', () {
+    // It is a bounded one-shot payload, so trimming it would silently drop
+    // restored history.
+    final subject = TerminalOutputBatcher(
+      write: writes.add,
+      maxCharsPerFrame: 1000,
+      maxPendingChars: 50,
+    );
+
+    subject.addSnapshot('y' * 300);
+
+    expect(subject.pendingChars, 300);
+  });
+
+  test('never splits a surrogate pair across frames', () {
+    final subject = batcher(maxCharsPerFrame: 3);
+    // Two UTF-16 code units each.
+    const emoji = '😀😀';
+
+    subject.add('ab$emoji');
+    subject.flushFrame();
+    subject.flushFrame();
+    subject.flushFrame();
+
+    expect(writes.join(), 'ab$emoji');
+    for (final write in writes) {
+      expect(
+        write.runes.any((rune) => rune >= 0xD800 && rune <= 0xDFFF),
+        isFalse,
+        reason: 'a half surrogate would render as a broken glyph',
+      );
+    }
+  });
+
+  test('empty input is ignored', () {
+    final subject = batcher();
+
+    subject.add('');
+    subject.flushFrame();
+
+    expect(writes, isEmpty);
+  });
+
+  test('dispose drops pending output', () {
+    final subject = batcher();
+
+    subject.add('pending');
+    subject.dispose();
+    subject.flushFrame();
+
+    expect(writes, isEmpty);
+    expect(subject.pendingChars, 0);
+  });
+}

--- a/rust/alera-cli/src/terminal_host/frame_codec.rs
+++ b/rust/alera-cli/src/terminal_host/frame_codec.rs
@@ -32,12 +32,20 @@ pub fn encode_json_frame(value: &Value) -> std::io::Result<Vec<u8>> {
 
 /// Encodes PTY output without base64, which is the whole point of the format.
 pub fn encode_output_frame(session_id: &str, data: &[u8]) -> Vec<u8> {
+    frame(FRAME_KIND_OUTPUT, &encode_output_payload(session_id, data))
+}
+
+/// The output payload on its own, without the length-prefixed header.
+///
+/// Used by the mobile WebSocket transport, which already frames messages, so
+/// it needs the session id and the raw bytes but not a length prefix.
+pub fn encode_output_payload(session_id: &str, data: &[u8]) -> Vec<u8> {
     let id = session_id.as_bytes();
     let mut payload = Vec::with_capacity(2 + id.len() + data.len());
     payload.extend_from_slice(&(id.len() as u16).to_be_bytes());
     payload.extend_from_slice(id);
     payload.extend_from_slice(data);
-    frame(FRAME_KIND_OUTPUT, &payload)
+    payload
 }
 
 fn frame(kind: u8, payload: &[u8]) -> Vec<u8> {

--- a/rust/alera-cli/src/terminal_host/mobile_gateway.rs
+++ b/rust/alera-cli/src/terminal_host/mobile_gateway.rs
@@ -10,6 +10,7 @@ use tokio::task::JoinHandle;
 use tokio_tungstenite::{accept_async, tungstenite::Message};
 
 use crate::terminal_host::client::{ClientFrame, ClientHandle, CLIENT_TERMINAL_OUT_QUEUE_CAPACITY};
+use crate::terminal_host::frame_codec::encode_output_payload;
 use crate::terminal_host::server::{ClientKind, ServerCommand};
 
 pub fn spawn_mobile_gateway_accept_loop(
@@ -60,6 +61,7 @@ async fn mobile_websocket_loop(
     mut terminal_out_rx: Receiver<ClientFrame>,
 ) {
     let (mut write, mut read) = socket.split();
+    let mut binary = false;
     loop {
         tokio::select! {
             inbound = read.next() => {
@@ -101,12 +103,14 @@ async fn mobile_websocket_loop(
                             let Ok(terminal_value) = terminal_out_rx.try_recv() else {
                                 break;
                             };
-                            if send_mobile_value(&mut write, &terminal_value).await.is_err() {
+                            if send_mobile_value(&mut write, &terminal_value, &mut binary)
+                                .await
+                                .is_err() {
                                 failed = true;
                                 break;
                             }
                         }
-                        if failed || send_mobile_value(&mut write, &value).await.is_err() {
+                        if failed || send_mobile_value(&mut write, &value, &mut binary).await.is_err() {
                             let _ = inbox.send(ServerCommand::ClientDisconnected { id });
                             break;
                         }
@@ -117,7 +121,7 @@ async fn mobile_websocket_loop(
             outbound = terminal_out_rx.recv() => {
                 match outbound {
                     Some(value) => {
-                        if send_mobile_value(&mut write, &value).await.is_err() {
+                        if send_mobile_value(&mut write, &value, &mut binary).await.is_err() {
                             let _ = inbox.send(ServerCommand::ClientDisconnected { id });
                             break;
                         }
@@ -129,12 +133,30 @@ async fn mobile_websocket_loop(
     }
 }
 
-/// The mobile transport is still text-only, so a frame is flattened back into
-/// the JSON event a mobile client expects.
+/// Sends one frame over the WebSocket.
+///
+/// The WebSocket already delimits messages, so a device that negotiated binary
+/// output just gets a `Message::Binary` with the session id and the raw bytes.
+/// No length-prefixed framing is needed here, unlike the local TCP socket.
 async fn send_mobile_value(
     write: &mut SplitSink<tokio_tungstenite::WebSocketStream<TcpStream>, Message>,
     frame: &ClientFrame,
+    binary: &mut bool,
 ) -> anyhow::Result<()> {
+    if let ClientFrame::UpgradeToBinary = frame {
+        *binary = true;
+        return Ok(());
+    }
+    if *binary {
+        if let ClientFrame::Output { session_id, data } = frame {
+            write
+                .send(Message::Binary(
+                    encode_output_payload(session_id, data).into(),
+                ))
+                .await?;
+            return Ok(());
+        }
+    }
     let Some(value) = frame.as_json() else {
         return Ok(());
     };

--- a/rust/alera-cli/src/terminal_host/server/requests.rs
+++ b/rust/alera-cli/src/terminal_host/server/requests.rs
@@ -24,8 +24,8 @@ use crate::terminal_host::host_error::{HostError, HostResult};
 use crate::terminal_host::protocol::{
     error_response, event, int_or, ok_response, require_object, TerminalHostConfig,
     TerminalHostLaunch, PROTOCOL_VERSION, RUNTIME_HOST_AGENT_QUOTA_CLAUDE_TUI_CAPABILITY,
-    RUNTIME_HOST_AGENT_STATUS_CAPABILITY, RUNTIME_HOST_BOOTSTRAP_CAPABILITY,
-    RUNTIME_HOST_CAPABILITY, RUNTIME_HOST_LIFECYCLE_CAPABILITY,
+    RUNTIME_HOST_AGENT_STATUS_CAPABILITY, RUNTIME_HOST_BINARY_FRAMES_CAPABILITY,
+    RUNTIME_HOST_BOOTSTRAP_CAPABILITY, RUNTIME_HOST_CAPABILITY, RUNTIME_HOST_LIFECYCLE_CAPABILITY,
     RUNTIME_HOST_MANAGED_WORKSPACE_CAPABILITY, RUNTIME_HOST_MOBILE_AGENT_QUOTA_CAPABILITY,
     RUNTIME_HOST_MOBILE_CAPABILITY, RUNTIME_HOST_MOBILE_HOST_TOOLS_CAPABILITY,
     RUNTIME_HOST_MOBILE_MUTATIONS_CAPABILITY, RUNTIME_HOST_MOBILE_PORTABLE_SETTINGS_CAPABILITY,
@@ -303,12 +303,23 @@ impl ServerActor {
                 )
                 .await
                 .map_err(|error| HostError::state(error.to_string()))?;
+                let binary_frames = payload
+                    .get("binaryFrames")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false);
                 if let Some(client) = self.clients.get_mut(&client_id) {
                     client.authenticated = true;
+                    client.binary_frames = binary_frames;
                     client.mobile_device_id = Some(device.id.clone());
                     client.mobile_device_name = Some(device.display_name.clone());
                 }
                 self.cancel_shutdown_timer();
+                if binary_frames {
+                    // Same in-band ordering as the desktop socket: queued
+                    // behind this response so the device never sees a binary
+                    // message before it knows to expect one.
+                    self.upgrade_client_to_binary(client_id);
+                }
                 self.broadcast_authenticated(event("mobileDevicesChanged", json!({})));
                 Ok(json!({
                     "protocolVersion": MOBILE_PROTOCOL_VERSION,
@@ -329,8 +340,10 @@ impl ServerActor {
                         RUNTIME_HOST_TERMINAL_DRIVER_CAPABILITY,
                         RUNTIME_HOST_LIFECYCLE_CAPABILITY,
                         RUNTIME_HOST_AGENT_STATUS_CAPABILITY,
+                        RUNTIME_HOST_BINARY_FRAMES_CAPABILITY,
                     ],
                     "authenticated": true,
+                    "binaryFrames": binary_frames,
                     "device": device,
                 }))
             }


### PR DESCRIPTION
Stacked on #186. Final stage.

## What applies to mobile, and what does not

The memory budget from #184 **does not apply**: `terminal_tab_view.dart` builds its `Terminal` in the `State`, there is a single `_TerminalSurface` instance, and it is not under an `IndexedStack`/`PageView` with keep-alive, so it is destroyed on navigation. Nothing accumulates.

What does apply is the output pipeline, and mobile was in worse shape than desktop ever was.

## 1. Batching, which did not exist at all

`_TerminalSurface` wrote every chunk straight to the emulator, and wrote the whole restored snapshot synchronously in `initState`. A noisy build parsed and repainted many times inside one frame.

New `terminal_output_batcher.dart` in the mobile package, not a copy of the desktop file: that one is a `part of terminal_runtime.dart` and tied to the desktop handle. It keeps whole chunks in a queue rather than one growing buffer, so draining a backlog is linear rather than quadratic, and a restored snapshot is exempt from the backlog cap since it is bounded and one-shot.

## 2. Binary output over the WebSocket

Much cheaper than the desktop equivalent: the WebSocket already delimits messages, so this needs only `[u16be idLength][sessionId][raw bytes]` and none of the length-prefixed framing.

The device sends `binaryFrames: true` in `mobile.hello`; the runtime answers with what it granted and, if granted, queues the same in-band upgrade marker used on the desktop lane so the device never sees a binary message before it knows to expect one.

**Feature-detected, never version-gated.** `mobile/AGENTS.md` already forbids bumping `aleraMobileProtocolVersion` for additive changes, and this is exactly why: the runtime demands an exact match, so a bump locks out every device that has not updated at the same moment.

## 3. Not done: an isolate on mobile

Left out deliberately and flagged in the plan as measurement-gated. With batching in place and base64 gone, the phone's UI thread may well have enough headroom, and an isolate there costs base memory and lifecycle complexity when the app is backgrounded. Worth deciding with a timeline, not in advance.

## Validation

- New `terminal_output_batcher_test.dart`: a burst becomes one write per frame, output past the budget carries over, a runaway process cannot grow the backlog, a snapshot is exempt from the cap, and a surrogate pair is never split across frames.
- New `mobile_runtime_binary_output_test.dart` against a real loopback WebSocket: negotiation and raw output including non-UTF-8 bytes, a runtime that declines still sending base64, and a truncated binary message being ignored rather than killing the stream.
- `flutter test` and `flutter analyze` from `mobile/`: green. Desktop `flutter test`, `flutter analyze`, `make rust-test`, and the max-lines ratchet: green except the two pre-existing native PTY failures.
- `mobile_runtime_client.dart` was kept under 500 by splitting the payload decoder into its own file.