### PR TITLE
fix: keep ghostty source builds clean

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -20,7 +20,7 @@
 [submodule "third_party/dart_terminal"]
 	path = third_party/dart_terminal
 	url = https://github.com/leynier/dart_terminal.git
-	branch = next
+	branch = master
 [submodule "reference_projects/code_forge"]
 	path = reference_projects/code_forge
 	url = https://github.com/heckmon/code_forge.git

--- a/docs/terminal-dependency-forks.md
+++ b/docs/terminal-dependency-forks.md
@@ -1,6 +1,6 @@
 # Terminal dependency forks
 
-Alera keeps terminal dependency fixes local through submodules while the fixes are reviewed upstream.
+Alera keeps terminal dependency fixes reproducible through submodules while the fixes are released from maintained forks or reviewed upstream.
 
 ## Pattern
 
@@ -14,5 +14,5 @@ Alera keeps terminal dependency fixes local through submodules while the fixes a
 
 | Package | Submodule | Fork branch | Upstream PR |
 | --- | --- | --- | --- |
-| `ghostty_vte` | `third_party/dart_terminal` | `fix/puro-pub-cache-detection` | <https://github.com/kingwill101/dart_terminal/pull/15> |
+| `ghostty_vte` | `third_party/dart_terminal` | `master` | <https://github.com/kingwill101/dart_terminal/pull/15> |
 | `xterm` | `third_party/xterm` | `next` | See `third_party/xterm/ALERA_PATCHES.md` |

--- a/docs/terminal-dependency-forks.md
+++ b/docs/terminal-dependency-forks.md
@@ -2,6 +2,8 @@
 
 Alera keeps terminal dependency fixes reproducible through submodules while the fixes are released from maintained forks or reviewed upstream.
 
+The `ghostty_vte` package names remain owned and published by the upstream project on pub.dev. Alera consumes the maintained fork only through the path overrides in `pubspec.yaml`; the fork's GitHub releases supply the matching native artifacts.
+
 ## Pattern
 
 - Create a fork under `leynier/*`.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   path: ^1.9.1
   uuid: ^4.5.3
   path_provider: ^2.1.5
-  ghostty_vte_flutter: ^0.1.3
+  ghostty_vte_flutter: ^0.1.5
   ffi: ^2.2.0
   portable_pty: ^0.0.5
   xterm: ^4.0.0
@@ -80,8 +80,8 @@ dev_dependencies:
 dependency_overrides:
   ghostty_vte:
     path: third_party/dart_terminal/pkgs/vte/ghostty_vte
-  # Pinned alongside ghostty_vte: the published 0.1.3 does not compile against
-  # the newer generated bindings, whose enums carry a width sentinel.
+  # Pinned alongside ghostty_vte so Alera consumes the source-clean build hook
+  # and verified prebuilts from the maintained fork.
   ghostty_vte_flutter:
     path: third_party/dart_terminal/pkgs/vte/ghostty_vte_flutter
   # Keeps local terminal fixes pinned while upstream PRs are reviewed.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   path: ^1.9.1
   uuid: ^4.5.3
   path_provider: ^2.1.5
-  ghostty_vte_flutter: ^0.1.5
+  ghostty_vte_flutter: ^0.1.3
   ffi: ^2.2.0
   portable_pty: ^0.0.5
   xterm: ^4.0.0
@@ -80,8 +80,8 @@ dev_dependencies:
 dependency_overrides:
   ghostty_vte:
     path: third_party/dart_terminal/pkgs/vte/ghostty_vte
-  # Pinned alongside ghostty_vte so Alera consumes the source-clean build hook
-  # and verified prebuilts from the maintained fork.
+  # Override both upstream pub.dev packages together so Alera consumes the
+  # source-clean build hook and verified prebuilts from the maintained fork.
   ghostty_vte_flutter:
     path: third_party/dart_terminal/pkgs/vte/ghostty_vte_flutter
   # Keeps local terminal fixes pinned while upstream PRs are reviewed.


### PR DESCRIPTION
## Summary
- pin the maintained dart_terminal fork to its stable master branch
- keep the public ghostty_vte_flutter constraint on upstream 0.1.3
- consume the fork-local 0.1.5 packages only through paired path overrides
- mark both fork packages as non-publishable and document the distribution boundary

## Validation
- flutter pub get
- flutter test test/unit/native_asset_preflight_test.dart -r expanded
- flutter analyze
- verified both dart_terminal and its nested Ghostty checkout remain clean after validation
- verified pub.dev still serves upstream 0.1.3 for both package names and no credentials were stored
- gh act pull_request -j static -W .github/workflows/pr.yml (blocked by external-worktree gitdir emulation before workflow steps: fatal: not a git repository: (null))

## Notes
- fork-native artifact release: https://github.com/leynier/dart_terminal/releases/tag/ghostty_vte-v0.1.5
- source-clean build implementation: https://github.com/leynier/dart_terminal/pull/9
- distribution-boundary correction: https://github.com/leynier/dart_terminal/pull/10