### PR TITLE
test: pin the orchestration skill version to the binary constant

### DIFF
--- a/rust/alera-cli/tests/skill_version_matches_binary.rs
+++ b/rust/alera-cli/tests/skill_version_matches_binary.rs
@@ -1,0 +1,89 @@
+use std::path::PathBuf;
+
+/// The shipped skill guide declares a version, and so does the binary that runs
+/// the commands it documents. Nothing kept the two in step.
+///
+/// `alera version --json` reports both `skillVersion` and
+/// `runtimeHostSkillVersion` so a CLI/host mismatch is detectable, and the
+/// guide tells agents to consult it. All of that is built on the guide's own
+/// number being true. Bump one side and forget the other and the command
+/// reports a compatibility that does not hold, confidently.
+#[test]
+fn the_orchestration_skill_guide_declares_the_version_the_binary_ships() {
+    let guide = repository_path(&["skills", "alera-orchestration", "SKILL.md"]);
+    let contents = std::fs::read_to_string(&guide)
+        .unwrap_or_else(|error| panic!("cannot read {}: {error}", guide.display()));
+
+    let declared = frontmatter_version(&contents).unwrap_or_else(|| {
+        panic!(
+            "{} has no `version:` in its frontmatter, so nothing pins it to the binary",
+            guide.display()
+        )
+    });
+
+    assert_eq!(
+        declared,
+        alera_cli_orchestration_skill_version(),
+        "{} declares version {declared} but the binary ships \
+         ORCHESTRATION_SKILL_VERSION {}. Bump both together: `alera version --json` \
+         reports the binary's number, so a one-sided bump makes it lie.",
+        guide.display(),
+        alera_cli_orchestration_skill_version(),
+    );
+}
+
+/// Read the constant from its source rather than linking the binary crate,
+/// which an integration test cannot import.
+fn alera_cli_orchestration_skill_version() -> i64 {
+    let protocol = repository_path(&["rust", "alera-cli", "src", "terminal_host", "protocol.rs"]);
+    let contents = std::fs::read_to_string(&protocol)
+        .unwrap_or_else(|error| panic!("cannot read {}: {error}", protocol.display()));
+    let declaration = contents
+        .lines()
+        .find_map(|line| {
+            line.trim()
+                .strip_prefix("pub const ORCHESTRATION_SKILL_VERSION: i64 = ")
+        })
+        .unwrap_or_else(|| {
+            panic!(
+                "ORCHESTRATION_SKILL_VERSION is no longer declared as expected in {}",
+                protocol.display()
+            )
+        });
+    declaration
+        .trim_end_matches(';')
+        .trim()
+        .parse()
+        .unwrap_or_else(|error| panic!("unreadable ORCHESTRATION_SKILL_VERSION: {error}"))
+}
+
+/// The first `version:` inside the leading `---` frontmatter block.
+fn frontmatter_version(contents: &str) -> Option<i64> {
+    let mut lines = contents.lines();
+    if lines.next()?.trim() != "---" {
+        return None;
+    }
+    lines
+        .take_while(|line| line.trim() != "---")
+        .find_map(|line| line.trim().strip_prefix("version:"))
+        .and_then(|value| value.trim().parse().ok())
+}
+
+fn repository_path(segments: &[&str]) -> PathBuf {
+    // CARGO_MANIFEST_DIR is <repo>/rust/alera-cli.
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.pop();
+    path.pop();
+    path.extend(segments);
+    path
+}
+
+#[test]
+fn the_frontmatter_reader_only_trusts_a_leading_block() {
+    // A `version:` further down the document describes something else, and
+    // reading it would let the real one drift unnoticed.
+    assert_eq!(frontmatter_version("---\nversion: 7\n---\nbody\n"), Some(7));
+    assert_eq!(frontmatter_version("---\nname: x\n---\nversion: 9\n"), None);
+    assert_eq!(frontmatter_version("version: 9\n"), None);
+    assert_eq!(frontmatter_version("---\nname: x\n---\n"), None);
+}


### PR DESCRIPTION
## Summary

`ORCHESTRATION_SKILL_VERSION` in `protocol.rs` and the version in the shipped `SKILL.md` frontmatter have to agree, in two languages, by hand, with nothing checking. `alera version --json` reports both the CLI's and the host's number so a mismatch is detectable, and the guide itself tells agents to consult it when compatibility is uncertain, but all of that rests on the guide's own number being true. Bump one side and forget the other and the command reports a compatibility that does not hold, with no hint that it is guessing.

## Validation

`make rust-test` clean. Verified the guard fails on a one-sided bump, naming both places and why it matters.

## Notes

The constant is read from its source rather than linked, because an integration test cannot import the binary crate. The frontmatter reader only trusts a leading block, so a `version:` further down cannot stand in for the real one, and that is pinned too.

Out of scope by decision: giving `skills/alera-cli/SKILL.md` a version of its own (it has none today) and converting either guide to a hybrid stub.