### PR TITLE
perf: share one runtime change coalescer across all watchers

### DIFF
--- a/lib/src/features/mobile_devices/application/mobile_access_providers.dart
+++ b/lib/src/features/mobile_devices/application/mobile_access_providers.dart
@@ -7,7 +7,10 @@ part 'mobile_access_providers.g.dart';
 
 @Riverpod(keepAlive: true)
 RuntimeMobileAccessRepository mobileAccessRepository(Ref ref) {
-  return RuntimeMobileAccessRepository(ref.watch(runtimeHostClientProvider));
+  return RuntimeMobileAccessRepository(
+    ref.watch(runtimeHostClientProvider),
+    coalescer: ref.watch(runtimeChangeCoalescerProvider),
+  );
 }
 
 @Riverpod(keepAlive: true)

--- a/lib/src/features/mobile_devices/application/mobile_access_providers.g.dart
+++ b/lib/src/features/mobile_devices/application/mobile_access_providers.g.dart
@@ -57,7 +57,7 @@ final class MobileAccessRepositoryProvider
 }
 
 String _$mobileAccessRepositoryHash() =>
-    r'40b2ea4f85f3c8fb08561e8deb1984dc8ca5f14f';
+    r'3cb4338c9deb755a319634872cc2134d9ee45329';
 
 @ProviderFor(mobileAccessStatus)
 final mobileAccessStatusProvider = MobileAccessStatusProvider._();

--- a/lib/src/features/projects/application/project_providers.dart
+++ b/lib/src/features/projects/application/project_providers.dart
@@ -33,6 +33,7 @@ ProjectRepository projectRepository(Ref ref) {
   return RuntimeProjectRepository(
     ref.watch(runtimeHostClientProvider),
     beforeAccess: ref.watch(runtimeStateMigrationProvider).ensureMigrated,
+    coalescer: ref.watch(runtimeChangeCoalescerProvider),
   );
 }
 
@@ -46,6 +47,7 @@ ProjectConfigRepository projectConfigRepository(Ref ref) {
   return RuntimeProjectConfigRepository(
     ref.watch(runtimeHostClientProvider),
     beforeAccess: ref.watch(runtimeStateMigrationProvider).ensureMigrated,
+    coalescer: ref.watch(runtimeChangeCoalescerProvider),
   );
 }
 

--- a/lib/src/features/projects/application/project_providers.g.dart
+++ b/lib/src/features/projects/application/project_providers.g.dart
@@ -143,7 +143,7 @@ final class ProjectRepositoryProvider
   }
 }
 
-String _$projectRepositoryHash() => r'b4b7463c17f617fdbee9bd3d53f3e60db761ada9';
+String _$projectRepositoryHash() => r'8bd00ca14d93ab693a5609a51e09bd273fdfde8a';
 
 @ProviderFor(projectList)
 final projectListProvider = ProjectListProvider._();
@@ -230,7 +230,7 @@ final class ProjectConfigRepositoryProvider
 }
 
 String _$projectConfigRepositoryHash() =>
-    r'482eaa38d3736a9e96fa7708141e943b2e5576f9';
+    r'672bb0f4478a9be3f4962fe3454048c47a71a748';
 
 @ProviderFor(projectConfigFileStore)
 final projectConfigFileStoreProvider = ProjectConfigFileStoreProvider._();

--- a/lib/src/features/pull_requests/application/pull_request_providers.dart
+++ b/lib/src/features/pull_requests/application/pull_request_providers.dart
@@ -37,6 +37,7 @@ LinkedReviewRepository linkedReviewRepository(Ref ref) {
   return RuntimeLinkedReviewRepository(
     ref.watch(runtimeHostClientProvider),
     beforeAccess: ref.watch(runtimeStateMigrationProvider).ensureMigrated,
+    coalescer: ref.watch(runtimeChangeCoalescerProvider),
   );
 }
 

--- a/lib/src/features/pull_requests/application/pull_request_providers.g.dart
+++ b/lib/src/features/pull_requests/application/pull_request_providers.g.dart
@@ -199,7 +199,7 @@ final class LinkedReviewRepositoryProvider
 }
 
 String _$linkedReviewRepositoryHash() =>
-    r'e4a5a933abb650b1e336a9db0d34c04e0049d96b';
+    r'87854e165f36a6db238c7c4c6bbd6466a35a37aa';
 
 /// The effective git-hosting-provider override for a project (UI override or
 /// repo `alera.toml`), or null when the project should auto-detect. Feeds the

