### PR TITLE
fix: obscure browser surfaces during tab drag

### DIFF
--- a/lib/src/features/browser/application/browser_session_commands.dart
+++ b/lib/src/features/browser/application/browser_session_commands.dart
@@ -111,41 +111,16 @@ extension _BrowserSessionRegistryCommands on BrowserSessionRegistry {
   Future<T> _withFlutterOverlay<T>(
     _BrowserSessionEntry entry,
     Future<T> Function() operation,
-  ) {
-    return _runCommand<T>(entry, BrowserLifecycleReason.overlay, () async {
-      final firstOverlay = entry.overlayCount++ == 0;
-      try {
-        if (firstOverlay) {
-          await _queueOverlay(
-            entry,
-            () => _engine.setPageObscured(entry.pageId, obscured: true),
-          );
-        } else {
-          await entry.overlayTail;
-        }
-        return await operation();
-      } finally {
-        if (entry.overlayCount > 0) {
-          entry.overlayCount -= 1;
-        }
-        if (entry.overlayCount == 0) {
-          await _queueOverlay(
-            entry,
-            () => _engine.setPageObscured(entry.pageId, obscured: false),
-          );
-        }
-      }
-    }, serialized: false);
-  }
-
-  Future<void> _queueOverlay(
-    _BrowserSessionEntry entry,
-    Future<void> Function() operation,
-  ) {
-    final next = entry.overlayTail
-        .catchError((Object _) {})
-        .then((_) => operation());
-    entry.overlayTail = next;
-    return next;
+  ) async {
+    final obscuration = _acquireObscuration(
+      entry,
+      BrowserObscurationReason.overlay,
+    );
+    try {
+      await obscuration.ready;
+      return await operation();
+    } finally {
+      await obscuration.dispose();
+    }
   }
 }

--- a/lib/src/features/browser/application/browser_session_handle.dart
+++ b/lib/src/features/browser/application/browser_session_handle.dart
@@ -128,6 +128,9 @@ final class BrowserSessionHandle {
   BrowserVisibilityLease acquireVisibility(BrowserVisibilityReason reason) =>
       _registry._acquireVisibility(_entry, reason);
 
+  BrowserObscurationLease acquireObscuration(BrowserObscurationReason reason) =>
+      _registry._acquireObscuration(_entry, reason);
+
   BrowserLifecycleLease acquireLifecycle(BrowserLifecycleReason reason) =>
       _registry._acquireLifecycleForHandle(_entry, reason);
 
@@ -159,6 +162,27 @@ final class BrowserVisibilityLease {
   }) : _release = release; // ignore: prefer_initializing_formals
 
   final BrowserVisibilityReason reason;
