### PR TITLE
feat: add blog with content collections and rss feed

### DIFF
--- a/landing/AGENTS.md
+++ b/landing/AGENTS.md
@@ -14,12 +14,19 @@ This document defines governance only. It does not change runtime APIs, schemas,
 - `astro.config.mjs` MUST keep `output: 'static'` and the canonical site URL `https://alera.build`.
 - Use the existing landing structure before adding new patterns:
   - `src/pages/*.astro` for page composition: `index.astro` is the marketing home, `download.astro` is the install page, and the trust documents live at `privacy.astro`, `terms.astro`, and `account/delete.astro`.
+  - `src/pages/blog/index.astro` is the blog index, and `src/pages/blog/[id].astro` renders individual posts from the `blog` content collection.
+  - `src/pages/rss.xml.ts` emits the blog RSS feed at `/rss.xml`.
+  - `src/content.config.ts` defines the `blog` content collection (Zod schema + `glob` loader). Posts live as Markdown files under `src/content/blog/`.
+  - `src/lib/blog.ts` holds shared blog helpers (`getPublishedBlogPosts`, date formatting). Draft posts (`draft: true`) MUST be omitted from production builds and remain visible in local/dev builds.
+  - `src/components/blog/` holds blog-specific presentational components (`BlogPostCard`, `BlogPostHeader`, `Prose`).
   - `src/components/TrustDocument.astro` for legal and policy pages, which carry their own navigation instead of the marketing navbar.
-  - `src/layouts/Layout.astro` for document metadata, global imports, fonts, analytics, and page shell.
+  - `src/layouts/Layout.astro` for document metadata, global imports, fonts, analytics, and page shell. Blog posts MAY pass `ogType="article"` plus optional `publishedTime` / `modifiedTime`.
   - `src/components/*.astro` for page sections and reusable UI.
   - `src/styles/global.css` for the Tailwind `@theme` tokens, global layers, CSS variables, and shared `@utility` definitions (Tailwind CSS v4 has no `tailwind.config.mjs`; the plugin is registered in `astro.config.mjs` via `@tailwindcss/vite`).
   - `public/` for static assets referenced with root-relative paths.
+  - `@astrojs/sitemap` is registered in `astro.config.mjs` and MUST stay enabled while `site` is set.
 - Do not edit `dist/`, `.astro/`, `node_modules/`, or other generated output as source.
+- Prefer Astro Content Collections for blog posts. Do not add loose Markdown routes under `src/pages/blog/` or use removed APIs such as `Astro.glob()` / `entry.slug`.
 
 ## Bun Usage
 

--- a/landing/astro.config.mjs
+++ b/landing/astro.config.mjs
@@ -1,9 +1,11 @@
 import { defineConfig } from 'astro/config';
