### PR TITLE
fix: distinguish an incompatible host from a missing one

### DIFF
--- a/lib/src/features/workbench/infra/terminal_host/terminal_host_client.dart
+++ b/lib/src/features/workbench/infra/terminal_host/terminal_host_client.dart
@@ -24,6 +24,7 @@ part 'terminal_host_client_lifecycle.dart';
 part 'terminal_host_client_heartbeat.dart';
 part 'terminal_host_client_session_events.dart';
 part 'terminal_host_client_socket_reader.dart';
+part 'terminal_host_control_file.dart';
 
 final class SocketTerminalHostClient
     with _TerminalHostClientHeartbeat, _TerminalHostClientSessionEvents
@@ -466,6 +467,7 @@ final class SocketTerminalHostClient
     File controlFile, {
     required bool requireOrchestration,
   }) async {
+    await _failIfIncompatibleHostHoldsRuntime(runtime);
     final token = _newToken();
     await _launcher.start(
       runtimeDir: runtime.runtimeDir.path,
@@ -697,49 +699,6 @@ final class SocketTerminalHostClient
       controlFile: File(p.join(runtimeDir.path, 'host.json')),
       runtimeControlFile: File(p.join(runtimeDir.path, 'runtime-host.json')),
     );
-  }
-
-  Future<_TerminalHostControl?> _readControl(File file) async {
-    try {
-      if (!await file.exists()) {
-        return null;
-      }
-      final decoded = jsonDecode(await file.readAsString());
-      final map = asTerminalHostMap(decoded, 'terminal host control');
-      if (map['protocolVersion'] != aleraTerminalHostProtocolVersion) {
-        return null;
-      }
-      final capabilities = asTerminalHostStringList(map['runtimeCapabilities']);
-      final port = map['port'];
-      final token = map['token'];
-      if (port is! int || token is! String || token.isEmpty) {
-        return null;
-      }
-      return _TerminalHostControl(
-        port: port,
-        token: token,
-        supportsRuntime:
-            capabilities.contains(aleraRuntimeHostCapability) &&
-            capabilities.contains(aleraRuntimeHostBootstrapCapability) &&
-            capabilities.contains(aleraRuntimeHostManagedWorkspaceCapability),
-        supportsOrchestration: capabilities.contains(
-          aleraRuntimeHostOrchestrationCapability,
-        ),
-        supportsBinaryFrames: capabilities.contains(
-          aleraRuntimeHostBinaryFramesCapability,
-        ),
-      );
-    } catch (_) {
-      return null;
-    }
-  }
-
-  Future<void> _deleteControlFile(File file) async {
-    try {
-      if (await file.exists()) {
-        await file.delete();
-      }
-    } catch (_) {}
   }
 
   String _newToken() {

--- a/lib/src/features/workbench/infra/terminal_host/terminal_host_control_file.dart
+++ b/lib/src/features/workbench/infra/terminal_host/terminal_host_control_file.dart
@@ -1,0 +1,130 @@
+part of 'terminal_host_client.dart';
+
+/// Reading, validating, and clearing the host control file.
+///
+/// Top-level rather than methods on the client, following `_controlAcceptsHello`:
+/// none of this touches client state, and keeping it out of the class is what
+/// keeps the client file reviewable.
+
+/// Refuse to launch when a live host of another protocol version already owns
+/// this runtime directory.
+///
+/// `_readControl` answers null for such a file, which is the same answer it
+/// gives for no file at all, so without this the launch went ahead against a
+/// directory that was already taken, re-read the same incompatible file every
+/// hundred milliseconds, and failed the whole startup timeout later with
+/// "did not start in time" and no last error. The cause was known at the
+/// first read; this reports it there instead.
+///
+/// The usual way to arrive here is an app update leaving the previous
+/// `alera terminal-host` running, which is what `make host-stop` exists for.
+/// A control file whose host is gone is stale rather than blocking, so it is
+/// deleted and the launch proceeds.
+Future<void> _failIfIncompatibleHostHoldsRuntime(
+  _TerminalHostPaths runtime,
+) async {
+  for (final file in <File>[runtime.controlFile, runtime.runtimeControlFile]) {
+    final version = await _readIncompatibleProtocolVersion(file);
+    if (version == null) {
+      continue;
+    }
+    if (await _portIsListening(version.port)) {
+      throw StateError(
+        'A terminal host speaking protocol ${version.protocolVersion} is '
+        'already running, but this app speaks '
+        '$aleraTerminalHostProtocolVersion. Stop the running host '
+        '(`make host-stop`, or quit every other Alera build) and try again.',
+      );
+    }
+    await _deleteControlFile(file);
+  }
+}
+
+/// The protocol version and port of a control file this app cannot speak, or
+/// null when the file is absent, unreadable, or compatible.
+Future<({int protocolVersion, int port})?> _readIncompatibleProtocolVersion(
+  File file,
+) async {
+  try {
+    if (!await file.exists()) {
+      return null;
+    }
+    final decoded = jsonDecode(await file.readAsString());
+    final map = asTerminalHostMap(decoded, 'terminal host control');
+    final version = map['protocolVersion'];
+    final port = map['port'];
+    if (version is! int ||
+        version == aleraTerminalHostProtocolVersion ||
+        port is! int) {
+      return null;
+    }
+    return (protocolVersion: version, port: port);
+  } catch (_) {
+    // An unreadable file is not evidence that anything owns the directory.
+    return null;
+  }
+}
+
+/// Whether something still answers on the port a control file advertises.
+///
+/// A bare connect rather than a hello: a host of another protocol version
+/// would reject our hello, so a handshake cannot tell it apart from a dead
+/// one, and accepting the connection is all the proof of ownership needed.
+Future<bool> _portIsListening(int port) async {
+  Socket? socket;
+  try {
+    socket = await Socket.connect(
+      InternetAddress.loopbackIPv4,
+      port,
+      timeout: _terminalHostConnectTimeout,
+    );
+    return true;
+  } catch (_) {
+    return false;
+  } finally {
+    socket?.destroy();
+  }
+}
+
+Future<_TerminalHostControl?> _readControl(File file) async {
+  try {
+    if (!await file.exists()) {
+      return null;
+    }
+    final decoded = jsonDecode(await file.readAsString());
+    final map = asTerminalHostMap(decoded, 'terminal host control');
+    if (map['protocolVersion'] != aleraTerminalHostProtocolVersion) {
+      return null;
+    }
+    final capabilities = asTerminalHostStringList(map['runtimeCapabilities']);
+    final port = map['port'];
+    final token = map['token'];
+    if (port is! int || token is! String || token.isEmpty) {
+      return null;
+    }
+    return _TerminalHostControl(
+      port: port,
+      token: token,
+      supportsRuntime:
+          capabilities.contains(aleraRuntimeHostCapability) &&
+          capabilities.contains(aleraRuntimeHostBootstrapCapability) &&
+          capabilities.contains(aleraRuntimeHostManagedWorkspaceCapability),
+      supportsOrchestration: capabilities.contains(
+        aleraRuntimeHostOrchestrationCapability,
+      ),
+      supportsBinaryFrames: capabilities.contains(
+        aleraRuntimeHostBinaryFramesCapability,
+      ),
+    );
+  } catch (_) {
+    return null;
+  }
+}
+
+Future<void> _deleteControlFile(File file) async {
+  try {
+    if (await file.exists()) {
+      await file.delete();
+    }
+  } catch (_) {}
+}

--- a/test/unit/terminal_host_client_protocol_mismatch_cases.dart
+++ b/test/unit/terminal_host_client_protocol_mismatch_cases.dart
@@ -1,0 +1,99 @@
+part of 'terminal_host_client_test.dart';
+
+/// A live host speaking another protocol version owns the runtime directory.
+///
+/// `_readControl` answers null for that file, exactly as it does for no file at
+/// all, so the client used to launch anyway, re-read the same incompatible file
+/// every hundred milliseconds, and fail the whole startup timeout later with
+/// "did not start in time" and no last error. The cause was knowable at the
+/// first read. Arriving here is ordinary: an app update leaves the previous
+/// `alera terminal-host` running, which is what `make host-stop` is for.
+void _registerTerminalHostClientProtocolMismatchTests() {
+  test(
+    'a live host of another protocol version is reported, not launched',
+    () async {
+      final tempDir = await Directory.systemTemp.createTemp(
+        'alera-host-client-mismatch-',
+      );
+      addTearDown(() async {
+        if (await tempDir.exists()) {
+          await tempDir.delete(recursive: true);
+        }
+      });
+      final server = await _TerminalHostTestServer.start();
+      addTearDown(server.dispose);
+      await _writeControlFile(
+        tempDir: tempDir,
+        port: server.port,
+        token: 'existing-token',
+        protocolVersion: aleraTerminalHostProtocolVersion + 1,
+      );
+      final launcher = _NoopTerminalHostLauncher();
+      final client = SocketTerminalHostClient(
+        launcher: launcher,
+        applicationSupportDirectory: () async => tempDir,
+        // Long enough that a test finishing quickly proves the timeout was never
+        // waited out.
+        startupTimeout: const Duration(minutes: 5),
+      );
+      addTearDown(client.dispose);
+
+      await expectLater(
+        client.ensureStarted(config: TerminalHostConfig.defaults),
+        throwsA(
+          isA<StateError>().having(
+            (error) => error.message,
+            'message',
+            allOf(
+              contains('${aleraTerminalHostProtocolVersion + 1}'),
+              contains('host-stop'),
+            ),
+          ),
+        ),
+      );
+      expect(
+        launcher.starts,
+        0,
+        reason: 'launched a second host into a directory another host owns',
+      );
+    },
+  );
+
+  test(
+    'a stale control file of another version does not block a launch',
+    () async {
+      // The host that wrote it is gone, so the file is leftover rather than
+      // evidence of an owner. Refusing here would turn a crashed old host into a
+      // permanently unusable runtime directory.
+      final tempDir = await Directory.systemTemp.createTemp(
+        'alera-host-client-stale-mismatch-',
+      );
+      addTearDown(() async {
+        if (await tempDir.exists()) {
+          await tempDir.delete(recursive: true);
+        }
+      });
+      final deadServer = await _TerminalHostTestServer.start();
+      final deadPort = deadServer.port;
+      await deadServer.dispose();
+      await _writeControlFile(
+        tempDir: tempDir,
+        port: deadPort,
+        token: 'stale-token',
+        protocolVersion: aleraTerminalHostProtocolVersion + 1,
+      );
+      final server = await _TerminalHostTestServer.start();
+      addTearDown(server.dispose);
+      final launcher = _FakeTerminalHostLauncher(server: server);
+      final client = SocketTerminalHostClient(
+        launcher: launcher,
+        applicationSupportDirectory: () async => tempDir,
+      );
+      addTearDown(client.dispose);
+
+      await client.ensureStarted(config: TerminalHostConfig.defaults);
+
+      expect(launcher.starts, 1);
+    },
+  );
+}

--- a/test/unit/terminal_host_client_test.dart
+++ b/test/unit/terminal_host_client_test.dart
@@ -12,12 +12,14 @@ import 'package:path/path.dart' as p;
 part 'terminal_host_client_resilience_cases.dart';
 part 'terminal_host_client_timeout_cases.dart';
 part 'terminal_host_client_binary_frames_cases.dart';
+part 'terminal_host_client_protocol_mismatch_cases.dart';
 part 'terminal_host_test_server.dart';
 
 void main() {
   _registerTerminalHostClientResilienceTests();
   _registerTerminalHostClientTimeoutTests();
   _registerTerminalHostClientBinaryFrameTests();
+  _registerTerminalHostClientProtocolMismatchTests();
 
   test('connects through launcher and sends lifecycle requests', () async {
     final tempDir = await Directory.systemTemp.createTemp('alera-host-client-');
@@ -977,6 +979,7 @@ Future<void> _writeControlFile({
   String fileName = 'host.json',
   required int port,
   required String token,
+  int protocolVersion = aleraTerminalHostProtocolVersion,
   bool includeRuntimeCapability = true,
   bool includeBootstrapCapability = true,
   bool includeManagedWorkspaceCapability = true,
@@ -986,7 +989,7 @@ Future<void> _writeControlFile({
   final runtimeDir = Directory(p.join(tempDir.path, 'terminal_host'));
   await runtimeDir.create(recursive: true);
   final payload = <String, Object?>{
-    'protocolVersion': aleraTerminalHostProtocolVersion,
+    'protocolVersion': protocolVersion,
     'port': port,
     'token': token,
   };


### PR DESCRIPTION
## Summary

`_readControl` answered null for a control file naming a protocol version this app cannot speak, which is the same answer it gives for no file at all. So the client launched a second host into a runtime directory another host already owned, re-read that same incompatible file every hundred milliseconds, and failed the whole startup timeout later with "did not start in time" and a null last error. Everything needed to say what was wrong was in hand at the first read.

Getting here is ordinary rather than exotic. Dev and release use different bundle ids and do not collide, but updating the app while a previous `alera terminal-host` is still running does exactly this, and that is the case `make host-stop` exists for. AGENTS.md already warns three times that a version mismatch makes the app treat a live host as unusable; that was a rule for contributors with no handling behind it.

## Validation

`flutter analyze` clean, 1902 tests pass. Verified the new case times out at 30s without the guard and fails fast with it.

## Notes

Liveness is probed with a bare connect rather than a hello, because a host of another protocol version would reject our hello and so could not be told apart from a dead one. Accepting the connection is all the proof of ownership needed.

A control file whose host is gone stays a stale file: it is deleted and the launch proceeds, so a crashed old host cannot make a runtime directory permanently unusable. That case is covered too.

Splits the control-file helpers into their own part file, which the max-lines ratchet required and which follows `_controlAcceptsHello`: none of them touch client state.

Pre-existing on main and unrelated: the two real-pty adapter cases in `terminal_runtime_native_test` fail on a clean checkout too.