### PR TITLE
fix: report the effective orchestration wait timeout

### DIFF
--- a/rust/alera-cli/src/cli_orchestration.rs
+++ b/rust/alera-cli/src/cli_orchestration.rs
@@ -3,6 +3,7 @@ use clap::{Args, Subcommand};
 use crate::cli::{OutputArgs, RuntimeDirArgs};
 pub use crate::cli_orchestration_runs::*;
 pub use crate::cli_orchestration_terminal::*;
+use crate::cli_orchestration_timeouts::parse_wait_timeout_ms;
 
 /// `alera orchestration ...` - inter-agent messaging, task DAG, dispatch,
 /// decision gates, and the coordinator loop. All verbs are RPC calls to the
@@ -216,7 +217,7 @@ pub struct OrchestrationCheckArgs {
     pub wait: bool,
 
     /// Wait timeout in milliseconds (default 120000).
-    #[arg(long = "timeout-ms", value_name = "ms")]
+    #[arg(long = "timeout-ms", value_name = "ms", value_parser = parse_wait_timeout_ms)]
     pub timeout_ms: Option<u64>,
 
     /// Maximum messages returned with --all.
@@ -268,7 +269,7 @@ pub struct OrchestrationAskArgs {
     pub options: Option<String>,
 
     /// Wait timeout in milliseconds (default 120000).
-    #[arg(long = "timeout-ms", value_name = "ms")]
+    #[arg(long = "timeout-ms", value_name = "ms", value_parser = parse_wait_timeout_ms)]
     pub timeout_ms: Option<u64>,
 }
 
@@ -343,7 +344,7 @@ pub struct OrchestrationTaskWaitArgs {
         default_value = "completed,failed,stalled,cancelled"
     )]
     pub targets: String,
-    #[arg(long = "timeout-ms", default_value_t = 120_000)]
+    #[arg(long = "timeout-ms", default_value_t = 120_000, value_parser = parse_wait_timeout_ms)]
     pub timeout_ms: u64,
 }
 

--- a/rust/alera-cli/src/cli_orchestration_terminal.rs
+++ b/rust/alera-cli/src/cli_orchestration_terminal.rs
@@ -1,5 +1,6 @@
 use clap::Args;
 
+use crate::cli_orchestration_timeouts::parse_agent_spawn_timeout_ms;
 use crate::terminal_host::protocol::ORCHESTRATION_ACCEPTANCE_TIMEOUT_MS;
 
 #[derive(Debug, Args)]
@@ -72,32 +73,4 @@ pub struct OrchestrationAgentSpawnArgs {
         value_parser = parse_agent_spawn_timeout_ms
     )]
     pub timeout_ms: u64,
-}
-
-fn parse_agent_spawn_timeout_ms(value: &str) -> Result<u64, String> {
-    let timeout = value
-        .parse::<u64>()
-        .map_err(|_| "timeout must be an integer number of milliseconds".to_string())?;
-    if !(1..=ORCHESTRATION_ACCEPTANCE_TIMEOUT_MS).contains(&timeout) {
-        return Err(format!(
-            "timeout must be between 1 and {ORCHESTRATION_ACCEPTANCE_TIMEOUT_MS} milliseconds"
-        ));
-    }
-    Ok(timeout)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn agent_spawn_timeout_respects_host_acceptance_limit() {
-        assert_eq!(parse_agent_spawn_timeout_ms("1").unwrap(), 1);
-        assert_eq!(
-            parse_agent_spawn_timeout_ms("90000").unwrap(),
-            ORCHESTRATION_ACCEPTANCE_TIMEOUT_MS
-        );
-        assert!(parse_agent_spawn_timeout_ms("0").is_err());
-        assert!(parse_agent_spawn_timeout_ms("90001").is_err());
-    }
 }