--- a/lib/src/features/remote_hosts/application/ssh_target_providers.dart
+++ b/lib/src/features/remote_hosts/application/ssh_target_providers.dart
@@ -7,7 +7,10 @@ part 'ssh_target_providers.g.dart';
 
 @Riverpod(keepAlive: true)
 RuntimeSshTargetRepository sshTargetRepository(Ref ref) {
-  return RuntimeSshTargetRepository(ref.watch(runtimeHostClientProvider));
+  return RuntimeSshTargetRepository(
+    ref.watch(runtimeHostClientProvider),
+    coalescer: ref.watch(runtimeChangeCoalescerProvider),
+  );
 }
 
 @Riverpod(keepAlive: true)

--- a/lib/src/features/remote_hosts/application/ssh_target_providers.g.dart
+++ b/lib/src/features/remote_hosts/application/ssh_target_providers.g.dart
@@ -55,7 +55,7 @@ final class SshTargetRepositoryProvider
 }
 
 String _$sshTargetRepositoryHash() =>
-    r'73c67f91237c24e951641ba149998fc17588fecf';
+    r'f00455c6dcfdfda442f77a426c68ea8d02daf212';
 
 @ProviderFor(sshTargets)
 final sshTargetsProvider = SshTargetsProvider._();

--- a/lib/src/features/workbench/application/workbench_controller.g.dart
+++ b/lib/src/features/workbench/application/workbench_controller.g.dart
@@ -42,7 +42,7 @@ final class WorkbenchControllerProvider
 }
 
 String _$workbenchControllerHash() =>
-    r'6f5426224f9871e43bb341d7f0a91a9ccb0d085d';
+    r'4608f891ce4dec8bb9e49bd1934006e5f0c2cc00';
 
 abstract class _$WorkbenchController extends $Notifier<WorkbenchState> {
   WorkbenchState build();

--- a/lib/src/features/workbench/application/workbench_providers.dart
+++ b/lib/src/features/workbench/application/workbench_providers.dart
@@ -53,6 +53,7 @@ WorkbenchRepository workbenchRepository(Ref ref) {
   return RuntimeWorkbenchRepository(
     ref.watch(runtimeHostClientProvider),
     beforeAccess: ref.watch(runtimeStateMigrationProvider).ensureMigrated,
+    coalescer: ref.watch(runtimeChangeCoalescerProvider),
   );
 }
 

--- a/lib/src/features/workbench/application/workbench_providers.g.dart
+++ b/lib/src/features/workbench/application/workbench_providers.g.dart
@@ -55,7 +55,7 @@ final class WorkbenchRepositoryProvider
 }
 
 String _$workbenchRepositoryHash() =>
-    r'382cb08ed64259de6254c2daeb3c0e6d23bd57ef';
+    r'8c1302e94b473115830f6b43e487e1a2d8b87156';
 
 @ProviderFor(workspaceGraphRepository)
 final workspaceGraphRepositoryProvider = WorkspaceGraphRepositoryProvider._();

--- a/lib/src/shared/infra/runtime/runtime_host_providers.dart
+++ b/lib/src/shared/infra/runtime/runtime_host_providers.dart
@@ -1,4 +1,5 @@
 import 'package:alera/src/features/workbench/infra/terminal_host/terminal_host_client.dart';
+import 'package:alera/src/shared/infra/runtime/runtime_change_coalescer.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'runtime_host_providers.g.dart';
@@ -8,4 +9,14 @@ SocketTerminalHostClient runtimeHostClient(Ref ref) {
   final client = SocketTerminalHostClient();
   ref.onDispose(client.dispose);
   return client;
+}
+
+/// One coalescer for every runtime watcher, keyed by namespaced strings
+/// (`tabs:<id>`, `workspaces:<id>`, `projects`, ...), so there is a single
+/// place to instrument and tune how change events fan out into RPC.
+@Riverpod(keepAlive: true)
+RuntimeChangeCoalescer runtimeChangeCoalescer(Ref ref) {
+  final coalescer = RuntimeChangeCoalescer();
+  ref.onDispose(coalescer.dispose);
+  return coalescer;
 }

--- a/lib/src/shared/infra/runtime/runtime_host_providers.g.dart
+++ b/lib/src/shared/infra/runtime/runtime_host_providers.g.dart
@@ -55,3 +55,62 @@ final class RuntimeHostClientProvider
 }
 
 String _$runtimeHostClientHash() => r'60780d6cfec535f1c297fb6b66e31d23fc23837a';
