### PR TITLE
fix: drop the repeated project name from agent status notifications

### DIFF
--- a/lib/src/features/agent_status/application/agent_status_notifications.dart
+++ b/lib/src/features/agent_status/application/agent_status_notifications.dart
@@ -193,7 +193,10 @@ String _notificationLocationBody({
 }) {
   final project = projectName?.trim() ?? '';
   final workspace = workspaceName?.trim() ?? '';
-  if (workspace.isNotEmpty && project.isNotEmpty) {
+  // A workspace named after its project reads as "Workspace alera in alera".
+  if (workspace.isNotEmpty &&
+      project.isNotEmpty &&
+      workspace.toLowerCase() != project.toLowerCase()) {
     return 'Workspace $workspace in $project';
   }
   if (workspace.isNotEmpty) {

--- a/test/unit/agent_status_notifications_test.dart
+++ b/test/unit/agent_status_notifications_test.dart
@@ -121,6 +121,22 @@ void main() {
       expect(tabOnly.body, 'Terminal Terminal 2');
     });
 
+    test('drops the project when it repeats the workspace name', () {
+      final sameName = composeAgentStatusNotification(
+        entry: _entry(AgentStatusState.waiting),
+        projectName: 'alera',
+        workspaceName: 'alera',
+      );
+      final sameNameDifferentCase = composeAgentStatusNotification(
+        entry: _entry(AgentStatusState.done),
+        projectName: 'Alera',
+        workspaceName: ' alera ',
+      );
+
+      expect(sameName!.body, 'Workspace alera');
+      expect(sameNameDifferentCase!.body, 'Workspace alera');
+    });
+
     test('deduplicates unchanged states by terminal and state start time', () {
       final tracker = AgentStatusNotificationTracker();
       final firstWaiting = _entry(AgentStatusState.waiting);


### PR DESCRIPTION
## Summary

A workspace named after its project produced notification bodies like `Workspace alera in alera`. When the workspace and project names match (trimmed, case-insensitive), the body now collapses to `Workspace alera`.

## Validation

- `flutter test test/unit/agent_status_notifications_test.dart test/unit/app_providers_test.dart` (26 passed)
- `dart format`, `flutter analyze` on the touched paths
- `dart run tool/quality/check_max_lines.dart`

## Notes

Used `toLowerCase()` instead of `equalsIgnoreAsciiCase` because `package:collection` is only a transitive dependency here. No documentation changes needed: this is internal notification copy with no documented rule in `docs/`.