### PR TITLE
fix: align collapsed sidebar toggle right

### DIFF
--- a/lib/src/features/projects/presentation/widgets/sidebar_brand_row.dart
+++ b/lib/src/features/projects/presentation/widgets/sidebar_brand_row.dart
@@ -31,7 +31,7 @@ class SidebarBrandRow extends StatelessWidget {
     if (collapsed) {
       return SizedBox(
         height: AleraTokens.sidebarHeaderHeight,
-        child: Center(child: toggle),
+        child: Align(alignment: Alignment.centerRight, child: toggle),
       );
     }
     return Container(

--- a/test/widget/sidebar_brand_row_test.dart
+++ b/test/widget/sidebar_brand_row_test.dart
@@ -59,6 +59,10 @@ void main() {
     expect(find.byTooltip('Collapse Sidebar'), findsNothing);
     expect(find.byTooltip('Expand Sidebar'), findsOneWidget);
 
+    final headerRect = tester.getRect(find.byType(SidebarBrandRow));
+    final expandRect = tester.getRect(find.byTooltip('Expand Sidebar'));
+    expect(expandRect.right, headerRect.right);
+
     await tester.tap(find.byTooltip('Expand Sidebar'));
 
     expect(addProjectTaps, 0);


### PR DESCRIPTION
## Summary

- align the collapsed sidebar toggle with the right edge of its header
- add a widget regression assertion for the final geometry

## Validation

- native asset preflight
- `dart format --output=none --set-exit-if-changed lib test integration_test tool`
- `dart run tool/quality/check_max_lines.dart`
- `flutter analyze`
- `CI=true flutter test --coverage --exclude-tags golden -r compact` (2,413 passed, 2 skipped)
- maintained domain coverage: 100.00% (2708/2708)

## Risk

Low. The change is limited to the collapsed sidebar header layout and its widget test.