+
+/// One coalescer for every runtime watcher, keyed by namespaced strings
+/// (`tabs:<id>`, `workspaces:<id>`, `projects`, ...), so there is a single
+/// place to instrument and tune how change events fan out into RPC.
+
+@ProviderFor(runtimeChangeCoalescer)
+final runtimeChangeCoalescerProvider = RuntimeChangeCoalescerProvider._();
+
+/// One coalescer for every runtime watcher, keyed by namespaced strings
+/// (`tabs:<id>`, `workspaces:<id>`, `projects`, ...), so there is a single
+/// place to instrument and tune how change events fan out into RPC.
+
+final class RuntimeChangeCoalescerProvider
+    extends
+        $FunctionalProvider<
+          RuntimeChangeCoalescer,
+          RuntimeChangeCoalescer,
+          RuntimeChangeCoalescer
+        >
+    with $Provider<RuntimeChangeCoalescer> {
+  /// One coalescer for every runtime watcher, keyed by namespaced strings
+  /// (`tabs:<id>`, `workspaces:<id>`, `projects`, ...), so there is a single
+  /// place to instrument and tune how change events fan out into RPC.
+  RuntimeChangeCoalescerProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'runtimeChangeCoalescerProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$runtimeChangeCoalescerHash();
+
+  @$internal
+  @override
+  $ProviderElement<RuntimeChangeCoalescer> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  RuntimeChangeCoalescer create(Ref ref) {
+    return runtimeChangeCoalescer(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(RuntimeChangeCoalescer value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<RuntimeChangeCoalescer>(value),
+    );
+  }
+}
+
+String _$runtimeChangeCoalescerHash() =>
+    r'75b6461c1b37366d95491768ae3db2f2f8c75246';

--- a/test/unit/runtime_change_coalescer_wiring_test.dart
+++ b/test/unit/runtime_change_coalescer_wiring_test.dart
@@ -1,0 +1,63 @@
+import 'package:alera/src/shared/infra/runtime/runtime_change_coalescer.dart';
+import 'package:alera/src/shared/infra/runtime/runtime_host_providers.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('every runtime watcher shares one coalescer instance', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    final first = container.read(runtimeChangeCoalescerProvider);
+    final second = container.read(runtimeChangeCoalescerProvider);
+
+    expect(identical(first, second), isTrue);
+  });
+
+  test('disposing the container stops the coalescer', () async {
+    final container = ProviderContainer();
+    final coalescer = container.read(runtimeChangeCoalescerProvider);
+    var runs = 0;
+
+    container.dispose();
+    coalescer.schedule('key', () async => runs += 1);
+    await Future<void>.delayed(const Duration(milliseconds: 250));
+
+    expect(runs, 0, reason: 'a disposed coalescer must not leak timers');
+  });
+
+  test('coalescer keys used by the repositories do not collide', () {
+    // The coalescer is shared process-wide, so these namespaces are the
+    // contract that keeps unrelated refreshes from merging.
+    const keys = <String>[
+      'workspaces:project-1',
+      'tabs:workspace-1',
+      'projects',
+      'projectConfigs',
+      'sshTargets',
+      'linkedReview:workspace-1',
+      'mobileStatus',
+    ];
+
+    expect(keys.toSet(), hasLength(keys.length));
+  });
+
+  test('a shared coalescer keeps unrelated keys independent', () async {
+    final coalescer = RuntimeChangeCoalescer(
+      debounce: const Duration(milliseconds: 10),
+      maxDelay: const Duration(milliseconds: 50),
+    );
+    addTearDown(coalescer.dispose);
+    var tabRuns = 0;
+    var projectRuns = 0;
+
+    for (var i = 0; i < 5; i++) {
+      coalescer.schedule('tabs:workspace-1', () async => tabRuns += 1);
+    }
+    coalescer.schedule('projects', () async => projectRuns += 1);
+    await Future<void>.delayed(const Duration(milliseconds: 80));
+
+    expect(tabRuns, 1);
+    expect(projectRuns, 1);
+  });
+}


### PR DESCRIPTION
Replaces #178, which GitHub auto-closed when its base branch was deleted on merge of #177. Same content, rebased onto `main`.

## Summary

#177 gave every runtime repository its own `RuntimeChangeCoalescer`, so the debounce applied per repository rather than process-wide. This exposes a single keepAlive `runtimeChangeCoalescerProvider` and injects it into all six repositories, so there is one place to instrument and tune how host change events fan out into RPC.

## Changes

- `runtimeChangeCoalescerProvider` in `lib/src/shared/infra/runtime/runtime_host_providers.dart`, disposed with the container.
- Injected at the six construction sites (workbench, projects, project configs, linked reviews, ssh targets, mobile access).
- Test covering the wiring: single shared instance, disposal stops it, the key namespaces used by the repositories do not collide, and unrelated keys stay independent.

## Validation

- `flutter test`: green except the two pre-existing `terminal_runtime_native_test.dart` native PTY failures.
- `flutter analyze`, `dart run tool/quality/check_max_lines.dart`: clean.