+  final Future<void> ready;
+  final Future<void> Function() _release;
+  var _disposed = false;
+
+  Future<void> dispose() async {
+    if (_disposed) {
+      return;
+    }
+    _disposed = true;
+    await _release();
+  }
+}
+
+final class BrowserObscurationLease {
+  BrowserObscurationLease._({
+    required this.reason,
+    required this.ready,
+    required Future<void> Function() release,
+  }) : _release = release; // ignore: prefer_initializing_formals
+
+  final BrowserObscurationReason reason;
   final Future<void> ready;
   final Future<void> Function() _release;
   var _disposed = false;

--- a/lib/src/features/browser/application/browser_session_leases.dart
+++ b/lib/src/features/browser/application/browser_session_leases.dart
@@ -1,0 +1,115 @@
+part of 'browser_session_registry.dart';
+
+extension _BrowserSessionRegistryLeases on BrowserSessionRegistry {
+  BrowserVisibilityLease _acquireVisibility(
+    _BrowserSessionEntry entry,
+    BrowserVisibilityReason reason,
+  ) {
+    _ensureOpen(entry);
+    final first = entry.visibilityCount++ == 0;
+    final ready = first
+        ? _queueVisibility(entry, () async {
+            await entry.ready.future;
+            await _ensureOperational(entry);
+            await _engine.attachPage(entry.pageId);
+          })
+        : entry.visibilityTail;
+    return BrowserVisibilityLease._(
+      reason: reason,
+      ready: ready,
+      release: () async {
+        if (--entry.visibilityCount == 0) {
+          await _queueVisibility(entry, () async {
+            if (entry.created && !entry.closed) {
+              await _engine.detachPage(entry.pageId);
+            }
+          });
+        }
+      },
+    );
+  }
+
+  BrowserObscurationLease _acquireObscuration(
+    _BrowserSessionEntry entry,
+    BrowserObscurationReason reason,
+  ) {
+    _ensureOpen(entry);
+    final lifecycle = _acquireLifecycle(entry, BrowserLifecycleReason.overlay);
+    final first = entry.obscurationCount++ == 0;
+    final ready = first
+        ? _queueObscuration(entry, () async {
+            await entry.ready.future;
+            await _ensureOperational(entry);
+            await _engine.setPageObscured(entry.pageId, obscured: true);
+          })
+        : entry.obscurationTail;
+    return BrowserObscurationLease._(
+      reason: reason,
+      ready: ready,
+      release: () async {
+        try {
+          if (entry.obscurationCount > 0) {
+            entry.obscurationCount -= 1;
+          }
+          if (entry.obscurationCount == 0) {
+            await _queueObscuration(entry, () async {
+              if (entry.created && !entry.closed) {
+                await _engine.setPageObscured(entry.pageId, obscured: false);
+              }
+            });
+          }
+        } finally {
+          await lifecycle.dispose();
+        }
+      },
+    );
+  }
+
+  BrowserLifecycleLease _acquireLifecycleForHandle(
+    _BrowserSessionEntry entry,
+    BrowserLifecycleReason reason,
+  ) => _acquireLifecycle(entry, reason);
+
+  BrowserLifecycleLease _acquireLifecycle(
+    _BrowserSessionEntry entry,
+    BrowserLifecycleReason reason,
+  ) {
+    _ensureOpen(entry);
+    entry.lifecycleCount += 1;
+    return BrowserLifecycleLease._(
+      reason: reason,
+      release: () => _releaseLifecycle(entry),
+    );
+  }
+
+  Future<void> _releaseLifecycle(_BrowserSessionEntry entry) async {
+    if (entry.lifecycleCount > 0) {
+      entry.lifecycleCount -= 1;
+    }
+    if (entry.closing && entry.lifecycleCount == 0) {
+      await _finishClose(entry);
+    }
+  }
+
+  Future<void> _queueVisibility(
+    _BrowserSessionEntry entry,
+    Future<void> Function() operation,
+  ) {
+    final next = entry.visibilityTail
+        .catchError((Object _) {})
+        .then((_) => operation());
+    entry.visibilityTail = next;
+    return next;
+  }
+
+  Future<void> _queueObscuration(
+    _BrowserSessionEntry entry,
+    Future<void> Function() operation,
+  ) {
+    final next = entry.obscurationTail
+        .catchError((Object _) {})
+        .then((_) => operation());
+    entry.obscurationTail = next;
+    return next;
+  }
+}

--- a/lib/src/features/browser/application/browser_session_registry.dart
+++ b/lib/src/features/browser/application/browser_session_registry.dart
@@ -16,9 +16,12 @@ import 'package:flutter/foundation.dart';
 
 part 'browser_session_handle.dart';
 part 'browser_session_commands.dart';
+part 'browser_session_leases.dart';
 part 'browser_session_reconciliation.dart';
 
 enum BrowserVisibilityReason { user, automation, capture, popup }
+
+enum BrowserObscurationReason { overlay, tabDrag }
 
 enum BrowserLifecycleReason { command, automation, capture, overlay, popup }
 
@@ -213,60 +216,6 @@ final class BrowserSessionRegistry {
     }
   }
 
