### PR TITLE
fix: synchronize terminal pointer input on tab switch

### DIFF
--- a/lib/src/features/workbench/presentation/terminal_runtime.dart
+++ b/lib/src/features/workbench/presentation/terminal_runtime.dart
@@ -34,6 +34,7 @@ part 'terminal_runtime_session_handle.dart';
 part 'terminal_runtime_clipboard.dart';
 part 'terminal_runtime_output_batching.dart';
 part 'terminal_runtime_output_pipeline.dart';
+part 'terminal_runtime_pointer_synchronization.dart';
 part 'terminal_runtime_startup_delivery.dart';
 part 'terminal_runtime_interactive_view.dart';
 part 'terminal_runtime_shell_launches.dart';

--- a/lib/src/features/workbench/presentation/terminal_runtime_buffer_accounting.dart
+++ b/lib/src/features/workbench/presentation/terminal_runtime_buffer_accounting.dart
@@ -13,10 +13,12 @@ extension _TerminalBufferAccounting on _XtermTerminalSessionHandle {
     _visible = visible;
     if (visible) {
       _lastVisibleAt = DateTime.now();
+    }
+    _syncPtyOutputVisibility();
+    if (visible) {
       // Whatever arrived while hidden was queued without a frame callback.
       _scheduleTerminalOutputFlush();
     }
-    _syncPtyOutputVisibility();
     _onVisibilityChanged(this);
   }
 

--- a/lib/src/features/workbench/presentation/terminal_runtime_output_batching.dart
+++ b/lib/src/features/workbench/presentation/terminal_runtime_output_batching.dart
@@ -27,19 +27,23 @@ void _queueSessionTerminalOutput(
   // without bound. Newer output is what the user is looking at.
   while (handle._output.length > _terminalOutputMaxPendingChars &&
       handle._output.pending.length > 1) {
-    handle._output.length -= handle._output.headRemaining;
+    final dropped = handle._output.headRemaining;
+    handle._output.length -= dropped;
     handle._output.pending.removeFirst();
     handle._output.head = 0;
+    handle._discardPointerInputCatchUp(dropped);
   }
   if (handle._output.length > _terminalOutputMaxPendingChars) {
     // A single chunk can exceed the cap on its own, so trim its head too.
     final chunk = handle._output.pending.first;
+    final previousHead = handle._output.head;
     final start = _terminalOutputHeadTrimStart(
       chunk,
       chunk.length - _terminalOutputMaxPendingChars,
     );
     handle._output.head = start;
     handle._output.length = chunk.length - start;
+    handle._discardPointerInputCatchUp(start - previousHead);
   }
   handle._scheduleTerminalOutputFlush();
 }
@@ -138,6 +142,7 @@ void _drainSessionTerminalOutputChunk(_XtermTerminalSessionHandle handle) {
   }
   handle._writeToTerminal(frame.toString());
   handle._advanceRestore(written);
