### PR TITLE
fix: refresh every runtime snapshot subscriber

### DIFF
--- a/lib/src/features/agent_status/application/runtime_agent_status_sync.dart
+++ b/lib/src/features/agent_status/application/runtime_agent_status_sync.dart
@@ -14,6 +14,7 @@ const String _agentPresenceCoalesceKey = 'agentPresence';
 void runtimeAgentStatusSync(Ref ref) {
   final client = ref.watch(runtimeHostClientProvider);
   final coalescer = ref.watch(runtimeChangeCoalescerProvider);
+  final coalesceOwner = Object();
   var disposed = false;
   var generation = 0;
 
@@ -47,17 +48,17 @@ void runtimeAgentStatusSync(Ref ref) {
     // task emits a steady stream of them. Each one costs a full snapshot RPC
     // plus a rebuild of every listener, hence the coalescing.
     if (event.name == 'agentPresenceChanged') {
-      coalescer.schedule(_agentPresenceCoalesceKey, refresh);
+      coalescer.schedule(_agentPresenceCoalesceKey, coalesceOwner, refresh);
     } else if (event.name == aleraRuntimeHostConnectedEvent) {
       // Reconnecting means the local snapshot may be stale in either
       // direction, so resync now instead of waiting out the debounce.
-      coalescer.cancel(_agentPresenceCoalesceKey);
+      coalescer.cancel(_agentPresenceCoalesceKey, coalesceOwner);
       unawaited(refresh());
     }
   });
   ref.onDispose(() {
     disposed = true;
-    coalescer.cancel(_agentPresenceCoalesceKey);
+    coalescer.cancel(_agentPresenceCoalesceKey, coalesceOwner);
     unawaited(subscription.cancel());
   });
   unawaited(refresh());

--- a/lib/src/features/agent_status/application/runtime_agent_status_sync.g.dart
+++ b/lib/src/features/agent_status/application/runtime_agent_status_sync.g.dart
@@ -49,4 +49,4 @@ final class RuntimeAgentStatusSyncProvider
 }
 
 String _$runtimeAgentStatusSyncHash() =>
-    r'ec77ac3b54de7bd33d7f64c5e951c62c43c6bb72';
+    r'aeb5cc640eb9515ecc699ec0bf6d98e743e8669d';

--- a/lib/src/shared/infra/runtime/runtime_change_coalescer.dart
+++ b/lib/src/shared/infra/runtime/runtime_change_coalescer.dart
@@ -1,12 +1,13 @@
 import 'dart:async';
 
-/// Collapses bursts of runtime host change events into at most one refresh per
+/// Collapses bursts of runtime host change events into one refresh batch per
 /// key.
 ///
 /// The host broadcasts one change event per mutation, so orchestration spawning
 /// many terminals emits one event per terminal. Without coalescing every one of
 /// those costs a socket round-trip per watcher, which is what saturates the
