### PR TITLE
feat: project host resource samples onto the workbench tree

### DIFF
--- a/lib/src/features/resource_manager/application/resource_manager_providers.dart
+++ b/lib/src/features/resource_manager/application/resource_manager_providers.dart
@@ -1,0 +1,94 @@
+import 'dart:async';
+import 'dart:io' show pid;
+
+import 'package:alera/src/features/resource_manager/application/resource_snapshot_projection.dart';
+import 'package:alera/src/features/resource_manager/domain/resource_snapshot.dart';
+import 'package:alera/src/features/resource_manager/domain/resource_tree.dart';
+import 'package:alera/src/features/workbench/application/workbench_controller.dart';
+import 'package:alera/src/features/workbench/domain/workspace.dart';
+import 'package:alera/src/features/workbench/domain/workspace_tab_record.dart';
+import 'package:alera/src/features/workbench/infra/terminal_host/terminal_host_protocol.dart';
+import 'package:alera/src/shared/infra/runtime/runtime_host_providers.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'resource_manager_providers.g.dart';
+
+/// Cadence while the panel is open. Matches the host's own sampling interval,
+/// so the UI never polls faster than new data can appear.
+const resourceSnapshotOpenInterval = Duration(seconds: 2);
+
+/// Cadence while the panel is closed. The status-bar chip still needs a number,
+/// but nobody is watching it change, and each poll keeps the host's sampler
+/// alive.
+const resourceSnapshotClosedInterval = Duration(seconds: 15);
+
+const _resourceSnapshotTimeout = Duration(seconds: 5);
+
+/// Whether the resource panel is on screen. Drives the polling cadence.
+@riverpod
+class ResourcePanelOpen extends _$ResourcePanelOpen {
+  @override
+  bool build() => false;
+
+  void set({required bool open}) => state = open;
+}
+
+@Riverpod(keepAlive: true)
+Future<ResourceSnapshot> resourceSnapshot(Ref ref) async {
+  final open = ref.watch(resourcePanelOpenProvider);
+  final client = ref.watch(runtimeHostClientProvider);
+  final interval = open
+      ? resourceSnapshotOpenInterval
+      : resourceSnapshotClosedInterval;
+  final timer = Timer.periodic(interval, (_) => ref.invalidateSelf());
+  ref.onDispose(timer.cancel);
+  return fetchResourceSnapshot(client: client, appPid: pid);
+}
+
+/// Ask the runtime host for its latest sweep.
+///
+/// A host that predates the resource monitor simply rejects the verb, so a
+/// failure degrades to an unavailable snapshot instead of an error state: the
+/// chip is ambient UI and must never break the status bar.
+Future<ResourceSnapshot> fetchResourceSnapshot({
+  required RuntimeHostClient client,
+  required int appPid,
+}) async {
+  try {
+    final payload = await client.runtimeRequest(
+      'resources.snapshot',
+      <String, Object?>{'appPid': appPid},
+      _resourceSnapshotTimeout,
+    );
+    if (payload is! Map) {
+      return ResourceSnapshot.unavailable(
+        error: 'The runtime host returned an unexpected resource payload.',
+      );
+    }
+    return ResourceSnapshot.fromJson(Map<String, Object?>.from(payload));
+  } catch (error) {
+    return ResourceSnapshot.unavailable(error: error.toString());
+  }
+}
+
+/// The snapshot projected onto the workbench tree, ready to render.
+@riverpod
+ResourceTree resourceTree(Ref ref, ResourceSortColumn sortColumn) {
+  final snapshot = ref.watch(resourceSnapshotProvider).value;
+  if (snapshot == null) {
+    return ResourceTree.empty;
+  }
+  final workbench = ref.watch(workbenchControllerProvider);
+  return buildResourceTree(
+    snapshot: snapshot,
+    projects: workbench.projects,
+    workspaces: <Workspace>[
+      for (final workspaces in workbench.workspacesByProject.values)
+        ...workspaces,
+    ],
+    tabs: <WorkspaceTabRecord>[
+      for (final tabs in workbench.tabsByWorkspace.values) ...tabs,
+    ],
+    sortColumn: sortColumn,
+  );
+}

