### PR TITLE
perf: park the codex transcript watchdog while the app is hidden

### DIFF
--- a/lib/src/features/agent_status/application/agent_status_providers.dart
+++ b/lib/src/features/agent_status/application/agent_status_providers.dart
@@ -17,6 +17,8 @@ import 'package:alera/src/features/agent_status/infra/window_manager_agent_windo
 import 'package:alera/src/features/projects/domain/project.dart';
 import 'package:alera/src/features/settings/application/settings_controller.dart';
 import 'package:alera/src/features/settings/domain/alera_settings.dart';
+import 'package:alera/src/features/agent_status/infra/codex_transcript_status_watcher.dart';
+import 'package:alera/src/features/app_window/application/app_window_providers.dart';
 import 'package:alera/src/features/workbench/application/workbench_controller.dart';
 import 'package:alera/src/features/workbench/application/workbench_providers.dart';
 import 'package:alera/src/features/workbench/application/workbench_state.dart';
@@ -33,6 +35,13 @@ AgentHookReceiver agentHookReceiver(Ref ref) {
   final receiver = AgentHookReceiver(
     statusSink: ref.read(agentStatusControllerProvider.notifier),
     hookServer: ref.watch(agentHookServerProvider),
+    // The transcript watchdog is the one poller that scales with how many
+    // agents are running, so it is the one that parks while hidden.
+    codexTranscriptStatusWatcher: CodexTranscriptStatusWatcher(
+      ref.read(agentStatusControllerProvider.notifier),
+      const Duration(seconds: 5),
+      ref.watch(appForegroundProvider),
+    ),
     isAgentEnabled: (agentType) => isAgentStatusHookEnabled(
       ref.read(settingsControllerProvider).agents.agentStatusHooks,
       agentType,

--- a/lib/src/features/agent_status/application/agent_status_providers.g.dart
+++ b/lib/src/features/agent_status/application/agent_status_providers.g.dart
@@ -54,7 +54,7 @@ final class AgentHookReceiverProvider
   }
 }
 
-String _$agentHookReceiverHash() => r'f9ef39ed83de7482972c0e578165972d1d18d216';
+String _$agentHookReceiverHash() => r'ea63ae8465f9a04a8a74701313323480d861a1cc';
 
 @ProviderFor(agentHookServer)
 final agentHookServerProvider = AgentHookServerProvider._();

--- a/lib/src/features/agent_status/infra/codex_transcript_status_watcher.dart
+++ b/lib/src/features/agent_status/infra/codex_transcript_status_watcher.dart
@@ -5,6 +5,7 @@ import 'dart:math' as math;
 
 import 'package:alera/src/features/agent_status/application/agent_status_controller.dart';
 import 'package:alera/src/features/agent_status/domain/agent_status.dart';
+import 'package:alera/src/features/app_window/domain/app_foreground.dart';
 
 part 'codex_transcript_watch.dart';
 
@@ -12,10 +13,12 @@ class CodexTranscriptStatusWatcher {
   CodexTranscriptStatusWatcher(
     this._statusSink, [
     this._watchdogInterval = const Duration(seconds: 5),
+    this._appForeground = const AlwaysForeground(),
   ]);
 
   final AgentStatusSink _statusSink;
   final Duration _watchdogInterval;
+  final AppForeground _appForeground;
   final Map<String, _CodexTranscriptWatch> _watches =
       <String, _CodexTranscriptWatch>{};
 
@@ -50,6 +53,7 @@ class CodexTranscriptStatusWatcher {
       transcriptPath: transcriptPath,
       turnId: _readString(event.payload, const <String>['turn_id', 'turnId']),
       watchdogInterval: _watchdogInterval,
+      appForeground: _appForeground,
     );
     _watches[event.terminalSessionId] = watch;
     watch.start();

--- a/lib/src/features/agent_status/infra/codex_transcript_watch.dart
+++ b/lib/src/features/agent_status/infra/codex_transcript_watch.dart
@@ -9,6 +9,7 @@ class _CodexTranscriptWatch {
     required this.transcriptPath,
     required this.turnId,
     required this.watchdogInterval,
+    required this.appForeground,
   });
 
   final AgentStatusSink _statusSink;
@@ -18,11 +19,18 @@ class _CodexTranscriptWatch {
   final String transcriptPath;
   final String? turnId;
   final Duration watchdogInterval;
+  final AppForeground appForeground;
   final Map<String, String> _pendingToolsByCallId = <String, String>{};
   final Set<String> _emittedCallIds = <String>{};
   StreamSubscription<FileSystemEvent>? _subscription;
+  StreamSubscription<bool>? _foregroundSubscription;
   Timer? _watchdogTimer;
   Timer? _pollTimer;
+
+  /// Whether polling was the active strategy when the app went to the
+  /// background, so returning restores the same one rather than upgrading a
+  /// degraded watch back to a file-event watch that already failed.
+  var _polling = false;
   var _offset = 0;
   var _partialLine = '';
   var _armed = false;
@@ -33,6 +41,7 @@ class _CodexTranscriptWatch {
   Completer<void>? _activeScan;
 
   void start() {
+    _foregroundSubscription = appForeground.changes.listen(_applyForeground);
     final file = File(transcriptPath);
     try {
       final length = file.existsSync() ? file.lengthSync() : 0;
@@ -91,11 +100,43 @@ class _CodexTranscriptWatch {
   void dispose() {
     _disposed = true;
     unawaited(_subscription?.cancel());
+    unawaited(_foregroundSubscription?.cancel());
     _watchdogTimer?.cancel();
     _pollTimer?.cancel();
     _subscription = null;
+    _foregroundSubscription = null;
     _watchdogTimer = null;
     _pollTimer = null;
+  }
+
+  /// Park the timers while the app is hidden, and catch up on return.
+  ///
+  /// This is the one poller in the app that scales with how many agents are
+  /// running: a stat plus an incremental read per transcript, every interval,
+  /// whether or not anyone can see the status it produces.
+  ///
+  /// The file watch keeps running while parked. It is event driven, so it costs
+  /// nothing idle, and leaving it subscribed means a transcript that changes
+  /// while hidden is still noticed. Only the safety net stops. Nothing is lost
+  /// either way: scanning resumes from the same byte offset, so returning to
+  /// the foreground reads whatever accumulated.
+  void _applyForeground(bool isForeground) {
+    if (_disposed) {
+      return;
+    }
+    if (!isForeground) {
+      _watchdogTimer?.cancel();
+      _watchdogTimer = null;
+      _pollTimer?.cancel();
+      _pollTimer = null;
+      return;
+    }
+    if (_polling) {
+      _startPollTimer();
+    } else {
+      _armWatchdog();
+    }
+    _scheduleScan();
   }
 
   void _scheduleScan() {
@@ -103,7 +144,7 @@ class _CodexTranscriptWatch {
   }
 
   void _armWatchdog() {
-    if (_disposed || _pollTimer != null) {
+    if (_disposed || _polling || !appForeground.isForeground) {
       return;
     }
     _watchdogTimer?.cancel();
@@ -114,13 +155,21 @@ class _CodexTranscriptWatch {
   }
 
   void _enablePolling() {
-    if (_disposed || _pollTimer != null) {
+    if (_disposed || _polling) {
       return;
     }
+    _polling = true;
     _watchdogTimer?.cancel();
     _watchdogTimer = null;
     unawaited(_subscription?.cancel());
     _subscription = null;
+    _startPollTimer();
+  }
+
+  void _startPollTimer() {
+    if (_disposed || _pollTimer != null || !appForeground.isForeground) {
+      return;
+    }
     _pollTimer = Timer.periodic(watchdogInterval, (_) => _scheduleScan());
   }
 

--- a/lib/src/features/app_window/application/app_window_providers.dart
+++ b/lib/src/features/app_window/application/app_window_providers.dart
@@ -1,6 +1,8 @@
 import 'package:alera/src/features/app_window/application/app_window_controller.dart';
 import 'package:alera/src/features/app_window/application/app_window_state_repository.dart';
+import 'package:alera/src/features/app_window/domain/app_foreground.dart';
 import 'package:alera/src/features/app_window/infra/drift_app_window_state_repository.dart';
+import 'package:alera/src/features/app_window/infra/lifecycle_app_foreground.dart';
 import 'package:alera/src/features/app_window/infra/platform_app_window_close_strategy.dart';
 import 'package:alera/src/features/app_window/infra/screen_retriever_app_window_display_provider.dart';
 import 'package:alera/src/features/app_window/infra/window_manager_app_window_controller.dart';
@@ -43,4 +45,13 @@ AppWindowLifecycleCoordinator appWindowLifecycleCoordinator(Ref ref) {
     coordinator.stop();
   });
   return coordinator;
+}
+
+/// Observes the app lifecycle so recurring work can park while nobody can see
+/// its results.
+@Riverpod(keepAlive: true)
+AppForeground appForeground(Ref ref) {
+  final foreground = LifecycleAppForeground();
+  ref.onDispose(foreground.dispose);
+  return foreground;
 }

--- a/lib/src/features/app_window/application/app_window_providers.g.dart
+++ b/lib/src/features/app_window/application/app_window_providers.g.dart
@@ -203,3 +203,52 @@ final class AppWindowLifecycleCoordinatorProvider
 
 String _$appWindowLifecycleCoordinatorHash() =>
     r'cd701c2b5038caf5c56604db638e08dcc663e6c1';
+
+/// Observes the app lifecycle so recurring work can park while nobody can see
+/// its results.
+
+@ProviderFor(appForeground)
+final appForegroundProvider = AppForegroundProvider._();
+
+/// Observes the app lifecycle so recurring work can park while nobody can see
+/// its results.
+
+final class AppForegroundProvider
+    extends $FunctionalProvider<AppForeground, AppForeground, AppForeground>
+    with $Provider<AppForeground> {
+  /// Observes the app lifecycle so recurring work can park while nobody can see
+  /// its results.
+  AppForegroundProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'appForegroundProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$appForegroundHash();
+
+  @$internal
+  @override
+  $ProviderElement<AppForeground> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  AppForeground create(Ref ref) {
+    return appForeground(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(AppForeground value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<AppForeground>(value),
+    );
+  }
+}
+
+String _$appForegroundHash() => r'dceb40705264e2c77686d3c1eceb4b7a565bd934';

--- a/lib/src/features/app_window/domain/app_foreground.dart
+++ b/lib/src/features/app_window/domain/app_foreground.dart
@@ -1,0 +1,33 @@
+/// Whether the app is in the foreground.
+///
+/// Exists for recurring work whose results nobody can see while the app is
+/// hidden. Such work should park rather than keep running, because it costs a
+/// laptop real cycles to produce answers that will be recomputed on return.
+abstract class AppForeground {
+  /// Whether the app is currently visible to the user.
+  bool get isForeground;
+
+  /// Emits on every change to [isForeground].
+  Stream<bool> get changes;
+
+  void dispose();
+}
+
+/// An [AppForeground] that never parks.
+///
+/// The default wherever there is no running app to observe: tests, headless
+/// use, and anything constructed before the binding exists. Defaulting to
+/// foreground keeps the parking opt-in, so a missed wiring degrades to the
+/// behavior that was there before rather than to silence.
+class AlwaysForeground implements AppForeground {
+  const AlwaysForeground();
+
+  @override
+  bool get isForeground => true;
+
+  @override
+  Stream<bool> get changes => const Stream<bool>.empty();
+
+  @override
+  void dispose() {}
+}

--- a/lib/src/features/app_window/infra/lifecycle_app_foreground.dart
+++ b/lib/src/features/app_window/infra/lifecycle_app_foreground.dart
@@ -1,0 +1,58 @@
+import 'dart:async';
+
+import 'package:alera/src/features/app_window/domain/app_foreground.dart';
+import 'package:flutter/widgets.dart';
+
+/// [AppForeground] backed by the Flutter app lifecycle.
+class LifecycleAppForeground implements AppForeground {
+  LifecycleAppForeground() {
+    try {
+      _listener = AppLifecycleListener(onStateChange: _apply);
+    } catch (_) {
+      // No widgets binding, so there is no lifecycle to observe: a unit test,
+      // or anything constructed before `runApp`. Reporting a permanent
+      // foreground degrades to the behavior from before parking existed, which
+      // is the safe direction. Going the other way would silently stop work
+      // that nothing would ever restart.
+      _listener = null;
+    }
+  }
+
+  AppLifecycleListener? _listener;
+  final StreamController<bool> _changes = StreamController<bool>.broadcast();
+  var _isForeground = true;
+
+  @override
+  bool get isForeground => _isForeground;
+
+  @override
+  Stream<bool> get changes => _changes.stream;
+
+  @override
+  void dispose() {
+    _listener?.dispose();
+    unawaited(_changes.close());
+  }
+
+  void _apply(AppLifecycleState state) {
+    final next = _isForegroundState(state);
+    if (next == _isForeground) {
+      return;
+    }
+    _isForeground = next;
+    _changes.add(next);
+  }
+}
+
+/// On desktop `inactive` means the window merely lost focus, which happens
+/// every time the user reads something in another app. Parking there would stop
+/// updating state the user is about to look back at, so only states where the
+/// window is actually gone from view count as background.
+bool _isForegroundState(AppLifecycleState state) {
+  return switch (state) {
+    AppLifecycleState.resumed || AppLifecycleState.inactive => true,
+    AppLifecycleState.hidden ||
+    AppLifecycleState.paused ||
+    AppLifecycleState.detached => false,
+  };
+}

--- a/test/unit/app_foreground_test.dart
+++ b/test/unit/app_foreground_test.dart
@@ -1,0 +1,24 @@
+import 'package:alera/src/features/app_window/domain/app_foreground.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('AlwaysForeground', () {
+    test('never parks and never reports a change', () async {
+      // The default wherever there is no running app to observe. Reporting a
+      // permanent foreground is what makes parking opt-in: a missed wiring
+      // degrades to the behavior from before parking existed rather than to
+      // work that nothing would ever restart.
+      const foreground = AlwaysForeground();
+
+      expect(foreground.isForeground, isTrue);
+      expect(await foreground.changes.isEmpty, isTrue);
+    });
+
+    test('disposing is a no-op', () {
+      const foreground = AlwaysForeground();
+
+      expect(foreground.dispose, returnsNormally);
+      expect(foreground.isForeground, isTrue);
+    });
+  });
+}

--- a/test/unit/codex_transcript_watchdog_parking_test.dart
+++ b/test/unit/codex_transcript_watchdog_parking_test.dart
@@ -1,0 +1,179 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:alera/src/features/agent_status/application/agent_status_controller.dart';
+import 'package:alera/src/features/agent_status/domain/agent_status.dart';
+import 'package:alera/src/features/agent_status/infra/codex_transcript_status_watcher.dart';
+import 'package:alera/src/features/app_window/domain/app_foreground.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// The transcript watchdog is the only poller in the app that scales with how
+/// many agents are running: a stat plus an incremental read per transcript,
+/// every interval. These cases pin that it stops while nobody can see its
+/// results, and that stopping never costs an update.
+void main() {
+  group('Codex transcript watchdog parking', () {
+    late Directory tempDir;
+    late File transcript;
+    late _FakeStatusSink sink;
+    late _FakeAppForeground foreground;
+    late CodexTranscriptStatusWatcher watcher;
+
+    const watchdogInterval = Duration(milliseconds: 20);
+
+    setUp(() async {
+      tempDir = await Directory.systemTemp.createTemp('alera-codex-parking-');
+      transcript = File('${tempDir.path}/rollout.jsonl');
+      transcript.writeAsStringSync(_turnStart);
+      sink = _FakeStatusSink();
+      foreground = _FakeAppForeground();
+      watcher = CodexTranscriptStatusWatcher(
+        sink,
+        watchdogInterval,
+        foreground,
+      );
+    });
+
+    tearDown(() {
+      watcher.dispose();
+      foreground.dispose();
+      if (tempDir.existsSync()) {
+        tempDir.deleteSync(recursive: true);
+      }
+    });
+
+    /// Watching starts on the prompt that opens a turn.
+    void startWatching() {
+      watcher.observeHookEvent(
+        AgentHookEvent(
+          terminalSessionId: 'session-1',
+          workspaceId: 'workspace-1',
+          tabId: 'tab-1',
+          agentType: AgentType.codex,
+          hookEventName: 'UserPromptSubmit',
+          payload: <String, Object?>{
+            'turn_id': 'turn-1',
+            'transcript_path': transcript.path,
+          },
+        ),
+      );
+    }
+
+    /// Append the line that ends the turn, without touching the watcher, so a
+    /// scan is the only thing that can observe it.
+    void completeTurnOnDisk() {
+      transcript.writeAsStringSync(_turnComplete, mode: FileMode.append);
+    }
+
+    Future<void> waitOutSeveralIntervals() async {
+      await Future<void>.delayed(watchdogInterval * 8);
+    }
+
+    /// Kill the file watch so polling is the only thing left driving scans.
+    ///
+    /// Deleting the path ends the subscription, which is what the watcher
+    /// treats as "file watching is not working here" and falls back on. Without
+    /// this the assertions below could not tell a parked timer from an event
+    /// the file watch delivered anyway.
+    Future<void> forcePollingFallback() async {
+      transcript.deleteSync();
+      await Future<void>.delayed(watchdogInterval * 3);
+      transcript.writeAsStringSync(_turnStart);
+      await Future<void>.delayed(watchdogInterval * 3);
+    }
+
+    test('a backgrounded app stops polling the transcript', () async {
+      startWatching();
+      await forcePollingFallback();
+      final before = sink.events.length;
+
+      foreground.setForeground(false);
+      completeTurnOnDisk();
+      await waitOutSeveralIntervals();
+
+      expect(
+        sink.events.length,
+        before,
+        reason: 'the poll timer kept reading the transcript while hidden',
+      );
+    });
+
+    test('polling resumes on return and reads what accumulated', () async {
+      startWatching();
+      await forcePollingFallback();
+      foreground.setForeground(false);
+      completeTurnOnDisk();
+      await waitOutSeveralIntervals();
+
+      foreground.setForeground(true);
+      await Future<void>.delayed(watchdogInterval * 3);
+
+      expect(sink.events.map((event) => event.hookEventName), contains('Stop'));
+    });
+
+    test('returning to the foreground catches up on what was missed', () async {
+      startWatching();
+      await Future<void>.delayed(watchdogInterval * 2);
+      foreground.setForeground(false);
+      completeTurnOnDisk();
+      await waitOutSeveralIntervals();
+
+      foreground.setForeground(true);
+      await Future<void>.delayed(watchdogInterval * 2);
+
+      // Nothing is lost by parking: the scan resumes from the same byte offset,
+      // so the completion written while hidden is read on return.
+      expect(sink.events.map((event) => event.hookEventName), contains('Stop'));
+    });
+
+    test('a watch disposed while hidden stays disposed', () async {
+      // Resuming must not revive a watch whose turn already ended, which is
+      // what a stale foreground subscription would do.
+      startWatching();
+      completeTurnOnDisk();
+      await Future<void>.delayed(watchdogInterval * 3);
+      final afterStop = sink.events.length;
+
+      foreground.setForeground(false);
+      foreground.setForeground(true);
+      await waitOutSeveralIntervals();
+
+      expect(sink.events.length, afterStop);
+    });
+  });
+}
+
+const _turnStart =
+    '{"type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}\n';
+const _turnComplete =
+    '{"type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1"}}\n';
+
+class _FakeAppForeground implements AppForeground {
+  final StreamController<bool> _changes = StreamController<bool>.broadcast();
+  var _isForeground = true;
+
+  @override
+  bool get isForeground => _isForeground;
+
+  @override
+  Stream<bool> get changes => _changes.stream;
+
+  void setForeground(bool value) {
+    _isForeground = value;
+    _changes.add(value);
+  }
+
+  @override
+  void dispose() {
+    unawaited(_changes.close());
+  }
+}
+
+class _FakeStatusSink implements AgentStatusSink {
+  final List<AgentHookEvent> events = <AgentHookEvent>[];
+
+  @override
+  void applyHookEvent(AgentHookEvent event) {
+    events.add(event);
+  }
+}


### PR DESCRIPTION
## Summary

The transcript watchdog is the one poller in the app that scales with how many agents are running: a stat plus an incremental read per transcript, every five seconds, whether or not anyone can see the status it produces. Everything else periodic here is already bounded - the heartbeat only runs after a request has timed out, the pairing tick only while its dialog is open, and the host status refresh is a single tick that does not grow.

Alera observed the app lifecycle nowhere, so this adds that too, as an `AppForeground` the infra layer can consult without reaching for widgets. It defaults to `AlwaysForeground`: a missed wiring degrades to the behavior from before parking existed rather than to silence, and the lifecycle-backed implementation degrades the same way when there is no binding to observe.

The file watch stays subscribed while parked. It is event driven, so it costs nothing idle, and leaving it up means a transcript that changes while hidden is still noticed. Only the unconditional timer stops, and nothing is lost either way: scanning resumes from the same byte offset.

## Validation

`flutter analyze` clean, 1902 tests pass. Cases cover parking, resuming with catch-up, and not reviving a watch whose turn ended while hidden; verified they fail when the parking is removed.

## Notes

On desktop, `inactive` means the window merely lost focus, which happens every time the user reads something elsewhere. Only states where the window is actually gone count as background.

Pre-existing on main and unrelated: the two real-pty adapter cases in `terminal_runtime_native_test` fail on a clean checkout too.