### PR TITLE
fix: keep browser content and address bar in their slots

### DIFF
--- a/docs/browser-tabs.md
+++ b/docs/browser-tabs.md
@@ -70,4 +70,4 @@ The address policy accepts `http`, `https`, and internal `about:blank`. A hostna
 
 ## Platform Packaging
 
-macOS browser tabs require macOS 14 or newer. Windows uses the installed evergreen WebView2 runtime. Linux CI installs `libwebkit2gtk-4.1-dev`; Debian packages depend on `libwebkit2gtk-4.1-0`, and RPM packages require `webkit2gtk4.1`. The Linux runner places the Flutter view inside a `GtkOverlay` so the browser plugin can position and explicitly obscure its native child surface.
+macOS browser tabs require macOS 14 or newer. Windows uses the installed evergreen WebView2 runtime. Linux CI installs `libwebkit2gtk-4.1-dev`; Debian packages depend on `libwebkit2gtk-4.1-0`, and RPM packages require `webkit2gtk4.1`. The Linux runner places the Flutter view inside a `GtkOverlay` so the browser plugin can position and explicitly obscure its native child surface. Overlay children are hard-allocated to the Flutter-reported frame through `get-child-position`, so WebKitGTK preferred size cannot expand past the workbench content slot.

--- a/lib/src/design_system/forms/alera_text_field.dart
+++ b/lib/src/design_system/forms/alera_text_field.dart
@@ -6,9 +6,10 @@ import 'package:flutter/services.dart';
 ///
 /// - Default ([dense] == false): relies on the global `inputDecorationTheme`
 ///   (the standard surface-variant field used in dialogs and settings).
