### PR TITLE
feat: prompt users to star the github repo after real usage

### DIFF
--- a/lib/src/features/settings/domain/github_star_prompt_eligibility.dart
+++ b/lib/src/features/settings/domain/github_star_prompt_eligibility.dart
@@ -1,0 +1,39 @@
+import 'package:alera/src/features/projects/domain/project.dart';
+import 'package:alera/src/features/settings/application/github_star_controller.dart';
+
+/// Minimum time since the oldest project was created before the support prompt
+/// may appear. Keeps the ask off first-run setup.
+const Duration kGitHubStarPromptMinProjectAge = Duration(days: 3);
+
+/// Whether the one-time GitHub star support prompt should be offered.
+///
+/// Callers still own once-per-process guards and loading waits. This only
+/// answers the durable product rules: not muted, real usage age, and not
+/// already starred.
+bool shouldOfferGitHubStarPrompt({
+  required bool starClicked,
+  required List<Project> projects,
+  required GitHubStarState starState,
+  required DateTime now,
+  Duration minProjectAge = kGitHubStarPromptMinProjectAge,
+}) {
+  if (starClicked || projects.isEmpty) {
+    return false;
+  }
+  if (starState == GitHubStarState.loading ||
+      starState == GitHubStarState.starring ||
+      starState == GitHubStarState.starred) {
+    return false;
+  }
+  DateTime? oldest;
+  for (final project in projects) {
+    final createdAt = project.createdAt;
+    if (oldest == null || createdAt.isBefore(oldest)) {
+      oldest = createdAt;
+    }
+  }
+  if (oldest == null) {
+    return false;
+  }
+  return !now.isBefore(oldest.add(minProjectAge));
+}

--- a/lib/src/features/settings/presentation/github_star_prompt_watch.dart
+++ b/lib/src/features/settings/presentation/github_star_prompt_watch.dart
@@ -1,0 +1,138 @@
+import 'dart:async';
+
+import 'package:alera/src/app/providers.dart';
+import 'package:alera/src/design_system/layout/alera_confirm_dialog.dart';
+import 'package:alera/src/features/projects/domain/project.dart';
+import 'package:alera/src/features/settings/domain/alera_settings.dart';
+import 'package:alera/src/features/settings/domain/github_star_prompt_eligibility.dart';
+import 'package:alera/src/features/settings/infra/github_star_service.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Offers a one-time GitHub star prompt after the user has real project history.
+///
+/// Must sit under a [Navigator] route (shell home), not in
+/// `MaterialApp.builder`. Declining or completing the flow mutes the prompt via
+/// [SettingsController.markStarClicked].
+class GitHubStarPromptWatch extends ConsumerStatefulWidget {
+  const GitHubStarPromptWatch({super.key, required this.child});
+
+  final Widget child;
+
+  @override
+  ConsumerState<GitHubStarPromptWatch> createState() =>
+      _GitHubStarPromptWatchState();
+}
+
+class _GitHubStarPromptWatchState extends ConsumerState<GitHubStarPromptWatch> {
+  var _asked = false;
+  var _promptQueued = false;
+
+  @override
+  Widget build(BuildContext context) {
+    ref.listen<AleraSettings>(settingsControllerProvider, (previous, next) {
+      _schedulePromptCheck();
+    });
+    ref.listen<AsyncValue<List<Project>>>(projectListProvider, (
+      previous,
+      next,
+    ) {
+      _schedulePromptCheck();
+    });
+    ref.listen<GitHubStarState>(gitHubStarControllerProvider, (previous, next) {
+      _schedulePromptCheck();
+    });
+    _schedulePromptCheck();
+    return widget.child;
+  }
+
+  void _schedulePromptCheck() {
+    if (_asked || _promptQueued) {
+      return;
+    }
+    _promptQueued = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _promptQueued = false;
+      if (!mounted || _asked) {
+        return;
+      }
+      unawaited(_maybePrompt());
+    });
+  }
+
+  Future<void> _maybePrompt() async {
+    if (_asked || !mounted) {
+      return;
+    }
+
+    // Settings start as defaults and load async; refresh before deciding so a
+    // previously muted install does not flash the dialog on cold start.
+    await ref.read(settingsControllerProvider.notifier).load();
+    if (!mounted || _asked) {
+      return;
+    }
+
+    final settings = ref.read(settingsControllerProvider);
+    final projects = ref.read(projectListProvider).asData?.value;
+    final starState = ref.read(gitHubStarControllerProvider);
+    if (projects == null) {
+      return;
+    }
+    if (!shouldOfferGitHubStarPrompt(
+      starClicked: settings.general.starClicked,
+      projects: projects,
+      starState: starState,
+      now: DateTime.now().toUtc(),
+    )) {
+      return;
+    }
+
+    _asked = true;
+    await _ask();
+  }
+
+  Future<void> _ask() async {
+    final accepted = await showDialog<bool>(
+      context: context,
+      builder: (context) => const AleraConfirmDialog(
+        title: 'Support Alera',
+        message:
+            'If this is useful, consider starring the repo. '
+            'It helps more developers discover it.',
+        confirmLabel: 'Star On GitHub',
+        cancelLabel: 'Not Now',
+      ),
+    );
+    if (!mounted) {
+      return;
+    }
+    if (accepted == true) {
+      await _starOrOpenUrl();
+    }
+    if (!mounted) {
+      return;
+    }
+    await ref.read(settingsControllerProvider.notifier).markStarClicked();
+  }
+
+  Future<void> _starOrOpenUrl() async {
+    final starState = ref.read(gitHubStarControllerProvider);
+    if (starState == GitHubStarState.notStarred ||
+        starState == GitHubStarState.error) {
+      await ref.read(gitHubStarControllerProvider.notifier).star();
+    }
+    if (!mounted) {
+      return;
+    }
+    if (ref.read(gitHubStarControllerProvider) == GitHubStarState.starred) {
+      return;
+    }
+    try {
+      await ref
+          .read(externalUriLauncherProvider)
+          .open(Uri.parse(aleraGitHubUrl));
+    } catch (_) {
+      // Opening the browser is best-effort; the mute still applies.
+    }
+  }
+}

