### PR TITLE
fix: keep workspace agents in creation order in the sidebar

### DIFF
--- a/lib/src/features/workbench/application/workspace_agent_status_projection.dart
+++ b/lib/src/features/workbench/application/workspace_agent_status_projection.dart
@@ -8,6 +8,8 @@ class WorkspaceAgentRun {
   final AgentStatusEntry status;
 }
 
+// Runs keep the incoming tab order (creation order): sorting by status or
+// recency would reshuffle sidebar rows on every agent hook event.
 List<WorkspaceAgentRun> visibleWorkspaceAgentRuns({
   required Iterable<WorkspaceTabRecord> tabs,
   required Map<String, AgentStatusEntry> agentStatuses,
@@ -23,7 +25,6 @@ List<WorkspaceAgentRun> visibleWorkspaceAgentRuns({
     }
     runs.add(WorkspaceAgentRun(tab: tab, status: entry));
   }
-  runs.sort(_compareAgentRuns);
   return runs;
 }
 
@@ -35,7 +36,16 @@ AgentStatusEntry? aggregateWorkspaceAgentStatus({
     tabs: tabs,
     agentStatuses: agentStatuses,
   );
-  return runs.isEmpty ? null : runs.first.status;
+  if (runs.isEmpty) {
+    return null;
+  }
+  var mostUrgent = runs.first;
+  for (final run in runs.skip(1)) {
+    if (_compareAgentRuns(run, mostUrgent) < 0) {
+      mostUrgent = run;
+    }
+  }
+  return mostUrgent.status;
 }
 
 AgentStatusEntry? matchingAgentStatusForTab({
@@ -55,6 +65,8 @@ AgentStatusEntry? matchingAgentStatusForTab({
   return entry;
 }
 
+// Urgency ranking for the aggregate workspace status only; row order stays
+// in creation order.
 int _compareAgentRuns(WorkspaceAgentRun a, WorkspaceAgentRun b) {
   final aPriority = _workspaceStatusPriority(a.status.state);
   final bPriority = _workspaceStatusPriority(b.status.state);

--- a/lib/src/features/workbench/presentation/project_workbench_workspace_rows.dart
+++ b/lib/src/features/workbench/presentation/project_workbench_workspace_rows.dart
@@ -533,9 +533,8 @@ class _WorkspaceAgentRunList extends StatelessWidget {
       crossAxisAlignment: CrossAxisAlignment.stretch,
       mainAxisSize: MainAxisSize.min,
       children: <Widget>[
-        // Keyed by tab: the run order tracks recency, so an unkeyed row would
-        // be reused by index across a reorder and briefly paint the previous
-        // agent's identity.
+        // Keyed by tab so each row keeps its identity and state across the
+        // status updates that refresh this list.
         for (final run in runs)
           _AgentRunRow(
             key: ValueKey<String>(run.tab.id),

--- a/lib/src/features/workbench/presentation/widgets/workspace_agent_compact_summary.dart
+++ b/lib/src/features/workbench/presentation/widgets/workspace_agent_compact_summary.dart
@@ -146,9 +146,8 @@ class _GroupCluster extends StatelessWidget {
 
 /// One run per agent type, ordered by agent type rather than by the run order.
 ///
-/// Runs are sorted by recency, which changes on every hook event, so taking
-/// them as they come would shuffle a group's icons on every update of any
-/// agent in it.
+/// Runs arrive in creation order; sorting the representatives by agent type
+/// keeps a group's icons in a fixed order regardless of status churn.
 List<WorkspaceAgentRun> _representativeRunsByAgentType(
   List<WorkspaceAgentRun> runs,
 ) {

--- a/test/unit/workspace_agent_status_projection_test.dart
+++ b/test/unit/workspace_agent_status_projection_test.dart
@@ -56,7 +56,7 @@ void main() {
       expect(status?.tabId, secondTab.id);
     });
 
-    test('returns visible runs sorted by status priority and recency', () {
+    test('keeps visible runs in creation order regardless of status churn', () {
       final doneTab = _tab('tab-done');
       final waitingTab = _tab('tab-waiting');
       final workingTab = _tab('tab-working');
@@ -79,9 +79,9 @@ void main() {
       );
 
       expect(runs.map((run) => run.tab.id), <String>[
+        'tab-done',
         'tab-waiting',
         'tab-working',
-        'tab-done',
       ]);
     });
 


### PR DESCRIPTION
## Summary

- The expanded agent rows inside a workspace were re-sorted on every agent hook event (status priority, then status recency, then creation date), so agents constantly reshuffled. They now stay in creation order, which is the order the storage layer already returns (`createdAt ASC`).
- `aggregateWorkspaceAgentStatus` no longer relies on the removed sort to pick the workspace status dot; it selects the most urgent run explicitly, so the dot still surfaces blocked/waiting correctly.
- Updated stale comments in the workspace rows and compact summary pill, and the projection unit test now asserts stable creation order.

## Validation

- `flutter analyze` on the touched feature and tests: no issues.
- `flutter test`: projection, compact summary, run groups, activity sort, and listing suites all pass (48 tests).

## Notes

- No generated surfaces touched (no Riverpod/Drift/mappable changes), no docs updates needed.