--- a/lib/src/features/resource_manager/application/resource_manager_providers.g.dart
+++ b/lib/src/features/resource_manager/application/resource_manager_providers.g.dart
@@ -1,0 +1,192 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'resource_manager_providers.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// Whether the resource panel is on screen. Drives the polling cadence.
+
+@ProviderFor(ResourcePanelOpen)
+final resourcePanelOpenProvider = ResourcePanelOpenProvider._();
+
+/// Whether the resource panel is on screen. Drives the polling cadence.
+final class ResourcePanelOpenProvider
+    extends $NotifierProvider<ResourcePanelOpen, bool> {
+  /// Whether the resource panel is on screen. Drives the polling cadence.
+  ResourcePanelOpenProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'resourcePanelOpenProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$resourcePanelOpenHash();
+
+  @$internal
+  @override
+  ResourcePanelOpen create() => ResourcePanelOpen();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(bool value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<bool>(value),
+    );
+  }
+}
+
+String _$resourcePanelOpenHash() => r'bc22c6b74fdcbfc79dc5befcc04b43a1f8109d94';
+
+/// Whether the resource panel is on screen. Drives the polling cadence.
+
+abstract class _$ResourcePanelOpen extends $Notifier<bool> {
+  bool build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final ref = this.ref as $Ref<bool, bool>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<bool, bool>,
+              bool,
+              Object?,
+              Object?
+            >;
+    element.handleCreate(ref, build);
+  }
+}
+
+@ProviderFor(resourceSnapshot)
+final resourceSnapshotProvider = ResourceSnapshotProvider._();
+
+final class ResourceSnapshotProvider
+    extends
+        $FunctionalProvider<
+          AsyncValue<ResourceSnapshot>,
+          ResourceSnapshot,
+          FutureOr<ResourceSnapshot>
+        >
+    with $FutureModifier<ResourceSnapshot>, $FutureProvider<ResourceSnapshot> {
+  ResourceSnapshotProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'resourceSnapshotProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$resourceSnapshotHash();
+
+  @$internal
+  @override
+  $FutureProviderElement<ResourceSnapshot> $createElement(
+    $ProviderPointer pointer,
+  ) => $FutureProviderElement(pointer);
+
+  @override
+  FutureOr<ResourceSnapshot> create(Ref ref) {
+    return resourceSnapshot(ref);
+  }
+}
+
+String _$resourceSnapshotHash() => r'f41238a4739e9ae38c3b0c9cecb1ad76ec9ccd10';
+
+/// The snapshot projected onto the workbench tree, ready to render.
+
+@ProviderFor(resourceTree)
+final resourceTreeProvider = ResourceTreeFamily._();
+
+/// The snapshot projected onto the workbench tree, ready to render.
+
+final class ResourceTreeProvider
+    extends $FunctionalProvider<ResourceTree, ResourceTree, ResourceTree>
+    with $Provider<ResourceTree> {
+  /// The snapshot projected onto the workbench tree, ready to render.
+  ResourceTreeProvider._({
+    required ResourceTreeFamily super.from,
+    required ResourceSortColumn super.argument,
+  }) : super(
+         retry: null,
+         name: r'resourceTreeProvider',
+         isAutoDispose: true,
+         dependencies: null,
+         $allTransitiveDependencies: null,
+       );
+
+  @override
+  String debugGetCreateSourceHash() => _$resourceTreeHash();
+
+  @override
+  String toString() {
+    return r'resourceTreeProvider'
+        ''
+        '($argument)';
+  }
+
+  @$internal
+  @override
+  $ProviderElement<ResourceTree> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  ResourceTree create(Ref ref) {
+    final argument = this.argument as ResourceSortColumn;
+    return resourceTree(ref, argument);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(ResourceTree value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<ResourceTree>(value),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is ResourceTreeProvider && other.argument == argument;
+  }
+
+  @override
+  int get hashCode {
+    return argument.hashCode;
+  }
+}
+
+String _$resourceTreeHash() => r'171b800b95589ee4f6b8a0db0c031b9639231da9';
+
+/// The snapshot projected onto the workbench tree, ready to render.
+
+final class ResourceTreeFamily extends $Family
+    with $FunctionalFamilyOverride<ResourceTree, ResourceSortColumn> {
+  ResourceTreeFamily._()
+    : super(
+        retry: null,
+        name: r'resourceTreeProvider',
+        dependencies: null,
+        $allTransitiveDependencies: null,
+        isAutoDispose: true,
+      );
+
+  /// The snapshot projected onto the workbench tree, ready to render.
+
+  ResourceTreeProvider call(ResourceSortColumn sortColumn) =>
+      ResourceTreeProvider._(argument: sortColumn, from: this);
+
+  @override
+  String toString() => r'resourceTreeProvider';
+}

--- a/lib/src/features/resource_manager/application/resource_snapshot_projection.dart
+++ b/lib/src/features/resource_manager/application/resource_snapshot_projection.dart
@@ -1,0 +1,165 @@
+import 'package:alera/src/features/projects/domain/project.dart';
+import 'package:alera/src/features/resource_manager/domain/resource_snapshot.dart';
+import 'package:alera/src/features/resource_manager/domain/resource_tree.dart';
+import 'package:alera/src/features/workbench/domain/workspace.dart';
+import 'package:alera/src/features/workbench/domain/workspace_tab_record.dart';
+
+/// Join the host's flat session list with the app's workspace tree.
+///
+/// The host knows pids and workspace/tab ids; only the app knows project and
+/// workspace names, which tabs still exist, and which workspaces live on
+/// another machine. Keeping this a pure function is deliberate: every ordering
+/// and orphan rule below is covered by unit tests rather than by driving a
+/// widget.
+ResourceTree buildResourceTree({
+  required ResourceSnapshot snapshot,
+  required List<Project> projects,
+  required List<Workspace> workspaces,
+  required List<WorkspaceTabRecord> tabs,
+  ResourceSortColumn sortColumn = ResourceSortColumn.memory,
+}) {
+  final workspacesById = <String, Workspace>{
+    for (final workspace in workspaces) workspace.id: workspace,
+  };
+  final projectsById = <String, Project>{
+    for (final project in projects) project.id: project,
+  };
+  final tabsBySessionId = <String, WorkspaceTabRecord>{
+    for (final tab in tabs)
+      if (tab.kind == WorkspaceTabKind.terminal) tab.terminalSessionId: tab,
+  };
+
+  final sessionsByWorkspace = <String, List<ResourceSessionRow>>{};
+  final orphans = <ResourceSessionRow>[];
+  for (final session in snapshot.sessions) {
+    final tab = tabsBySessionId[session.sessionId];
+    final workspace = workspacesById[session.workspaceId];
+    final remote = workspace != null && workspace.hostId != 'local';
+    final row = ResourceSessionRow(
+      sessionId: session.sessionId,
+      label: tab?.title.trim().isNotEmpty ?? false
+          ? tab!.title.trim()
+          : session.sessionId,
+      tabId: session.tabId,
+      running: session.running,
+      // A session is orphaned when no terminal tab claims it. The workspace
+      // being gone is not enough on its own: the host may simply be ahead of
+      // an app that has not synced yet.
+      orphan: tab == null,
+      cpuPercent: remote || !session.measured ? null : session.cpuPercent,
+      memoryBytes: remote || !session.measured ? null : session.memoryBytes,
+      processCount: session.processCount,
+      history: session.history,
+    );
+    if (row.orphan) {
+      orphans.add(row);
+      continue;
+    }
+    sessionsByWorkspace
+        .putIfAbsent(session.workspaceId, () => <ResourceSessionRow>[])
+        .add(row);
+  }
+
+  final workspacesByProject = <String, List<ResourceWorkspaceRow>>{};
+  for (final entry in sessionsByWorkspace.entries) {
+    final workspace = workspacesById[entry.key];
+    if (workspace == null) {
+      // The app has a tab for these sessions but no workspace, which only
+      // happens mid-sync. Dropping them beats inventing a group.
+      continue;
+    }
+    final sessions = entry.value..sort(_sessionComparator(sortColumn));
+    final row = ResourceWorkspaceRow(
+      workspaceId: workspace.id,
+      name: workspace.name,
+      projectId: workspace.projectId,
+      remote: workspace.hostId != 'local',
+      sessions: List<ResourceSessionRow>.unmodifiable(sessions),
+    );
+    workspacesByProject
+        .putIfAbsent(workspace.projectId, () => <ResourceWorkspaceRow>[])
+        .add(row);
+  }
+
+  final groups = <ResourceProjectGroup>[];
+  for (final entry in workspacesByProject.entries) {
+    final project = projectsById[entry.key];
+    final rows = entry.value..sort(_workspaceComparator(sortColumn));
+    groups.add(
+      ResourceProjectGroup(
+        projectId: entry.key,
+        name: project?.name ?? entry.key,
+        workspaces: List<ResourceWorkspaceRow>.unmodifiable(rows),
+      ),
+    );
+  }
+  groups.sort(_projectComparator(sortColumn));
+  orphans.sort(_sessionComparator(sortColumn));
+
+  return ResourceTree(
+    projects: List<ResourceProjectGroup>.unmodifiable(groups),
+    orphanSessions: List<ResourceSessionRow>.unmodifiable(orphans),
+  );
+}
+
+int Function(ResourceSessionRow, ResourceSessionRow) _sessionComparator(
+  ResourceSortColumn column,
+) {
+  return (left, right) => switch (column) {
+    ResourceSortColumn.name => _byName(left.label, right.label),
+    ResourceSortColumn.cpu => _thenByName(
+      compareMetricDescending(left.cpuPercent, right.cpuPercent),
+      left.label,
+      right.label,
+    ),
+    ResourceSortColumn.memory => _thenByName(
+      compareMetricDescending(left.memoryBytes, right.memoryBytes),
+      left.label,
+      right.label,
+    ),
+  };
+}
+
+int Function(ResourceWorkspaceRow, ResourceWorkspaceRow) _workspaceComparator(
+  ResourceSortColumn column,
+) {
+  return (left, right) => switch (column) {
+    ResourceSortColumn.name => _byName(left.name, right.name),
+    ResourceSortColumn.cpu => _thenByName(
+      compareMetricDescending(left.cpuPercent, right.cpuPercent),
+      left.name,
+      right.name,
+    ),
+    ResourceSortColumn.memory => _thenByName(
+      compareMetricDescending(left.memoryBytes, right.memoryBytes),
+      left.name,
+      right.name,
+    ),
+  };
+}
+
+int Function(ResourceProjectGroup, ResourceProjectGroup) _projectComparator(
+  ResourceSortColumn column,
+) {
+  return (left, right) => switch (column) {
+    ResourceSortColumn.name => _byName(left.name, right.name),
+    ResourceSortColumn.cpu => _thenByName(
+      compareMetricDescending(left.cpuPercent, right.cpuPercent),
+      left.name,
+      right.name,
+    ),
+    ResourceSortColumn.memory => _thenByName(
+      compareMetricDescending(left.memoryBytes, right.memoryBytes),
+      left.name,
+      right.name,
+    ),
+  };
+}
+
+int _byName(String left, String right) =>
+    left.toLowerCase().compareTo(right.toLowerCase());
+
+/// Name is the tiebreaker for every metric sort, so rows keep a stable order
+/// instead of shuffling between polls when two of them read the same.
+int _thenByName(int comparison, String left, String right) =>
+    comparison != 0 ? comparison : _byName(left, right);

--- a/lib/src/features/resource_manager/domain/resource_snapshot.dart
+++ b/lib/src/features/resource_manager/domain/resource_snapshot.dart
@@ -1,0 +1,248 @@
+/// Wire models for the runtime host's `resources.snapshot` response.
+///
+/// Read-only data off the socket, so these parse defensively: the app can
+/// attach to an older sidecar that answers with fewer fields, and a missing
+/// value must degrade to "unknown" rather than throw.
+library;
+
+class ResourceHostMetrics {
+  const ResourceHostMetrics({
+    required this.totalMemoryBytes,
+    required this.availableMemoryBytes,
+    required this.usedMemoryBytes,
+    required this.memoryUsagePercent,
+    required this.cpuCoreCount,
+    required this.loadAverage1m,
+  });
+
+  factory ResourceHostMetrics.fromJson(Map<String, Object?> json) {
+    return ResourceHostMetrics(
+      totalMemoryBytes: _intValue(json['totalMemoryBytes']),
+      availableMemoryBytes: _intValue(json['availableMemoryBytes']),
+      usedMemoryBytes: _intValue(json['usedMemoryBytes']),
+      memoryUsagePercent: _doubleValue(json['memoryUsagePercent']),
+      cpuCoreCount: _intValue(json['cpuCoreCount']),
+      loadAverage1m: _doubleValue(json['loadAverage1m']),
+    );
+  }
+
+  static const empty = ResourceHostMetrics(
+    totalMemoryBytes: 0,
+    availableMemoryBytes: 0,
+    usedMemoryBytes: 0,
+    memoryUsagePercent: 0,
+    cpuCoreCount: 0,
+    loadAverage1m: 0,
+  );
+
+  final int totalMemoryBytes;
+  final int availableMemoryBytes;
+  final int usedMemoryBytes;
+  final double memoryUsagePercent;
+  final int cpuCoreCount;
+
+  /// Always zero on Windows, which has no load average.
+  final double loadAverage1m;
+
+  bool get hasMemoryReading => totalMemoryBytes > 0;
+}
+
+/// One measured process subtree: the app itself or the runtime host.
+class ResourceProcessSample {
+  const ResourceProcessSample({
+    required this.pid,
+    required this.cpuPercent,
+    required this.memoryBytes,
+    required this.processCount,
+    required this.history,
+  });
+
+  static ResourceProcessSample? tryFromJson(Object? value) {
+    if (value is! Map) {
+      return null;
+    }
+    final json = Map<String, Object?>.from(value);
+    return ResourceProcessSample(
+      pid: _intValue(json['pid']),
+      cpuPercent: _doubleValue(json['cpuPercent']),
+      memoryBytes: _intValue(json['memoryBytes']),
+      processCount: _intValue(json['processCount']),
+      history: _intList(json['history']),
+    );
+  }
+
+  final int pid;
+  final double cpuPercent;
+  final int memoryBytes;
+  final int processCount;
+
+  /// Memory samples, oldest first. Only memory is historized; a CPU sparkline
+  /// at this cadence is noise.
+  final List<int> history;
+}
+
+/// One terminal session as the host sees it, whether or not the app still has
+/// a tab for it.
+class ResourceSessionSample {
+  const ResourceSessionSample({
+    required this.sessionId,
+    required this.workspaceId,
+    required this.tabId,
+    required this.running,
+    required this.shellPid,
+    required this.measured,
+    required this.cpuPercent,
+    required this.memoryBytes,
+    required this.processCount,
+    required this.history,
+  });
+
+  static ResourceSessionSample? tryFromJson(Object? value) {
+    if (value is! Map) {
+      return null;
+    }
+    final json = Map<String, Object?>.from(value);
+    final sessionId = json['sessionId'];
+    if (sessionId is! String || sessionId.isEmpty) {
+      return null;
+    }
+    return ResourceSessionSample(
+      sessionId: sessionId,
+      workspaceId: _stringValue(json['workspaceId']),
+      tabId: _stringValue(json['tabId']),
+      running: json['running'] == true,
+      shellPid: json['shellPid'] is num
+          ? (json['shellPid']! as num).toInt()
+          : null,
+      measured: json['measured'] == true,
+      cpuPercent: _doubleValue(json['cpuPercent']),
+      memoryBytes: _intValue(json['memoryBytes']),
+      processCount: _intValue(json['processCount']),
+      history: _intList(json['history']),
+    );
+  }
+
+  final String sessionId;
+  final String workspaceId;
+  final String tabId;
+  final bool running;
+
+  /// Absent once the shell exits: the OS recycles pids, so the host drops it
+  /// rather than let a stale value point at an unrelated process.
+  final int? shellPid;
+
+  /// Whether the host actually found this session's process in the table.
+  final bool measured;
+  final double cpuPercent;
+  final int memoryBytes;
+  final int processCount;
+  final List<int> history;
+}
+
+class ResourceSnapshot {
+  const ResourceSnapshot({
+    required this.collectedAt,
+    required this.warming,
+    required this.host,
+    required this.hostProcess,
+    required this.appProcess,
+    required this.sessions,
+    required this.totalCpuPercent,
+    required this.totalMemoryBytes,
+    this.error,
+  });
+
+  factory ResourceSnapshot.fromJson(Map<String, Object?> json) {
+    final processes = json['processes'];
+    final processMap = processes is Map
+        ? Map<String, Object?>.from(processes)
+        : const <String, Object?>{};
+    final host = json['host'];
+    final totals = json['totals'];
+    final totalsMap = totals is Map
+        ? Map<String, Object?>.from(totals)
+        : const <String, Object?>{};
+    return ResourceSnapshot(
+      collectedAt: _timestamp(json['collectedAt']),
+      warming: json['warming'] == true,
+      host: host is Map
+          ? ResourceHostMetrics.fromJson(Map<String, Object?>.from(host))
+          : ResourceHostMetrics.empty,
+      hostProcess: ResourceProcessSample.tryFromJson(processMap['host']),
+      appProcess: ResourceProcessSample.tryFromJson(processMap['app']),
+      sessions: <ResourceSessionSample>[
+        for (final item in (json['sessions'] as List? ?? const <Object?>[]))
+          ?ResourceSessionSample.tryFromJson(item),
+      ],
+      totalCpuPercent: _doubleValue(totalsMap['cpuPercent']),
+      totalMemoryBytes: _intValue(totalsMap['memoryBytes']),
+    );
+  }
+
+  /// The state before any reading exists: a host that does not support the
+  /// verb, a failed request, or the moment right after the panel opens.
+  factory ResourceSnapshot.unavailable({String? error}) {
+    return ResourceSnapshot(
+      collectedAt: DateTime.now().toUtc(),
+      warming: true,
+      host: ResourceHostMetrics.empty,
+      hostProcess: null,
+      appProcess: null,
+      sessions: const <ResourceSessionSample>[],
+      totalCpuPercent: 0,
+      totalMemoryBytes: 0,
+      error: error,
+    );
+  }
+
+  final DateTime collectedAt;
+
+  /// The sampler has not produced two refreshes yet, so CPU is not meaningful.
+  final bool warming;
+  final ResourceHostMetrics host;
+  final ResourceProcessSample? hostProcess;
+  final ResourceProcessSample? appProcess;
+  final List<ResourceSessionSample> sessions;
+  final double totalCpuPercent;
+  final int totalMemoryBytes;
+  final String? error;
+
+  bool get hasReading => !warming && error == null;
+
+  ResourceSnapshot withError(String error) {
+    return ResourceSnapshot(
+      collectedAt: collectedAt,
+      warming: warming,
+      host: host,
+      hostProcess: hostProcess,
+      appProcess: appProcess,
+      sessions: sessions,
+      totalCpuPercent: totalCpuPercent,
+      totalMemoryBytes: totalMemoryBytes,
+      error: error,
+    );
+  }
+}
+
+DateTime _timestamp(Object? value) {
+  if (value is num) {
+    return DateTime.fromMillisecondsSinceEpoch(value.toInt(), isUtc: true);
+  }
+  return DateTime.now().toUtc();
+}
+
+int _intValue(Object? value) => value is num ? value.toInt() : 0;
+
+double _doubleValue(Object? value) => value is num ? value.toDouble() : 0;
+
+String _stringValue(Object? value) => value is String ? value : '';
+
+List<int> _intList(Object? value) {
+  if (value is! List) {
+    return const <int>[];
+  }
+  return <int>[
+    for (final item in value)
+      if (item is num) item.toInt(),
+  ];
+}

--- a/lib/src/features/resource_manager/domain/resource_tree.dart
+++ b/lib/src/features/resource_manager/domain/resource_tree.dart
@@ -1,0 +1,134 @@
+/// The workbench-shaped view of a resource snapshot: Project -> Workspace ->
+/// Terminal session.
+///
+/// Metrics are nullable because not every row can be measured. A workspace on
+/// an SSH host runs its PTYs on another machine, so its numbers are absent
+/// rather than zero, and the panel renders a dash instead of a misleading 0%.
+library;
+
+enum ResourceSortColumn { name, cpu, memory }
+
+class ResourceSessionRow {
+  const ResourceSessionRow({
+    required this.sessionId,
+    required this.label,
+    required this.tabId,
+    required this.running,
+    required this.orphan,
+    required this.cpuPercent,
+    required this.memoryBytes,
+    required this.processCount,
+    required this.history,
+  });
+
+  final String sessionId;
+  final String label;
+  final String tabId;
+  final bool running;
+
+  /// The host still has this session but the app has no tab for it. Killing an
+  /// orphan is safe without a confirmation: there is no pane to lose.
+  final bool orphan;
+  final double? cpuPercent;
+  final int? memoryBytes;
+  final int processCount;
+  final List<int> history;
+}
+
+class ResourceWorkspaceRow {
+  const ResourceWorkspaceRow({
+    required this.workspaceId,
+    required this.name,
+    required this.projectId,
+    required this.remote,
+    required this.sessions,
+  });
+
+  final String workspaceId;
+  final String name;
+  final String projectId;
+
+  /// Driven by the workspace's `hostId`, never by missing samples: a local
+  /// session that reconnected to a warm host has no samples for a moment and
+  /// must not be relabelled as remote.
+  final bool remote;
+  final List<ResourceSessionRow> sessions;
+
+  double? get cpuPercent =>
+      _sumDoubles(sessions.map((session) => session.cpuPercent));
+
+  int? get memoryBytes =>
+      _sumInts(sessions.map((session) => session.memoryBytes));
+}
+
+class ResourceProjectGroup {
+  const ResourceProjectGroup({
+    required this.projectId,
+    required this.name,
+    required this.workspaces,
+  });
+
+  final String projectId;
+  final String name;
+  final List<ResourceWorkspaceRow> workspaces;
+
+  double? get cpuPercent =>
+      _sumDoubles(workspaces.map((workspace) => workspace.cpuPercent));
+
+  int? get memoryBytes =>
+      _sumInts(workspaces.map((workspace) => workspace.memoryBytes));
+}
+
+class ResourceTree {
+  const ResourceTree({required this.projects, required this.orphanSessions});
+
+  static const empty = ResourceTree(
+    projects: <ResourceProjectGroup>[],
+    orphanSessions: <ResourceSessionRow>[],
+  );
+
+  final List<ResourceProjectGroup> projects;
+
+  /// Sessions the host reports that no tab claims, flattened out of the tree
+  /// so the panel can offer a single "kill them all" action.
+  final List<ResourceSessionRow> orphanSessions;
+
+  bool get isEmpty => projects.isEmpty && orphanSessions.isEmpty;
+}
+
+/// Descending comparison where an absent metric always sorts last, so unmeasured
+/// remote rows never displace real readings at the top of the panel.
+int compareMetricDescending(num? left, num? right) {
+  if (left == null && right == null) {
+    return 0;
+  }
+  if (left == null) {
+    return 1;
+  }
+  if (right == null) {
+    return -1;
+  }
+  return right.compareTo(left);
+}
+
+double? _sumDoubles(Iterable<double?> values) {
+  double? total;
+  for (final value in values) {
+    if (value == null) {
+      continue;
+    }
+    total = (total ?? 0) + value;
+  }
+  return total;
+}
+
+int? _sumInts(Iterable<int?> values) {
+  int? total;
+  for (final value in values) {
+    if (value == null) {
+      continue;
+    }
+    total = (total ?? 0) + value;
+  }
+  return total;
+}

--- a/test/unit/resource_manager_providers_test.dart
+++ b/test/unit/resource_manager_providers_test.dart
@@ -1,0 +1,94 @@
+import 'dart:async';
+
+import 'package:alera/src/features/resource_manager/application/resource_manager_providers.dart';
+import 'package:alera/src/features/workbench/infra/terminal_host/terminal_host_protocol.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+final class _FakeRuntimeHostClient implements RuntimeHostClient {
+  _FakeRuntimeHostClient({this.payload, this.failure});
+
+  final Object? payload;
+  final Object? failure;
+  final List<Map<String, Object?>> requests = <Map<String, Object?>>[];
+  final List<String> types = <String>[];
+
+  @override
+  Stream<RuntimeHostEvent> get runtimeEvents =>
+      const Stream<RuntimeHostEvent>.empty();
+
+  @override
+  Future<Object?> runtimeRequest(
+    String type, [
+    Map<String, Object?> payload = const <String, Object?>{},
+    Duration? timeout,
+  ]) async {
+    types.add(type);
+    requests.add(payload);
+    if (failure != null) {
+      throw failure!;
+    }
+    return this.payload;
+  }
+}
+
+void main() {
+  group('fetchResourceSnapshot', () {
+    test(
+      'sends the app pid so the host can attribute the app process',
+      () async {
+        final client = _FakeRuntimeHostClient(
+          payload: <String, Object?>{
+            'warming': false,
+            'totals': <String, Object?>{'memoryBytes': 42},
+          },
+        );
+
+        final snapshot = await fetchResourceSnapshot(
+          client: client,
+          appPid: 1234,
+        );
+
+        expect(client.types, <String>['resources.snapshot']);
+        expect(client.requests.single['appPid'], 1234);
+        expect(snapshot.totalMemoryBytes, 42);
+        expect(snapshot.hasReading, isTrue);
+      },
+    );
+
+    test('a host that rejects the verb degrades instead of throwing', () async {
+      // An older sidecar has no resource monitor. The chip is ambient UI and
+      // must not break the status bar when it is missing.
+      final client = _FakeRuntimeHostClient(
+        failure: StateError('Unsupported request type: resources.snapshot'),
+      );
+
+      final snapshot = await fetchResourceSnapshot(client: client, appPid: 1);
+
+      expect(snapshot.hasReading, isFalse);
+      expect(snapshot.error, contains('resources.snapshot'));
+      expect(snapshot.sessions, isEmpty);
+    });
+
+    test('a non-object response is reported as an error', () async {
+      final client = _FakeRuntimeHostClient(payload: 'nonsense');
+
+      final snapshot = await fetchResourceSnapshot(client: client, appPid: 1);
+
+      expect(snapshot.hasReading, isFalse);
+      expect(snapshot.error, contains('unexpected resource payload'));
+    });
+  });
+
+  group('polling cadence', () {
+    test('the panel polls faster while it is open', () {
+      // Open matches the host's own 2s sampling; closed keeps the chip fresh
+      // without paying for a sweep nobody is watching.
+      expect(resourceSnapshotOpenInterval, const Duration(seconds: 2));
+      expect(resourceSnapshotClosedInterval, const Duration(seconds: 15));
+      expect(
+        resourceSnapshotClosedInterval,
+        greaterThan(resourceSnapshotOpenInterval),
+      );
+    });
+  });
+}