--- a/lib/src/features/settings/presentation/panes/application_support_section.dart
+++ b/lib/src/features/settings/presentation/panes/application_support_section.dart
@@ -13,6 +13,14 @@ class SupportAleraSection extends ConsumerWidget {
 
   final GitHubStarState state;
 
+  Future<void> _starFromSettings(WidgetRef ref) async {
+    await ref.read(gitHubStarControllerProvider.notifier).star();
+    if (ref.read(gitHubStarControllerProvider) != GitHubStarState.starred) {
+      return;
+    }
+    await ref.read(settingsControllerProvider.notifier).markStarClicked();
+  }
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final theme = Theme.of(context);
@@ -39,8 +47,7 @@ class SupportAleraSection extends ConsumerWidget {
               description: null,
               child: _StarControl(
                 state: state,
-                onStar: () =>
-                    ref.read(gitHubStarControllerProvider.notifier).star(),
+                onStar: () => _starFromSettings(ref),
               ),
             ),
           ],

--- a/lib/src/features/shell/presentation/alera_shell_page.dart
+++ b/lib/src/features/shell/presentation/alera_shell_page.dart
@@ -28,6 +28,7 @@ import 'package:alera/src/features/workbench/presentation/welcome_dashboard.dart
 import 'package:alera/src/features/workbench/application/terminal_driver_presence_controller.dart';
 import 'package:alera/src/features/workbench/presentation/mobile_driver_overlay.dart';
 import 'package:alera/src/features/workbench/presentation/workspace_workbench_view.dart';
+import 'package:alera/src/features/settings/presentation/github_star_prompt_watch.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -42,7 +43,7 @@ class AleraShellPage extends ConsumerWidget {
     return dbAsync.when(
       loading: () => const _ShellLoading(),
       error: (error, _) => _ShellError(error: error.toString()),
-      data: (_) => const _AleraShellPageBody(),
+      data: (_) => const GitHubStarPromptWatch(child: _AleraShellPageBody()),
     );
   }
 }