--- a/rust/alera-cli/src/cli_orchestration_timeouts.rs
+++ b/rust/alera-cli/src/cli_orchestration_timeouts.rs
@@ -1,0 +1,75 @@
+use crate::terminal_host::protocol::{
+    ORCHESTRATION_ACCEPTANCE_TIMEOUT_MS, ORCHESTRATION_MAX_WAIT_TIMEOUT_MS,
+};
+
+/// Parse-time validation for the `--timeout-ms` flags.
+///
+/// The host caps both kinds of timeout and applies the cap silently, so a
+/// caller that asks for more only finds out when the call returns early. These
+/// turn that into an immediate error at the flag instead of a puzzle minutes
+/// later, and keeping them side by side is what keeps them consistent.
+fn parse_timeout_ms(value: &str, ceiling: u64) -> Result<u64, String> {
+    let timeout = value
+        .parse::<u64>()
+        .map_err(|_| "timeout must be an integer number of milliseconds".to_string())?;
+    if !(1..=ceiling).contains(&timeout) {
+        return Err(format!(
+            "timeout must be between 1 and {ceiling} milliseconds"
+        ));
+    }
+    Ok(timeout)
+}
+
+/// Bounded by how long the host will wait for a spawned agent to accept.
+pub(crate) fn parse_agent_spawn_timeout_ms(value: &str) -> Result<u64, String> {
+    parse_timeout_ms(value, ORCHESTRATION_ACCEPTANCE_TIMEOUT_MS)
+}
+
+/// Bounded by how long the host will hold a parked wait open.
+pub(crate) fn parse_wait_timeout_ms(value: &str) -> Result<u64, String> {
+    parse_timeout_ms(value, ORCHESTRATION_MAX_WAIT_TIMEOUT_MS)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn agent_spawn_timeout_respects_host_acceptance_limit() {
+        assert_eq!(parse_agent_spawn_timeout_ms("1").unwrap(), 1);
+        assert_eq!(
+            parse_agent_spawn_timeout_ms(&ORCHESTRATION_ACCEPTANCE_TIMEOUT_MS.to_string()).unwrap(),
+            ORCHESTRATION_ACCEPTANCE_TIMEOUT_MS
+        );
+        assert!(parse_agent_spawn_timeout_ms("0").is_err());
+        assert!(parse_agent_spawn_timeout_ms(
+            &(ORCHESTRATION_ACCEPTANCE_TIMEOUT_MS + 1).to_string()
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn a_wait_timeout_within_the_host_ceiling_is_accepted() {
+        assert_eq!(parse_wait_timeout_ms("1").unwrap(), 1);
+        assert_eq!(
+            parse_wait_timeout_ms(&ORCHESTRATION_MAX_WAIT_TIMEOUT_MS.to_string()).unwrap(),
+            ORCHESTRATION_MAX_WAIT_TIMEOUT_MS
+        );
+    }
+
+    #[test]
+    fn a_wait_timeout_the_host_would_clamp_is_refused() {
+        // The case this exists for: asking for an hour and being answered at
+        // ten minutes used to look like the wait had genuinely expired.
+        let error = parse_wait_timeout_ms("3600000").unwrap_err();
+
+        assert!(error.contains(&ORCHESTRATION_MAX_WAIT_TIMEOUT_MS.to_string()));
+    }
+
+    #[test]
+    fn a_nonsense_timeout_is_refused() {
+        assert!(parse_wait_timeout_ms("0").is_err());
+        assert!(parse_wait_timeout_ms("-1").is_err());
+        assert!(parse_wait_timeout_ms("soon").is_err());
+    }
+}

--- a/rust/alera-cli/src/main.rs
+++ b/rust/alera-cli/src/main.rs
@@ -4,6 +4,7 @@ mod cli;
 mod cli_orchestration;
 mod cli_orchestration_runs;
 mod cli_orchestration_terminal;
+mod cli_orchestration_timeouts;
 #[cfg(test)]
 mod cli_tests;
 mod host_tools;

--- a/rust/alera-cli/src/terminal_host/protocol.rs
+++ b/rust/alera-cli/src/terminal_host/protocol.rs
@@ -13,6 +13,10 @@ pub const ORCHESTRATION_PROTOCOL_VERSION: i64 = 2;
 pub const DISPATCH_PREAMBLE_VERSION: i64 = 2;
 pub const ORCHESTRATION_SKILL_VERSION: i64 = 3;
 pub const ORCHESTRATION_ACCEPTANCE_TIMEOUT_MS: u64 = 90_000;
+/// Longest wait the host will hold a parked orchestration request for. Shared
+/// with the CLI so `--timeout-ms` can refuse a budget the host would silently
+/// cut down to this.
+pub const ORCHESTRATION_MAX_WAIT_TIMEOUT_MS: u64 = 600_000;
 pub const RUNTIME_HOST_CAPABILITY: &str = "runtimeStore";
 pub const RUNTIME_HOST_BOOTSTRAP_CAPABILITY: &str = "sshTargetBootstrap";
 pub const RUNTIME_HOST_MANAGED_WORKSPACE_CAPABILITY: &str = "managedWorkspaceLifecycle";

--- a/rust/alera-cli/src/terminal_host/server.rs
+++ b/rust/alera-cli/src/terminal_host/server.rs
@@ -168,7 +168,7 @@ pub enum ServerCommand {
     /// A parked `check --wait`/`ask` request hit its server-side deadline.
     OrchestrationWaitTimeout {
         waiter_id: u64,
-        waited_ms: u64,
+        effective_timeout_ms: u64,
     },
     OrchestrationStateWaitPoll(u64),
     /// Fires the deferred Enter after an injected orchestration banner.
@@ -643,9 +643,9 @@ impl ServerActor {
             } => self.handle_host_tool_finished(client_id, request_id, result, operation_id, skill),
             ServerCommand::OrchestrationWaitTimeout {
                 waiter_id,
-                waited_ms,
+                effective_timeout_ms,
             } => {
-                self.handle_orchestration_wait_timeout(waiter_id, waited_ms)
+                self.handle_orchestration_wait_timeout(waiter_id, effective_timeout_ms)
                     .await
             }
             ServerCommand::OrchestrationStateWaitPoll(waiter_id) => {

--- a/rust/alera-cli/src/terminal_host/server/orchestration_requests.rs
+++ b/rust/alera-cli/src/terminal_host/server/orchestration_requests.rs
@@ -1911,7 +1911,7 @@ impl ServerActor {
     pub(super) async fn handle_orchestration_wait_timeout(
         &mut self,
         waiter_id: u64,
-        waited_ms: u64,
+        effective_timeout_ms: u64,
     ) {
         let Some(waiter) = self.orchestration_waiters.take_by_id(waiter_id) else {
             return;
@@ -1920,7 +1920,7 @@ impl ServerActor {
             &waiter.kind,
             WaitKind::TerminalState { .. } | WaitKind::TaskState { .. }
         ) {
-            self.finish_orchestration_state_wait_timeout(waiter, waited_ms)
+            self.finish_orchestration_state_wait_timeout(waiter, effective_timeout_ms)
                 .await;
             return;
         }
@@ -1931,17 +1931,22 @@ impl ServerActor {
         };
         payload["timedOut"] = Value::Bool(true);
         payload["outcome"] = Value::String("timeout".to_string());
-        payload["waitedMs"] = json!(waited_ms);
+        // Reaching the deadline means the wait ran its whole budget, so the two
+        // figures coincide. They are still reported apart, because they answer
+        // different questions and only one of them survives a future change to
+        // how the elapsed time is measured.
+        payload["waitedMs"] = json!(effective_timeout_ms);
+        payload["effectiveTimeoutMs"] = json!(effective_timeout_ms);
         self.client_write(waiter.client_id, ok_response(waiter.request_id, payload));
     }
 
-    pub(super) fn spawn_wait_timeout(&self, waiter_id: u64, timeout_ms: u64) {
+    pub(super) fn spawn_wait_timeout(&self, waiter_id: u64, effective_timeout_ms: u64) {
         let inbox = self.inbox.clone();
         tokio::spawn(async move {
-            tokio::time::sleep(Duration::from_millis(timeout_ms)).await;
+            tokio::time::sleep(Duration::from_millis(effective_timeout_ms)).await;
             let _ = inbox.send(ServerCommand::OrchestrationWaitTimeout {
                 waiter_id,
-                waited_ms: timeout_ms,
+                effective_timeout_ms,
             });
         });
     }

--- a/rust/alera-cli/src/terminal_host/server/orchestration_validation.rs
+++ b/rust/alera-cli/src/terminal_host/server/orchestration_validation.rs
@@ -4,8 +4,8 @@ use alera_core::runtime::{
 use serde_json::Value;
 
 use crate::terminal_host::host_error::{HostError, HostResult};
+use crate::terminal_host::protocol::ORCHESTRATION_MAX_WAIT_TIMEOUT_MS as MAX_WAIT_TIMEOUT_MS;
 
-const MAX_WAIT_TIMEOUT_MS: u64 = 600_000;
 const DEFAULT_WAIT_TIMEOUT_MS: u64 = 120_000;
 
 pub(super) fn optional_string(payload: &Value, key: &str) -> Option<String> {

--- a/rust/alera-cli/src/terminal_host/server/orchestration_wait_requests.rs
+++ b/rust/alera-cli/src/terminal_host/server/orchestration_wait_requests.rs
@@ -90,7 +90,7 @@ impl ServerActor {
     pub(super) async fn finish_orchestration_state_wait_timeout(
         &mut self,
         waiter: MessageWaiter,
-        waited_ms: u64,
+        effective_timeout_ms: u64,
     ) {
         match self.state_wait_result(&waiter).await {
             Ok(Some(payload)) => {
@@ -107,10 +107,14 @@ impl ServerActor {
                     waiter.client_id,
                     ok_response(
                         waiter.request_id,
+                        // See the sibling finisher: the wait ran its whole
+                        // budget, so elapsed and budget coincide here, and both
+                        // are reported because they answer different questions.
                         json!({
                             "outcome": "timeout",
                             "timedOut": true,
-                            "waitedMs": waited_ms,
+                            "waitedMs": effective_timeout_ms,
+                            "effectiveTimeoutMs": effective_timeout_ms,
                         }),
                     ),
                 );

--- a/rust/alera-cli/tests/orchestration_conformance/messaging.rs
+++ b/rust/alera-cli/tests/orchestration_conformance/messaging.rs
@@ -122,4 +122,48 @@ fn check_wait_times_out_cleanly() {
     ));
     assert_eq!(timed_out["timedOut"], json!(true));
     assert_eq!(timed_out["messages"], json!([]));
+    // An honoured budget echoes back unchanged, which is what lets the clamped
+    // case below be recognised as a clamp.
+    assert_eq!(timed_out["effectiveTimeoutMs"], json!(700));
+}
+
+#[test]
+fn a_state_wait_timeout_also_reports_the_budget_the_host_applied() {
+    // State waits finish through their own timeout path, so the budget has to
+    // be echoed there too. Without it a caller that asked for more than the
+    // host ceiling cannot tell a server-side clamp from a real expiry, and the
+    // two call for opposite responses: wait again, or escalate.
+    //
+    // The clamp itself cannot be driven from here, since observing it would
+    // mean sitting out the full ceiling. It is pinned as a unit case on
+    // `state_wait_timeout_ms` instead.
+    let host = start_host();
+    let (mut writer, mut reader) = connect(host.port);
+    handshake(&mut writer, &mut reader, &host.token);
+    // A freshly created task is pending, so waiting for a terminal state parks
+    // rather than answering straight away.
+    let task = expect_ok(request(
+        &mut writer,
+        &mut reader,
+        20,
+        "orchestration.taskCreate",
+        json!({
+            "spec": "never finishes",
+            "workspace": "ws",
+            "coordinator": "coord",
+            "createdBy": "coord",
+        }),
+    ));
+    let task_id = task["id"].as_str().expect("task id").to_string();
+
+    let timed_out = expect_ok(request(
+        &mut writer,
+        &mut reader,
+        21,
+        "orchestration.taskWait",
+        json!({"task": task_id, "targets": ["completed"], "timeoutMs": 700}),
+    ));
+
+    assert_eq!(timed_out["timedOut"], json!(true));
+    assert_eq!(timed_out["effectiveTimeoutMs"], json!(700));
 }


### PR DESCRIPTION
## Summary

The host clamps `timeoutMs` to its own ceiling and says nothing about it. The elapsed figure was already honest, so a caller was never told the wrong time, but it still could not tell "the wait expired" from "the host cut my budget" - and those call for opposite responses: escalate, or wait again.

Echoes the applied budget as `effectiveTimeoutMs` from both timeout finishers. State waits finish through their own path, so covering only one would have left half the surface.

Also refuses an over-cap `--timeout-ms` at parse time, so a CLI caller fails at the flag instead of discovering the cap minutes later. Mirrors the acceptance-timeout guard the crate already had; the two validators now sit in one module where their consistency is visible.

## Validation

`make rust-test` clean. Conformance covers both finishers; CLI rejection covered by unit cases and checked by hand against the built binary.

The clamp itself is not driven end to end, since observing it would mean sitting out the whole ceiling. It stays pinned as a unit case on `state_wait_timeout_ms`.

## Notes

`effectiveTimeoutMs` is additive and does not bump `aleraTerminalHostProtocolVersion`; older clients that ignore it are unaffected. The shipped skill guides already use values inside the cap, so nothing documented starts failing.