### PR TITLE
fix: restore terminal snapshots without live output eviction

### DIFF
--- a/docs/performance.md
+++ b/docs/performance.md
@@ -11,7 +11,7 @@ Alera treats performance as a product contract. Optimization work starts with a 
 - The explorer computes one Git status snapshot per workspace refresh and reuses it for expanded directories.
 - Obsolete workspace searches are cancelled in Rust as soon as the query generation changes.
 - Bundled Inter and JetBrains Mono assets remove runtime font-network and font-loader work.
-- Terminal output is batched, byte-bounded in the host, character-bounded before Flutter rendering, and recovered from the host's per-client delivery cursor when a client falls behind, so a tab switch or a backpressure resync costs the bytes that were missed rather than a replay of the scrollback. A cold attach still replays, capped to what the emulator will keep. RPC responses and runtime events use a separate control lane so terminal backpressure cannot disconnect the workbench.
+- Terminal output is batched, byte-bounded in the host, character-bounded before Flutter rendering, and recovered from the host's per-client delivery cursor when a client falls behind, so a tab switch or a backpressure resync costs the bytes that were missed rather than a replay of the scrollback. A cold attach still replays, capped to what the emulator will keep. Restore and control segments are protected from the live-output backlog cap, and restore progress advances only for snapshot characters that reached the emulator. Per-client terminal sequence watermarks keep output included in an attachment snapshot before its control response and later output after it. RPC responses and runtime events use a separate control lane so terminal backpressure cannot disconnect the workbench.
 - Terminal output flushes are paced by a cadence floor (33 ms), so a process writing without pause cannot drive the frame loop at full vsync. The floor is measured from the moment a frame is requested, not from the flush that follows, or the vsync wait would be charged to the next interval too and pace the terminal at 20 Hz instead of 30. A terminal that has been quiet still flushes on the very next frame, so echo latency while typing is unchanged.
 - The mobile gateway gets a deeper terminal lane than the desktop socket, because a WAN send can stall for hundreds of milliseconds and the queue depth the local socket was tuned for turns one stall into a permanent pause. Depth only buys time: the mobile client answers the host's backpressure resync the same way the desktop does, which is what actually clears the pause.
 