--- a/test/unit/github_star_prompt_eligibility_test.dart
+++ b/test/unit/github_star_prompt_eligibility_test.dart
@@ -1,0 +1,128 @@
+import 'package:alera/src/features/projects/domain/project.dart';
+import 'package:alera/src/features/settings/application/github_star_controller.dart';
+import 'package:alera/src/features/settings/domain/github_star_prompt_eligibility.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  final now = DateTime.utc(2026, 7, 28, 12);
+  final oldProject = _project(createdAt: now.subtract(const Duration(days: 3)));
+  final youngProject = _project(
+    createdAt: now.subtract(
+      const Duration(days: 3) - const Duration(seconds: 1),
+    ),
+  );
+
+  group('shouldOfferGitHubStarPrompt', () {
+    test('requires a project at least three days old', () {
+      expect(
+        shouldOfferGitHubStarPrompt(
+          starClicked: false,
+          projects: <Project>[oldProject],
+          starState: GitHubStarState.notStarred,
+          now: now,
+        ),
+        isTrue,
+      );
+      expect(
+        shouldOfferGitHubStarPrompt(
+          starClicked: false,
+          projects: <Project>[youngProject],
+          starState: GitHubStarState.notStarred,
+          now: now,
+        ),
+        isFalse,
+      );
+      expect(
+        shouldOfferGitHubStarPrompt(
+          starClicked: false,
+          projects: const <Project>[],
+          starState: GitHubStarState.notStarred,
+          now: now,
+        ),
+        isFalse,
+      );
+    });
+
+    test('uses the oldest project when several exist', () {
+      expect(
+        shouldOfferGitHubStarPrompt(
+          starClicked: false,
+          projects: <Project>[youngProject, oldProject],
+          starState: GitHubStarState.notStarred,
+          now: now,
+        ),
+        isTrue,
+      );
+    });
+
+    test('stays off after mute or when already starred', () {
+      expect(
+        shouldOfferGitHubStarPrompt(
+          starClicked: true,
+          projects: <Project>[oldProject],
+          starState: GitHubStarState.notStarred,
+          now: now,
+        ),
+        isFalse,
+      );
+      expect(
+        shouldOfferGitHubStarPrompt(
+          starClicked: false,
+          projects: <Project>[oldProject],
+          starState: GitHubStarState.starred,
+          now: now,
+        ),
+        isFalse,
+      );
+      expect(
+        shouldOfferGitHubStarPrompt(
+          starClicked: false,
+          projects: <Project>[oldProject],
+          starState: GitHubStarState.loading,
+          now: now,
+        ),
+        isFalse,
+      );
+      expect(
+        shouldOfferGitHubStarPrompt(
+          starClicked: false,
+          projects: <Project>[oldProject],
+          starState: GitHubStarState.starring,
+          now: now,
+        ),
+        isFalse,
+      );
+    });
+
+    test('still offers when gh is unavailable so the URL path can run', () {
+      expect(
+        shouldOfferGitHubStarPrompt(
+          starClicked: false,
+          projects: <Project>[oldProject],
+          starState: GitHubStarState.hidden,
+          now: now,
+        ),
+        isTrue,
+      );
+      expect(
+        shouldOfferGitHubStarPrompt(
+          starClicked: false,
+          projects: <Project>[oldProject],
+          starState: GitHubStarState.error,
+          now: now,
+        ),
+        isTrue,
+      );
+    });
+  });
+}
+
+Project _project({required DateTime createdAt}) {
+  return Project(
+    id: 'project-1',
+    name: 'Alera',
+    repoPath: '/tmp/alera',
+    createdAt: createdAt,
+    updatedAt: createdAt,
+  );
+}

