### PR TITLE
feat: add autonomous desktop updates

### DIFF
--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -133,6 +133,16 @@ jobs:
           BASE_URL: ${{ env.ALERA_UPDATE_BASE_URL }}
           RELEASE_PAGE_URL: https://github.com/${{ github.repository }}/releases/tag/${{ needs.plan.outputs.desktop_tag }}
           ALERA_UPDATE_MANIFEST_PUBLIC_KEY: ${{ secrets.ALERA_UPDATE_MANIFEST_PUBLIC_KEY }}
+          APPLE_DEVELOPER_ID_APPLICATION: ${{ secrets.APPLE_DEVELOPER_ID_APPLICATION }}
+          APPLE_DEVELOPER_ID_TEAM_ID: ${{ secrets.APPLE_DEVELOPER_ID_TEAM_ID }}
+          APPLE_CERTIFICATE_P12_BASE64: ${{ secrets.APPLE_CERTIFICATE_P12_BASE64 }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          WINDOWS_CERTIFICATE_PFX_BASE64: ${{ secrets.WINDOWS_CERTIFICATE_PFX_BASE64 }}
+          WINDOWS_CERTIFICATE_PASSWORD: ${{ secrets.WINDOWS_CERTIFICATE_PASSWORD }}
+          ALERA_LINUX_GPG_PRIVATE_KEY_BASE64: ${{ secrets.ALERA_LINUX_GPG_PRIVATE_KEY_BASE64 }}
+          ALERA_LINUX_GPG_KEY_ID: ${{ secrets.ALERA_LINUX_GPG_KEY_ID }}
         run: |
           set -euo pipefail
           archive_file="app-archive.json"
@@ -147,6 +157,26 @@ jobs:
           fi
           archive_url="${BASE_URL}/${archive_file}"
           runtime_archive_url="https://github.com/${{ github.repository }}/releases/download/${{ needs.plan.outputs.desktop_tag }}/${runtime_archive_file}"
+          auto_install_enabled=false
+          if [[ "$CHANNEL" == "rc" ]]; then
+            auto_install_enabled=true
+          elif [[ "$PLATFORM" == "macos" \
+            && -n "${APPLE_DEVELOPER_ID_APPLICATION:-}" \
+            && -n "${APPLE_DEVELOPER_ID_TEAM_ID:-}" \
+            && -n "${APPLE_CERTIFICATE_P12_BASE64:-}" \
+            && -n "${APPLE_CERTIFICATE_PASSWORD:-}" \
+            && -n "${APPLE_ID:-}" \
+            && -n "${APPLE_APP_SPECIFIC_PASSWORD:-}" ]]; then
+            auto_install_enabled=true
+          elif [[ "$PLATFORM" == "windows" \
+            && -n "${WINDOWS_CERTIFICATE_PFX_BASE64:-}" \
+            && -n "${WINDOWS_CERTIFICATE_PASSWORD:-}" ]]; then
+            auto_install_enabled=true
+          elif [[ "$PLATFORM" == "linux" \
+            && -n "${ALERA_LINUX_GPG_PRIVATE_KEY_BASE64:-}" \
+            && -n "${ALERA_LINUX_GPG_KEY_ID:-}" ]]; then
+            auto_install_enabled=true
+          fi
           dart run desktop_updater:release "$PLATFORM" \
             --dart-define "ALERA_FLAVOR=release" \
             --dart-define "ALERA_UPDATE_CHANNEL=$CHANNEL" \
@@ -154,7 +184,7 @@ jobs:
             --dart-define "ALERA_RUNTIME_ARCHIVE_URL=$runtime_archive_url" \
             --dart-define "ALERA_RUNTIME_VERSION=${{ needs.plan.outputs.desktop_release_version }}" \
             --dart-define "ALERA_RELEASE_PAGE_URL=$RELEASE_PAGE_URL" \
-            --dart-define "ALERA_UPDATE_AUTO_INSTALL_ENABLED=false" \
+            --dart-define "ALERA_UPDATE_AUTO_INSTALL_ENABLED=$auto_install_enabled" \
             --dart-define "ALERA_SIGNED_RELEASE=true" \
             --dart-define "ALERA_UPDATE_MANIFEST_PUBLIC_KEY=$ALERA_UPDATE_MANIFEST_PUBLIC_KEY"
 

--- a/docs/release-trust.md
+++ b/docs/release-trust.md
@@ -26,7 +26,7 @@ Mobile release APKs must be signed with the stable upload keystore, because Andr
 
 The public update indexes use `schemaVersion: 2` and include SHA-256 and size for each platform artifact. The manifest is signed with Ed25519 and the release build embeds the public key through `ALERA_UPDATE_MANIFEST_PUBLIC_KEY`. Stable update checks reject unsigned or tampered manifests when `ALERA_SIGNED_RELEASE=true`. GitHub artifact attestations are published through GitHub's attestation service; they are not advertised as R2 sidecar URLs unless matching sidecar files are generated and uploaded.
 
-Stable automatic installation remains disabled unless the build is signed, the manifest public key is embedded, and the platform apply path explicitly allows the artifact type.
+Stable automatic installation is enabled per platform only when the build job has the matching trust credentials, the manifest public key is embedded, and the platform apply path supports the artifact type. The app streams the selected artifact to a temporary directory, checks its signed size and SHA-256 before staging it, and keeps the current process running until a replacement helper has prepared a sibling copy and accepted the handoff. The helper restores and relaunches the previous installation if the final swap fails. Linux package updates stay in the running app until `pkexec` reports a successful `.deb` or `.rpm` transaction, then Alera launches the installed executable and exits.
 
 ## Runtime sidecar archive
 

--- a/lib/src/features/app_menu/presentation/app_menu_actions.dart
+++ b/lib/src/features/app_menu/presentation/app_menu_actions.dart
@@ -87,6 +87,7 @@ AleraToastTone _toastToneForUpdateStatus(AleraUpdateStatus status) {
     AleraUpdateStatus.idle ||
     AleraUpdateStatus.checking ||
     AleraUpdateStatus.notAvailable ||
-    AleraUpdateStatus.downloading => AleraToastTone.info,
+    AleraUpdateStatus.downloading ||
+    AleraUpdateStatus.applying => AleraToastTone.info,
   };
 }

--- a/lib/src/features/updater/application/update_controller.dart
+++ b/lib/src/features/updater/application/update_controller.dart
@@ -102,8 +102,17 @@ class AleraUpdateController extends _$AleraUpdateController {
         return;
       }
       state = state.copyWith(
+        status: AleraUpdateStatus.applying,
+        message: 'Installing update ${latest.version}. Alera will restart.',
+        progress: 1,
+      );
+      await _service.restartApp();
+      if (_disposed) {
+        return;
+      }
+      state = state.copyWith(
         status: AleraUpdateStatus.downloaded,
-        message: 'Update downloaded. Restart Alera to finish installing.',
+        message: 'Update handoff complete. Alera will restart shortly.',
         progress: 1,
       );
     } catch (error) {
@@ -112,7 +121,9 @@ class AleraUpdateController extends _$AleraUpdateController {
       }
       state = state.copyWith(
         status: AleraUpdateStatus.error,
-        message: 'Update download failed: $error',
+        message:
+            'Update installation failed: $error '
+            'Alera is still running. Try again.',
       );
     }
   }

--- a/lib/src/features/updater/application/update_controller.g.dart
+++ b/lib/src/features/updater/application/update_controller.g.dart
@@ -42,7 +42,7 @@ final class AleraUpdateControllerProvider
 }
 
 String _$aleraUpdateControllerHash() =>
