### PR TITLE
feat: track the shell pid for each terminal session

### DIFF
--- a/rust/alera-cli/src/terminal_host/session.rs
+++ b/rust/alera-cli/src/terminal_host/session.rs
@@ -116,6 +116,10 @@ pub struct Session {
     running: bool,
     exit_code: Option<i32>,
     ended_at: Option<DateTime<Utc>>,
+    /// PID of the shell this session spawned, while it is still alive. Cleared
+    /// on exit and on terminate: the OS recycles PIDs, so a stale value would
+    /// attribute an unrelated process to this session.
+    shell_pid: Option<u32>,
     master: Option<Box<dyn MasterPty + Send>>,
     input_tx: Option<SyncSender<PtyWrite>>,
     killer: Option<Box<dyn ChildKiller + Send + Sync>>,
@@ -189,6 +193,9 @@ impl Session {
         drop(pair.slave);
 
         let killer = child.clone_killer();
+        // Read before the child moves into the reader thread, which owns it
+        // until exit. This is the root the resource sampler walks down from.
+        let shell_pid = child.process_id();
         let reader = pair
             .master
             .try_clone_reader()
@@ -218,6 +225,7 @@ impl Session {
             running: true,
             exit_code: None,
             ended_at: None,
+            shell_pid,
             master: Some(pair.master),
             input_tx: Some(input_tx),
             killer: Some(killer),
@@ -249,6 +257,14 @@ impl Session {
 
     pub fn workspace_id(&self) -> &str {
         &self.workspace_id
+    }
+
+    /// PID of the live shell, or `None` once it has exited or was never spawned
+    /// (restored checkpoints and test stubs have no process behind them).
+    // Read by the resource sampler, which lands in the following change.
+    #[allow(dead_code)]
+    pub fn shell_pid(&self) -> Option<u32> {
+        self.shell_pid
     }
 
     pub fn instance_id(&self) -> u64 {
@@ -370,6 +386,7 @@ impl Session {
         self.running = false;
         self.exit_code = Some(exit_code);
         self.ended_at = Some(Utc::now());
+        self.shell_pid = None;
         Some(json!({ "sessionId": self.id, "exitCode": exit_code }))
     }
 
@@ -414,6 +431,7 @@ impl Session {
     pub async fn terminate(&mut self, remove_history: bool, store: &TerminalHostHistoryStore) {
         self.terminated = true;
         self.running = false;
+        self.shell_pid = None;
         if let Some(mut killer) = self.killer.take() {
             // The child may have already exited between checks.
             let _ = killer.kill();

--- a/rust/alera-cli/src/terminal_host/session/checkpoint_restore.rs
+++ b/rust/alera-cli/src/terminal_host/session/checkpoint_restore.rs
@@ -37,6 +37,7 @@ impl Session {
             running: false,
             exit_code,
             ended_at,
+            shell_pid: None,
             master: None,
             input_tx: None,
             killer: None,

--- a/rust/alera-cli/src/terminal_host/session/driver_test_stub.rs
+++ b/rust/alera-cli/src/terminal_host/session/driver_test_stub.rs
@@ -20,6 +20,7 @@ impl Session {
             running: true,
             exit_code: None,
             ended_at: None,
+            shell_pid: None,
             master: None,
             input_tx: None,
             killer: None,

--- a/rust/alera-cli/src/terminal_host/session/tests.rs
+++ b/rust/alera-cli/src/terminal_host/session/tests.rs
@@ -64,6 +64,7 @@ fn test_session() -> Session {
         running: true,
         exit_code: None,
         ended_at: None,
+        shell_pid: None,
         master: None,
         input_tx: None,
         killer: None,
@@ -232,6 +233,39 @@ async fn restored_session_recovers_the_latest_title_from_scrollback() {
     .unwrap();
 
     assert_eq!(session.runtime_title(), Some("Restored Task"));
+}
+
+#[test]
+fn exiting_clears_the_shell_pid() {
+    let mut session = test_session();
+    session.shell_pid = Some(4242);
+    assert_eq!(session.shell_pid(), Some(4242));
+
+    session.handle_exit(0);
+
+    // The OS recycles PIDs, so keeping the old value would let the resource
+    // sampler attribute an unrelated process to this session.
+    assert_eq!(session.shell_pid(), None);
+}
+
+#[tokio::test]
+async fn terminating_clears_the_shell_pid() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = TerminalHostHistoryStore::open(dir.path()).await.unwrap();
+    let mut session = test_session();
+    session.shell_pid = Some(4242);
+
+    session.terminate(true, &store).await;
+
+    assert_eq!(session.shell_pid(), None);
+}
+
+#[test]
+fn a_session_without_a_pty_has_no_shell_pid() {
+    // Stubs and restored checkpoints have no process behind them, so there is
+    // nothing to sample.
+    let session = Session::driver_test_stub("stub", 80, 24);
+    assert_eq!(session.shell_pid(), None);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Records the PTY child's pid on `Session` so a later change can attribute CPU and memory to the terminal that spawned it. The pid is read before the child moves into the reader thread, which owns it until exit.

The pid is cleared on both `handle_exit` and `terminate`. The OS recycles pids, so keeping a stale value would attribute an unrelated process to a dead session.

No behavior changes on its own: the getter is `#[allow(dead_code)]` until the sampler lands.

## Validation

- `make rust-test`: fmt, clippy with warnings denied, and all workspace tests pass.
- Three new unit tests cover clearing on exit, clearing on terminate, and sessions with no PTY behind them.
- Confirmed out of band that `portable_pty::Child::process_id()` returns a real pid for a spawned shell.