+  handle._advancePointerInputCatchUp(written);
 }
 
 void _flushSessionTerminalOutputNow(_XtermTerminalSessionHandle handle) {
@@ -146,6 +151,7 @@ void _flushSessionTerminalOutputNow(_XtermTerminalSessionHandle handle) {
     return;
   }
   handle._output.restartFlushClock();
+  final pendingChars = handle._output.length;
   final head = handle._output.head;
   final buffer = StringBuffer();
   var first = true;
@@ -157,6 +163,7 @@ void _flushSessionTerminalOutputNow(_XtermTerminalSessionHandle handle) {
   handle._writeToTerminal(buffer.toString());
   // Everything queued is on screen now, including a restore this bypassed.
   handle._finishRestore();
+  handle._advancePointerInputCatchUp(pendingChars);
 }
 
 /// Start index for a head trim that never lands inside a surrogate pair.

--- a/lib/src/features/workbench/presentation/terminal_runtime_pointer_synchronization.dart
+++ b/lib/src/features/workbench/presentation/terminal_runtime_pointer_synchronization.dart
@@ -1,0 +1,114 @@
+part of 'terminal_runtime.dart';
+
+/// Keeps pointer events behind the output that determines terminal mouse mode.
+///
+/// A hidden terminal can leave the emulator in a TUI mouse mode while the host
+/// has already returned to the shell. The missed cleanup bytes arrive during
+/// resume, so clicks stay suspended until that prefix has been parsed.
+extension _TerminalPointerSynchronization on _XtermTerminalSessionHandle {
+  void _syncPtyOutputVisibility() {
+    final generation = ++_outputVisibilityGeneration;
+    final session = _ptySession;
+    if (_disposed || session == null) {
+      _pointerInputResumePending = false;
+      _refreshPointerInputSuspension();
+      return;
+    }
+
+    final paused = !_visible;
+    _pointerInputResumePending = !paused;
+    _refreshPointerInputSuspension();
+    unawaited(
+      _applyPtyOutputVisibility(
+        session: session,
+        paused: paused,
+        generation: generation,
+      ),
+    );
+  }
+
+  Future<void> _applyPtyOutputVisibility({
+    required TerminalPtySession session,
+    required bool paused,
+    required int generation,
+  }) async {
+    try {
+      await session.setOutputPaused(paused);
+    } catch (error) {
+      if (!_disposed &&
+          identical(_ptySession, session) &&
+          generation == _outputVisibilityGeneration) {
+        _setTerminalHostError(error);
+      }
+      return;
+    }
+    if (_disposed ||
+        paused ||
+        !_visible ||
+        !identical(_ptySession, session) ||
+        generation != _outputVisibilityGeneration) {
+      return;
+    }
+    _schedulePointerInputResume(generation);
+  }
+
+  void _schedulePointerInputResume(int generation) {
+    SchedulerBinding.instance.scheduleFrameCallback((_) {
+      if (_disposed || !_visible || generation != _outputVisibilityGeneration) {
+        return;
+      }
+      _pointerInputResumePending = false;
+      if (_output.length > _pointerInputCatchUpChars) {
+        _pointerInputCatchUpChars = _output.length;
+      }
+      _refreshPointerInputSuspension();
+    });
+    SchedulerBinding.instance.ensureVisualUpdate();
+  }
+
+  void _preparePointerInputForSnapshot() {
+    _pointerInputCatchUpChars = 0;
+    _setPointerInputSuspended(true);
+  }
+
+  void _completePointerInputSnapshotCatchUp() {
+    _pointerInputCatchUpChars = _output.length;
+    _refreshPointerInputSuspension();
+  }
+
+  void _advancePointerInputCatchUp(int chars) {
+    if (chars <= 0 || _pointerInputCatchUpChars <= 0) {
+      return;
+    }
+    if (chars >= _pointerInputCatchUpChars) {
+      _pointerInputCatchUpChars = 0;
+    } else {
+      _pointerInputCatchUpChars -= chars;
+    }
+    _refreshPointerInputSuspension();
+  }
+
+  void _discardPointerInputCatchUp(int chars) {
+    _advancePointerInputCatchUp(chars);
+  }
+
+  void _resetPointerInputSynchronization() {
+    _outputVisibilityGeneration += 1;
+    _pointerInputResumePending = false;
+    _pointerInputCatchUpChars = 0;
+    _refreshPointerInputSuspension();
+  }
+
+  void _refreshPointerInputSuspension() {
+    _setPointerInputSuspended(
+      !_visible || _pointerInputResumePending || _pointerInputCatchUpChars > 0,
+    );
+  }
+
+  void _setPointerInputSuspended(bool suspended) {
+    if (_terminalController.suspendedPointerInputs == suspended) {
+      return;
+    }
+    _terminalController.setSuspendPointerInput(suspended);
+  }
+}

--- a/lib/src/features/workbench/presentation/terminal_runtime_session_handle.dart
+++ b/lib/src/features/workbench/presentation/terminal_runtime_session_handle.dart
@@ -86,6 +86,9 @@ class _XtermTerminalSessionHandle extends TerminalSessionHandle {
       ValueNotifier<TerminalRestoreProgress?>(null);
   int _restoreTotalChars = 0, _restoreWrittenChars = 0;
   bool _pendingInteractionModeReset = false;
+  int _pointerInputCatchUpChars = 0;
+  bool _pointerInputResumePending = false;
+  int _outputVisibilityGeneration = 0;
   bool _disposed = false;
 
   @override
@@ -207,6 +210,7 @@ class _XtermTerminalSessionHandle extends TerminalSessionHandle {
     _running = false;
     notifyListeners();
     await _stopPtySession(suppressExit: true);
+    _resetPointerInputSynchronization();
     await ensureStarted();
   }
 
@@ -461,10 +465,12 @@ class _XtermTerminalSessionHandle extends TerminalSessionHandle {
         _pendingInteractionModeReset |= resetInteractionModes;
         if (_visible) {
           final shouldResetInteractionModes = _pendingInteractionModeReset;
+          _preparePointerInputForSnapshot();
           _replaceTerminalWithSnapshot(
             data,
             resetInteractionModes: shouldResetInteractionModes,
           );
+          _completePointerInputSnapshotCatchUp();
           _pendingInteractionModeReset = false;
         }
       case TerminalPtyExitEvent(:final exitCode):
@@ -558,18 +564,6 @@ class _XtermTerminalSessionHandle extends TerminalSessionHandle {
     _output.clear();
   }
 
-  void _syncPtyOutputVisibility() {
-    final session = _ptySession;
-    if (_disposed || session == null) {
-      return;
-    }
-    unawaited(
-      session.setOutputPaused(!_visible).catchError((Object error) {
-        _setTerminalHostError(error);
-      }),
-    );
-  }
-
   void _setTerminalHostError(Object error) {
     if (_disposed) {
       return;
@@ -635,8 +629,11 @@ class _XtermTerminalSessionHandle extends TerminalSessionHandle {
   void dispose({bool terminatePty = true}) {
     _disposed = true;
     _startAttempt += 1;
+    _outputVisibilityGeneration += 1;
     _visibilityLeases.clear();
     _visible = false;
+    _pointerInputResumePending = false;
+    _pointerInputCatchUpChars = 0;
     _osc8LinkTracker.dispose();
     _terminalController.removeListener(_handleSelectionChanged);
     _terminalController.dispose();

--- a/lib/src/features/workbench/presentation/terminal_runtime_testing.dart
+++ b/lib/src/features/workbench/presentation/terminal_runtime_testing.dart
@@ -124,6 +124,13 @@ xterm.MouseMode terminalMouseModeForTesting(TerminalSessionHandle session) {
 }
 
 @visibleForTesting
+bool terminalPointerInputSuspendedForTesting(TerminalSessionHandle session) {
+  return (session as _XtermTerminalSessionHandle)
+      ._terminalController
+      .suspendedPointerInputs;
+}
+
+@visibleForTesting
 bool terminalBracketedPasteModeForTesting(TerminalSessionHandle session) {
   return (session as _XtermTerminalSessionHandle)._terminal.bracketedPasteMode;
 }

--- a/test/unit/terminal_runtime_snapshot_cases.dart
+++ b/test/unit/terminal_runtime_snapshot_cases.dart
@@ -100,4 +100,36 @@ void _registerTerminalRuntimeSnapshotTests() {
       debugDefaultTargetPlatformOverride = null;
     }
   });
+
+  test('a snapshot keeps pointer input suspended until it is parsed', () async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+    final fakeSession = _FakeTerminalPtySession();
+    final runtime = XtermTerminalRuntime(
+      ptySessionFactory: _FakeTerminalPtySessionFactory(
+        sessions: <_FakeTerminalPtySession>[fakeSession],
+      ),
+      shellLaunchesBuilder: () => <GhosttyTerminalShellLaunch>[
+        _launch('shell', shell: '/bin/sh'),
+      ],
+    );
+    addTearDown(runtime.dispose);
+    final session = runtime.sessionFor(workspace: _workspace(), tab: _tab());
+    final visibility = acquireTerminalVisibilityForTesting(session);
+    try {
+      await session.ensureStarted();
+
+      fakeSession.emitSnapshot(utf8.encode('\x1b[?1000h\x1b[?1006hactive tui'));
+      await Future<void>.delayed(Duration.zero);
+
+      expect(terminalPointerInputSuspendedForTesting(session), isTrue);
+
+      flushTerminalOutputForTesting(session);
+
+      expect(terminalPointerInputSuspendedForTesting(session), isFalse);
+      expect(terminalMouseModeForTesting(session), isNot(xterm.MouseMode.none));
+    } finally {
+      visibility.dispose();
+      debugDefaultTargetPlatformOverride = null;
+    }
+  });
 }

--- a/test/widget/terminal_surface_tab_switch_test_cases.dart
+++ b/test/widget/terminal_surface_tab_switch_test_cases.dart
@@ -1,0 +1,157 @@
+part of 'terminal_surface_test.dart';
+
+void _registerTerminalSurfaceTabSwitchTests() {
+  testWidgets(
+    'a resumed shell does not receive a click before TUI cleanup is parsed',
+    (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.linux;
+      try {
+        final factory = _FakeTerminalPtySessionFactory();
+        final runtime = XtermTerminalRuntime(
+          ptySessionFactory: factory,
+          shellLaunchesBuilder: _testShellLaunches,
+        );
+        addTearDown(runtime.dispose);
+        final session = runtime.sessionFor(
+          workspace: _workspace(),
+          tab: _tab(),
+        );
+
+        await _pumpTerminalSurface(tester, session);
+        final pty = factory.sessions.single;
+        pty.emitOutput(utf8.encode('\x1b[?1000h\x1b[?1006h'));
+        await _pumpTerminalOutput(tester);
+        expect(
+          terminalMouseModeForTesting(session),
+          isNot(xterm.MouseMode.none),
+        );
+        pty.writes.clear();
+
+        await _hideTerminalSurface(tester);
+        pty.emitOutput(utf8.encode('\x1b[?1000l\x1b[?1006l\r\nshell prompt'));
+        await tester.pump();
+        expect(
+          terminalMouseModeForTesting(session),
+          isNot(xterm.MouseMode.none),
+        );
+
+        final resume = Completer<void>();
+        pty.nextResumeCompleter = resume;
+        await tester.pumpWidget(_terminalSurfaceFixture(session));
+        await tester.pump();
+        expect(pty.outputPausedCalls.last, isFalse);
+        expect(terminalPointerInputSuspendedForTesting(session), isTrue);
+
+        await tester.tapAt(_cellCenter(tester, const xterm.CellOffset(2, 0)));
+        await tester.pump(const Duration(milliseconds: 300));
+
+        expect(pty.writes, isEmpty);
+
+        resume.complete();
+        await tester.pump();
+        await _pumpTerminalOutput(tester);
+
+        expect(terminalMouseModeForTesting(session), xterm.MouseMode.none);
+        expect(terminalPointerInputSuspendedForTesting(session), isFalse);
+      } finally {
+        debugDefaultTargetPlatformOverride = null;
+      }
+    },
+  );
+
+  testWidgets(
+    'a live TUI receives pointer input after resume synchronization',
+    (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.linux;
+      try {
+        final factory = _FakeTerminalPtySessionFactory();
+        final runtime = XtermTerminalRuntime(
+          ptySessionFactory: factory,
+          shellLaunchesBuilder: _testShellLaunches,
+        );
+        addTearDown(runtime.dispose);
+        final session = runtime.sessionFor(
+          workspace: _workspace(),
+          tab: _tab(),
+        );
+
+        await _pumpTerminalSurface(tester, session);
+        final pty = factory.sessions.single;
+        pty.emitOutput(utf8.encode('\x1b[?1000h\x1b[?1006h'));
+        await _pumpTerminalOutput(tester);
+        pty.writes.clear();
+
+        await _hideTerminalSurface(tester);
+        final resume = Completer<void>();
+        pty.nextResumeCompleter = resume;
+        await tester.pumpWidget(_terminalSurfaceFixture(session));
+        await tester.pump();
+
+        await tester.tapAt(_cellCenter(tester, const xterm.CellOffset(2, 0)));
+        await tester.pump(const Duration(milliseconds: 300));
+        expect(pty.writes, isEmpty);
+
+        resume.complete();
+        await tester.pump();
+        await tester.pump();
+        expect(terminalPointerInputSuspendedForTesting(session), isFalse);
+
+        await tester.tapAt(_cellCenter(tester, const xterm.CellOffset(2, 0)));
+        await tester.pump(const Duration(milliseconds: 300));
+
+        expect(
+          utf8.decode(pty.writes.expand((bytes) => bytes).toList()),
+          contains('\x1b[<0;'),
+        );
+      } finally {
+        debugDefaultTargetPlatformOverride = null;
+      }
+    },
+  );
+
+  testWidgets('a stale resume cannot enable pointer input while hidden', (
+    tester,
+  ) async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.linux;
+    try {
+      final factory = _FakeTerminalPtySessionFactory();
+      final runtime = XtermTerminalRuntime(
+        ptySessionFactory: factory,
+        shellLaunchesBuilder: _testShellLaunches,
+      );
+      addTearDown(runtime.dispose);
+      final session = runtime.sessionFor(workspace: _workspace(), tab: _tab());
+
+      await _pumpTerminalSurface(tester, session);
+      final pty = factory.sessions.single;
+      await _hideTerminalSurface(tester);
+      final resume = Completer<void>();
+      pty.nextResumeCompleter = resume;
+      await tester.pumpWidget(_terminalSurfaceFixture(session));
+      await tester.pump();
+      await _hideTerminalSurface(tester);
+
+      resume.complete();
+      await tester.pump();
+      await tester.pump();
+
+      expect(terminalPointerInputSuspendedForTesting(session), isTrue);
+      await tester.pump(const Duration(milliseconds: 200));
+    } finally {
+      debugDefaultTargetPlatformOverride = null;
+    }
+  });
+}
+
+Widget _terminalSurfaceFixture(TerminalSessionHandle session) {
+  return MaterialApp(
+    home: Scaffold(
+      body: SizedBox.expand(child: TerminalSurface(session: session)),
+    ),
+  );
+}
+
+Future<void> _hideTerminalSurface(WidgetTester tester) async {
+  await tester.pumpWidget(const MaterialApp(home: SizedBox.shrink()));
+  await tester.pump();
+}

--- a/test/widget/terminal_surface_test.dart
+++ b/test/widget/terminal_surface_test.dart
@@ -22,9 +22,11 @@ import 'package:xterm/xterm.dart' as xterm;
 
 part 'terminal_surface_core_test_cases.dart';
 part 'terminal_surface_interaction_test_cases.dart';
+part 'terminal_surface_tab_switch_test_cases.dart';
 part 'terminal_surface_test_harness.dart';
 
 void main() {
   _registerTerminalSurfaceRuntimeTests();
   _registerTerminalSurfaceInteractionTests();
+  _registerTerminalSurfaceTabSwitchTests();
 }

--- a/test/widget/terminal_surface_test_harness.dart
+++ b/test/widget/terminal_surface_test_harness.dart
@@ -93,6 +93,8 @@ class _FakeTerminalPtySessionFactory implements TerminalPtySessionFactory {
 class _FakeTerminalPtySession implements TerminalPtySession {
   final StreamController<TerminalPtySessionEvent> _events =
       StreamController<TerminalPtySessionEvent>.broadcast();
+  final List<List<int>> writes = <List<int>>[];
+  final List<bool> outputPausedCalls = <bool>[];
   GhosttyTerminalShellLaunch? startedLaunch;
   int? startedCols;
   int? startedRows;
@@ -100,6 +102,7 @@ class _FakeTerminalPtySession implements TerminalPtySession {
   bool disposed = false;
   bool terminated = false;
   int? exitCodeOnDispose;
+  Completer<void>? nextResumeCompleter;
 
   @override
   Stream<TerminalPtySessionEvent> get events => _events.stream;
@@ -123,7 +126,10 @@ class _FakeTerminalPtySession implements TerminalPtySession {
   }
 
   @override
-  bool writeBytes(List<int> bytes) => bytes.isNotEmpty;
+  bool writeBytes(List<int> bytes) {
+    writes.add(List<int>.from(bytes));
+    return bytes.isNotEmpty;
+  }
 
   @override
   Future<bool> writeBytesAndWait(List<int> bytes) async => writeBytes(bytes);
@@ -132,7 +138,15 @@ class _FakeTerminalPtySession implements TerminalPtySession {
   void resize(int cols, int rows, int cellWidthPx, int cellHeightPx) {}
 
   @override
-  Future<void> setOutputPaused(bool paused) async {}
+  Future<void> setOutputPaused(bool paused) async {
+    outputPausedCalls.add(paused);
+    if (paused) {
+      return;
+    }
+    final completer = nextResumeCompleter;
+    nextResumeCompleter = null;
+    await completer?.future;
+  }
 
   void emitExit(int exitCode) {
     if (_events.isClosed) {


### PR DESCRIPTION
## Summary

- suspend terminal pointer input while a hidden tab resumes and catches up on queued output
- prevent stale resume callbacks from re-enabling input after the tab becomes hidden again
- add regression coverage for shell cleanup, live TUI mouse input, stale resumes, and snapshots

## Root Cause

The terminal emulator could still report TUI mouse mode when a hidden tab became visible, before the host's queued cleanup bytes had been parsed. A click during that gap was encoded as terminal mouse control characters and written to the shell.

## Impact

Clicks made immediately after switching tabs are ignored until the terminal state is synchronized. Mouse-enabled TUIs continue receiving pointer input once catch-up completes.

## Validation

- `dart format --output=none --set-exit-if-changed ...`
- `dart tool/quality/check_max_lines.dart`
- `flutter analyze`
- `CI=true flutter test --reporter compact` (1,979 passed, 2 expected real-PTY skips)
- `CI=true flutter test test/unit/terminal_runtime_native_test.dart test/widget/terminal_surface_test.dart`