--- a/test/unit/resource_snapshot_projection_test.dart
+++ b/test/unit/resource_snapshot_projection_test.dart
@@ -1,0 +1,357 @@
+import 'package:alera/src/features/projects/domain/project.dart';
+import 'package:alera/src/features/resource_manager/application/resource_snapshot_projection.dart';
+import 'package:alera/src/features/resource_manager/domain/resource_snapshot.dart';
+import 'package:alera/src/features/resource_manager/domain/resource_tree.dart';
+import 'package:alera/src/features/workbench/domain/workspace.dart';
+import 'package:alera/src/features/workbench/domain/workspace_tab_record.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+final _now = DateTime.utc(2026, 7, 25);
+
+Project _project(String id, String name) => Project(
+  id: id,
+  name: name,
+  repoPath: '/repos/$id',
+  createdAt: _now,
+  updatedAt: _now,
+);
+
+Workspace _workspace(
+  String id,
+  String name, {
+  String projectId = 'p1',
+  String hostId = 'local',
+}) => Workspace(
+  id: id,
+  projectId: projectId,
+  name: name,
+  path: '/repos/$projectId/$id',
+  createdAt: _now,
+  updatedAt: _now,
+  kind: WorkspaceKind.linked,
+  status: WorkspaceStatus.active,
+  hostId: hostId,
+);
+
+WorkspaceTabRecord _tab(
+  String id,
+  String workspaceId, {
+  required String sessionId,
+  String title = 'Terminal',
+  WorkspaceTabKind kind = WorkspaceTabKind.terminal,
+}) => WorkspaceTabRecord(
+  id: id,
+  workspaceId: workspaceId,
+  title: title,
+  createdAt: _now,
+  updatedAt: _now,
+  kind: kind,
+  payload: <String, Object?>{
+    workspaceTabTerminalSessionIdPayloadKey: sessionId,
+  },
+);
+
+ResourceSessionSample _session(
+  String sessionId, {
+  required String workspaceId,
+  required String tabId,
+  double cpuPercent = 0,
+  int memoryBytes = 0,
+  bool measured = true,
+  bool running = true,
+}) => ResourceSessionSample(
+  sessionId: sessionId,
+  workspaceId: workspaceId,
+  tabId: tabId,
+  running: running,
+  shellPid: running ? 4242 : null,
+  measured: measured,
+  cpuPercent: cpuPercent,
+  memoryBytes: memoryBytes,
+  processCount: 1,
+  history: const <int>[1, 2],
+);
+
+ResourceSnapshot _snapshot(List<ResourceSessionSample> sessions) =>
+    ResourceSnapshot(
+      collectedAt: _now,
+      warming: false,
+      host: ResourceHostMetrics.empty,
+      hostProcess: null,
+      appProcess: null,
+      sessions: sessions,
+      totalCpuPercent: 0,
+      totalMemoryBytes: 0,
+    );
+
+void main() {
+  group('buildResourceTree', () {
+    test('groups sessions under their workspace and project', () {
+      final tree = buildResourceTree(
+        snapshot: _snapshot(<ResourceSessionSample>[
+          _session(
+            's1',
+            workspaceId: 'w1',
+            tabId: 't1',
+            cpuPercent: 10,
+            memoryBytes: 100,
+          ),
+          _session(
+            's2',
+            workspaceId: 'w1',
+            tabId: 't2',
+            cpuPercent: 5,
+            memoryBytes: 50,
+          ),
+        ]),
+        projects: <Project>[_project('p1', 'Alera')],
+        workspaces: <Workspace>[_workspace('w1', 'Main')],
+        tabs: <WorkspaceTabRecord>[
+          _tab('t1', 'w1', sessionId: 's1', title: 'Agent'),
+          _tab('t2', 'w1', sessionId: 's2', title: 'Build'),
+        ],
+      );
+
+      final project = tree.projects.single;
+      expect(project.name, 'Alera');
+      expect(project.cpuPercent, 15);
+      expect(project.memoryBytes, 150);
+
+      final workspace = project.workspaces.single;
+      expect(workspace.name, 'Main');
+      expect(workspace.remote, isFalse);
+      expect(workspace.cpuPercent, 15);
+      expect(workspace.memoryBytes, 150);
+      expect(workspace.sessions.map((session) => session.label), <String>[
+        'Agent',
+        'Build',
+      ]);
+      expect(tree.orphanSessions, isEmpty);
+    });
+
+    test('a session with no tab becomes an orphan outside the tree', () {
+      final tree = buildResourceTree(
+        snapshot: _snapshot(<ResourceSessionSample>[
+          _session('kept', workspaceId: 'w1', tabId: 't1', memoryBytes: 10),
+          _session('lost', workspaceId: 'w1', tabId: 'gone', memoryBytes: 20),
+        ]),
+        projects: <Project>[_project('p1', 'Alera')],
+        workspaces: <Workspace>[_workspace('w1', 'Main')],
+        tabs: <WorkspaceTabRecord>[_tab('t1', 'w1', sessionId: 'kept')],
+      );
+
+      expect(
+        tree.projects.single.workspaces.single.sessions.map(
+          (session) => session.sessionId,
+        ),
+        <String>['kept'],
+      );
+      final orphan = tree.orphanSessions.single;
+      expect(orphan.sessionId, 'lost');
+      expect(orphan.orphan, isTrue);
+      // Falls back to the session id because there is no tab to name it.
+      expect(orphan.label, 'lost');
+      // The workspace aggregate must exclude the orphan.
+      expect(tree.projects.single.workspaces.single.memoryBytes, 10);
+    });
+
+    test('a non-terminal tab never claims a session', () {
+      // Only terminal tabs own PTYs; an editor tab sharing an id must not stop
+      // a session from being reported as orphaned.
+      final tree = buildResourceTree(
+        snapshot: _snapshot(<ResourceSessionSample>[
+          _session('s1', workspaceId: 'w1', tabId: 't1'),
+        ]),
+        projects: <Project>[_project('p1', 'Alera')],
+        workspaces: <Workspace>[_workspace('w1', 'Main')],
+        tabs: <WorkspaceTabRecord>[
+          _tab('s1', 'w1', sessionId: 's1', kind: WorkspaceTabKind.editor),
+        ],
+      );
+
+      expect(tree.projects, isEmpty);
+      expect(tree.orphanSessions.single.sessionId, 's1');
+    });
+
+    test('a remote workspace reports absent metrics rather than zero', () {
+      final tree = buildResourceTree(
+        snapshot: _snapshot(<ResourceSessionSample>[
+          _session(
+            's1',
+            workspaceId: 'w1',
+            tabId: 't1',
+            cpuPercent: 9,
+            memoryBytes: 90,
+          ),
+        ]),
+        projects: <Project>[_project('p1', 'Alera')],
+        workspaces: <Workspace>[_workspace('w1', 'Remote', hostId: 'ssh-box')],
+        tabs: <WorkspaceTabRecord>[_tab('t1', 'w1', sessionId: 's1')],
+      );
+
+      final workspace = tree.projects.single.workspaces.single;
+      expect(workspace.remote, isTrue);
+      expect(workspace.sessions.single.cpuPercent, isNull);
+      expect(workspace.sessions.single.memoryBytes, isNull);
+      expect(workspace.cpuPercent, isNull);
+      expect(workspace.memoryBytes, isNull);
+      expect(tree.projects.single.memoryBytes, isNull);
+    });
+
+    test('an unmeasured local session reports absent metrics', () {
+      final tree = buildResourceTree(
+        snapshot: _snapshot(<ResourceSessionSample>[
+          _session(
+            's1',
+            workspaceId: 'w1',
+            tabId: 't1',
+            measured: false,
+            running: false,
+          ),
+        ]),
+        projects: <Project>[_project('p1', 'Alera')],
+        workspaces: <Workspace>[_workspace('w1', 'Main')],
+        tabs: <WorkspaceTabRecord>[_tab('t1', 'w1', sessionId: 's1')],
+      );
+
+      expect(
+        tree.projects.single.workspaces.single.sessions.single.memoryBytes,
+        isNull,
+      );
+    });
+
+    test('sessions for an unknown workspace are dropped', () {
+      // Only happens mid-sync; inventing a group would be worse than waiting.
+      final tree = buildResourceTree(
+        snapshot: _snapshot(<ResourceSessionSample>[
+          _session('s1', workspaceId: 'ghost', tabId: 't1'),
+        ]),
+        projects: <Project>[_project('p1', 'Alera')],
+        workspaces: const <Workspace>[],
+        tabs: <WorkspaceTabRecord>[_tab('t1', 'ghost', sessionId: 's1')],
+      );
+
+      expect(tree.projects, isEmpty);
+      expect(tree.orphanSessions, isEmpty);
+      expect(tree.isEmpty, isTrue);
+    });
+
+    test('a project without a record falls back to its id', () {
+      final tree = buildResourceTree(
+        snapshot: _snapshot(<ResourceSessionSample>[
+          _session('s1', workspaceId: 'w1', tabId: 't1'),
+        ]),
+        projects: const <Project>[],
+        workspaces: <Workspace>[_workspace('w1', 'Main')],
+        tabs: <WorkspaceTabRecord>[_tab('t1', 'w1', sessionId: 's1')],
+      );
+
+      expect(tree.projects.single.name, 'p1');
+    });
+  });
+
+  group('sorting', () {
+    ResourceTree buildWithSort(ResourceSortColumn column) => buildResourceTree(
+      snapshot: _snapshot(<ResourceSessionSample>[
+        _session(
+          'low',
+          workspaceId: 'w1',
+          tabId: 't1',
+          cpuPercent: 1,
+          memoryBytes: 10,
+        ),
+        _session(
+          'high',
+          workspaceId: 'w1',
+          tabId: 't2',
+          cpuPercent: 9,
+          memoryBytes: 90,
+        ),
+        _session(
+          'absent',
+          workspaceId: 'w1',
+          tabId: 't3',
+          measured: false,
+          running: false,
+        ),
+      ]),
+      projects: <Project>[_project('p1', 'Alera')],
+      workspaces: <Workspace>[_workspace('w1', 'Main')],
+      tabs: <WorkspaceTabRecord>[
+        _tab('t1', 'w1', sessionId: 'low', title: 'Bravo'),
+        _tab('t2', 'w1', sessionId: 'high', title: 'Alpha'),
+        _tab('t3', 'w1', sessionId: 'absent', title: 'Charlie'),
+      ],
+    );
+
+    test('memory sorts descending with unmeasured rows last', () {
+      final sessions = buildWithSort(
+        ResourceSortColumn.memory,
+      ).projects.single.workspaces.single.sessions;
+
+      expect(sessions.map((session) => session.label), <String>[
+        'Alpha',
+        'Bravo',
+        'Charlie',
+      ]);
+    });
+
+    test('cpu sorts descending with unmeasured rows last', () {
+      final sessions = buildWithSort(
+        ResourceSortColumn.cpu,
+      ).projects.single.workspaces.single.sessions;
+
+      expect(sessions.last.label, 'Charlie');
+      expect(sessions.first.label, 'Alpha');
+    });
+
+    test('name sorts alphabetically regardless of usage', () {
+      final sessions = buildWithSort(
+        ResourceSortColumn.name,
+      ).projects.single.workspaces.single.sessions;
+
+      expect(sessions.map((session) => session.label), <String>[
+        'Alpha',
+        'Bravo',
+        'Charlie',
+      ]);
+    });
+
+    test('projects and workspaces sort by their aggregate', () {
+      final tree = buildResourceTree(
+        snapshot: _snapshot(<ResourceSessionSample>[
+          _session('s1', workspaceId: 'w1', tabId: 't1', memoryBytes: 10),
+          _session('s2', workspaceId: 'w2', tabId: 't2', memoryBytes: 900),
+        ]),
+        projects: <Project>[_project('p1', 'Small'), _project('p2', 'Large')],
+        workspaces: <Workspace>[
+          _workspace('w1', 'Small workspace'),
+          _workspace('w2', 'Large workspace', projectId: 'p2'),
+        ],
+        tabs: <WorkspaceTabRecord>[
+          _tab('t1', 'w1', sessionId: 's1'),
+          _tab('t2', 'w2', sessionId: 's2'),
+        ],
+      );
+
+      expect(tree.projects.map((project) => project.name), <String>[
+        'Large',
+        'Small',
+      ]);
+    });
+  });
+
+  group('compareMetricDescending', () {
+    test('absent values always sort last', () {
+      expect(compareMetricDescending(null, 1), greaterThan(0));
+      expect(compareMetricDescending(1, null), lessThan(0));
+      expect(compareMetricDescending(null, null), 0);
+    });
+
+    test('larger values sort first', () {
+      expect(compareMetricDescending(9, 1), lessThan(0));
+      expect(compareMetricDescending(1, 9), greaterThan(0));
+      expect(compareMetricDescending(5, 5), 0);
+    });
+  });
+}

