### PR TITLE
feat: detect os sleep by comparing wall clock against monotonic time

### DIFF
--- a/rust/alera-cli/src/terminal_host/mod.rs
+++ b/rust/alera-cli/src/terminal_host/mod.rs
@@ -11,3 +11,4 @@ pub mod protocol;
 pub mod resources;
 pub mod server;
 pub mod session;
+pub mod sleep_detector;

--- a/rust/alera-cli/src/terminal_host/server.rs
+++ b/rust/alera-cli/src/terminal_host/server.rs
@@ -1,10 +1,7 @@
 use std::collections::{HashMap, HashSet};
 use std::net::{Ipv4Addr, Ipv6Addr};
 use std::path::PathBuf;
-use std::sync::{
-    atomic::{AtomicU64, Ordering},
-    Arc,
-};
+use std::sync::{atomic::AtomicU64, Arc};
 use std::time::{Duration, Instant};
 
 use alera_core::runtime::{
@@ -39,10 +36,14 @@ use crate::terminal_host::orchestration::message_formatter::format_messages_for_
 use crate::terminal_host::orchestration::message_waiters::MessageWaiterRegistry;
 use crate::terminal_host::protocol::{event, TerminalHostConfig};
 use crate::terminal_host::session::{PtyEvent, PtyWriteCompletion, Session};
+use crate::terminal_host::sleep_detector::SleepDetector;
+
+use client_accept_loop::spawn_accept_loop;
 
 use resource_requests::ResourceMonitorState;
 
 mod agent_hook_events;
+mod client_accept_loop;
 mod client_delivery;
 mod coordinator_requests;
 mod coordinator_stall_policy;
@@ -312,52 +313,24 @@ pub async fn run_terminal_host_server(
     actor.reconcile_spawn_on_create_tabs().await;
     actor.schedule_shutdown_if_idle();
 
+    // Lives with the loop rather than the actor: it describes the machine the
+    // host is running on, not any of the state the actor owns.
+    let mut sleep_detector = SleepDetector::default();
     while let Some(command) = rx.recv().await {
+        if let Some(slept) = sleep_detector.observe() {
+            // The first thing to happen after a wake says so, which is what
+            // keeps a lid closed overnight from being read later as a freeze.
+            eprintln!(
+                "alera terminal host resumed after {}s of system sleep",
+                slept.as_secs()
+            );
+        }
         actor.handle(command).await;
         if actor.disposed {
             break;
         }
     }
     Ok(())
-}
-
-fn spawn_accept_loop(
-    listener: TcpListener,
-    inbox: UnboundedSender<ServerCommand>,
-    next_client_id: Arc<AtomicU64>,
-) {
-    tokio::spawn(async move {
-        while let Ok((stream, _)) = listener.accept().await {
-            let _ = stream.set_nodelay(true);
-            let id = next_client_id.fetch_add(1, Ordering::Relaxed);
-            let (control_out_tx, control_out_rx) = mpsc::unbounded_channel::<ClientFrame>();
-            let (terminal_out_tx, terminal_out_rx) =
-                mpsc::channel::<ClientFrame>(CLIENT_TERMINAL_OUT_QUEUE_CAPACITY);
-            // Register the client before its lines can arrive: the
-            // ClientConnected command is enqueued before the connection loop
-            // (and thus any ClientLine) starts.
-            if inbox
-                .send(ServerCommand::ClientConnected {
-                    id,
-                    handle: ClientHandle {
-                        control_out: control_out_tx,
-                        terminal_out: terminal_out_tx,
-                    },
-                    kind: ClientKind::Local,
-                })
-                .is_err()
-            {
-                break;
-            }
-            tokio::spawn(connection_loop(
-                stream,
-                id,
-                inbox.clone(),
-                control_out_rx,
-                terminal_out_rx,
-            ));
-        }
-    });
 }
 
 struct ServerActor {

--- a/rust/alera-cli/src/terminal_host/server/client_accept_loop.rs
+++ b/rust/alera-cli/src/terminal_host/server/client_accept_loop.rs
@@ -1,0 +1,50 @@
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+use tokio::net::TcpListener;
+use tokio::sync::mpsc::{self, UnboundedSender};
+
+use super::{
+    connection_loop, ClientFrame, ClientHandle, ClientKind, ServerCommand,
+    CLIENT_TERMINAL_OUT_QUEUE_CAPACITY,
+};
+
+/// Accept local clients and hand each one to its own connection loop.
+pub(super) fn spawn_accept_loop(
+    listener: TcpListener,
+    inbox: UnboundedSender<ServerCommand>,
+    next_client_id: Arc<AtomicU64>,
+) {
+    tokio::spawn(async move {
+        while let Ok((stream, _)) = listener.accept().await {
+            let _ = stream.set_nodelay(true);
+            let id = next_client_id.fetch_add(1, Ordering::Relaxed);
+            let (control_out_tx, control_out_rx) = mpsc::unbounded_channel::<ClientFrame>();
+            let (terminal_out_tx, terminal_out_rx) =
+                mpsc::channel::<ClientFrame>(CLIENT_TERMINAL_OUT_QUEUE_CAPACITY);
+            // Register the client before its lines can arrive: the
+            // ClientConnected command is enqueued before the connection loop
+            // (and thus any ClientLine) starts.
+            if inbox
+                .send(ServerCommand::ClientConnected {
+                    id,
+                    handle: ClientHandle {
+                        control_out: control_out_tx,
+                        terminal_out: terminal_out_tx,
+                    },
+                    kind: ClientKind::Local,
+                })
+                .is_err()
+            {
+                break;
+            }
+            tokio::spawn(connection_loop(
+                stream,
+                id,
+                inbox.clone(),
+                control_out_rx,
+                terminal_out_rx,
+            ));
+        }
+    });
+}

--- a/rust/alera-cli/src/terminal_host/sleep_detector.rs
+++ b/rust/alera-cli/src/terminal_host/sleep_detector.rs
@@ -1,0 +1,175 @@
+use std::time::{Duration, Instant, SystemTime};
+
+/// Sleeps shorter than this are not recorded.
+///
+/// A laptop lid closed for a couple of seconds explains nothing and would bury
+/// the gaps that do. Orca measured a week of real sleep cycles for the same
+/// decision: the median was 2 seconds and only about a quarter ran past a
+/// minute, so a threshold here cuts almost all of the traffic while still
+/// catching every gap long enough to be mistaken for a hang.
+const MIN_REPORTABLE_SLEEP: Duration = Duration::from_secs(60);
+
+/// Tells a machine that was asleep apart from a host that was wedged.
+///
+/// The two look identical from the outside: no output, no progress, a long
+/// silence. Telling them apart matters because only one of them is a bug, and
+/// mistaking a lid for a deadlock sends an investigation somewhere expensive.
+///
+/// No platform APIs involved. `Instant` runs on a monotonic clock that does not
+/// advance while the machine is suspended (`CLOCK_MONOTONIC` on Linux excludes
+/// suspended time, and `mach_absolute_time` pauses on macOS), while
+/// `SystemTime` keeps wall-clock time across the gap. When the two disagree,
+/// the difference is how long the machine was away.
+pub struct SleepDetector {
+    last_observed: Option<(Instant, SystemTime)>,
+    min_reportable: Duration,
+}
+
+impl Default for SleepDetector {
+    fn default() -> Self {
+        SleepDetector::new(MIN_REPORTABLE_SLEEP)
+    }
+}
+
+impl SleepDetector {
+    pub fn new(min_reportable: Duration) -> SleepDetector {
+        SleepDetector {
+            last_observed: None,
+            min_reportable,
+        }
+    }
+
+    /// Note that the host is doing something now, and report a sleep if the
+    /// wall clock ran ahead of the monotonic clock since the last observation.
+    ///
+    /// Called from the actor's command loop rather than a timer of its own, so
+    /// an idle host stays completely quiet and a wake is noticed by the first
+    /// thing that happens afterwards, which is exactly when someone is around
+    /// to care.
+    pub fn observe(&mut self) -> Option<Duration> {
+        self.observe_at(Instant::now(), SystemTime::now())
+    }
+
+    fn observe_at(&mut self, monotonic: Instant, wall: SystemTime) -> Option<Duration> {
+        let previous = self.last_observed.replace((monotonic, wall));
+        let (last_monotonic, last_wall) = previous?;
+        let awake = monotonic.saturating_duration_since(last_monotonic);
+        // A wall clock that went backwards is a correction, never a sleep.
+        let elapsed = wall.duration_since(last_wall).ok()?;
+        let slept = elapsed.checked_sub(awake)?;
+        (slept >= self.min_reportable).then_some(slept)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const THRESHOLD: Duration = Duration::from_secs(60);
+
+    fn detector() -> SleepDetector {
+        SleepDetector::new(THRESHOLD)
+    }
+
+    /// A suspend: wall time advances by `wall`, monotonic time by `awake`.
+    fn advance(
+        base: (Instant, SystemTime),
+        awake: Duration,
+        wall: Duration,
+    ) -> (Instant, SystemTime) {
+        (base.0 + awake, base.1 + wall)
+    }
+
+    fn origin() -> (Instant, SystemTime) {
+        (
+            Instant::now(),
+            SystemTime::UNIX_EPOCH + Duration::from_secs(1_700_000_000),
+        )
+    }
+
+    #[test]
+    fn the_first_observation_reports_nothing() {
+        // There is no earlier point to measure a gap against.
+        let start = origin();
+
+        assert_eq!(detector().observe_at(start.0, start.1), None);
+    }
+
+    #[test]
+    fn a_busy_host_reports_no_sleep() {
+        // Both clocks advance together, which is what being awake looks like.
+        let start = origin();
+        let mut detector = detector();
+        detector.observe_at(start.0, start.1);
+
+        let later = advance(
+            start,
+            Duration::from_secs(3_600),
+            Duration::from_secs(3_600),
+        );
+
+        assert_eq!(detector.observe_at(later.0, later.1), None);
+    }
+
+    #[test]
+    fn a_long_sleep_is_reported_with_its_span() {
+        let start = origin();
+        let mut detector = detector();
+        detector.observe_at(start.0, start.1);
+
+        // Eight hours of wall clock, thirty seconds of it awake.
+        let after_wake = advance(
+            start,
+            Duration::from_secs(30),
+            Duration::from_secs(8 * 3_600),
+        );
+
+        assert_eq!(
+            detector.observe_at(after_wake.0, after_wake.1),
+            Some(Duration::from_secs(8 * 3_600 - 30))
+        );
+    }
+
+    #[test]
+    fn a_short_sleep_stays_quiet() {
+        // The case the threshold exists for: frequent, brief, and explains
+        // nothing, so recording it would only bury the gaps that do.
+        let start = origin();
+        let mut detector = detector();
+        detector.observe_at(start.0, start.1);
+
+        let after_wake = advance(start, Duration::ZERO, Duration::from_secs(2));
+
+        assert_eq!(detector.observe_at(after_wake.0, after_wake.1), None);
+    }
+
+    #[test]
+    fn a_backwards_wall_clock_is_not_a_sleep() {
+        // An NTP correction, not a suspend.
+        let start = origin();
+        let mut detector = detector();
+        detector.observe_at(start.0, start.1);
+
+        let corrected = (
+            start.0 + Duration::from_secs(10),
+            start.1 - Duration::from_secs(600),
+        );
+
+        assert_eq!(detector.observe_at(corrected.0, corrected.1), None);
+    }
+
+    #[test]
+    fn each_sleep_is_measured_from_the_last_observation() {
+        // The stamp advances even on a quiet observation, so a single long gap
+        // is not reported twice.
+        let start = origin();
+        let mut detector = detector();
+        detector.observe_at(start.0, start.1);
+        let after_wake = advance(start, Duration::ZERO, Duration::from_secs(3_600));
+        assert!(detector.observe_at(after_wake.0, after_wake.1).is_some());
+
+        let busy = advance(after_wake, Duration::from_secs(60), Duration::from_secs(60));
+
+        assert_eq!(detector.observe_at(busy.0, busy.1), None);
+    }
+}


### PR DESCRIPTION
Lands on top of #209, now merged.

## Summary

A host that was on a sleeping laptop and a host that was wedged look identical from outside: no output, no progress, a long silence. Only one is a bug, and mistaking a closed lid for a deadlock is expensive - Orca lost a whole crash investigation to exactly that ambiguity before adding the equivalent breadcrumb.

`Instant` runs on a monotonic clock that does not advance while the machine is suspended, while `SystemTime` keeps wall-clock time across the gap, so their disagreement is the sleep. No platform APIs, no dependencies, and nothing to build first: reporting goes to the host log, which is the diagnostic surface that exists today.

Observed from the actor's command loop rather than a timer of its own. An idle host stays completely silent, and a wake is noticed by the first thing that happens after it, which is when someone is around to care. A dedicated ticker would have burned cycles on an idle machine to answer a question nobody was asking, which is the opposite of what #209 is for.

## Validation

`make rust-test` clean. Cases cover a busy host, a long sleep, a short sleep under the gate, a backwards wall clock, and not double-reporting one gap.

## Notes

Short sleeps are not recorded. Orca measured a week of real cycles for this threshold: median 2 seconds, only about a quarter past a minute, so a gate at sixty seconds drops nearly all the traffic and still catches everything long enough to be mistaken for a hang. A backwards wall clock is treated as an NTP correction, never a sleep.

Splits the client accept loop out of `server.rs`, which the max-lines ratchet caught with no room at 1810.