-/// single-threaded host actor under load.
+/// single-threaded host actor under load. Every owner registered for a key runs
+/// once in the batch, so one watcher cannot replace another watcher's refresh.
 class RuntimeChangeCoalescer {
   RuntimeChangeCoalescer({
     this.debounce = const Duration(milliseconds: 120),
@@ -24,14 +25,19 @@ class RuntimeChangeCoalescer {
   final Map<String, _CoalescedKey> _keys = <String, _CoalescedKey>{};
   bool _disposed = false;
 
-  /// Schedules [run] for [key], collapsing repeat calls inside the debounce
-  /// window into a single run. A call arriving while a run is in flight marks
-  /// the key dirty and re-runs exactly once after it settles.
-  void schedule(String key, Future<void> Function() run) {
+  /// Schedules [run] for [owner] under [key], collapsing repeat calls inside
+  /// the debounce window into a single batch. A call arriving while a batch is
+  /// in flight marks the key dirty and re-runs every live owner exactly once
+  /// after it settles.
+  void schedule(String key, Object owner, Future<void> Function() run) {
     if (_disposed) {
       return;
     }
-    final entry = _keys.putIfAbsent(key, _CoalescedKey.new)..run = run;
+    final entry = _keys.putIfAbsent(key, _CoalescedKey.new)..runs[owner] = run;
+    _schedule(key, entry);
+  }
+
+  void _schedule(String key, _CoalescedKey entry) {
     if (entry.inFlight != null) {
       entry.dirty = true;
       return;
@@ -54,7 +60,7 @@ class RuntimeChangeCoalescer {
   /// de-duplication. Returns once the resulting run settles.
   Future<void> flush(String key) async {
     final entry = _keys[key];
-    if (entry == null || entry.run == null) {
+    if (entry == null || entry.runs.isEmpty) {
       return;
     }
     entry.timer?.cancel();
@@ -74,10 +80,20 @@ class RuntimeChangeCoalescer {
     await _start(key, entry);
   }
 
-  void cancel(String key) {
-    final entry = _keys.remove(key);
-    entry?.timer?.cancel();
-    entry?.dirty = false;
+  /// Stops pending work for one [owner] without affecting other watchers that
+  /// share [key].
+  void cancel(String key, Object owner) {
+    final entry = _keys[key];
+    if (entry == null) {
+      return;
+    }
+    entry.runs.remove(owner);
+    if (entry.runs.isNotEmpty) {
+      return;
+    }
+    _keys.remove(key);
+    entry.timer?.cancel();
+    entry.dirty = false;
   }
 
   void dispose() {
@@ -89,14 +105,16 @@ class RuntimeChangeCoalescer {
   }
 
   Future<void> _start(String key, _CoalescedKey entry) async {
-    final run = entry.run;
-    if (run == null || !identical(_keys[key], entry)) {
+    if (entry.runs.isEmpty || !identical(_keys[key], entry)) {
       return;
     }
     entry.timer = null;
     entry.firstScheduledAt = null;
     entry.dirty = false;
-    final future = run();
+    final runs = entry.runs.values.toList(growable: false);
+    final future = Future.wait<void>(<Future<void>>[
+      for (final run in runs) run(),
+    ]);
     entry.inFlight = future;
     try {
       await future;
@@ -110,15 +128,16 @@ class RuntimeChangeCoalescer {
       // Go back through the debounce rather than re-running straight away.
       // Events that keep landing during a run would otherwise chain into one
       // run per event, which is the fan-out this class exists to prevent.
-      schedule(key, run);
+      _schedule(key, entry);
     }
   }
 }
 
 class _CoalescedKey {
+  final Map<Object, Future<void> Function()> runs =
+      <Object, Future<void> Function()>{};
   Timer? timer;
   Future<void>? inFlight;
   bool dirty = false;
   DateTime? firstScheduledAt;
-  Future<void> Function()? run;
 }

--- a/lib/src/shared/infra/runtime/runtime_snapshot_stream.dart
+++ b/lib/src/shared/infra/runtime/runtime_snapshot_stream.dart
@@ -52,6 +52,7 @@ Stream<T> runtimeSnapshotStream<T>({
   Duration retryDelay = const Duration(seconds: 1),
   Duration maxRetryDelay = const Duration(seconds: 15),
 }) {
+  final coalesceOwner = Object();
   late final StreamController<T> controller;
   StreamSubscription<RuntimeHostEvent>? eventSub;
   Timer? retryTimer;
@@ -86,11 +87,11 @@ Stream<T> runtimeSnapshotStream<T>({
           if (event.name == aleraRuntimeHostConnectedEvent) {
             retryTimer?.cancel();
             backoff = retryDelay;
-            coalescer.schedule(coalesceKey, refresh);
+            coalescer.schedule(coalesceKey, coalesceOwner, refresh);
             return;
           }
           if (eventNames.contains(event.name) && matchesScope(event.payload)) {
-            coalescer.schedule(coalesceKey, refresh);
+            coalescer.schedule(coalesceKey, coalesceOwner, refresh);
           }
         },
         onError: (Object _) {},
@@ -101,7 +102,7 @@ Stream<T> runtimeSnapshotStream<T>({
     onCancel: () {
       retryTimer?.cancel();
       retryTimer = null;
-      coalescer.cancel(coalesceKey);
+      coalescer.cancel(coalesceKey, coalesceOwner);
       final sub = eventSub;
       eventSub = null;
       return sub?.cancel();

--- a/test/unit/runtime_change_coalescer_test.dart
+++ b/test/unit/runtime_change_coalescer_test.dart
@@ -10,10 +10,11 @@ void main() {
       maxDelay: const Duration(milliseconds: 200),
     );
     addTearDown(coalescer.dispose);
+    final owner = Object();
     var runs = 0;
 
     for (var i = 0; i < 10; i++) {
-      coalescer.schedule('key', () async => runs += 1);
+      coalescer.schedule('key', owner, () async => runs += 1);
       await Future<void>.delayed(const Duration(milliseconds: 5));
     }
     expect(runs, 0, reason: 'still inside the debounce window');
@@ -28,11 +29,12 @@ void main() {
       maxDelay: const Duration(milliseconds: 50),
     );
     addTearDown(coalescer.dispose);
+    final owner = Object();
     var runs = 0;
 
     final ticker = Timer.periodic(
       const Duration(milliseconds: 10),
-      (_) => coalescer.schedule('key', () async => runs += 1),
+      (_) => coalescer.schedule('key', owner, () async => runs += 1),
     );
     await Future<void>.delayed(const Duration(milliseconds: 200));
     ticker.cancel();
@@ -52,8 +54,8 @@ void main() {
     addTearDown(coalescer.dispose);
     final ran = <String>[];
 
-    coalescer.schedule('a', () async => ran.add('a'));
-    coalescer.schedule('b', () async => ran.add('b'));
+    coalescer.schedule('a', Object(), () async => ran.add('a'));
+    coalescer.schedule('b', Object(), () async => ran.add('b'));
     await Future<void>.delayed(const Duration(milliseconds: 40));
 
     expect(ran..sort(), <String>['a', 'b']);
@@ -65,9 +67,10 @@ void main() {
       maxDelay: const Duration(seconds: 60),
     );
     addTearDown(coalescer.dispose);
+    final owner = Object();
     var runs = 0;
 
-    coalescer.schedule('key', () async => runs += 1);
+    coalescer.schedule('key', owner, () async => runs += 1);
     expect(runs, 0);
 
     await coalescer.flush('key');
@@ -80,10 +83,11 @@ void main() {
       maxDelay: const Duration(milliseconds: 50),
     );
     addTearDown(coalescer.dispose);
+    final owner = Object();
     var runs = 0;
     final gate = Completer<void>();
 
-    coalescer.schedule('key', () async {
+    coalescer.schedule('key', owner, () async {
       runs += 1;
       if (runs == 1) {
         await gate.future;
@@ -104,16 +108,39 @@ void main() {
       debounce: const Duration(milliseconds: 10),
       maxDelay: const Duration(milliseconds: 100),
     );
+    final owner = Object();
     var runs = 0;
 
-    coalescer.schedule('key', () async => runs += 1);
-    coalescer.cancel('key');
+    coalescer.schedule('key', owner, () async => runs += 1);
+    coalescer.cancel('key', owner);
     await Future<void>.delayed(const Duration(milliseconds: 40));
     expect(runs, 0);
 
-    coalescer.schedule('other', () async => runs += 1);
+    coalescer.schedule('other', Object(), () async => runs += 1);
     coalescer.dispose();
     await Future<void>.delayed(const Duration(milliseconds: 40));
     expect(runs, 0);
+  });
+
+  test('same key runs every owner and cancels them independently', () async {
+    final coalescer = RuntimeChangeCoalescer(
+      debounce: const Duration(milliseconds: 10),
+      maxDelay: const Duration(milliseconds: 100),
+    );
+    addTearDown(coalescer.dispose);
+    final firstOwner = Object();
+    final secondOwner = Object();
+    var firstRuns = 0;
+    var secondRuns = 0;
+
+    for (var i = 0; i < 5; i++) {
+      coalescer.schedule('key', firstOwner, () async => firstRuns += 1);
+      coalescer.schedule('key', secondOwner, () async => secondRuns += 1);
+    }
+    coalescer.cancel('key', firstOwner);
+    await Future<void>.delayed(const Duration(milliseconds: 40));
+
+    expect(firstRuns, 0);
+    expect(secondRuns, 1);
   });
 }

--- a/test/unit/runtime_change_coalescer_wiring_test.dart
+++ b/test/unit/runtime_change_coalescer_wiring_test.dart
@@ -20,7 +20,7 @@ void main() {
     var runs = 0;
 
     container.dispose();
-    coalescer.schedule('key', () async => runs += 1);
+    coalescer.schedule('key', Object(), () async => runs += 1);
     await Future<void>.delayed(const Duration(milliseconds: 250));
 
     expect(runs, 0, reason: 'a disposed coalescer must not leak timers');
@@ -50,11 +50,16 @@ void main() {
     addTearDown(coalescer.dispose);
     var tabRuns = 0;
     var projectRuns = 0;
+    final tabOwner = Object();
 
     for (var i = 0; i < 5; i++) {
-      coalescer.schedule('tabs:workspace-1', () async => tabRuns += 1);
+      coalescer.schedule(
+        'tabs:workspace-1',
+        tabOwner,
+        () async => tabRuns += 1,
+      );
     }
-    coalescer.schedule('projects', () async => projectRuns += 1);
+    coalescer.schedule('projects', Object(), () async => projectRuns += 1);
     await Future<void>.delayed(const Duration(milliseconds: 80));
 
     expect(tabRuns, 1);

--- a/test/unit/runtime_snapshot_stream_test.dart
+++ b/test/unit/runtime_snapshot_stream_test.dart
@@ -126,6 +126,50 @@ void main() {
     expect(reads, 2, reason: '10 events must collapse into one read');
   });
 
+  test('refreshes every snapshot stream that shares a key', () async {
+    final client = _FakeRuntimeHostClient();
+    final coalescer = _coalescer();
+    addTearDown(coalescer.dispose);
+    var firstValue = 0;
+    var secondValue = 10;
+    final firstEmitted = <int>[];
+    final secondEmitted = <int>[];
+
+    final firstSubscription = runtimeSnapshotStream<int>(
+      client: client,
+      eventNames: const <String>{'changed'},
+      readSnapshot: () async => ++firstValue,
+      coalesceKey: 'shared',
+      coalescer: coalescer,
+    ).listen(firstEmitted.add);
+    final secondSubscription = runtimeSnapshotStream<int>(
+      client: client,
+      eventNames: const <String>{'changed'},
+      readSnapshot: () async => ++secondValue,
+      coalesceKey: 'shared',
+      coalescer: coalescer,
+    ).listen(secondEmitted.add);
+    addTearDown(firstSubscription.cancel);
+    addTearDown(secondSubscription.cancel);
+
+    await _settle();
+    expect(firstEmitted, <int>[1]);
+    expect(secondEmitted, <int>[11]);
+
+    client.emit(const RuntimeHostEvent('changed', <String, Object?>{}));
+    await _settle();
+
+    expect(firstEmitted, <int>[1, 2]);
+    expect(secondEmitted, <int>[11, 12]);
+
+    await firstSubscription.cancel();
+    client.emit(const RuntimeHostEvent('changed', <String, Object?>{}));
+    await _settle();
+
+    expect(firstEmitted, <int>[1, 2]);
+    expect(secondEmitted, <int>[11, 12, 13]);
+  });
+
   test('de-duplicates an event arriving while a read is in flight', () async {
     final client = _FakeRuntimeHostClient();
     final coalescer = _coalescer();


### PR DESCRIPTION
## Summary

- Track coalesced runtime refresh callbacks by subscriber so watchers sharing a key all receive change events.
- Cancel only the departing subscriber instead of cancelling every watcher for that key.
- Add regressions for shared project snapshot streams and independent owner cancellation.

## Root cause and impact

The runtime change coalescer stored a single callback per key. The workbench project list and another project watcher both used the `projects` key, so whichever subscribed last replaced the other callback. New projects were persisted correctly, but the visible workbench could miss the refresh until the app restarted.

## Validation

- `flutter pub run build_runner build -d`
- `dart format --set-exit-if-changed lib test integration_test tool`
- `dart tool/quality/check_max_lines.dart`
- `flutter analyze`
- 20 focused unit tests
- `CI=true flutter test` - 2,418 passed, 2 skipped
- `gh act ... -j static` - passed

Local `gh act` could not faithfully complete the matrix test job because its containers run as root, lack the hosted artifact token, and hit parallel image-pull authentication errors. The native full suite passed, and hosted PR checks are the final gate.