### PR TITLE
fix: select workspace after creation

### DIFF
--- a/lib/src/features/workbench/application/workbench_controller_projects.dart
+++ b/lib/src/features/workbench/application/workbench_controller_projects.dart
@@ -138,6 +138,7 @@ mixin _WorkbenchControllerProjects
         reuseExistingBranch: reuseExistingBranch,
         name: name,
       );
+      _reconcileCreatedWorkspace(project, result.workspace);
       await selectWorkspace(project: project, workspace: result.workspace);
       final parentId = parentWorkspaceId?.trim();
       if (parentId != null && parentId.isNotEmpty) {
@@ -163,6 +164,21 @@ mixin _WorkbenchControllerProjects
       state = state.copyWith(error: error.toString());
       rethrow;
     }
+  }
+
+  void _reconcileCreatedWorkspace(Project project, Workspace workspace) {
+    final workspaces = List<Workspace>.from(state.workspacesFor(project.id));
+    final index = workspaces.indexWhere((entry) => entry.id == workspace.id);
+    if (index == -1) {
+      workspaces.add(workspace);
+    } else {
+      workspaces[index] = workspace;
+    }
+    state = state.copyWith(
+      workspacesByProject: Map<String, List<Workspace>>.from(
+        state.workspacesByProject,
+      )..[project.id] = workspaces,
+    );
   }
 
   Future<void> deleteWorkspace({
@@ -437,6 +453,7 @@ mixin _WorkbenchControllerProjects
     }
     await _workspaceTabService.ensureInitialTerminalTab(workspace.id);
     final tabs = await _workspaceTabService.listTabs(workspace.id);
+    _setTabsForWorkspace(workspace.id, tabs);
     final layout = await _ensureWorkbenchLayout(workspace.id, tabs);
     await _applyLayout(layout, persist: false);
   }

--- a/test/unit/workbench_controller_create_workspace_test_cases.dart
+++ b/test/unit/workbench_controller_create_workspace_test_cases.dart
@@ -38,6 +38,38 @@ void _registerWorkbenchControllerCreateWorkspaceTests() {
     expect(_controller.state.activeWorkspaceId, result.workspace.id);
   });
 
+  test(
+    'createWorkspace selects the workspace before its watcher catches up',
+    () async {
+      await _harness.dispose();
+      _harness = _WorkbenchHarness(
+        const _ManagedWorkspaceRuntimeWithoutWatcher(),
+      );
+      _controller = _harness._controller;
+      await _controller.bootstrap();
+      await _flushUntil(
+        () => _controller.state.workspacesFor(_harness.project.id).isNotEmpty,
+      );
+
+      final result = await _controller.createWorkspace(
+        project: _harness.project,
+        sourceBranch: 'main',
+        newBranchName: 'feature/delayed-workspace-event',
+      );
+
+      expect(_controller.state.activeProjectId, _harness.project.id);
+      expect(_controller.state.activeWorkspace, result.workspace);
+      expect(_controller.state.activeWorkspaceTab?.title, 'Terminal 1');
+      expect(_controller.state.activeLayout?.workspaceId, result.workspace.id);
+
+      await _harness.workbenchRepository.upsertWorkspace(result.workspace);
+      await _flush();
+
+      expect(_controller.state.activeWorkspace, result.workspace);
+      expect(_controller.state.activeWorkspaceTab?.title, 'Terminal 1');
+    },
+  );
+
   test('createWorkspace clears a previous error on success', () async {
     _harness.gitBackend.failingWorktreeAddBranches.add('feature/first-try');
     await expectLater(
@@ -59,4 +91,42 @@ void _registerWorkbenchControllerCreateWorkspaceTests() {
     expect(result.workspace.branch, 'feature/second-try');
     expect(_controller.state.error, isNull);
   });
+}
+
+class _ManagedWorkspaceRuntimeWithoutWatcher
+    implements ManagedWorkspaceRuntime {
+  const _ManagedWorkspaceRuntimeWithoutWatcher();
+
+  @override
+  Future<WorkspaceCreationResult> createLinkedWorkspace({
+    required Project project,
+    required String sourceBranch,
+    required String newBranchName,
+    required bool reuseExistingBranch,
+    String? name,
+  }) async {
+    final now = DateTime.utc(2026, 5, 22, 2);
+    return WorkspaceCreationResult(
+      workspace: Workspace(
+        id: 'workspace-with-delayed-event',
+        projectId: project.id,
+        name: name ?? newBranchName,
+        branch: newBranchName,
+        path: p.join(project.repoPath, 'delayed-workspace'),
+        createdAt: now,
+        updatedAt: now,
+        kind: WorkspaceKind.linked,
+        status: WorkspaceStatus.active,
+        sourceBranch: reuseExistingBranch ? null : sourceBranch,
+        reusesExistingBranch: reuseExistingBranch,
+      ),
+      setupReport: WorktreeSetupReport.empty,
+    );
+  }
+
+  @override
+  Future<void> removeWorkspace({
+    required Workspace workspace,
+    bool? deleteBranch,
+  }) async {}
 }

--- a/test/unit/workbench_controller_test_harness.dart
+++ b/test/unit/workbench_controller_test_harness.dart
@@ -28,7 +28,7 @@ Future<void> _flushUntil(bool Function() condition, {int attempts = 20}) async {
 }
 
 class _WorkbenchHarness {
-  _WorkbenchHarness() {
+  _WorkbenchHarness([ManagedWorkspaceRuntime? runtime]) {
     tempDir = Directory.systemTemp.createTempSync(
       'alera-workbench-_controller-',
     );
@@ -82,7 +82,7 @@ class _WorkbenchHarness {
         projectsServiceProvider.overrideWithValue(projectsService),
         workspaceTabServiceProvider.overrideWithValue(workspaceTabService),
         worktreeSetupRunnerProvider.overrideWithValue(worktreeSetupRunner),
-        managedWorkspaceRuntimeProvider.overrideWithValue(null),
+        managedWorkspaceRuntimeProvider.overrideWithValue(runtime),
         workbenchViewPrefsRepositoryProvider.overrideWithValue(
           viewPrefsRepository,
         ),


### PR DESCRIPTION
## Summary

- Reconcile a newly created workspace into controller state before selecting it.
- Hydrate the selected workspace tabs immediately so the workbench view is ready without waiting for the runtime watcher.
- Add a regression test that delays the workspace watcher snapshot and verifies selection survives reconciliation.

## Root Cause

The managed runtime returned the created workspace before the workspace watcher delivered its refreshed snapshot. The controller selected an ID that was not yet present in `WorkbenchState`, so reactive synchronization could clear the selection and leave the welcome dashboard visible.

## Validation

- `dart format --set-exit-if-changed lib test integration_test tool`
- `dart tool/quality/check_max_lines.dart`
- `flutter analyze`
- `flutter test test/unit/workbench_controller_test.dart` (69 tests)

## Risk

Low. This changes controller-side state reconciliation only and does not modify persisted schemas, runtime protocols, or generated APIs.