-  BrowserVisibilityLease _acquireVisibility(
-    _BrowserSessionEntry entry,
-    BrowserVisibilityReason reason,
-  ) {
-    _ensureOpen(entry);
-    final first = entry.visibilityCount++ == 0;
-    final ready = first
-        ? _queueVisibility(entry, () async {
-            await entry.ready.future;
-            await _ensureOperational(entry);
-            await _engine.attachPage(entry.pageId);
-          })
-        : entry.visibilityTail;
-    return BrowserVisibilityLease._(
-      reason: reason,
-      ready: ready,
-      release: () async {
-        if (--entry.visibilityCount == 0) {
-          await _queueVisibility(entry, () async {
-            if (entry.created && !entry.closed) {
-              await _engine.detachPage(entry.pageId);
-            }
-          });
-        }
-      },
-    );
-  }
-
-  BrowserLifecycleLease _acquireLifecycleForHandle(
-    _BrowserSessionEntry entry,
-    BrowserLifecycleReason reason,
-  ) => _acquireLifecycle(entry, reason);
-
-  BrowserLifecycleLease _acquireLifecycle(
-    _BrowserSessionEntry entry,
-    BrowserLifecycleReason reason,
-  ) {
-    _ensureOpen(entry);
-    entry.lifecycleCount += 1;
-    return BrowserLifecycleLease._(
-      reason: reason,
-      release: () => _releaseLifecycle(entry),
-    );
-  }
-
-  Future<void> _releaseLifecycle(_BrowserSessionEntry entry) async {
-    if (entry.lifecycleCount > 0) {
-      entry.lifecycleCount -= 1;
-    }
-    if (entry.closing && entry.lifecycleCount == 0) {
-      await _finishClose(entry);
-    }
-  }
-
   Future<void> closePage(String pageId) async {
     await _closePageIf(pageId, () => true);
   }
@@ -355,17 +304,6 @@ final class BrowserSessionRegistry {
     }
   }
 
