### PR TITLE
fix: stabilize mobile emulator playback

### DIFF
--- a/lib/src/features/mobile_emulator/presentation/mobile_emulator_playback_monitor.dart
+++ b/lib/src/features/mobile_emulator/presentation/mobile_emulator_playback_monitor.dart
@@ -1,13 +1,49 @@
 import 'dart:async';
 
+enum MobileEmulatorPlaybackRecoveryAction { retry, fail }
+
+class MobileEmulatorPlaybackRecoveryPolicy {
+  MobileEmulatorPlaybackRecoveryPolicy({
+    this.stabilityWindow = const Duration(seconds: 30),
+  });
+
+  final Duration stabilityWindow;
+  Timer? _stabilityTimer;
+  bool _automaticRetryUsed = false;
+
+  void playbackStarted() {
+    _stabilityTimer?.cancel();
+    _stabilityTimer = Timer(stabilityWindow, reset);
+  }
+
+  MobileEmulatorPlaybackRecoveryAction recordFailure() {
+    _stabilityTimer?.cancel();
+    _stabilityTimer = null;
+    if (_automaticRetryUsed) {
+      return MobileEmulatorPlaybackRecoveryAction.fail;
+    }
+    _automaticRetryUsed = true;
+    return MobileEmulatorPlaybackRecoveryAction.retry;
+  }
+
+  void reset() {
+    _stabilityTimer?.cancel();
+    _stabilityTimer = null;
+    _automaticRetryUsed = false;
+  }
+
+  void dispose() => reset();
+}
+
 class MobileEmulatorPlaybackMonitor {
   MobileEmulatorPlaybackMonitor({
     required Stream<String> errors,
     required Stream<bool> completions,
+    required this.onWarning,
     required this.onFailure,
     this.retryDelay = const Duration(milliseconds: 500),
   }) {
-    _errorSubscription = errors.listen((_) => _scheduleFailure());
+    _errorSubscription = errors.listen(_reportWarning);
     _completionSubscription = completions.listen((completed) {
       if (completed) {
         _scheduleFailure();
@@ -15,12 +51,22 @@ class MobileEmulatorPlaybackMonitor {
     });
   }
 
+  final void Function(String warning) onWarning;
   final void Function() onFailure;
   final Duration retryDelay;
   late final StreamSubscription<String> _errorSubscription;
   late final StreamSubscription<bool> _completionSubscription;
   Timer? _failureTimer;
+  bool _warningReported = false;
   bool _disposed = false;
+
+  void _reportWarning(String warning) {
+    if (_disposed || _warningReported) {
+      return;
+    }
+    _warningReported = true;
+    onWarning(warning);
+  }
 
   void _scheduleFailure() {
     if (_disposed || _failureTimer != null) {

--- a/lib/src/features/mobile_emulator/presentation/mobile_emulator_surface.dart
+++ b/lib/src/features/mobile_emulator/presentation/mobile_emulator_surface.dart
@@ -15,8 +15,11 @@ import 'package:alera/src/features/workbench/infra/terminal_host/terminal_host_p
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:logging/logging.dart';
 import 'package:media_kit/media_kit.dart';
 import 'package:media_kit_video/media_kit_video.dart';
+
+final Logger _log = Logger('MobileEmulatorSurface');
 
 class MobileEmulatorSurface extends ConsumerStatefulWidget {
   const MobileEmulatorSurface({
@@ -42,6 +45,8 @@ class _MobileEmulatorSurfaceState extends ConsumerState<MobileEmulatorSurface>
   MobileEmulatorPlaybackMonitor? _playbackMonitor;
   StreamSubscription<Object?>? _changeSubscription;
   Timer? _hiddenTimer;
+  final MobileEmulatorPlaybackRecoveryPolicy _playbackRecovery =
+      MobileEmulatorPlaybackRecoveryPolicy();
   late final MobileEmulatorPointerController _pointerController =
       MobileEmulatorPointerController(onPointer: _sendPointer);
   double? _decodedAspectRatio;
@@ -75,6 +80,7 @@ class _MobileEmulatorSurfaceState extends ConsumerState<MobileEmulatorSurface>
   void didUpdateWidget(covariant MobileEmulatorSurface oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.tab.id != widget.tab.id) {
+      _playbackRecovery.reset();
       _pointerController.finish();
       _wantsLease = false;
       _leaseGeneration += 1;
@@ -194,15 +200,9 @@ class _MobileEmulatorSurfaceState extends ConsumerState<MobileEmulatorSurface>
       final playbackMonitor = MobileEmulatorPlaybackMonitor(
         errors: player.stream.error,
         completions: player.stream.completed,
-        onFailure: () {
-          if (identical(_player, player) && _wantsLease && _leaseHeld) {
-            _pointerController.finish();
-            _session = null;
-            unawaited(
-              _disposePlayer().then((_) => _acquire(showLoading: false)),
-            );
-          }
-        },
+        onWarning: (_) =>
+            _log.warning('Emulator playback warning for tab ${target.tabId}.'),
+        onFailure: () => _handlePlaybackFailure(player),
       );
       final videoParamsSubscription = player.stream.videoParams.listen((
         params,
@@ -242,6 +242,7 @@ class _MobileEmulatorSurfaceState extends ConsumerState<MobileEmulatorSurface>
       _videoController = controller;
       _videoParamsSubscription = videoParamsSubscription;
       _playbackMonitor = playbackMonitor;
+      _playbackRecovery.playbackStarted();
       final params = player.state.videoParams;
       _decodedAspectRatio = mobileEmulatorDecodedAspectRatio(
         width: params.dw,
@@ -261,11 +262,50 @@ class _MobileEmulatorSurfaceState extends ConsumerState<MobileEmulatorSurface>
     }
   }
 
+  void _handlePlaybackFailure(Player player) {
+    if (!identical(_player, player) || !_wantsLease || !_leaseHeld) {
+      return;
+    }
+    _pointerController.finish();
+    _session = null;
+    switch (_playbackRecovery.recordFailure()) {
+      case MobileEmulatorPlaybackRecoveryAction.retry:
+        unawaited(_disposePlayer().then((_) => _acquire(showLoading: false)));
+      case MobileEmulatorPlaybackRecoveryAction.fail:
+        _wantsLease = false;
+        _leaseGeneration += 1;
+        _leaseHeld = false;
+        unawaited(
+          _disposePlayer().then(
+            (_) => _leases.suspend(widget.tab.id).catchError((_) {}),
+          ),
+        );
+        if (mounted) {
+          setState(() {
+            _loading = false;
+            _error = const MobileEmulatorException(
+              code: 'playback_unstable',
+              message: 'The Mobile Emulator Stream Became Unstable.',
+              nextSteps: <String>[
+                'The Android Device Was Left Running. Select Retry To Reconnect.',
+              ],
+            );
+          });
+        }
+    }
+  }
+
+  Future<void> _retryPlayback() {
+    _playbackRecovery.reset();
+    return _acquire();
+  }
+
   void _handleRuntimeChange(Object? rawEvent) {
     if (rawEvent is! RuntimeHostEvent) {
       return;
     }
     if (rawEvent.name == aleraRuntimeHostConnectedEvent) {
+      _playbackRecovery.reset();
       _wantsLease = true;
       _leaseGeneration += 1;
       _leaseHeld = false;
@@ -287,6 +327,7 @@ class _MobileEmulatorSurfaceState extends ConsumerState<MobileEmulatorSurface>
       case MobileEmulatorRuntimeChangeAction.ignore:
         return;
       case MobileEmulatorRuntimeChangeAction.stopped:
+        _playbackRecovery.reset();
         _wantsLease = false;
         _leaseGeneration += 1;
         _leaseHeld = false;
@@ -373,7 +414,7 @@ class _MobileEmulatorSurfaceState extends ConsumerState<MobileEmulatorSurface>
   @override
   Widget build(BuildContext context) {
     if (_error case final error?) {
-      return MobileEmulatorFailure(error: error, onRetry: _acquire);
+      return MobileEmulatorFailure(error: error, onRetry: _retryPlayback);
     }
     if (_loading || _videoController == null) {
       return MobileEmulatorLoading(state: _session?.state);
@@ -441,6 +482,7 @@ class _MobileEmulatorSurfaceState extends ConsumerState<MobileEmulatorSurface>
   void dispose() {
     _wantsLease = false;
     _leaseGeneration += 1;
+    _playbackRecovery.dispose();
     WidgetsBinding.instance.removeObserver(this);
     _hiddenTimer?.cancel();
     _pointerController.finish();

--- a/test/unit/mobile_emulator_playback_monitor_test.dart
+++ b/test/unit/mobile_emulator_playback_monitor_test.dart
@@ -4,16 +4,18 @@ import 'package:alera/src/features/mobile_emulator/presentation/mobile_emulator_
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  test('recovers once when a ready player later fails', () async {
+  test('reports player errors without treating them as completion', () async {
     final errors = StreamController<String>();
     final completions = StreamController<bool>();
     addTearDown(errors.close);
     addTearDown(completions.close);
+    final warnings = <String>[];
     var recoveries = 0;
     final monitor = MobileEmulatorPlaybackMonitor(
       errors: errors.stream,
       completions: completions.stream,
       retryDelay: Duration.zero,
+      onWarning: warnings.add,
       onFailure: () => recoveries += 1,
     );
     addTearDown(monitor.dispose);
@@ -22,12 +24,14 @@ void main() {
     await Future<void>.delayed(Duration.zero);
     expect(recoveries, 0);
 
-    errors.add('stream ended');
+    errors.add('transient decoder warning');
+    errors.add('repeated decoder warning');
     await Future<void>.delayed(const Duration(milliseconds: 1));
-    expect(recoveries, 1);
+    expect(warnings, <String>['transient decoder warning']);
+    expect(recoveries, 0);
 
     completions.add(true);
-    await Future<void>.delayed(Duration.zero);
+    await Future<void>.delayed(const Duration(milliseconds: 1));
     expect(recoveries, 1);
   });
 
@@ -41,6 +45,7 @@ void main() {
       errors: errors.stream,
       completions: completions.stream,
       retryDelay: Duration.zero,
+      onWarning: (_) {},
       onFailure: () => recoveries += 1,
     );
 
@@ -50,5 +55,36 @@ void main() {
     await Future<void>.delayed(Duration.zero);
 
     expect(recoveries, 0);
+  });
+
+  test('allows one automatic retry before playback is stable', () {
+    final policy = MobileEmulatorPlaybackRecoveryPolicy();
+    addTearDown(policy.dispose);
+
+    expect(policy.recordFailure(), MobileEmulatorPlaybackRecoveryAction.retry);
+    expect(policy.recordFailure(), MobileEmulatorPlaybackRecoveryAction.fail);
+  });
+
+  test('stable playback restores the automatic retry allowance', () async {
+    final policy = MobileEmulatorPlaybackRecoveryPolicy(
+      stabilityWindow: const Duration(milliseconds: 5),
+    );
+    addTearDown(policy.dispose);
+
+    expect(policy.recordFailure(), MobileEmulatorPlaybackRecoveryAction.retry);
+    policy.playbackStarted();
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+
+    expect(policy.recordFailure(), MobileEmulatorPlaybackRecoveryAction.retry);
+  });
+
+  test('explicit reset restores the automatic retry allowance', () {
+    final policy = MobileEmulatorPlaybackRecoveryPolicy();
+    addTearDown(policy.dispose);
+
+    expect(policy.recordFailure(), MobileEmulatorPlaybackRecoveryAction.retry);
+    policy.reset();
+
+    expect(policy.recordFailure(), MobileEmulatorPlaybackRecoveryAction.retry);
   });
 }


### PR DESCRIPTION
## Summary

- Treat media decoder errors as diagnostics instead of restarting the emulator stream.
- Retry one real playback completion automatically, then park the stream while leaving the Android device running.
- Restore the retry allowance after 30 seconds of stable playback or an explicit Retry action.
- Avoid logging raw decoder text that may contain a temporary stream URL.

## Root cause

Every `media_kit` error event was treated as a fatal playback failure. Reacquiring the stream could replay retained H.264 frames, which made the Android view appear to restart and return to an earlier Home frame.

## Validation

- `dart format --set-exit-if-changed` on the changed files
- `flutter analyze`
- 93 focused emulator and workbench tests
- max-lines ratchet and `git diff --check`
- full local suite: 2,303 tests passed; two unrelated native PTY tests remained reproducibly failing in isolation

`gh act` was attempted for the PR static job, but its container could not resolve this Alera worktree's external gitdir while initializing submodules. GitHub-hosted checks remain authoritative.