-    r'bbc2ce9a203c6346dedea61cc9c056dcb56d64b6';
+    r'5250c3a2acfd20e758b5264153fb1ef581fa02a9';
 
 abstract class _$AleraUpdateController extends $Notifier<AleraUpdateState> {
   AleraUpdateState build();

--- a/lib/src/features/updater/application/update_providers.dart
+++ b/lib/src/features/updater/application/update_providers.dart
@@ -1,5 +1,6 @@
 import 'package:alera/src/features/updater/application/update_service.dart';
 import 'package:alera/src/features/updater/infra/desktop_update_service.dart';
+import 'package:alera/src/shared/infra/process/process_providers.dart';
 import 'package:http/http.dart' as http;
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -16,6 +17,7 @@ http.Client aleraUpdateHttpClient(Ref ref) {
 AleraUpdateService aleraUpdateService(Ref ref) {
   final service = DesktopAleraUpdateService(
     client: ref.watch(aleraUpdateHttpClientProvider),
+    processRunner: ref.watch(processRunnerProvider),
   );
   ref.onDispose(service.dispose);
   return service;

--- a/lib/src/features/updater/application/update_providers.g.dart
+++ b/lib/src/features/updater/application/update_providers.g.dart
@@ -97,4 +97,4 @@ final class AleraUpdateServiceProvider
 }
 
 String _$aleraUpdateServiceHash() =>
-    r'809c06cf2512425a0479021be639090dc8f81836';
+    r'39471705611dc7ed46547918ace9138b5dd92fbd';

--- a/lib/src/features/updater/domain/alera_update.dart
+++ b/lib/src/features/updater/domain/alera_update.dart
@@ -191,6 +191,7 @@ enum AleraUpdateStatus {
   manualDownloadRequired,
   available,
   downloading,
+  applying,
   downloaded,
   error,
 }
@@ -259,6 +260,7 @@ class AleraUpdateState with AleraUpdateStateMappable {
 
   bool get isBusy {
     return status == AleraUpdateStatus.checking ||
-        status == AleraUpdateStatus.downloading;
+        status == AleraUpdateStatus.downloading ||
+        status == AleraUpdateStatus.applying;
   }
 }

--- a/lib/src/features/updater/domain/alera_update.mapper.dart
+++ b/lib/src/features/updater/domain/alera_update.mapper.dart
@@ -85,6 +85,8 @@ class AleraUpdateStatusMapper extends EnumMapper<AleraUpdateStatus> {
         return AleraUpdateStatus.available;
       case r'downloading':
         return AleraUpdateStatus.downloading;
+      case r'applying':
+        return AleraUpdateStatus.applying;
       case r'downloaded':
         return AleraUpdateStatus.downloaded;
       case r'error':
@@ -109,6 +111,8 @@ class AleraUpdateStatusMapper extends EnumMapper<AleraUpdateStatus> {
         return r'available';
       case AleraUpdateStatus.downloading:
         return r'downloading';
+      case AleraUpdateStatus.applying:
+        return r'applying';
       case AleraUpdateStatus.downloaded:
         return r'downloaded';
       case AleraUpdateStatus.error:

--- a/lib/src/features/updater/infra/desktop_update_artifact_selector.dart
+++ b/lib/src/features/updater/infra/desktop_update_artifact_selector.dart
@@ -1,0 +1,72 @@
+import 'dart:io';
+
+import 'package:alera/src/features/updater/domain/alera_update.dart';
+
+typedef DesktopUpdateArtifactPreferences =
+    Future<List<String>> Function(String platform, AleraUpdateChannel channel);
+
+Future<List<String>> loadDesktopUpdateArtifactPreferences(
+  String platform,
+  AleraUpdateChannel channel,
+) async {
+  return switch (platform) {
+    'macos' || 'windows' => const <String>['tar.gz'],
+    'linux' when channel == AleraUpdateChannel.rc => const <String>['tar.gz'],
+    'linux' => _linuxPackagePreference(),
+    _ => const <String>[],
+  };
+}
+
+Future<List<String>> _linuxPackagePreference() async {
+  final osRelease = File('/etc/os-release');
+  if (!await osRelease.exists()) {
+    return const <String>[];
+  }
+  final installerKind = linuxInstallerKindFromOsRelease(
+    await osRelease.readAsString(),
+  );
+  return installerKind == null ? const <String>[] : <String>[installerKind];
+}
+
+String? linuxInstallerKindFromOsRelease(String source) {
+  final values = <String, String>{};
+  for (final line in source.split('\n')) {
+    final separator = line.indexOf('=');
+    if (separator <= 0) {
+      continue;
+    }
+    final key = line.substring(0, separator).trim().toUpperCase();
+    final value = line
+        .substring(separator + 1)
+        .trim()
+        .replaceAll(RegExp(r'^"|"$'), '')
+        .toLowerCase();
+    values[key] = value;
+  }
+  final family = '${values['ID'] ?? ''} ${values['ID_LIKE'] ?? ''}';
+  if (_containsLinuxFamily(family, const <String>[
+    'debian',
+    'ubuntu',
+    'mint',
+    'pop',
+  ])) {
+    return 'deb';
+  }
+  if (_containsLinuxFamily(family, const <String>[
+    'fedora',
+    'rhel',
+    'centos',
+    'rocky',
+    'almalinux',
+    'suse',
+    'opensuse',
+  ])) {
+    return 'rpm';
+  }
+  return null;
+}
+
+bool _containsLinuxFamily(String source, List<String> families) {
+  final words = source.split(RegExp(r'\s+')).toSet();
+  return families.any(words.contains);
+}

--- a/lib/src/features/updater/infra/desktop_update_handoff.dart
+++ b/lib/src/features/updater/infra/desktop_update_handoff.dart
@@ -1,0 +1,427 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:alera/src/features/updater/infra/desktop_update_stager.dart';
+import 'package:alera/src/shared/infra/process/process_runner.dart';
+import 'package:path/path.dart' as p;
+
+typedef AleraAppExit = FutureOr<void> Function();
+typedef DesktopUpdateInstallRootExists = Future<bool> Function(String path);
+
+abstract interface class AleraDesktopUpdateHandoff {
+  Future<void> applyAndRestart(StagedDesktopUpdate stagedUpdate);
+}
+
+class DesktopUpdateHandoff implements AleraDesktopUpdateHandoff {
+  DesktopUpdateHandoff({
+    required this.processRunner,
+    required this.platform,
+    String? resolvedExecutable,
+    int? processId,
+    AleraAppExit? exitApp,
+    DesktopUpdateInstallRootExists? installRootExists,
+    this.handoffTimeout = const Duration(minutes: 2),
+  }) : _resolvedExecutable = resolvedExecutable ?? Platform.resolvedExecutable,
+       _processId = processId ?? pid,
+       _exitApp = exitApp ?? _exitCurrentApp,
+       _installRootExists = installRootExists ?? _defaultInstallRootExists;
+
+  final ProcessRunner processRunner;
+  final String platform;
+  final String _resolvedExecutable;
+  final int _processId;
+  final AleraAppExit _exitApp;
+  final DesktopUpdateInstallRootExists _installRootExists;
+  final Duration handoffTimeout;
+
+  @override
+  Future<void> applyAndRestart(StagedDesktopUpdate stagedUpdate) async {
+    if (platform == 'linux' &&
+        (stagedUpdate.update.installerKind == 'deb' ||
+            stagedUpdate.update.installerKind == 'rpm')) {
+      await _installLinuxPackage(stagedUpdate);
+      return;
+    }
+    await _launchReplacementHelper(stagedUpdate);
+  }
+
+  Future<void> _installLinuxPackage(StagedDesktopUpdate stagedUpdate) async {
+    final arguments = switch (stagedUpdate.update.installerKind) {
+      'deb' => <String>['dpkg', '--install', stagedUpdate.artifactPath],
+      'rpm' => <String>[
+        'rpm',
+        '--upgrade',
+        '--replacepkgs',
+        stagedUpdate.artifactPath,
+      ],
+      _ => throw StateError('Unsupported Linux package type.'),
+    };
+    final result = await processRunner.run('pkexec', arguments);
+    if (result.exitCode != 0) {
+      final details = result.stderr.trim();
+      throw ProcessException(
+        'pkexec',
+        arguments,
+        details.isEmpty
+            ? 'The package installer exited with code ${result.exitCode}.'
+            : details,
+        result.exitCode,
+      );
+    }
+
+    await processRunner.start(
+      _resolvedExecutable,
+      const <String>[],
+      workingDirectory: p.dirname(_resolvedExecutable),
+    );
+    await stagedUpdate.delete();
+    await _exitApp();
+  }
+
+  Future<void> _launchReplacementHelper(
+    StagedDesktopUpdate stagedUpdate,
+  ) async {
+    final payloadPath = stagedUpdate.payloadPath;
+    if (payloadPath == null) {
+      throw StateError('The update payload has not been prepared.');
+    }
+    final layout = desktopUpdateInstallLayout(
+      platform: platform,
+      resolvedExecutable: _resolvedExecutable,
+    );
+    if (!await _installRootExists(layout.installRoot)) {
+      throw StateError('The current Alera installation cannot be located.');
+    }
+
+    final token = p.basename(stagedUpdate.directory.path);
+    final pathContext = _pathContext(platform);
+    final installParent = pathContext.dirname(layout.installRoot);
+    final installName = pathContext.basename(layout.installRoot);
+    final readyPath = pathContext.join(
+      installParent,
+      '.$installName.alera-update-ready-$token',
+    );
+    final backupPath = pathContext.join(
+      installParent,
+      '.$installName.alera-update-backup-$token',
+    );
+    final handoffPath = p.join(stagedUpdate.directory.path, 'handoff.ready');
+    final failurePath = p.join(stagedUpdate.directory.path, 'handoff.error');
+    final command = await _writeHelper(
+      stagedUpdate.directory,
+      layout: layout,
+      payloadPath: payloadPath,
+      readyPath: readyPath,
+      backupPath: backupPath,
+      handoffPath: handoffPath,
+      failurePath: failurePath,
+    );
+    final child = await processRunner.start(
+      command.executable,
+      command.arguments,
+      workingDirectory: stagedUpdate.directory.path,
+    );
+
+    final exitCode = Completer<int>();
+    unawaited(
+      child.exitCode.then(
+        (value) {
+          if (!exitCode.isCompleted) {
+            exitCode.complete(value);
+          }
+        },
+        onError: (Object error, StackTrace stackTrace) {
+          if (!exitCode.isCompleted) {
+            exitCode.completeError(error, stackTrace);
+          }
+        },
+      ),
+    );
+    final deadline = DateTime.now().add(handoffTimeout);
+    while (DateTime.now().isBefore(deadline)) {
+      if (await File(handoffPath).exists()) {
+        await _exitApp();
+        return;
+      }
+      if (exitCode.isCompleted) {
+        final code = await exitCode.future;
+        final details = await _readFailure(failurePath);
+        throw ProcessException(
+          command.executable,
+          command.arguments,
+          details ?? 'The update helper exited before accepting the handoff.',
+          code,
+        );
+      }
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+    }
+    child.kill();
+    throw TimeoutException(
+      'The update helper did not accept the handoff.',
+      handoffTimeout,
+    );
+  }
+
+  Future<DesktopUpdateHandoffCommand> _writeHelper(
+    Directory directory, {
+    required DesktopUpdateInstallLayout layout,
+    required String payloadPath,
+    required String readyPath,
+    required String backupPath,
+    required String handoffPath,
+    required String failurePath,
+  }) async {
+    if (platform == 'windows') {
+      final script = File(p.join(directory.path, 'apply-update.ps1'));
+      await script.writeAsString(_windowsUpdateScript);
+      return DesktopUpdateHandoffCommand(
+        executable: 'powershell.exe',
+        arguments: <String>[
+          '-NoProfile',
+          '-NonInteractive',
+          '-ExecutionPolicy',
+          'Bypass',
+          '-File',
+          script.path,
+          '$_processId',
+          layout.installRoot,
+          payloadPath,
+          readyPath,
+          backupPath,
+          layout.relativeExecutable,
+          directory.path,
+          handoffPath,
+          failurePath,
+        ],
+      );
+    }
+
+    final script = File(p.join(directory.path, 'apply-update.sh'));
+    await script.writeAsString(_unixUpdateScript);
+    return DesktopUpdateHandoffCommand(
+      executable: '/bin/sh',
+      arguments: <String>[
+        script.path,
+        '$_processId',
+        layout.installRoot,
+        payloadPath,
+        readyPath,
+        backupPath,
+        layout.relativeExecutable,
+        directory.path,
+        handoffPath,
+        failurePath,
+      ],
+    );
+  }
+}
+
+class DesktopUpdateHandoffCommand {
+  const DesktopUpdateHandoffCommand({
+    required this.executable,
+    required this.arguments,
+  });
+
+  final String executable;
+  final List<String> arguments;
+}
+
+class DesktopUpdateInstallLayout {
+  const DesktopUpdateInstallLayout({
+    required this.installRoot,
+    required this.relativeExecutable,
+  });
+
+  final String installRoot;
+  final String relativeExecutable;
+}
+
+DesktopUpdateInstallLayout desktopUpdateInstallLayout({
+  required String platform,
+  required String resolvedExecutable,
+}) {
+  final context = _pathContext(platform);
+  final executable = context.normalize(resolvedExecutable);
+  if (platform != 'macos') {
+    return DesktopUpdateInstallLayout(
+      installRoot: context.dirname(executable),
+      relativeExecutable: context.basename(executable),
+    );
+  }
+
+  var current = context.dirname(executable);
+  while (current != context.dirname(current)) {
+    if (context.extension(current).toLowerCase() == '.app') {
+      return DesktopUpdateInstallLayout(
+        installRoot: current,
+        relativeExecutable: context.relative(executable, from: current),
+      );
+    }
+    current = context.dirname(current);
+  }
+  throw StateError('The current macOS Alera app bundle cannot be located.');
+}
+
+p.Context _pathContext(String platform) {
+  return p.Context(
+    style: platform == 'windows' ? p.Style.windows : p.Style.posix,
+  );
+}
+
+Future<String?> _readFailure(String path) async {
+  final file = File(path);
+  if (!await file.exists()) {
+    return null;
+  }
+  final contents = await file.readAsString(encoding: utf8);
+  final trimmed = contents.trim();
+  return trimmed.isEmpty ? null : trimmed;
+}
+
+Never _exitCurrentApp() => exit(0);
+
+Future<bool> _defaultInstallRootExists(String path) {
+  return Directory(path).exists();
+}
+
+const String _unixUpdateScript = r'''#!/bin/sh
+set -eu
+
+parent_pid="$1"
+install_root="$2"
+payload="$3"
+ready="$4"
+backup="$5"
+relative_executable="$6"
+stage_root="$7"
+handoff_file="$8"
+failure_file="$9"
+
+fail_before_handoff() {
+  printf '%s\n' "$1" >"$failure_file"
+  exit 1
+}
+
+[ -d "$install_root" ] || fail_before_handoff "The current Alera installation is missing."
+[ -d "$payload" ] || fail_before_handoff "The staged Alera update is missing."
+[ ! -e "$ready" ] || fail_before_handoff "A prepared update directory already exists."
+[ ! -e "$backup" ] || fail_before_handoff "An update backup directory already exists."
+
+if command -v ditto >/dev/null 2>&1; then
+  ditto "$payload" "$ready" || fail_before_handoff "The update could not be prepared beside Alera."
+else
+  mkdir "$ready" || fail_before_handoff "The update directory could not be created."
+  cp -a "$payload"/. "$ready"/ || fail_before_handoff "The update could not be prepared beside Alera."
+fi
+[ -x "$ready/$relative_executable" ] || fail_before_handoff "The prepared Alera executable is invalid."
+printf 'ready\n' >"$handoff_file"
+
+while kill -0 "$parent_pid" 2>/dev/null; do
+  sleep 1
+done
+
+swapped=0
+rollback() {
+  message="$1"
+  if [ "$swapped" -eq 1 ]; then
+    rm -rf "$install_root"
+    if [ -e "$backup" ]; then
+      mv "$backup" "$install_root"
+    fi
+  fi
+  if [ -x "$install_root/$relative_executable" ]; then
+    (
+      cd "$install_root"
+      "./$relative_executable" >/dev/null 2>&1 &
+    )
+  fi
+  printf '%s\n' "$message" >"$failure_file"
+  exit 1
+}
+
+mv "$install_root" "$backup" || rollback "The existing Alera installation could not be backed up."
+swapped=1
+mv "$ready" "$install_root" || rollback "The prepared Alera update could not be installed."
+(
+  cd "$install_root"
+  "./$relative_executable" >/dev/null 2>&1 &
+) || rollback "The updated Alera app could not be launched."
+swapped=0
+rm -rf "$backup"
+rm -rf "$stage_root"
+exit 0
+''';
+
+const String _windowsUpdateScript = r'''param(
+  [int]$ParentPid,
+  [string]$InstallRoot,
+  [string]$Payload,
+  [string]$Ready,
+  [string]$Backup,
+  [string]$RelativeExecutable,
+  [string]$StageRoot,
+  [string]$HandoffFile,
+  [string]$FailureFile
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Fail-BeforeHandoff([string]$Message) {
+  Set-Content -LiteralPath $FailureFile -Value $Message
+  exit 1
+}
+
+try {
+  if (-not (Test-Path -LiteralPath $InstallRoot -PathType Container)) {
+    Fail-BeforeHandoff 'The current Alera installation is missing.'
+  }
+  if (-not (Test-Path -LiteralPath $Payload -PathType Container)) {
+    Fail-BeforeHandoff 'The staged Alera update is missing.'
+  }
+  if ((Test-Path -LiteralPath $Ready) -or (Test-Path -LiteralPath $Backup)) {
+    Fail-BeforeHandoff 'An update preparation directory already exists.'
+  }
+  New-Item -ItemType Directory -Path $Ready | Out-Null
+  Get-ChildItem -LiteralPath $Payload -Force |
+    Copy-Item -Destination $Ready -Recurse -Force
+  $PreparedExecutable = Join-Path $Ready $RelativeExecutable
+  if (-not (Test-Path -LiteralPath $PreparedExecutable -PathType Leaf)) {
+    Fail-BeforeHandoff 'The prepared Alera executable is invalid.'
+  }
+  Set-Content -LiteralPath $HandoffFile -Value 'ready'
+} catch {
+  Fail-BeforeHandoff $_.Exception.Message
+}
+
+while (Get-Process -Id $ParentPid -ErrorAction SilentlyContinue) {
+  Start-Sleep -Milliseconds 250
+}
+
+$Swapped = $false
+try {
+  Move-Item -LiteralPath $InstallRoot -Destination $Backup
+  $Swapped = $true
+  Move-Item -LiteralPath $Ready -Destination $InstallRoot
+  $UpdatedExecutable = Join-Path $InstallRoot $RelativeExecutable
+  Start-Process -FilePath $UpdatedExecutable -WorkingDirectory $InstallRoot
+  $Swapped = $false
+  Remove-Item -LiteralPath $Backup -Recurse -Force
+  Remove-Item -LiteralPath $StageRoot -Recurse -Force -ErrorAction SilentlyContinue
+  exit 0
+} catch {
+  $Message = $_.Exception.Message
+  if ($Swapped) {
+    Remove-Item -LiteralPath $InstallRoot -Recurse -Force -ErrorAction SilentlyContinue
+    if (Test-Path -LiteralPath $Backup) {
+      Move-Item -LiteralPath $Backup -Destination $InstallRoot
+    }
+  }
+  $PreviousExecutable = Join-Path $InstallRoot $RelativeExecutable
+  if (Test-Path -LiteralPath $PreviousExecutable -PathType Leaf) {
+    Start-Process -FilePath $PreviousExecutable -WorkingDirectory $InstallRoot
+  }
+  Set-Content -LiteralPath $FailureFile -Value $Message
+  exit 1
+}
+''';

--- a/lib/src/features/updater/infra/desktop_update_service.dart
+++ b/lib/src/features/updater/infra/desktop_update_service.dart
@@ -1,9 +1,14 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:alera/src/features/updater/application/update_service.dart';
 import 'package:alera/src/features/updater/domain/alera_update.dart';
+import 'package:alera/src/features/updater/infra/desktop_update_artifact_selector.dart';
+import 'package:alera/src/features/updater/infra/desktop_update_handoff.dart';
+import 'package:alera/src/features/updater/infra/desktop_update_stager.dart';
 import 'package:alera/src/features/updater/infra/update_archive.dart';
-import 'package:desktop_updater/desktop_updater.dart';
+import 'package:alera/src/shared/infra/process/process_runner.dart';
+import 'package:alera/src/shared/infra/process/rust_process_runner.dart';
 import 'package:http/http.dart' as http;
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:url_launcher/url_launcher.dart' as url_launcher;
@@ -15,17 +20,36 @@ class DesktopAleraUpdateService implements AleraUpdateService {
   DesktopAleraUpdateService({
     AleraUpdateConfig? config,
     http.Client? client,
-    DesktopUpdater? desktopUpdater,
     PackageInfoLoader? loadPackageInfo,
     AleraUrlLauncher? launchUrl,
     String? platform,
+    DesktopUpdateArtifactPreferences? loadArtifactPreferences,
+    AleraDesktopUpdateStager? stager,
+    AleraDesktopUpdateHandoff? handoff,
+    ProcessRunner? processRunner,
+    String? resolvedExecutable,
+    int? processId,
+    AleraAppExit? exitApp,
   }) : config = config ?? AleraUpdateConfig.fromEnvironment(),
        _client = client ?? http.Client(),
        _ownsClient = client == null,
-       _desktopUpdater = desktopUpdater ?? DesktopUpdater(),
        _loadPackageInfo = loadPackageInfo ?? PackageInfo.fromPlatform,
        _launchUrl = launchUrl ?? _launchExternalUrl,
-       _platform = platform ?? Platform.operatingSystem;
+       _platform = platform ?? Platform.operatingSystem,
+       _loadArtifactPreferences =
+           loadArtifactPreferences ?? loadDesktopUpdateArtifactPreferences {
+    _stager =
+        stager ?? DesktopUpdateStager(client: _client, platform: _platform);
+    _handoff =
+        handoff ??
+        DesktopUpdateHandoff(
+          processRunner: processRunner ?? const RustProcessRunner(),
+          platform: _platform,
+          resolvedExecutable: resolvedExecutable,
+          processId: processId,
+          exitApp: exitApp,
+        );
+  }
 
   static const Set<String> _supportedPlatforms = <String>{
     'linux',
@@ -38,10 +62,13 @@ class DesktopAleraUpdateService implements AleraUpdateService {
 
   final http.Client _client;
   final bool _ownsClient;
-  final DesktopUpdater _desktopUpdater;
   final PackageInfoLoader _loadPackageInfo;
   final AleraUrlLauncher _launchUrl;
   final String _platform;
+  final DesktopUpdateArtifactPreferences _loadArtifactPreferences;
+  late final AleraDesktopUpdateStager _stager;
+  late final AleraDesktopUpdateHandoff _handoff;
+  StagedDesktopUpdate? _stagedUpdate;
 
   @override
   Future<AleraUpdateCheckResult> checkForUpdates() async {
@@ -50,30 +77,6 @@ class DesktopAleraUpdateService implements AleraUpdateService {
         message: 'Desktop updates are not available on $_platform.',
       );
     }
-    if (config.canAutoInstall &&
-        config.channel == AleraUpdateChannel.rc &&
-        !config.signedRelease) {
-      return _checkWithDesktopUpdater();
-    }
-    return _checkManually();
-  }
-
-  Future<AleraUpdateCheckResult> _checkWithDesktopUpdater() async {
-    final item = await _desktopUpdater.versionCheck(
-      appArchiveUrl: config.archiveUrl.toString(),
-    );
-    if (item == null) {
-      return const AleraUpdateCheckResult(message: 'Alera is up to date.');
-    }
-    final update = _fromItemModel(item);
-    return AleraUpdateCheckResult(
-      latest: update,
-      autoInstallAllowed: true,
-      message: 'Update ${update.version} is ready to install.',
-    );
-  }
-
-  Future<AleraUpdateCheckResult> _checkManually() async {
     final response = await _client.get(config.archiveUrl);
     if (response.statusCode == 404) {
       return const AleraUpdateCheckResult(
@@ -95,29 +98,50 @@ class DesktopAleraUpdateService implements AleraUpdateService {
             publicKeyBase64: config.manifestPublicKey,
           )
         : AleraUpdateArchive.fromJsonString(response.body);
+    final artifactPreferences = await _loadArtifactPreferences(
+      _platform,
+      config.channel,
+    );
     final latest = archive.latestFor(
       platform: _platform,
       currentBuildNumber: currentBuild,
       channel: config.channel,
+      preferredInstallerKinds: artifactPreferences,
     );
 
     if (latest == null) {
+      final newestPlatformUpdate = archive.latestFor(
+        platform: _platform,
+        currentBuildNumber: currentBuild,
+        channel: config.channel,
+      );
+      if (newestPlatformUpdate != null) {
+        return AleraUpdateCheckResult(
+          message:
+              'No compatible ${_platformLabel(_platform)} update artifact '
+              'is available for this installation.',
+        );
+      }
       return const AleraUpdateCheckResult(message: 'Alera is up to date.');
     }
 
-    if (_platform == 'linux') {
+    final autoInstallAllowed =
+        config.canAutoInstall &&
+        archive.schemaVersion >= 2 &&
+        latest.sha256 != null &&
+        latest.size != null &&
+        _autoInstallKinds.contains(latest.installerKind);
+    if (autoInstallAllowed) {
       return AleraUpdateCheckResult(
         latest: latest,
-        message: _linuxUpdateMessage(config.channel, latest),
+        autoInstallAllowed: true,
+        message: 'Update ${latest.version} is ready to install.',
       );
     }
 
     return AleraUpdateCheckResult(
       latest: latest,
-      autoInstallAllowed: config.canAutoInstall && archive.schemaVersion == 1,
-      message: config.autoInstallEnabled
-          ? _manualInstallBlockedMessage(archive)
-          : 'Update ${latest.version} is available for manual download.',
+      message: _manualUpdateMessage(config, archive, latest),
     );
   }
 
@@ -129,36 +153,37 @@ class DesktopAleraUpdateService implements AleraUpdateService {
     if (!config.canAutoInstall) {
       throw StateError('Automatic update installation is disabled.');
     }
-
-    final item = await _desktopUpdater.versionCheck(
-      appArchiveUrl: config.archiveUrl.toString(),
-    );
-    if (item == null) {
-      throw StateError('No update is available.');
+    if (!_autoInstallKinds.contains(update.installerKind)) {
+      throw StateError(
+        'Automatic installation does not support '
+        '${update.installerKind} artifacts.',
+      );
     }
 
-    final stream = await _desktopUpdater.updateApp(
-      remoteUpdateFolder: item.url,
-      changedFiles: item.changedFiles ?? const <FileHashModel?>[],
-    );
-    await for (final updateProgress in stream) {
-      final totalBytes = updateProgress.totalBytes;
-      if (totalBytes <= 0) {
-        continue;
-      }
-      onProgress?.call(updateProgress.receivedBytes / totalBytes);
+    final previousStage = _stagedUpdate;
+    _stagedUpdate = null;
+    if (previousStage != null) {
+      await previousStage.delete();
     }
-    onProgress?.call(1);
+    _stagedUpdate = await _stager.stage(update, onProgress: onProgress);
   }
 
   @override
   Future<void> openDownloadPage(AleraUpdateInfo? update) async {
-    await _launchUrl(config.downloadPageUrlFor(update));
+    final launched = await _launchUrl(config.downloadPageUrlFor(update));
+    if (!launched) {
+      throw StateError('The release download page could not be opened.');
+    }
   }
 
   @override
-  Future<void> restartApp() {
-    return _desktopUpdater.restartApp();
+  Future<void> restartApp() async {
+    final stagedUpdate = _stagedUpdate;
+    if (stagedUpdate == null) {
+      throw StateError('No verified update is ready to install.');
+    }
+    await _handoff.applyAndRestart(stagedUpdate);
+    _stagedUpdate = null;
   }
 
   @override
@@ -166,34 +191,39 @@ class DesktopAleraUpdateService implements AleraUpdateService {
     if (_ownsClient) {
       _client.close();
     }
+    final stagedUpdate = _stagedUpdate;
+    _stagedUpdate = null;
+    if (stagedUpdate != null) {
+      unawaited(stagedUpdate.delete());
+    }
   }
 }
 
-String _linuxUpdateMessage(AleraUpdateChannel channel, AleraUpdateInfo update) {
-  if (channel == AleraUpdateChannel.stable &&
+const Set<String> _autoInstallKinds = <String>{'tar.gz', 'deb', 'rpm'};
+
+String _manualUpdateMessage(
+  AleraUpdateConfig config,
+  AleraUpdateArchive archive,
+  AleraUpdateInfo update,
+) {
+  if (update.platform == 'linux' &&
+      config.channel == AleraUpdateChannel.stable &&
       (update.installerKind == 'deb' || update.installerKind == 'rpm')) {
     return 'Update ${update.version} is available through the Linux package repository.';
+  }
+  if (config.autoInstallEnabled && archive.schemaVersion < 2) {
+    return 'Automatic installation requires a signed update artifact with integrity metadata.';
   }
   return 'Update ${update.version} is available for manual download.';
 }
 
-String _manualInstallBlockedMessage(AleraUpdateArchive archive) {
-  if (archive.schemaVersion >= 2) {
-    return 'Update manifest is signed; automatic installation is pending for this artifact type.';
-  }
-  return 'Automatic installation is blocked until stable releases are signed.';
-}
-
-AleraUpdateInfo _fromItemModel(ItemModel item) {
-  return AleraUpdateInfo(
-    version: item.version,
-    shortVersion: item.shortVersion,
-    date: item.date,
-    mandatory: item.mandatory,
-    url: Uri.parse(item.url),
-    platform: item.platform,
-    changes: [for (final change in item.changes) change.message],
-  );
+String _platformLabel(String platform) {
+  return switch (platform) {
+    'macos' => 'macOS',
+    'windows' => 'Windows',
+    'linux' => 'Linux',
+    _ => platform,
+  };
 }
 
 Future<bool> _launchExternalUrl(Uri uri) {

--- a/lib/src/features/updater/infra/desktop_update_stager.dart
+++ b/lib/src/features/updater/infra/desktop_update_stager.dart
@@ -1,0 +1,198 @@
+import 'dart:async';
+import 'dart:io';
+import 'dart:isolate';
+
+import 'package:alera/src/features/updater/domain/alera_update.dart';
+import 'package:archive/archive_io.dart';
+import 'package:crypto/crypto.dart';
+import 'package:http/http.dart' as http;
+import 'package:path/path.dart' as p;
+
+class StagedDesktopUpdate {
+  const StagedDesktopUpdate({
+    required this.update,
+    required this.directory,
+    required this.artifactPath,
+    required this.payloadPath,
+  });
+
+  final AleraUpdateInfo update;
+  final Directory directory;
+  final String artifactPath;
+  final String? payloadPath;
+
+  Future<void> delete() async {
+    if (await directory.exists()) {
+      await directory.delete(recursive: true);
+    }
+  }
+}
+
+abstract interface class AleraDesktopUpdateStager {
+  Future<StagedDesktopUpdate> stage(
+    AleraUpdateInfo update, {
+    void Function(double progress)? onProgress,
+  });
+}
+
+class DesktopUpdateStager implements AleraDesktopUpdateStager {
+  const DesktopUpdateStager({required this.client, required this.platform});
+
+  final http.Client client;
+  final String platform;
+
+  @override
+  Future<StagedDesktopUpdate> stage(
+    AleraUpdateInfo update, {
+    void Function(double progress)? onProgress,
+  }) async {
+    final expectedSize = update.size;
+    final expectedSha256 = update.sha256;
+    if (expectedSize == null || expectedSize <= 0 || expectedSha256 == null) {
+      throw const FormatException(
+        'The update artifact is missing required integrity metadata.',
+      );
+    }
+    if (update.platform != platform) {
+      throw StateError(
+        'The ${update.platform} artifact cannot be installed on $platform.',
+      );
+    }
+
+    final stagingDirectory = await Directory.systemTemp.createTemp(
+      'alera-update-',
+    );
+    try {
+      final artifactName = _artifactName(update.url, update.installerKind);
+      final artifactPath = p.join(stagingDirectory.path, artifactName);
+      await _download(
+        update.url,
+        artifactPath,
+        expectedSize: expectedSize,
+        onProgress: onProgress,
+      );
+      onProgress?.call(0.86);
+
+      final actualSha256 = await Isolate.run(
+        () => _sha256ForFile(artifactPath),
+      );
+      if (actualSha256 != expectedSha256) {
+        throw const FormatException(
+          'The downloaded update failed SHA-256 verification.',
+        );
+      }
+      onProgress?.call(0.92);
+
+      final payloadPath = await _preparePayload(
+        update,
+        artifactPath,
+        stagingDirectory,
+      );
+      onProgress?.call(1);
+      return StagedDesktopUpdate(
+        update: update,
+        directory: stagingDirectory,
+        artifactPath: artifactPath,
+        payloadPath: payloadPath,
+      );
+    } catch (_) {
+      await stagingDirectory.delete(recursive: true);
+      rethrow;
+    }
+  }
+
+  Future<void> _download(
+    Uri source,
+    String destination, {
+    required int expectedSize,
+    void Function(double progress)? onProgress,
+  }) async {
+    final response = await client.send(http.Request('GET', source));
+    if (response.statusCode != HttpStatus.ok) {
+      throw HttpException(
+        'Update download failed with status ${response.statusCode}.',
+        uri: source,
+      );
+    }
+    if (response.contentLength case final int contentLength
+        when contentLength >= 0 && contentLength != expectedSize) {
+      throw const FormatException(
+        'The update download size does not match the signed manifest.',
+      );
+    }
+
+    final file = File(destination);
+    final sink = file.openWrite();
+    var received = 0;
+    try {
+      await for (final chunk in response.stream) {
+        received += chunk.length;
+        if (received > expectedSize) {
+          throw const FormatException(
+            'The update download exceeded its signed size.',
+          );
+        }
+        sink.add(chunk);
+        onProgress?.call((received / expectedSize * 0.85).clamp(0, 0.85));
+      }
+    } finally {
+      await sink.close();
+    }
+    if (received != expectedSize) {
+      throw const FormatException('The update download is incomplete.');
+    }
+  }
+
+  Future<String?> _preparePayload(
+    AleraUpdateInfo update,
+    String artifactPath,
+    Directory stagingDirectory,
+  ) async {
+    if (update.installerKind == 'deb' || update.installerKind == 'rpm') {
+      return null;
+    }
+    if (update.installerKind != 'tar.gz') {
+      throw StateError(
+        'Automatic installation does not support '
+        '${update.installerKind} artifacts.',
+      );
+    }
+
+    final payloadDirectory = Directory(
+      p.join(stagingDirectory.path, 'payload'),
+    );
+    await Isolate.run(
+      () => extractFileToDisk(artifactPath, payloadDirectory.path),
+    );
+    final payloadPath = switch (platform) {
+      'macos' => p.join(payloadDirectory.path, 'Alera.app'),
+      'windows' || 'linux' => payloadDirectory.path,
+      _ => throw StateError('Automatic installation is unavailable.'),
+    };
+    final executablePath = switch (platform) {
+      'macos' => p.join(payloadPath, 'Contents', 'MacOS', 'Alera'),
+      'windows' => p.join(payloadPath, 'Alera.exe'),
+      'linux' => p.join(payloadPath, 'alera'),
+      _ => throw StateError('Automatic installation is unavailable.'),
+    };
+    if (!await File(executablePath).exists()) {
+      throw const FormatException(
+        'The update archive does not contain the Alera executable.',
+      );
+    }
+    return payloadPath;
+  }
+}
+
+String _artifactName(Uri uri, String installerKind) {
+  final basename = p.posix.basename(uri.path);
+  if (basename.isNotEmpty && basename != '/') {
+    return basename;
+  }
+  return 'alera-update.$installerKind';
+}
+
+Future<String> _sha256ForFile(String path) async {
+  final digest = await sha256.bind(File(path).openRead()).first;
+  return digest.toString();
+}

--- a/lib/src/features/updater/infra/update_archive.dart
+++ b/lib/src/features/updater/infra/update_archive.dart
@@ -63,6 +63,7 @@ class AleraUpdateArchive {
     required String platform,
     required int currentBuildNumber,
     required AleraUpdateChannel channel,
+    List<String>? preferredInstallerKinds,
   }) {
     final candidates = items.where((item) {
       if (item.platform != platform) {
@@ -81,7 +82,21 @@ class AleraUpdateArchive {
       return null;
     }
     candidates.sort((a, b) => b.shortVersion.compareTo(a.shortVersion));
-    return candidates.first;
+    final latestBuild = candidates.first.shortVersion;
+    final latestCandidates = candidates
+        .where((item) => item.shortVersion == latestBuild)
+        .toList();
+    if (preferredInstallerKinds == null) {
+      return latestCandidates.first;
+    }
+    for (final installerKind in preferredInstallerKinds) {
+      for (final candidate in latestCandidates) {
+        if (candidate.installerKind == installerKind) {
+          return candidate;
+        }
+      }
+    }
+    return null;
   }
 }
 

--- a/lib/src/features/updater/presentation/update_settings_section.dart
+++ b/lib/src/features/updater/presentation/update_settings_section.dart
@@ -51,9 +51,14 @@ class UpdateSettingsSection extends ConsumerWidget {
                   Expanded(child: _UpdateStatusCopy(state: state)),
                 ],
               ),
-              if (state.status == AleraUpdateStatus.downloading) ...<Widget>[
+              if (state.status == AleraUpdateStatus.downloading ||
+                  state.status == AleraUpdateStatus.applying) ...<Widget>[
                 const SizedBox(height: AleraTokens.space12),
-                LinearProgressIndicator(value: state.progress),
+                LinearProgressIndicator(
+                  value: state.status == AleraUpdateStatus.downloading
+                      ? state.progress
+                      : null,
+                ),
               ],
               const SizedBox(height: AleraTokens.space16),
               Wrap(
@@ -80,13 +85,14 @@ class UpdateSettingsSection extends ConsumerWidget {
                     FilledButton.icon(
                       onPressed: controller.installLatest,
                       icon: const Icon(AleraIcons.download, size: 16),
-                      label: const Text('Download Update'),
+                      label: const Text('Install Update'),
                     ),
-                  if (state.status == AleraUpdateStatus.downloaded)
+                  if (state.status == AleraUpdateStatus.error &&
+                      state.latest != null)
                     FilledButton.icon(
-                      onPressed: controller.restartApp,
-                      icon: const Icon(AleraIcons.restart, size: 16),
-                      label: const Text('Restart Alera'),
+                      onPressed: controller.installLatest,
+                      icon: const Icon(AleraIcons.refresh, size: 16),
+                      label: const Text('Try Again'),
                     ),
                 ],
               ),
@@ -147,8 +153,9 @@ class _UpdateStatusCopy extends StatelessWidget {
       AleraUpdateStatus.manualDownloadRequired => 'Manual Update Available',
       AleraUpdateStatus.available => 'Update Available',
       AleraUpdateStatus.downloading => 'Downloading Update',
-      AleraUpdateStatus.downloaded => 'Restart Required',
-      AleraUpdateStatus.error => 'Update Check Failed',
+      AleraUpdateStatus.applying => 'Installing Update',
+      AleraUpdateStatus.downloaded => 'Restarting Alera',
+      AleraUpdateStatus.error => 'Update Failed',
     };
   }
 }
@@ -159,7 +166,8 @@ Color _colorForStatus(AleraUpdateStatus status) {
     AleraUpdateStatus.downloaded => AleraTokens.success,
     AleraUpdateStatus.available ||
     AleraUpdateStatus.manualDownloadRequired ||
-    AleraUpdateStatus.downloading => AleraTokens.info,
+    AleraUpdateStatus.downloading ||
+    AleraUpdateStatus.applying => AleraTokens.info,
     _ => AleraTokens.foregroundMuted,
   };
 }
@@ -171,7 +179,8 @@ IconData _iconForStatus(AleraUpdateStatus status) {
     AleraUpdateStatus.manualDownloadRequired => AleraIcons.downloadOffline,
     AleraUpdateStatus.available => AleraIcons.updateAvailable,
     AleraUpdateStatus.downloading => AleraIcons.downloading,
-    AleraUpdateStatus.downloaded => AleraIcons.restart,
+    AleraUpdateStatus.applying => AleraIcons.sync,
+    AleraUpdateStatus.downloaded => AleraIcons.check,
     AleraUpdateStatus.error => AleraIcons.error,
     AleraUpdateStatus.idle => AleraIcons.info,
   };

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -65,7 +65,7 @@ packages:
     source: hosted
     version: "2.0.3"
   archive:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: archive
       sha256: a96e8b390886ee8abb49b7bd3ac8df6f451c621619f52a26e815fdcf568959ff

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,6 +9,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  archive: ^4.0.9
   file_selector: ^1.1.0
   flutter_riverpod: ^3.3.1
   logging: ^1.3.0

--- a/test/unit/alera_update_test.dart
+++ b/test/unit/alera_update_test.dart
@@ -132,6 +132,7 @@ void main() {
         AleraUpdateStatus.manualDownloadRequired,
         AleraUpdateStatus.available,
         AleraUpdateStatus.downloading,
+        AleraUpdateStatus.applying,
         AleraUpdateStatus.downloaded,
         AleraUpdateStatus.error,
       ]);

--- a/test/unit/desktop_update_artifact_selector_test.dart
+++ b/test/unit/desktop_update_artifact_selector_test.dart
@@ -1,0 +1,42 @@
+import 'package:alera/src/features/updater/domain/alera_update.dart';
+import 'package:alera/src/features/updater/infra/desktop_update_artifact_selector.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('desktop update artifact selection', () {
+    test('uses tarballs for macOS, Windows, and Linux release candidates', () {
+      expect(
+        loadDesktopUpdateArtifactPreferences(
+          'macos',
+          AleraUpdateChannel.stable,
+        ),
+        completion(<String>['tar.gz']),
+      );
+      expect(
+        loadDesktopUpdateArtifactPreferences(
+          'windows',
+          AleraUpdateChannel.stable,
+        ),
+        completion(<String>['tar.gz']),
+      );
+      expect(
+        loadDesktopUpdateArtifactPreferences('linux', AleraUpdateChannel.rc),
+        completion(<String>['tar.gz']),
+      );
+    });
+
+    test('detects Debian and RPM distribution families', () {
+      expect(
+        linuxInstallerKindFromOsRelease('ID=ubuntu\nID_LIKE="debian"\n'),
+        'deb',
+      );
+      expect(
+        linuxInstallerKindFromOsRelease(
+          'ID="rocky"\nID_LIKE="rhel centos fedora"\n',
+        ),
+        'rpm',
+      );
+      expect(linuxInstallerKindFromOsRelease('ID=arch\n'), isNull);
+    });
+  });
+}

--- a/test/unit/desktop_update_handoff_test.dart
+++ b/test/unit/desktop_update_handoff_test.dart
@@ -1,0 +1,300 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:alera/src/features/updater/domain/alera_update.dart';
+import 'package:alera/src/features/updater/infra/desktop_update_handoff.dart';
+import 'package:alera/src/features/updater/infra/desktop_update_stager.dart';
+import 'package:alera/src/shared/infra/process/process_runner.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+
+void main() {
+  group('desktopUpdateInstallLayout', () {
+    test('resolves Linux and Windows bundle roots', () {
+      expect(
+        desktopUpdateInstallLayout(
+          platform: 'linux',
+          resolvedExecutable: '/opt/alera/alera',
+        ).installRoot,
+        '/opt/alera',
+      );
+      final windows = desktopUpdateInstallLayout(
+        platform: 'windows',
+        resolvedExecutable: r'C:\Program Files\Alera\Alera.exe',
+      );
+      expect(windows.installRoot, r'C:\Program Files\Alera');
+      expect(windows.relativeExecutable, 'Alera.exe');
+    });
+
+    test('resolves the complete macOS app bundle', () {
+      final layout = desktopUpdateInstallLayout(
+        platform: 'macos',
+        resolvedExecutable: '/Applications/Alera.app/Contents/MacOS/Alera',
+      );
+
+      expect(layout.installRoot, '/Applications/Alera.app');
+      expect(layout.relativeExecutable, 'Contents/MacOS/Alera');
+    });
+
+    test('rejects macOS executables outside an app bundle', () {
+      expect(
+        () => desktopUpdateInstallLayout(
+          platform: 'macos',
+          resolvedExecutable: '/tmp/Alera',
+        ),
+        throwsStateError,
+      );
+    });
+  });
+
+  group('DesktopUpdateHandoff', () {
+    for (final installerKind in <String>['deb', 'rpm']) {
+      test(
+        'installs a Linux $installerKind package before relaunch and exit',
+        () async {
+          final runner = _RecordingProcessRunner()
+            ..runResults.add(
+              const ProcessRunOutput(exitCode: 0, stdout: '', stderr: ''),
+            );
+          var exitCalls = 0;
+          final staged = await _packageStage(installerKind);
+          final handoff = DesktopUpdateHandoff(
+            processRunner: runner,
+            platform: 'linux',
+            resolvedExecutable: '/opt/alera/alera',
+            exitApp: () => exitCalls += 1,
+          );
+
+          await handoff.applyAndRestart(staged);
+
+          expect(runner.runs.single.executable, 'pkexec');
+          expect(
+            runner.runs.single.arguments,
+            installerKind == 'deb'
+                ? <String>['dpkg', '--install', staged.artifactPath]
+                : <String>[
+                    'rpm',
+                    '--upgrade',
+                    '--replacepkgs',
+                    staged.artifactPath,
+                  ],
+          );
+          expect(runner.starts.single.executable, '/opt/alera/alera');
+          expect(exitCalls, 1);
+          expect(await staged.directory.exists(), isFalse);
+        },
+      );
+    }
+
+    test('keeps Alera running when a Linux package install fails', () async {
+      final runner = _RecordingProcessRunner()
+        ..runResults.add(
+          const ProcessRunOutput(
+            exitCode: 1,
+            stdout: '',
+            stderr: 'Authentication was cancelled.',
+          ),
+        );
+      var exitCalls = 0;
+      final staged = await _packageStage('deb');
+      addTearDown(staged.delete);
+      final handoff = DesktopUpdateHandoff(
+        processRunner: runner,
+        platform: 'linux',
+        resolvedExecutable: '/opt/alera/alera',
+        exitApp: () => exitCalls += 1,
+      );
+
+      await expectLater(
+        handoff.applyAndRestart(staged),
+        throwsA(
+          isA<ProcessException>().having(
+            (error) => error.message,
+            'message',
+            contains('Authentication was cancelled'),
+          ),
+        ),
+      );
+
+      expect(exitCalls, 0);
+      expect(runner.starts, isEmpty);
+      expect(await staged.directory.exists(), isTrue);
+    });
+
+    for (final fixture
+        in <
+          ({
+            String platform,
+            String resolvedExecutable,
+            String command,
+            String scriptName,
+          })
+        >[
+          (
+            platform: 'macos',
+            resolvedExecutable: '/Applications/Alera.app/Contents/MacOS/Alera',
+            command: '/bin/sh',
+            scriptName: 'apply-update.sh',
+          ),
+          (
+            platform: 'windows',
+            resolvedExecutable: r'C:\Program Files\Alera\Alera.exe',
+            command: 'powershell.exe',
+            scriptName: 'apply-update.ps1',
+          ),
+          (
+            platform: 'linux',
+            resolvedExecutable: '/opt/alera/alera',
+            command: '/bin/sh',
+            scriptName: 'apply-update.sh',
+          ),
+        ]) {
+      test(
+        'prepares ${fixture.platform} replacement helper before exit',
+        () async {
+          final runner = _RecordingProcessRunner()
+            ..createHandoffMarkerOnStart = true;
+          var exitCalls = 0;
+          final staged = await _tarballStage(fixture.platform);
+          addTearDown(staged.delete);
+          final handoff = DesktopUpdateHandoff(
+            processRunner: runner,
+            platform: fixture.platform,
+            resolvedExecutable: fixture.resolvedExecutable,
+            processId: 4321,
+            exitApp: () => exitCalls += 1,
+            installRootExists: (_) async => true,
+            handoffTimeout: const Duration(seconds: 1),
+          );
+
+          await handoff.applyAndRestart(staged);
+
+          expect(runner.starts.single.executable, fixture.command);
+          expect(runner.starts.single.arguments, contains('4321'));
+          expect(exitCalls, 1);
+          final script = File(
+            p.join(staged.directory.path, fixture.scriptName),
+          );
+          expect(await script.exists(), isTrue);
+          final source = await script.readAsString();
+          expect(source.toLowerCase(), contains('backup'));
+          expect(source.toLowerCase(), contains('handoff'));
+        },
+      );
+    }
+
+    test('does not exit when the replacement helper rejects handoff', () async {
+      final runner = _RecordingProcessRunner()..helperExitCode = 3;
+      var exitCalls = 0;
+      final staged = await _tarballStage('linux');
+      addTearDown(staged.delete);
+      final handoff = DesktopUpdateHandoff(
+        processRunner: runner,
+        platform: 'linux',
+        resolvedExecutable: '/opt/alera/alera',
+        exitApp: () => exitCalls += 1,
+        installRootExists: (_) async => true,
+        handoffTimeout: const Duration(seconds: 1),
+      );
+
+      await expectLater(
+        handoff.applyAndRestart(staged),
+        throwsA(isA<ProcessException>()),
+      );
+
+      expect(exitCalls, 0);
+    });
+  });
+}
+
+Future<StagedDesktopUpdate> _packageStage(String installerKind) async {
+  final directory = await Directory.systemTemp.createTemp('handoff-test-');
+  final artifact = File(p.join(directory.path, 'alera.$installerKind'));
+  await artifact.writeAsString('package');
+  return StagedDesktopUpdate(
+    update: _update('linux', installerKind),
+    directory: directory,
+    artifactPath: artifact.path,
+    payloadPath: null,
+  );
+}
+
+Future<StagedDesktopUpdate> _tarballStage(String platform) async {
+  final directory = await Directory.systemTemp.createTemp('handoff-test-');
+  final payload = Directory(p.join(directory.path, 'payload'));
+  await payload.create();
+  final artifact = File(p.join(directory.path, 'alera.tar.gz'));
+  await artifact.writeAsString('archive');
+  return StagedDesktopUpdate(
+    update: _update(platform, 'tar.gz'),
+    directory: directory,
+    artifactPath: artifact.path,
+    payloadPath: payload.path,
+  );
+}
+
+AleraUpdateInfo _update(String platform, String installerKind) {
+  return AleraUpdateInfo(
+    version: '1.2.3',
+    shortVersion: 2,
+    date: '2026-07-27',
+    mandatory: false,
+    url: Uri.parse('https://example.com/alera.$installerKind'),
+    platform: platform,
+    changes: const <String>['Update Alera'],
+    installerKind: installerKind,
+    sha256: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    size: 7,
+  );
+}
+
+class _RecordingProcessRunner implements ProcessRunner {
+  final List<_Invocation> runs = <_Invocation>[];
+  final List<_Invocation> starts = <_Invocation>[];
+  final List<ProcessRunOutput> runResults = <ProcessRunOutput>[];
+  bool createHandoffMarkerOnStart = false;
+  int? helperExitCode;
+
+  @override
+  Future<ProcessRunOutput> run(
+    String executable,
+    List<String> arguments, {
+    String? workingDirectory,
+    Map<String, String>? environment,
+  }) async {
+    runs.add(_Invocation(executable, arguments));
+    return runResults.removeAt(0);
+  }
+
+  @override
+  Future<StartedProcess> start(
+    String executable,
+    List<String> arguments, {
+    String? workingDirectory,
+    Map<String, String>? environment,
+  }) async {
+    starts.add(_Invocation(executable, arguments));
+    if (createHandoffMarkerOnStart) {
+      final handoffPath = arguments[arguments.length - 2];
+      await File(handoffPath).writeAsString('ready');
+    }
+    final exitCode = helperExitCode == null
+        ? Completer<int>().future
+        : Future<int>.value(helperExitCode);
+    return StartedProcess(
+      stdinWrite: (_) {},
+      stdout: const Stream<List<int>>.empty(),
+      stderr: const Stream<List<int>>.empty(),
+      pid: 12,
+      exitCode: exitCode,
+      kill: ([dynamic signal]) => true,
+    );
+  }
+}
+
+class _Invocation {
+  const _Invocation(this.executable, this.arguments);
+
+  final String executable;
+  final List<String> arguments;
+}

--- a/test/unit/desktop_update_service_test.dart
+++ b/test/unit/desktop_update_service_test.dart
@@ -2,10 +2,11 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:alera/src/features/updater/domain/alera_update.dart';
+import 'package:alera/src/features/updater/infra/desktop_update_handoff.dart';
 import 'package:alera/src/features/updater/infra/desktop_update_service.dart';
+import 'package:alera/src/features/updater/infra/desktop_update_stager.dart';
 import 'package:alera/src/features/updater/infra/update_manifest_signature.dart';
 import 'package:cryptography/cryptography.dart';
-import 'package:desktop_updater/desktop_updater.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
@@ -25,317 +26,223 @@ void main() {
       expect(result.message, 'Desktop updates are not available on android.');
     });
 
-    test('uses the desktop updater when auto-install is allowed', () async {
-      final updater = _FakeDesktopUpdater()
-        ..versionCheckResult = _item(
-          version: '0.1.4-rc.0',
-          shortVersion: 4,
-          url: 'https://example.com/updates/0.1.4+4-macos',
+    test(
+      'verifies signed manifests and enables trusted tarball updates',
+      () async {
+        final signed = await _signedArchive(<Map<String, Object?>>[
+          _archiveItem(platform: 'macos', installerKind: 'tar.gz'),
+        ]);
+        final service = DesktopAleraUpdateService(
+          config: _config(
+            autoInstallEnabled: true,
+            signedRelease: true,
+            manifestPublicKey: signed.publicKey,
+          ),
+          client: MockClient((_) async => http.Response(signed.manifest, 200)),
+          loadPackageInfo: () async => _packageInfo('1'),
           platform: 'macos',
         );
+
+        final result = await service.checkForUpdates();
+
+        expect(result.latest?.installerKind, 'tar.gz');
+        expect(result.autoInstallAllowed, isTrue);
+        expect(result.message, 'Update 1.2.3 is ready to install.');
+      },
+    );
+
+    for (final installerKind in <String>['deb', 'rpm']) {
+      test('selects the Linux $installerKind artifact', () async {
+        final service = DesktopAleraUpdateService(
+          config: _config(
+            channel: AleraUpdateChannel.rc,
+            autoInstallEnabled: true,
+          ),
+          client: MockClient(
+            (_) async => http.Response(
+              jsonEncode(
+                _archive(<Map<String, Object?>>[
+                  _archiveItem(
+                    platform: 'linux',
+                    installerKind: 'deb',
+                    version: '1.2.3-rc.0',
+                  ),
+                  _archiveItem(
+                    platform: 'linux',
+                    installerKind: 'rpm',
+                    version: '1.2.3-rc.0',
+                  ),
+                ]),
+              ),
+              200,
+            ),
+          ),
+          loadPackageInfo: () async => _packageInfo('1'),
+          loadArtifactPreferences: (_, _) async => <String>[installerKind],
+          platform: 'linux',
+        );
+
+        final result = await service.checkForUpdates();
+
+        expect(result.latest?.installerKind, installerKind);
+        expect(result.autoInstallAllowed, isTrue);
+      });
+    }
+
+    test('reports when no compatible Linux package is published', () async {
+      final service = DesktopAleraUpdateService(
+        client: MockClient(
+          (_) async => http.Response(
+            jsonEncode(
+              _archive(<Map<String, Object?>>[
+                _archiveItem(platform: 'linux', installerKind: 'deb'),
+              ]),
+            ),
+            200,
+          ),
+        ),
+        loadPackageInfo: () async => _packageInfo('1'),
+        loadArtifactPreferences: (_, _) async => const <String>[],
+        platform: 'linux',
+      );
+
+      final result = await service.checkForUpdates();
+
+      expect(result.latest, isNull);
+      expect(
+        result.message,
+        'No compatible Linux update artifact is available for this installation.',
+      );
+    });
+
+    test('keeps legacy artifacts on the manual download path', () async {
       final service = DesktopAleraUpdateService(
         config: _config(
           channel: AleraUpdateChannel.rc,
           autoInstallEnabled: true,
         ),
-        desktopUpdater: updater,
+        client: MockClient((_) async => http.Response(_legacyArchive, 200)),
+        loadPackageInfo: () async => _packageInfo('1'),
+        loadArtifactPreferences: (_, _) async => const <String>['directory'],
         platform: 'macos',
       );
 
       final result = await service.checkForUpdates();
 
-      expect(updater.checkedArchiveUrls, <String>[
-        'https://example.com/archive.json',
-      ]);
-      expect(result.autoInstallAllowed, isTrue);
-      expect(result.latest?.version, '0.1.4-rc.0');
-      expect(result.message, 'Update 0.1.4-rc.0 is ready to install.');
+      expect(result.latest, isNotNull);
+      expect(result.autoInstallAllowed, isFalse);
+      expect(
+        result.message,
+        'Automatic installation requires a signed update artifact with integrity metadata.',
+      );
     });
 
     test(
-      'checks the published archive manually when auto-install is blocked',
-      () async {
-        final service = DesktopAleraUpdateService(
-          config: _config(autoInstallEnabled: true),
-          client: MockClient((request) async {
-            expect(request.url.toString(), 'https://example.com/archive.json');
-            return http.Response(_archiveJson, 200);
-          }),
-          loadPackageInfo: () async => _packageInfo(buildNumber: '1'),
-          platform: 'macos',
-        );
-
-        final result = await service.checkForUpdates();
-
-        expect(result.latest?.version, '0.1.2');
-        expect(
-          result.message,
-          'Automatic installation is blocked until stable releases are signed.',
-        );
-      },
-    );
-
-    test(
-      'manual checks describe downloadable updates when auto-install is off',
-      () async {
-        final service = DesktopAleraUpdateService(
-          config: _config(),
-          client: MockClient((_) async => http.Response(_archiveJson, 200)),
-          loadPackageInfo: () async => _packageInfo(buildNumber: '1'),
-          platform: 'macos',
-        );
-
-        final result = await service.checkForUpdates();
-
-        expect(
-          result.message,
-          'Update 0.1.2 is available for manual download.',
-        );
-      },
-    );
-
-    test(
-      'returns friendly manual-update messages for 404 and no newer build',
+      'handles missing indexes, current builds, and HTTP failures',
       () async {
         final notPublished = DesktopAleraUpdateService(
           client: MockClient((_) async => http.Response('', 404)),
-          platform: 'linux',
-        );
-        final upToDate = DesktopAleraUpdateService(
-          client: MockClient((_) async => http.Response(_archiveJson, 200)),
-          loadPackageInfo: () async => _packageInfo(buildNumber: '3'),
           platform: 'macos',
         );
-
-        final notPublishedResult = await notPublished.checkForUpdates();
-        final upToDateResult = await upToDate.checkForUpdates();
-
-        expect(notPublishedResult.message, 'No update index is published yet.');
-        expect(upToDateResult.message, 'Alera is up to date.');
-      },
-    );
-
-    test(
-      'verifies signed manifests and routes Linux updates through packages',
-      () async {
-        final signed = await _signedArchiveV2Json();
-        final service = DesktopAleraUpdateService(
-          config: AleraUpdateConfig(
-            archiveUrl: Uri.parse('https://example.com/archive.json'),
-            releasePageUrl: Uri.parse('https://example.com/releases'),
-            channel: AleraUpdateChannel.stable,
-            autoInstallEnabled: true,
-            signedRelease: true,
-            manifestPublicKey: signed.publicKey,
+        final current = DesktopAleraUpdateService(
+          client: MockClient(
+            (_) async => http.Response(
+              jsonEncode(
+                _archive(<Map<String, Object?>>[
+                  _archiveItem(platform: 'macos', installerKind: 'tar.gz'),
+                ]),
+              ),
+              200,
+            ),
           ),
-          client: MockClient((_) async => http.Response(signed.manifest, 200)),
-          loadPackageInfo: () async => _packageInfo(buildNumber: '1'),
-          platform: 'linux',
+          loadPackageInfo: () async => _packageInfo('2'),
+          platform: 'macos',
         );
-
-        final result = await service.checkForUpdates();
-
-        expect(result.latest?.version, '1.0.0');
-        expect(result.latest?.installerKind, 'deb');
-        expect(result.autoInstallAllowed, isFalse);
-        expect(
-          result.message,
-          'Update 1.0.0 is available through the Linux package repository.',
-        );
-      },
-    );
-
-    test(
-      'routes Linux release-candidate tarballs to manual download',
-      () async {
-        final signed = await _signedArchiveV2Json(
-          channel: 'rc',
-          version: '1.0.0-rc.0',
-          installerKind: 'tar.gz',
-          artifactUrl: 'https://example.com/alera-linux.tar.gz',
-        );
-        final service = DesktopAleraUpdateService(
-          config: AleraUpdateConfig(
-            archiveUrl: Uri.parse('https://example.com/archive-rc.json'),
-            releasePageUrl: Uri.parse('https://example.com/releases'),
-            channel: AleraUpdateChannel.rc,
-            autoInstallEnabled: true,
-            signedRelease: true,
-            manifestPublicKey: signed.publicKey,
-          ),
-          client: MockClient((_) async => http.Response(signed.manifest, 200)),
-          loadPackageInfo: () async => _packageInfo(buildNumber: '1'),
-          platform: 'linux',
-        );
-
-        final result = await service.checkForUpdates();
-
-        expect(result.latest?.version, '1.0.0-rc.0');
-        expect(result.latest?.installerKind, 'tar.gz');
-        expect(result.autoInstallAllowed, isFalse);
-        expect(
-          result.message,
-          'Update 1.0.0-rc.0 is available for manual download.',
-        );
-      },
-    );
-
-    test(
-      'throws when the archive download fails with a non-404 status',
-      () async {
-        final service = DesktopAleraUpdateService(
-          config: _config(),
+        final failed = DesktopAleraUpdateService(
           client: MockClient((_) async => http.Response('boom', 500)),
           platform: 'macos',
         );
 
+        expect(
+          (await notPublished.checkForUpdates()).message,
+          'No update index is published yet.',
+        );
+        expect(
+          (await current.checkForUpdates()).message,
+          'Alera is up to date.',
+        );
         await expectLater(
-          service.checkForUpdates(),
+          failed.checkForUpdates(),
           throwsA(isA<HttpException>()),
         );
       },
     );
 
-    test(
-      'installs an available update and reports progress until completion',
-      () async {
-        final updater = _FakeDesktopUpdater()
-          ..versionCheckResult = _item(
-            version: '0.1.4-rc.0',
-            shortVersion: 4,
-            url: 'https://example.com/updates/0.1.4+4-macos',
-            platform: 'macos',
-            changedFiles: <FileHashModel?>[
-              FileHashModel(
-                filePath: 'Alera.app',
-                calculatedHash: 'abc',
-                length: 42,
-              ),
-            ],
-          )
-          ..updateStream = Stream<UpdateProgress>.fromIterable(<UpdateProgress>[
-            UpdateProgress(
-              totalBytes: 100,
-              receivedBytes: 25,
-              currentFile: 'Alera.app',
-              totalFiles: 1,
-              completedFiles: 0,
-            ),
-            UpdateProgress(
-              totalBytes: 100,
-              receivedBytes: 100,
-              currentFile: 'Alera.app',
-              totalFiles: 1,
-              completedFiles: 1,
-            ),
-          ]);
-        final service = DesktopAleraUpdateService(
-          config: _config(
-            channel: AleraUpdateChannel.rc,
-            autoInstallEnabled: true,
-          ),
-          desktopUpdater: updater,
-          platform: 'macos',
-        );
-        final progress = <double>[];
+    test('stages, reports progress, and hands off a verified update', () async {
+      final stager = _FakeStager();
+      final handoff = _FakeHandoff();
+      final service = DesktopAleraUpdateService(
+        config: _config(
+          channel: AleraUpdateChannel.rc,
+          autoInstallEnabled: true,
+        ),
+        stager: stager,
+        handoff: handoff,
+        platform: 'macos',
+      );
+      final update = _update();
+      final progress = <double>[];
 
-        await service.installUpdate(
-          _updateInfo(
-            version: '0.1.4-rc.0',
-            shortVersion: 4,
-            url: 'https://example.com/updates/0.1.4+4-macos',
-          ),
-          onProgress: progress.add,
-        );
+      await service.installUpdate(update, onProgress: progress.add);
+      await service.restartApp();
 
-        expect(updater.updatedFolders, <String>[
-          'https://example.com/updates/0.1.4+4-macos',
-        ]);
-        expect(updater.updatedChangedFiles.single, hasLength(1));
-        expect(progress, <double>[0.25, 1, 1]);
-      },
-    );
+      expect(stager.update, same(update));
+      expect(progress, <double>[0.5, 1]);
+      expect(handoff.stagedUpdate?.update, same(update));
+    });
 
-    test('rejects installation when automatic updates are disabled', () async {
+    test('rejects automatic install when the build disables it', () async {
       final service = DesktopAleraUpdateService(
         config: _config(),
+        stager: _FakeStager(),
+        handoff: _FakeHandoff(),
         platform: 'macos',
       );
 
-      await expectLater(
-        service.installUpdate(
-          _updateInfo(url: 'https://example.com/updates/0.1.2+3-macos'),
+      await expectLater(service.installUpdate(_update()), throwsStateError);
+      await expectLater(service.restartApp(), throwsStateError);
+    });
+
+    test('opens release pages and reports launcher refusal', () async {
+      final launched = <Uri>[];
+      final service = DesktopAleraUpdateService(
+        config: _config(
+          releasePageUrl: Uri.parse(
+            'https://github.com/leynier/alera/releases/tag/v1.0.0',
+          ),
         ),
-        throwsA(isA<StateError>()),
+        launchUrl: (uri) async {
+          launched.add(uri);
+          return true;
+        },
+        platform: 'windows',
       );
+      final refused = DesktopAleraUpdateService(
+        config: _config(),
+        launchUrl: (_) async => false,
+        platform: 'windows',
+      );
+
+      await service.openDownloadPage(_update(version: '1.2.3'));
+
+      expect(
+        launched.single,
+        Uri.parse('https://github.com/leynier/alera/releases/tag/v1.2.3'),
+      );
+      await expectLater(refused.openDownloadPage(null), throwsStateError);
     });
 
-    test(
-      'installUpdate throws when the updater has no available item',
-      () async {
-        final service = DesktopAleraUpdateService(
-          config: _config(
-            channel: AleraUpdateChannel.rc,
-            autoInstallEnabled: true,
-          ),
-          desktopUpdater: _FakeDesktopUpdater(),
-          platform: 'macos',
-        );
-
-        await expectLater(
-          service.installUpdate(
-            _updateInfo(
-              version: '0.1.4-rc.0',
-              shortVersion: 4,
-              url: 'https://example.com/updates/0.1.4+4-macos',
-            ),
-          ),
-          throwsStateError,
-        );
-      },
-    );
-
-    test('dispose closes owned clients without throwing', () {
-      final service = DesktopAleraUpdateService(platform: 'macos');
-
-      expect(service.dispose, returnsNormally);
-      service.dispose();
-    });
-
-    test(
-      'opens the detected update release page and restarts via delegates',
-      () async {
-        final launched = <Uri>[];
-        final updater = _FakeDesktopUpdater();
-        final service = DesktopAleraUpdateService(
-          config: _config(
-            releasePageUrl: Uri.parse(
-              'https://github.com/leynier/alera/releases/tag/v0.9.0',
-            ),
-          ),
-          desktopUpdater: updater,
-          launchUrl: (uri) async {
-            launched.add(uri);
-            return true;
-          },
-          platform: 'windows',
-        );
-
-        await service.openDownloadPage(null);
-        await service.openDownloadPage(
-          _updateInfo(version: '0.10.0', shortVersion: 23, platform: 'linux'),
-        );
-        await service.restartApp();
-
-        expect(launched, <Uri>[
-          Uri.parse('https://github.com/leynier/alera/releases/tag/v0.9.0'),
-          Uri.parse('https://github.com/leynier/alera/releases/tag/v0.10.0'),
-        ]);
-        expect(updater.restartCalls, 1);
-      },
-    );
-
-    test('openDownloadPage uses the default url_launcher delegate', () async {
+    test('uses the default url launcher delegate', () async {
       final previousPlatform = UrlLauncherPlatform.instance;
       final fakePlatform = _FakeUrlLauncherPlatform();
       UrlLauncherPlatform.instance = fakePlatform;
@@ -355,124 +262,34 @@ void main() {
   });
 }
 
-AleraUpdateConfig _config({
-  Uri? releasePageUrl,
-  AleraUpdateChannel channel = AleraUpdateChannel.stable,
-  bool autoInstallEnabled = false,
-  bool signedRelease = false,
-  String manifestPublicKey = '',
-}) {
-  return AleraUpdateConfig(
-    archiveUrl: Uri.parse('https://example.com/archive.json'),
-    releasePageUrl: releasePageUrl ?? Uri.parse('https://example.com/releases'),
-    channel: channel,
-    autoInstallEnabled: autoInstallEnabled,
-    signedRelease: signedRelease,
-    manifestPublicKey: manifestPublicKey,
-  );
-}
-
-AleraUpdateInfo _updateInfo({
-  String version = '0.1.2',
-  int shortVersion = 3,
-  String url = 'https://example.com/updates/0.1.2+3-macos',
-  String platform = 'macos',
-  List<String> changes = const <String>['Preview'],
-}) {
-  return AleraUpdateInfo(
-    version: version,
-    shortVersion: shortVersion,
-    date: '2026-05-25',
-    mandatory: false,
-    url: Uri.parse(url),
-    platform: platform,
-    changes: changes,
-  );
-}
-
-PackageInfo _packageInfo({required String buildNumber}) {
-  return PackageInfo(
-    appName: 'Alera',
-    packageName: 'dev.alera',
-    version: '0.1.0',
-    buildNumber: buildNumber,
-  );
-}
-
-Future<({String manifest, String publicKey})> _signedArchiveV2Json({
-  String channel = 'stable',
-  String version = '1.0.0',
-  String installerKind = 'deb',
-  String artifactUrl = 'https://example.com/alera.deb',
-}) async {
-  final keyPair = await Ed25519().newKeyPairFromSeed(List.filled(32, 2));
-  final keyData = await keyPair.extract();
-  final publicKeyData = await keyPair.extractPublicKey();
-  final privateKey = base64Encode(keyData.bytes);
-  final publicKey = base64Encode(publicKeyData.bytes);
-  final decoded = _archiveV2Json(
-    channel: channel,
-    version: version,
-    installerKind: installerKind,
-    artifactUrl: artifactUrl,
-  );
-  final signed = await signAleraManifest(
-    manifest: decoded,
-    privateKeyBase64: privateKey,
-    publicKeyBase64: publicKey,
-    publicKeyId: 'test-key',
-  );
-  return (manifest: jsonEncode(signed), publicKey: publicKey);
-}
-
-ItemModel _item({
-  required String version,
-  required int shortVersion,
-  required String url,
-  required String platform,
-  List<FileHashModel?>? changedFiles,
-}) {
-  return ItemModel(
-    version: version,
-    shortVersion: shortVersion,
-    changes: <ChangeModel>[ChangeModel(message: 'Preview')],
-    date: '2026-05-25',
-    mandatory: false,
-    url: url,
-    platform: platform,
-    changedFiles: changedFiles,
-  );
-}
-
-class _FakeDesktopUpdater extends DesktopUpdater {
-  final List<String> checkedArchiveUrls = <String>[];
-  final List<String> updatedFolders = <String>[];
-  final List<List<FileHashModel?>> updatedChangedFiles =
-      <List<FileHashModel?>>[];
-
-  ItemModel? versionCheckResult;
-  Stream<UpdateProgress> updateStream = const Stream<UpdateProgress>.empty();
-  int restartCalls = 0;
+class _FakeStager implements AleraDesktopUpdateStager {
+  AleraUpdateInfo? update;
 
   @override
-  Future<ItemModel?> versionCheck({required String appArchiveUrl}) async {
-    checkedArchiveUrls.add(appArchiveUrl);
-    return versionCheckResult;
-  }
-
-  @override
-  Future<Stream<UpdateProgress>> updateApp({
-    required String remoteUpdateFolder,
-    required List<FileHashModel?> changedFiles,
+  Future<StagedDesktopUpdate> stage(
+    AleraUpdateInfo update, {
+    void Function(double progress)? onProgress,
   }) async {
-    updatedFolders.add(remoteUpdateFolder);
-    updatedChangedFiles.add(changedFiles);
-    return updateStream;
+    this.update = update;
+    onProgress?.call(0.5);
+    onProgress?.call(1);
+    final directory = await Directory.systemTemp.createTemp('service-test-');
+    return StagedDesktopUpdate(
+      update: update,
+      directory: directory,
+      artifactPath: '${directory.path}/artifact',
+      payloadPath: '${directory.path}/payload',
+    );
   }
+}
+
+class _FakeHandoff implements AleraDesktopUpdateHandoff {
+  StagedDesktopUpdate? stagedUpdate;
 
   @override
-  Future<void> restartApp() async {
-    restartCalls += 1;
+  Future<void> applyAndRestart(StagedDesktopUpdate stagedUpdate) async {
+    this.stagedUpdate = stagedUpdate;
+    await stagedUpdate.delete();
   }
 }
 
@@ -502,63 +319,107 @@ class _FakeUrlLauncherPlatform extends UrlLauncherPlatform
   }
 }
 
-const String _archiveJson = '''
+AleraUpdateConfig _config({
+  Uri? releasePageUrl,
+  AleraUpdateChannel channel = AleraUpdateChannel.stable,
+  bool autoInstallEnabled = false,
+  bool signedRelease = false,
+  String manifestPublicKey = '',
+}) {
+  return AleraUpdateConfig(
+    archiveUrl: Uri.parse('https://example.com/archive.json'),
+    releasePageUrl: releasePageUrl ?? Uri.parse('https://example.com/releases'),
+    channel: channel,
+    autoInstallEnabled: autoInstallEnabled,
+    signedRelease: signedRelease,
+    manifestPublicKey: manifestPublicKey,
+  );
+}
+
+AleraUpdateInfo _update({String version = '1.2.3'}) {
+  return AleraUpdateInfo(
+    version: version,
+    shortVersion: 2,
+    date: '2026-07-27',
+    mandatory: false,
+    url: Uri.parse('https://example.com/alera.tar.gz'),
+    platform: 'macos',
+    changes: const <String>['Update Alera'],
+    installerKind: 'tar.gz',
+    sha256: _sha256,
+    size: 42,
+  );
+}
+
+PackageInfo _packageInfo(String buildNumber) {
+  return PackageInfo(
+    appName: 'Alera',
+    packageName: 'dev.leynier.alera',
+    version: '1.0.0',
+    buildNumber: buildNumber,
+  );
+}
+
+Map<String, Object?> _archive(List<Map<String, Object?>> items) {
+  return <String, Object?>{
+    'schemaVersion': 2,
+    'appName': 'Alera',
+    'items': items,
+  };
+}
+
+Map<String, Object?> _archiveItem({
+  required String platform,
+  required String installerKind,
+  String version = '1.2.3',
+}) {
+  return <String, Object?>{
+    'version': version,
+    'shortVersion': 2,
+    'date': '2026-07-27',
+    'mandatory': false,
+    'changes': const <Object?>[],
+    'platform': platform,
+    'installerKind': installerKind,
+    'url': 'https://example.com/alera.$installerKind',
+    'sha256': _sha256,
+    'size': 42,
+  };
+}
+
+Future<({String manifest, String publicKey})> _signedArchive(
+  List<Map<String, Object?>> items,
+) async {
+  final keyPair = await Ed25519().newKeyPairFromSeed(List<int>.filled(32, 9));
+  final keyData = await keyPair.extract();
+  final publicKeyData = await keyPair.extractPublicKey();
+  final privateKey = base64Encode(keyData.bytes);
+  final publicKey = base64Encode(publicKeyData.bytes);
+  final signed = await signAleraManifest(
+    manifest: _archive(items),
+    privateKeyBase64: privateKey,
+    publicKeyBase64: publicKey,
+    publicKeyId: 'test-key',
+  );
+  return (manifest: jsonEncode(signed), publicKey: publicKey);
+}
+
+const String _sha256 =
+    'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+
+const String _legacyArchive = '''
 {
   "appName": "Alera",
-  "description": "Alera desktop agentic development environment.",
   "items": [
     {
-      "version": "0.1.2",
-      "shortVersion": 3,
-      "changes": [{"type": "fix", "message": "Fix two."}],
-      "date": "2026-05-24",
-      "mandatory": false,
-      "url": "https://example.com/updates/0.1.2+3-macos",
-      "platform": "macos"
-    },
-    {
-      "version": "0.1.1",
+      "version": "1.2.3-rc.0",
       "shortVersion": 2,
-      "changes": [{"type": "fix", "message": "Linux fix."}],
-      "date": "2026-05-24",
+      "date": "2026-07-27",
       "mandatory": false,
-      "url": "https://example.com/updates/0.1.1+2-linux",
-      "platform": "linux"
+      "changes": [],
+      "platform": "macos",
+      "url": "https://example.com/update-directory"
     }
   ]
 }
 ''';
-
-Map<String, Object?> _archiveV2Json({
-  required String channel,
-  required String version,
-  required String installerKind,
-  required String artifactUrl,
-}) {
-  return <String, Object?>{
-    'schemaVersion': 2,
-    'appName': 'Alera',
-    'description': 'Alera desktop agentic development environment.',
-    'channel': channel,
-    'version': version,
-    'buildNumber': 10,
-    'publishedAt': '2026-06-06T00:00:00Z',
-    'items': <Object?>[
-      <String, Object?>{
-        'version': version,
-        'shortVersion': 10,
-        'changes': <Object?>[
-          <String, Object?>{'type': 'fix', 'message': 'Fix release.'},
-        ],
-        'date': '2026-06-06',
-        'mandatory': false,
-        'platform': 'linux',
-        'installerKind': installerKind,
-        'url': artifactUrl,
-        'sha256':
-            'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-        'size': 42,
-      },
-    ],
-  };
-}

--- a/test/unit/desktop_update_stager_test.dart
+++ b/test/unit/desktop_update_stager_test.dart
@@ -1,0 +1,175 @@
+import 'dart:io';
+
+import 'package:alera/src/features/updater/domain/alera_update.dart';
+import 'package:alera/src/features/updater/infra/desktop_update_stager.dart';
+import 'package:archive/archive.dart';
+import 'package:crypto/crypto.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:path/path.dart' as p;
+
+void main() {
+  group('DesktopUpdateStager', () {
+    for (final fixture in <({String platform, String executable})>[
+      (platform: 'macos', executable: 'Alera.app/Contents/MacOS/Alera'),
+      (platform: 'windows', executable: 'Alera.exe'),
+      (platform: 'linux', executable: 'alera'),
+    ]) {
+      test(
+        'downloads, verifies, and extracts ${fixture.platform} tarballs',
+        () async {
+          final artifact = _tarGzip(<String, String>{
+            fixture.executable: 'updated executable',
+            'data/flutter_assets/version.json': '{"build_number":"2"}',
+          });
+          final stager = DesktopUpdateStager(
+            client: MockClient(
+              (_) async => http.Response.bytes(artifact, HttpStatus.ok),
+            ),
+            platform: fixture.platform,
+          );
+          final progress = <double>[];
+
+          final staged = await stager.stage(
+            _update(
+              platform: fixture.platform,
+              artifact: artifact,
+              installerKind: 'tar.gz',
+            ),
+            onProgress: progress.add,
+          );
+          addTearDown(staged.delete);
+
+          final executablePath = fixture.platform == 'macos'
+              ? p.join(staged.payloadPath!, 'Contents', 'MacOS', 'Alera')
+              : p.join(staged.payloadPath!, p.basename(fixture.executable));
+          expect(
+            await File(executablePath).readAsString(),
+            'updated executable',
+          );
+          expect(progress, isNotEmpty);
+          expect(progress.last, 1);
+          expect(progress, orderedEquals(<double>[...progress]..sort()));
+        },
+      );
+    }
+
+    test('keeps verified Linux packages without extracting them', () async {
+      final artifact = <int>[1, 2, 3, 4];
+      final stager = DesktopUpdateStager(
+        client: MockClient(
+          (_) async => http.Response.bytes(artifact, HttpStatus.ok),
+        ),
+        platform: 'linux',
+      );
+
+      final staged = await stager.stage(
+        _update(platform: 'linux', artifact: artifact, installerKind: 'deb'),
+      );
+      addTearDown(staged.delete);
+
+      expect(staged.payloadPath, isNull);
+      expect(await File(staged.artifactPath).readAsBytes(), artifact);
+    });
+
+    test('rejects incomplete and tampered downloads', () async {
+      final bytes = <int>[1, 2, 3];
+      final incomplete = DesktopUpdateStager(
+        client: MockClient(
+          (_) async => http.Response.bytes(bytes, HttpStatus.ok),
+        ),
+        platform: 'linux',
+      );
+      final tampered = DesktopUpdateStager(
+        client: MockClient(
+          (_) async => http.Response.bytes(bytes, HttpStatus.ok),
+        ),
+        platform: 'linux',
+      );
+
+      await expectLater(
+        incomplete.stage(
+          _update(
+            platform: 'linux',
+            artifact: <int>[...bytes, 4],
+            installerKind: 'deb',
+          ),
+        ),
+        throwsA(
+          isA<FormatException>().having(
+            (error) => error.message,
+            'message',
+            contains('size'),
+          ),
+        ),
+      );
+      await expectLater(
+        tampered.stage(
+          _update(
+            platform: 'linux',
+            artifact: bytes,
+            installerKind: 'deb',
+            sha256Override:
+                '0000000000000000000000000000000000000000000000000000000000000000',
+          ),
+        ),
+        throwsA(
+          isA<FormatException>().having(
+            (error) => error.message,
+            'message',
+            contains('SHA-256'),
+          ),
+        ),
+      );
+    });
+
+    test('rejects artifacts for a different platform', () async {
+      final stager = DesktopUpdateStager(
+        client: MockClient((_) async => http.Response('', HttpStatus.ok)),
+        platform: 'windows',
+      );
+
+      await expectLater(
+        stager.stage(
+          _update(
+            platform: 'macos',
+            artifact: const <int>[1],
+            installerKind: 'tar.gz',
+          ),
+        ),
+        throwsStateError,
+      );
+    });
+  });
+}
+
+AleraUpdateInfo _update({
+  required String platform,
+  required List<int> artifact,
+  required String installerKind,
+  String? sha256Override,
+}) {
+  return AleraUpdateInfo(
+    version: '1.2.3',
+    shortVersion: 2,
+    date: '2026-07-27',
+    mandatory: false,
+    url: Uri.parse('https://example.com/alera.$installerKind'),
+    platform: platform,
+    changes: const <String>['Update Alera'],
+    installerKind: installerKind,
+    sha256: sha256Override ?? sha256.convert(artifact).toString(),
+    size: artifact.length,
+  );
+}
+
+List<int> _tarGzip(Map<String, String> files) {
+  final archive = Archive();
+  for (final entry in files.entries) {
+    final bytes = entry.value.codeUnits;
+    archive.addFile(ArchiveFile(entry.key, bytes.length, bytes));
+  }
+  final tar = TarEncoder().encode(archive);
+  return GZipEncoder().encode(tar);
+}

--- a/test/unit/release_app_archive_scripts_test.dart
+++ b/test/unit/release_app_archive_scripts_test.dart
@@ -65,6 +65,28 @@ void main() {
   });
 
   group('release archive scripts', () {
+    test('gates stable autonomous updates on platform trust credentials', () {
+      final workflow = File(
+        '.github/workflows/release-cut.yml',
+      ).readAsStringSync();
+
+      expect(
+        workflow,
+        contains(
+          '--dart-define "ALERA_UPDATE_AUTO_INSTALL_ENABLED=\$auto_install_enabled"',
+        ),
+      );
+      expect(workflow, contains('APPLE_DEVELOPER_ID_APPLICATION'));
+      expect(workflow, contains('WINDOWS_CERTIFICATE_PFX_BASE64'));
+      expect(workflow, contains('ALERA_LINUX_GPG_PRIVATE_KEY_BASE64'));
+      expect(
+        workflow,
+        isNot(
+          contains('--dart-define "ALERA_UPDATE_AUTO_INSTALL_ENABLED=false"'),
+        ),
+      );
+    });
+
     test(
       'builds and verifies a stable manifest without sidecar URLs',
       () async {

--- a/test/unit/update_archive_test.dart
+++ b/test/unit/update_archive_test.dart
@@ -8,6 +8,61 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group('AleraUpdateArchive', () {
+    test('selects the preferred installer for the latest platform build', () {
+      final archive = AleraUpdateArchive.fromJsonString('''
+{
+  "schemaVersion": 2,
+  "items": [
+    {
+      "version": "1.2.3",
+      "shortVersion": 12,
+      "date": "2026-07-27",
+      "mandatory": false,
+      "changes": [],
+      "platform": "linux",
+      "installerKind": "deb",
+      "url": "https://example.com/alera.deb",
+      "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "size": 10
+    },
+    {
+      "version": "1.2.3",
+      "shortVersion": 12,
+      "date": "2026-07-27",
+      "mandatory": false,
+      "changes": [],
+      "platform": "linux",
+      "installerKind": "rpm",
+      "url": "https://example.com/alera.rpm",
+      "sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "size": 11
+    }
+  ]
+}
+''');
+
+      expect(
+        archive
+            .latestFor(
+              platform: 'linux',
+              currentBuildNumber: 1,
+              channel: AleraUpdateChannel.stable,
+              preferredInstallerKinds: const <String>['rpm'],
+            )
+            ?.installerKind,
+        'rpm',
+      );
+      expect(
+        archive.latestFor(
+          platform: 'linux',
+          currentBuildNumber: 1,
+          channel: AleraUpdateChannel.stable,
+          preferredInstallerKinds: const <String>[],
+        ),
+        isNull,
+      );
+    });
+
     test('selects latest stable update for the current platform', () {
       final archive = AleraUpdateArchive.fromJsonString(_archiveJson);
 

--- a/test/unit/update_controller_test.dart
+++ b/test/unit/update_controller_test.dart
@@ -144,7 +144,7 @@ void main() {
     );
 
     test(
-      'downloads an auto-installable update and reaches downloaded state',
+      'installs an auto-installable update and completes the handoff',
       () async {
         final service = _FakeUpdateService(
           config: AleraUpdateConfig(
@@ -176,6 +176,7 @@ void main() {
         );
         expect(container.read(aleraUpdateControllerProvider).progress, 1);
         expect(service.installedUpdate, _update);
+        expect(service.restartCalls, 1);
       },
     );
 
@@ -213,6 +214,36 @@ void main() {
       );
     });
 
+    test('installLatest keeps Alera usable when handoff fails', () async {
+      final service = _FakeUpdateService(
+        config: AleraUpdateConfig(
+          archiveUrl: _archiveUrl,
+          releasePageUrl: _releasePageUrl,
+          channel: AleraUpdateChannel.rc,
+          autoInstallEnabled: true,
+          signedRelease: false,
+        ),
+        result: AleraUpdateCheckResult(
+          latest: _update,
+          autoInstallAllowed: true,
+        ),
+        restartError: StateError('helper unavailable'),
+      );
+      final container = ProviderContainer(
+        overrides: [aleraUpdateServiceProvider.overrideWithValue(service)],
+      );
+      addTearDown(container.dispose);
+      final controller = container.read(aleraUpdateControllerProvider.notifier);
+
+      await controller.checkForUpdates();
+      await controller.installLatest();
+
+      final state = container.read(aleraUpdateControllerProvider);
+      expect(state.status, AleraUpdateStatus.error);
+      expect(state.message, contains('helper unavailable'));
+      expect(state.message, contains('Alera is still running'));
+    });
+
     test('restartApp delegates to the update service', () async {
       final service = _FakeUpdateService();
       final container = ProviderContainer(
@@ -234,6 +265,7 @@ class _FakeUpdateService implements AleraUpdateService {
     AleraUpdateConfig? config,
     this.checkError,
     this.installError,
+    this.restartError,
   }) : config =
            config ??
            AleraUpdateConfig(
@@ -250,6 +282,7 @@ class _FakeUpdateService implements AleraUpdateService {
   final AleraUpdateCheckResult result;
   final Object? checkError;
   final Object? installError;
+  final Object? restartError;
   AleraUpdateInfo? openedUpdate;
   AleraUpdateInfo? installedUpdate;
   int restartCalls = 0;
@@ -282,6 +315,9 @@ class _FakeUpdateService implements AleraUpdateService {
 
   @override
   Future<void> restartApp() async {
+    if (restartError case final Object error) {
+      throw error;
+    }
     restartCalls += 1;
   }
 

--- a/test/widget/update_settings_section_test.dart
+++ b/test/widget/update_settings_section_test.dart
@@ -59,7 +59,7 @@ void main() {
         );
         await tester.pump();
         expect(find.text('Update Available'), findsOneWidget);
-        expect(find.text('Download Update'), findsOneWidget);
+        expect(find.text('Install Update'), findsOneWidget);
 
         controller.setState(
           _state(
@@ -75,26 +75,46 @@ void main() {
 
         controller.setState(
           _state(
-            status: AleraUpdateStatus.downloaded,
+            status: AleraUpdateStatus.applying,
             latest: _latest(),
-            message: 'Restart Alera to finish installing.',
+            message: 'Installing update 1.2.3. Alera will restart.',
             progress: 1,
           ),
         );
         await tester.pump();
-        expect(find.text('Restart Required'), findsOneWidget);
-        expect(find.text('Restart Alera'), findsOneWidget);
+        expect(find.text('Installing Update'), findsOneWidget);
+        expect(
+          tester
+              .widget<LinearProgressIndicator>(
+                find.byType(LinearProgressIndicator),
+              )
+              .value,
+          isNull,
+        );
+
+        controller.setState(
+          _state(
+            status: AleraUpdateStatus.downloaded,
+            latest: _latest(),
+            message: 'Update handoff complete.',
+            progress: 1,
+          ),
+        );
+        await tester.pump();
+        expect(find.text('Restarting Alera'), findsOneWidget);
+        expect(find.text('Update handoff complete.'), findsOneWidget);
 
         controller.setState(
           _state(
             status: AleraUpdateStatus.error,
             latest: _latest(),
-            message: 'Update check failed: boom',
+            message: 'Update installation failed: boom',
           ),
         );
         await tester.pump();
-        expect(find.text('Update Check Failed'), findsOneWidget);
-        expect(find.text('Update check failed: boom'), findsOneWidget);
+        expect(find.text('Update Failed'), findsOneWidget);
+        expect(find.text('Update installation failed: boom'), findsOneWidget);
+        expect(find.text('Try Again'), findsOneWidget);
       },
     );
 
@@ -123,17 +143,17 @@ void main() {
         _state(status: AleraUpdateStatus.available, latest: _latest()),
       );
       await tester.pump();
-      await tester.tap(find.text('Download Update'));
+      await tester.tap(find.text('Install Update'));
       await tester.pump();
       expect(controller.installLatestCalls, 1);
 
       controller.setState(
-        _state(status: AleraUpdateStatus.downloaded, latest: _latest()),
+        _state(status: AleraUpdateStatus.error, latest: _latest()),
       );
       await tester.pump();
-      await tester.tap(find.text('Restart Alera'));
+      await tester.tap(find.text('Try Again'));
       await tester.pump();
-      expect(controller.restartAppCalls, 1);
+      expect(controller.installLatestCalls, 2);
     });
   });
 }


### PR DESCRIPTION
## Summary

- select the correct signed desktop artifact for macOS, Windows, and Linux
- verify size and SHA-256 while reporting download/apply progress
- use rollback-capable replacement handoff or privileged Linux package installation, then relaunch Alera
- gate stable autonomous installs on platform trust credentials

## Validation

- `flutter analyze`
- focused updater/release tests: 71 passed
- `CI=true flutter test --coverage`: 1,998 passed, 2 expected skips
- maintained-domain coverage: 100% (1,735/1,735)
- formatting, max-lines, and diff checks
- `flutter build linux --release`

## Notes

Local `gh act` setup reached the PR static job but could not resolve this Alera worktree's external `.git` pointer inside its container. The equivalent native checks above passed; hosted macOS and Windows builds remain the platform-native verification.