### PR TITLE
fix: collapse new tab actions into a plus menu

### DIFF
--- a/integration_test/alera_smoke_flow_test.dart
+++ b/integration_test/alera_smoke_flow_test.dart
@@ -126,10 +126,12 @@ void main() {
     await tester.ensureVisible(workspaceRow);
     await tester.pumpAndSettle();
     await tester.tap(workspaceRow);
-    await _pumpUntilFound(tester, find.byTooltip('New Terminal'));
+    await _pumpUntilFound(tester, find.byTooltip('New Tab'));
     await _pumpUntilFound(tester, find.text('E2E terminal: Terminal 1'));
 
-    await tester.tap(find.byTooltip('New Terminal').first);
+    await tester.tap(find.byTooltip('New Tab').first);
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('New Terminal'));
     await _pumpUntilFound(tester, find.text('E2E terminal: Terminal 2'));
 
     expect(

--- a/lib/src/features/workbench/presentation/workspace_workbench_tab_strip.dart
+++ b/lib/src/features/workbench/presentation/workspace_workbench_tab_strip.dart
@@ -138,11 +138,11 @@ class _WorkspaceTabStripState extends State<_WorkspaceTabStrip> {
   @override
   Widget build(BuildContext context) {
     WidgetsBinding.instance.addPostFrameCallback((_) => _syncOverflow());
-    final addButton = _NewTerminalButton(onPressed: widget.onCreateTab);
-    final browserButton = widget.onCreateBrowserTab == null
-        ? null
-        : _NewBrowserButton(onPressed: widget.onCreateBrowserTab!);
-    final emulatorButton = _NewMobileEmulatorButton(groupId: widget.groupId);
+    final addButton = _NewTabButton(
+      groupId: widget.groupId,
+      onCreateTab: widget.onCreateTab,
+      onCreateBrowserTab: widget.onCreateBrowserTab,
+    );
     return ColoredBox(
       color: AleraTokens.surface,
       child: _TabStripAppendDropTarget(
@@ -205,11 +205,7 @@ class _WorkspaceTabStripState extends State<_WorkspaceTabStrip> {
                             onSplit: widget.onSplitGroup,
                           ),
                         ),
-                      if (!_hasOverflow) ...<Widget>[
-                        emulatorButton,
-                        addButton,
-                        ?browserButton,
-                      ],
+                      if (!_hasOverflow) addButton,
                     ],
                   ),
                 ),
@@ -217,14 +213,7 @@ class _WorkspaceTabStripState extends State<_WorkspaceTabStrip> {
               if (_hasOverflow)
                 Padding(
                   padding: const EdgeInsets.only(right: AleraTokens.space8),
-                  child: Row(
-                    mainAxisSize: MainAxisSize.min,
-                    children: <Widget>[
-                      emulatorButton,
-                      addButton,
-                      ?browserButton,
-                    ],
-                  ),
+                  child: addButton,
                 ),
               _PaneMenuButton(
                 canCloseSplit: widget.canCloseSplit,
@@ -380,62 +369,98 @@ class _SplitDirectionPainter extends CustomPainter {
   }
 }
 
-class _NewTerminalButton extends StatelessWidget {
-  const _NewTerminalButton({required this.onPressed});
+enum _NewTabMenuAction { terminal, browser, mobileEmulator }
 
-  final VoidCallback onPressed;
+class _NewTabButton extends StatelessWidget {
+  const _NewTabButton({
+    required this.groupId,
+    required this.onCreateTab,
+    required this.onCreateBrowserTab,
+  });
+
+  final String groupId;
+  final VoidCallback onCreateTab;
+  final VoidCallback? onCreateBrowserTab;
+
+  Future<void> _openMenu(BuildContext context) async {
+    final onOpenMobileEmulator = _MobileEmulatorOpenScope.maybeOf(context);
+    final button = context.findRenderObject()! as RenderBox;
+    final overlay =
+        Navigator.of(context).overlay!.context.findRenderObject()! as RenderBox;
+    final topLeft = button.localToGlobal(
+      button.size.bottomLeft(Offset.zero),
+      ancestor: overlay,
+    );
+    final bottomRight = button.localToGlobal(
+      button.size.bottomRight(Offset.zero),
+      ancestor: overlay,
+    );
+    final selected = await showMenu<_NewTabMenuAction>(
+      context: context,
+      position: RelativeRect.fromRect(
+        Rect.fromPoints(topLeft, bottomRight),
+        Offset.zero & overlay.size,
+      ),
+      items: <PopupMenuEntry<_NewTabMenuAction>>[
+        const AleraDropdownEntry<_NewTabMenuAction>(
+          value: _NewTabMenuAction.terminal,
+          label: 'New Terminal',
+          leading: Icon(
+            AleraIcons.terminal,
+            size: 16,
+            color: AleraTokens.foregroundMuted,
+          ),
+        ),
+        if (onCreateBrowserTab != null)
+          const AleraDropdownEntry<_NewTabMenuAction>(
+            value: _NewTabMenuAction.browser,
+            label: 'New Browser Tab',
+            leading: Icon(
+              AleraIcons.public,
+              size: 16,
+              color: AleraTokens.foregroundMuted,
+            ),
+          ),
+        AleraDropdownEntry<_NewTabMenuAction>(
+          value: _NewTabMenuAction.mobileEmulator,
+          label: 'New Mobile Emulator',
+          enabled: onOpenMobileEmulator != null,
+          leading: const Icon(
+            AleraIcons.mobileDevice,
+            size: 16,
+            color: AleraTokens.foregroundMuted,
+          ),
+        ),
+      ],
+    );
+
+    if (selected == null) {
+      return;
+    }
+
+    switch (selected) {
+      case _NewTabMenuAction.terminal:
+        onCreateTab();
+      case _NewTabMenuAction.browser:
+        onCreateBrowserTab?.call();
+      case _NewTabMenuAction.mobileEmulator:
+        final open = onOpenMobileEmulator;
+        if (open != null) {
+          unawaited(open(targetGroupId: groupId));
+        }
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
     return AleraIconButton(
-      tooltip: 'New Terminal',
+      tooltip: 'New Tab',
       icon: AleraIcons.add,
       iconSize: 16,
       minSize: 28,
       hoverColor: AleraTokens.surfaceElevated,
       borderRadius: AleraTokens.radiusSm,
-      onPressed: onPressed,
-    );
-  }
-}
-
-class _NewBrowserButton extends StatelessWidget {
-  const _NewBrowserButton({required this.onPressed});
-
-  final VoidCallback onPressed;
-
-  @override
-  Widget build(BuildContext context) {
-    return AleraIconButton(
-      tooltip: 'New Browser Tab',
-      icon: AleraIcons.public,
-      iconSize: AleraTokens.space16,
-      minSize: AleraTokens.space24 + AleraTokens.space4,
-      hoverColor: AleraTokens.surfaceElevated,
-      borderRadius: AleraTokens.radiusSm,
-      onPressed: onPressed,
-    );
-  }
-}
-
-class _NewMobileEmulatorButton extends StatelessWidget {
-  const _NewMobileEmulatorButton({required this.groupId});
-
-  final String groupId;
-
-  @override
-  Widget build(BuildContext context) {
-    final onOpen = _MobileEmulatorOpenScope.maybeOf(context);
-    return AleraIconButton(
-      tooltip: 'Open Mobile Emulator',
-      icon: AleraIcons.mobileDevice,
-      iconSize: 16,
-      minSize: 28,
-      hoverColor: AleraTokens.surfaceElevated,
-      borderRadius: AleraTokens.radiusSm,
-      onPressed: onOpen == null
-          ? null
-          : () => unawaited(onOpen(targetGroupId: groupId)),
+      onPressed: () => unawaited(_openMenu(context)),
     );
   }
 }

--- a/test/widget/alera_shell_page_workbench_test_cases.dart
+++ b/test/widget/alera_shell_page_workbench_test_cases.dart
@@ -6,7 +6,7 @@ void _registerAleraShellWorkbenchTests() {
   ) async {
     await _pumpShell(tester, state: _populatedWorkbenchState());
 
-    expect(find.byTooltip('New Terminal'), findsOneWidget);
+    expect(find.byTooltip('New Tab'), findsOneWidget);
     expect(find.text('New Terminal'), findsNothing);
     expect(
       find.byKey(const ValueKey<String>('fake-terminal-tab-1')),
@@ -59,7 +59,7 @@ void _registerAleraShellWorkbenchTests() {
   ) async {
     await _pumpShell(tester, state: _splitWorkbenchState());
 
-    expect(find.byTooltip('New Terminal'), findsNWidgets(2));
+    expect(find.byTooltip('New Tab'), findsNWidgets(2));
     expect(
       find.byKey(const ValueKey<String>('fake-terminal-tab-1')),
       findsOneWidget,
@@ -106,7 +106,7 @@ void _registerAleraShellWorkbenchTests() {
 
     final tabs = find.byWidgetPredicate((widget) => widget is Draggable);
     expect(tabs, findsNWidgets(2));
-    expect(find.byTooltip('New Terminal'), findsOneWidget);
+    expect(find.byTooltip('New Tab'), findsOneWidget);
 
     final secondTabStart = tester.getTopLeft(tabs.at(1)) + const Offset(24, 20);
     final terminalRect = tester.getRect(
@@ -122,7 +122,7 @@ void _registerAleraShellWorkbenchTests() {
     await gesture.up();
     await tester.pumpAndSettle();
 
-    expect(find.byTooltip('New Terminal'), findsNWidgets(2));
+    expect(find.byTooltip('New Tab'), findsNWidgets(2));
     expect(
       find.byKey(const ValueKey<String>('fake-terminal-tab-1')),
       findsOneWidget,
@@ -188,7 +188,7 @@ void _registerAleraShellWorkbenchTests() {
     expect(find.text('Quick Start'), findsOneWidget);
     expect(find.text('Keyboard Shortcuts'), findsOneWidget);
     expect(find.text('Projects & Workspaces'), findsNothing);
-    expect(find.byTooltip('New Terminal'), findsNothing);
+    expect(find.byTooltip('New Tab'), findsNothing);
   });
 
   testWidgets('terminal exit closes its tab and activates the remaining tab', (
@@ -256,7 +256,9 @@ void _registerAleraShellWorkbenchTests() {
   ) async {
     final harness = await _pumpShell(tester, state: _populatedWorkbenchState());
 
-    await tester.tap(find.byTooltip('New Terminal'));
+    await tester.tap(find.byTooltip('New Tab'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('New Terminal'));
     // First pump runs the await chain; the second pump runs the
     // post-frame callback that requestFocus() defers to.
     await tester.pump();

--- a/test/widget/workspace_workbench_view_pane_test_cases.dart
+++ b/test/widget/workspace_workbench_view_pane_test_cases.dart
@@ -400,10 +400,14 @@ void _registerWorkspaceWorkbenchViewPaneTests() {
       updatedRatios: updatedRatios,
     );
 
-    await tester.tap(find.byTooltip('New Terminal'));
-    await tester.pump();
-    await tester.tap(find.byTooltip('New Browser Tab'));
-    await tester.pump();
+    await tester.tap(find.byTooltip('New Tab'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('New Terminal'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byTooltip('New Tab'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('New Browser Tab'));
+    await tester.pumpAndSettle();
     await tester.tap(find.text('Terminal 1'));
     await tester.pump();
 


### PR DESCRIPTION
## Summary
- Replace the separate New Terminal, New Browser Tab, and Mobile Emulator tab-strip buttons with a single `+` control.
- Open a menu on click with New Terminal, New Browser Tab, then New Mobile Emulator, matching Orca's new-tab flow.
- Update widget and smoke tests for the new interaction.

## Test plan
- [ ] Open a workspace and confirm the tab strip shows one `+` button instead of three create actions.
- [ ] Click `+` and verify menu order: New Terminal, New Browser Tab, New Mobile Emulator.
- [ ] Create each tab type from the menu and confirm focus/selection behave as before.
- [ ] With split panes, confirm each pane still has its own `+` menu.
- [ ] Confirm CI widget/smoke coverage for the new menu path passes.


Made with [Cursor](https://cursor.com)