-  Future<void> _queueVisibility(
-    _BrowserSessionEntry entry,
-    Future<void> Function() operation,
-  ) {
-    final next = entry.visibilityTail
-        .catchError((Object _) {})
-        .then((_) => operation());
-    entry.visibilityTail = next;
-    return next;
-  }
-
   void _emit(
     BrowserRegistryEventKind kind,
     _BrowserSessionEntry entry, {
@@ -433,10 +371,10 @@ final class _BrowserSessionEntry {
   final Completer<void> ready = Completer<void>();
   late final BrowserSessionHandle handle;
   Future<void> visibilityTail = Future<void>.value();
-  Future<void> overlayTail = Future<void>.value();
+  Future<void> obscurationTail = Future<void>.value();
   Completer<void>? closeCompleter;
   int visibilityCount = 0;
-  int overlayCount = 0;
+  int obscurationCount = 0;
   int lifecycleCount = 0;
   bool commandInFlight = false;
   bool created = false;

--- a/lib/src/features/browser/presentation/browser_tab_drag_placeholder.dart
+++ b/lib/src/features/browser/presentation/browser_tab_drag_placeholder.dart
@@ -1,0 +1,21 @@
+import 'package:alera/src/app/theme/alera_tokens.dart';
+import 'package:alera/src/design_system/feedback/alera_empty_state.dart';
+import 'package:alera/src/design_system/icons/alera_icons.dart';
+import 'package:flutter/material.dart';
+
+class BrowserTabDragPlaceholder extends StatelessWidget {
+  const BrowserTabDragPlaceholder({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const ColoredBox(
+      key: ValueKey<String>('browser-tab-drag-placeholder'),
+      color: AleraTokens.bg,
+      child: AleraEmptyState(
+        icon: AleraIcons.public,
+        title: 'Browser Temporarily Hidden',
+        message: 'Release The Tab To Restore This Page.',
+      ),
+    );
+  }
+}

--- a/lib/src/features/browser/presentation/browser_tab_surface.dart
+++ b/lib/src/features/browser/presentation/browser_tab_surface.dart
@@ -11,6 +11,7 @@ import 'package:alera/src/features/browser/presentation/browser_downloads_dialog
 import 'package:alera/src/features/browser/presentation/browser_page_body.dart';
 import 'package:alera/src/features/browser/presentation/browser_profile_picker_dialog.dart';
 import 'package:alera/src/features/browser/presentation/browser_security_dialog.dart';
+import 'package:alera/src/features/browser/presentation/browser_tab_drag_placeholder.dart';
 import 'package:alera/src/features/browser/presentation/browser_toolbar.dart';
 import 'package:alera/src/features/workbench/application/workbench_controller.dart';
 import 'package:alera/src/features/workbench/domain/workspace_tab_record.dart';
@@ -26,10 +27,12 @@ class BrowserTabSurface extends ConsumerStatefulWidget {
     super.key,
     required this.tab,
     this.autofocus = false,
+    this.pageObscured = false,
   });
 
   final WorkspaceTabRecord tab;
   final bool autofocus;
+  final bool pageObscured;
 
   @override
   ConsumerState<BrowserTabSurface> createState() => _BrowserTabSurfaceState();
@@ -41,9 +44,12 @@ class _BrowserTabSurfaceState extends ConsumerState<BrowserTabSurface> {
   Future<BrowserSessionHandle>? _session;
   List<BrowserProfile> _profileValues = const <BrowserProfile>[];
   BrowserVisibilityLease? _visibility;
+  BrowserObscurationLease? _obscuration;
   Object? _sessionIdentity;
   bool _wantsNativeVisibility = false;
+  bool _wantsNativeObscuration = false;
   final Set<Object> _visibilityAcquisitions = <Object>{};
+  final Set<Object> _obscurationAcquisitions = <Object>{};
 
   @override
   void initState() {
@@ -66,7 +72,7 @@ class _BrowserTabSurfaceState extends ConsumerState<BrowserTabSurface> {
     if (oldWidget.tab.id != widget.tab.id ||
         oldWidget.tab.workspaceId != widget.tab.workspaceId ||
         oldWidget.tab.browserProfileId != widget.tab.browserProfileId) {
-      unawaited(_releaseVisibility());
+      unawaited(_releasePresentation());
       _session = _loadSession();
       unawaited(_loadProfiles());
     }
@@ -74,7 +80,7 @@ class _BrowserTabSurfaceState extends ConsumerState<BrowserTabSurface> {
 
   @override
   void dispose() {
-    unawaited(_releaseVisibility());
+    unawaited(_releasePresentation());
     _addressController.dispose();
     _addressFocusNode.dispose();
     super.dispose();
@@ -120,12 +126,18 @@ class _BrowserTabSurfaceState extends ConsumerState<BrowserTabSurface> {
     return values;
   }
 
-  Future<void> _releaseVisibility() async {
+  Future<void> _releasePresentation() async {
     _wantsNativeVisibility = false;
+    _wantsNativeObscuration = false;
     _sessionIdentity = null;
     final visibility = _visibility;
+    final obscuration = _obscuration;
     _visibility = null;
-    await visibility?.dispose();
+    _obscuration = null;
+    await Future.wait(<Future<void>>[
+      if (visibility != null) visibility.dispose(),
+      if (obscuration != null) obscuration.dispose(),
+    ]);
   }
 
   @override
@@ -158,6 +170,7 @@ class _BrowserTabSurfaceState extends ConsumerState<BrowserTabSurface> {
               handle,
               browserStateShowsNativeSurface(state) && routeIsCurrent,
             );
+            _syncNativeObscuration(handle, widget.pageObscured);
             return Column(
               crossAxisAlignment: CrossAxisAlignment.stretch,
               children: <Widget>[
@@ -191,13 +204,22 @@ class _BrowserTabSurfaceState extends ConsumerState<BrowserTabSurface> {
                 ),
                 const Divider(height: AleraTokens.dividerExtent),
                 Expanded(
-                  child: BrowserPageBody(
-                    state: state,
-                    surface: _BrowserNativePageSurface(pageId: handle.pageId),
-                    onRetry: () => _runCommand(handle.reload),
-                    onOpenExternally: canOpenBrowserUrlExternally(state.url)
-                        ? () => _openExternally(state.url)
-                        : null,
+                  child: Stack(
+                    fit: StackFit.expand,
+                    children: <Widget>[
+                      BrowserPageBody(
+                        state: state,
+                        surface: _BrowserNativePageSurface(
+                          pageId: handle.pageId,
+                        ),
+                        onRetry: () => _runCommand(handle.reload),
+                        onOpenExternally: canOpenBrowserUrlExternally(state.url)
+                            ? () => _openExternally(state.url)
+                            : null,
+                      ),
+                      if (widget.pageObscured)
+                        const BrowserTabDragPlaceholder(),
+                    ],
                   ),
                 ),
               ],
@@ -243,6 +265,45 @@ class _BrowserTabSurfaceState extends ConsumerState<BrowserTabSurface> {
         await lease.dispose();
       } finally {
         _visibilityAcquisitions.remove(identity);
+      }
+    }());
+  }
+
+  void _syncNativeObscuration(
+    BrowserSessionHandle handle,
+    bool shouldBeObscured,
+  ) {
+    _wantsNativeObscuration = shouldBeObscured;
+    if (!shouldBeObscured) {
+      final obscuration = _obscuration;
+      _obscuration = null;
+      if (obscuration != null) {
+        unawaited(obscuration.dispose());
+      }
+      return;
+    }
+    if (_obscuration != null) {
+      return;
+    }
+    final identity = _sessionIdentity;
+    if (identity == null || !_obscurationAcquisitions.add(identity)) {
+      return;
+    }
+    final lease = handle.acquireObscuration(BrowserObscurationReason.tabDrag);
+    unawaited(() async {
+      try {
+        await lease.ready;
+        if (!mounted ||
+            !_wantsNativeObscuration ||
+            !identical(_sessionIdentity, identity)) {
+          await lease.dispose();
+        } else {
+          _obscuration = lease;
+        }
+      } catch (_) {
+        await lease.dispose();
+      } finally {
+        _obscurationAcquisitions.remove(identity);
       }
     }());
   }
@@ -323,7 +384,7 @@ class _BrowserTabSurfaceState extends ConsumerState<BrowserTabSurface> {
     WorkspaceTabRecord tab, {
     bool reconcileIdentity = false,
   }) async {
-    await _releaseVisibility();
+    await _releasePresentation();
     if (!mounted) {
       return;
     }

--- a/lib/src/features/workbench/presentation/workspace_workbench_tab_chips.dart
+++ b/lib/src/features/workbench/presentation/workspace_workbench_tab_chips.dart
@@ -33,6 +33,7 @@ class _DraggableWorkspaceTabChip extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final tabDragController = _WorkbenchTabDragScope.controllerOf(context);
     // peek, not sessionFor: building a handle here allocated a full xterm
     // buffer for every tab of the active workspace, including ones the user
     // never opened. Selecting the tab is what actually needs a session.
@@ -50,6 +51,9 @@ class _DraggableWorkspaceTabChip extends StatelessWidget {
     return Padding(
       padding: const EdgeInsets.only(right: AleraTokens.space8),
       child: Draggable<_WorkspaceTabDragData>(
+        onDragStarted: tabDragController.begin,
+        onDragEnd: (_) => tabDragController.finishAfterLayout(),
+        onDraggableCanceled: (_, _) => tabDragController.finishAfterLayout(),
         data: _WorkspaceTabDragData(
           workspaceId: workspace.id,
           sourceGroupId: groupId,

--- a/lib/src/features/workbench/presentation/workspace_workbench_tab_content.dart
+++ b/lib/src/features/workbench/presentation/workspace_workbench_tab_content.dart
@@ -79,6 +79,7 @@ class _WorkspaceTabContent extends StatelessWidget {
       WorkspaceTabKind.browser => BrowserTabSurface(
         tab: tab,
         autofocus: autofocus,
+        pageObscured: _WorkbenchTabDragScope.isActiveOf(context),
       ),
       WorkspaceTabKind.mobileEmulator => MobileEmulatorSurface(
         workspace: workspace,

--- a/lib/src/features/workbench/presentation/workspace_workbench_view.dart
+++ b/lib/src/features/workbench/presentation/workspace_workbench_view.dart
@@ -157,7 +157,7 @@ bool splitDirectionPainterShouldRepaintForTesting(
   ).shouldRepaint(_SplitDirectionPainter(zone: previousZone));
 }
 
-class WorkspaceWorkbenchView extends StatelessWidget {
+class WorkspaceWorkbenchView extends StatefulWidget {
   const WorkspaceWorkbenchView({
     super.key,
     required this.project,
@@ -214,43 +214,113 @@ class WorkspaceWorkbenchView extends StatelessWidget {
   final UpdateWorkbenchSplitRatioCallback onUpdateSplitRatio;
 
   @override
+  State<WorkspaceWorkbenchView> createState() => _WorkspaceWorkbenchViewState();
+}
+
+class _WorkspaceWorkbenchViewState extends State<WorkspaceWorkbenchView> {
+  final _tabDragController = _WorkbenchTabDragController();
+
+  @override
+  void dispose() {
+    _tabDragController.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     final resolvedLayout =
-        layout ??
+        widget.layout ??
         WorkbenchLayout.single(
-          workspaceId: workspace.id,
-          tabIds: <String>[for (final tab in tabs) tab.id],
+          workspaceId: widget.workspace.id,
+          tabIds: <String>[for (final tab in widget.tabs) tab.id],
         );
-    return _MobileEmulatorOpenScope(
-      onOpen: onOpenMobileEmulator,
-      child: _WorkbenchLayoutView(
-        workspace: workspace,
-        sourceControlScope: sourceControlScope,
-        tabs: tabs,
-        layout: resolvedLayout,
-        node: resolvedLayout.root,
-        nodePath: const <int>[],
-        terminalRuntime: terminalRuntime,
-        mobileDriverPresence: mobileDriverPresence,
-        agentStatuses: agentStatuses,
-        completionAcknowledgements: completionAcknowledgements,
-        onCreateTab: onCreateTab,
-        onCreateBrowserTab: onCreateBrowserTab,
-        onOpenEditorTab: onOpenEditorTab,
-        onOpenMarkdownViewerTab: onOpenMarkdownViewerTab,
-        onSelectTab: onSelectTab,
-        onCloseTab: onCloseTab,
-        onCloseTabs: onCloseTabs,
-        onRenameTab: onRenameTab,
-        onOpenEditor: onOpenEditor,
-        onOpenMermanPreview: onOpenMermanPreview,
-        onMoveTab: onMoveTab,
-        onSplitGroup: onSplitGroup,
-        onMergeGroup: onMergeGroup,
-        onActivateGroup: onActivateGroup,
-        onUpdateSplitRatio: onUpdateSplitRatio,
+    return _WorkbenchTabDragScope(
+      notifier: _tabDragController,
+      child: _MobileEmulatorOpenScope(
+        onOpen: widget.onOpenMobileEmulator,
+        child: _WorkbenchLayoutView(
+          workspace: widget.workspace,
+          sourceControlScope: widget.sourceControlScope,
+          tabs: widget.tabs,
+          layout: resolvedLayout,
+          node: resolvedLayout.root,
+          nodePath: const <int>[],
+          terminalRuntime: widget.terminalRuntime,
+          mobileDriverPresence: widget.mobileDriverPresence,
+          agentStatuses: widget.agentStatuses,
+          completionAcknowledgements: widget.completionAcknowledgements,
+          onCreateTab: widget.onCreateTab,
+          onCreateBrowserTab: widget.onCreateBrowserTab,
+          onOpenEditorTab: widget.onOpenEditorTab,
+          onOpenMarkdownViewerTab: widget.onOpenMarkdownViewerTab,
+          onSelectTab: widget.onSelectTab,
+          onCloseTab: widget.onCloseTab,
+          onCloseTabs: widget.onCloseTabs,
+          onRenameTab: widget.onRenameTab,
+          onOpenEditor: widget.onOpenEditor,
+          onOpenMermanPreview: widget.onOpenMermanPreview,
+          onMoveTab: widget.onMoveTab,
+          onSplitGroup: widget.onSplitGroup,
+          onMergeGroup: widget.onMergeGroup,
+          onActivateGroup: widget.onActivateGroup,
+          onUpdateSplitRatio: widget.onUpdateSplitRatio,
+        ),
       ),
     );
+  }
+}
+
+class _WorkbenchTabDragController extends ValueNotifier<bool> {
+  _WorkbenchTabDragController() : super(false);
+
+  var _generation = 0;
+  var _disposed = false;
+
+  void begin() {
+    if (_disposed) {
+      return;
+    }
+    _generation += 1;
+    value = true;
+  }
+
+  void finishAfterLayout() {
+    if (_disposed) {
+      return;
+    }
+    final generation = ++_generation;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!_disposed && generation == _generation) {
+        value = false;
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    _disposed = true;
+    _generation += 1;
+    super.dispose();
+  }
+}
+
+class _WorkbenchTabDragScope
+    extends InheritedNotifier<_WorkbenchTabDragController> {
+  const _WorkbenchTabDragScope({required super.notifier, required super.child});
+
+  static _WorkbenchTabDragController controllerOf(BuildContext context) {
+    final element = context
+        .getElementForInheritedWidgetOfExactType<_WorkbenchTabDragScope>();
+    final scope = element?.widget as _WorkbenchTabDragScope?;
+    return scope!.notifier!;
+  }
+
+  static bool isActiveOf(BuildContext context) {
+    return context
+            .dependOnInheritedWidgetOfExactType<_WorkbenchTabDragScope>()
+            ?.notifier
+            ?.value ??
+        false;
   }
 }
 

--- a/test/unit/features/browser/browser_session_registry_test.dart
+++ b/test/unit/features/browser/browser_session_registry_test.dart
@@ -131,6 +131,28 @@ void main() {
     );
   });
 
+  test('tab drag and Flutter overlay share obscuration state', () async {
+    final handle = await registry.sessionFor(_tab());
+    final drag = handle.acquireObscuration(BrowserObscurationReason.tabDrag);
+    await drag.ready;
+    final overlayBarrier = Completer<void>();
+    final overlay = handle.withFlutterOverlay(() => overlayBarrier.future);
+
+    await Future<void>.delayed(Duration.zero);
+    await drag.dispose();
+    expect(
+      engine.calls.where((call) => call.startsWith('obscured:')).toList(),
+      <String>['obscured:page-1:true'],
+    );
+
+    overlayBarrier.complete();
+    await overlay;
+    expect(
+      engine.calls.where((call) => call.startsWith('obscured:')).toList(),
+      <String>['obscured:page-1:true', 'obscured:page-1:false'],
+    );
+  });
+
   test('close waits for lifecycle leases', () async {
     final handle = await registry.sessionFor(_tab());
     final lease = handle.acquireLifecycle(BrowserLifecycleReason.popup);

--- a/test/widget/workspace_workbench_view_tab_drop_test_cases.dart
+++ b/test/widget/workspace_workbench_view_tab_drop_test_cases.dart
@@ -31,6 +31,137 @@ void _registerWorkspaceWorkbenchViewTabDropTests() {
     await tester.pumpAndSettle();
   }
 
+  testWidgets(
+    'obscures every browser page while dragging any tab and restores on exit',
+    (tester) async {
+      final firstBrowser = _tab(
+        'browser-1',
+        title: 'Browser 1',
+        kind: WorkspaceTabKind.browser,
+      );
+      final terminal = _tab('terminal-1', title: 'Terminal');
+      final secondBrowser = _tab(
+        'browser-2',
+        title: 'Browser 2',
+        kind: WorkspaceTabKind.browser,
+      );
+      final tabs = <WorkspaceTabRecord>[firstBrowser, terminal, secondBrowser];
+      final browserEngine = FakeBrowserEngine();
+      final layout = WorkbenchLayout(
+        workspaceId: _workspaceId,
+        root: WorkbenchLayoutNode.split(
+          axis: WorkbenchSplitAxis.horizontal,
+          ratio: 0.5,
+          first: WorkbenchLayoutNode.leaf('group-a'),
+          second: WorkbenchLayoutNode.leaf('group-b'),
+        ),
+        groups: <String, WorkbenchPaneGroup>{
+          'group-a': WorkbenchPaneGroup(
+            id: 'group-a',
+            tabIds: <String>[firstBrowser.id, terminal.id],
+            activeTabId: firstBrowser.id,
+          ),
+          'group-b': WorkbenchPaneGroup(
+            id: 'group-b',
+            tabIds: <String>[secondBrowser.id],
+            activeTabId: secondBrowser.id,
+          ),
+        },
+        activeGroupId: 'group-a',
+      );
+
+      await _pumpWorkbenchView(
+        tester,
+        tabs: tabs,
+        terminalRuntime: terminalRuntime,
+        layout: layout,
+        createdTabs: createdTabs,
+        selectedTabs: selectedTabs,
+        closedTabs: closedTabs,
+        closedTabGroups: closedTabGroups,
+        renamedTabs: renamedTabs,
+        movedTabs: movedTabs,
+        splitGroups: splitGroups,
+        mergedGroups: mergedGroups,
+        updatedRatios: updatedRatios,
+        providedBrowserEngine: browserEngine,
+        size: const Size(900, 420),
+      );
+      await tester.pumpAndSettle();
+
+      const placeholderKey = ValueKey<String>('browser-tab-drag-placeholder');
+      expect(find.byKey(placeholderKey), findsNothing);
+      expect(find.text('Search Or Enter Address'), findsNWidgets(2));
+
+      final terminalDraggable = find.ancestor(
+        of: find.text('Terminal'),
+        matching: draggableTabs(),
+      );
+      var gesture = await tester.startGesture(
+        tester.getTopLeft(terminalDraggable) + grabDelta,
+      );
+      await tester.pump();
+      await gesture.moveBy(const Offset(0, 80));
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(find.byKey(placeholderKey), findsNWidgets(2));
+      expect(find.text('Browser Temporarily Hidden'), findsNWidgets(2));
+      expect(find.text('Search Or Enter Address'), findsNWidgets(2));
+      expect(
+        browserEngine.calls
+            .where(
+              (call) => call.startsWith('obscured:') && call.endsWith(':true'),
+            )
+            .toSet(),
+        <String>{'obscured:browser-1:true', 'obscured:browser-2:true'},
+      );
+
+      await gesture.moveTo(const Offset(2, 2));
+      await gesture.up();
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(placeholderKey), findsNothing);
+      expect(
+        browserEngine.calls
+            .where(
+              (call) => call.startsWith('obscured:') && call.endsWith(':false'),
+            )
+            .toSet(),
+        <String>{'obscured:browser-1:false', 'obscured:browser-2:false'},
+      );
+
+      gesture = await tester.startGesture(
+        tester.getTopLeft(terminalDraggable) + grabDelta,
+      );
+      await tester.pump();
+      await gesture.moveBy(const Offset(0, 80));
+      await tester.pump(const Duration(milliseconds: 100));
+      expect(find.byKey(placeholderKey), findsNWidgets(2));
+
+      final secondBrowserChip = find.text('Browser 2');
+      await dropAt(tester, gesture, tester.getCenter(secondBrowserChip));
+
+      expect(find.byKey(placeholderKey), findsNothing);
+      expect(movedTabs, isNotEmpty);
+      expect(
+        browserEngine.calls
+            .where(
+              (call) => call.startsWith('obscured:') && call.endsWith(':true'),
+            )
+            .length,
+        4,
+      );
+      expect(
+        browserEngine.calls
+            .where(
+              (call) => call.startsWith('obscured:') && call.endsWith(':false'),
+            )
+            .length,
+        4,
+      );
+    },
+  );
+
   testWidgets('dropping on the right half of a chip reorders the tab', (
     tester,
   ) async {

--- a/test/widget/workspace_workbench_view_test_harness.dart
+++ b/test/widget/workspace_workbench_view_test_harness.dart
@@ -21,8 +21,9 @@ Future<void> _pumpWorkbenchView(
   Size size = const Size(420, 280),
   Map<String, AgentStatusEntry> agentStatuses =
       const <String, AgentStatusEntry>{},
+  FakeBrowserEngine? providedBrowserEngine,
 }) async {
-  final browserEngine = FakeBrowserEngine();
+  final browserEngine = providedBrowserEngine ?? FakeBrowserEngine();
   final browserRegistry = BrowserSessionRegistry(engine: browserEngine);
   addTearDown(browserEngine.dispose);
   await tester.pumpWidget(
@@ -166,13 +167,11 @@ WorkspaceTabRecord _tab(
   String? filePath,
   bool mermanPreview = false,
 }) {
-  final payload = filePath == null
-      ? const <String, Object?>{}
-      : <String, Object?>{
-          workspaceTabFilePathPayloadKey: filePath,
-          if (mermanPreview)
-            workspaceTabFileRolePayloadKey: workspaceTabFileRoleMermanPreview,
-        };
+  final payload = <String, Object?>{
+    workspaceTabFilePathPayloadKey: ?filePath,
+    if (mermanPreview)
+      workspaceTabFileRolePayloadKey: workspaceTabFileRoleMermanPreview,
+  };
   return WorkspaceTabRecord(
     id: id,
     workspaceId: _workspaceId,


### PR DESCRIPTION
## Summary

- temporarily obscure every visible native browser page while any workbench tab is dragged
- keep the browser toolbar mounted and show a browser-specific placeholder over the page body until layout settles after the drop
- coordinate drag obscuration with existing Flutter overlays through counted leases so overlapping states cannot reveal the native surface early
- preserve the dense address field sizing and add regression coverage for drag, drop, cancellation, and overlapping obscuration

## Root cause

The native browser surface remained visible while Flutter recomputed split geometry. Because it is composited outside the normal Flutter layer tree, it could temporarily cover the drag-and-drop UI until the drop completed.

## Validation

- `dart format --set-exit-if-changed lib test integration_test tool`
- `dart tool/quality/check_max_lines.dart`
- `flutter analyze --no-pub`
- `flutter test --no-pub test/unit/features/browser/browser_session_registry_test.dart test/widget/browser_toolbar_test.dart test/widget/workspace_workbench_view_test.dart` (51 tests)
- `git diff --check`

## Notes

Local `gh act pull_request -W .github/workflows/pr.yml -j static` reached workflow setup but could not resolve the linked worktree gitdir (`fatal: not a git repository: (null)`), so hosted GitHub checks remain authoritative.