+import sitemap from '@astrojs/sitemap';
 import tailwindcss from '@tailwindcss/vite';
 
 export default defineConfig({
   site: 'https://alera.build',
   output: 'static',
+  integrations: [sitemap()],
   vite: {
     plugins: [tailwindcss()],
   },

--- a/landing/bun.lock
+++ b/landing/bun.lock
@@ -5,6 +5,8 @@
     "": {
       "name": "alera-landing",
       "dependencies": {
+        "@astrojs/rss": "^4.0.19",
+        "@astrojs/sitemap": "^3.7.3",
         "@vercel/analytics": "^2.0.1",
         "astro": "^7.1.0",
       },
@@ -45,6 +47,10 @@
     "@astrojs/markdown-satteri": ["@astrojs/markdown-satteri@0.3.4", "", { "dependencies": { "@astrojs/internal-helpers": "0.10.1", "@astrojs/prism": "4.0.2", "github-slugger": "^2.0.0", "hast-util-from-html": "^2.0.3", "satteri": "^0.9.1" } }, "sha512-6Lvt/bQZEBW+zzdhPblvfZEy5PGEYJaUsUqaCgwHeRPxZJL1gc9I+DRLKWJjjYTWDzVUTzXlMq4WwSK+X34CVw=="],
 
     "@astrojs/prism": ["@astrojs/prism@4.0.2", "", { "dependencies": { "prismjs": "^1.30.0" } }, "sha512-KTivpmnz6lDsC6o9H4+DNm2SrE/GHzw8cNAvEJwAvUT+eoaEnn/4NtbDNfRRaxaJHdp15gf+tfHAWiXR4wB3BA=="],
+
+    "@astrojs/rss": ["@astrojs/rss@4.0.19", "", { "dependencies": { "fast-xml-parser": "^5.5.7", "piccolore": "^0.1.3", "zod": "^4.3.6" } }, "sha512-e+z5wYeYtffQdHQO8c2tkSd2JEBdAuRXJV4ZEU5IxkYeE6e39woDd7nw1PH1Kk2tEYNCYuKdylnnbhGmt61awA=="],
+
+    "@astrojs/sitemap": ["@astrojs/sitemap@3.7.3", "", { "dependencies": { "sitemap": "^9.0.0", "stream-replace-string": "^2.0.0", "zod": "^4.3.6" } }, "sha512-f8euLVsyeAmAkSm/1M2Kb8sL8byQmfgbvBNaHFItCheTj/IpiJYSEWVcqDHZ/yEHxiS7+w87mQkzwZaPHmk5GA=="],
 
     "@astrojs/telemetry": ["@astrojs/telemetry@3.3.3", "", { "dependencies": { "ci-info": "^4.4.0", "dset": "^3.1.4", "is-docker": "^4.0.0", "package-manager-detector": "^1.6.0" } }, "sha512-C1TLn5sPJr0x4vk56piHWKbnqlEB8BKyte5Y45V02U+D7BGO5eMqZDH5aPjnkXQWJggvmsTXxH03QMZ9NgWLzQ=="],
 
@@ -200,6 +206,8 @@
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.6", "", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg=="],
 
+    "@nodable/entities": ["@nodable/entities@3.0.0", "", {}, "sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw=="],
+
     "@oslojs/encoding": ["@oslojs/encoding@1.1.0", "", {}, "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ=="],
 
     "@oxc-project/types": ["@oxc-project/types@0.139.0", "", {}, "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw=="],
@@ -350,6 +358,8 @@
 
     "@types/node": ["@types/node@26.1.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw=="],
 
+    "@types/sax": ["@types/sax@1.2.7", "", { "dependencies": { "@types/node": "*" } }, "sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A=="],
+
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
     "@typescript/typescript-aix-ppc64": ["@typescript/typescript-aix-ppc64@7.0.2", "", { "os": "aix", "cpu": "ppc64" }, "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ=="],
@@ -399,6 +409,10 @@
     "am-i-vibing": ["am-i-vibing@0.4.0", "", { "dependencies": { "process-ancestry": "^0.1.0" }, "bin": { "am-i-vibing": "dist/cli.mjs" } }, "sha512-MxT4XZL7pzLHpuvhDKdMaQHMGGkJDLluKBLsbstn+8wv9sWcFT6h+0ve9qkml95amVTZtZV83gQe2hY+ojgHLg=="],
 
     "anymatch": ["anymatch@3.1.3", "", { "dependencies": { "normalize-path": "^3.0.0", "picomatch": "^2.0.4" } }, "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw=="],
+
+    "anynum": ["anynum@1.0.1", "", {}, "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A=="],
+
+    "arg": ["arg@5.0.2", "", {}, "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg=="],
 
     "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
 
@@ -490,6 +504,10 @@
 
     "fast-wrap-ansi": ["fast-wrap-ansi@0.2.0", "", { "dependencies": { "fast-string-width": "^3.0.2" } }, "sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w=="],
 
+    "fast-xml-builder": ["fast-xml-builder@1.3.0", "", { "dependencies": { "path-expression-matcher": "^1.6.2", "xml-naming": "^0.3.0" } }, "sha512-F74cZEdCvuw9P41GAC3rod4X04jjWGM1JPEv/GWSqFTWLsdyMSBMBMlm9Hk3GLBgLBbdBNY8yee0pQh2RBVESQ=="],
+
+    "fast-xml-parser": ["fast-xml-parser@5.10.1", "", { "dependencies": { "@nodable/entities": "^3.0.0", "fast-xml-builder": "^1.2.0", "is-unsafe": "^2.0.0", "path-expression-matcher": "^1.6.2", "strnum": "^2.4.1", "xml-naming": "^0.3.0" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-IEMIf7298kXuZSRFoGfMYrl7is8LpavODgbNz1cwIudv7KwVFnuU+UsMporfq6PD6aXSlawZlARiA3UywCTfMw=="],
+
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
     "flattie": ["flattie@1.1.1", "", {}, "sha512-9UbaD6XdAL97+k/n+N7JwX46K/M6Zc6KcFYskrYL8wbBV/Uyk0CTAMY0VT+qiK5PM7AIc9aTWYtq65U7T+aCNQ=="],
@@ -531,6 +549,8 @@
     "is-docker": ["is-docker@4.0.0", "", { "bin": { "is-docker": "cli.js" } }, "sha512-LHE+wROyG/Y/0ZnbktRCoTix2c1RhgWaZraMZ8o1Q7zCh0VSrICJQO5oqIIISrcSBtrXv0o233w1IYwsWCjTzA=="],
 
     "is-plain-obj": ["is-plain-obj@4.1.0", "", {}, "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="],
+
+    "is-unsafe": ["is-unsafe@2.0.0", "", {}, "sha512-2LdV822R+wmI86unXA93WCFpL6g+av8ynWk0nrHyJqGop5VoocYsSLFgN8jrfalT6iGeLNM4KXuVSsULP53kEA=="],
 
     "jiti": ["jiti@2.7.0", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ=="],
 
@@ -618,6 +638,8 @@
 
     "parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
 
+    "path-expression-matcher": ["path-expression-matcher@1.6.2", "", {}, "sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ=="],
+
     "piccolore": ["piccolore@0.1.3", "", {}, "sha512-o8bTeDWjE086iwKrROaDf31K0qC/BENdm15/uH9usSC/uZjJOKb2YGiVHfLY4GhwsERiPI1jmwI2XrA7ACOxVw=="],
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
@@ -662,13 +684,19 @@
 
     "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
 
+    "sitemap": ["sitemap@9.0.1", "", { "dependencies": { "@types/node": "^24.9.2", "@types/sax": "^1.2.1", "arg": "^5.0.0", "sax": "^1.4.1" }, "bin": { "sitemap": "dist/esm/cli.js" } }, "sha512-S6hzjGJSG3d6if0YoF5kTyeRJvia6FSTBroE5fQ0bu1QNxyJqhhinfUsXi9fH3MgtXODWvwo2BDyQSnhPQ88uQ=="],
+
     "smol-toml": ["smol-toml@1.6.1", "", {}, "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
     "space-separated-tokens": ["space-separated-tokens@2.0.2", "", {}, "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="],
 
+    "stream-replace-string": ["stream-replace-string@2.0.0", "", {}, "sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w=="],
+
     "stringify-entities": ["stringify-entities@4.0.4", "", { "dependencies": { "character-entities-html4": "^2.0.0", "character-entities-legacy": "^3.0.0" } }, "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg=="],
+
+    "strnum": ["strnum@2.4.1", "", { "dependencies": { "anynum": "^1.0.1" } }, "sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg=="],
 
     "svgo": ["svgo@4.0.1", "", { "dependencies": { "commander": "^11.1.0", "css-select": "^5.1.0", "css-tree": "^3.0.1", "css-what": "^6.1.0", "csso": "^5.0.5", "picocolors": "^1.1.1", "sax": "^1.5.0" }, "bin": "./bin/svgo.js" }, "sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w=="],
 
@@ -728,6 +756,8 @@
 
     "web-namespaces": ["web-namespaces@2.0.1", "", {}, "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ=="],
 
+    "xml-naming": ["xml-naming@0.3.0", "", {}, "sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ=="],
+
     "xxhash-wasm": ["xxhash-wasm@1.1.0", "", {}, "sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA=="],
 
     "yargs-parser": ["yargs-parser@22.0.0", "", {}, "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw=="],
@@ -762,10 +792,14 @@
 
     "dom-serializer/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 
+    "sitemap/@types/node": ["@types/node@24.13.3", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q=="],
+
     "vite/picomatch": ["picomatch@4.0.5", "", {}, "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A=="],
 
     "vite/tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
 
     "csso/css-tree/mdn-data": ["mdn-data@2.0.28", "", {}, "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g=="],
+
+    "sitemap/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
   }
 }

--- a/landing/package.json
+++ b/landing/package.json
@@ -10,6 +10,8 @@
     "astro": "astro"
   },
   "dependencies": {
+    "@astrojs/rss": "^4.0.19",
+    "@astrojs/sitemap": "^3.7.3",
     "@vercel/analytics": "^2.0.1",
     "astro": "^7.1.0"
   },

--- a/landing/src/components/Footer.astro
+++ b/landing/src/components/Footer.astro
@@ -11,6 +11,7 @@
       </a>
 
       <div class="flex flex-wrap items-center justify-center gap-x-5 gap-y-2 text-body-md text-foreground-faint">
+        <a href="/blog" class="transition-colors duration-fast hover:text-foreground">Blog</a>
         <a href="/privacy" class="transition-colors duration-fast hover:text-foreground">Privacy</a>
         <a href="/terms" class="transition-colors duration-fast hover:text-foreground">Terms</a>
         <a href="/account/delete" class="transition-colors duration-fast hover:text-foreground">Delete Account</a>

--- a/landing/src/components/Navbar.astro
+++ b/landing/src/components/Navbar.astro
@@ -16,9 +16,16 @@ const repo = 'leynier/alera';
       <a href="/#stack" class="text-body-md text-foreground-faint hover:text-foreground-muted transition-colors duration-fast">Stack</a>
       <a href="/#roadmap" class="text-body-md text-foreground-faint hover:text-foreground-muted transition-colors duration-fast">Roadmap</a>
       <a href="/#faq" class="text-body-md text-foreground-faint hover:text-foreground-muted transition-colors duration-fast">FAQ</a>
+      <a href="/blog" class="text-body-md text-foreground-faint hover:text-foreground-muted transition-colors duration-fast">Blog</a>
     </div>
 
     <div class="flex items-center gap-3 shrink-0">
+      <a
+        href="/blog"
+        class="md:hidden text-body-md text-foreground-faint hover:text-foreground transition-colors duration-fast"
+      >
+        Blog
+      </a>
       <a
         href={`https://github.com/${repo}/stargazers`}
         target="_blank"

--- a/landing/src/components/blog/BlogPostCard.astro
+++ b/landing/src/components/blog/BlogPostCard.astro
@@ -1,0 +1,36 @@
+---
+import type { BlogPost } from '../../lib/blog';
+import { formatBlogDate } from '../../lib/blog';
+
+interface Props {
+  post: BlogPost;
+}
+
+const { post } = Astro.props;
+const href = `/blog/${post.id}`;
+---
+
+<a
+  href={href}
+  class="group block border-b border-border-subtle py-8 first:pt-0 last:border-b-0 transition-colors duration-fast"
+>
+  <time
+    datetime={post.data.pubDate.toISOString()}
+    class="text-label-md uppercase tracking-wide text-foreground-faint"
+  >
+    {formatBlogDate(post.data.pubDate)}
+  </time>
+  <h2
+    class="mt-2 text-headline-sm text-foreground group-hover:text-accent transition-colors duration-fast"
+  >
+    {post.data.title}
+  </h2>
+  <p class="mt-2 text-[15px] text-foreground-muted leading-relaxed">
+    {post.data.description}
+  </p>
+  <span
+    class="mt-3 inline-block text-body-md text-foreground-faint group-hover:text-foreground transition-colors duration-fast"
+  >
+    Read Post
+  </span>
+</a>

--- a/landing/src/components/blog/BlogPostHeader.astro
+++ b/landing/src/components/blog/BlogPostHeader.astro
@@ -1,0 +1,36 @@
+---
+import { formatBlogDate } from '../../lib/blog';
+
+interface Props {
+  title: string;
+  description: string;
+  pubDate: Date;
+  updatedDate?: Date;
+}
+
+const { title, description, pubDate, updatedDate } = Astro.props;
+---
+
+<header class="mb-10 pb-8 border-b border-border-subtle">
+  <div class="flex flex-wrap items-center gap-x-3 gap-y-1 text-label-md uppercase tracking-wide text-foreground-faint mb-4">
+    <time datetime={pubDate.toISOString()}>{formatBlogDate(pubDate)}</time>
+    {
+      updatedDate && (
+        <span>
+          Updated{' '}
+          <time datetime={updatedDate.toISOString()}>
+            {formatBlogDate(updatedDate)}
+          </time>
+        </span>
+      )
+    }
+  </div>
+  <h1
+    class="text-headline-lg md:text-[32px] font-semibold tracking-tight text-foreground mb-4"
+  >
+    {title}
+  </h1>
+  <p class="text-[15px] text-foreground-muted leading-relaxed">
+    {description}
+  </p>
+</header>

--- a/landing/src/components/blog/Prose.astro
+++ b/landing/src/components/blog/Prose.astro
@@ -1,0 +1,114 @@
+---
+---
+
+<div class="blog-prose">
+  <slot />
+</div>
+
+<style>
+  .blog-prose :global(h2) {
+    margin-top: 2rem;
+    margin-bottom: 0.75rem;
+    font-size: var(--text-headline-sm);
+    line-height: var(--text-headline-sm--line-height);
+    letter-spacing: var(--text-headline-sm--letter-spacing);
+    font-weight: var(--text-headline-sm--font-weight);
+    color: var(--color-foreground);
+  }
+
+  .blog-prose :global(h3) {
+    margin-top: 1.5rem;
+    margin-bottom: 0.5rem;
+    font-size: var(--text-title-lg);
+    line-height: var(--text-title-lg--line-height);
+    font-weight: var(--text-title-lg--font-weight);
+    color: var(--color-foreground);
+  }
+
+  .blog-prose :global(p) {
+    margin-bottom: 1rem;
+    font-size: 15px;
+    line-height: 1.7;
+    color: var(--color-foreground-muted);
+  }
+
+  .blog-prose :global(ul),
+  .blog-prose :global(ol) {
+    margin-bottom: 1rem;
+    padding-left: 1.25rem;
+    font-size: 15px;
+    line-height: 1.7;
+    color: var(--color-foreground-muted);
+  }
+
+  .blog-prose :global(ul) {
+    list-style-type: disc;
+  }
+
+  .blog-prose :global(ol) {
+    list-style-type: decimal;
+  }
+
+  .blog-prose :global(li) {
+    margin-bottom: 0.35rem;
+  }
+
+  .blog-prose :global(li::marker) {
+    color: var(--color-foreground-faint);
+  }
+
+  .blog-prose :global(a) {
+    color: var(--color-foreground);
+    text-decoration: underline;
+    text-underline-offset: 3px;
+    text-decoration-color: var(--color-border);
+    transition: text-decoration-color var(--transition-duration-fast) ease;
+  }
+
+  .blog-prose :global(a:hover) {
+    text-decoration-color: var(--color-foreground-muted);
+  }
+
+  .blog-prose :global(strong) {
+    color: var(--color-foreground);
+    font-weight: 600;
+  }
+
+  .blog-prose :global(code) {
+    font-family: var(--font-mono);
+    font-size: 0.875em;
+    padding: 0.15em 0.35em;
+    border-radius: var(--radius-sm);
+    background: var(--color-surface-variant);
+    color: var(--color-foreground);
+  }
+
+  .blog-prose :global(pre) {
+    margin-bottom: 1.25rem;
+    padding: 1rem 1.125rem;
+    overflow-x: auto;
+    border-radius: var(--radius-lg);
+    border: 1px solid var(--color-border);
+    background: var(--color-surface-variant);
+  }
+
+  .blog-prose :global(pre code) {
+    padding: 0;
+    background: transparent;
+    font-size: var(--text-body-md);
+    line-height: 1.6;
+  }
+
+  .blog-prose :global(blockquote) {
+    margin: 1.25rem 0;
+    padding-left: 1rem;
+    border-left: 2px solid var(--color-border);
+    color: var(--color-foreground-muted);
+  }
+
+  .blog-prose :global(hr) {
+    margin: 2rem 0;
+    border: 0;
+    border-top: 1px solid var(--color-border-subtle);
+  }
+</style>

--- a/landing/src/content.config.ts
+++ b/landing/src/content.config.ts
@@ -1,0 +1,16 @@
+import { defineCollection } from 'astro:content';
+import { glob } from 'astro/loaders';
+import { z } from 'astro/zod';
+
+const blog = defineCollection({
+  loader: glob({ base: './src/content/blog', pattern: '**/*.md' }),
+  schema: z.object({
+    title: z.string(),
+    description: z.string(),
+    pubDate: z.coerce.date(),
+    updatedDate: z.coerce.date().optional(),
+    draft: z.boolean().default(false),
+  }),
+});
+
+export const collections = { blog };

--- a/landing/src/content/blog/automate-new-worktree-setup-with-alera-toml.md
+++ b/landing/src/content/blog/automate-new-worktree-setup-with-alera-toml.md
@@ -1,0 +1,52 @@
+---
+title: "Automate New Worktree Setup With Alera.toml"
+description: "Every new worktree needs the same ritual: copy the .env, install dependencies, bootstrap. We made the repo describe it once."
+pubDate: 2026-07-28T13:00:00.000Z
+---
+
+You know the ritual. You create a fresh worktree for an agent, and before it can do anything useful you are copying `.env` from the main checkout, remembering which config files are gitignored but required, running install, running bootstrap. Ninety seconds of chores, every single time, multiplied by every agent you want in parallel.
+
+We got tired of performing that ritual by hand, so we taught Alera to perform it for us. The instructions live in a file you own: `alera.toml`, at the project root.
+
+## What It Looks Like
+
+```toml
+[worktree]
+copy = [
+  { from = ".env", to = ".env", overwrite = false },
+  { from = ".claude/settings.local.json" }
+]
+setup = [
+  "pnpm install",
+  "make bootstrap"
+]
+```
+
+Two ideas, nothing more:
+
+- `copy` brings files or directories from the main project checkout into the new linked workspace. `to` defaults to `from`, and `overwrite` defaults to `false` so an existing file never gets clobbered silently.
+- `setup` runs commands sequentially from the new workspace root and stops at the first non-zero exit, because continuing a bootstrap after a failure is how you get mysteriously broken environments.
+
+Paths are repo-relative literals. Absolute paths and `..` escapes are rejected outright. Globs and custom command environments did not make v1; we would rather ship a small feature that is easy to reason about than a clever one that surprises you.
+
+## When It Runs (And When It Does Not)
+
+Setup applies only to **new linked workspaces that Alera creates**. It does not run for the main workspace, for workspaces discovered during reconcile, or on removal. That scoping is deliberate: automation should fire at the one moment you asked for something new, not retroactively on things that already exist.
+
+Failure handling follows the same philosophy. If a copy or setup step fails after the Git worktree already exists, Alera keeps and opens the workspace and shows you a setup warning. A half-configured worktree you can see and fix beats a silent rollback you never hear about.
+
+## Precedence: Your UI Choice Wins
+
+Per-project settings in **Settings → Projects** are the source of truth when present. Choosing **Use Repo File** clears that override and falls back to `alera.toml`. When neither exists, there is simply no setup, and nothing happens. No hidden defaults.
+
+## One File, One More Job
+
+The same file can also declare how Pull Requests should talk to your forge:
+
+```toml
+git_hosting_provider = "github" # or "gitlab" / "azureDevops"
+```
+
+Without it, Alera auto-detects GitHub.com, GitLab.com, and Azure DevOps from `origin`. Set it explicitly for self-hosted instances. Authentication stays where it belongs, with `gh`, `glab`, or `az`.
+
+Combined with [worktree-native parallel agents](/blog/run-cli-agents-in-parallel-with-git-worktrees), this turns "new branch for this agent" from a checklist into a non-event. Write the ritual once, then forget it exists.

--- a/landing/src/content/blog/bring-your-own-cli-agent-to-alera.md
+++ b/landing/src/content/blog/bring-your-own-cli-agent-to-alera.md
@@ -1,0 +1,43 @@
+---
+title: "Bring Your Own CLI Agent To Alera"
+description: "We did not want to invent another agent protocol. If it runs in a terminal, it runs in Alera - and the big ones get first-class treatment."
+pubDate: 2026-07-28T15:00:00.000Z
+---
+
+Every few weeks a new coding agent CLI appears, and every few weeks someone asks whether Alera supports it. Our answer has become a reflex: does it run in a terminal? Then yes.
+
+That is not a dodge. It is the design. We never wanted Alera to be a product you adopt by abandoning your tools, and we definitely did not want to invent yet another agent protocol for the world to standardize on. The terminal is already the universal interface. We just give it a better home.
+
+## First-Class Today
+
+Some agents get more than a PTY. These ship with icons, managed lifecycle hooks, and live activity tracking in the workbench:
+
+- Claude Code
+- Codex
+- Amp
+- Antigravity
+- OpenCode
+- Cursor
+- Copilot
+- Pi
+- Grok Build
+
+The hooks stream status into Alera, which is what lets the sidebar and activity surfaces tell you who is working and who is quietly waiting for your input. When you run a handful of agents at once, that glanceable state is the difference between conducting and guessing.
+
+## Everything Else
+
+Any other CLI gets the full workbench around it as a normal terminal process: worktree isolation, persistent sessions, quotas, resource tracking, the works. Launch it in a workspace tab exactly the way you would in any shell. Gemini CLI, Goose, Aider, your own in-house script that nobody else has heard of: if your terminal can run it, so can we.
+
+We like this rule because it ages well. The agent landscape reshuffles monthly. A workbench that only supports a fixed list is a workbench with an expiration date.
+
+## Orchestration Adapters
+
+If you go further and coordinate agents through [orchestration](/blog/inter-agent-orchestration-in-alera), agent profiles bind to a built-in adapter registry (`codex`, `claude`, `copilot`, `cursor`, `agy`, `opencode`, `pi`, `amp`, and related defaults). Profiles are your configuration: you approve the launch command, the coordinator dispatches to it, and nobody invents commands on your behalf.
+
+## Tips From Our Own Setup
+
+- Give each long-running agent task its own [linked worktree workspace](/blog/run-cli-agents-in-parallel-with-git-worktrees). Parallel agents sharing one checkout end in stash fights.
+- If GUI-launched terminals cannot see Homebrew or similar prefixes, check the login-shell PATH settings. This one bites macOS users most.
+- Keep provider [quotas](/blog/track-coding-agent-quotas-without-leaving-the-workbench) visible while several CLIs run. Parallel agents drain buckets faster than intuition suggests.
+
+Bring the CLI you already trust. [Download Alera](/download) and it will be running in a native PTY within the minute.

--- a/landing/src/content/blog/how-alera-keeps-terminals-alive-after-you-quit.md
+++ b/landing/src/content/blog/how-alera-keeps-terminals-alive-after-you-quit.md
@@ -1,0 +1,42 @@
+---
+title: "How Alera Keeps Terminals Alive After You Quit"
+description: "Closing a window should never kill a three-hour agent run. The trick is who owns the PTY, and it is not the UI."
+pubDate: 2026-07-28T18:00:00.000Z
+---
+
+Everyone who runs CLI agents has the scar. You close a window out of habit, or the app updates itself, or you reboot for an unrelated reason, and a run that had been going for two hours is just gone. The agent was mid-refactor. The scrollback with its reasoning is gone too.
+
+We decided early that in Alera, this class of accident simply should not exist. The way we got there is a process boundary: your terminal sessions belong to a Rust runtime host, not to the Flutter window you look at.
+
+## The Split That Makes It Work
+
+The desktop app is the workbench: layout, tabs, interaction. The actual sessions live in a sidecar, the `alera` CLI running as `alera runtime-host`, which owns the things that must survive:
+
+- PTY processes and their whole shell trees
+- Bounded scrollback and checkpoints
+- Reattach by `terminalSessionId` when a client comes back
+
+Closing the app detaches from those PTYs instead of tearing them down. Reopen Alera and your tabs, layouts, and running processes are where you left them. The window is a viewer. The host is the thing doing the work.
+
+## What Actually Survives
+
+- Terminal tabs and their session ids
+- Whatever scrollback the host still retains
+- Processes you launched inside those PTYs (within the host lifecycle limits below)
+- Workbench layouts tied to the workspace
+
+Lifecycle hooks for the major CLI agents keep streaming state into the host while you are gone, so when you return you can immediately see who finished, who is still working, and who is blocked waiting for you.
+
+## The Host Has A Lifecycle Too
+
+Persistence does not mean a zombie process that never dies. Desktop-started hosts stay alive while they are useful: when clients disconnect and no PTYs are running, the host stops after an empty-host delay. When PTYs are still running, detached sessions stay up for a detached-session delay (one hour by default) before the host checkpoints and exits.
+
+All of this is yours to tune. **Settings → Application → Runtime** controls the empty-host shutdown, the detached-session shutdown, and **Keep Runtime Open When App Quits**. The status bar **Runtime** chip shows whether the host is up and exposes Start / Stop / Update Runtime.
+
+And if you want real permanence, run the host somewhere that is not your laptop: `alera runtime start` on a workstation or VPS, `alera runtime status` to inspect it, `alera runtime stop` when you are done. Pair that with the [mobile companion](/blog/pair-a-phone-to-your-alera-runtime) and you can check on a long run from your phone while your laptop lid is closed.
+
+## Why We Care This Much
+
+Agent runs are long, stateful, and expensive to lose. Treating "the user closed the window" as a reason to kill them is a category error inherited from apps where the window *is* the program. Once the host owns the sessions, a whole family of features becomes easy: reattach, mobile access, remote hosts. That is why the boundary sits at the core of the product instead of in a settings footnote.
+
+Next time you have a run you cannot afford to lose, [leave it with the host](/download) instead of with a window.

--- a/landing/src/content/blog/inter-agent-orchestration-in-alera.md
+++ b/landing/src/content/blog/inter-agent-orchestration-in-alera.md
@@ -1,0 +1,52 @@
+---
+title: "Inter-Agent Orchestration In Alera"
+description: "Tabs full of agents are useful until they need to coordinate. How orchestration protocol v2 adds ownership, gates, and a real coordinator."
+pubDate: 2026-07-28T17:00:00.000Z
+---
+
+Running five agents in parallel is a superpower right up until they need to work *together*. Who owns this task? Did that worker finish or crash? Which agent is allowed to approve the risky step? "A bunch of terminals" has no answers to those questions, and we learned that by watching our own multi-agent sessions dissolve into guesswork.
+
+Orchestration is our answer, and it lives where it has to: in the Rust runtime host, as orchestration protocol v2, not bolted onto the UI.
+
+## What Ships Today
+
+- **Workspace-scoped coordinator runs.** A workspace has at most one active run. Unrelated workspaces can coordinate concurrently without knowing about each other.
+- **Durable task ownership.** Tasks and dispatches persist in the runtime SQLite database, so a restart does not vaporize who was doing what.
+- **Atomic spawn, readiness, and acceptance.** Workers start through registered adapters and explicitly accept dispatches. No half-launched ghosts.
+- **Decision gates and messaging.** Blocking decisions and persistent messages between agents, for the moments that need a judgment call.
+- **Agent profiles.** User-declared launch configurations the coordinator may dispatch to. More on these below, because they embody the design philosophy.
+
+One rule sits under all of it: mutations pass through the authenticated host actor. Authority comes from the run or task coordinator, not from whichever terminal happened to call a command. It sounds abstract until an agent tries to promote its own work; then it sounds obvious.
+
+## Agent Profiles: The Catalog Is Yours
+
+Profiles live in Settings → Agent Profiles. Each one has a name, an adapter from the built-in registry (`codex`, `claude`, `copilot`, `cursor`, `agy`, `opencode`, `pi`, `amp`, and related defaults), an interactive launch command, a description that acts as a routing signal, and an optional quota group.
+
+The CLI can list them:
+
+```bash
+alera orchestration agent-profiles --json
+```
+
+Here is the part we care about: only you create or edit profiles. A coordinator picks from that closed catalog; it never invents a launch command. The moment a coordinator can compose its own commands, your approval flow is theater. We chose the boring, auditable option on purpose.
+
+## A Minimal Loop
+
+```bash
+alera orchestration task-create --workspace <workspace-id> --spec "Review tests"
+alera orchestration run --workspace <workspace-id> --agent codex --spec "Audit the repository"
+alera orchestration run-list --workspace <workspace-id>
+alera orchestration run-show --id <run-id>
+```
+
+Workers accept, heartbeat, escalate, and complete through the orchestration CLI, with context inferred from the active terminal. Completion validates structured results and promotes dependent work in a single response, so a finished task can unblock the next one without a human relay.
+
+## Execution Policies, Opt-In
+
+A run may carry a stage plan that you approve before dispatch: a preferred profile per stage, plus ordered fallbacks. Scheduling holds until you approve or reject the plan. Runs without a policy behave exactly as before, because coordination you did not ask for should never change how your workspace behaves.
+
+## The Honest Scope
+
+Orchestration is for durable multi-agent coordination inside Alera-managed workspaces. It does not replace your agent CLIs; it schedules and owns the work they accept. The full contract lives in the repo docs, and we expect it to keep evolving as we run more of our own work through it.
+
+When one agent stops being enough, you will know. That is the moment to [open a coordinator run](/download).

--- a/landing/src/content/blog/native-first-agent-workbench.md
+++ b/landing/src/content/blog/native-first-agent-workbench.md
@@ -1,0 +1,34 @@
+---
+title: "A Native-First Agent Workbench"
+description: "Why we bet on Flutter, Rust, and Ghostty instead of shipping another Electron shell around CLI agents."
+pubDate: 2026-07-28
+---
+
+Every few months someone asks us why Alera is not an Electron app. It is a fair question. Electron is the path of least resistance for a desktop tool, and if your product is essentially a chat window, the tradeoffs are easy to swallow.
+
+But a workbench for CLI agents is not a chat window. It is a terminal emulator, a process supervisor, and a workspace manager that happen to share a screen. Those are exactly the workloads where a web view shows its seams.
+
+## The Workload Nobody Designs For
+
+Agent sessions are chatty in a way human sessions are not. A single agent can stream output for an hour straight. Multiply that by four or five agents in parallel, add process trees, scrollback, and workspace state, and you have a UI that never gets to idle.
+
+We watched early prototypes spend more CPU redrawing terminal output than the agents spent producing it. That is the moment the architecture stops being a preference and becomes the product.
+
+## The Bet We Made
+
+Alera splits into two processes with a clear contract:
+
+- **Flutter for the UI.** Native rendering on macOS, Windows, and Linux, one codebase, no browser runtime in the frame pipeline.
+- **Rust for everything that can hurt you.** PTYs, process trees, scrollback, and resource sampling live in a sidecar that owns the dangerous parts and keeps working even when the UI is not open.
+
+Terminal parsing follows Ghostty's VTE path, which is battle-tested by people who care about terminal correctness far more than most.
+
+We wrote about the streaming side of this story in [why terminal output performance matters](/blog/why-terminal-output-performance-matters-for-agent-workbenches), including the Linux-specific surprises that made us pace frame production instead of just optimizing frames.
+
+## What You Actually Get
+
+None of this matters because it is elegant. It matters because of what falls out of it: agents that survive a closed window, a status bar that can afford to sample CPU per tab, and a workbench that feels like part of your machine instead of a tab you accidentally opened outside the browser.
+
+We are not claiming native is free. Three platforms mean three sets of platform behavior to respect, and some things (Windows console quirks, we are looking at you) cost us real time. We still think the bet was right, and this blog will keep showing our work.
+
+If that trade sounds good to you, [download Alera](/download) and judge the feel for yourself.

--- a/landing/src/content/blog/pair-a-phone-to-your-alera-runtime.md
+++ b/landing/src/content/blog/pair-a-phone-to-your-alera-runtime.md
@@ -1,0 +1,36 @@
+---
+title: "Pair A Phone To Your Alera Runtime"
+description: "The mobile companion is honest about what it is: a window into your runtime host, not a phone IDE. Here is what it does today."
+pubDate: 2026-07-28T10:00:00.000Z
+---
+
+Picture the usual moment: you kicked off a long agent run, stepped away, and now you are on the couch wondering whether it finished, stalled, or is waiting for a yes/no only you can give. Walking back to the desk to check feels silly. SSHing from your phone feels worse.
+
+That is the itch the Alera mobile companion scratches. And we want to be upfront about what it is: a foundation for remote awareness and terminal access, not an attempt to squeeze a full IDE onto a phone.
+
+## What Ships Today
+
+The companion is a separate Flutter app under `mobile/`, targeting Android and iOS. Pairing starts from **Settings → Mobile Devices** on the desktop, or through `alera mobile ...`.
+
+The phone stores its device tokens in platform secure storage and connects to the runtime host's mobile WebSocket gateway. Once paired, it can:
+
+- Mirror the desktop sidebar: grouping, sorting, filters, tags, pins, activity, agent presence, terminal indicators
+- Browse the host filesystem and manage projects
+- Rename workspace tabs and use managed-workspace actions
+- Inspect and configure agent quotas
+- Stream terminals, with local Terminal Quick Keys for the keys phones lack
+- Install Alera agent skills and register the host CLI, no desktop process required
+
+Just as important is what it cannot do. Host-admin RPCs and arbitrary runtime mutations stay off the mobile allowlist, so a paired phone cannot manage other devices or rewrite unrestricted runtime state. A lost phone should be an inconvenience, not an incident.
+
+## The Desktop Does Not Have To Stay Open
+
+This is the part that makes the companion genuinely useful rather than a demo. Because sessions belong to the [runtime host](/blog/how-alera-keeps-terminals-alive-after-you-quit) and not to the desktop window, you can quit the desktop UI entirely, keep the host running (including `alera runtime start` on a workstation or VPS), and still attach from the phone.
+
+Your agents keep working on a machine that is awake. You keep an eye on them from a device that is in your pocket. Each one does what it is good at.
+
+## What Comes Later
+
+The roadmap lists richer file review and non-terminal surfaces for mobile, and we will get there. But we would rather ship a trustworthy remote window today than promise a pocket workbench we cannot yet stand behind. If you try it, treat it as what it is: awareness and terminal access to a host you already trust.
+
+[Download Alera](/download) on desktop, enable Mobile Devices, and pair the next time a long run would otherwise chain you to your desk.

--- a/landing/src/content/blog/pull-requests-and-ci-checks-per-worktree.md
+++ b/landing/src/content/blog/pull-requests-and-ci-checks-per-worktree.md
@@ -1,0 +1,34 @@
+---
+title: "Pull Requests And CI Checks Per Worktree"
+description: "Review belongs next to the work. How the Pull Requests panel keeps GitHub, GitLab, and Azure DevOps scoped to the worktree that produced the branch."
+pubDate: 2026-07-28T12:00:00.000Z
+---
+
+Parallel agents produce parallel branches. That is the point of the whole worktree model. But it creates a review problem nobody talks about: when three agents ship three branches at once, where do you actually review them?
+
+Our first answer was "in the browser, like everyone else." It did not last. Hopping between the workbench and a forge tab for every PR broke the exact flow we built the worktrees for, and worse, it detached review from context. You would look at a diff and have to reconstruct which agent, which task, which workspace produced it.
+
+So the Pull Requests panel in Alera operates per worktree. Open it from a linked workspace and you are looking at the branch that workspace owns. The review surface matches the agent that did the work, by construction.
+
+## What You Can Do Without Leaving
+
+- Create, edit, comment (with Markdown), toggle draft, and merge
+- Inspect CI checks grouped by status, with drill-down into the details when something goes red
+- Generate PR titles and descriptions from the branch's changes with AI assistance, which is handy when the agent was terse
+- Jump to the repository in your browser from the workspace menu, for the moments you genuinely want the forge UI
+
+## GitHub, GitLab, And Azure DevOps
+
+We did not build forge clients from scratch. Alera speaks to the official CLIs you already authenticate with:
+
+- GitHub and GitHub Enterprise Server, via `gh`
+- GitLab, including self-managed, via `glab` (review pagination needs `glab` 1.80.0 or newer)
+- Azure DevOps, via `az`
+
+Self-hosted GitHub and GitLab instances are selected explicitly in project settings or in [`alera.toml`](/blog/automate-new-worktree-setup-with-alera-toml). Alera reads the hostname from the repository remote and hands it to the right CLI. Authentication is `gh auth login`, `glab auth login`, or `az login`, with hostname flags for enterprise hosts. One honest caveat: our landing page's feature summary highlights GitHub and Azure DevOps, but GitLab works the same way through `glab`, as described above.
+
+## Why Per Worktree, Again
+
+It comes back to [worktree isolation](/blog/run-cli-agents-in-parallel-with-git-worktrees). Reviewing from a shared primary checkout mixes diffs and check results across tasks. Scoping the panel to the linked workspace means the branch you merge is the branch the agent touched, the checks you see belong to that branch, and nothing bleeds across contexts.
+
+If your forge CLI is already authenticated, you are one workspace away from trying this. [Download Alera](/download) and open Pull Requests from the worktree that owns the branch.

--- a/landing/src/content/blog/run-cli-agents-in-parallel-with-git-worktrees.md
+++ b/landing/src/content/blog/run-cli-agents-in-parallel-with-git-worktrees.md
@@ -1,0 +1,41 @@
+---
+title: "Run CLI Agents In Parallel With Git Worktrees"
+description: "Two agents sharing one working tree is a stash fight waiting to happen. Here is the model we use instead."
+pubDate: 2026-07-28T20:00:00.000Z
+---
+
+The first time we ran two coding agents against the same checkout, they lasted about ten minutes before trampling each other. One was refactoring a module, the other was adding tests for it, and suddenly we were staring at a working tree full of half-related changes, doing git stash gymnastics to figure out what belonged to whom.
+
+That experience is why parallelism in Alera is not "open more tabs." It is built on a boring, solid Git primitive: the worktree.
+
+## The Model: Project, Workspace, Worktree
+
+Three words carry the whole design, so it is worth being precise.
+
+A **project** is a folder you register in Alera. An existing local path, or a clone from a URL.
+
+A **workspace** is your working context inside that project. The primary workspace points at the project path itself. Linked workspaces, available for Git-backed projects, each point at a separate checkout.
+
+A **worktree** is the Git mechanism behind a linked workspace. When you create one, Alera makes a new local branch from a source branch, or attaches the workspace to a branch you already have. Non-Git folders are not second-class citizens; they just get a single primary workspace, because there is nothing to link.
+
+## Why Isolation Changes The Experience
+
+With one worktree per task, the failure mode from our opening story mostly disappears:
+
+- Each agent sees a clean branch with only its own changes in it
+- Diffs stay scoped, so reviewing agent A's work never includes agent B's debris
+- You can jump between contexts without tearing anything down, stashing, or remembering what was half-done
+
+There is a subtle benefit we did not fully anticipate: it changes how you delegate. When handing a task to an agent costs one worktree instead of a negotiation with your current branch, you start handing off smaller, better-defined tasks. The tooling nudges you toward the workflow that works.
+
+## From Repo To Running Agents
+
+The loop itself is three steps:
+
+1. Register a project (local folder or clone)
+2. Open a linked worktree workspace for each task you want in flight
+3. Launch Claude, Codex, Amp, or any other CLI agent in that workspace's terminals
+
+The one annoyance left in this loop used to be setup: every new worktree needs its `.env`, its dependencies, its bootstrap commands. We automated that ritual with [`alera.toml`](/blog/automate-new-worktree-setup-with-alera-toml), and when the work is done, [pull requests and CI checks stay scoped to the same worktree](/blog/pull-requests-and-ci-checks-per-worktree) so what you review is exactly what the agent produced.
+
+If you have been running agents sequentially because parallel felt dangerous, this is the post we wrote for you. [Download Alera](/download), open a Git-backed project, and give your next task its own worktree.

--- a/landing/src/content/blog/see-which-agent-is-eating-your-cpu.md
+++ b/landing/src/content/blog/see-which-agent-is-eating-your-cpu.md
@@ -1,0 +1,39 @@
+---
+title: "See Which Agent Is Eating Your CPU"
+description: "Five agents in parallel and the fans spin up. The Resource Manager names the culprit per tab - including the time it blamed us, 26 times over."
+pubDate: 2026-07-28T14:00:00.000Z
+---
+
+The moment you run several coding agents at once, your machine turns into a mystery. The fans spin up, everything feels slightly sticky, and the question is always the same: which one of them is doing this?
+
+Answering that with `top` or Activity Monitor means mapping process trees to agent sessions by hand, every time. We wanted the answer in one click, labeled in the vocabulary you already think in. So the Resource Manager attributes live CPU and memory to **Project → Workspace → Terminal tab**, straight from the Rust runtime host that owns those sessions anyway.
+
+## What The Panel Shows
+
+A status-bar chip opens the panel. Per row you get live CPU and memory with sparklines, plus Alera's own app and sidecar rows so we cannot hide our own cost, plus machine-wide memory and load for context.
+
+Our favorite row type is the orphan: a terminal session the host still holds but no tab claims anymore. Those show up labeled as orphans and can be killed in one click. In a workbench with [persistent terminals](/blog/how-alera-keeps-terminals-alive-after-you-quit), orphans are how you catch the agent that outlived its tab.
+
+## The Bug That Taught Us Humility
+
+Here is the part we would rather not admit, except it is too good a story to skip.
+
+While building the sampler, our Linux build started reporting that the Alera app was using 26 times its real memory. Twenty-six. The cause: on Linux, every thread shows up in the process table as a child entry that reports the whole process's RSS. Our app had 97 threads at the time, the sampler dutifully summed all of them, and CPU got double-counted too because the leader's stats already aggregate the thread group.
+
+Nothing in our tree arithmetic could catch it, because every thread id looked like a legitimately distinct process. What caught it was a plausibility check we had almost not written: attributed memory should fit inside the machine's physical memory. It did not, by a factor of 26.
+
+The fix is one flag (skip task entries when refreshing the process table), but the lesson shaped the feature: any number the panel shows must be defensible, or the panel is worse than useless.
+
+## Sampling That Stays Out Of The Way
+
+Two more design rules fell out of that mindset.
+
+Sampling runs in the Rust sidecar, never on the Flutter UI isolate, and only while something is watching. An idle workbench pays nothing for the feature.
+
+And CPU is normalized as a share of the machine, per-core samples divided by core count, so the CPU column reads on the same scale as the memory column. When the core count is unknown, the panel shows nothing rather than a number it cannot stand behind. After the 26x incident, we are sentimental about that rule.
+
+## Why It Matters With Parallel Agents
+
+A stuck install, a runaway build, an agent that forked more children than expected: all of these are trivial to spot when the cost is labeled by workspace and tab, and nearly invisible when it is an anonymous process tree. Parallel agents are only comfortable if you can afford to not think about the machine. This panel is how we get there.
+
+Run a few agents and [open the Resource Manager](/download) while they work. The sparklines tell stories.

--- a/landing/src/content/blog/track-coding-agent-quotas-without-leaving-the-workbench.md
+++ b/landing/src/content/blog/track-coding-agent-quotas-without-leaving-the-workbench.md
@@ -1,0 +1,48 @@
+---
+title: "Track Coding Agent Quotas Without Leaving The Workbench"
+description: "Hitting a provider limit mid-run is the worst way to learn your quota. We put Claude, Codex, Kimi, Grok, Cursor, and more in the status bar."
+pubDate: 2026-07-28T16:00:00.000Z
+---
+
+There is a specific kind of frustration that only agent users know: a run dies mid-task, you dig through the output, and the cause is a rate limit you did not know you were near. The fix was never technical. You just needed to see the number before it hit zero.
+
+With several agents running in parallel, that visibility stops being optional. Each provider drains a different bucket at a different rate, and the buckets live on websites you do not want to keep open. So we brought them into the workbench: a quota bar at the bottom of the window, next to the terminals you are already watching.
+
+## What You See
+
+Each enabled provider shows its agent icon and its available usage windows. Hovering opens a card with the remaining percentage, a completion bar, and a countdown to reset. Clicking pins the card open; one card at a time, because a status bar is not a dashboard.
+
+Quotas refresh every 15 minutes, can be refreshed by hand, and keep the last successful snapshot marked as stale when a refresh fails. Stale-but-labeled beats blank.
+
+## Who Is Covered
+
+- Claude Code (default account and CCS profiles)
+- Codex
+- Kimi Code
+- Grok Build
+- Cursor
+- Antigravity
+- MiniMax Token Plan
+- Z.ai
+
+Provider order is configurable in **Settings → Quotas → Providers**, and Claude CCS profiles can be reordered independently. Show the ones you actually pay for; hide the rest.
+
+## The Part We Designed Most Carefully: Credentials
+
+Quota checks need credentials, and credentials are where a feature like this can go wrong. So the rules are strict.
+
+Alera stores environment variable *names* for API-based plans. Never values. Local desktop and mobile requests go through the runtime-host quota service, and for the local host, missing variables can be resolved from your login shell and held in memory without being persisted into quota responses.
+
+SSH workspaces query through `alera runtime-proxy` on the remote host, so credentials stay on the machine where the agent actually runs. They never travel to your laptop just so a widget can render.
+
+## Claude CCS Profiles
+
+If you run Claude against more than one account, **Settings → Quotas → Claude** handles Default and CCS profiles, each with an alias and a CCS instance directory. Quota lookups set `CLAUDE_CONFIG_DIR` only for the lookup itself; how your terminals launch Claude is untouched.
+
+When a profile is unhealthy and the runtime supports it, the card can offer **Try With TUI**, which scrapes `/usage` for that account only. It is a fallback, not the normal path, and it stays scoped to the profile that needs it.
+
+## Why It Lives In The Workbench
+
+We could have shipped this as a standalone widget or a browser extension. It belongs in the status bar for the same reason [orchestration](/blog/inter-agent-orchestration-in-alera) and live activity do: the decisions quota informs (dispatch another agent now, or wait for the reset?) happen where the agents run.
+
+Enable the providers you use and stop learning about limits from failed runs. [Download Alera](/download) to try it.

--- a/landing/src/content/blog/welcome-to-alera.md
+++ b/landing/src/content/blog/welcome-to-alera.md
@@ -1,0 +1,34 @@
+---
+title: "Welcome To Alera"
+description: "Why we started building a native workbench for CLI coding agents, and what you can do with it today."
+pubDate: 2026-07-28
+---
+
+This blog starts with a confession: we built Alera because we could not find the tool we wanted to use ourselves.
+
+Our days already revolved around CLI coding agents. Claude Code in one terminal, Codex in another, something new every other week. The agents kept getting better, but the setup around them stayed stuck: a pile of terminal windows, a few tmux sessions we were afraid to close, and a constant low-grade anxiety about which agent was touching which files.
+
+The new wave of AI IDEs did not solve it for us. They wrap a single chat backend inside an Electron shell and ask you to leave your CLI behind. We did not want to leave the CLI behind. The CLI is where the agents live.
+
+So Alera takes the opposite bet. It is a native, performance-first workbench for CLI coding agents: Claude Code, Codex, Amp, Antigravity, OpenCode, Cursor, Copilot, Pi, or anything else that runs in a terminal. Flutter and Rust under the hood, Ghostty's VTE for terminal parsing. No Electron, no bundled Chromium, no browser pretending to be a terminal.
+
+## What You Can Do Today
+
+- Run several agents in parallel, each in its own workspace and Git worktree, without them stepping on each other
+- Close the window without killing your agents; sessions belong to a runtime host, not to the UI
+- See which agent is working, which is waiting on you, and which one is eating your CPU
+- Use the same workbench on macOS, Windows, and Linux, with a signed package repository on Linux
+
+We wrote up the details in follow-up posts, linked throughout this one. The short version: the boring infrastructure around agents (worktrees, PTYs, quotas, resources) is the part we think deserves real engineering.
+
+## Get Started
+
+Install from the [download page](/download), or run:
+
+```bash
+curl -fsSL https://alera.build/install.sh | sh
+```
+
+Then open Alera and start an agent the same way you would in any terminal. If something feels off, we want to hear about it: issues and feedback live on [GitHub](https://github.com/leynier/alera), and we read them.
+
+This is an early preview and it is moving fast. We will use this blog to write honestly about what we are building, what broke along the way, and what we changed our minds about. Thanks for being here at the start.

--- a/landing/src/content/blog/why-alera-is-terminal-first-not-another-ai-ide.md
+++ b/landing/src/content/blog/why-alera-is-terminal-first-not-another-ai-ide.md
@@ -1,0 +1,37 @@
+---
+title: "Why Alera Is Terminal-First (Not Another AI IDE)"
+description: "The case for building around the CLIs you already use instead of wrapping one provider's chat in an Electron shell."
+pubDate: 2026-07-28T19:00:00.000Z
+---
+
+Here is an opinion we hold strongly enough to build a product on: the CLI is the real interface for coding agents, and it will stay that way for a while.
+
+Every agent team that matters ships a terminal client first. Claude Code, Codex, Amp, Cursor Agent, Copilot CLI, OpenCode, Pi. The terminal is where new capabilities show up earliest, where power users already live, and where the agents compose with the rest of your tools. So when we see an AI IDE embed one provider's chat in a web view and call it the future, our reaction is: that is a wrapper, not a workbench.
+
+## What A Single Chat Shell Costs You
+
+One embedded chat is comfortable if you use one assistant for one thing at a time. The friction starts the moment you want more:
+
+- Several agents on different tasks at once, without them sharing one transcript
+- The exact CLI you already configured, with your flags, your aliases, your muscle memory
+- A workbench that does not put a browser runtime between you and a process that streams for hours
+
+Wrapping a terminal tool in a web view adds weight and removes control. You inherit someone else's idea of the loop instead of keeping your own.
+
+## What Terminal-First Means In Practice
+
+In Alera, the terminal is not a fallback. It is the point.
+
+- **Any CLI agent runs.** If it works in a terminal, it works in Alera. Open a tab, launch it like you always do.
+- **Parallel is the default.** Agents get native PTYs across workspaces and split panes. They are processes, not tabs competing inside one chat history.
+- **No Electron, no Chromium.** Flutter renders the UI, Rust owns processes and PTYs, Ghostty's VTE parses terminal output.
+
+Agents we integrate first-class get icons, lifecycle hooks, and live activity tracking on top of that. Everything else still works as a plain terminal process, which is the whole idea: first-class is a bonus, not a gate.
+
+## We Will Say The Quiet Part Too
+
+AI IDEs are not a mistake. If you want one vendor's opinionated chat experience next to a full LSP editor in the same window, they are genuinely good at that, and we are not trying to replace your editor.
+
+Alera is for a different moment: the agent is already a CLI you trust, the repo needs worktree isolation, and you want three of them running at once without negotiating with a single chat box. If that moment sounds familiar, we built this for you.
+
+The natural next read is how [worktrees keep parallel agents from colliding](/blog/run-cli-agents-in-parallel-with-git-worktrees). Or skip the reading and [bring the CLI you already use](/download).

--- a/landing/src/content/blog/why-terminal-output-performance-matters-for-agent-workbenches.md
+++ b/landing/src/content/blog/why-terminal-output-performance-matters-for-agent-workbenches.md
@@ -1,0 +1,36 @@
+---
+title: "Why Terminal Output Performance Matters For Agent Workbenches"
+description: "A chatty agent can stream output for an hour straight. That is a frame budget problem, and on Linux it is worse than you think."
+pubDate: 2026-07-28T11:00:00.000Z
+---
+
+Here is a workload most UI frameworks never have to survive: a process that writes to the terminal continuously, for an hour, while four of its siblings do the same in neighboring panes. That is a normal afternoon for a coding agent workbench, and it breaks the assumptions most desktop apps are built on.
+
+We learned this the hard way on Linux, and the story is worth telling because it changed how we think about frames.
+
+## The Linux Surprise
+
+On Linux, Alera's GTK embedder composites in software. Every frame costs CPU proportional to the window's pixel count, whether or not anything meaningful changed on screen. There is no GDK setting that makes it free.
+
+The consequence is counterintuitive: when output never stops, reducing *how many frames you produce* beats making each frame cheaper. A slightly more efficient frame, produced at full vsync for an hour, still melts the pipeline. Fewer frames is the optimization.
+
+## What Alera Actually Does
+
+- **Paced flushes.** Terminal output flushes have a cadence floor of about 33 ms, so a process writing non-stop cannot drive the frame loop at full vsync. Quiet terminals still flush on the next frame, because typing echo has to feel instant. Streaming bulk output and human input are different workloads and we pace them differently.
+- **Host-owned backpressure.** The Rust host batches output and bounds it in bytes. A client that falls behind resynchronizes from a delivery cursor instead of replaying the whole scrollback, which is the difference between a hiccup and a flood.
+- **Separate lanes.** RPC and runtime events travel on a control lane, so terminal backpressure can never disconnect the workbench. The moment control traffic shares a lane with bulk output, a chatty agent becomes a denial-of-service attack on your own UI.
+- **Sampling off the UI.** [Resource Manager](/blog/see-which-agent-is-eating-your-cpu) sweeps stay in the sidecar. Process table scans have no business on the isolate that renders frames.
+
+The broader split stays as designed: Flutter renders, Rust owns PTYs and processes, parsing follows Ghostty's VTE path. No Electron, no Chromium event loop anywhere in that hot path.
+
+## Measure First, Claim Second
+
+Our rule for performance work is that it starts from a reproducible profile, not from vibes. The repo carries the harnesses (`make perf-linux`, `make app-profile`, resource benchmarks) and we change one bounded subsystem at a time so regressions have somewhere to hide.
+
+It also disciplines what we say publicly. You will not see us claim "fastest IDE." You will see claims like "fewer wasted frames under sustained stream," because that is what we can measure. We would rather be boringly right than loudly wrong.
+
+## The Other Half Of Native
+
+This post is the operational sibling of [native-first](/blog/native-first-agent-workbench). The architecture only pays off if streaming agents do not melt the frame pipeline, and getting that right is ongoing work, not a launch checkbox.
+
+If you want to see it under stress: [download Alera](/download), point your chattiest agent at a big repo, and watch the Resource Manager while it streams. That is the scenario we optimize for.

--- a/landing/src/layouts/Layout.astro
+++ b/landing/src/layouts/Layout.astro
@@ -7,9 +7,19 @@ interface Props {
   description?: string;
   canonicalPath?: string;
   noIndex?: boolean;
+  ogType?: 'website' | 'article';
+  publishedTime?: Date;
+  modifiedTime?: Date;
 }
 
-const { title, canonicalPath = Astro.url.pathname, noIndex = false } = Astro.props;
+const {
+  title,
+  canonicalPath = Astro.url.pathname,
+  noIndex = false,
+  ogType = 'website',
+  publishedTime,
+  modifiedTime,
+} = Astro.props;
 
 const defaultDescription = 'Run every CLI coding agent in parallel: Claude Code, Codex, Amp, Antigravity, OpenCode, Cursor, Copilot, Pi, or any other CLI agent. Native performance with Flutter + Rust + Ghostty. No Electron, no Chromium. Available for macOS, Windows, and Linux.';
 const description = Astro.props.description ?? defaultDescription;
@@ -18,8 +28,9 @@ const siteUrl = 'https://alera.build';
 const canonicalUrl = new URL(canonicalPath, siteUrl).toString();
 const ogImage = `${siteUrl}/og-banner.jpg`;
 const ogImageAlt = 'Alera: Run Every CLI Coding Agent In Parallel';
+const twitterDescription = Astro.props.description ?? shortDescription;
 
-const jsonLd = {
+const softwareJsonLd = {
   '@context': 'https://schema.org',
   '@type': 'SoftwareApplication',
   name: 'Alera',
@@ -43,6 +54,37 @@ const jsonLd = {
   codeRepository: 'https://github.com/leynier/alera',
   programmingLanguage: ['Dart', 'Rust'],
 };
+
+const articleJsonLd =
+  ogType === 'article'
+    ? {
+        '@context': 'https://schema.org',
+        '@type': 'BlogPosting',
+        headline: title,
+        description,
+        url: canonicalUrl,
+        image: ogImage,
+        datePublished: publishedTime?.toISOString(),
+        dateModified: (modifiedTime ?? publishedTime)?.toISOString(),
+        author: {
+          '@type': 'Person',
+          name: 'Leynier Gutiérrez González',
+          url: 'https://github.com/leynier',
+        },
+        publisher: {
+          '@type': 'Organization',
+          name: 'Alera',
+          url: siteUrl,
+          logo: `${siteUrl}/logo.png`,
+        },
+        mainEntityOfPage: {
+          '@type': 'WebPage',
+          '@id': canonicalUrl,
+        },
+      }
+    : null;
+
+const jsonLd = articleJsonLd ?? softwareJsonLd;
 ---
 
 <!doctype html>
@@ -56,6 +98,12 @@ const jsonLd = {
     <!-- Canonical -->
     <link rel="canonical" href={canonicalUrl} />
     {noIndex && <meta name="robots" content="noindex, nofollow" />}
+    <link
+      rel="alternate"
+      type="application/rss+xml"
+      title="Alera Blog"
+      href="/rss.xml"
+    />
 
     <!-- Favicons -->
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
@@ -65,7 +113,7 @@ const jsonLd = {
     <!-- Open Graph -->
     <meta property="og:title" content={title} />
     <meta property="og:description" content={description} />
-    <meta property="og:type" content="website" />
+    <meta property="og:type" content={ogType} />
     <meta property="og:url" content={canonicalUrl} />
     <meta property="og:image" content={ogImage} />
     <meta property="og:image:type" content="image/jpeg" />
@@ -73,11 +121,27 @@ const jsonLd = {
     <meta property="og:image:height" content="630" />
     <meta property="og:image:alt" content={ogImageAlt} />
     <meta property="og:site_name" content="Alera" />
+    {
+      publishedTime && (
+        <meta
+          property="article:published_time"
+          content={publishedTime.toISOString()}
+        />
+      )
+    }
+    {
+      modifiedTime && (
+        <meta
+          property="article:modified_time"
+          content={modifiedTime.toISOString()}
+        />
+      )
+    }
 
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content={title} />
-    <meta name="twitter:description" content={shortDescription} />
+    <meta name="twitter:description" content={twitterDescription} />
     <meta name="twitter:image" content={ogImage} />
     <meta name="twitter:image:alt" content={ogImageAlt} />
 

--- a/landing/src/lib/blog.ts
+++ b/landing/src/lib/blog.ts
@@ -1,0 +1,23 @@
+import { getCollection, type CollectionEntry } from 'astro:content';
+
+export type BlogPost = CollectionEntry<'blog'>;
+
+/** Published posts in production; drafts stay visible in local/dev builds. */
+export async function getPublishedBlogPosts(): Promise<BlogPost[]> {
+  const posts = await getCollection('blog', ({ data }) =>
+    import.meta.env.PROD ? data.draft !== true : true,
+  );
+
+  return posts.sort(
+    (a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf(),
+  );
+}
+
+export function formatBlogDate(date: Date): string {
+  return date.toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+    timeZone: 'UTC',
+  });
+}

--- a/landing/src/pages/blog/[id].astro
+++ b/landing/src/pages/blog/[id].astro
@@ -1,0 +1,54 @@
+---
+import { render } from 'astro:content';
+import Layout from '../../layouts/Layout.astro';
+import Navbar from '../../components/Navbar.astro';
+import Footer from '../../components/Footer.astro';
+import BlogPostHeader from '../../components/blog/BlogPostHeader.astro';
+import Prose from '../../components/blog/Prose.astro';
+import { getPublishedBlogPosts } from '../../lib/blog';
+
+export async function getStaticPaths() {
+  const posts = await getPublishedBlogPosts();
+  return posts.map((post) => ({
+    params: { id: post.id },
+    props: { post },
+  }));
+}
+
+const { post } = Astro.props;
+const { Content } = await render(post);
+const canonicalPath = `/blog/${post.id}`;
+---
+
+<Layout
+  title={`${post.data.title} - Alera Blog`}
+  description={post.data.description}
+  canonicalPath={canonicalPath}
+  ogType="article"
+  publishedTime={post.data.pubDate}
+  modifiedTime={post.data.updatedDate}
+>
+  <Navbar />
+  <main class="px-6 pt-24 pb-20">
+    <article class="mx-auto max-w-3xl">
+      <p class="mb-8">
+        <a
+          href="/blog"
+          class="text-body-md text-foreground-faint hover:text-foreground transition-colors duration-fast"
+        >
+          Back To Blog
+        </a>
+      </p>
+      <BlogPostHeader
+        title={post.data.title}
+        description={post.data.description}
+        pubDate={post.data.pubDate}
+        updatedDate={post.data.updatedDate}
+      />
+      <Prose>
+        <Content />
+      </Prose>
+    </article>
+  </main>
+  <Footer />
+</Layout>

--- a/landing/src/pages/blog/index.astro
+++ b/landing/src/pages/blog/index.astro
@@ -1,0 +1,53 @@
+---
+import Layout from '../../layouts/Layout.astro';
+import Navbar from '../../components/Navbar.astro';
+import Footer from '../../components/Footer.astro';
+import BlogPostCard from '../../components/blog/BlogPostCard.astro';
+import { getPublishedBlogPosts } from '../../lib/blog';
+
+const posts = await getPublishedBlogPosts();
+---
+
+<Layout
+  title="Blog - Alera"
+  description="Notes from the team building Alera, a native workbench for CLI coding agents."
+  canonicalPath="/blog"
+>
+  <Navbar />
+  <main class="px-6 pt-24 pb-20">
+    <div class="mx-auto max-w-3xl">
+      <div class="mb-12">
+        <div class="flex items-end justify-between gap-4 mb-4">
+          <h1
+            class="text-headline-lg md:text-[32px] font-semibold tracking-tight text-foreground"
+          >
+            Blog
+          </h1>
+          <a
+            href="/rss.xml"
+            class="text-body-md text-foreground-faint hover:text-foreground transition-colors duration-fast shrink-0"
+          >
+            RSS
+          </a>
+        </div>
+        <p class="text-[15px] text-foreground-muted leading-relaxed">
+          What we are building, what broke along the way, and what we changed
+          our minds about.
+        </p>
+      </div>
+
+      {
+        posts.length === 0 ? (
+          <p class="text-[15px] text-foreground-muted">No Posts Yet.</p>
+        ) : (
+          <div>
+            {posts.map((post) => (
+              <BlogPostCard post={post} />
+            ))}
+          </div>
+        )
+      }
+    </div>
+  </main>
+  <Footer />
+</Layout>

--- a/landing/src/pages/rss.xml.ts
+++ b/landing/src/pages/rss.xml.ts
@@ -1,0 +1,20 @@
+import rss from '@astrojs/rss';
+import type { APIContext } from 'astro';
+import { getPublishedBlogPosts } from '../lib/blog';
+
+export async function GET(context: APIContext) {
+  const posts = await getPublishedBlogPosts();
+
+  return rss({
+    title: 'Alera Blog',
+    description:
+      'Notes from the team building Alera, a native workbench for CLI coding agents.',
+    site: context.site!,
+    items: posts.map((post) => ({
+      title: post.data.title,
+      description: post.data.description,
+      pubDate: post.data.pubDate,
+      link: `/blog/${post.id}`,
+    })),
+  });
+}


### PR DESCRIPTION
## Summary

- Add an Astro Content Collection for Markdown blog posts with schema validation, date sorting, and draft filtering.
- Add blog index and post pages with reusable cards, headers, and prose styling.
- Add 14 initial articles covering Alera’s architecture, terminals, worktrees, orchestration, quotas, resources, mobile access, and CI workflows.
- Add RSS feed generation at `/rss.xml` and register the sitemap integration.
- Add article Open Graph metadata, JSON-LD, published/modified timestamps, and RSS discovery metadata.
- Add Blog links to the main navigation and footer.
- Document the new blog structure and content collection conventions.