@@ -69,6 +69,18 @@ flutter test integration_test/terminal_flush_cadence_benchmark.dart -d linux
 ```
 
 The first drives xterm directly and pumps its own frames, reporting what a frame costs (`BENCH_PUMP_MS` sets the cadence). The second feeds output through `XtermTerminalRuntime` and lets the runtime schedule the flushes, reporting flushes per second and process CPU: 60.0 flushes/s and ~100% of a core before the cadence floor, 29.1 flushes/s and ~80% after. Neither is a pass/fail test; run one before and after a rendering change and compare.
+
+## Terminal Restore Harness
+
+Run:
+
+```bash
+flutter test integration_test/terminal_restore_benchmark.dart -d linux
+```
+
+The benchmark mounts and starts `TerminalSurface` before timing, sends the default 2.56 MB snapshot with 420,000 ANSI escape characters, immediately follows it with a 1 MiB live-output backlog, and waits through the framework post-frame callback after the restore overlay is removed. It discards one warm-up and reports five measured replays, including accepted, first-chunk and framework post-frame latency, flushes, CPU, build and raster timings. The boundary starts when the snapshot event reaches Flutter, so it isolates the replay bottleneck and intentionally excludes tab selection, host attachment, storage and transport.
+
+On the Linux development machine with Flutter 3.44.8, the protected restore queue completed all five samples within the three-second target: 1,373.74 ms median, 1,403.85 ms p95 and maximum, 24.91 ms MAD, and exactly 40 flushes per restore. The three-second target is scoped to the default 10,000-line, 2.56 MB replay budget. Larger user-configured histories preserve their additional content and scale with payload size. This is a comparison benchmark rather than a timing assertion because desktop hardware and display composition materially affect the result.
 
 ## Measurement Rules
 

--- a/integration_test/terminal_restore_benchmark.dart
+++ b/integration_test/terminal_restore_benchmark.dart
@@ -1,0 +1,416 @@
+/// Snapshot-replay benchmark for an already-mounted terminal surface.
+///
+/// This emits live output immediately behind a default-size snapshot, which is
+/// the production ordering that used to evict the snapshot and leave the
+/// "Restoring Terminal" overlay waiting for minutes.
+///
+///     flutter test integration_test/terminal_restore_benchmark.dart -d linux
+///
+/// Deliberately not named `*_test.dart`: this is a hardware-dependent
+/// measurement tool, not a CI check. The three-second target applies to the
+/// default 2.56 MB replay after its event reaches Flutter, not to host attach.
+library;
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:alera/src/features/workbench/domain/workspace.dart';
+import 'package:alera/src/features/workbench/domain/workspace_tab_record.dart';
+import 'package:alera/src/features/workbench/presentation/terminal_runtime.dart';
+import 'package:alera/src/features/workbench/presentation/terminal_surface.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:ghostty_vte_flutter/ghostty_vte_flutter.dart';
+import 'package:integration_test/integration_test.dart';
+
+const _snapshotBytes = 2_560_000;
+const _liveOutputBytes = 1024 * 1024;
+const _measuredRuns = 5;
+const _restoreTarget = Duration(seconds: 3);
+const _watchdog = Duration(seconds: 30);
+const _restoreMarker = 'RESTORE-END';
+const _liveMarker = 'LIVE-AFTER-SNAPSHOT';
+
+void main() {
+  final binding = IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('default terminal snapshot replay latency', (tester) async {
+    binding.framePolicy = LiveTestWidgetsFlutterBindingFramePolicy.fullyLive;
+    final fakeSession = _BenchmarkPtySession();
+    final runtime = XtermTerminalRuntime(
+      ptySessionFactory: _BenchmarkPtySessionFactory(fakeSession),
+      shellLaunchesBuilder: () => <GhosttyTerminalShellLaunch>[
+        const GhosttyTerminalShellLaunch(
+          label: 'Benchmark',
+          shell: '/bin/sh',
+          environment: <String, String>{'TERM': 'xterm-256color'},
+        ),
+      ],
+    );
+    addTearDown(runtime.dispose);
+    final session = runtime.sessionFor(workspace: _workspace(), tab: _tab());
+
+    await tester.pumpWidget(
+      ProviderScope(
+        child: MaterialApp(
+          debugShowCheckedModeBanner: false,
+          home: Scaffold(body: TerminalSurface(session: session)),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(fakeSession.started, isTrue);
+
+    final snapshot = _buildSnapshot();
+    expect(snapshot.length, _snapshotBytes);
+    final liveOutput = _buildLiveOutput();
+    expect(utf8.encode(liveOutput), hasLength(_liveOutputBytes));
+
+    await _measureRestore(
+      tester: tester,
+      binding: binding,
+      fakeSession: fakeSession,
+      session: session,
+      snapshot: snapshot,
+      liveOutput: liveOutput,
+    );
+    final samples = <_RestoreSample>[];
+    for (var run = 0; run < _measuredRuns; run++) {
+      samples.add(
+        await _measureRestore(
+          tester: tester,
+          binding: binding,
+          fakeSession: fakeSession,
+          session: session,
+          snapshot: snapshot,
+          liveOutput: liveOutput,
+        ),
+      );
+    }
+
+    final report = _RestoreReport(samples);
+    // ignore: avoid_print
+    print(report.format(snapshot));
+    expect(samples, hasLength(_measuredRuns));
+    expect(samples.every((sample) => sample.frames.isNotEmpty), isTrue);
+  });
+}
+
+Future<_RestoreSample> _measureRestore({
+  required WidgetTester tester,
+  required IntegrationTestWidgetsFlutterBinding binding,
+  required _BenchmarkPtySession fakeSession,
+  required TerminalSessionHandle session,
+  required Uint8List snapshot,
+  required String liveOutput,
+}) async {
+  final watch = Stopwatch();
+  Duration? accepted;
+  Duration? firstChunk;
+  final frameworkReady = Completer<void>();
+  var sawProgress = false;
+
+  void observeProgress() {
+    final progress = session.restoreProgress.value;
+    if (progress != null) {
+      sawProgress = true;
+      accepted ??= watch.elapsed;
+      if (progress.writtenChars > 0) {
+        firstChunk ??= watch.elapsed;
+      }
+      return;
+    }
+    if (!sawProgress || frameworkReady.isCompleted) {
+      return;
+    }
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!frameworkReady.isCompleted) {
+        frameworkReady.complete();
+      }
+    });
+  }
+
+  final frames = <FrameTiming>[];
+  void collectFrames(List<FrameTiming> timings) => frames.addAll(timings);
+
+  session.restoreProgress.addListener(observeProgress);
+  binding.addTimingsCallback(collectFrames);
+  final flushesBefore = terminalOutputFlushCountForTesting(session);
+  final cpuBefore = _processCpuSeconds();
+  try {
+    watch.start();
+    fakeSession.emit(TerminalPtySnapshotEvent(snapshot));
+    fakeSession.emit(TerminalPtyOutputTextEvent(liveOutput));
+
+    await tester.runAsync(() => frameworkReady.future.timeout(_watchdog));
+    watch.stop();
+    final elapsed = watch.elapsed;
+    final cpuAfter = _processCpuSeconds();
+    final flushes = terminalOutputFlushCountForTesting(session) - flushesBefore;
+    await tester.runAsync(
+      () => Future<void>.delayed(const Duration(milliseconds: 50)),
+    );
+
+    final text = terminalBufferTextForTesting(session);
+    final restoreOffset = text.indexOf(_restoreMarker);
+    final liveOffset = text.indexOf(_liveMarker);
+    expect(sawProgress, isTrue);
+    expect(accepted, isNotNull);
+    expect(firstChunk, isNotNull);
+    expect(session.restoreProgress.value, isNull);
+    expect(terminalPointerInputSuspendedForTesting(session), isFalse);
+    expect(find.text('Restoring Terminal'), findsNothing);
+    expect(restoreOffset, greaterThanOrEqualTo(0));
+    expect(liveOffset, greaterThan(restoreOffset));
+    expect(pendingLiveTerminalOutputCharsForTesting(session), greaterThan(0));
+
+    return _RestoreSample(
+      accepted: accepted!,
+      firstChunk: firstChunk!,
+      frameworkReady: elapsed,
+      flushes: flushes,
+      cpuSeconds: cpuBefore == null || cpuAfter == null
+          ? null
+          : cpuAfter - cpuBefore,
+      frames: List<FrameTiming>.unmodifiable(frames),
+    );
+  } finally {
+    if (watch.isRunning) {
+      watch.stop();
+    }
+    binding.removeTimingsCallback(collectFrames);
+    session.restoreProgress.removeListener(observeProgress);
+  }
+}
+
+Uint8List _buildSnapshot() {
+  const styledToken = '\x1b[32mOK\x1b[0m';
+  final body = List<String>.filled(21, styledToken).join();
+  final records = List<String>.generate(10_000, (index) {
+    final suffix = index == 9_999
+        ? _restoreMarker
+        : 'ROW-${index.toString().padLeft(5, '0')}';
+    return '$body${suffix.padRight(23, '.')}\r\n';
+  });
+  return Uint8List.fromList(utf8.encode(records.join()));
+}
+
+String _buildLiveOutput() {
+  const prefix = '\r\n$_liveMarker\r\n';
+  const control = '\x1b[0m';
+  final bodyBytes = _liveOutputBytes - prefix.length;
+  final controls = List<String>.filled(bodyBytes ~/ control.length, control);
+  final padding = List<String>.filled(bodyBytes % control.length, ' ');
+  return '$prefix${controls.join()}${padding.join()}';
+}
+
+double? _processCpuSeconds() {
+  if (!Platform.isLinux) {
+    return null;
+  }
+  try {
+    final stat = File('/proc/self/stat').readAsStringSync();
+    final fields = stat.substring(stat.lastIndexOf(')') + 2).split(' ');
+    return (int.parse(fields[11]) + int.parse(fields[12])) / 100;
+  } catch (_) {
+    return null;
+  }
+}
+
+double _median(Iterable<double> values) {
+  final sorted = values.toList()..sort();
+  final middle = sorted.length ~/ 2;
+  if (sorted.length.isOdd) {
+    return sorted[middle];
+  }
+  return (sorted[middle - 1] + sorted[middle]) / 2;
+}
+
+double _percentile(Iterable<double> values, double percentile) {
+  final sorted = values.toList()..sort();
+  final index = (sorted.length * percentile).ceil() - 1;
+  return sorted[index.clamp(0, sorted.length - 1)];
+}
+
+double _milliseconds(Duration duration) =>
+    duration.inMicroseconds / Duration.microsecondsPerMillisecond;
+
+final class _RestoreSample {
+  const _RestoreSample({
+    required this.accepted,
+    required this.firstChunk,
+    required this.frameworkReady,
+    required this.flushes,
+    required this.cpuSeconds,
+    required this.frames,
+  });
+
+  final Duration accepted;
+  final Duration firstChunk;
+  final Duration frameworkReady;
+  final int flushes;
+  final double? cpuSeconds;
+  final List<FrameTiming> frames;
+}
+
+final class _RestoreReport {
+  const _RestoreReport(this.samples);
+
+  final List<_RestoreSample> samples;
+
+  String format(Uint8List snapshot) {
+    final ready = samples
+        .map((sample) => _milliseconds(sample.frameworkReady))
+        .toList();
+    final accepted = samples
+        .map((sample) => _milliseconds(sample.accepted))
+        .toList();
+    final firstChunk = samples
+        .map((sample) => _milliseconds(sample.firstChunk))
+        .toList();
+    final readyMedian = _median(ready);
+    final deviations = ready
+        .map((value) => (value - readyMedian).abs())
+        .toList();
+    final builds = <double>[
+      for (final sample in samples)
+        for (final frame in sample.frames)
+          frame.buildDuration.inMicroseconds / 1000,
+    ];
+    final rasters = <double>[
+      for (final sample in samples)
+        for (final frame in sample.frames)
+          frame.rasterDuration.inMicroseconds / 1000,
+    ];
+    final cpu = <double>[
+      for (final sample in samples)
+        if (sample.cpuSeconds case final seconds?)
+          seconds * 100 / (sample.frameworkReady.inMicroseconds / 1000000),
+    ];
+    final withinTarget = samples
+        .where((sample) => sample.frameworkReady <= _restoreTarget)
+        .length;
+    final escapeCount = snapshot.where((byte) => byte == 0x1B).length;
+    final throughput = (_snapshotBytes / (1024 * 1024)) / (readyMedian / 1000);
+    final slowFrames = <FrameTiming>[
+      for (final sample in samples)
+        ...sample.frames.where(
+          (frame) => frame.totalSpan > const Duration(microseconds: 16_700),
+        ),
+    ];
+
+    return '\n=== terminal snapshot replay ===\n'
+        '  snapshot ${snapshot.length} bytes, $escapeCount ESC characters; '
+        'live backlog $_liveOutputBytes bytes\n'
+        '  accepted median ${_median(accepted).toStringAsFixed(2)} ms; '
+        'first chunk median ${_median(firstChunk).toStringAsFixed(2)} ms\n'
+        '  framework post-frame median ${readyMedian.toStringAsFixed(2)} ms, '
+        'p95 ${_percentile(ready, 0.95).toStringAsFixed(2)} ms, '
+        'max ${ready.reduce((a, b) => a > b ? a : b).toStringAsFixed(2)} ms, '
+        'MAD ${_median(deviations).toStringAsFixed(2)} ms\n'
+        '  target max 3000 ms: $withinTarget/${samples.length}; '
+        'throughput ${throughput.toStringAsFixed(2)} MiB/s\n'
+        '  flushes ${samples.map((sample) => sample.flushes).join(', ')}; '
+        'frames ${samples.fold<int>(0, (sum, sample) => sum + sample.frames.length)}, '
+        'slow frames ${slowFrames.length}\n'
+        '  cpu ${cpu.isEmpty ? '?' : '${_median(cpu).toStringAsFixed(1)}%'} '
+        'of a core; build median '
+        '${builds.isEmpty ? '?' : _median(builds).toStringAsFixed(2)} ms, '
+        'p95 ${builds.isEmpty ? '?' : _percentile(builds, 0.95).toStringAsFixed(2)} ms; '
+        'raster median '
+        '${rasters.isEmpty ? '?' : _median(rasters).toStringAsFixed(2)} ms, '
+        'p95 ${rasters.isEmpty ? '?' : _percentile(rasters, 0.95).toStringAsFixed(2)} ms';
+  }
+}
+
+Workspace _workspace() {
+  final now = DateTime.utc(2026, 7, 27);
+  return Workspace(
+    id: 'workspace-restore-bench',
+    projectId: 'project-restore-bench',
+    name: 'Restore Bench',
+    branch: 'main',
+    path: '/repo/restore-bench',
+    createdAt: now,
+    updatedAt: now,
+    kind: WorkspaceKind.main,
+    status: WorkspaceStatus.active,
+  );
+}
+
+WorkspaceTabRecord _tab() {
+  final now = DateTime.utc(2026, 7, 27);
+  return WorkspaceTabRecord(
+    id: 'tab-restore-bench',
+    workspaceId: 'workspace-restore-bench',
+    title: 'Restore Bench',
+    createdAt: now,
+    updatedAt: now,
+    payload: const <String, Object?>{},
+  );
+}
+
+final class _BenchmarkPtySessionFactory implements TerminalPtySessionFactory {
+  const _BenchmarkPtySessionFactory(this.session);
+
+  final _BenchmarkPtySession session;
+
+  @override
+  TerminalPtySession create({
+    required String sessionId,
+    required String workspaceId,
+    required String tabId,
+  }) => session;
+}
+
+final class _BenchmarkPtySession implements TerminalPtySession {
+  final StreamController<TerminalPtySessionEvent> _events =
+      StreamController<TerminalPtySessionEvent>.broadcast(sync: true);
+
+  bool started = false;
+
+  @override
+  Stream<TerminalPtySessionEvent> get events => _events.stream;
+
+  @override
+  bool get startedNewProcess => false;
+
+  @override
+  Future<void> start({
+    required GhosttyTerminalShellLaunch launch,
+    required String workingDirectory,
+    required int cols,
+    required int rows,
+    Future<void> Function()? onProcessCreated,
+  }) async {
+    started = true;
+  }
+
+  void emit(TerminalPtySessionEvent event) => _events.add(event);
+
+  @override
+  bool writeBytes(List<int> bytes) => bytes.isNotEmpty;
+
+  @override
+  Future<bool> writeBytesAndWait(List<int> bytes) async => writeBytes(bytes);
+
+  @override
+  void resize(int cols, int rows, int cellWidthPx, int cellHeightPx) {}
+
+  @override
+  Future<void> setOutputPaused(bool paused) async {}
+
+  @override
+  void dispose() {
+    if (!_events.isClosed) {
+      unawaited(_events.close());
+    }
+  }
+
+  @override
+  void terminate() => dispose();
+}

--- a/lib/src/features/workbench/presentation/terminal_runtime_output_batching.dart
+++ b/lib/src/features/workbench/presentation/terminal_runtime_output_batching.dart
@@ -10,42 +10,35 @@ void _writeSessionTerminal(_XtermTerminalSessionHandle handle, String data) {
 void _queueSessionTerminalOutput(
   _XtermTerminalSessionHandle handle,
   String data, {
-  bool bounded = true,
+  _TerminalOutputSource source = _TerminalOutputSource.live,
 }) {
   if (data.isEmpty || handle._disposed) {
     return;
   }
-  handle._output.pending.add(data);
-  handle._output.length += data.length;
-  if (!bounded) {
-    // A restored snapshot is a bounded one-shot payload, so it is exempt from
-    // the backlog cap that exists to contain a runaway live process.
-    handle._scheduleTerminalOutputFlush();
-    return;
-  }
-  // Drop the oldest output rather than let a runaway process grow the backlog
-  // without bound. Newer output is what the user is looking at.
-  while (handle._output.length > _terminalOutputMaxPendingChars &&
-      handle._output.pending.length > 1) {
-    final dropped = handle._output.headRemaining;
-    handle._output.length -= dropped;
-    handle._output.pending.removeFirst();
-    handle._output.head = 0;
-    handle._discardPointerInputCatchUp(dropped);
-  }
-  if (handle._output.length > _terminalOutputMaxPendingChars) {
-    // A single chunk can exceed the cap on its own, so trim its head too.
-    final chunk = handle._output.pending.first;
-    final previousHead = handle._output.head;
-    final start = _terminalOutputHeadTrimStart(
-      chunk,
-      chunk.length - _terminalOutputMaxPendingChars,
-    );
-    handle._output.head = start;
-    handle._output.length = chunk.length - start;
-    handle._discardPointerInputCatchUp(start - previousHead);
+  handle._output.add(_TerminalOutputSegment(data, source));
+  if (source == _TerminalOutputSource.live) {
+    _trimSessionLiveOutputBacklog(handle);
   }
   handle._scheduleTerminalOutputFlush();
+}
+
+void _trimSessionLiveOutputBacklog(_XtermTerminalSessionHandle handle) {
+  final output = handle._output;
+  // Preserve the snapshot and its mode reset. Only old live output is
+  // expendable, even when it sits behind a multi-megabyte restore segment.
+  while (output.liveLength > _terminalOutputMaxPendingChars) {
+    final segment = output.pending.firstWhere(
+      (candidate) => candidate.source == _TerminalOutputSource.live,
+    );
+    final offset = output.offsetOf(segment);
+    final excess = output.liveLength - _terminalOutputMaxPendingChars;
+    final trim = excess < segment.remaining ? excess : segment.remaining;
+    final target = segment.head + trim;
+    final nextHead = _terminalOutputHeadTrimStart(segment.text, target);
+    final dropped = nextHead - segment.head;
+    output.consume(segment, dropped);
+    handle._discardPointerInputCatchUp(offset: offset, chars: dropped);
+  }
 }
 
 void _scheduleSessionTerminalOutputFlush(_XtermTerminalSessionHandle handle) {
@@ -113,35 +106,40 @@ void _drainSessionTerminalOutputChunk(_XtermTerminalSessionHandle handle) {
   }
   final frame = StringBuffer();
   var written = 0;
+  var restoreWritten = 0;
   while (pending.isNotEmpty && written < _terminalOutputMaxCharsPerFrame) {
-    final chunk = pending.first;
-    final head = handle._output.head;
-    final available = chunk.length - head;
+    final segment = pending.first;
+    final head = segment.head;
+    final available = segment.remaining;
     final remaining = _terminalOutputMaxCharsPerFrame - written;
     if (available <= remaining) {
-      pending.removeFirst();
-      handle._output.head = 0;
-      handle._output.length -= available;
-      frame.write(head == 0 ? chunk : chunk.substring(head));
+      frame.write(segment.remainingText);
+      handle._output.consume(segment, available);
       written += available;
+      if (segment.source == _TerminalOutputSource.restore) {
+        restoreWritten += available;
+      }
       continue;
     }
     // Absolute index, because the budget is measured from the head, not from
     // the start of the chunk.
-    final cutoff = _terminalOutputChunkCutoff(chunk, head + remaining);
+    final cutoff = _terminalOutputChunkCutoff(segment.text, head + remaining);
     if (cutoff <= head) {
       break;
     }
-    handle._output.head = cutoff;
-    handle._output.length -= cutoff - head;
-    frame.write(chunk.substring(head, cutoff));
-    written += cutoff - head;
+    final consumed = cutoff - head;
+    frame.write(segment.text.substring(head, cutoff));
+    handle._output.consume(segment, consumed);
+    written += consumed;
+    if (segment.source == _TerminalOutputSource.restore) {
+      restoreWritten += consumed;
+    }
   }
   if (written == 0) {
     return;
   }
   handle._writeToTerminal(frame.toString());
-  handle._advanceRestore(written);
+  handle._advanceRestore(restoreWritten);
   handle._advancePointerInputCatchUp(written);
 }
 
@@ -152,12 +150,9 @@ void _flushSessionTerminalOutputNow(_XtermTerminalSessionHandle handle) {
   }
   handle._output.restartFlushClock();
   final pendingChars = handle._output.length;
-  final head = handle._output.head;
   final buffer = StringBuffer();
-  var first = true;
-  for (final chunk in handle._output.pending) {
-    buffer.write(first && head > 0 ? chunk.substring(head) : chunk);
-    first = false;
+  for (final segment in handle._output.pending) {
+    buffer.write(segment.remainingText);
   }
   handle._clearPendingTerminalOutput();
   handle._writeToTerminal(buffer.toString());

--- a/lib/src/features/workbench/presentation/terminal_runtime_output_pipeline.dart
+++ b/lib/src/features/workbench/presentation/terminal_runtime_output_pipeline.dart
@@ -1,5 +1,21 @@
 part of 'terminal_runtime.dart';
 
+enum _TerminalOutputSource { restore, control, live }
+
+class _TerminalOutputSegment {
+  _TerminalOutputSegment(this.text, this.source);
+
+  final String text;
+  final _TerminalOutputSource source;
+
+  /// How far this segment has already been consumed or deliberately trimmed.
+  int head = 0;
+
+  int get remaining => text.length - head;
+
+  String get remainingText => head == 0 ? text : text.substring(head);
+}
+
 /// Everything one terminal session needs to get PTY output onto the screen:
 /// the backlog waiting to be written and the cadence at which it is flushed.
 ///
@@ -9,16 +25,19 @@ part of 'terminal_runtime.dart';
 class _TerminalOutputPipeline {
   /// Pending output held as whole chunks rather than one growing buffer: a
   /// single buffer forced a full copy plus two substrings on every drain, so
-  /// draining a full backlog was quadratic in its size. The head chunk is
-  /// consumed in place through [head] for the same reason; a restored snapshot
-  /// arrives as one multi-megabyte chunk.
-  final Queue<String> pending = Queue<String>();
+  /// draining a full backlog was quadratic in its size. Each segment owns its
+  /// consumed head so live output behind a restore can be trimmed without
+  /// copying or discarding the protected prefix.
+  final Queue<_TerminalOutputSegment> pending = Queue<_TerminalOutputSegment>();
 
-  /// How far the head chunk has already been consumed.
-  int head = 0;
-
-  /// Chars still to write, already net of [head].
+  /// Chars still to write across every source.
   int length = 0;
+
+  /// Live chars subject to the runaway-output backlog cap.
+  int liveLength = 0;
+
+  /// Snapshot chars that still have to reach the emulator.
+  int restoreLength = 0;
 
   /// A flush is pending, either as a frame callback or as a deferred timer.
   bool flushScheduled = false;
@@ -36,21 +55,79 @@ class _TerminalOutputPipeline {
   /// produces on its own.
   int flushCount = 0;
 
-  /// Chars left in the head chunk.
-  int get headRemaining => pending.first.length - head;
+  void add(_TerminalOutputSegment segment) {
+    pending.add(segment);
+    length += segment.remaining;
+    switch (segment.source) {
+      case _TerminalOutputSource.restore:
+        restoreLength += segment.remaining;
+        break;
+      case _TerminalOutputSource.control:
+        break;
+      case _TerminalOutputSource.live:
+        liveLength += segment.remaining;
+        break;
+    }
+  }
+
+  void consume(_TerminalOutputSegment segment, int chars) {
+    assert(chars >= 0 && chars <= segment.remaining);
+    if (chars <= 0) {
+      return;
+    }
+    segment.head += chars;
+    length -= chars;
+    switch (segment.source) {
+      case _TerminalOutputSource.restore:
+        restoreLength -= chars;
+        break;
+      case _TerminalOutputSource.control:
+        break;
+      case _TerminalOutputSource.live:
+        liveLength -= chars;
+        break;
+    }
+    if (segment.remaining > 0) {
+      return;
+    }
+    if (pending.isNotEmpty && identical(pending.first, segment)) {
+      pending.removeFirst();
+    } else {
+      pending.remove(segment);
+    }
+  }
+
+  int offsetOf(_TerminalOutputSegment target) {
+    var offset = 0;
+    for (final segment in pending) {
+      if (identical(segment, target)) {
+        return offset;
+      }
+      offset += segment.remaining;
+    }
+    throw StateError('Terminal output segment is not pending.');
+  }
 
   void restartFlushClock() => sinceFlushRequest
     ..reset()
     ..start();
 
   void cancelDeferredFlush() {
-    flushTimer?.cancel();
+    final timer = flushTimer;
+    timer?.cancel();
     flushTimer = null;
+    // A queued frame has no timer and must keep owning the scheduled flush.
+    // Cancelling a timer, however, releases that ownership so replacement
+    // output can schedule itself.
+    if (timer != null) {
+      flushScheduled = false;
+    }
   }
 
   void clear() {
     pending.clear();
-    head = 0;
     length = 0;
+    liveLength = 0;
+    restoreLength = 0;
   }
 }

--- a/lib/src/features/workbench/presentation/terminal_runtime_pointer_synchronization.dart
+++ b/lib/src/features/workbench/presentation/terminal_runtime_pointer_synchronization.dart
@@ -88,8 +88,14 @@ extension _TerminalPointerSynchronization on _XtermTerminalSessionHandle {
     _refreshPointerInputSuspension();
   }
 
-  void _discardPointerInputCatchUp(int chars) {
-    _advancePointerInputCatchUp(chars);
+  void _discardPointerInputCatchUp({required int offset, required int chars}) {
+    if (chars <= 0 || offset >= _pointerInputCatchUpChars) {
+      return;
+    }
+    final prefixRemaining = _pointerInputCatchUpChars - offset;
+    _advancePointerInputCatchUp(
+      chars < prefixRemaining ? chars : prefixRemaining,
+    );
   }
 
   void _resetPointerInputSynchronization() {

--- a/lib/src/features/workbench/presentation/terminal_runtime_restore_progress.dart
+++ b/lib/src/features/workbench/presentation/terminal_runtime_restore_progress.dart
@@ -67,9 +67,12 @@ extension _TerminalRestoreProgressTracking on _XtermTerminalSessionHandle {
     // the same per-frame batcher as live output instead.
     final restored = const Utf8Decoder(allowMalformed: true).convert(data);
     _beginRestore(restored.length);
-    _queueTerminalOutput(restored, bounded: false);
+    _queueTerminalOutput(restored, source: _TerminalOutputSource.restore);
     if (resetInteractionModes) {
-      _queueTerminalOutput(terminalInteractionModeReset, bounded: false);
+      _queueTerminalOutput(
+        terminalInteractionModeReset,
+        source: _TerminalOutputSource.control,
+      );
     }
   }
 }

--- a/lib/src/features/workbench/presentation/terminal_runtime_session_handle.dart
+++ b/lib/src/features/workbench/presentation/terminal_runtime_session_handle.dart
@@ -539,8 +539,10 @@ class _XtermTerminalSessionHandle extends TerminalSessionHandle {
 
   void _writeToTerminal(String data) => _writeSessionTerminal(this, data);
 
-  void _queueTerminalOutput(String data, {bool bounded = true}) =>
-      _queueSessionTerminalOutput(this, data, bounded: bounded);
+  void _queueTerminalOutput(
+    String data, {
+    _TerminalOutputSource source = _TerminalOutputSource.live,
+  }) => _queueSessionTerminalOutput(this, data, source: source);
 
   void _scheduleTerminalOutputFlush() =>
       _scheduleSessionTerminalOutputFlush(this);

--- a/lib/src/features/workbench/presentation/terminal_runtime_testing.dart
+++ b/lib/src/features/workbench/presentation/terminal_runtime_testing.dart
@@ -76,6 +76,14 @@ bool terminalOutputFlushDeferredForTesting(TerminalSessionHandle session) {
 }
 
 @visibleForTesting
+void forceDeferredTerminalOutputFlushForTesting(TerminalSessionHandle session) {
+  final output = (session as _XtermTerminalSessionHandle)._output;
+  output.flushTimer?.cancel();
+  output.flushScheduled = true;
+  output.flushTimer = Timer(const Duration(hours: 1), () {});
+}
+
+@visibleForTesting
 int terminalOutputFlushCountForTesting(TerminalSessionHandle session) {
   return (session as _XtermTerminalSessionHandle)._output.flushCount;
 }
@@ -94,6 +102,16 @@ int pendingTerminalOutputCharsForTesting(TerminalSessionHandle session) {
   return (session as _XtermTerminalSessionHandle)._output.length;
 }
 
+@visibleForTesting
+int pendingLiveTerminalOutputCharsForTesting(TerminalSessionHandle session) {
+  return (session as _XtermTerminalSessionHandle)._output.liveLength;
+}
+
+@visibleForTesting
+int pendingRestoreTerminalOutputCharsForTesting(TerminalSessionHandle session) {
+  return (session as _XtermTerminalSessionHandle)._output.restoreLength;
+}
+
 /// The head chunk itself, so a test can assert it is consumed in place rather
 /// than re-queued as a fresh copy on every drain.
 @visibleForTesting
@@ -101,12 +119,13 @@ String? pendingTerminalOutputHeadChunkForTesting(
   TerminalSessionHandle session,
 ) {
   final pending = (session as _XtermTerminalSessionHandle)._output.pending;
-  return pending.isEmpty ? null : pending.first;
+  return pending.isEmpty ? null : pending.first.text;
 }
 
 @visibleForTesting
 int pendingTerminalOutputHeadForTesting(TerminalSessionHandle session) {
-  return (session as _XtermTerminalSessionHandle)._output.head;
+  final pending = (session as _XtermTerminalSessionHandle)._output.pending;
+  return pending.isEmpty ? 0 : pending.first.head;
 }
 
 @visibleForTesting

--- a/rust/alera-cli/src/terminal_host/client.rs
+++ b/rust/alera-cli/src/terminal_host/client.rs
@@ -1,7 +1,14 @@
+use std::sync::{
+    atomic::{AtomicU64, Ordering},
+    Arc,
+};
+
 use serde_json::Value;
 use tokio::io::{AsyncBufReadExt as _, AsyncWriteExt as _, BufReader};
 use tokio::net::TcpStream;
-use tokio::sync::mpsc::{Receiver, Sender, UnboundedReceiver, UnboundedSender};
+use tokio::sync::mpsc::{
+    error::TryRecvError, Receiver, Sender, UnboundedReceiver, UnboundedSender,
+};
 
 use crate::terminal_host::frame_codec::{encode_json_frame, encode_output_frame};
 use crate::terminal_host::protocol::BINARY_FRAMES_ENABLED_EVENT;
@@ -17,8 +24,24 @@ use crate::terminal_host::server::ServerCommand;
 #[derive(Debug, Clone)]
 pub enum ClientFrame {
     Json(Value),
-    Output { session_id: String, data: Vec<u8> },
+    Output {
+        session_id: String,
+        data: Vec<u8>,
+    },
     UpgradeToBinary,
+    /// Control frames carry the last terminal sequence accepted before them.
+    /// The writer uses it as a causal barrier between snapshot replies and
+    /// output produced after that snapshot.
+    OrderedControl {
+        terminal_watermark: u64,
+        frame: Box<ClientFrame>,
+    },
+    /// Terminal sequence numbers are internal to one connection and never
+    /// appear on the wire.
+    SequencedTerminal {
+        sequence: u64,
+        frame: Box<ClientFrame>,
+    },
 }
 
 impl From<Value> for ClientFrame {
@@ -31,7 +54,7 @@ impl ClientFrame {
     /// The JSON this frame would be on a text-only transport, or None for the
     /// upgrade marker, which has no representation there.
     pub fn as_json(&self) -> Option<Value> {
-        match self {
+        match self.payload() {
             ClientFrame::Json(value) => Some(value.clone()),
             ClientFrame::Output { session_id, data } => {
                 Some(crate::terminal_host::protocol::event(
@@ -43,6 +66,37 @@ impl ClientFrame {
                 ))
             }
             ClientFrame::UpgradeToBinary => None,
+            ClientFrame::OrderedControl { .. } | ClientFrame::SequencedTerminal { .. } => {
+                unreachable!("payload strips internal ordering envelopes")
+            }
+        }
+    }
+
+    fn payload(&self) -> &ClientFrame {
+        let mut frame = self;
+        loop {
+            frame = match frame {
+                ClientFrame::OrderedControl { frame, .. }
+                | ClientFrame::SequencedTerminal { frame, .. } => frame,
+                _ => return frame,
+            };
+        }
+    }
+
+    fn into_control(self) -> (u64, ClientFrame) {
+        match self {
+            ClientFrame::OrderedControl {
+                terminal_watermark,
+                frame,
+            } => (terminal_watermark, *frame),
+            frame => (u64::MAX, frame),
+        }
+    }
+
+    fn into_terminal(self) -> (u64, ClientFrame) {
+        match self {
+            ClientFrame::SequencedTerminal { sequence, frame } => (sequence, *frame),
+            frame => (0, frame),
         }
     }
 }
@@ -51,8 +105,44 @@ impl ClientFrame {
 /// from bounded terminal output so a terminal burst cannot drop RPC responses.
 #[derive(Clone)]
 pub struct ClientHandle {
-    pub control_out: UnboundedSender<ClientFrame>,
-    pub terminal_out: Sender<ClientFrame>,
+    control_out: UnboundedSender<ClientFrame>,
+    terminal_out: Sender<ClientFrame>,
+    terminal_sequence: Arc<AtomicU64>,
+}
+
+impl ClientHandle {
+    pub fn new(
+        control_out: UnboundedSender<ClientFrame>,
+        terminal_out: Sender<ClientFrame>,
+    ) -> Self {
+        Self {
+            control_out,
+            terminal_out,
+            terminal_sequence: Arc::new(AtomicU64::new(0)),
+        }
+    }
+
+    pub fn send_control(
+        &self,
+        frame: ClientFrame,
+    ) -> Result<(), tokio::sync::mpsc::error::SendError<ClientFrame>> {
+        let terminal_watermark = self.terminal_sequence.load(Ordering::SeqCst);
+        self.control_out.send(ClientFrame::OrderedControl {
+            terminal_watermark,
+            frame: Box::new(frame),
+        })
+    }
+
+    pub fn try_send_terminal(
+        &self,
+        frame: ClientFrame,
+    ) -> Result<(), tokio::sync::mpsc::error::TrySendError<ClientFrame>> {
+        let sequence = self.terminal_sequence.fetch_add(1, Ordering::SeqCst) + 1;
+        self.terminal_out.try_send(ClientFrame::SequencedTerminal {
+            sequence,
+            frame: Box::new(frame),
+        })
+    }
 }
 
 #[cfg(test)]
@@ -61,13 +151,7 @@ impl ClientHandle {
         let (control_out, control_out_rx) = tokio::sync::mpsc::unbounded_channel();
         let (terminal_out, _terminal_out_rx) =
             tokio::sync::mpsc::channel(CLIENT_TERMINAL_OUT_QUEUE_CAPACITY);
-        (
-            Self {
-                control_out,
-                terminal_out,
-            },
-            control_out_rx,
-        )
+        (Self::new(control_out, terminal_out), control_out_rx)
     }
 
     /// Keeps the terminal lane receiver alive, so a test can read what was
@@ -77,13 +161,54 @@ impl ClientHandle {
         let (control_out, _control_out_rx) = tokio::sync::mpsc::unbounded_channel();
         let (terminal_out, terminal_out_rx) =
             tokio::sync::mpsc::channel(CLIENT_TERMINAL_OUT_QUEUE_CAPACITY);
-        (
-            Self {
-                control_out,
-                terminal_out,
-            },
-            terminal_out_rx,
-        )
+        (Self::new(control_out, terminal_out), terminal_out_rx)
+    }
+}
+
+#[derive(Default)]
+pub(crate) struct ClientFrameOrdering {
+    pending_terminal: Option<(u64, ClientFrame)>,
+}
+
+impl ClientFrameOrdering {
+    pub(crate) fn stage_terminal(&mut self, frame: ClientFrame) {
+        debug_assert!(self.pending_terminal.is_none());
+        self.pending_terminal = Some(frame.into_terminal());
+    }
+
+    pub(crate) fn take_pending_terminal(&mut self) -> Option<ClientFrame> {
+        self.pending_terminal.take().map(|(_, frame)| frame)
+    }
+
+    pub(crate) fn has_pending_terminal(&self) -> bool {
+        self.pending_terminal.is_some()
+    }
+
+    pub(crate) fn before_control(
+        &mut self,
+        control: ClientFrame,
+        terminal_out_rx: &mut Receiver<ClientFrame>,
+    ) -> (Vec<ClientFrame>, ClientFrame) {
+        let (terminal_watermark, control) = control.into_control();
+        let mut terminal = Vec::new();
+        loop {
+            let next = self.pending_terminal.take().or_else(|| {
+                terminal_out_rx
+                    .try_recv()
+                    .ok()
+                    .map(ClientFrame::into_terminal)
+            });
+            let Some((sequence, frame)) = next else {
+                break;
+            };
+            if sequence <= terminal_watermark {
+                terminal.push(frame);
+            } else {
+                self.pending_terminal = Some((sequence, frame));
+                break;
+            }
+        }
+        (terminal, control)
     }
 }
 
@@ -102,7 +227,42 @@ pub async fn connection_loop(
     let (read_half, mut write_half) = stream.into_split();
     let mut lines = BufReader::new(read_half).lines();
     let mut binary = false;
+    let mut ordering = ClientFrameOrdering::default();
     loop {
+        if ordering.has_pending_terminal() {
+            match control_out_rx.try_recv() {
+                Ok(control) => {
+                    if write_control_frame(
+                        &mut write_half,
+                        control,
+                        &mut terminal_out_rx,
+                        &mut ordering,
+                        &mut binary,
+                    )
+                    .await
+                    .is_err()
+                    {
+                        let _ = inbox.send(ServerCommand::ClientDisconnected { id });
+                        break;
+                    }
+                    continue;
+                }
+                Err(TryRecvError::Empty) => {
+                    let frame = ordering
+                        .take_pending_terminal()
+                        .expect("pending terminal frame just checked");
+                    if write_frame(&mut write_half, frame, &mut binary)
+                        .await
+                        .is_err()
+                    {
+                        let _ = inbox.send(ServerCommand::ClientDisconnected { id });
+                        break;
+                    }
+                    continue;
+                }
+                Err(TryRecvError::Disconnected) => break,
+            }
+        }
         tokio::select! {
             line = lines.next_line() => {
                 match line {
@@ -120,25 +280,16 @@ pub async fn connection_loop(
             }
             message = control_out_rx.recv() => {
                 match message {
-                    Some(value) => {
-                        let queued_terminal_frames = terminal_out_rx.len();
-                        let mut failed = false;
-                        for _ in 0..queued_terminal_frames {
-                            let Ok(terminal_value) = terminal_out_rx.try_recv() else {
-                                break;
-                            };
-                            if write_frame(&mut write_half, terminal_value, &mut binary)
-                                .await
-                                .is_err()
-                            {
-                                failed = true;
-                                break;
-                            }
-                        }
-                        if failed
-                            || write_frame(&mut write_half, value, &mut binary)
-                                .await
-                                .is_err()
+                    Some(control) => {
+                        if write_control_frame(
+                            &mut write_half,
+                            control,
+                            &mut terminal_out_rx,
+                            &mut ordering,
+                            &mut binary,
+                        )
+                        .await
+                        .is_err()
                         {
                             let _ = inbox.send(ServerCommand::ClientDisconnected { id });
                             break;
@@ -150,11 +301,28 @@ pub async fn connection_loop(
             }
             message = terminal_out_rx.recv() => {
                 match message {
-                    Some(value) => {
-                        if write_frame(&mut write_half, value, &mut binary)
-                            .await
-                            .is_err()
-                        {
+                    Some(terminal) => {
+                        ordering.stage_terminal(terminal);
+                        let result = match control_out_rx.try_recv() {
+                            Ok(control) => {
+                                write_control_frame(
+                                    &mut write_half,
+                                    control,
+                                    &mut terminal_out_rx,
+                                    &mut ordering,
+                                    &mut binary,
+                                )
+                                .await
+                            }
+                            Err(TryRecvError::Empty) => {
+                                let frame = ordering
+                                    .take_pending_terminal()
+                                    .expect("terminal frame was just staged");
+                                write_frame(&mut write_half, frame, &mut binary).await
+                            }
+                            Err(TryRecvError::Disconnected) => break,
+                        };
+                        if result.is_err() {
                             let _ = inbox.send(ServerCommand::ClientDisconnected { id });
                             break;
                         }
@@ -166,15 +334,36 @@ pub async fn connection_loop(
     }
 }
 
+async fn write_control_frame(
+    write_half: &mut tokio::net::tcp::OwnedWriteHalf,
+    control: ClientFrame,
+    terminal_out_rx: &mut Receiver<ClientFrame>,
+    ordering: &mut ClientFrameOrdering,
+    binary: &mut bool,
+) -> std::io::Result<()> {
+    let (terminal, control) = ordering.before_control(control, terminal_out_rx);
+    for frame in terminal {
+        write_frame(write_half, frame, binary).await?;
+    }
+    write_frame(write_half, control, binary).await
+}
+
 /// Writes one outbound item, honouring the mode this connection is currently
 /// in. `binary` flips only when an [`ClientFrame::UpgradeToBinary`] is reached
 /// in the stream, which is what keeps the switch ordered against the hello
 /// response.
 async fn write_frame(
     write_half: &mut tokio::net::tcp::OwnedWriteHalf,
-    frame: ClientFrame,
+    mut frame: ClientFrame,
     binary: &mut bool,
 ) -> std::io::Result<()> {
+    loop {
+        frame = match frame {
+            ClientFrame::OrderedControl { frame, .. }
+            | ClientFrame::SequencedTerminal { frame, .. } => *frame,
+            _ => break,
+        };
+    }
     match frame {
         ClientFrame::UpgradeToBinary => {
             // A sentinel line, not a silent flag flip. The reader may live in
@@ -200,6 +389,9 @@ async fn write_frame(
             write_half
                 .write_all(&encode_output_frame(&session_id, &data))
                 .await
+        }
+        ClientFrame::OrderedControl { .. } | ClientFrame::SequencedTerminal { .. } => {
+            unreachable!("ordering envelopes were stripped before writing")
         }
         // A client that never negotiated the capability still gets the base64
         // JSON event it expects.
@@ -240,7 +432,7 @@ mod tests {
     use tokio::net::TcpListener;
 
     #[tokio::test]
-    async fn queued_terminal_frames_keep_causal_order_before_control() {
+    async fn control_response_stays_between_its_causal_terminal_frames() {
         let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
         let address = listener.local_addr().unwrap();
         let client = TcpStream::connect(address).await.unwrap();
@@ -249,12 +441,17 @@ mod tests {
         let (control_tx, control_rx) = tokio::sync::mpsc::unbounded_channel();
         let (terminal_tx, terminal_rx) =
             tokio::sync::mpsc::channel(CLIENT_TERMINAL_OUT_QUEUE_CAPACITY);
+        let handle = ClientHandle::new(control_tx, terminal_tx);
 
-        terminal_tx
-            .send(json!({"event": "output"}).into())
-            .await
+        handle
+            .try_send_terminal(json!({"event": "output-a"}).into())
             .unwrap();
-        control_tx.send(json!({"event": "exit"}).into()).unwrap();
+        handle
+            .send_control(json!({"response": "attachment"}).into())
+            .unwrap();
+        handle
+            .try_send_terminal(json!({"event": "output-b"}).into())
+            .unwrap();
         let task = tokio::spawn(connection_loop(server, 1, inbox, control_rx, terminal_rx));
         let mut lines = BufReader::new(client).lines();
 
@@ -262,11 +459,13 @@ mod tests {
             serde_json::from_str(&lines.next_line().await.unwrap().unwrap()).unwrap();
         let second: Value =
             serde_json::from_str(&lines.next_line().await.unwrap().unwrap()).unwrap();
-        assert_eq!(first["event"], json!("output"));
-        assert_eq!(second["event"], json!("exit"));
+        let third: Value =
+            serde_json::from_str(&lines.next_line().await.unwrap().unwrap()).unwrap();
+        assert_eq!(first["event"], json!("output-a"));
+        assert_eq!(second["response"], json!("attachment"));
+        assert_eq!(third["event"], json!("output-b"));
 
-        drop(control_tx);
-        drop(terminal_tx);
+        drop(handle);
         task.await.unwrap();
     }
 }

--- a/rust/alera-cli/src/terminal_host/mobile_gateway.rs
+++ b/rust/alera-cli/src/terminal_host/mobile_gateway.rs
@@ -5,12 +5,12 @@ use std::sync::{
 
 use futures_util::{stream::SplitSink, SinkExt as _, StreamExt as _};
 use tokio::net::{TcpListener, TcpStream};
-use tokio::sync::mpsc::{self, Receiver, UnboundedReceiver, UnboundedSender};
+use tokio::sync::mpsc::{self, error::TryRecvError, Receiver, UnboundedReceiver, UnboundedSender};
 use tokio::task::JoinHandle;
 use tokio_tungstenite::{accept_async, tungstenite::Message};
 
 use crate::terminal_host::client::{
-    ClientFrame, ClientHandle, MOBILE_CLIENT_TERMINAL_OUT_QUEUE_CAPACITY,
+    ClientFrame, ClientFrameOrdering, ClientHandle, MOBILE_CLIENT_TERMINAL_OUT_QUEUE_CAPACITY,
 };
 use crate::terminal_host::frame_codec::encode_output_payload;
 use crate::terminal_host::server::{ClientKind, ServerCommand};
@@ -45,10 +45,7 @@ async fn accept_mobile_connection(
         mpsc::channel::<ClientFrame>(MOBILE_CLIENT_TERMINAL_OUT_QUEUE_CAPACITY);
     inbox.send(ServerCommand::ClientConnected {
         id,
-        handle: ClientHandle {
-            control_out: control_out_tx,
-            terminal_out: terminal_out_tx,
-        },
+        handle: ClientHandle::new(control_out_tx, terminal_out_tx),
         kind: ClientKind::Mobile,
     })?;
     mobile_websocket_loop(socket, id, inbox, control_out_rx, terminal_out_rx).await;
@@ -64,7 +61,42 @@ async fn mobile_websocket_loop(
 ) {
     let (mut write, mut read) = socket.split();
     let mut binary = false;
+    let mut ordering = ClientFrameOrdering::default();
     loop {
+        if ordering.has_pending_terminal() {
+            match control_out_rx.try_recv() {
+                Ok(control) => {
+                    if send_mobile_control_frame(
+                        &mut write,
+                        control,
+                        &mut terminal_out_rx,
+                        &mut ordering,
+                        &mut binary,
+                    )
+                    .await
+                    .is_err()
+                    {
+                        let _ = inbox.send(ServerCommand::ClientDisconnected { id });
+                        break;
+                    }
+                    continue;
+                }
+                Err(TryRecvError::Empty) => {
+                    let frame = ordering
+                        .take_pending_terminal()
+                        .expect("pending terminal frame just checked");
+                    if send_mobile_value(&mut write, &frame, &mut binary)
+                        .await
+                        .is_err()
+                    {
+                        let _ = inbox.send(ServerCommand::ClientDisconnected { id });
+                        break;
+                    }
+                    continue;
+                }
+                Err(TryRecvError::Disconnected) => break,
+            }
+        }
         tokio::select! {
             inbound = read.next() => {
                 match inbound {
@@ -98,21 +130,16 @@ async fn mobile_websocket_loop(
             }
             outbound = control_out_rx.recv() => {
                 match outbound {
-                    Some(value) => {
-                        let queued_terminal_frames = terminal_out_rx.len();
-                        let mut failed = false;
-                        for _ in 0..queued_terminal_frames {
-                            let Ok(terminal_value) = terminal_out_rx.try_recv() else {
-                                break;
-                            };
-                            if send_mobile_value(&mut write, &terminal_value, &mut binary)
-                                .await
-                                .is_err() {
-                                failed = true;
-                                break;
-                            }
-                        }
-                        if failed || send_mobile_value(&mut write, &value, &mut binary).await.is_err() {
+                    Some(control) => {
+                        if send_mobile_control_frame(
+                            &mut write,
+                            control,
+                            &mut terminal_out_rx,
+                            &mut ordering,
+                            &mut binary,
+                        )
+                        .await
+                        .is_err() {
                             let _ = inbox.send(ServerCommand::ClientDisconnected { id });
                             break;
                         }
@@ -122,8 +149,28 @@ async fn mobile_websocket_loop(
             }
             outbound = terminal_out_rx.recv() => {
                 match outbound {
-                    Some(value) => {
-                        if send_mobile_value(&mut write, &value, &mut binary).await.is_err() {
+                    Some(terminal) => {
+                        ordering.stage_terminal(terminal);
+                        let result = match control_out_rx.try_recv() {
+                            Ok(control) => {
+                                send_mobile_control_frame(
+                                    &mut write,
+                                    control,
+                                    &mut terminal_out_rx,
+                                    &mut ordering,
+                                    &mut binary,
+                                )
+                                .await
+                            }
+                            Err(TryRecvError::Empty) => {
+                                let frame = ordering
+                                    .take_pending_terminal()
+                                    .expect("terminal frame was just staged");
+                                send_mobile_value(&mut write, &frame, &mut binary).await
+                            }
+                            Err(TryRecvError::Disconnected) => break,
+                        };
+                        if result.is_err() {
                             let _ = inbox.send(ServerCommand::ClientDisconnected { id });
                             break;
                         }
@@ -133,6 +180,20 @@ async fn mobile_websocket_loop(
             }
         }
     }
+}
+
+async fn send_mobile_control_frame(
+    write: &mut SplitSink<tokio_tungstenite::WebSocketStream<TcpStream>, Message>,
+    control: ClientFrame,
+    terminal_out_rx: &mut Receiver<ClientFrame>,
+    ordering: &mut ClientFrameOrdering,
+    binary: &mut bool,
+) -> anyhow::Result<()> {
+    let (terminal, control) = ordering.before_control(control, terminal_out_rx);
+    for frame in &terminal {
+        send_mobile_value(write, frame, binary).await?;
+    }
+    send_mobile_value(write, &control, binary).await
 }
 
 /// Sends one frame over the WebSocket.
@@ -165,4 +226,50 @@ async fn send_mobile_value(
     let text = serde_json::to_string(&value)?;
     write.send(Message::Text(text.into())).await?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::{json, Value};
+    use tokio_tungstenite::connect_async;
+
+    #[tokio::test]
+    async fn control_response_stays_between_mobile_terminal_frames() {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let (inbox, _inbox_rx) = mpsc::unbounded_channel();
+        let (control_tx, control_rx) = mpsc::unbounded_channel();
+        let (terminal_tx, terminal_rx) = mpsc::channel(MOBILE_CLIENT_TERMINAL_OUT_QUEUE_CAPACITY);
+        let handle = ClientHandle::new(control_tx, terminal_tx);
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let socket = accept_async(stream).await.unwrap();
+            mobile_websocket_loop(socket, 1, inbox, control_rx, terminal_rx).await;
+        });
+        let (mut client, _) = connect_async(format!("ws://{address}")).await.unwrap();
+
+        handle
+            .try_send_terminal(json!({"event": "output-a"}).into())
+            .unwrap();
+        handle
+            .send_control(json!({"response": "attachment"}).into())
+            .unwrap();
+        handle
+            .try_send_terminal(json!({"event": "output-b"}).into())
+            .unwrap();
+
+        let mut frames = Vec::new();
+        for _ in 0..3 {
+            let message = client.next().await.unwrap().unwrap();
+            let text = message.into_text().unwrap();
+            frames.push(serde_json::from_str::<Value>(&text).unwrap());
+        }
+        assert_eq!(frames[0]["event"], json!("output-a"));
+        assert_eq!(frames[1]["response"], json!("attachment"));
+        assert_eq!(frames[2]["event"], json!("output-b"));
+
+        drop(handle);
+        server.await.unwrap();
+    }
 }

--- a/rust/alera-cli/src/terminal_host/server/client_accept_loop.rs
+++ b/rust/alera-cli/src/terminal_host/server/client_accept_loop.rs
@@ -28,10 +28,7 @@ pub(super) fn spawn_accept_loop(
             if inbox
                 .send(ServerCommand::ClientConnected {
                     id,
-                    handle: ClientHandle {
-                        control_out: control_out_tx,
-                        terminal_out: terminal_out_tx,
-                    },
+                    handle: ClientHandle::new(control_out_tx, terminal_out_tx),
                     kind: ClientKind::Local,
                 })
                 .is_err()

--- a/rust/alera-cli/src/terminal_host/server/client_delivery.rs
+++ b/rust/alera-cli/src/terminal_host/server/client_delivery.rs
@@ -55,8 +55,7 @@ impl ServerActor {
         if let Some(client) = self.clients.get(&client_id) {
             if client
                 .handle
-                .control_out
-                .send(ClientFrame::UpgradeToBinary)
+                .send_control(ClientFrame::UpgradeToBinary)
                 .is_err()
             {
                 self.disconnect_client_soon(client_id);
@@ -66,7 +65,7 @@ impl ServerActor {
 
     pub(super) fn client_write(&self, client_id: u64, message: Value) {
         if let Some(client) = self.clients.get(&client_id) {
-            if client.handle.control_out.send(message.into()).is_err() {
+            if client.handle.send_control(message.into()).is_err() {
                 self.disconnect_client_soon(client_id);
             }
         }
@@ -75,12 +74,7 @@ impl ServerActor {
     pub(super) fn broadcast(&self, client_ids: &[u64], message: Value) {
         for id in client_ids {
             if let Some(client) = self.clients.get(id) {
-                if client
-                    .handle
-                    .control_out
-                    .send(message.clone().into())
-                    .is_err()
-                {
+                if client.handle.send_control(message.clone().into()).is_err() {
                     self.disconnect_client_soon(*id);
                 }
             }
@@ -89,13 +83,7 @@ impl ServerActor {
 
     pub(super) fn broadcast_authenticated(&self, message: Value) {
         for (client_id, client) in &self.clients {
-            if client.authenticated
-                && client
-                    .handle
-                    .control_out
-                    .send(message.clone().into())
-                    .is_err()
-            {
+            if client.authenticated && client.handle.send_control(message.clone().into()).is_err() {
                 self.disconnect_client_soon(*client_id);
             }
         }
@@ -105,11 +93,7 @@ impl ServerActor {
         for (client_id, client) in &self.clients {
             if client.authenticated
                 && client.kind == ClientKind::Mobile
-                && client
-                    .handle
-                    .control_out
-                    .send(message.clone().into())
-                    .is_err()
+                && client.handle.send_control(message.clone().into()).is_err()
             {
                 self.disconnect_client_soon(*client_id);
             }
@@ -156,10 +140,7 @@ mod tests {
             clients: HashMap::from([(
                 1,
                 ClientState {
-                    handle: ClientHandle {
-                        control_out,
-                        terminal_out,
-                    },
+                    handle: ClientHandle::new(control_out, terminal_out),
                     authenticated: true,
                     binary_frames: false,
                     kind: ClientKind::Local,

--- a/rust/alera-cli/src/terminal_host/server/output_delivery.rs
+++ b/rust/alera-cli/src/terminal_host/server/output_delivery.rs
@@ -44,7 +44,7 @@ impl ServerActor {
         let result = self
             .clients
             .get(&client_id)
-            .map(|client| client.handle.terminal_out.try_send(frame));
+            .map(|client| client.handle.try_send_terminal(frame));
         match result {
             Some(Ok(())) => {
                 if let Some(session) = self.sessions.get_mut(session_id) {
@@ -151,7 +151,7 @@ impl ServerActor {
         let result = self
             .clients
             .get(&client_id)
-            .map(|client| client.handle.terminal_out.try_send(frame.clone().into()));
+            .map(|client| client.handle.try_send_terminal(frame.clone().into()));
         match result {
             Some(Ok(())) => {
                 if let Some(session) = self.sessions.get_mut(&session_id) {

--- a/rust/alera-cli/src/terminal_host/server/output_resume_tests.rs
+++ b/rust/alera-cli/src/terminal_host/server/output_resume_tests.rs
@@ -63,7 +63,11 @@ async fn resume_serves_only_the_bytes_the_client_missed() {
     assert_eq!(payload.get("snapshotBase64"), None);
     let _ = terminal_rx.try_recv().expect("the delivered hello");
     let missed = terminal_rx.try_recv().expect("the resume delta");
-    assert!(matches!(missed, ClientFrame::Output { ref data, .. } if data == b" world"));
+    assert!(matches!(
+        missed,
+        ClientFrame::SequencedTerminal { frame, .. }
+            if matches!(*frame, ClientFrame::Output { ref data, .. } if data == b" world")
+    ));
     let session = &actor.sessions["s1"];
     assert_eq!(session.delivered_output_cursor(2), Some(11));
     assert_eq!(session.output_clients(), vec![2]);

--- a/test/unit/terminal_runtime_snapshot_cases.dart
+++ b/test/unit/terminal_runtime_snapshot_cases.dart
@@ -1,5 +1,17 @@
 part of 'terminal_runtime_native_test.dart';
 
+String _terminalRestorePayload(int length, String suffix) {
+  const control = '\x1b[0m';
+  final bodyLength = length - suffix.length;
+  assert(bodyLength >= 0);
+  final controls = List<String>.filled(
+    bodyLength ~/ control.length,
+    control,
+  ).join();
+  final padding = List<String>.filled(bodyLength - controls.length, ' ').join();
+  return '$controls$padding$suffix';
+}
+
 void _registerTerminalRuntimeSnapshotTests() {
   test(
     'pauses hidden terminal output and restores from snapshots when visible',
@@ -127,6 +139,194 @@ void _registerTerminalRuntimeSnapshotTests() {
 
       expect(terminalPointerInputSuspendedForTesting(session), isFalse);
       expect(terminalMouseModeForTesting(session), isNot(xterm.MouseMode.none));
+    } finally {
+      visibility.dispose();
+      debugDefaultTargetPlatformOverride = null;
+    }
+  });
+
+  test('live output cannot evict a restore before its first flush', () async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+    final fakeSession = _FakeTerminalPtySession();
+    final runtime = XtermTerminalRuntime(
+      ptySessionFactory: _FakeTerminalPtySessionFactory(
+        sessions: <_FakeTerminalPtySession>[fakeSession],
+      ),
+      shellLaunchesBuilder: () => <GhosttyTerminalShellLaunch>[
+        _launch('shell', shell: '/bin/sh'),
+      ],
+    );
+    addTearDown(runtime.dispose);
+    final session = runtime.sessionFor(workspace: _workspace(), tab: _tab());
+    final visibility = acquireTerminalVisibilityForTesting(session);
+    try {
+      await session.ensureStarted();
+      const snapshotLength = 64 * 1024 * 18;
+      const snapshotMarker = 'snapshot-tail-marker';
+      const liveMarker = 'live-tail-marker';
+      final snapshot = _terminalRestorePayload(
+        snapshotLength,
+        '\r\n$snapshotMarker\r\n',
+      );
+
+      fakeSession.emitSnapshot(utf8.encode(snapshot));
+      await Future<void>.delayed(Duration.zero);
+      fakeSession.emitOutput(utf8.encode('$liveMarker\r\n'));
+      await Future<void>.delayed(Duration.zero);
+
+      expect(
+        pendingRestoreTerminalOutputCharsForTesting(session),
+        snapshotLength,
+      );
+      expect(
+        pendingLiveTerminalOutputCharsForTesting(session),
+        '$liveMarker\r\n'.length,
+      );
+      expect(session.restoreProgress.value?.totalChars, snapshotLength);
+
+      while (pendingRestoreTerminalOutputCharsForTesting(session) > 0) {
+        flushTerminalOutputForTesting(session);
+        final remaining = pendingRestoreTerminalOutputCharsForTesting(session);
+        final progress = session.restoreProgress.value;
+        if (remaining == 0) {
+          expect(progress, isNull);
+        } else {
+          expect(progress, isNotNull);
+          expect(progress!.writtenChars + remaining, snapshotLength);
+        }
+      }
+
+      expect(
+        pendingLiveTerminalOutputCharsForTesting(session),
+        '$liveMarker\r\n'.length,
+      );
+      while (pendingTerminalOutputCharsForTesting(session) > 0) {
+        flushTerminalOutputForTesting(session);
+      }
+      final text = terminalBufferTextForTesting(session);
+      expect(text, contains(snapshotMarker));
+      expect(text, contains(liveMarker));
+      expect(text.indexOf(snapshotMarker), lessThan(text.indexOf(liveMarker)));
+    } finally {
+      visibility.dispose();
+      debugDefaultTargetPlatformOverride = null;
+    }
+  });
+
+  test(
+    'backpressure trims only live output during a partial restore',
+    () async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+      final fakeSession = _FakeTerminalPtySession();
+      final runtime = XtermTerminalRuntime(
+        ptySessionFactory: _FakeTerminalPtySessionFactory(
+          sessions: <_FakeTerminalPtySession>[fakeSession],
+        ),
+        shellLaunchesBuilder: () => <GhosttyTerminalShellLaunch>[
+          _launch('shell', shell: '/bin/sh'),
+        ],
+      );
+      addTearDown(runtime.dispose);
+      final session = runtime.sessionFor(workspace: _workspace(), tab: _tab());
+      final visibility = acquireTerminalVisibilityForTesting(session);
+      try {
+        await session.ensureStarted();
+        const snapshotLength = 64 * 1024 * 18;
+        const snapshotMarker = 'protected-snapshot-marker';
+        const oldLiveMarker = 'discarded-live-marker';
+        const newLiveMarker = 'retained-live-marker';
+        final snapshot = _terminalRestorePayload(
+          snapshotLength,
+          '\r\n$snapshotMarker\r\n\x1b[?1000h\x1b[?2004h',
+        );
+
+        fakeSession.emitSnapshot(
+          utf8.encode(snapshot),
+          resetInteractionModes: true,
+        );
+        await Future<void>.delayed(Duration.zero);
+        flushTerminalOutputForTesting(session);
+        final restoreAfterFirstFlush =
+            pendingRestoreTerminalOutputCharsForTesting(session);
+
+        const oldLivePrefix = '$oldLiveMarker\r\n';
+        final oldLive =
+            oldLivePrefix +
+            _terminalRestorePayload(128 * 1024 - oldLivePrefix.length, '');
+        final newLive = _terminalRestorePayload(
+          1200 * 1024,
+          '$newLiveMarker\r\n',
+        );
+        fakeSession.emitOutput(utf8.encode(oldLive));
+        fakeSession.emitOutput(utf8.encode(newLive));
+        await Future<void>.delayed(Duration.zero);
+
+        expect(
+          pendingRestoreTerminalOutputCharsForTesting(session),
+          restoreAfterFirstFlush,
+        );
+        expect(
+          pendingLiveTerminalOutputCharsForTesting(session),
+          lessThanOrEqualTo(1024 * 1024),
+        );
+        expect(terminalPointerInputSuspendedForTesting(session), isTrue);
+
+        while (pendingRestoreTerminalOutputCharsForTesting(session) > 0) {
+          flushTerminalOutputForTesting(session);
+        }
+        expect(session.restoreProgress.value, isNull);
+        expect(terminalPointerInputSuspendedForTesting(session), isTrue);
+
+        while (pendingTerminalOutputCharsForTesting(session) > 0) {
+          flushTerminalOutputForTesting(session);
+        }
+
+        final text = terminalBufferTextForTesting(session);
+        expect(terminalPointerInputSuspendedForTesting(session), isFalse);
+        expect(text, contains(snapshotMarker));
+        expect(text, isNot(contains(oldLiveMarker)));
+        expect(text, contains(newLiveMarker));
+        expect(terminalMouseModeForTesting(session), xterm.MouseMode.none);
+        expect(terminalBracketedPasteModeForTesting(session), isFalse);
+      } finally {
+        visibility.dispose();
+        debugDefaultTargetPlatformOverride = null;
+      }
+    },
+  );
+
+  testWidgets('a snapshot reschedules the deferred flush it replaces', (
+    tester,
+  ) async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+    final fakeSession = _FakeTerminalPtySession();
+    final runtime = XtermTerminalRuntime(
+      ptySessionFactory: _FakeTerminalPtySessionFactory(
+        sessions: <_FakeTerminalPtySession>[fakeSession],
+      ),
+      shellLaunchesBuilder: () => <GhosttyTerminalShellLaunch>[
+        _launch('shell', shell: '/bin/sh'),
+      ],
+    );
+    addTearDown(runtime.dispose);
+    final session = runtime.sessionFor(workspace: _workspace(), tab: _tab());
+    final visibility = acquireTerminalVisibilityForTesting(session);
+    try {
+      await session.ensureStarted();
+      queueTerminalOutputForTesting(session, 'first');
+      await tester.pump();
+      expect(pendingTerminalOutputCharsForTesting(session), 0);
+      queueTerminalOutputForTesting(session, 'pending before replacement');
+      forceDeferredTerminalOutputFlushForTesting(session);
+      expect(terminalOutputFlushDeferredForTesting(session), isTrue);
+
+      const replacement = 'replacement snapshot';
+      fakeSession.emitSnapshot(utf8.encode(replacement));
+      await tester.pump(terminalOutputMinFlushIntervalForTesting * 2);
+
+      expect(pendingRestoreTerminalOutputCharsForTesting(session), 0);
+      expect(session.restoreProgress.value, isNull);
+      expect(terminalBufferTextForTesting(session), contains(replacement));
     } finally {
       visibility.dispose();
       debugDefaultTargetPlatformOverride = null;


### PR DESCRIPTION
## Summary

- protect restore and control segments from live-output backpressure
- keep terminal output causally ordered around attachment responses on TCP and WebSocket
- add restore regressions, a reproducible benchmark, and performance documentation

## Validation

- flutter analyze
- CI=true flutter test
- make rust-test
- flutter test integration_test/terminal_restore_benchmark.dart -d linux (5/5 samples below 3 seconds; 1.404 seconds maximum)

## Notes

- no terminal-host protocol version bump or wire-schema change
- larger user-configured restore histories remain preserved and scale with payload size