### PR TITLE
fix: update mobile sentry for kotlin 2

### DIFF
--- a/mobile/lib/src/features/diagnostics/infra/crash_reporting.dart
+++ b/mobile/lib/src/features/diagnostics/infra/crash_reporting.dart
@@ -29,33 +29,26 @@ abstract final class CrashReporting {
       return null;
     }
     final message = event.message;
-    return event.copyWith(
-      message: message == null
-          ? null
-          : SentryMessage(
-              redactLogText(message.formatted),
-              template: message.template,
-              params: message.params,
-            ),
-      exceptions: event.exceptions
-          ?.map(
-            (exception) => exception.copyWith(
-              value: exception.value == null
-                  ? null
-                  : redactLogText(exception.value!),
-            ),
-          )
-          .toList(),
-      breadcrumbs: event.breadcrumbs
-          ?.map(
-            (crumb) => crumb.copyWith(
-              message: crumb.message == null
-                  ? null
-                  : redactLogText(crumb.message!),
-            ),
-          )
-          .toList(),
-    );
+    if (message != null) {
+      event.message = SentryMessage(
+        redactLogText(message.formatted),
+        template: message.template,
+        params: message.params,
+      );
+    }
+    for (final exception in event.exceptions ?? const <SentryException>[]) {
+      final value = exception.value;
+      if (value != null) {
+        exception.value = redactLogText(value);
+      }
+    }
+    for (final breadcrumb in event.breadcrumbs ?? const <Breadcrumb>[]) {
+      final message = breadcrumb.message;
+      if (message != null) {
+        breadcrumb.message = redactLogText(message);
+      }
+    }
+    return event;
   }
 
   static void _applyOptions(SentryFlutterOptions options, String release) {

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -484,18 +484,10 @@ packages:
     dependency: transitive
     description:
       name: jni
-      sha256: c2230682d5bc2362c1c9e8d3c7f406d9cbba23ab3f2e203a025dd47e0fb2e68f
+      sha256: d2c361082d554d4593c3012e26f6b188f902acd291330f13d6427641a92b3da1
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
-  jni_flutter:
-    dependency: transitive
-    description:
-      name: jni_flutter
-      sha256: "8b59e590786050b1cd866677dddaf76b1ade5e7bc751abe04b86e84d379d3ba6"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.1"
+    version: "0.14.2"
   json_annotation:
     dependency: transitive
     description:
@@ -668,10 +660,10 @@ packages:
     dependency: transitive
     description:
       name: path_provider_android
-      sha256: "69cbd515a62b94d32a7944f086b2f82b4ac40a1d45bebfc00813a430ab2dabcd"
+      sha256: "149441ca6e4f38193b2e004c0ca6376a3d11f51fa5a77552d8bd4d2b0c0912ba"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.1"
+    version: "2.2.23"
   path_provider_foundation:
     dependency: transitive
     description:
@@ -820,18 +812,18 @@ packages:
     dependency: transitive
     description:
       name: sentry
-      sha256: "599701ca0693a74da361bc780b0752e1abc98226cf5095f6b069648116c896bb"
+      sha256: a84bf3a83b3ce1c89fce28b9f97659e3826df14a73a256952465aac2c5efdf5a
       url: "https://pub.dev"
     source: hosted
-    version: "8.14.2"
+    version: "9.25.0"
   sentry_flutter:
     dependency: "direct main"
     description:
       name: sentry_flutter
-      sha256: "5ba2cf40646a77d113b37a07bd69f61bb3ec8a73cbabe5537b05a7c89d2656f8"
+      sha256: c85575266d91f57364e9b4cb522835156ec3c5581c78339dc7fae491cd0c6f76
       url: "https://pub.dev"
     source: hosted
-    version: "8.14.2"
+    version: "9.25.0"
   share_plus:
     dependency: "direct main"
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -48,7 +48,7 @@ dependencies:
   logging: ^1.3.0
   path_provider: ^2.1.6
   share_plus: ^12.0.2
-  sentry_flutter: ^8.14.2
+  sentry_flutter: ^9.25.0
   path: ^1.9.1
 
 dev_dependencies:

--- a/mobile/test/crash_reporting_test.dart
+++ b/mobile/test/crash_reporting_test.dart
@@ -1,0 +1,34 @@
+import 'package:alera_mobile/src/features/diagnostics/infra/crash_reporting.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
+
+void main() {
+  tearDown(CrashReporting.resetForTesting);
+
+  test('drops events while crash reporting is disabled', () {
+    final event = SentryEvent(message: SentryMessage('boom'));
+
+    expect(CrashReporting.filterEvent(event), isNull);
+  });
+
+  test('redacts text-bearing event fields before sending', () {
+    CrashReporting.setEnabled(true);
+    final event = SentryEvent(
+      message: SentryMessage('token=abcdef123456'),
+      exceptions: <SentryException>[
+        SentryException(type: 'StateError', value: 'token=abcdef123456'),
+      ],
+      breadcrumbs: <Breadcrumb>[Breadcrumb(message: 'token=abcdef123456')],
+    );
+
+    final filtered = CrashReporting.filterEvent(event);
+
+    expect(filtered, same(event));
+    expect(filtered!.message!.formatted, isNot(contains('abcdef123456')));
+    expect(filtered.exceptions!.single.value, isNot(contains('abcdef123456')));
+    expect(
+      filtered.breadcrumbs!.single.message,
+      isNot(contains('abcdef123456')),
+    );
+  });
+}


### PR DESCRIPTION
## Summary

- upgrade the mobile Sentry SDK from 8.14.2 to 9.25.0
- migrate crash-event redaction to Sentry 9 mutable models
- add regression coverage for disabled reporting and redaction

## Root cause

Flutter 3.44.8 no longer accepts the Kotlin 1.6 language level forced by `sentry_flutter` 8.14.2, so `Cut Release` failed in `:sentry_flutter:compileReleaseKotlin`.

## Validation

- `cd mobile && flutter analyze`
- `cd mobile && flutter test` (154 tests)
- `cd mobile && flutter build apk --release`
- `cd mobile && flutter build apk --release --split-per-abi`
- `dart run tool/quality/check_max_lines.dart`
- `git diff --check`

`gh act pull_request -W .github/workflows/pr.yml -j mobile` was attempted, but the local emulator could not resolve the external Alera worktree gitdir during submodule initialization. It failed before running project code; GitHub-hosted checks remain authoritative.

## Risk

Low and limited to the mobile crash-reporting dependency. Reporting remains opt-in and the existing redaction behavior is covered by focused tests.