--- a/test/unit/resource_snapshot_test.dart
+++ b/test/unit/resource_snapshot_test.dart
@@ -1,0 +1,169 @@
+import 'package:alera/src/features/resource_manager/domain/resource_snapshot.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+Map<String, Object?> _payload({
+  List<Object?> sessions = const <Object?>[],
+  bool warming = false,
+}) {
+  return <String, Object?>{
+    'collectedAt': 1730000000000,
+    'warming': warming,
+    'host': <String, Object?>{
+      'totalMemoryBytes': 16000000000,
+      'availableMemoryBytes': 4000000000,
+      'usedMemoryBytes': 12000000000,
+      'memoryUsagePercent': 75.0,
+      'cpuCoreCount': 8,
+      'loadAverage1m': 1.25,
+    },
+    'processes': <String, Object?>{
+      'host': <String, Object?>{
+        'pid': 1001,
+        'cpuPercent': 2.5,
+        'memoryBytes': 40000000,
+        'processCount': 1,
+        'history': <Object?>[10, 20, 30],
+      },
+      'app': <String, Object?>{
+        'pid': 1002,
+        'cpuPercent': 0.5,
+        'memoryBytes': 280000000,
+        'processCount': 1,
+        'history': <Object?>[100],
+      },
+    },
+    'sessions': sessions,
+    'totals': <String, Object?>{'cpuPercent': 12.5, 'memoryBytes': 900000000},
+  };
+}
+
+void main() {
+  group('ResourceSnapshot.fromJson', () {
+    test('parses a full payload', () {
+      final snapshot = ResourceSnapshot.fromJson(
+        _payload(
+          sessions: <Object?>[
+            <String, Object?>{
+              'sessionId': 's1',
+              'workspaceId': 'w1',
+              'tabId': 't1',
+              'running': true,
+              'shellPid': 4242,
+              'measured': true,
+              'cpuPercent': 12.0,
+              'memoryBytes': 500000000,
+              'processCount': 7,
+              'history': <Object?>[1, 2],
+            },
+          ],
+        ),
+      );
+
+      expect(snapshot.warming, isFalse);
+      expect(snapshot.hasReading, isTrue);
+      expect(
+        snapshot.collectedAt,
+        DateTime.fromMillisecondsSinceEpoch(1730000000000, isUtc: true),
+      );
+      expect(snapshot.host.cpuCoreCount, 8);
+      expect(snapshot.host.loadAverage1m, 1.25);
+      expect(snapshot.host.hasMemoryReading, isTrue);
+      expect(snapshot.hostProcess?.pid, 1001);
+      expect(snapshot.appProcess?.memoryBytes, 280000000);
+      expect(snapshot.appProcess?.history, <int>[100]);
+      expect(snapshot.totalCpuPercent, 12.5);
+      expect(snapshot.totalMemoryBytes, 900000000);
+
+      final session = snapshot.sessions.single;
+      expect(session.sessionId, 's1');
+      expect(session.workspaceId, 'w1');
+      expect(session.tabId, 't1');
+      expect(session.running, isTrue);
+      expect(session.shellPid, 4242);
+      expect(session.measured, isTrue);
+      expect(session.processCount, 7);
+      expect(session.history, <int>[1, 2]);
+    });
+
+    test('a warming payload is not a reading', () {
+      final snapshot = ResourceSnapshot.fromJson(_payload(warming: true));
+
+      expect(snapshot.warming, isTrue);
+      expect(snapshot.hasReading, isFalse);
+    });
+
+    test('an exited session reports no shell pid', () {
+      final snapshot = ResourceSnapshot.fromJson(
+        _payload(
+          sessions: <Object?>[
+            <String, Object?>{
+              'sessionId': 's1',
+              'workspaceId': 'w1',
+              'tabId': 't1',
+              'running': false,
+              'shellPid': null,
+              'measured': false,
+            },
+          ],
+        ),
+      );
+
+      final session = snapshot.sessions.single;
+      expect(session.shellPid, isNull);
+      expect(session.measured, isFalse);
+      expect(session.memoryBytes, 0);
+      expect(session.history, isEmpty);
+    });
+
+    test('tolerates an older host that omits fields', () {
+      // The app can attach to a sidecar that predates a field, so a missing
+      // value has to degrade instead of throwing.
+      final snapshot = ResourceSnapshot.fromJson(<String, Object?>{});
+
+      expect(snapshot.host, ResourceHostMetrics.empty);
+      expect(snapshot.host.hasMemoryReading, isFalse);
+      expect(snapshot.hostProcess, isNull);
+      expect(snapshot.appProcess, isNull);
+      expect(snapshot.sessions, isEmpty);
+      expect(snapshot.totalMemoryBytes, 0);
+    });
+
+    test('drops session entries without an id', () {
+      final snapshot = ResourceSnapshot.fromJson(
+        _payload(
+          sessions: <Object?>[
+            'not a map',
+            <String, Object?>{'workspaceId': 'w1'},
+            <String, Object?>{'sessionId': ''},
+            <String, Object?>{'sessionId': 'kept'},
+          ],
+        ),
+      );
+
+      expect(snapshot.sessions.map((session) => session.sessionId), <String>[
+        'kept',
+      ]);
+    });
+  });
+
+  group('ResourceSnapshot.unavailable', () {
+    test('carries the error and is not a reading', () {
+      final snapshot = ResourceSnapshot.unavailable(error: 'host is down');
+
+      expect(snapshot.error, 'host is down');
+      expect(snapshot.hasReading, isFalse);
+      expect(snapshot.sessions, isEmpty);
+    });
+
+    test('withError keeps the last good values visible', () {
+      // A failed poll should not blank the panel: the previous numbers stay on
+      // screen, flagged as stale.
+      final snapshot = ResourceSnapshot.fromJson(_payload()).withError('boom');
+
+      expect(snapshot.error, 'boom');
+      expect(snapshot.hasReading, isFalse);
+      expect(snapshot.totalMemoryBytes, 900000000);
+      expect(snapshot.hostProcess?.pid, 1001);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Dart side of the resource manager: wire models, the projection onto the workbench tree, and the Riverpod providers. No UI yet.

`buildResourceTree` is a pure function so every ordering and orphan rule is covered by unit tests rather than by driving a widget. The host knows pids and ids; only the app knows project and workspace names, which tabs still exist, and which workspaces live on another machine.

Rules worth reviewing:

- A session with no terminal tab is an orphan, listed apart from the tree. Only terminal tabs can claim a session.
- Metrics are nullable rather than zero. A workspace whose `hostId` is not `local` runs its PTYs elsewhere, so the panel will render a dash instead of a misleading 0%.
- Remoteness is decided by `hostId`, never by missing samples: a local session that just reconnected to a warm host must not be relabelled as remote.
- Name is the tiebreaker for every metric sort, so rows keep a stable order instead of shuffling between polls when two of them read the same.
- The panel polls every 2s while open and every 15s while closed, keeping the chip fresh without paying for sweeps nobody is watching.
- A host that does not support the verb degrades to an unavailable snapshot rather than an error: the chip is ambient UI and must not break the status bar.

## Validation

- `flutter analyze`: no issues.
- `flutter test`: passes.
- 24 new unit tests across payload parsing, the projection, and the providers.

The two failures in `test/unit/terminal_runtime_native_test.dart` are pre-existing on `main` in this environment (real PTY adapters timing out) and are unrelated to this change.