### PR TITLE
feat: add the resource manager status bar panel

### DIFF
--- a/lib/src/design_system/feedback/alera_sparkline.dart
+++ b/lib/src/design_system/feedback/alera_sparkline.dart
@@ -1,0 +1,101 @@
+import 'package:alera/src/app/theme/alera_tokens.dart';
+import 'package:flutter/material.dart';
+
+/// Compact trend line for a short series of samples, drawn min/max normalized
+/// so a flat-but-high series and a flat-but-low one look the same.
+///
+/// Hand-rolled rather than pulled from a charting package: the whole widget is
+/// one polyline, and a chart library would be several orders of magnitude more
+/// code for the same pixels.
+class AleraSparkline extends StatelessWidget {
+  const AleraSparkline({
+    super.key,
+    required this.samples,
+    this.width = 48,
+    this.height = 14,
+    this.color,
+  });
+
+  /// Values oldest first. Fewer than two points draws nothing: a single sample
+  /// has no trend to show.
+  final List<int> samples;
+  final double width;
+  final double height;
+  final Color? color;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: width,
+      height: height,
+      child: CustomPaint(
+        painter: _SparklinePainter(
+          samples: samples,
+          color: color ?? AleraTokens.foregroundMuted,
+        ),
+      ),
+    );
+  }
+}
+
+class _SparklinePainter extends CustomPainter {
+  const _SparklinePainter({required this.samples, required this.color});
+
+  final List<int> samples;
+  final Color color;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    if (samples.length < 2 || size.width <= 0 || size.height <= 0) {
+      return;
+    }
+    var lowest = samples.first;
+    var highest = samples.first;
+    for (final sample in samples) {
+      if (sample < lowest) {
+        lowest = sample;
+      }
+      if (sample > highest) {
+        highest = sample;
+      }
+    }
+    final span = highest - lowest;
+    final stepX = size.width / (samples.length - 1);
+    final path = Path();
+    for (var index = 0; index < samples.length; index++) {
+      // A flat series has no span to normalize against, so it rides the middle
+      // instead of dividing by zero or pinning to an edge.
+      final normalized = span == 0 ? 0.5 : (samples[index] - lowest) / span;
+      final x = stepX * index;
+      final y = size.height - (normalized * size.height);
+      if (index == 0) {
+        path.moveTo(x, y);
+      } else {
+        path.lineTo(x, y);
+      }
+    }
+    canvas.drawPath(
+      path,
+      Paint()
+        ..color = color
+        ..style = PaintingStyle.stroke
+        ..strokeWidth = 1
+        ..strokeJoin = StrokeJoin.round
+        ..strokeCap = StrokeCap.round,
+    );
+  }
+
+  @override
+  bool shouldRepaint(_SparklinePainter oldDelegate) {
+    if (oldDelegate.color != color ||
+        oldDelegate.samples.length != samples.length) {
+      return true;
+    }
+    for (var index = 0; index < samples.length; index++) {
+      if (oldDelegate.samples[index] != samples[index]) {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/lib/src/design_system/feedback/alera_sparkline.preview.dart
+++ b/lib/src/design_system/feedback/alera_sparkline.preview.dart
@@ -1,0 +1,18 @@
+import 'package:alera/src/design_system/alera_preview.dart';
+import 'package:alera/src/design_system/feedback/alera_sparkline.dart';
+import 'package:flutter/material.dart';
+
+@AleraPreview(name: 'Rising', group: 'Sparkline')
+Widget aleraSparklineRisingPreview() =>
+    const AleraSparkline(samples: <int>[10, 14, 12, 22, 30, 28, 44, 60]);
+
+@AleraPreview(name: 'Flat', group: 'Sparkline')
+Widget aleraSparklineFlatPreview() =>
+    const AleraSparkline(samples: <int>[30, 30, 30, 30, 30]);
+
+@AleraPreview(name: 'Single Sample', group: 'Sparkline')
+Widget aleraSparklineSingleSamplePreview() =>
+    const AleraSparkline(samples: <int>[30]);
+
+@AleraPreview(name: 'Empty', group: 'Sparkline')
+Widget aleraSparklineEmptyPreview() => const AleraSparkline(samples: <int>[]);

--- a/lib/src/design_system/icons/alera_icons.dart
+++ b/lib/src/design_system/icons/alera_icons.dart
@@ -139,6 +139,8 @@ abstract final class AleraIcons {
   static const IconData tune = LucideIcons.slidersHorizontal;
   static const IconData agent = LucideIcons.bot;
   static const IconData quota = LucideIcons.gauge;
+  static const IconData resources = LucideIcons.activity;
+  static const IconData warning = LucideIcons.triangleAlert;
   static const IconData terminal = LucideIcons.terminal;
   static const IconData code = LucideIcons.code;
   static const IconData keyboard = LucideIcons.keyboard;

--- a/lib/src/features/resource_manager/presentation/resource_status_bar_control.dart
+++ b/lib/src/features/resource_manager/presentation/resource_status_bar_control.dart
@@ -1,0 +1,193 @@
+import 'dart:async';
+
+import 'package:alera/src/design_system/layout/alera_confirm_dialog.dart';
+import 'package:alera/src/features/resource_manager/application/resource_manager_providers.dart';
+import 'package:alera/src/features/resource_manager/domain/resource_snapshot.dart';
+import 'package:alera/src/features/resource_manager/domain/resource_tree.dart';
+import 'package:alera/src/features/resource_manager/presentation/resource_status_chip.dart';
+import 'package:alera/src/features/resource_manager/presentation/resource_status_panel.dart';
+import 'package:alera/src/features/workbench/application/workbench_controller.dart';
+import 'package:alera/src/features/workbench/domain/workspace.dart';
+import 'package:alera/src/shared/infra/runtime/runtime_host_providers.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Status-bar entry point for the resource manager: a chip that opens the
+/// panel in an overlay anchored above it.
+class ResourceStatusBarControl extends ConsumerStatefulWidget {
+  const ResourceStatusBarControl({super.key});
+
+  @override
+  ConsumerState<ResourceStatusBarControl> createState() =>
+      _ResourceStatusBarControlState();
+}
+
+class _ResourceStatusBarControlState
+    extends ConsumerState<ResourceStatusBarControl> {
+  final OverlayPortalController _overlay = OverlayPortalController();
+  final LayerLink _layerLink = LayerLink();
+  ResourceSortColumn _sortColumn = ResourceSortColumn.memory;
+  final Set<String> _collapsedProjectIds = <String>{};
+
+  @override
+  Widget build(BuildContext context) {
+    final snapshot =
+        ref.watch(resourceSnapshotProvider).value ??
+        ResourceSnapshot.unavailable();
+    final tree = ref.watch(resourceTreeProvider(_sortColumn));
+    final sessionCount = tree.projects.fold<int>(
+      0,
+      (total, project) =>
+          total +
+          project.workspaces.fold<int>(
+            0,
+            (subtotal, workspace) => subtotal + workspace.sessions.length,
+          ),
+    );
+
+    return CompositedTransformTarget(
+      link: _layerLink,
+      child: OverlayPortal(
+        controller: _overlay,
+        overlayChildBuilder: (context) {
+          return Stack(
+            children: <Widget>[
+              Positioned.fill(
+                child: GestureDetector(
+                  behavior: HitTestBehavior.opaque,
+                  onTap: _close,
+                  child: const ColoredBox(color: Colors.transparent),
+                ),
+              ),
+              CompositedTransformFollower(
+                link: _layerLink,
+                showWhenUnlinked: false,
+                targetAnchor: Alignment.topRight,
+                followerAnchor: Alignment.bottomRight,
+                offset: const Offset(0, -8),
+                child: ResourceStatusPanel(
+                  snapshot: snapshot,
+                  tree: tree,
+                  sortColumn: _sortColumn,
+                  hostUnreachable: snapshot.error != null,
+                  collapsedProjectIds: _collapsedProjectIds,
+                  onSortColumnChanged: (column) =>
+                      setState(() => _sortColumn = column),
+                  onToggleProject: (projectId) => setState(() {
+                    if (!_collapsedProjectIds.remove(projectId)) {
+                      _collapsedProjectIds.add(projectId);
+                    }
+                  }),
+                  onOpenSession: _openSession,
+                  onKillSession: (session) => unawaited(_killSession(session)),
+                  onKillOrphans: () =>
+                      unawaited(_killOrphans(tree.orphanSessions)),
+                ),
+              ),
+            ],
+          );
+        },
+        child: ResourceStatusChip(
+          snapshot: snapshot,
+          sessionCount: sessionCount,
+          orphanCount: tree.orphanSessions.length,
+          onPressed: _toggle,
+        ),
+      ),
+    );
+  }
+
+  void _toggle() {
+    if (_overlay.isShowing) {
+      _close();
+      return;
+    }
+    _overlay.show();
+    // Opening switches the poll to the host's own 2 s cadence, and also keeps
+    // the host's sampler alive while the panel is on screen.
+    ref.read(resourcePanelOpenProvider.notifier).set(open: true);
+    ref.invalidate(resourceSnapshotProvider);
+  }
+
+  void _close() {
+    _overlay.hide();
+    ref.read(resourcePanelOpenProvider.notifier).set(open: false);
+  }
+
+  void _openSession(ResourceSessionRow session) {
+    final controller = ref.read(workbenchControllerProvider.notifier);
+    final state = ref.read(workbenchControllerProvider);
+    final workspace = _workspaceForTab(session.tabId);
+    if (workspace == null) {
+      return;
+    }
+    final project = state.projects
+        .where((candidate) => candidate.id == workspace.projectId)
+        .firstOrNull;
+    if (project == null) {
+      return;
+    }
+    _close();
+    unawaited(() async {
+      await controller.selectWorkspace(project: project, workspace: workspace);
+      controller.setActiveTab(workspaceId: workspace.id, tabId: session.tabId);
+    }());
+  }
+
+  /// Killing a session with a tab closes the tab, which is the flow the user
+  /// already knows. An orphan has no pane to lose, so it is terminated
+  /// directly and without a prompt.
+  Future<void> _killSession(ResourceSessionRow session) async {
+    if (session.orphan) {
+      await ref.read(runtimeHostClientProvider).terminate(session.sessionId);
+      ref.invalidate(resourceSnapshotProvider);
+      return;
+    }
+    final workspace = _workspaceForTab(session.tabId);
+    if (workspace == null) {
+      return;
+    }
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (_) => AleraConfirmDialog(
+        title: 'Close Terminal Session',
+        message:
+            'Force-quits ${session.label}. Anything running in that terminal '
+            'is lost.',
+        confirmLabel: 'Close',
+        destructive: true,
+      ),
+    );
+    if (confirmed != true) {
+      return;
+    }
+    await ref
+        .read(workbenchControllerProvider.notifier)
+        .closeWorkspaceTab(workspace: workspace, tabId: session.tabId);
+    ref.invalidate(resourceSnapshotProvider);
+  }
+
+  Future<void> _killOrphans(List<ResourceSessionRow> orphans) async {
+    final client = ref.read(runtimeHostClientProvider);
+    await Future.wait(<Future<void>>[
+      for (final orphan in orphans) client.terminate(orphan.sessionId),
+    ]);
+    ref.invalidate(resourceSnapshotProvider);
+  }
+
+  Workspace? _workspaceForTab(String tabId) {
+    final state = ref.read(workbenchControllerProvider);
+    for (final entry in state.tabsByWorkspace.entries) {
+      if (entry.value.any((tab) => tab.id == tabId)) {
+        for (final workspaces in state.workspacesByProject.values) {
+          for (final workspace in workspaces) {
+            if (workspace.id == entry.key) {
+              return workspace;
+            }
+          }
+        }
+      }
+    }
+    return null;
+  }
+}

--- a/lib/src/features/resource_manager/presentation/resource_status_chip.dart
+++ b/lib/src/features/resource_manager/presentation/resource_status_chip.dart
@@ -1,0 +1,84 @@
+import 'package:alera/src/app/theme/alera_tokens.dart';
+import 'package:alera/src/design_system/icons/alera_icons.dart';
+import 'package:alera/src/features/resource_manager/domain/resource_snapshot.dart';
+import 'package:alera/src/features/resource_manager/presentation/resource_value_format.dart';
+import 'package:flutter/material.dart';
+
+/// Status-bar chip: total memory plus the running session count, with the
+/// orphan count called out when there is one.
+class ResourceStatusChip extends StatelessWidget {
+  const ResourceStatusChip({
+    super.key,
+    required this.snapshot,
+    required this.sessionCount,
+    required this.orphanCount,
+    required this.onPressed,
+  });
+
+  final ResourceSnapshot snapshot;
+  final int sessionCount;
+  final int orphanCount;
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    final memory = snapshot.hasReading
+        ? formatResourceMemory(snapshot.totalMemoryBytes)
+        : resourceAbsentReading;
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        onTap: onPressed,
+        // Every clickable chip in the status bar uses the hand cursor; the
+        // InkWell default stays an arrow off the web.
+        mouseCursor: WidgetStateMouseCursor.clickable,
+        child: Tooltip(
+          message: 'Resource Manager',
+          child: Container(
+            height: AleraTokens.statusBarHeight,
+            padding: const EdgeInsets.symmetric(horizontal: AleraTokens.space8),
+            decoration: const BoxDecoration(
+              border: Border(left: BorderSide(color: AleraTokens.borderSubtle)),
+            ),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: <Widget>[
+                const Icon(
+                  AleraIcons.resources,
+                  size: 13,
+                  color: AleraTokens.foregroundMuted,
+                ),
+                const SizedBox(width: AleraTokens.space6),
+                Text(
+                  memory,
+                  style: AleraTokens.monoStyle.copyWith(fontSize: 10),
+                ),
+                const SizedBox(width: AleraTokens.space6),
+                const Icon(
+                  AleraIcons.terminal,
+                  size: 11,
+                  color: AleraTokens.foregroundMuted,
+                ),
+                const SizedBox(width: AleraTokens.space4),
+                Text(
+                  '$sessionCount',
+                  style: AleraTokens.monoStyle.copyWith(fontSize: 10),
+                ),
+                if (orphanCount > 0) ...<Widget>[
+                  const SizedBox(width: AleraTokens.space4),
+                  Text(
+                    '($orphanCount)',
+                    style: AleraTokens.monoStyle.copyWith(
+                      fontSize: 10,
+                      color: AleraTokens.warning,
+                    ),
+                  ),
+                ],
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/features/resource_manager/presentation/resource_status_panel.dart
+++ b/lib/src/features/resource_manager/presentation/resource_status_panel.dart
@@ -1,0 +1,131 @@
+import 'package:alera/src/app/theme/alera_tokens.dart';
+import 'package:alera/src/design_system/buttons/alera_icon_button.dart';
+import 'package:alera/src/design_system/feedback/alera_empty_state.dart';
+import 'package:alera/src/design_system/feedback/alera_sparkline.dart';
+import 'package:alera/src/design_system/feedback/alera_status_dot.dart';
+import 'package:alera/src/design_system/icons/alera_icons.dart';
+import 'package:alera/src/features/resource_manager/domain/resource_snapshot.dart';
+import 'package:alera/src/features/resource_manager/domain/resource_tree.dart';
+import 'package:alera/src/features/resource_manager/presentation/resource_value_format.dart';
+import 'package:flutter/material.dart';
+
+part 'resource_status_panel_chrome.dart';
+part 'resource_status_panel_rows.dart';
+
+const double resourcePanelWidth = 400;
+const double resourcePanelMaxHeight = 420;
+
+/// Width of the CPU and memory columns. Fixed so the numbers line up down the
+/// tree even though rows sit at different indent depths.
+const double _metricColumnWidth = 68;
+
+/// Presentational resource panel. Data and callbacks arrive as parameters so it
+/// stays previewable and testable without a runtime host.
+class ResourceStatusPanel extends StatelessWidget {
+  const ResourceStatusPanel({
+    super.key,
+    required this.snapshot,
+    required this.tree,
+    required this.sortColumn,
+    required this.onSortColumnChanged,
+    required this.onOpenSession,
+    required this.onKillSession,
+    required this.onKillOrphans,
+    this.collapsedProjectIds = const <String>{},
+    this.onToggleProject,
+    this.hostUnreachable = false,
+  });
+
+  final ResourceSnapshot snapshot;
+  final ResourceTree tree;
+  final ResourceSortColumn sortColumn;
+  final ValueChanged<ResourceSortColumn> onSortColumnChanged;
+  final ValueChanged<ResourceSessionRow> onOpenSession;
+  final ValueChanged<ResourceSessionRow> onKillSession;
+  final VoidCallback onKillOrphans;
+  final Set<String> collapsedProjectIds;
+  final ValueChanged<String>? onToggleProject;
+  final bool hostUnreachable;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: resourcePanelWidth,
+      constraints: const BoxConstraints(maxHeight: resourcePanelMaxHeight),
+      decoration: BoxDecoration(
+        color: AleraTokens.surfaceElevated,
+        borderRadius: BorderRadius.circular(AleraTokens.radiusLg),
+        border: Border.all(color: AleraTokens.border),
+      ),
+      child: Material(
+        color: Colors.transparent,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: <Widget>[
+            const _PanelHeader(),
+            if (hostUnreachable) const _HostUnreachableNotice(),
+            _TotalsRow(snapshot: snapshot),
+            _SortHeader(
+              sortColumn: sortColumn,
+              onSortColumnChanged: onSortColumnChanged,
+            ),
+            Flexible(child: _PanelBody(panel: this)),
+            if (tree.orphanSessions.isNotEmpty)
+              _OrphanFooter(
+                count: tree.orphanSessions.length,
+                onKillOrphans: onKillOrphans,
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _PanelBody extends StatelessWidget {
+  const _PanelBody({required this.panel});
+
+  final ResourceStatusPanel panel;
+
+  @override
+  Widget build(BuildContext context) {
+    final snapshot = panel.snapshot;
+    if (panel.tree.isEmpty) {
+      return Padding(
+        padding: const EdgeInsets.symmetric(vertical: AleraTokens.space24),
+        child: AleraEmptyState(
+          icon: AleraIcons.resources,
+          message: switch (snapshot) {
+            ResourceSnapshot(error: final String error) => error,
+            ResourceSnapshot(warming: true) => 'Measuring Resource Usage',
+            _ => 'No Terminal Sessions Are Running',
+          },
+        ),
+      );
+    }
+    return SingleChildScrollView(
+      padding: const EdgeInsets.only(bottom: AleraTokens.space8),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: <Widget>[
+          for (final project in panel.tree.projects)
+            _ProjectSection(
+              project: project,
+              collapsed: panel.collapsedProjectIds.contains(project.projectId),
+              onToggle: panel.onToggleProject,
+              onOpenSession: panel.onOpenSession,
+              onKillSession: panel.onKillSession,
+            ),
+          if (panel.tree.orphanSessions.isNotEmpty)
+            _OrphanSection(
+              sessions: panel.tree.orphanSessions,
+              onKillSession: panel.onKillSession,
+            ),
+          _AleraSection(snapshot: snapshot),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/src/features/resource_manager/presentation/resource_status_panel.preview.dart
+++ b/lib/src/features/resource_manager/presentation/resource_status_panel.preview.dart
@@ -1,0 +1,146 @@
+import 'package:alera/src/design_system/alera_preview.dart';
+import 'package:alera/src/features/resource_manager/domain/resource_snapshot.dart';
+import 'package:alera/src/features/resource_manager/domain/resource_tree.dart';
+import 'package:alera/src/features/resource_manager/presentation/resource_status_chip.dart';
+import 'package:alera/src/features/resource_manager/presentation/resource_status_panel.dart';
+import 'package:flutter/material.dart';
+
+const _history = <int>[120, 180, 160, 240, 300, 280, 420, 500];
+
+ResourceSnapshot _snapshot({bool warming = false, String? error}) {
+  return ResourceSnapshot(
+    collectedAt: DateTime.utc(2026, 7, 25),
+    warming: warming,
+    host: const ResourceHostMetrics(
+      totalMemoryBytes: 16 * 1024 * 1024 * 1024,
+      availableMemoryBytes: 6 * 1024 * 1024 * 1024,
+      usedMemoryBytes: 10 * 1024 * 1024 * 1024,
+      memoryUsagePercent: 62.5,
+      cpuCoreCount: 8,
+      loadAverage1m: 2.4,
+    ),
+    hostProcess: const ResourceProcessSample(
+      pid: 4100,
+      cpuPercent: 1.2,
+      memoryBytes: 42 * 1024 * 1024,
+      processCount: 1,
+      history: _history,
+    ),
+    appProcess: const ResourceProcessSample(
+      pid: 4200,
+      cpuPercent: 0.6,
+      memoryBytes: 280 * 1024 * 1024,
+      processCount: 1,
+      history: _history,
+    ),
+    sessions: const <ResourceSessionSample>[],
+    totalCpuPercent: 187.4,
+    totalMemoryBytes: 1400 * 1024 * 1024,
+    error: error,
+  );
+}
+
+ResourceSessionRow _session(
+  String label, {
+  double? cpuPercent = 12.5,
+  int? memoryBytes = 500 * 1024 * 1024,
+  bool orphan = false,
+}) => ResourceSessionRow(
+  sessionId: 'session-$label',
+  label: label,
+  tabId: 'tab-$label',
+  running: true,
+  orphan: orphan,
+  cpuPercent: cpuPercent,
+  memoryBytes: memoryBytes,
+  processCount: 7,
+  history: _history,
+);
+
+ResourceTree _tree({
+  List<ResourceSessionRow> orphans = const <ResourceSessionRow>[],
+  bool remote = false,
+}) => ResourceTree(
+  projects: <ResourceProjectGroup>[
+    ResourceProjectGroup(
+      projectId: 'p1',
+      name: 'Alera',
+      workspaces: <ResourceWorkspaceRow>[
+        ResourceWorkspaceRow(
+          workspaceId: 'w1',
+          name: 'Main',
+          projectId: 'p1',
+          remote: false,
+          sessions: <ResourceSessionRow>[
+            _session('Codex Agent'),
+            _session('Build', cpuPercent: 3.1, memoryBytes: 90 * 1024 * 1024),
+          ],
+        ),
+        if (remote)
+          ResourceWorkspaceRow(
+            workspaceId: 'w2',
+            name: 'Mini PC',
+            projectId: 'p1',
+            remote: true,
+            sessions: <ResourceSessionRow>[
+              _session('Remote Shell', cpuPercent: null, memoryBytes: null),
+            ],
+          ),
+      ],
+    ),
+  ],
+  orphanSessions: orphans,
+);
+
+Widget _panel(
+  ResourceSnapshot snapshot,
+  ResourceTree tree, {
+  bool host = false,
+}) {
+  return ResourceStatusPanel(
+    snapshot: snapshot,
+    tree: tree,
+    sortColumn: ResourceSortColumn.memory,
+    hostUnreachable: host,
+    onSortColumnChanged: (_) {},
+    onOpenSession: (_) {},
+    onKillSession: (_) {},
+    onKillOrphans: () {},
+  );
+}
+
+@AleraPreview(name: 'Populated', group: 'Resource manager')
+Widget resourceStatusPanelPopulatedPreview() => _panel(_snapshot(), _tree());
+
+@AleraPreview(name: 'With Orphans', group: 'Resource manager')
+Widget resourceStatusPanelOrphansPreview() => _panel(
+  _snapshot(),
+  _tree(
+    orphans: <ResourceSessionRow>[
+      _session('session-abc', orphan: true, cpuPercent: 0.2),
+    ],
+  ),
+);
+
+@AleraPreview(name: 'Remote Workspace', group: 'Resource manager')
+Widget resourceStatusPanelRemotePreview() =>
+    _panel(_snapshot(), _tree(remote: true));
+
+@AleraPreview(name: 'Warming', group: 'Resource manager')
+Widget resourceStatusPanelWarmingPreview() =>
+    _panel(_snapshot(warming: true), ResourceTree.empty);
+
+@AleraPreview(name: 'Host Unreachable', group: 'Resource manager')
+Widget resourceStatusPanelUnreachablePreview() => _panel(
+  _snapshot(error: 'The runtime host is not running.'),
+  ResourceTree.empty,
+  host: true,
+);
+
+@AleraPreview(name: 'Chip', group: 'Resource manager')
+Widget resourceStatusChipPreview() => ResourceStatusChip(
+  snapshot: _snapshot(),
+  sessionCount: 7,
+  orphanCount: 2,
+  onPressed: () {},
+);

--- a/lib/src/features/resource_manager/presentation/resource_status_panel_chrome.dart
+++ b/lib/src/features/resource_manager/presentation/resource_status_panel_chrome.dart
@@ -1,0 +1,269 @@
+part of 'resource_status_panel.dart';
+
+// Panel chrome: the title bar, the host notice, the totals strip and the
+// sortable column header. Everything here frames the tree without knowing what
+// is in it.
+
+class _PanelHeader extends StatelessWidget {
+  const _PanelHeader();
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.fromLTRB(
+        AleraTokens.space12,
+        AleraTokens.space8,
+        AleraTokens.space8,
+        AleraTokens.space8,
+      ),
+      decoration: const BoxDecoration(
+        border: Border(bottom: BorderSide(color: AleraTokens.borderSubtle)),
+      ),
+      child: Row(
+        children: <Widget>[
+          const Icon(
+            AleraIcons.resources,
+            size: 13,
+            color: AleraTokens.foregroundMuted,
+          ),
+          const SizedBox(width: AleraTokens.space8),
+          Text(
+            'Resource Manager',
+            style: Theme.of(
+              context,
+            ).textTheme.labelLarge?.copyWith(color: AleraTokens.foreground),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// The host is unreachable, so the panel points at the runtime host control
+/// rather than duplicating its Start/Stop/Restart flow.
+class _HostUnreachableNotice extends StatelessWidget {
+  const _HostUnreachableNotice();
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(
+        horizontal: AleraTokens.space12,
+        vertical: AleraTokens.space8,
+      ),
+      color: AleraTokens.warning.withValues(alpha: 0.12),
+      child: Row(
+        children: <Widget>[
+          const Icon(AleraIcons.warning, size: 13, color: AleraTokens.warning),
+          const SizedBox(width: AleraTokens.space8),
+          Expanded(
+            child: Text(
+              'The Runtime Host Is Not Responding. Use The Host Chip To '
+              'Restart It.',
+              style: Theme.of(
+                context,
+              ).textTheme.bodySmall?.copyWith(color: AleraTokens.warning),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _TotalsRow extends StatelessWidget {
+  const _TotalsRow({required this.snapshot});
+
+  final ResourceSnapshot snapshot;
+
+  @override
+  Widget build(BuildContext context) {
+    final warming = !snapshot.hasReading;
+    final cpu = warming ? null : snapshot.totalCpuPercent;
+    final memory = warming ? null : snapshot.totalMemoryBytes;
+    return Container(
+      padding: const EdgeInsets.symmetric(
+        horizontal: AleraTokens.space12,
+        vertical: AleraTokens.space8,
+      ),
+      decoration: const BoxDecoration(
+        border: Border(bottom: BorderSide(color: AleraTokens.borderSubtle)),
+      ),
+      child: Row(
+        children: <Widget>[
+          _TotalsValue(
+            label: 'CPU',
+            value: formatResourceCpu(cpu),
+            tooltip:
+                'Total CPU across Alera and every terminal it spawned. '
+                'Percent of one core, so it can exceed 100%.',
+          ),
+          const SizedBox(width: AleraTokens.space16),
+          _TotalsValue(
+            label: 'Memory',
+            value: formatResourceMemory(memory),
+            tooltip:
+                'Resident memory of Alera, the runtime host, and every '
+                'terminal process.',
+          ),
+          const Spacer(),
+          // Flexible with an ellipsis so a wide reading degrades instead of
+          // overflowing the fixed-width panel.
+          Flexible(
+            child: Tooltip(
+              message: 'Share of the machine memory these processes hold.',
+              child: Text(
+                formatResourceShareOfSystem(
+                  memory,
+                  snapshot.host.totalMemoryBytes,
+                ),
+                overflow: TextOverflow.ellipsis,
+                style: AleraTokens.monoStyle.copyWith(fontSize: 10),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _TotalsValue extends StatelessWidget {
+  const _TotalsValue({
+    required this.label,
+    required this.value,
+    required this.tooltip,
+  });
+
+  final String label;
+  final String value;
+  final String tooltip;
+
+  @override
+  Widget build(BuildContext context) {
+    return Tooltip(
+      message: tooltip,
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: <Widget>[
+          Text(
+            label,
+            style: Theme.of(
+              context,
+            ).textTheme.bodySmall?.copyWith(color: AleraTokens.foregroundFaint),
+          ),
+          const SizedBox(width: AleraTokens.space6),
+          Text(
+            value,
+            style: AleraTokens.monoStyle.copyWith(
+              fontSize: 11,
+              color: AleraTokens.foreground,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SortHeader extends StatelessWidget {
+  const _SortHeader({
+    required this.sortColumn,
+    required this.onSortColumnChanged,
+  });
+
+  final ResourceSortColumn sortColumn;
+  final ValueChanged<ResourceSortColumn> onSortColumnChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(
+        horizontal: AleraTokens.space12,
+        vertical: AleraTokens.space4,
+      ),
+      decoration: const BoxDecoration(
+        border: Border(bottom: BorderSide(color: AleraTokens.borderSubtle)),
+      ),
+      child: Row(
+        children: <Widget>[
+          Expanded(
+            child: _SortButton(
+              label: 'Name',
+              column: ResourceSortColumn.name,
+              sortColumn: sortColumn,
+              onPressed: onSortColumnChanged,
+              alignment: Alignment.centerLeft,
+            ),
+          ),
+          SizedBox(
+            width: _metricColumnWidth,
+            child: _SortButton(
+              label: 'CPU',
+              column: ResourceSortColumn.cpu,
+              sortColumn: sortColumn,
+              onPressed: onSortColumnChanged,
+              alignment: Alignment.centerRight,
+            ),
+          ),
+          SizedBox(
+            width: _metricColumnWidth,
+            child: _SortButton(
+              label: 'Memory',
+              column: ResourceSortColumn.memory,
+              sortColumn: sortColumn,
+              onPressed: onSortColumnChanged,
+              alignment: Alignment.centerRight,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SortButton extends StatelessWidget {
+  const _SortButton({
+    required this.label,
+    required this.column,
+    required this.sortColumn,
+    required this.onPressed,
+    required this.alignment,
+  });
+
+  final String label;
+  final ResourceSortColumn column;
+  final ResourceSortColumn sortColumn;
+  final ValueChanged<ResourceSortColumn> onPressed;
+  final Alignment alignment;
+
+  @override
+  Widget build(BuildContext context) {
+    final selected = column == sortColumn;
+    return Semantics(
+      selected: selected,
+      button: true,
+      child: Tooltip(
+        message: 'Sort By $label',
+        child: InkWell(
+          onTap: () => onPressed(column),
+          mouseCursor: WidgetStateMouseCursor.clickable,
+          child: Align(
+            alignment: alignment,
+            child: Padding(
+              padding: const EdgeInsets.symmetric(vertical: AleraTokens.space4),
+              child: Text(
+                label,
+                style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                  color: selected
+                      ? AleraTokens.foreground
+                      : AleraTokens.foregroundFaint,
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/features/resource_manager/presentation/resource_status_panel_rows.dart
+++ b/lib/src/features/resource_manager/presentation/resource_status_panel_rows.dart
@@ -1,0 +1,336 @@
+part of 'resource_status_panel.dart';
+
+// The tree itself: project, workspace, session and the shared metric row they
+// all render through, plus Alera's own processes and the orphan footer.
+
+class _ProjectSection extends StatelessWidget {
+  const _ProjectSection({
+    required this.project,
+    required this.collapsed,
+    required this.onToggle,
+    required this.onOpenSession,
+    required this.onKillSession,
+  });
+
+  final ResourceProjectGroup project;
+  final bool collapsed;
+  final ValueChanged<String>? onToggle;
+  final ValueChanged<ResourceSessionRow> onOpenSession;
+  final ValueChanged<ResourceSessionRow> onKillSession;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: <Widget>[
+        _MetricRow(
+          indent: 0,
+          label: project.name,
+          cpuPercent: project.cpuPercent,
+          memoryBytes: project.memoryBytes,
+          leading: Icon(
+            collapsed ? AleraIcons.chevronRight : AleraIcons.chevronDown,
+            size: 12,
+            color: AleraTokens.foregroundFaint,
+          ),
+          bold: true,
+          onTap: onToggle == null ? null : () => onToggle!(project.projectId),
+        ),
+        if (!collapsed)
+          for (final workspace in project.workspaces)
+            _WorkspaceSection(
+              workspace: workspace,
+              onOpenSession: onOpenSession,
+              onKillSession: onKillSession,
+            ),
+      ],
+    );
+  }
+}
+
+class _WorkspaceSection extends StatelessWidget {
+  const _WorkspaceSection({
+    required this.workspace,
+    required this.onOpenSession,
+    required this.onKillSession,
+  });
+
+  final ResourceWorkspaceRow workspace;
+  final ValueChanged<ResourceSessionRow> onOpenSession;
+  final ValueChanged<ResourceSessionRow> onKillSession;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: <Widget>[
+        _MetricRow(
+          indent: 1,
+          label: workspace.name,
+          suffix: workspace.remote ? 'remote' : null,
+          cpuPercent: workspace.cpuPercent,
+          memoryBytes: workspace.memoryBytes,
+        ),
+        for (final session in workspace.sessions)
+          _SessionRow(
+            session: session,
+            onOpen: () => onOpenSession(session),
+            onKill: () => onKillSession(session),
+          ),
+      ],
+    );
+  }
+}
+
+class _OrphanSection extends StatelessWidget {
+  const _OrphanSection({required this.sessions, required this.onKillSession});
+
+  final List<ResourceSessionRow> sessions;
+  final ValueChanged<ResourceSessionRow> onKillSession;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: <Widget>[
+        _MetricRow(
+          indent: 0,
+          label: 'Unattributed Terminals',
+          cpuPercent: null,
+          memoryBytes: null,
+          bold: true,
+        ),
+        for (final session in sessions)
+          _SessionRow(
+            session: session,
+            onOpen: null,
+            onKill: () => onKillSession(session),
+          ),
+      ],
+    );
+  }
+}
+
+class _SessionRow extends StatelessWidget {
+  const _SessionRow({
+    required this.session,
+    required this.onOpen,
+    required this.onKill,
+  });
+
+  final ResourceSessionRow session;
+  final VoidCallback? onOpen;
+  final VoidCallback onKill;
+
+  @override
+  Widget build(BuildContext context) {
+    return _MetricRow(
+      indent: 2,
+      label: session.label,
+      cpuPercent: session.cpuPercent,
+      memoryBytes: session.memoryBytes,
+      onTap: onOpen,
+      leading: AleraStatusDot(active: session.running, size: 6),
+      trailing: AleraIconButton(
+        icon: AleraIcons.close,
+        iconSize: 11,
+        minSize: 18,
+        tooltip: session.orphan
+            ? 'Kill Orphan Terminal'
+            : 'Close Terminal Session',
+        onPressed: onKill,
+      ),
+      sparkline: session.history,
+    );
+  }
+}
+
+/// One row of the tree. Every level shares this so the metric columns keep the
+/// same x position no matter how deep the row sits.
+class _MetricRow extends StatelessWidget {
+  const _MetricRow({
+    required this.indent,
+    required this.label,
+    required this.cpuPercent,
+    required this.memoryBytes,
+    this.leading,
+    this.trailing,
+    this.suffix,
+    this.onTap,
+    this.bold = false,
+    this.sparkline = const <int>[],
+  });
+
+  final int indent;
+  final String label;
+  final double? cpuPercent;
+  final int? memoryBytes;
+  final Widget? leading;
+  final Widget? trailing;
+  final String? suffix;
+  final VoidCallback? onTap;
+  final bool bold;
+  final List<int> sparkline;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final row = Padding(
+      padding: EdgeInsets.only(
+        left: AleraTokens.space12 + (indent * AleraTokens.space12),
+        right: AleraTokens.space12,
+        top: AleraTokens.space4,
+        bottom: AleraTokens.space4,
+      ),
+      child: Row(
+        children: <Widget>[
+          if (leading != null) ...<Widget>[
+            leading!,
+            const SizedBox(width: AleraTokens.space6),
+          ],
+          Expanded(
+            child: Row(
+              children: <Widget>[
+                Flexible(
+                  child: Text(
+                    label,
+                    overflow: TextOverflow.ellipsis,
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: AleraTokens.foreground,
+                      fontWeight: bold ? FontWeight.w600 : FontWeight.w400,
+                    ),
+                  ),
+                ),
+                if (suffix != null) ...<Widget>[
+                  const SizedBox(width: AleraTokens.space6),
+                  Text(
+                    suffix!,
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: AleraTokens.foregroundFaint,
+                    ),
+                  ),
+                ],
+              ],
+            ),
+          ),
+          if (sparkline.length > 1) ...<Widget>[
+            AleraSparkline(samples: sparkline),
+            const SizedBox(width: AleraTokens.space8),
+          ],
+          _MetricCell(value: formatResourceCpu(cpuPercent)),
+          _MetricCell(value: formatResourceMemory(memoryBytes)),
+          ?trailing,
+        ],
+      ),
+    );
+    if (onTap == null) {
+      return row;
+    }
+    return InkWell(
+      onTap: onTap,
+      mouseCursor: WidgetStateMouseCursor.clickable,
+      child: row,
+    );
+  }
+}
+
+class _MetricCell extends StatelessWidget {
+  const _MetricCell({required this.value});
+
+  final String value;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: _metricColumnWidth,
+      child: Text(
+        value,
+        textAlign: TextAlign.right,
+        style: AleraTokens.monoStyle.copyWith(fontSize: 10),
+      ),
+    );
+  }
+}
+
+/// Alera's own processes, kept apart from the workspace tree so the app and the
+/// sidecar never look like somebody's terminal.
+class _AleraSection extends StatelessWidget {
+  const _AleraSection({required this.snapshot});
+
+  final ResourceSnapshot snapshot;
+
+  @override
+  Widget build(BuildContext context) {
+    final app = snapshot.appProcess;
+    final host = snapshot.hostProcess;
+    if (app == null && host == null) {
+      return const SizedBox.shrink();
+    }
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: <Widget>[
+        const Divider(height: 1, color: AleraTokens.borderSubtle),
+        _MetricRow(
+          indent: 0,
+          label: 'Alera',
+          cpuPercent: (app?.cpuPercent ?? 0) + (host?.cpuPercent ?? 0),
+          memoryBytes: (app?.memoryBytes ?? 0) + (host?.memoryBytes ?? 0),
+          bold: true,
+        ),
+        if (app != null)
+          _MetricRow(
+            indent: 1,
+            label: 'App',
+            cpuPercent: app.cpuPercent,
+            memoryBytes: app.memoryBytes,
+            sparkline: app.history,
+          ),
+        if (host != null)
+          _MetricRow(
+            indent: 1,
+            label: 'Runtime Host',
+            cpuPercent: host.cpuPercent,
+            memoryBytes: host.memoryBytes,
+            sparkline: host.history,
+          ),
+      ],
+    );
+  }
+}
+
+class _OrphanFooter extends StatelessWidget {
+  const _OrphanFooter({required this.count, required this.onKillOrphans});
+
+  final int count;
+  final VoidCallback onKillOrphans;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(
+        horizontal: AleraTokens.space12,
+        vertical: AleraTokens.space6,
+      ),
+      decoration: const BoxDecoration(
+        border: Border(top: BorderSide(color: AleraTokens.borderSubtle)),
+      ),
+      child: Row(
+        children: <Widget>[
+          Expanded(
+            child: Text(
+              '$count Orphan Terminal${count == 1 ? '' : 's'}',
+              style: Theme.of(
+                context,
+              ).textTheme.bodySmall?.copyWith(color: AleraTokens.warning),
+            ),
+          ),
+          TextButton(onPressed: onKillOrphans, child: const Text('Kill All')),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/src/features/resource_manager/presentation/resource_value_format.dart
+++ b/lib/src/features/resource_manager/presentation/resource_value_format.dart
@@ -1,0 +1,40 @@
+/// Rendering of resource readings, including the "no reading" case.
+///
+/// An absent metric is a dash, never a zero: a remote or unmeasured row reading
+/// "0%" would claim it is idle, which is a different statement from "we cannot
+/// see it from here".
+library;
+
+const String resourceAbsentReading = '-';
+
+String formatResourceMemory(int? bytes) {
+  if (bytes == null) {
+    return resourceAbsentReading;
+  }
+  const kilobyte = 1024;
+  const megabyte = kilobyte * 1024;
+  const gigabyte = megabyte * 1024;
+  if (bytes < megabyte) {
+    return '${(bytes / kilobyte).round()} KB';
+  }
+  if (bytes < gigabyte) {
+    return '${(bytes / megabyte).toStringAsFixed(1)} MB';
+  }
+  return '${(bytes / gigabyte).toStringAsFixed(2)} GB';
+}
+
+String formatResourceCpu(double? percent) {
+  if (percent == null) {
+    return resourceAbsentReading;
+  }
+  return '${percent.toStringAsFixed(1)}%';
+}
+
+/// Kept short on purpose: it shares one status-bar-width row with the CPU and
+/// memory totals, and a longer phrase pushes that row into an overflow.
+String formatResourceShareOfSystem(int? bytes, int totalBytes) {
+  if (bytes == null || totalBytes <= 0) {
+    return resourceAbsentReading;
+  }
+  return '${(bytes * 100 / totalBytes).toStringAsFixed(0)}% of RAM';
+}

--- a/lib/src/features/shell/presentation/alera_shell_page.dart
+++ b/lib/src/features/shell/presentation/alera_shell_page.dart
@@ -5,6 +5,7 @@ import 'package:alera/src/app/theme/alera_tokens.dart';
 import 'package:alera/src/features/agent_status/application/runtime_agent_status_sync.dart';
 import 'package:alera/src/features/agent_quota/presentation/agent_quota_status_bar.dart';
 import 'package:alera/src/features/runtime_host/presentation/runtime_host_status_bar.dart';
+import 'package:alera/src/features/resource_manager/presentation/resource_status_bar_control.dart';
 import 'package:alera/src/design_system/feedback/alera_toast.dart';
 import 'package:alera/src/design_system/icons/alera_icons.dart';
 import 'package:alera/src/design_system/layout/alera_confirm_dialog.dart';

--- a/lib/src/features/shell/presentation/alera_shell_page_body.dart
+++ b/lib/src/features/shell/presentation/alera_shell_page_body.dart
@@ -223,7 +223,13 @@ class _AleraShellPageBodyState extends ConsumerState<_AleraShellPageBody> {
                     ),
                   ),
                   const AgentQuotaStatusBar(
-                    trailing: RuntimeHostStatusBarControl(),
+                    trailing: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: <Widget>[
+                        ResourceStatusBarControl(),
+                        RuntimeHostStatusBarControl(),
+                      ],
+                    ),
                   ),
                 ],
               );

--- a/test/widget/resource_status_panel_test.dart
+++ b/test/widget/resource_status_panel_test.dart
@@ -1,0 +1,282 @@
+import 'package:alera/src/app/theme/alera_dark_theme.dart';
+import 'package:alera/src/features/resource_manager/domain/resource_snapshot.dart';
+import 'package:alera/src/features/resource_manager/domain/resource_tree.dart';
+import 'package:alera/src/features/resource_manager/presentation/resource_status_chip.dart';
+import 'package:alera/src/features/resource_manager/presentation/resource_status_panel.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+ResourceSnapshot _snapshot({bool warming = false, String? error}) =>
+    ResourceSnapshot(
+      collectedAt: DateTime.utc(2026, 7, 25),
+      warming: warming,
+      host: const ResourceHostMetrics(
+        totalMemoryBytes: 16 * 1024 * 1024 * 1024,
+        availableMemoryBytes: 6 * 1024 * 1024 * 1024,
+        usedMemoryBytes: 10 * 1024 * 1024 * 1024,
+        memoryUsagePercent: 62.5,
+        cpuCoreCount: 8,
+        loadAverage1m: 2.4,
+      ),
+      hostProcess: const ResourceProcessSample(
+        pid: 4100,
+        cpuPercent: 1.2,
+        memoryBytes: 42 * 1024 * 1024,
+        processCount: 1,
+        history: <int>[1, 2, 3],
+      ),
+      appProcess: const ResourceProcessSample(
+        pid: 4200,
+        cpuPercent: 0.6,
+        memoryBytes: 280 * 1024 * 1024,
+        processCount: 1,
+        history: <int>[1, 2, 3],
+      ),
+      sessions: const <ResourceSessionSample>[],
+      totalCpuPercent: 12.5,
+      totalMemoryBytes: 1024 * 1024 * 1024,
+      error: error,
+    );
+
+ResourceSessionRow _session(
+  String label, {
+  bool orphan = false,
+  double? cpuPercent = 12.5,
+  int? memoryBytes = 500 * 1024 * 1024,
+}) => ResourceSessionRow(
+  sessionId: 'session-$label',
+  label: label,
+  tabId: 'tab-$label',
+  running: true,
+  orphan: orphan,
+  cpuPercent: cpuPercent,
+  memoryBytes: memoryBytes,
+  processCount: 3,
+  history: const <int>[1, 2, 3],
+);
+
+ResourceTree _tree({
+  List<ResourceSessionRow> sessions = const <ResourceSessionRow>[],
+  List<ResourceSessionRow> orphans = const <ResourceSessionRow>[],
+  bool remote = false,
+}) => ResourceTree(
+  projects: <ResourceProjectGroup>[
+    ResourceProjectGroup(
+      projectId: 'p1',
+      name: 'Alera',
+      workspaces: <ResourceWorkspaceRow>[
+        ResourceWorkspaceRow(
+          workspaceId: 'w1',
+          name: 'Main',
+          projectId: 'p1',
+          remote: remote,
+          sessions: sessions,
+        ),
+      ],
+    ),
+  ],
+  orphanSessions: orphans,
+);
+
+Future<void> _pump(
+  WidgetTester tester, {
+  required ResourceSnapshot snapshot,
+  required ResourceTree tree,
+  ResourceSortColumn sortColumn = ResourceSortColumn.memory,
+  ValueChanged<ResourceSortColumn>? onSortColumnChanged,
+  ValueChanged<ResourceSessionRow>? onOpenSession,
+  ValueChanged<ResourceSessionRow>? onKillSession,
+  VoidCallback? onKillOrphans,
+  bool hostUnreachable = false,
+}) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      theme: aleraDarkTheme,
+      home: Scaffold(
+        body: Center(
+          child: ResourceStatusPanel(
+            snapshot: snapshot,
+            tree: tree,
+            sortColumn: sortColumn,
+            hostUnreachable: hostUnreachable,
+            onSortColumnChanged: onSortColumnChanged ?? (_) {},
+            onOpenSession: onOpenSession ?? (_) {},
+            onKillSession: onKillSession ?? (_) {},
+            onKillOrphans: onKillOrphans ?? () {},
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  testWidgets('renders the project, workspace and session tree', (
+    tester,
+  ) async {
+    await _pump(
+      tester,
+      snapshot: _snapshot(),
+      tree: _tree(sessions: <ResourceSessionRow>[_session('Codex Agent')]),
+    );
+
+    expect(find.text('Resource Manager'), findsOneWidget);
+    expect(find.text('Alera'), findsWidgets);
+    expect(find.text('Main'), findsOneWidget);
+    expect(find.text('Codex Agent'), findsOneWidget);
+    // The same reading appears on the session row and on the workspace and
+    // project aggregates above it.
+    expect(find.text('500.0 MB'), findsNWidgets(3));
+    expect(find.text('12.5%'), findsWidgets);
+    // The app and sidecar get their own rows, apart from the workspace tree.
+    expect(find.text('App'), findsOneWidget);
+    expect(find.text('Runtime Host'), findsOneWidget);
+  });
+
+  testWidgets('a remote session shows a dash instead of zero', (tester) async {
+    await _pump(
+      tester,
+      snapshot: _snapshot(),
+      tree: _tree(
+        remote: true,
+        sessions: <ResourceSessionRow>[
+          _session('Remote Shell', cpuPercent: null, memoryBytes: null),
+        ],
+      ),
+    );
+
+    expect(find.text('remote'), findsOneWidget);
+    // A dash for the session's CPU and memory, plus the workspace aggregate.
+    expect(find.text('-'), findsWidgets);
+    expect(find.text('0.0%'), findsNothing);
+  });
+
+  testWidgets('a warming snapshot does not report totals as zero', (
+    tester,
+  ) async {
+    await _pump(
+      tester,
+      snapshot: _snapshot(warming: true),
+      tree: ResourceTree.empty,
+    );
+
+    expect(find.text('Measuring Resource Usage'), findsOneWidget);
+    expect(find.text('0.0%'), findsNothing);
+  });
+
+  testWidgets('an unreachable host points at the host chip', (tester) async {
+    await _pump(
+      tester,
+      snapshot: _snapshot(error: 'connection refused'),
+      tree: ResourceTree.empty,
+      hostUnreachable: true,
+    );
+
+    expect(
+      find.textContaining('Runtime Host Is Not Responding'),
+      findsOneWidget,
+    );
+    // The error itself is surfaced rather than a generic empty state.
+    expect(find.text('connection refused'), findsOneWidget);
+  });
+
+  testWidgets('orphans are listed apart with a kill-all action', (
+    tester,
+  ) async {
+    var killedAll = false;
+    ResourceSessionRow? killed;
+    await _pump(
+      tester,
+      snapshot: _snapshot(),
+      tree: _tree(
+        sessions: <ResourceSessionRow>[_session('Codex Agent')],
+        orphans: <ResourceSessionRow>[_session('stray', orphan: true)],
+      ),
+      onKillOrphans: () => killedAll = true,
+      onKillSession: (session) => killed = session,
+    );
+
+    expect(find.text('Unattributed Terminals'), findsOneWidget);
+    expect(find.text('1 Orphan Terminal'), findsOneWidget);
+
+    await tester.tap(find.text('Kill All'));
+    await tester.pump();
+    expect(killedAll, isTrue);
+
+    await tester.tap(find.byTooltip('Kill Orphan Terminal'));
+    await tester.pump();
+    expect(killed?.sessionId, 'session-stray');
+  });
+
+  testWidgets('tapping a session row opens it', (tester) async {
+    ResourceSessionRow? opened;
+    await _pump(
+      tester,
+      snapshot: _snapshot(),
+      tree: _tree(sessions: <ResourceSessionRow>[_session('Codex Agent')]),
+      onOpenSession: (session) => opened = session,
+    );
+
+    await tester.tap(find.text('Codex Agent'));
+    await tester.pump();
+
+    expect(opened?.sessionId, 'session-Codex Agent');
+  });
+
+  testWidgets('the sort header reports the selected column', (tester) async {
+    ResourceSortColumn? selected;
+    await _pump(
+      tester,
+      snapshot: _snapshot(),
+      tree: _tree(sessions: <ResourceSessionRow>[_session('Codex Agent')]),
+      onSortColumnChanged: (column) => selected = column,
+    );
+
+    await tester.tap(find.byTooltip('Sort By CPU'));
+    await tester.pump();
+
+    expect(selected, ResourceSortColumn.cpu);
+  });
+
+  testWidgets('the chip shows memory, session count and orphans', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: aleraDarkTheme,
+        home: Scaffold(
+          body: ResourceStatusChip(
+            snapshot: _snapshot(),
+            sessionCount: 7,
+            orphanCount: 2,
+            onPressed: () {},
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('1.00 GB'), findsOneWidget);
+    expect(find.text('7'), findsOneWidget);
+    expect(find.text('(2)'), findsOneWidget);
+  });
+
+  testWidgets('the chip hides the orphan count when there are none', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: aleraDarkTheme,
+        home: Scaffold(
+          body: ResourceStatusChip(
+            snapshot: _snapshot(),
+            sessionCount: 1,
+            orphanCount: 0,
+            onPressed: () {},
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('(0)'), findsNothing);
+  });
+}


### PR DESCRIPTION
## Summary

The user-facing surface: a status-bar chip that opens a panel showing live CPU and memory attributed to Project, Workspace and Terminal tab.

- New `AleraSparkline` design-system component with previews. Hand-rolled `CustomPainter` polyline; a charting package would be orders of magnitude more code for the same pixels.
- Chip shows total memory, running session count, and the orphan count in warning color when there is one.
- Panel has a totals strip, sortable Name/CPU/Memory header, the collapsible tree, an Alera section for the app and sidecar processes, and an orphan footer.
- Killing a session that still has a tab goes through the normal tab-close flow behind a confirm dialog. An orphan is terminated directly without a prompt: there is no pane to lose.
- Host health is not duplicated here. When the host is unreachable the panel shows a notice pointing at the existing runtime host chip.

Follows the `RuntimeHostStatusBarControl` recipe for the chip and overlay, and slots next to it in the status bar.

## Validation

- `flutter analyze`: no issues.
- `flutter test`: passes, including 9 new widget tests over the tree, the remote dash, the warming state, the unreachable notice, the orphan actions, row activation, sorting and the chip.
- `dart run tool/quality/check_max_lines.dart`: passes.

Two things found and fixed while testing: the totals row overflowed by 65px at the panel width, and the panel body exceeded the 500-line limit, so it is split into `_chrome` and `_rows`.

The two failures in `test/unit/terminal_runtime_native_test.dart` are pre-existing on `main` in this environment and unrelated.