-/// - [dense] == true: the compact, surface-filled variant used inside the
-///   narrow sidebar, where the field must contrast against a surface-variant
-///   background.
+/// - [dense] == true: the compact filled variant. Defaults to a surface fill
+///   for surface-variant backgrounds (sidebars). On a surface chrome bar,
+///   pass [fillColor] as [AleraTokens.surfaceVariant] so the field still
+///   contrasts.
 class AleraTextField extends StatelessWidget {
   const AleraTextField({
     super.key,
@@ -27,6 +28,7 @@ class AleraTextField extends StatelessWidget {
     this.onTap,
     this.autofocus = false,
     this.dense = false,
+    this.fillColor,
     this.readOnly = false,
     this.enabled,
   });
@@ -46,6 +48,9 @@ class AleraTextField extends StatelessWidget {
   final VoidCallback? onTap;
   final bool autofocus;
   final bool dense;
+
+  /// Dense fill color. Defaults to [AleraTokens.surface].
+  final Color? fillColor;
   final bool readOnly;
   final bool? enabled;
 
@@ -100,7 +105,7 @@ class AleraTextField extends StatelessWidget {
         decoration: InputDecoration(
           isDense: true,
           filled: true,
-          fillColor: AleraTokens.surface,
+          fillColor: fillColor ?? AleraTokens.surface,
           labelText: labelText,
           hintText: hintText,
           errorText: errorText,

--- a/lib/src/features/browser/presentation/browser_toolbar.dart
+++ b/lib/src/features/browser/presentation/browser_toolbar.dart
@@ -40,6 +40,9 @@ class BrowserToolbar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    // denseHeight (40) must fit inside sidebarHeaderHeight (44). Vertical
+    // padding would clip the address field borders and text, so center the
+    // row instead and only pad horizontally.
     return Material(
       color: AleraTokens.surface,
       child: SizedBox(
@@ -52,11 +55,8 @@ class BrowserToolbar extends StatelessWidget {
               fit: StackFit.expand,
               children: <Widget>[
                 Padding(
-                  padding: const EdgeInsets.fromLTRB(
-                    AleraTokens.space8,
-                    AleraTokens.space4,
-                    AleraTokens.space8,
-                    AleraTokens.space4,
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: AleraTokens.space8,
                   ),
                   child: Row(
                     children: <Widget>[
@@ -96,6 +96,9 @@ class BrowserToolbar extends StatelessWidget {
                           controller: addressController,
                           focusNode: addressFocusNode,
                           dense: true,
+                          // Toolbar chrome is surface; dense defaults to a
+                          // surface fill meant for surface-variant sidebars.
+                          fillColor: AleraTokens.surfaceVariant,
                           hintText: 'Search Or Enter Address',
                           onSubmitted: onSubmitAddress,
                         ),

--- a/packages/alera_browser/lib/src/native_browser_surface.dart
+++ b/packages/alera_browser/lib/src/native_browser_surface.dart
@@ -77,6 +77,14 @@ final class _AleraNativeBrowserSurfaceState
   @override
   Widget build(BuildContext context) {
     _scheduleBoundsUpdate();
-    return const SizedBox.expand();
+    // Layout-only size changes (sidebar/split resize without metrics change)
+    // must still push page.setBounds to the native overlay.
+    return NotificationListener<SizeChangedLayoutNotification>(
+      onNotification: (notification) {
+        _scheduleBoundsUpdate();
+        return true;
+      },
+      child: const SizeChangedLayoutNotifier(child: SizedBox.expand()),
+    );
   }
 }

--- a/packages/alera_browser/linux/alera_browser_plugin.cc
+++ b/packages/alera_browser/linux/alera_browser_plugin.cc
@@ -107,6 +107,11 @@ void alera_browser_plugin_register_with_registrar(FlPluginRegistrar* registrar) 
     GtkWidget* parent = gtk_widget_get_parent(GTK_WIDGET(view));
     if (parent != nullptr && GTK_IS_OVERLAY(parent)) {
       plugin->overlay = GTK_OVERLAY(parent);
+      // Hard-allocate browser pages to the Flutter-reported frame. Without
+      // this, WebKitGTK's preferred size grows across the overlay and covers
+      // the right sidebar and status bar.
+      g_signal_connect(plugin->overlay, "get-child-position",
+                       G_CALLBACK(browser_overlay_get_child_position), plugin);
     }
   }
 

--- a/packages/alera_browser/linux/browser_overlay_allocation.h
+++ b/packages/alera_browser/linux/browser_overlay_allocation.h
@@ -1,0 +1,32 @@
+#ifndef ALERA_BROWSER_LINUX_BROWSER_OVERLAY_ALLOCATION_H_
+#define ALERA_BROWSER_LINUX_BROWSER_OVERLAY_ALLOCATION_H_
+
+// Pure frame math for GtkOverlay get-child-position. Kept free of GTK so the
+// linux unit tests can exercise the gate without linking the full plugin.
+struct BrowserOverlayAllocation {
+  int x;
+  int y;
+  int width;
+  int height;
+};
+
+// Fills [allocation] with the exact Flutter-reported frame for a browser page
+// overlay child. Returns true only when width and height are positive so
+// GtkOverlay keeps its default layout for invalid or unmeasured pages.
+inline bool browser_page_fill_overlay_allocation(
+    int frame_x,
+    int frame_y,
+    int frame_width,
+    int frame_height,
+    BrowserOverlayAllocation* allocation) {
+  if (allocation == nullptr || frame_width <= 0 || frame_height <= 0) {
+    return false;
+  }
+  allocation->x = frame_x;
+  allocation->y = frame_y;
+  allocation->width = frame_width;
+  allocation->height = frame_height;
+  return true;
+}
+
+#endif

--- a/packages/alera_browser/linux/browser_pages.cc
+++ b/packages/alera_browser/linux/browser_pages.cc
@@ -1,5 +1,7 @@
 #include "browser_state.h"
 
+#include "browser_overlay_allocation.h"
+
 namespace {
 
 GQuark page_error_quark() {
@@ -14,6 +16,12 @@ void add_page_to_overlay(AleraBrowserPlugin* plugin, LinuxBrowserPage* page) {
   gtk_widget_set_vexpand(widget, FALSE);
   gtk_widget_set_can_focus(widget, TRUE);
   gtk_widget_set_sensitive(widget, FALSE);
+  // Position comes only from get-child-position; margins must stay zero so the
+  // hard allocation is not double-offset.
+  gtk_widget_set_margin_start(widget, 0);
+  gtk_widget_set_margin_top(widget, 0);
+  gtk_widget_set_margin_end(widget, 0);
+  gtk_widget_set_margin_bottom(widget, 0);
   gtk_widget_set_size_request(widget, 1, 1);
   gtk_overlay_add_overlay(plugin->overlay, widget);
   gtk_overlay_set_overlay_pass_through(plugin->overlay, widget, FALSE);
@@ -91,13 +99,40 @@ void browser_page_destroy(gpointer data) {
   g_free(page);
 }
 
+gboolean browser_overlay_get_child_position(GtkOverlay* overlay,
+                                            GtkWidget* widget,
+                                            GdkRectangle* allocation,
+                                            gpointer user_data) {
+  (void)overlay;
+  (void)user_data;
+  LinuxBrowserPage* page = static_cast<LinuxBrowserPage*>(
+      g_object_get_data(G_OBJECT(widget), "alera-browser-page"));
+  if (page == nullptr || allocation == nullptr) {
+    return FALSE;
+  }
+  BrowserOverlayAllocation frame{};
+  if (!browser_page_fill_overlay_allocation(page->frame_x, page->frame_y,
+                                            page->frame_width,
+                                            page->frame_height, &frame)) {
+    return FALSE;
+  }
+  allocation->x = frame.x;
+  allocation->y = frame.y;
+  allocation->width = frame.width;
+  allocation->height = frame.height;
+  return TRUE;
+}
+
 void browser_page_update_visibility(LinuxBrowserPage* page) {
   GtkWidget* widget = GTK_WIDGET(page->web_view);
   const gboolean visible =
       page->attached && !page->obscured && page->frame_width > 0 &&
       page->frame_height > 0;
-  gtk_widget_set_margin_start(widget, page->frame_x);
-  gtk_widget_set_margin_top(widget, page->frame_y);
+  // Origin is applied only by get-child-position; keep margins zero.
+  gtk_widget_set_margin_start(widget, 0);
+  gtk_widget_set_margin_top(widget, 0);
+  gtk_widget_set_margin_end(widget, 0);
+  gtk_widget_set_margin_bottom(widget, 0);
   gtk_widget_set_size_request(
       widget, MAX(page->frame_width, 1), MAX(page->frame_height, 1));
   gtk_widget_set_sensitive(widget, visible);
@@ -106,6 +141,8 @@ void browser_page_update_visibility(LinuxBrowserPage* page) {
   } else {
     gtk_widget_hide(widget);
   }
+  // Force GtkOverlay to re-query get-child-position after frame changes.
+  gtk_widget_queue_resize(widget);
   browser_update_flutter_input_region(page->plugin);
 }
 

--- a/packages/alera_browser/linux/browser_state.h
+++ b/packages/alera_browser/linux/browser_state.h
@@ -108,6 +108,12 @@ LinuxBrowserPage* browser_page_create(AleraBrowserPlugin* plugin,
 void browser_page_destroy(gpointer data);
 void browser_page_update_visibility(LinuxBrowserPage* page);
 void browser_update_flutter_input_region(AleraBrowserPlugin* plugin);
+// Exact overlay allocation for WebKitGTK children. Connected once on the
+// runner GtkOverlay so preferred-size growth cannot cover Flutter chrome.
+gboolean browser_overlay_get_child_position(GtkOverlay* overlay,
+                                            GtkWidget* widget,
+                                            GdkRectangle* allocation,
+                                            gpointer user_data);
 void browser_page_connect_signals(LinuxBrowserPage* page);
 void browser_page_handle_method(AleraBrowserPlugin* plugin,
                                 FlMethodCall* method_call,

--- a/packages/alera_browser/linux/test/CMakeLists.txt
+++ b/packages/alera_browser/linux/test/CMakeLists.txt
@@ -20,6 +20,23 @@ add_test(
   COMMAND alera_browser_linux_navigation_state_tests
 )
 
+add_executable(alera_browser_linux_overlay_allocation_tests
+  "browser_overlay_allocation_test.cc"
+)
+target_compile_features(
+  alera_browser_linux_overlay_allocation_tests PRIVATE cxx_std_17)
+target_compile_options(alera_browser_linux_overlay_allocation_tests PRIVATE
+  -Wall
+  -Wextra
+  -Werror
+)
+target_include_directories(
+  alera_browser_linux_overlay_allocation_tests PRIVATE "..")
+add_test(
+  NAME alera_browser_linux_overlay_allocation_tests
+  COMMAND alera_browser_linux_overlay_allocation_tests
+)
+
 add_executable(alera_browser_linux_profile_selection_tests
   "../browser_import_profile_selection.cc"
   "browser_import_profile_selection_test.cc"

--- a/packages/alera_browser/linux/test/browser_overlay_allocation_test.cc
+++ b/packages/alera_browser/linux/test/browser_overlay_allocation_test.cc
@@ -1,0 +1,43 @@
+#include "../browser_overlay_allocation.h"
+
+#include <iostream>
+
+namespace {
+
+bool Expect(bool value, const char* message) {
+  if (!value) {
+    std::cerr << message << '\n';
+  }
+  return value;
+}
+
+}  // namespace
+
+int main() {
+  bool succeeded = true;
+  BrowserOverlayAllocation allocation{};
+
+  succeeded &= Expect(
+      browser_page_fill_overlay_allocation(12, 34, 640, 480, &allocation),
+      "a valid frame should fill the overlay allocation");
+  succeeded &= Expect(allocation.x == 12, "frame x was not applied");
+  succeeded &= Expect(allocation.y == 34, "frame y was not applied");
+  succeeded &= Expect(allocation.width == 640, "frame width was not applied");
+  succeeded &=
+      Expect(allocation.height == 480, "frame height was not applied");
+
+  succeeded &= Expect(
+      !browser_page_fill_overlay_allocation(0, 0, 0, 100, &allocation),
+      "zero width should not claim overlay allocation");
+  succeeded &= Expect(
+      !browser_page_fill_overlay_allocation(0, 0, 100, 0, &allocation),
+      "zero height should not claim overlay allocation");
+  succeeded &= Expect(
+      !browser_page_fill_overlay_allocation(0, 0, -1, 100, &allocation),
+      "negative width should not claim overlay allocation");
+  succeeded &= Expect(
+      !browser_page_fill_overlay_allocation(0, 0, 100, 100, nullptr),
+      "a null allocation pointer should not claim overlay allocation");
+
+  return succeeded ? 0 : 1;
+}

--- a/packages/alera_browser/test/native_browser_surface_test.dart
+++ b/packages/alera_browser/test/native_browser_surface_test.dart
@@ -1,0 +1,105 @@
+import 'package:alera_browser/src/native_browser_surface.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('reports the first layout bounds', (tester) async {
+    final boundsLog = <Rect>[];
+    await tester.pumpWidget(
+      MediaQuery(
+        data: const MediaQueryData(devicePixelRatio: 1),
+        child: Directionality(
+          textDirection: TextDirection.ltr,
+          child: Center(
+            child: SizedBox(
+              width: 320,
+              height: 240,
+              child: AleraNativeBrowserSurface(
+                onBoundsChanged: (bounds, scale) async {
+                  expect(scale, 1);
+                  boundsLog.add(bounds);
+                },
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+
+    expect(boundsLog, hasLength(1));
+    expect(boundsLog.single.size, const Size(320, 240));
+  });
+
+  testWidgets('reports layout-only size changes', (tester) async {
+    final boundsLog = <Size>[];
+    final size = ValueNotifier<Size>(const Size(320, 240));
+
+    await tester.pumpWidget(
+      MediaQuery(
+        data: const MediaQueryData(devicePixelRatio: 1),
+        child: Directionality(
+          textDirection: TextDirection.ltr,
+          child: Center(
+            child: ValueListenableBuilder<Size>(
+              valueListenable: size,
+              builder: (context, value, _) {
+                return SizedBox(
+                  width: value.width,
+                  height: value.height,
+                  child: AleraNativeBrowserSurface(
+                    onBoundsChanged: (bounds, scale) async {
+                      boundsLog.add(bounds.size);
+                    },
+                  ),
+                );
+              },
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+    expect(boundsLog, contains(const Size(320, 240)));
+
+    size.value = const Size(480, 360);
+    await tester.pump();
+    await tester.pump();
+
+    expect(boundsLog.last, const Size(480, 360));
+  });
+
+  testWidgets('dedupes identical bounds', (tester) async {
+    var callbacks = 0;
+    await tester.pumpWidget(
+      MediaQuery(
+        data: const MediaQueryData(devicePixelRatio: 1),
+        child: Directionality(
+          textDirection: TextDirection.ltr,
+          child: Center(
+            child: SizedBox(
+              width: 200,
+              height: 100,
+              child: AleraNativeBrowserSurface(
+                onBoundsChanged: (bounds, scale) async {
+                  callbacks++;
+                },
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+    expect(callbacks, 1);
+
+    await tester.pump();
+    await tester.pump();
+    expect(callbacks, 1);
+  });
+}

--- a/test/widget/browser_toolbar_test.dart
+++ b/test/widget/browser_toolbar_test.dart
@@ -1,3 +1,5 @@
+import 'package:alera/src/app/theme/alera_tokens.dart';
+import 'package:alera/src/design_system/forms/alera_text_field.dart';
 import 'package:alera/src/features/browser/domain/browser_page.dart';
 import 'package:alera/src/features/browser/domain/browser_page_state.dart';
 import 'package:alera/src/features/browser/domain/browser_security.dart';
@@ -96,10 +98,49 @@ void main() {
     expect(find.byTooltip('Stop Loading'), findsOneWidget);
     expect(find.byTooltip('Browser Profile: Research'), findsOneWidget);
     expect(find.byTooltip('Open DevTools'), findsNothing);
-    expect(
-      tester.widget<TextField>(find.byType(TextField)).decoration?.hintText,
-      'Search Or Enter Address',
+    final field = tester.widget<TextField>(find.byType(TextField));
+    expect(field.decoration?.hintText, 'Search Or Enter Address');
+    expect(field.decoration?.fillColor, AleraTokens.surfaceVariant);
+  });
+
+  testWidgets('fits the dense address field inside the toolbar height', (
+    tester,
+  ) async {
+    final controller = TextEditingController();
+    final focusNode = FocusNode();
+    addTearDown(controller.dispose);
+    addTearDown(focusNode.dispose);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Align(
+          child: SizedBox(
+            width: 900,
+            child: BrowserToolbar(
+              state: _state(),
+              addressController: controller,
+              addressFocusNode: focusNode,
+              profileLabel: 'Default',
+              onBack: null,
+              onForward: null,
+              onStopOrReload: () {},
+              onSubmitAddress: (_) {},
+              onShowSecurity: () {},
+              onSelectProfile: () {},
+              onShowDownloads: () {},
+              onOpenDevTools: () {},
+              onOpenExternally: () {},
+            ),
+          ),
+        ),
+      ),
     );
+
+    final toolbarSize = tester.getSize(find.byType(BrowserToolbar));
+    final fieldSize = tester.getSize(find.byType(TextField));
+    expect(toolbarSize.height, AleraTokens.sidebarHeaderHeight);
+    expect(fieldSize.height, AleraTextField.denseHeight);
+    expect(fieldSize.height, lessThanOrEqualTo(toolbarSize.height));
   });
 }
 


### PR DESCRIPTION
## Summary
- Hard-allocate Linux WebKitGTK browser overlay children to the Flutter-reported frame via `get-child-position`, so the native page no longer expands under the right sidebar or status bar.
- Remeasure native surface bounds on layout-only size changes (sidebar/split resize).
- Fix the browser address bar: surface-variant fill for contrast on surface chrome, and remove vertical padding that clipped the dense field inside the 44px toolbar.

## Validation
- `flutter test test/widget/browser_toolbar_test.dart packages/alera_browser/test/native_browser_surface_test.dart`
- Linux unit tests under `packages/alera_browser/linux/test` (allocation + existing tests)
- Manual on Linux: open a browser tab with Source Control visible and confirm the page stays in the content slot; check address field visibility.

## Notes
- Docs: one sentence in `docs/browser-tabs.md` about hard allocation.
- No FRB / Riverpod regeneration.