### PR TITLE
fix: merge login shell path into app terminal sessions

### DIFF
--- a/rust/alera-cli/src/agent_status/launch_environment.rs
+++ b/rust/alera-cli/src/agent_status/launch_environment.rs
@@ -200,6 +200,39 @@ mod tests {
     }
 
     #[test]
+    fn login_merged_path_keeps_sidecar_first_and_preserves_login_only_entries() {
+        let executable_dir = std::env::current_exe()
+            .unwrap()
+            .parent()
+            .unwrap()
+            .to_path_buf();
+        let login_only = std::env::temp_dir().join("alera-login-only-bin");
+        let path = std::env::join_paths([
+            login_only.clone(),
+            Path::new("/usr/bin").to_path_buf(),
+            Path::new("/bin").to_path_buf(),
+        ])
+        .unwrap()
+        .to_string_lossy()
+        .into_owned();
+        let mut environment = BTreeMap::from([("PATH".to_string(), path)]);
+
+        prepare_launch_environment(
+            Path::new("/runtime/custom"),
+            "session-1",
+            "workspace-1",
+            "tab-1",
+            &RuntimeAgentStatusHookSettings::default(),
+            &mut environment,
+        )
+        .unwrap();
+
+        let entries = std::env::split_paths(&environment["PATH"]).collect::<Vec<_>>();
+        assert_eq!(entries.first(), Some(&executable_dir));
+        assert!(entries.contains(&login_only));
+    }
+
+    #[test]
     fn inherited_agent_overlays_are_restored_or_removed_before_launch() {
         let wrapper = std::env::temp_dir().join("alera-wrapper-test");
         let retained = std::env::temp_dir().join("alera-retained-test");

--- a/rust/alera-cli/src/terminal_host/server/terminal_spawn.rs
+++ b/rust/alera-cli/src/terminal_host/server/terminal_spawn.rs
@@ -158,6 +158,13 @@ impl ServerActor {
         let launch_workspace_id = workspace_id.clone();
         let launch_tab_id = tab_id.clone();
         let mut environment = std::mem::take(&mut launch.environment);
+        if let Some(path) = crate::login_shell_environment::login_shell_merged_path(
+            environment.get("PATH").map(String::as_str),
+        )
+        .await
+        {
+            environment.insert("PATH".to_string(), path);
+        }
         launch.environment = tokio::task::spawn_blocking(move || {
             prepare_launch_environment(
                 &runtime_dir,


### PR DESCRIPTION
## Summary

App-created desktop terminals (`createOrAttach` / `terminal.restart`) never received the host's login-shell `PATH` merge that `docs/architecture.md` promises for terminals and that every other spawn path already performs (host-owned `spawnOnCreate`/Mobile launches, the Claude/Codex quota probes, and host tools). They started with exactly the environment the app sent - which, for a Finder/Dock launch on macOS, is the minimal `launchd` `PATH`.

This merges the login-shell `PATH` (`login_shell_merged_path`, a cached `$SHELL -ilc` probe) in the shared `start_new_terminal_session` funnel, so all three app-terminal entry points get it. It is a floor that holds regardless of the interactive shell, the Use Login Shell setting, or whether the user's rc files rebuild `PATH`.

Note: this closes a real gap but is defense-in-depth rather than the only thing standing between the user and a correct `PATH`. In the common configuration (macOS, Use Login Shell on, `$SHELL` set) the terminal already runs `/bin/zsh -l -i`, which rebuilds the full `PATH` from the user's rc files on its own. The merge matters when that does not happen: Use Login Shell disabled, `$SHELL` unset (shell selection then falls back to a clean rc-skipping shell - fixed in the follow-up #230), non-zsh shells, or a slow/failing profile. It also aligns the implementation with behavior `docs/architecture.md` already documents as active.

## Screenshots

No visual change.

## Testing

- [x] `make rust-test` (fmt + clippy `-D warnings` + workspace tests)
- [x] `make cli-build` (change compiles into the shipped sidecar)
- [x] Added a regression test (`login_merged_path_keeps_sidecar_first_and_preserves_login_only_entries`) locking in that login segments merge in while the sidecar dir stays first
- [x] Reproduced the host `$SHELL -ilc` hydration from a scrubbed, `SHELL`-less minimal env and confirmed the full `PATH` (Homebrew, flutter, pnpm) is recovered

Cross-platform: the merge is a no-op on Windows (`login_shell_merged_path` returns `None`); POSIX-only, macOS-focused.

## Security Audit

Process execution only: reuses the existing, cached login-shell `PATH` resolver; no new input handling or command construction.

## Notes

Follow-up in #230: fix the `$SHELL`-unset shell-selection fallback (so the terminal shell itself sources rc rather than starting clean) and harden the hydration cache against permanent poisoning on a slow/failed probe.