--- a/test/widget/github_star_prompt_watch_test.dart
+++ b/test/widget/github_star_prompt_watch_test.dart
@@ -1,0 +1,264 @@
+import 'package:alera/src/app/providers.dart';
+import 'package:alera/src/app/theme/alera_dark_theme.dart';
+import 'package:alera/src/features/projects/domain/project.dart';
+import 'package:alera/src/features/settings/application/settings_repository.dart';
+import 'package:alera/src/features/settings/domain/alera_settings.dart';
+import 'package:alera/src/features/settings/infra/github_star_service.dart';
+import 'package:alera/src/features/settings/presentation/github_star_prompt_watch.dart';
+import 'package:alera/src/shared/infra/uri/external_uri_launcher.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  // Far enough in the past that DateTime.now() in the prompt host always qualifies.
+  final oldProject = Project(
+    id: 'project-1',
+    name: 'Alera',
+    repoPath: '/tmp/alera',
+    createdAt: DateTime.utc(2020, 1, 1),
+    updatedAt: DateTime.utc(2020, 1, 1),
+  );
+  final youngProject = Project(
+    id: 'project-2',
+    name: 'Fresh',
+    repoPath: '/tmp/fresh',
+    createdAt: DateTime.now().toUtc().subtract(const Duration(hours: 2)),
+    updatedAt: DateTime.now().toUtc().subtract(const Duration(hours: 2)),
+  );
+
+  group('GitHubStarPromptWatch', () {
+    testWidgets('shows once when usage is old enough and not muted', (
+      tester,
+    ) async {
+      await _pump(
+        tester,
+        projects: <Project>[oldProject],
+        starState: GitHubStarState.notStarred,
+      );
+
+      expect(find.text('Support Alera'), findsOneWidget);
+      expect(
+        find.text(
+          'If this is useful, consider starring the repo. '
+          'It helps more developers discover it.',
+        ),
+        findsOneWidget,
+      );
+      expect(find.text('Star On GitHub'), findsOneWidget);
+      expect(find.text('Not Now'), findsOneWidget);
+    });
+
+    testWidgets('does not show when muted, too early, or already starred', (
+      tester,
+    ) async {
+      await _pump(
+        tester,
+        projects: <Project>[oldProject],
+        starState: GitHubStarState.notStarred,
+        settings: AleraSettings.defaults.copyWith(
+          general: const GeneralSettings(starClicked: true),
+        ),
+      );
+      expect(find.text('Support Alera'), findsNothing);
+
+      await _pump(
+        tester,
+        projects: <Project>[youngProject],
+        starState: GitHubStarState.notStarred,
+      );
+      expect(find.text('Support Alera'), findsNothing);
+
+      await _pump(
+        tester,
+        projects: <Project>[oldProject],
+        starState: GitHubStarState.starred,
+      );
+      expect(find.text('Support Alera'), findsNothing);
+    });
+
+    testWidgets('Not Now mutes permanently', (tester) async {
+      final repository = _FakeSettingsRepository();
+      final container = await _pump(
+        tester,
+        projects: <Project>[oldProject],
+        starState: GitHubStarState.notStarred,
+        repository: repository,
+      );
+
+      await tester.tap(find.text('Not Now'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Support Alera'), findsNothing);
+      expect(
+        container.read(settingsControllerProvider).general.starClicked,
+        isTrue,
+      );
+      expect((await repository.load()).general.starClicked, isTrue);
+    });
+
+    testWidgets('confirm stars via gh when available and mutes', (
+      tester,
+    ) async {
+      final repository = _FakeSettingsRepository();
+      final launcher = _FakeExternalUriLauncher();
+      final starController = _FakeGitHubStarController(
+        GitHubStarState.notStarred,
+        nextStarState: GitHubStarState.starred,
+      );
+      final container = await _pump(
+        tester,
+        projects: <Project>[oldProject],
+        starController: starController,
+        repository: repository,
+        launcher: launcher,
+      );
+
+      await tester.tap(find.text('Star On GitHub'));
+      await tester.pumpAndSettle();
+
+      expect(starController.starCalls, 1);
+      expect(launcher.opened, isEmpty);
+      expect(
+        container.read(settingsControllerProvider).general.starClicked,
+        isTrue,
+      );
+      expect(find.text('Support Alera'), findsNothing);
+    });
+
+    testWidgets('confirm opens the repo URL when gh cannot star', (
+      tester,
+    ) async {
+      final repository = _FakeSettingsRepository();
+      final launcher = _FakeExternalUriLauncher();
+      final starController = _FakeGitHubStarController(GitHubStarState.hidden);
+      final container = await _pump(
+        tester,
+        projects: <Project>[oldProject],
+        starController: starController,
+        repository: repository,
+        launcher: launcher,
+      );
+
+      await tester.tap(find.text('Star On GitHub'));
+      await tester.pumpAndSettle();
+
+      expect(starController.starCalls, 0);
+      expect(launcher.opened, <Uri>[Uri.parse(aleraGitHubUrl)]);
+      expect(
+        container.read(settingsControllerProvider).general.starClicked,
+        isTrue,
+      );
+    });
+
+    testWidgets('confirm falls back to the URL after a failed star', (
+      tester,
+    ) async {
+      final launcher = _FakeExternalUriLauncher();
+      final starController = _FakeGitHubStarController(
+        GitHubStarState.notStarred,
+        nextStarState: GitHubStarState.error,
+      );
+      await _pump(
+        tester,
+        projects: <Project>[oldProject],
+        starController: starController,
+        launcher: launcher,
+      );
+
+      await tester.tap(find.text('Star On GitHub'));
+      await tester.pumpAndSettle();
+
+      expect(starController.starCalls, 1);
+      expect(launcher.opened, <Uri>[Uri.parse(aleraGitHubUrl)]);
+    });
+  });
+}
+
+Future<ProviderContainer> _pump(
+  WidgetTester tester, {
+  required List<Project> projects,
+  GitHubStarState starState = GitHubStarState.notStarred,
+  _FakeGitHubStarController? starController,
+  AleraSettings settings = AleraSettings.defaults,
+  _FakeSettingsRepository? repository,
+  _FakeExternalUriLauncher? launcher,
+}) async {
+  final settingsRepository = repository ?? _FakeSettingsRepository(settings);
+  final star = starController ?? _FakeGitHubStarController(starState);
+  final uriLauncher = launcher ?? _FakeExternalUriLauncher();
+  final container = ProviderContainer(
+    overrides: [
+      settingsRepositoryProvider.overrideWithValue(settingsRepository),
+      projectListProvider.overrideWith((ref) => Stream.value(projects)),
+      gitHubStarControllerProvider.overrideWith(() => star),
+      externalUriLauncherProvider.overrideWithValue(uriLauncher),
+    ],
+  );
+  addTearDown(container.dispose);
+
+  await tester.pumpWidget(
+    UncontrolledProviderScope(
+      container: container,
+      child: MaterialApp(
+        theme: buildAleraDarkTheme(),
+        home: const GitHubStarPromptWatch(
+          child: Scaffold(body: SizedBox.shrink()),
+        ),
+      ),
+    ),
+  );
+  // Settings load + post-frame dialog presentation.
+  await tester.pump();
+  await tester.pump();
+  await tester.pump(const Duration(milliseconds: 50));
+  return container;
+}
+
+class _FakeSettingsRepository implements SettingsRepository {
+  _FakeSettingsRepository([AleraSettings? initialSettings])
+    : _settings = initialSettings ?? AleraSettings.defaults;
+
+  AleraSettings _settings;
+
+  @override
+  Future<AleraSettings> load() async => _settings;
+
+  @override
+  Future<void> save(AleraSettings settings) async {
+    _settings = settings;
+  }
+}
+
+class _FakeGitHubStarController extends GitHubStarController {
+  _FakeGitHubStarController(this.initialState, {this.nextStarState});
+
+  final GitHubStarState initialState;
+  final GitHubStarState? nextStarState;
+  int starCalls = 0;
+
+  @override
+  GitHubStarState build() => initialState;
+
+  @override
+  Future<void> refresh() async {}
+
+  @override
+  Future<void> star() async {
+    starCalls += 1;
+    if (state != GitHubStarState.notStarred && state != GitHubStarState.error) {
+      return;
+    }
+    state = GitHubStarState.starring;
+    state = nextStarState ?? GitHubStarState.starred;
+  }
+}
+
+class _FakeExternalUriLauncher implements ExternalUriLauncher {
+  final List<Uri> opened = <Uri>[];
+
+  @override
+  Future<void> open(Uri uri) async {
+    opened.add(uri);
+  }
+}

--- a/test/widget/settings_dialog_core_test_cases.dart
+++ b/test/widget/settings_dialog_core_test_cases.dart
@@ -814,6 +814,10 @@ void _registerSettingsDialogCoreTests() {
       await tester.pump(const Duration(milliseconds: 100));
 
       expect(find.text('Thanks for the support!'), findsOneWidget);
+      expect(
+        container.read(settingsControllerProvider).general.starClicked,
+        isTrue,
+      );
 
       final errorController = _FakeGitHubStarController(
         GitHubStarState.error,


### PR DESCRIPTION
## Summary
- Show a one-time Support Alera modal after real usage (at least one project whose oldest `createdAt` is >= 3 days).
- Primary action stars via `gh` when available, otherwise opens `https://github.com/leynier/alera`.
- Not Now / dismiss permanently mutes via `general.starClicked`; Settings star success also mutes the nag.

## Validation
- `dart analyze` on touched files: clean
- `flutter test test/unit/github_star_prompt_eligibility_test.dart test/widget/github_star_prompt_watch_test.dart`: 10/10 passed
- Settings support-section star test still covers mute after successful star

## Notes
- No docs/AGENTS changes needed: local UX on existing star plumbing.