### PR TITLE
feat: add terminal refresh control

### DIFF
--- a/lib/src/features/workbench/presentation/terminal_runtime.dart
+++ b/lib/src/features/workbench/presentation/terminal_runtime.dart
@@ -103,6 +103,12 @@ abstract class TerminalSessionHandle extends ChangeNotifier {
     FocusOnKeyEventCallback? onKeyEvent,
   });
 
+  /// Reapplies the mounted viewport and schedules a one-shot repaint.
+  ///
+  /// Handles without a measured view intentionally do nothing. Refreshing must
+  /// never replace the emulator or the PTY session.
+  void refreshRendering() {}
+
   /// Moves keyboard focus to this terminal's text input so subsequent
   /// keypresses are routed to its PTY instead of any sidebar control.
   void requestFocus();

--- a/lib/src/features/workbench/presentation/terminal_runtime_session_handle.dart
+++ b/lib/src/features/workbench/presentation/terminal_runtime_session_handle.dart
@@ -316,6 +316,31 @@ class _XtermTerminalSessionHandle extends TerminalSessionHandle {
     session.resize(size.cols, size.rows, size.cellWidthPx, size.cellHeightPx);
   }
 
+  @override
+  void refreshRendering() {
+    if (_disposed) {
+      return;
+    }
+    final viewState = _terminalViewKey.currentState;
+    if (viewState == null) {
+      return;
+    }
+    final renderTerminal = viewState.renderTerminal;
+    if (!renderTerminal.attached ||
+        !renderTerminal.hasSize ||
+        renderTerminal.size.isEmpty) {
+      return;
+    }
+    final cellSize = renderTerminal.cellSize;
+    _terminal.resize(
+      _terminal.viewWidth,
+      _terminal.viewHeight,
+      cellSize.width.round(),
+      cellSize.height.round(),
+    );
+    renderTerminal.markNeedsLayout();
+  }
+
   Future<bool> _startPtySession() async {
     final launches = _shellLaunchesBuilder();
     if (launches.isEmpty) {

--- a/lib/src/features/workbench/presentation/terminal_surface.dart
+++ b/lib/src/features/workbench/presentation/terminal_surface.dart
@@ -2,6 +2,8 @@ import 'dart:async';
 
 import 'package:alera/src/app/providers.dart';
 import 'package:alera/src/app/theme/alera_tokens.dart';
+import 'package:alera/src/design_system/buttons/alera_icon_button.dart';
+import 'package:alera/src/design_system/icons/alera_icons.dart';
 import 'package:alera/src/features/keyboard/application/keybinding_resolver.dart';
 import 'package:alera/src/features/keyboard/application/keyboard_command_dispatcher.dart';
 import 'package:alera/src/features/keyboard/domain/key_chord.dart';
@@ -89,43 +91,58 @@ class _TerminalSurfaceState extends ConsumerState<TerminalSurface> {
     return AnimatedBuilder(
       animation: widget.session,
       builder: (context, _) {
-        if (widget.session.errorMessage case final String error
-            when error.trim().isNotEmpty) {
-          return _TerminalErrorState(
-            message: error,
-            onReconnect: widget.session.reconnect,
-            onRestart: widget.session.canRestart
-                ? () => _confirmRestart(context)
-                : null,
-          );
-        }
+        final error = switch (widget.session.errorMessage) {
+          final String message when message.trim().isNotEmpty => message,
+          _ => null,
+        };
+        final operation = error == null ? widget.session.operation : null;
         return Stack(
           children: <Widget>[
             Positioned.fill(
-              child: DecoratedBox(
-                decoration: const BoxDecoration(color: AleraTokens.bg),
-                child: widget.session.buildView(
-                  autofocus: widget.autofocus,
-                  onKeyEvent: _handleTerminalKey,
-                ),
-              ),
+              child: error == null
+                  ? DecoratedBox(
+                      decoration: const BoxDecoration(color: AleraTokens.bg),
+                      child: widget.session.buildView(
+                        autofocus: widget.autofocus,
+                        onKeyEvent: _handleTerminalKey,
+                      ),
+                    )
+                  : _TerminalErrorState(
+                      message: error,
+                      onReconnect: widget.session.reconnect,
+                      onRestart: widget.session.canRestart
+                          ? () => _confirmRestart(context)
+                          : null,
+                    ),
             ),
-            if (widget.session.operation case final operation?)
+            if (operation != null)
               Positioned.fill(
                 child: _TerminalOperationState(operation: operation),
               ),
             // Restoring an evicted terminal replays its whole scrollback over
             // several frames. The corner spinner does not read as a wait that
             // long, so cover the area until the history is back.
-            Positioned.fill(
-              child: ValueListenableBuilder<TerminalRestoreProgress?>(
-                valueListenable: widget.session.restoreProgress,
-                builder: (context, progress, _) {
-                  if (progress == null) {
-                    return const SizedBox.shrink();
-                  }
-                  return _TerminalRestoreState(progress: progress);
-                },
+            if (error == null)
+              Positioned.fill(
+                child: ValueListenableBuilder<TerminalRestoreProgress?>(
+                  valueListenable: widget.session.restoreProgress,
+                  builder: (context, progress, _) {
+                    if (progress == null) {
+                      return const SizedBox.shrink();
+                    }
+                    return _TerminalRestoreState(progress: progress);
+                  },
+                ),
+              ),
+            Positioned(
+              top: AleraTokens.space4,
+              right: AleraTokens.space4,
+              child: AleraIconButton(
+                tooltip: 'Refresh Terminal',
+                icon: AleraIcons.refresh,
+                backgroundColor: AleraTokens.surfaceElevated,
+                borderColor: AleraTokens.borderSubtle,
+                onPressed: widget.session.refreshRendering,
               ),
             ),
           ],

--- a/mobile/lib/src/design_system/icons/alera_icons.dart
+++ b/mobile/lib/src/design_system/icons/alera_icons.dart
@@ -30,6 +30,7 @@ abstract final class AleraIcons {
   static const IconData edit = LucideIcons.pencil;
   static const IconData delete = LucideIcons.trash2;
   static const IconData copy = LucideIcons.copy;
+  static const IconData refresh = LucideIcons.refreshCw;
   static const IconData link = LucideIcons.link;
   static const IconData external = LucideIcons.externalLink;
   static const IconData theme = LucideIcons.moon;

--- a/mobile/lib/src/features/terminal/presentation/terminal_tab_state_widgets.dart
+++ b/mobile/lib/src/features/terminal/presentation/terminal_tab_state_widgets.dart
@@ -1,0 +1,198 @@
+part of 'terminal_tab_view.dart';
+
+class _OutputEndedBanner extends StatelessWidget {
+  const _OutputEndedBanner({required this.onReconnect});
+
+  final Future<void> Function() onReconnect;
+
+  @override
+  Widget build(BuildContext context) {
+    return ColoredBox(
+      color: AleraTokens.surfaceVariant,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(
+          horizontal: AleraTokens.spaceLg,
+          vertical: AleraTokens.spaceXs,
+        ),
+        child: Row(
+          children: <Widget>[
+            const Icon(Icons.link_off, size: AleraTokens.spaceLg),
+            const SizedBox(width: AleraTokens.spaceSm),
+            Text(
+              'Terminal Output Stopped',
+              style: Theme.of(context).textTheme.labelSmall,
+            ),
+            const Spacer(),
+            TextButton(
+              onPressed: () => unawaited(onReconnect()),
+              child: const Text('Reconnect'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _DirectModeBanner extends StatelessWidget {
+  const _DirectModeBanner();
+
+  @override
+  Widget build(BuildContext context) {
+    return ColoredBox(
+      color: AleraTokens.surfaceVariant,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(
+          horizontal: AleraTokens.spaceLg,
+          vertical: AleraTokens.spaceXs,
+        ),
+        child: Row(
+          children: <Widget>[
+            const Icon(Icons.bolt, size: AleraTokens.spaceLg),
+            const SizedBox(width: AleraTokens.spaceSm),
+            Text(
+              'Keys Go Directly To The Terminal',
+              style: Theme.of(context).textTheme.labelSmall,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+enum _TerminalLoadingOperation { starting, reconnecting, restarting }
+
+class _SessionLoading extends StatefulWidget {
+  const _SessionLoading({required this.operation});
+
+  final _TerminalLoadingOperation operation;
+
+  @override
+  State<_SessionLoading> createState() => _SessionLoadingState();
+}
+
+class _SessionLoadingState extends State<_SessionLoading> {
+  Timer? _timer;
+  late DateTime _startedAt;
+
+  @override
+  void initState() {
+    super.initState();
+    _startClock();
+  }
+
+  @override
+  void didUpdateWidget(_SessionLoading oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.operation != widget.operation) {
+      _startClock();
+    }
+  }
+
+  void _startClock() {
+    _timer?.cancel();
+    _startedAt = DateTime.now();
+    _timer = Timer.periodic(const Duration(seconds: 1), (_) {
+      if (mounted) {
+        setState(() {});
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    _timer?.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final elapsed = DateTime.now().difference(_startedAt).inSeconds;
+    final label = switch (widget.operation) {
+      _TerminalLoadingOperation.starting => 'Starting Terminal',
+      _TerminalLoadingOperation.reconnecting => 'Reconnecting Terminal',
+      _TerminalLoadingOperation.restarting => 'Restarting Terminal',
+    };
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: <Widget>[
+          const CircularProgressIndicator(),
+          const SizedBox(height: AleraTokens.spaceMd),
+          Text(label, style: Theme.of(context).textTheme.bodyMedium),
+          if (elapsed >= 3) ...<Widget>[
+            const SizedBox(height: AleraTokens.spaceSm),
+            Text(
+              'Elapsed: ${elapsed}s',
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                color: AleraTokens.foregroundMuted,
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _SessionError extends StatelessWidget {
+  const _SessionError({
+    required this.error,
+    required this.onReconnect,
+    this.onRestart,
+  });
+
+  final Object error;
+  final Future<void> Function() onReconnect;
+  final Future<void> Function()? onRestart;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: AleraTokens.contentPadding,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            Icon(
+              Icons.terminal,
+              size: AleraTokens.emptyIcon,
+              color: Theme.of(context).colorScheme.error,
+            ),
+            const SizedBox(height: AleraTokens.spaceLg),
+            Text(
+              'Terminal Unavailable',
+              style: Theme.of(context).textTheme.titleLarge,
+            ),
+            const SizedBox(height: AleraTokens.spaceSm),
+            Text(
+              error.toString(),
+              textAlign: TextAlign.center,
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
+            const SizedBox(height: AleraTokens.spaceLg),
+            Wrap(
+              spacing: AleraTokens.spaceSm,
+              runSpacing: AleraTokens.spaceSm,
+              alignment: WrapAlignment.center,
+              children: <Widget>[
+                FilledButton.icon(
+                  onPressed: () => unawaited(onReconnect()),
+                  icon: const Icon(Icons.refresh),
+                  label: const Text('Reconnect'),
+                ),
+                if (onRestart case final restart?)
+                  OutlinedButton.icon(
+                    onPressed: () => unawaited(restart()),
+                    icon: const Icon(Icons.restart_alt),
+                    label: const Text('Restart Terminal'),
+                  ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/src/features/terminal/presentation/terminal_tab_view.dart
+++ b/mobile/lib/src/features/terminal/presentation/terminal_tab_view.dart
@@ -2,6 +2,8 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:alera_mobile/src/app/theme/alera_tokens.dart';
+import 'package:alera_mobile/src/design_system/buttons/alera_icon_button.dart';
+import 'package:alera_mobile/src/design_system/icons/alera_icons.dart';
 import 'package:alera_mobile/src/features/runtime/domain/runtime_client_surfaces.dart';
 import 'package:alera_mobile/src/features/terminal/application/terminal_accessory_layout_controller.dart';
 import 'package:alera_mobile/src/features/terminal/application/terminal_input_mode_controller.dart';
@@ -15,18 +17,32 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:alera_mobile/src/features/terminal/domain/terminal_output_batcher.dart';
 import 'package:xterm/xterm.dart';
 
+part 'terminal_tab_state_widgets.dart';
+
 /// One terminal tab filling the available space, with the quick-key bar and
 /// the compose/direct input modes stacked above the keyboard.
-class TerminalTabView extends ConsumerWidget {
+class TerminalTabView extends ConsumerStatefulWidget {
   const TerminalTabView({super.key, required this.hostId, required this.tabId});
 
   final String hostId;
   final String tabId;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final session = ref.watch(terminalSessionControllerProvider(hostId, tabId));
-    final inputMode = ref.watch(terminalInputModeControllerProvider(tabId));
+  ConsumerState<TerminalTabView> createState() => _TerminalTabViewState();
+}
+
+class _TerminalTabViewState extends ConsumerState<TerminalTabView> {
+  final GlobalKey<_TerminalSurfaceState> _surfaceKey =
+      GlobalKey<_TerminalSurfaceState>();
+
+  @override
+  Widget build(BuildContext context) {
+    final session = ref.watch(
+      terminalSessionControllerProvider(widget.hostId, widget.tabId),
+    );
+    final inputMode = ref.watch(
+      terminalInputModeControllerProvider(widget.tabId),
+    );
     final accessoryKeys =
         ref
             .watch(terminalAccessoryLayoutControllerProvider)
@@ -34,14 +50,14 @@ class TerminalTabView extends ConsumerWidget {
             ?.visibleKeys() ??
         const <TerminalAccessoryKey>[];
     final notifier = ref.read(
-      terminalSessionControllerProvider(hostId, tabId).notifier,
+      terminalSessionControllerProvider(widget.hostId, widget.tabId).notifier,
     );
-    return switch (session) {
+    final content = switch (session) {
       AsyncData(value: final tabSession) => Column(
         children: <Widget>[
           Expanded(
             child: _TerminalSurface(
-              key: ValueKey<String>(tabSession.sessionId),
+              key: _surfaceKey,
               session: tabSession,
               inputMode: inputMode,
               onInput: (data) => notifier.write(utf8.encode(data)),
@@ -55,7 +71,9 @@ class TerminalTabView extends ConsumerWidget {
             inputMode: inputMode,
             onKey: notifier.write,
             onToggleMode: ref
-                .read(terminalInputModeControllerProvider(tabId).notifier)
+                .read(
+                  terminalInputModeControllerProvider(widget.tabId).notifier,
+                )
                 .toggle,
           ),
           if (inputMode == TerminalInputMode.compose)
@@ -77,6 +95,27 @@ class TerminalTabView extends ConsumerWidget {
         },
       ),
     };
+    return Stack(
+      fit: StackFit.expand,
+      children: <Widget>[
+        content,
+        Positioned(
+          top: AleraTokens.spaceXs,
+          right: AleraTokens.spaceXs,
+          child: AleraIconButton(
+            tooltip: 'Refresh Terminal',
+            icon: AleraIcons.refresh,
+            backgroundColor: AleraTokens.surfaceElevated,
+            borderColor: AleraTokens.borderSubtle,
+            onPressed: _refreshTerminal,
+          ),
+        ),
+      ],
+    );
+  }
+
+  void _refreshTerminal() {
+    _surfaceKey.currentState?.refreshRendering();
   }
 
   Future<void> _confirmRestart(
@@ -133,6 +172,8 @@ class _TerminalSurface extends StatefulWidget {
 class _TerminalSurfaceState extends State<_TerminalSurface> {
   late Terminal _terminal;
   final TerminalController _controller = TerminalController();
+  final GlobalKey<TerminalViewState> _terminalViewKey =
+      GlobalKey<TerminalViewState>();
   TerminalOutputBatcher? _batcher;
   StreamSubscription<MobileTerminalOutputEvent>? _outputSub;
   bool _outputEnded = false;
@@ -218,6 +259,27 @@ class _TerminalSurfaceState extends State<_TerminalSurface> {
     setState(() => _outputEnded = true);
   }
 
+  void refreshRendering() {
+    final viewState = _terminalViewKey.currentState;
+    if (viewState == null) {
+      return;
+    }
+    final renderTerminal = viewState.renderTerminal;
+    if (!renderTerminal.attached ||
+        !renderTerminal.hasSize ||
+        renderTerminal.size.isEmpty) {
+      return;
+    }
+    final cellSize = renderTerminal.cellSize;
+    _terminal.resize(
+      _terminal.viewWidth,
+      _terminal.viewHeight,
+      cellSize.width.round(),
+      cellSize.height.round(),
+    );
+    renderTerminal.markNeedsLayout();
+  }
+
   @override
   Widget build(BuildContext context) {
     final direct = widget.inputMode == TerminalInputMode.direct;
@@ -229,6 +291,7 @@ class _TerminalSurfaceState extends State<_TerminalSurface> {
             color: AleraTokens.background,
             child: TerminalView(
               _terminal,
+              key: _terminalViewKey,
               controller: _controller,
               // Compose mode keeps the terminal read-only so tapping it scrolls
               // instead of raising the soft keyboard; direct mode streams keys.
@@ -243,203 +306,6 @@ class _TerminalSurfaceState extends State<_TerminalSurface> {
           ),
         ),
       ],
-    );
-  }
-}
-
-class _OutputEndedBanner extends StatelessWidget {
-  const _OutputEndedBanner({required this.onReconnect});
-
-  final Future<void> Function() onReconnect;
-
-  @override
-  Widget build(BuildContext context) {
-    return ColoredBox(
-      color: AleraTokens.surfaceVariant,
-      child: Padding(
-        padding: const EdgeInsets.symmetric(
-          horizontal: AleraTokens.spaceLg,
-          vertical: AleraTokens.spaceXs,
-        ),
-        child: Row(
-          children: <Widget>[
-            const Icon(Icons.link_off, size: AleraTokens.spaceLg),
-            const SizedBox(width: AleraTokens.spaceSm),
-            Text(
-              'Terminal Output Stopped',
-              style: Theme.of(context).textTheme.labelSmall,
-            ),
-            const Spacer(),
-            TextButton(
-              onPressed: () => unawaited(onReconnect()),
-              child: const Text('Reconnect'),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-}
-
-class _DirectModeBanner extends StatelessWidget {
-  const _DirectModeBanner();
-
-  @override
-  Widget build(BuildContext context) {
-    return ColoredBox(
-      color: AleraTokens.surfaceVariant,
-      child: Padding(
-        padding: const EdgeInsets.symmetric(
-          horizontal: AleraTokens.spaceLg,
-          vertical: AleraTokens.spaceXs,
-        ),
-        child: Row(
-          children: <Widget>[
-            const Icon(Icons.bolt, size: AleraTokens.spaceLg),
-            const SizedBox(width: AleraTokens.spaceSm),
-            Text(
-              'Keys Go Directly To The Terminal',
-              style: Theme.of(context).textTheme.labelSmall,
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-}
-
-enum _TerminalLoadingOperation { starting, reconnecting, restarting }
-
-class _SessionLoading extends StatefulWidget {
-  const _SessionLoading({required this.operation});
-
-  final _TerminalLoadingOperation operation;
-
-  @override
-  State<_SessionLoading> createState() => _SessionLoadingState();
-}
-
-class _SessionLoadingState extends State<_SessionLoading> {
-  Timer? _timer;
-  late DateTime _startedAt;
-
-  @override
-  void initState() {
-    super.initState();
-    _startClock();
-  }
-
-  @override
-  void didUpdateWidget(_SessionLoading oldWidget) {
-    super.didUpdateWidget(oldWidget);
-    if (oldWidget.operation != widget.operation) {
-      _startClock();
-    }
-  }
-
-  void _startClock() {
-    _timer?.cancel();
-    _startedAt = DateTime.now();
-    _timer = Timer.periodic(const Duration(seconds: 1), (_) {
-      if (mounted) {
-        setState(() {});
-      }
-    });
-  }
-
-  @override
-  void dispose() {
-    _timer?.cancel();
-    super.dispose();
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final elapsed = DateTime.now().difference(_startedAt).inSeconds;
-    final label = switch (widget.operation) {
-      _TerminalLoadingOperation.starting => 'Starting Terminal',
-      _TerminalLoadingOperation.reconnecting => 'Reconnecting Terminal',
-      _TerminalLoadingOperation.restarting => 'Restarting Terminal',
-    };
-    return Center(
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: <Widget>[
-          const CircularProgressIndicator(),
-          const SizedBox(height: AleraTokens.spaceMd),
-          Text(label, style: Theme.of(context).textTheme.bodyMedium),
-          if (elapsed >= 3) ...<Widget>[
-            const SizedBox(height: AleraTokens.spaceSm),
-            Text(
-              'Elapsed: ${elapsed}s',
-              style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                color: AleraTokens.foregroundMuted,
-              ),
-            ),
-          ],
-        ],
-      ),
-    );
-  }
-}
-
-class _SessionError extends StatelessWidget {
-  const _SessionError({
-    required this.error,
-    required this.onReconnect,
-    this.onRestart,
-  });
-
-  final Object error;
-  final Future<void> Function() onReconnect;
-  final Future<void> Function()? onRestart;
-
-  @override
-  Widget build(BuildContext context) {
-    return Center(
-      child: Padding(
-        padding: AleraTokens.contentPadding,
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: <Widget>[
-            Icon(
-              Icons.terminal,
-              size: AleraTokens.emptyIcon,
-              color: Theme.of(context).colorScheme.error,
-            ),
-            const SizedBox(height: AleraTokens.spaceLg),
-            Text(
-              'Terminal Unavailable',
-              style: Theme.of(context).textTheme.titleLarge,
-            ),
-            const SizedBox(height: AleraTokens.spaceSm),
-            Text(
-              error.toString(),
-              textAlign: TextAlign.center,
-              style: Theme.of(context).textTheme.bodyMedium,
-            ),
-            const SizedBox(height: AleraTokens.spaceLg),
-            Wrap(
-              spacing: AleraTokens.spaceSm,
-              runSpacing: AleraTokens.spaceSm,
-              alignment: WrapAlignment.center,
-              children: <Widget>[
-                FilledButton.icon(
-                  onPressed: () => unawaited(onReconnect()),
-                  icon: const Icon(Icons.refresh),
-                  label: const Text('Reconnect'),
-                ),
-                if (onRestart case final restart?)
-                  OutlinedButton.icon(
-                    onPressed: () => unawaited(restart()),
-                    icon: const Icon(Icons.restart_alt),
-                    label: const Text('Restart Terminal'),
-                  ),
-              ],
-            ),
-          ],
-        ),
-      ),
     );
   }
 }

--- a/mobile/test/tabs_controller_test.dart
+++ b/mobile/test/tabs_controller_test.dart
@@ -249,6 +249,33 @@ void main() {
     expect(client.calls, contains('detach session-tab-1'));
   });
 
+  test('Session controller forwards a repeated viewport size', () async {
+    final client = FakeTerminalClient()
+      ..tabs = <WorkspaceTabSummary>[fakeTab(id: 'tab-1', title: 'Terminal 1')];
+    final container = _container(client);
+    final subscription = container.listen(
+      terminalSessionControllerProvider('host-1', 'tab-1'),
+      (_, _) {},
+    );
+    addTearDown(subscription.close);
+    await container.read(
+      terminalSessionControllerProvider('host-1', 'tab-1').future,
+    );
+    final notifier = container.read(
+      terminalSessionControllerProvider('host-1', 'tab-1').notifier,
+    );
+
+    await notifier.resize(48, 22);
+    await notifier.resize(48, 22);
+
+    expect(
+      client.calls.where((call) => call == 'resize session-tab-1 48 22'),
+      hasLength(2),
+    );
+    expect(client.writes, isEmpty);
+    expect(client.calls, isNot(contains('restart tab-1')));
+  });
+
   test('Session recovery reconnects before an explicit restart', () async {
     final client = FakeTerminalClient()
       ..tabs = <WorkspaceTabSummary>[fakeTab(id: 'tab-1', title: 'Terminal 1')];

--- a/mobile/test/terminal_tab_view_test.dart
+++ b/mobile/test/terminal_tab_view_test.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:typed_data';
 
+import 'package:alera_mobile/src/app/theme/alera_tokens.dart';
 import 'package:alera_mobile/src/features/runtime/domain/workspace_tab_summary.dart';
 import 'package:alera_mobile/src/features/terminal/application/terminal_providers.dart';
 import 'package:alera_mobile/src/features/terminal/presentation/terminal_tab_view.dart';
@@ -13,6 +14,62 @@ import 'package:xterm/xterm.dart';
 import 'support/fake_terminal_client.dart';
 
 void main() {
+  testWidgets(
+    'Refresh control is top right and preserves the terminal session',
+    (tester) async {
+      final client = FakeTerminalClient()
+        ..tabs = <WorkspaceTabSummary>[
+          fakeTab(id: 'tab-1', title: 'Terminal 1'),
+        ];
+      await _pumpTab(tester, client);
+      final before = _terminalOf(tester);
+      final resizeCountBefore = client.calls
+          .where((call) => call.startsWith('resize session-tab-1 '))
+          .length;
+      final terminalRect = tester.getRect(find.byType(TerminalView));
+      final refreshRect = tester.getRect(find.byTooltip('Refresh Terminal'));
+      expect(
+        refreshRect.top,
+        closeTo(terminalRect.top + AleraTokens.spaceXs, 0.01),
+      );
+      expect(
+        refreshRect.right,
+        closeTo(terminalRect.right - AleraTokens.spaceXs, 0.01),
+      );
+
+      await tester.tap(find.byTooltip('Refresh Terminal'));
+      await tester.pumpAndSettle();
+
+      expect(_terminalOf(tester), same(before));
+      expect(
+        client.calls
+            .where((call) => call.startsWith('resize session-tab-1 '))
+            .length,
+        resizeCountBefore + 1,
+      );
+      expect(client.writes, isEmpty);
+      expect(client.calls, isNot(contains('restart tab-1')));
+    },
+  );
+
+  testWidgets('Refresh control is safe after the connection is lost', (
+    tester,
+  ) async {
+    final client = FakeTerminalClient()
+      ..tabs = <WorkspaceTabSummary>[fakeTab(id: 'tab-1', title: 'Terminal 1')];
+    await _pumpTab(tester, client);
+    await client.dispose();
+    await tester.pumpAndSettle();
+    final callsBefore = List<String>.of(client.calls);
+
+    await tester.tap(find.byTooltip('Refresh Terminal'));
+    await tester.pump();
+
+    expect(find.text('Terminal Unavailable'), findsOneWidget);
+    expect(client.calls, callsBefore);
+    expect(tester.takeException(), isNull);
+  });
+
   testWidgets('Live output keeps the same emulator', (tester) async {
     final client = FakeTerminalClient()
       ..tabs = <WorkspaceTabSummary>[fakeTab(id: 'tab-1', title: 'Terminal 1')];

--- a/test/unit/terminal_runtime_xterm_widget_cases.dart
+++ b/test/unit/terminal_runtime_xterm_widget_cases.dart
@@ -2,6 +2,57 @@ part of 'terminal_runtime_native_test.dart';
 
 void _registerXtermRuntimeWidgetTests() {
   testWidgets(
+    'render refresh reapplies the measured viewport without replacing state',
+    (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+      final fakeSession = _FakeTerminalPtySession();
+      final runtime = XtermTerminalRuntime(
+        ptySessionFactory: _FakeTerminalPtySessionFactory(
+          sessions: <_FakeTerminalPtySession>[fakeSession],
+        ),
+        shellLaunchesBuilder: () => <GhosttyTerminalShellLaunch>[
+          _launch('shell', shell: '/bin/sh'),
+        ],
+      );
+      addTearDown(runtime.dispose);
+      final session = runtime.sessionFor(workspace: _workspace(), tab: _tab());
+      try {
+        session.refreshRendering();
+        expect(fakeSession.resizeCalls, isEmpty);
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(body: SizedBox.expand(child: session.buildView())),
+          ),
+        );
+        await tester.pump();
+        await session.ensureStarted();
+        await tester.pump(const Duration(milliseconds: 200));
+        fakeSession.resizeCalls.clear();
+        fakeSession.writes.clear();
+        writeTerminalOutputForTesting(session, 'preserved output');
+        final bufferBefore = terminalBufferTextForTesting(session);
+
+        session.refreshRendering();
+        await tester.pump(const Duration(milliseconds: 200));
+
+        expect(fakeSession.resizeCalls, hasLength(1));
+        expect(fakeSession.resizeCalls.single.cols, greaterThan(0));
+        expect(fakeSession.resizeCalls.single.rows, greaterThan(0));
+        expect(terminalBufferTextForTesting(session), bufferBefore);
+        expect(runtime.peekSession('tab-1'), same(session));
+        expect(fakeSession.writes, isEmpty);
+        expect(fakeSession.terminated, isFalse);
+      } finally {
+        runtime.dispose();
+        await tester.pumpWidget(const SizedBox.shrink());
+        await tester.pump();
+        debugDefaultTargetPlatformOverride = null;
+      }
+    },
+  );
+
+  testWidgets(
     'build view supports deferred focus, direct input, and OSC updates',
     (tester) async {
       debugDefaultTargetPlatformOverride = TargetPlatform.macOS;

--- a/test/widget/terminal_surface_core_test_cases.dart
+++ b/test/widget/terminal_surface_core_test_cases.dart
@@ -1,6 +1,47 @@
 part of 'terminal_surface_test.dart';
 
 void _registerTerminalSurfaceRuntimeTests() {
+  testWidgets('refresh control is top right and invokes the current session', (
+    tester,
+  ) async {
+    final session = _ImmediateNotifySessionHandle(tabId: 'tab-1');
+
+    await _pumpTerminalSurface(tester, session);
+
+    final surfaceRect = tester.getRect(find.byType(TerminalSurface));
+    final refreshRect = tester.getRect(find.byTooltip('Refresh Terminal'));
+    expect(
+      refreshRect.top,
+      closeTo(surfaceRect.top + AleraTokens.space4, 0.01),
+    );
+    expect(
+      refreshRect.right,
+      closeTo(surfaceRect.right - AleraTokens.space4, 0.01),
+    );
+
+    await tester.tap(find.byTooltip('Refresh Terminal'));
+    await tester.pump();
+
+    expect(session.refreshRenderingCallCount, 1);
+    expect(session.ensureStartedCallCount, 1);
+  });
+
+  testWidgets('refresh control is safe while the terminal is unavailable', (
+    tester,
+  ) async {
+    final session = _ErrorSessionHandle(
+      tabId: 'tab-1',
+      message: 'disconnected',
+    );
+
+    await _pumpTerminalSurface(tester, session);
+    await tester.tap(find.byTooltip('Refresh Terminal'));
+    await tester.pump();
+
+    expect(find.text('Terminal Unavailable'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+
   test('working directory launch keeps the shell usable if cd fails', () {
     const launch = GhosttyTerminalShellLaunch(
       label: 'zsh',

--- a/test/widget/terminal_surface_test.dart
+++ b/test/widget/terminal_surface_test.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:alera/src/app/providers.dart';
+import 'package:alera/src/app/theme/alera_tokens.dart';
 import 'package:alera/src/features/keyboard/domain/keyboard_action.dart';
 import 'package:alera/src/shared/infra/uri/external_uri_launcher.dart';
 import 'package:alera/src/features/settings/domain/alera_settings.dart';

--- a/test/widget/terminal_surface_test_harness.dart
+++ b/test/widget/terminal_surface_test_harness.dart
@@ -195,6 +195,7 @@ class _ImmediateNotifySessionHandle extends TerminalSessionHandle {
   final String tabId;
 
   int ensureStartedCallCount = 0;
+  int refreshRenderingCallCount = 0;
   bool _started = false;
 
   @override
@@ -238,6 +239,11 @@ class _ImmediateNotifySessionHandle extends TerminalSessionHandle {
     FocusOnKeyEventCallback? onKeyEvent,
   }) {
     return SizedBox.expand(key: ValueKey<String>('terminal-$tabId'));
+  }
+
+  @override
+  void refreshRendering() {
+    refreshRenderingCallCount += 1;
   }
 
   @override


### PR DESCRIPTION
## Summary

- add a compact top-right `Refresh Terminal` control on desktop and mobile terminal surfaces
- reapply the current measured viewport and request a one-shot layout/repaint without replacing the emulator, PTY, shell, or scrollback
- keep refresh safe while loading, disconnected, or not yet measured, and split mobile state widgets to preserve the max-lines limit

## Validation

- `CI=true flutter test --coverage -r failures-only` (`+1983`, 2 skipped)
- `cd mobile && flutter test` (`+130`)
- `flutter analyze`
- `cd mobile && flutter analyze`
- `dart tool/quality/coverage_report.dart --input coverage/lcov.info --min-lines 100 --worst 25` (100.00%, 1734/1734)
- root and mobile format checks
- `dart tool/quality/check_max_lines.dart`
- `git diff --check`

## Notes

No Rust or protocol changes. Refresh uses the existing platform-specific PTY resize path with the current dimensions and never applies a temporary size. Local `gh act` could not run the shared setup action in this linked worktree because the container reported `fatal: not a git repository: (null)`; native repository checks above completed successfully.