### PR TITLE
fix: refresh terminal rendering reliably

### DIFF
--- a/integration_test/terminal_restore_benchmark.dart
+++ b/integration_test/terminal_restore_benchmark.dart
@@ -402,6 +402,14 @@ final class _BenchmarkPtySession implements TerminalPtySession {
   void resize(int cols, int rows, int cellWidthPx, int cellHeightPx) {}
 
   @override
+  Future<void> refreshViewport(
+    int cols,
+    int rows,
+    int cellWidthPx,
+    int cellHeightPx,
+  ) async {}
+
+  @override
   Future<void> setOutputPaused(bool paused) async {}
 
   @override

--- a/lib/src/features/workbench/infra/terminal_host/terminal_host_pty_session.dart
+++ b/lib/src/features/workbench/infra/terminal_host/terminal_host_pty_session.dart
@@ -64,6 +64,7 @@ final class TerminalHostPtySession implements RecoverableTerminalPtySession {
   bool _startedNewProcess = false;
   bool _outputPaused = false;
   Future<void>? _startFuture;
+  Future<void> _resizeOperations = Future<void>.value();
   Future<void> Function()? _onProcessCreated;
 
   @override
@@ -199,7 +200,37 @@ final class TerminalHostPtySession implements RecoverableTerminalPtySession {
     if (!_started) {
       return;
     }
-    unawaited(_resize(cols: cols, rows: rows).catchError(_emitHostError));
+    unawaited(_enqueueResize(() => _resize(cols: cols, rows: rows)));
+  }
+
+  @override
+  Future<void> refreshViewport(
+    int cols,
+    int rows,
+    int cellWidthPx,
+    int cellHeightPx,
+  ) {
+    if (_disposed || !_started) {
+      return Future<void>.value();
+    }
+    _cols = cols;
+    _rows = rows;
+    final pulseCols = cols > 1 ? cols - 1 : cols + 1;
+    return _enqueueResize(() async {
+      try {
+        await _resize(cols: pulseCols, rows: rows);
+      } finally {
+        await _resize(cols: cols, rows: rows);
+      }
+    });
+  }
+
+  Future<void> _enqueueResize(Future<void> Function() operation) {
+    final next = _resizeOperations
+        .then((_) => _disposed ? null : operation())
+        .catchError(_emitHostError);
+    _resizeOperations = next;
+    return next;
   }
 
   Future<void> _writeBytes(List<int> bytes) async {

--- a/lib/src/features/workbench/presentation/terminal_runtime.dart
+++ b/lib/src/features/workbench/presentation/terminal_runtime.dart
@@ -104,11 +104,11 @@ abstract class TerminalSessionHandle extends ChangeNotifier {
     FocusOnKeyEventCallback? onKeyEvent,
   });
 
-  /// Reapplies the mounted viewport and schedules a one-shot repaint.
+  /// Pulses the mounted PTY viewport and schedules a one-shot repaint.
   ///
   /// Handles without a measured view intentionally do nothing. Refreshing must
   /// never replace the emulator or the PTY session.
-  void refreshRendering() {}
+  Future<void> refreshRendering() async {}
 
   /// Moves keyboard focus to this terminal's text input so subsequent
   /// keypresses are routed to its PTY instead of any sidebar control.
@@ -228,6 +228,17 @@ abstract interface class TerminalPtySession {
   Future<bool> writeBytesAndWait(List<int> bytes);
 
   void resize(int cols, int rows, int cellWidthPx, int cellHeightPx);
+
+  /// Briefly applies an adjacent PTY size before restoring the measured size.
+  ///
+  /// This forces full-screen terminal apps to redraw without resizing the
+  /// Flutter view or replacing the emulator.
+  Future<void> refreshViewport(
+    int cols,
+    int rows,
+    int cellWidthPx,
+    int cellHeightPx,
+  );
 
   Future<void> setOutputPaused(bool paused);
 

--- a/lib/src/features/workbench/presentation/terminal_runtime_ghostty_adapter.dart
+++ b/lib/src/features/workbench/presentation/terminal_runtime_ghostty_adapter.dart
@@ -84,6 +84,25 @@ class _GhosttyTerminalPtySessionAdapter implements TerminalPtySession {
   }
 
   @override
+  Future<void> refreshViewport(
+    int cols,
+    int rows,
+    int cellWidthPx,
+    int cellHeightPx,
+  ) async {
+    final session = _session;
+    if (_disposed || session == null) {
+      return;
+    }
+    final pulseCols = cols > 1 ? cols - 1 : cols + 1;
+    try {
+      session.resize(rows: rows, cols: pulseCols);
+    } finally {
+      session.resize(rows: rows, cols: cols);
+    }
+  }
+
+  @override
   Future<void> setOutputPaused(bool paused) async {}
 
   @override

--- a/lib/src/features/workbench/presentation/terminal_runtime_posix_adapter.dart
+++ b/lib/src/features/workbench/presentation/terminal_runtime_posix_adapter.dart
@@ -78,6 +78,37 @@ class _PosixPortablePtySessionAdapter implements TerminalPtySession {
   }
 
   @override
+  Future<void> refreshViewport(
+    int cols,
+    int rows,
+    int cellWidthPx,
+    int cellHeightPx,
+  ) async {
+    final pty = _pty;
+    if (_disposed || pty == null) {
+      return;
+    }
+    final pulseCols = cols > 1 ? cols - 1 : cols + 1;
+    try {
+      _resizePty(
+        rows: rows,
+        cols: pulseCols,
+        resize: ({required rows, required cols}) =>
+            pty.resize(rows: rows, cols: cols),
+        events: _events,
+      );
+    } finally {
+      _resizePty(
+        rows: rows,
+        cols: cols,
+        resize: ({required rows, required cols}) =>
+            pty.resize(rows: rows, cols: cols),
+        events: _events,
+      );
+    }
+  }
+
+  @override
   Future<void> setOutputPaused(bool paused) async {}
 
   void _handleReadMessage(Object? message) {

--- a/lib/src/features/workbench/presentation/terminal_runtime_session_handle.dart
+++ b/lib/src/features/workbench/presentation/terminal_runtime_session_handle.dart
@@ -317,8 +317,12 @@ class _XtermTerminalSessionHandle extends TerminalSessionHandle {
   }
 
   @override
-  void refreshRendering() {
+  Future<void> refreshRendering() async {
     if (_disposed) {
+      return;
+    }
+    final session = _ptySession;
+    if (session == null) {
       return;
     }
     final viewState = _terminalViewKey.currentState;
@@ -332,13 +336,19 @@ class _XtermTerminalSessionHandle extends TerminalSessionHandle {
       return;
     }
     final cellSize = renderTerminal.cellSize;
-    _terminal.resize(
+    await session.refreshViewport(
       _terminal.viewWidth,
       _terminal.viewHeight,
       cellSize.width.round(),
       cellSize.height.round(),
     );
+    if (_disposed ||
+        !identical(_terminalViewKey.currentState, viewState) ||
+        !renderTerminal.attached) {
+      return;
+    }
     renderTerminal.markNeedsLayout();
+    renderTerminal.markNeedsPaint();
   }
 
   Future<bool> _startPtySession() async {

--- a/lib/src/features/workbench/presentation/terminal_surface.dart
+++ b/lib/src/features/workbench/presentation/terminal_surface.dart
@@ -29,6 +29,8 @@ class TerminalSurface extends ConsumerStatefulWidget {
 
 class _TerminalSurfaceState extends ConsumerState<TerminalSurface> {
   TerminalVisibilityLease? _visibilityLease;
+  bool _refreshing = false;
+  int _refreshGeneration = 0;
 
   @override
   void initState() {
@@ -41,6 +43,8 @@ class _TerminalSurfaceState extends ConsumerState<TerminalSurface> {
   void didUpdateWidget(TerminalSurface oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.session != widget.session) {
+      _refreshGeneration += 1;
+      _refreshing = false;
       _visibilityLease?.dispose();
       _visibilityLease = widget.session.acquireVisibility();
       _scheduleStart(widget.session);
@@ -61,6 +65,21 @@ class _TerminalSurfaceState extends ConsumerState<TerminalSurface> {
       }
       unawaited(session.ensureStarted());
     });
+  }
+
+  Future<void> _refreshTerminal() async {
+    if (_refreshing) {
+      return;
+    }
+    final generation = ++_refreshGeneration;
+    setState(() => _refreshing = true);
+    try {
+      await widget.session.refreshRendering();
+    } finally {
+      if (mounted && generation == _refreshGeneration) {
+        setState(() => _refreshing = false);
+      }
+    }
   }
 
   /// Intercepts Alera shortcuts before the key reaches the PTY. Returning
@@ -138,11 +157,15 @@ class _TerminalSurfaceState extends ConsumerState<TerminalSurface> {
               top: AleraTokens.space4,
               right: AleraTokens.space4,
               child: AleraIconButton(
-                tooltip: 'Refresh Terminal',
-                icon: AleraIcons.refresh,
+                tooltip: _refreshing
+                    ? 'Refreshing Terminal'
+                    : 'Refresh Terminal',
+                icon: _refreshing ? AleraIcons.loading : AleraIcons.refresh,
                 backgroundColor: AleraTokens.surfaceElevated,
                 borderColor: AleraTokens.borderSubtle,
-                onPressed: widget.session.refreshRendering,
+                onPressed: _refreshing
+                    ? null
+                    : () => unawaited(_refreshTerminal()),
               ),
             ),
           ],

--- a/mobile/lib/src/design_system/icons/alera_icons.dart
+++ b/mobile/lib/src/design_system/icons/alera_icons.dart
@@ -31,6 +31,7 @@ abstract final class AleraIcons {
   static const IconData delete = LucideIcons.trash2;
   static const IconData copy = LucideIcons.copy;
   static const IconData refresh = LucideIcons.refreshCw;
+  static const IconData loading = LucideIcons.loaderCircle;
   static const IconData link = LucideIcons.link;
   static const IconData external = LucideIcons.externalLink;
   static const IconData theme = LucideIcons.moon;

--- a/mobile/lib/src/features/terminal/presentation/terminal_tab_view.dart
+++ b/mobile/lib/src/features/terminal/presentation/terminal_tab_view.dart
@@ -34,6 +34,7 @@ class TerminalTabView extends ConsumerStatefulWidget {
 class _TerminalTabViewState extends ConsumerState<TerminalTabView> {
   final GlobalKey<_TerminalSurfaceState> _surfaceKey =
       GlobalKey<_TerminalSurfaceState>();
+  bool _refreshing = false;
 
   @override
   Widget build(BuildContext context) {
@@ -103,19 +104,29 @@ class _TerminalTabViewState extends ConsumerState<TerminalTabView> {
           top: AleraTokens.spaceXs,
           right: AleraTokens.spaceXs,
           child: AleraIconButton(
-            tooltip: 'Refresh Terminal',
-            icon: AleraIcons.refresh,
+            tooltip: _refreshing ? 'Refreshing Terminal' : 'Refresh Terminal',
+            icon: _refreshing ? AleraIcons.loading : AleraIcons.refresh,
             backgroundColor: AleraTokens.surfaceElevated,
             borderColor: AleraTokens.borderSubtle,
-            onPressed: _refreshTerminal,
+            onPressed: _refreshing ? null : _refreshTerminal,
           ),
         ),
       ],
     );
   }
 
-  void _refreshTerminal() {
-    _surfaceKey.currentState?.refreshRendering();
+  Future<void> _refreshTerminal() async {
+    if (_refreshing) {
+      return;
+    }
+    setState(() => _refreshing = true);
+    try {
+      await _surfaceKey.currentState?.refreshRendering();
+    } finally {
+      if (mounted) {
+        setState(() => _refreshing = false);
+      }
+    }
   }
 
   Future<void> _confirmRestart(
@@ -172,11 +183,13 @@ class _TerminalSurface extends StatefulWidget {
 class _TerminalSurfaceState extends State<_TerminalSurface> {
   late Terminal _terminal;
   final TerminalController _controller = TerminalController();
-  final GlobalKey<TerminalViewState> _terminalViewKey =
-      GlobalKey<TerminalViewState>();
+  final ScrollController _scrollController = ScrollController();
+  final FocusNode _focusNode = FocusNode(debugLabel: 'MobileTerminal');
   TerminalOutputBatcher? _batcher;
   StreamSubscription<MobileTerminalOutputEvent>? _outputSub;
   bool _outputEnded = false;
+  int _viewGeneration = 0;
+  (int, int)? _suppressedViewportSize;
 
   @override
   void initState() {
@@ -201,6 +214,8 @@ class _TerminalSurfaceState extends State<_TerminalSurface> {
     unawaited(_outputSub?.cancel());
     _batcher?.dispose();
     _controller.dispose();
+    _scrollController.dispose();
+    _focusNode.dispose();
     super.dispose();
   }
 
@@ -230,7 +245,7 @@ class _TerminalSurfaceState extends State<_TerminalSurface> {
     final next = Terminal(
       maxLines: 5000,
       onOutput: (data) => widget.onInput(data),
-      onResize: (width, height, _, _) => widget.onViewportResize(width, height),
+      onResize: (width, height, _, _) => _handleViewportResize(width, height),
     );
     // One write per frame. Writing every chunk straight through made a noisy
     // build parse and repaint many times inside a single frame.
@@ -259,25 +274,26 @@ class _TerminalSurfaceState extends State<_TerminalSurface> {
     setState(() => _outputEnded = true);
   }
 
-  void refreshRendering() {
-    final viewState = _terminalViewKey.currentState;
-    if (viewState == null) {
+  void _handleViewportResize(int width, int height) {
+    final suppressed = _suppressedViewportSize;
+    _suppressedViewportSize = null;
+    if (suppressed == (width, height)) {
       return;
     }
-    final renderTerminal = viewState.renderTerminal;
-    if (!renderTerminal.attached ||
-        !renderTerminal.hasSize ||
-        renderTerminal.size.isEmpty) {
+    widget.onViewportResize(width, height);
+  }
+
+  Future<void> refreshRendering() async {
+    if (!mounted) {
       return;
     }
-    final cellSize = renderTerminal.cellSize;
-    _terminal.resize(
-      _terminal.viewWidth,
-      _terminal.viewHeight,
-      cellSize.width.round(),
-      cellSize.height.round(),
-    );
-    renderTerminal.markNeedsLayout();
+    final restoreFocus = _focusNode.hasFocus;
+    _suppressedViewportSize = (_terminal.viewWidth, _terminal.viewHeight);
+    setState(() => _viewGeneration += 1);
+    await WidgetsBinding.instance.endOfFrame;
+    if (mounted && restoreFocus) {
+      _focusNode.requestFocus();
+    }
   }
 
   @override
@@ -291,12 +307,14 @@ class _TerminalSurfaceState extends State<_TerminalSurface> {
             color: AleraTokens.background,
             child: TerminalView(
               _terminal,
-              key: _terminalViewKey,
+              key: ValueKey<int>(_viewGeneration),
               controller: _controller,
+              scrollController: _scrollController,
+              focusNode: _focusNode,
               // Compose mode keeps the terminal read-only so tapping it scrolls
               // instead of raising the soft keyboard; direct mode streams keys.
               readOnly: !direct,
-              autofocus: direct,
+              autofocus: direct && _viewGeneration == 0,
               backgroundOpacity: 0,
               textStyle: const TerminalStyle(
                 fontFamily: AleraTokens.monoFontFamily,

--- a/mobile/test/terminal_tab_view_test.dart
+++ b/mobile/test/terminal_tab_view_test.dart
@@ -15,7 +15,7 @@ import 'support/fake_terminal_client.dart';
 
 void main() {
   testWidgets(
-    'Refresh control is top right and preserves the terminal session',
+    'Refresh control remounts the view and preserves terminal state',
     (tester) async {
       final client = FakeTerminalClient()
         ..tabs = <WorkspaceTabSummary>[
@@ -23,9 +23,20 @@ void main() {
         ];
       await _pumpTab(tester, client);
       final before = _terminalOf(tester);
-      final resizeCountBefore = client.calls
-          .where((call) => call.startsWith('resize session-tab-1 '))
-          .length;
+      final viewStateBefore = tester.state<TerminalViewState>(
+        find.byType(TerminalView),
+      );
+      final viewBefore = tester.widget<TerminalView>(find.byType(TerminalView));
+      final controller = viewBefore.controller!;
+      final scrollController = viewBefore.scrollController!;
+      final focusNode = viewBefore.focusNode!;
+      controller.setSelection(
+        before.buffer.createAnchor(0, 0),
+        before.buffer.createAnchor(1, 0),
+      );
+      focusNode.requestFocus();
+      await tester.pump();
+      final callsBefore = List<String>.of(client.calls);
       final terminalRect = tester.getRect(find.byType(TerminalView));
       final refreshRect = tester.getRect(find.byTooltip('Refresh Terminal'));
       expect(
@@ -38,17 +49,27 @@ void main() {
       );
 
       await tester.tap(find.byTooltip('Refresh Terminal'));
+      await tester.pump();
+
+      expect(find.byTooltip('Refreshing Terminal'), findsOneWidget);
+      expect(
+        tester.state<TerminalViewState>(find.byType(TerminalView)),
+        isNot(same(viewStateBefore)),
+      );
+
       await tester.pumpAndSettle();
 
       expect(_terminalOf(tester), same(before));
-      expect(
-        client.calls
-            .where((call) => call.startsWith('resize session-tab-1 '))
-            .length,
-        resizeCountBefore + 1,
-      );
+      final viewAfter = tester.widget<TerminalView>(find.byType(TerminalView));
+      expect(viewAfter.controller, same(controller));
+      expect(viewAfter.scrollController, same(scrollController));
+      expect(viewAfter.focusNode, same(focusNode));
+      expect(controller.selection, isNotNull);
+      expect(focusNode.hasFocus, isTrue);
+      expect(client.calls, callsBefore);
       expect(client.writes, isEmpty);
       expect(client.calls, isNot(contains('restart tab-1')));
+      expect(find.byTooltip('Refresh Terminal'), findsOneWidget);
     },
   );
 

--- a/test/unit/terminal_host_pty_refresh_cases.dart
+++ b/test/unit/terminal_host_pty_refresh_cases.dart
@@ -1,0 +1,63 @@
+part of 'terminal_host_pty_session_test.dart';
+
+void _registerTerminalHostPtyRefreshTests() {
+  test('host PTY session pulses and restores the viewport in order', () async {
+    final client = FakeTerminalHostClient(
+      attachment: TerminalHostAttachment(
+        sessionId: 'session-1',
+        created: true,
+        running: true,
+        snapshot: Uint8List(0),
+      ),
+    );
+    final session = TerminalHostPtySession(
+      client: client,
+      sessionId: 'session-1',
+      workspaceId: 'workspace-1',
+      tabId: 'tab-1',
+    );
+    addTearDown(session.dispose);
+
+    await session.start(
+      launch: _launch(),
+      workingDirectory: '/repo',
+      cols: 80,
+      rows: 24,
+    );
+    await session.refreshViewport(120, 40, 8, 16);
+
+    expect(client.resizes, <(String, int, int)>[
+      ('session-1', 119, 40),
+      ('session-1', 120, 40),
+    ]);
+    expect(client.writes, isEmpty);
+    expect(client.restarted, isEmpty);
+    expect(client.terminated, isEmpty);
+
+    client.resizes.clear();
+    await session.refreshViewport(1, 1, 8, 16);
+
+    expect(client.resizes, <(String, int, int)>[
+      ('session-1', 2, 1),
+      ('session-1', 1, 1),
+    ]);
+
+    client.resizeErrors.add(StateError('resize failed'));
+    client.resizes.clear();
+    await session.refreshViewport(80, 24, 8, 16);
+
+    expect(client.resizes, <(String, int, int)>[('session-1', 80, 24)]);
+
+    client.resizes.clear();
+    final refresh = session.refreshViewport(100, 30, 8, 16);
+    session.resize(130, 50, 8, 16);
+    await refresh;
+    await _flushAsync();
+
+    expect(client.resizes, <(String, int, int)>[
+      ('session-1', 99, 30),
+      ('session-1', 100, 30),
+      ('session-1', 130, 50),
+    ]);
+  });
+}

--- a/test/unit/terminal_host_pty_session_test.dart
+++ b/test/unit/terminal_host_pty_session_test.dart
@@ -11,6 +11,7 @@ import 'package:ghostty_vte_flutter/ghostty_vte_flutter.dart';
 import 'terminal_host_test_fakes.dart';
 
 part 'terminal_host_pty_output_resync_cases.dart';
+part 'terminal_host_pty_refresh_cases.dart';
 part 'terminal_host_pty_resume_cases.dart';
 
 void main() {
@@ -134,6 +135,8 @@ void main() {
       expect(client.terminated, <String>['session-2']);
     },
   );
+
+  _registerTerminalHostPtyRefreshTests();
 
   test(
     'reconnect attaches without restarting and restart is explicit',

--- a/test/unit/terminal_runtime_native_test_harness.dart
+++ b/test/unit/terminal_runtime_native_test_harness.dart
@@ -204,6 +204,18 @@ class _FakeTerminalPtySession implements TerminalPtySession {
   }
 
   @override
+  Future<void> refreshViewport(
+    int cols,
+    int rows,
+    int cellWidthPx,
+    int cellHeightPx,
+  ) async {
+    final pulseCols = cols > 1 ? cols - 1 : cols + 1;
+    resize(pulseCols, rows, cellWidthPx, cellHeightPx);
+    resize(cols, rows, cellWidthPx, cellHeightPx);
+  }
+
+  @override
   Future<void> setOutputPaused(bool paused) async {
     outputPausedCalls.add(paused);
   }

--- a/test/unit/terminal_runtime_xterm_widget_cases.dart
+++ b/test/unit/terminal_runtime_xterm_widget_cases.dart
@@ -17,7 +17,7 @@ void _registerXtermRuntimeWidgetTests() {
       addTearDown(runtime.dispose);
       final session = runtime.sessionFor(workspace: _workspace(), tab: _tab());
       try {
-        session.refreshRendering();
+        await session.refreshRendering();
         expect(fakeSession.resizeCalls, isEmpty);
 
         await tester.pumpWidget(
@@ -33,12 +33,20 @@ void _registerXtermRuntimeWidgetTests() {
         writeTerminalOutputForTesting(session, 'preserved output');
         final bufferBefore = terminalBufferTextForTesting(session);
 
-        session.refreshRendering();
+        await session.refreshRendering();
         await tester.pump(const Duration(milliseconds: 200));
 
-        expect(fakeSession.resizeCalls, hasLength(1));
-        expect(fakeSession.resizeCalls.single.cols, greaterThan(0));
-        expect(fakeSession.resizeCalls.single.rows, greaterThan(0));
+        expect(fakeSession.resizeCalls, hasLength(2));
+        expect(
+          fakeSession.resizeCalls.first.cols,
+          fakeSession.resizeCalls.last.cols - 1,
+        );
+        expect(
+          fakeSession.resizeCalls.first.rows,
+          fakeSession.resizeCalls.last.rows,
+        );
+        expect(fakeSession.resizeCalls.last.cols, greaterThan(0));
+        expect(fakeSession.resizeCalls.last.rows, greaterThan(0));
         expect(terminalBufferTextForTesting(session), bufferBefore);
         expect(runtime.peekSession('tab-1'), same(session));
         expect(fakeSession.writes, isEmpty);

--- a/test/widget/terminal_surface_core_test_cases.dart
+++ b/test/widget/terminal_surface_core_test_cases.dart
@@ -42,6 +42,33 @@ void _registerTerminalSurfaceRuntimeTests() {
     expect(tester.takeException(), isNull);
   });
 
+  testWidgets('refresh control stays busy and ignores repeated presses', (
+    tester,
+  ) async {
+    final refreshCompleter = Completer<void>();
+    final session = _ImmediateNotifySessionHandle(
+      tabId: 'tab-1',
+      refreshCompleter: refreshCompleter,
+    );
+
+    await _pumpTerminalSurface(tester, session);
+    await tester.tap(find.byTooltip('Refresh Terminal'));
+    await tester.pump();
+
+    expect(find.byTooltip('Refreshing Terminal'), findsOneWidget);
+    expect(
+      tester.widget<IconButton>(find.byType(IconButton)).onPressed,
+      isNull,
+    );
+    expect(session.refreshRenderingCallCount, 1);
+
+    refreshCompleter.complete();
+    await tester.pumpAndSettle();
+
+    expect(find.byTooltip('Refresh Terminal'), findsOneWidget);
+    expect(session.refreshRenderingCallCount, 1);
+  });
+
   test('working directory launch keeps the shell usable if cd fails', () {
     const launch = GhosttyTerminalShellLaunch(
       label: 'zsh',

--- a/test/widget/terminal_surface_test_harness.dart
+++ b/test/widget/terminal_surface_test_harness.dart
@@ -138,6 +138,14 @@ class _FakeTerminalPtySession implements TerminalPtySession {
   void resize(int cols, int rows, int cellWidthPx, int cellHeightPx) {}
 
   @override
+  Future<void> refreshViewport(
+    int cols,
+    int rows,
+    int cellWidthPx,
+    int cellHeightPx,
+  ) async {}
+
+  @override
   Future<void> setOutputPaused(bool paused) async {
     outputPausedCalls.add(paused);
     if (paused) {
@@ -189,10 +197,11 @@ class _FakeTerminalPtySession implements TerminalPtySession {
 }
 
 class _ImmediateNotifySessionHandle extends TerminalSessionHandle {
-  _ImmediateNotifySessionHandle({required this.tabId});
+  _ImmediateNotifySessionHandle({required this.tabId, this.refreshCompleter});
 
   @override
   final String tabId;
+  final Completer<void>? refreshCompleter;
 
   int ensureStartedCallCount = 0;
   int refreshRenderingCallCount = 0;
@@ -242,8 +251,9 @@ class _ImmediateNotifySessionHandle extends TerminalSessionHandle {
   }
 
   @override
-  void refreshRendering() {
+  Future<void> refreshRendering() async {
     refreshRenderingCallCount += 1;
+    await refreshCompleter?.future;
   }
 
   @override


### PR DESCRIPTION
## Summary
- pulse and restore the desktop PTY viewport so refresh forces a real redraw without replacing the session or emulator
- remount the mobile terminal view while preserving terminal state, scroll, selection, and focus
- show a busy refresh control and add desktop, host, and mobile regression coverage

## Root Cause
The desktop refresh only requested a same-size layout update, which could be a no-op for stale PTY rendering. Mobile did not remount its render surface, so the action could appear to re-enter the terminal without a reliable redraw contract.

## Validation
- `flutter analyze`
- `flutter analyze` in `mobile/`
- full root Flutter suite: 2302 passed, 2 skipped
- full mobile Flutter suite: 143 passed
- coverage: 100.00% (2448/2448)
- max-lines and formatting checks
- refresh-focused host, runtime, desktop widget, and mobile widget tests after rebasing onto `main`
- `gh act pull_request -W .github/workflows/pr.yml -P ubuntu-latest=catthehacker/ubuntu:act-latest` (limited by linked-worktree setup and root-container permission semantics; hosted checks are authoritative)