### PR TITLE
feat: enable mobile input autocorrect

### DIFF
--- a/mobile/lib/src/features/terminal/presentation/terminal_compose_bar.dart
+++ b/mobile/lib/src/features/terminal/presentation/terminal_compose_bar.dart
@@ -97,8 +97,8 @@ class _TerminalComposeBarState extends State<TerminalComposeBar> {
                 controller: _controller,
                 minLines: 1,
                 maxLines: AleraTokens.composeBarMaxLines,
-                autocorrect: false,
-                enableSuggestions: false,
+                autocorrect: true,
+                enableSuggestions: true,
                 textInputAction: TextInputAction.newline,
                 style: const TextStyle(fontFamily: AleraTokens.monoFontFamily),
                 decoration: const InputDecoration(

--- a/mobile/test/terminal_input_test.dart
+++ b/mobile/test/terminal_input_test.dart
@@ -61,6 +61,35 @@ void main() {
     ]);
   });
 
+  testWidgets(
+    'Compose bar enables native correction and keeps Enter multiline',
+    (tester) async {
+      final sent = <(String, bool)>[];
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: TerminalComposeBar(
+              onSend: (text, {required bool withEnter}) {
+                sent.add((text, withEnter));
+              },
+            ),
+          ),
+        ),
+      );
+
+      final field = tester.widget<TextField>(find.byType(TextField));
+      expect(field.autocorrect, isTrue);
+      expect(field.enableSuggestions, isTrue);
+      expect(field.textInputAction, TextInputAction.newline);
+
+      await tester.enterText(find.byType(TextField), 'first\nsecond');
+      await tester.pump();
+
+      expect(field.controller!.text, 'first\nsecond');
+      expect(sent, isEmpty);
+    },
+  );
+
   testWidgets('Compose bar sends text with Enter and clears the field', (
     tester,
   ) async {


### PR DESCRIPTION
## Summary

- Enable OS-native autocorrection and text suggestions in the mobile terminal compose field.
- Preserve multiline editing and existing Enter/send behavior.
- Add focused regression coverage for the input configuration and compose behavior.

## Validation

- `cd mobile && flutter test test/terminal_input_test.dart test/terminal_compose_send_test.dart`
- `cd mobile && flutter test`
- `cd mobile && flutter analyze`
- `dart tool/quality/check_max_lines.dart`
- `git diff --check`

## Notes

- Local `gh act` reached the mobile job but could not resolve this linked worktree's external gitdir inside its container; the equivalent native checks above passed.