### PR TITLE
fix: prioritize active workspaces in agent activity sort

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -20,7 +20,7 @@ env:
 jobs:
   build:
     name: build ${{ matrix.platform }}
-    timeout-minutes: 40
+    timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:

--- a/lib/src/features/workbench/application/workbench_agent_activity_sort.dart
+++ b/lib/src/features/workbench/application/workbench_agent_activity_sort.dart
@@ -23,6 +23,17 @@ class WorkspaceAttention {
   final DateTime? attentionAt;
 }
 
+/// Comparable activity for a workspace that currently has an open terminal.
+class AgentActivityRank {
+  const AgentActivityRank({
+    required this.attentionClass,
+    required this.activityAt,
+  });
+
+  final AgentAttentionClass attentionClass;
+  final DateTime activityAt;
+}
+
 /// Classifies a workspace by its live agent runs for the Agent Activity sort.
 WorkspaceAttention workspaceAttention({
   required Iterable<WorkspaceTabRecord> tabs,
@@ -74,63 +85,103 @@ bool _moreUrgent(WorkspaceAttention a, WorkspaceAttention b) {
   return aAt.isAfter(bAt);
 }
 
-/// Comparator for the Agent Activity sort: urgency class ascending, then the
-/// attention (or fallback recency) timestamp descending, then name.
-int compareByAgentActivity({
-  required WorkspaceAttention aAttention,
-  required DateTime aFallback,
-  required String aName,
-  required WorkspaceAttention bAttention,
-  required DateTime bFallback,
-  required String bName,
+AgentActivityRank agentActivityRank({
+  required WorkspaceAttention attention,
+  required DateTime fallback,
 }) {
-  final byClass = aAttention.attentionClass.index.compareTo(
-    bAttention.attentionClass.index,
+  return AgentActivityRank(
+    attentionClass: attention.attentionClass,
+    activityAt: attention.attentionAt ?? fallback,
   );
+}
+
+int compareAgentActivityRanks(AgentActivityRank a, AgentActivityRank b) {
+  final byClass = a.attentionClass.index.compareTo(b.attentionClass.index);
   if (byClass != 0) {
     return byClass;
   }
-  final aAt = aAttention.attentionAt ?? aFallback;
-  final bAt = bAttention.attentionAt ?? bFallback;
-  final byTime = bAt.compareTo(aAt);
-  if (byTime != 0) {
-    return byTime;
+  return b.activityAt.compareTo(a.activityAt);
+}
+
+AgentActivityRank? bestAgentActivityRank(
+  AgentActivityRank? current,
+  AgentActivityRank? candidate,
+) {
+  if (current == null) {
+    return candidate;
+  }
+  if (candidate == null) {
+    return current;
+  }
+  return compareAgentActivityRanks(candidate, current) < 0
+      ? candidate
+      : current;
+}
+
+/// Returns each workspace's best activity across itself and its visible
+/// descendants. A cycle edge contributes the node's direct activity without
+/// recursing again.
+Map<String, AgentActivityRank?> aggregateAgentActivityBySubtree({
+  required Iterable<({String id, String? parentId})> workspaces,
+  required Map<String, AgentActivityRank?> directActivityByWorkspaceId,
+}) {
+  final entries = workspaces.toList(growable: false);
+  final ids = <String>{for (final entry in entries) entry.id};
+  final childrenByParentId = <String, List<String>>{};
+  for (final entry in entries) {
+    final parentId = entry.parentId;
+    if (parentId == null || parentId == entry.id || !ids.contains(parentId)) {
+      continue;
+    }
+    childrenByParentId.putIfAbsent(parentId, () => <String>[]).add(entry.id);
+  }
+
+  final aggregateById = <String, AgentActivityRank?>{};
+  final visiting = <String>{};
+
+  AgentActivityRank? visit(String workspaceId) {
+    final cached = aggregateById[workspaceId];
+    if (cached != null || aggregateById.containsKey(workspaceId)) {
+      return cached;
+    }
+    if (!visiting.add(workspaceId)) {
+      return directActivityByWorkspaceId[workspaceId];
+    }
+    var best = directActivityByWorkspaceId[workspaceId];
+    for (final childId in childrenByParentId[workspaceId] ?? const <String>[]) {
+      best = bestAgentActivityRank(best, visit(childId));
+    }
+    visiting.remove(workspaceId);
+    aggregateById[workspaceId] = best;
+    return best;
+  }
+
+  for (final entry in entries) {
+    visit(entry.id);
+  }
+  return aggregateById;
+}
+
+/// Comparator for the Agent Activity sort. Entries with terminal activity
+/// rank first by urgency and time; entries without terminals sort by name.
+int compareByAgentActivity({
+  required AgentActivityRank? aActivity,
+  required String aName,
+  required AgentActivityRank? bActivity,
+  required String bName,
+}) {
+  if (aActivity == null || bActivity == null) {
+    if (aActivity != null) {
+      return -1;
+    }
+    if (bActivity != null) {
+      return 1;
+    }
+    return aName.toLowerCase().compareTo(bName.toLowerCase());
+  }
+  final byActivity = compareAgentActivityRanks(aActivity, bActivity);
+  if (byActivity != 0) {
+    return byActivity;
   }
   return aName.toLowerCase().compareTo(bName.toLowerCase());
-}
-
-/// Mutable holder for the workspace order of the last sidebar render. Owned by
-/// a keep-alive provider so [buildSidebarRows] can stay pure while the active
-/// row keeps its position across rebuilds.
-class SidebarOrderMemory {
-  List<String> order = const <String>[];
-}
-
-/// Re-inserts the active workspace at the index it occupied in the previously
-/// rendered order so live status changes never reorder the row the user is
-/// interacting with.
-List<T> stabilizeActiveEntry<T>({
-  required List<T> sorted,
-  required String Function(T) idOf,
-  required List<String> previousOrder,
-  required String? activeId,
-}) {
-  if (activeId == null) {
-    return sorted;
-  }
-  final currentIndex = sorted.indexWhere((entry) => idOf(entry) == activeId);
-  if (currentIndex < 0) {
-    return sorted;
-  }
-  final previousIndex = previousOrder.indexOf(activeId);
-  if (previousIndex < 0 || previousIndex == currentIndex) {
-    return sorted;
-  }
-  final result = List<T>.from(sorted);
-  final entry = result.removeAt(currentIndex);
-  result.insert(
-    previousIndex >= result.length ? result.length : previousIndex,
-    entry,
-  );
-  return result;
 }

--- a/lib/src/features/workbench/application/workbench_listing.dart
+++ b/lib/src/features/workbench/application/workbench_listing.dart
@@ -11,20 +11,18 @@ import 'package:alera/src/features/workbench/domain/workspace.dart';
 import 'package:alera/src/features/workbench/domain/workspace_tab_record.dart';
 
 part 'workbench_sidebar_rows.dart';
+part 'workbench_listing_sort.dart';
 
 /// Builds the flat list of rows the sidebar should render for the current
 /// [state]. Pure function - easy to unit test.
 ///
 /// [lastActivityByWorkspaceId] supplies the persisted recency fallback for the
-/// Agent Activity sort; [previousWorkspaceOrder] is the workspace-id order of
-/// the previous render, used to keep the active workspace pinned in place
-/// while live statuses reshuffle its siblings.
+/// Agent Activity sort.
 List<WorkbenchSidebarRow> buildSidebarRows(
   WorkbenchState state, {
   Map<String, AgentStatusEntry> agentStatuses =
       const <String, AgentStatusEntry>{},
   Map<String, DateTime> lastActivityByWorkspaceId = const <String, DateTime>{},
-  List<String> previousWorkspaceOrder = const <String>[],
   DateTime? now,
 }) {
   final prefs = state.viewPrefs;
@@ -54,6 +52,22 @@ List<WorkbenchSidebarRow> buildSidebarRows(
 
   DateTime fallbackActivityOf(Workspace workspace) {
     return lastActivityByWorkspaceId[workspace.id] ?? workspace.updatedAt;
+  }
+
+  final activityCache = <String, AgentActivityRank?>{};
+  AgentActivityRank? activityOf(Workspace workspace) {
+    if (activityCache.containsKey(workspace.id)) {
+      return activityCache[workspace.id];
+    }
+    final tabs = state.tabsFor(workspace.id);
+    final activity = tabs.any((tab) => tab.kind == WorkspaceTabKind.terminal)
+        ? agentActivityRank(
+            attention: attentionOf(workspace),
+            fallback: fallbackActivityOf(workspace),
+          )
+        : null;
+    activityCache[workspace.id] = activity;
+    return activity;
   }
 
   bool workspaceVisible(Project project, Workspace workspace) {
@@ -89,96 +103,22 @@ List<WorkbenchSidebarRow> buildSidebarRows(
     List<Workspace> workspaces, {
     required bool pinMainOnRecent,
   }) {
-    final sorted = List<Workspace>.from(workspaces);
-    switch (prefs.workspaceSort) {
-      case WorkbenchSortBy.name:
-        sorted.sort((a, b) {
-          // Keep the main worktree pinned at the top regardless of name.
-          if (a.isMain != b.isMain) {
-            return a.isMain ? -1 : 1;
-          }
-          return a.name.toLowerCase().compareTo(b.name.toLowerCase());
-        });
-      case WorkbenchSortBy.recent:
-        sorted.sort((a, b) {
-          if (pinMainOnRecent && a.isMain != b.isMain) {
-            return a.isMain ? -1 : 1;
-          }
-          return b.updatedAt.compareTo(a.updatedAt);
-        });
-      case WorkbenchSortBy.activity:
-        // Urgency outranks the main-worktree pin in this mode.
-        sorted.sort(
-          (a, b) => compareByAgentActivity(
-            aAttention: attentionOf(a),
-            aFallback: fallbackActivityOf(a),
-            aName: a.name,
-            bAttention: attentionOf(b),
-            bFallback: fallbackActivityOf(b),
-            bName: b.name,
-          ),
-        );
-    }
-    return stabilizeActiveEntry(
-      sorted: sorted,
-      idOf: (workspace) => workspace.id,
-      previousOrder: previousWorkspaceOrder,
-      activeId: prefs.workspaceSort == WorkbenchSortBy.activity
-          ? state.activeWorkspaceId
-          : null,
+    return _sortSidebarWorkspaces(
+      workspaces,
+      sortBy: prefs.workspaceSort,
+      pinMainOnRecent: pinMainOnRecent,
+      activityOf: activityOf,
     );
   }
 
   List<Project> sortProjects(List<Project> projects) {
-    final sorted = List<Project>.from(projects);
-    switch (prefs.projectSort) {
-      case WorkbenchSortBy.name:
-        sorted.sort(
-          (a, b) => a.name.toLowerCase().compareTo(b.name.toLowerCase()),
-        );
-      case WorkbenchSortBy.recent:
-        sorted.sort((a, b) => b.updatedAt.compareTo(a.updatedAt));
-      case WorkbenchSortBy.activity:
-        // Rank each project by its most urgent / most recently active visible
-        // workspace.
-        final rank = <String, ({WorkspaceAttention attention, DateTime at})>{};
-        for (final project in sorted) {
-          var best = WorkspaceAttention.idle;
-          var bestAt = project.updatedAt;
-          for (final workspace in state.workspacesFor(project.id)) {
-            if (!workspaceVisible(project, workspace)) {
-              continue;
-            }
-            final attention = attentionOf(workspace);
-            final at = attention.attentionAt ?? fallbackActivityOf(workspace);
-            final better =
-                attention.attentionClass.index < best.attentionClass.index ||
-                (attention.attentionClass == best.attentionClass &&
-                    at.isAfter(bestAt));
-            if (better) {
-              best = attention;
-              bestAt = at;
-            }
-          }
-          rank[project.id] = (attention: best, at: bestAt);
-        }
-        sorted.sort((a, b) {
-          final ra = rank[a.id]!;
-          final rb = rank[b.id]!;
-          final byClass = ra.attention.attentionClass.index.compareTo(
-            rb.attention.attentionClass.index,
-          );
-          if (byClass != 0) {
-            return byClass;
-          }
-          final byTime = rb.at.compareTo(ra.at);
-          if (byTime != 0) {
-            return byTime;
-          }
-          return a.name.toLowerCase().compareTo(b.name.toLowerCase());
-        });
-    }
-    return sorted;
+    return _sortSidebarProjects(
+      projects,
+      sortBy: prefs.projectSort,
+      workspacesFor: state.workspacesFor,
+      workspaceVisible: workspaceVisible,
+      activityOf: activityOf,
+    );
   }
 
   void appendWorkspaceTreeRows(
@@ -233,27 +173,52 @@ List<WorkbenchSidebarRow> buildSidebarRows(
   var pinnedWorkspaceCount = 0;
   switch (prefs.groupBy) {
     case WorkbenchGroupBy.project:
-      for (final project in sortProjects(visibleProjects)) {
-        final pinned = sortWorkspaces(
-          state
-              .workspacesFor(project.id)
-              .where(
-                (workspace) =>
-                    workspace.isPinned && workspaceVisible(project, workspace),
-              )
-              .toList(),
-          pinMainOnRecent: true,
-        );
-        pinnedWorkspaceCount += pinned.length;
+      if (prefs.workspaceSort == WorkbenchSortBy.activity) {
+        final projectByWorkspaceId = <String, Project>{};
+        final pinned = <Workspace>[];
+        for (final project in visibleProjects) {
+          for (final workspace in state.workspacesFor(project.id)) {
+            if (!workspace.isPinned || !workspaceVisible(project, workspace)) {
+              continue;
+            }
+            projectByWorkspaceId[workspace.id] = project;
+            pinned.add(workspace);
+          }
+        }
+        pinnedWorkspaceCount = pinned.length;
         appendWorkspaceTreeRows(
           pinnedRows,
-          workspaces: pinned,
-          projectOf: (_) => project,
+          workspaces: sortWorkspaces(pinned, pinMainOnRecent: false),
+          projectOf: (workspace) => projectByWorkspaceId[workspace.id]!,
           baseIndent: 0,
           showProjectChip: true,
           isPinnedCopy: true,
           collapsedParentIds: const <String>{},
         );
+      } else {
+        for (final project in sortProjects(visibleProjects)) {
+          final pinned = sortWorkspaces(
+            state
+                .workspacesFor(project.id)
+                .where(
+                  (workspace) =>
+                      workspace.isPinned &&
+                      workspaceVisible(project, workspace),
+                )
+                .toList(),
+            pinMainOnRecent: true,
+          );
+          pinnedWorkspaceCount += pinned.length;
+          appendWorkspaceTreeRows(
+            pinnedRows,
+            workspaces: pinned,
+            projectOf: (_) => project,
+            baseIndent: 0,
+            showProjectChip: true,
+            isPinnedCopy: true,
+            collapsedParentIds: const <String>{},
+          );
+        }
       }
     case WorkbenchGroupBy.none:
       final projectByWorkspaceId = <String, Project>{};
@@ -467,8 +432,7 @@ bool _workspaceVisible(
   return false;
 }
 
-/// The workspace-id order of the rendered rows, used to remember the previous
-/// ordering for [buildSidebarRows]'s active-row stabilization.
+/// The workspace-id order of the rendered non-pinned rows.
 List<String> workspaceOrderOfRows(List<WorkbenchSidebarRow> rows) {
   return <String>[
     for (final row in rows)

--- a/lib/src/features/workbench/application/workbench_listing_sort.dart
+++ b/lib/src/features/workbench/application/workbench_listing_sort.dart
@@ -1,0 +1,84 @@
+part of 'workbench_listing.dart';
+
+List<Workspace> _sortSidebarWorkspaces(
+  List<Workspace> workspaces, {
+  required WorkbenchSortBy sortBy,
+  required bool pinMainOnRecent,
+  required AgentActivityRank? Function(Workspace) activityOf,
+}) {
+  final sorted = List<Workspace>.from(workspaces);
+  switch (sortBy) {
+    case WorkbenchSortBy.name:
+      sorted.sort((a, b) {
+        if (a.isMain != b.isMain) {
+          return a.isMain ? -1 : 1;
+        }
+        return a.name.toLowerCase().compareTo(b.name.toLowerCase());
+      });
+    case WorkbenchSortBy.recent:
+      sorted.sort((a, b) {
+        if (pinMainOnRecent && a.isMain != b.isMain) {
+          return a.isMain ? -1 : 1;
+        }
+        return b.updatedAt.compareTo(a.updatedAt);
+      });
+    case WorkbenchSortBy.activity:
+      final subtreeActivity = aggregateAgentActivityBySubtree(
+        workspaces: sorted.map(
+          (workspace) =>
+              (id: workspace.id, parentId: workspace.parentWorkspaceId),
+        ),
+        directActivityByWorkspaceId: <String, AgentActivityRank?>{
+          for (final workspace in sorted) workspace.id: activityOf(workspace),
+        },
+      );
+      sorted.sort(
+        (a, b) => compareByAgentActivity(
+          aActivity: subtreeActivity[a.id],
+          aName: a.name,
+          bActivity: subtreeActivity[b.id],
+          bName: b.name,
+        ),
+      );
+  }
+  return sorted;
+}
+
+List<Project> _sortSidebarProjects(
+  List<Project> projects, {
+  required WorkbenchSortBy sortBy,
+  required Iterable<Workspace> Function(String projectId) workspacesFor,
+  required bool Function(Project, Workspace) workspaceVisible,
+  required AgentActivityRank? Function(Workspace) activityOf,
+}) {
+  final sorted = List<Project>.from(projects);
+  switch (sortBy) {
+    case WorkbenchSortBy.name:
+      sorted.sort(
+        (a, b) => a.name.toLowerCase().compareTo(b.name.toLowerCase()),
+      );
+    case WorkbenchSortBy.recent:
+      sorted.sort((a, b) => b.updatedAt.compareTo(a.updatedAt));
+    case WorkbenchSortBy.activity:
+      final rank = <String, AgentActivityRank?>{};
+      for (final project in sorted) {
+        AgentActivityRank? best;
+        for (final workspace in workspacesFor(project.id)) {
+          if (!workspaceVisible(project, workspace)) {
+            continue;
+          }
+          best = bestAgentActivityRank(best, activityOf(workspace));
+        }
+        rank[project.id] = best;
+      }
+      sorted.sort(
+        (a, b) => compareByAgentActivity(
+          aActivity: rank[a.id],
+          aName: a.name,
+          bActivity: rank[b.id],
+          bName: b.name,
+        ),
+      );
+  }
+  return sorted;
+}

--- a/lib/src/features/workbench/application/workbench_providers.dart
+++ b/lib/src/features/workbench/application/workbench_providers.dart
@@ -15,7 +15,6 @@ import 'package:alera/src/features/workbench/application/workbench_listing.dart'
 import 'package:alera/src/features/workbench/application/workbench_repository.dart';
 import 'package:alera/src/features/workbench/application/workbench_state.dart';
 import 'package:alera/src/features/workbench/application/workbench_view_prefs_repository.dart';
-import 'package:alera/src/features/workbench/application/workbench_agent_activity_sort.dart';
 import 'package:alera/src/features/workbench/application/workspace_activity_controller.dart';
 import 'package:alera/src/features/workbench/application/workspace_activity_repository.dart';
 import 'package:alera/src/features/workbench/application/workspace_file_service.dart';
@@ -80,11 +79,6 @@ WorkbenchViewPrefsRepository workbenchViewPrefsRepository(Ref ref) {
   );
 }
 
-@Riverpod(keepAlive: true)
-SidebarOrderMemory sidebarOrderMemory(Ref ref) {
-  return SidebarOrderMemory();
-}
-
 /// The sidebar row list, recomputed once per state change instead of once per
 /// widget rebuild.
 ///
@@ -96,7 +90,6 @@ List<WorkbenchSidebarRow> workbenchSidebarRows(Ref ref) {
   final state = ref.watch(
     workbenchControllerProvider.select(
       (state) => (
-        activeWorkspaceId: state.activeWorkspaceId,
         projects: state.projects,
         searchQuery: state.searchQuery,
         tabsByWorkspace: state.tabsByWorkspace,
@@ -105,22 +98,17 @@ List<WorkbenchSidebarRow> workbenchSidebarRows(Ref ref) {
       ),
     ),
   );
-  final orderMemory = ref.read(sidebarOrderMemoryProvider);
-  final rows = buildSidebarRows(
+  return buildSidebarRows(
     WorkbenchState(
       projects: state.projects,
       workspacesByProject: state.workspacesByProject,
       tabsByWorkspace: state.tabsByWorkspace,
       viewPrefs: state.viewPrefs,
-      activeWorkspaceId: state.activeWorkspaceId,
       searchQuery: state.searchQuery,
     ),
     agentStatuses: ref.watch(agentStatusControllerProvider),
     lastActivityByWorkspaceId: ref.watch(workspaceActivityControllerProvider),
-    previousWorkspaceOrder: orderMemory.order,
   );
-  orderMemory.order = workspaceOrderOfRows(rows);
-  return rows;
 }
 
 /// Keeps the terminal runtime's pinned workspace in sync with the active one,

--- a/lib/src/features/workbench/application/workbench_providers.g.dart
+++ b/lib/src/features/workbench/application/workbench_providers.g.dart
@@ -154,54 +154,6 @@ final class WorkbenchViewPrefsRepositoryProvider
 String _$workbenchViewPrefsRepositoryHash() =>
     r'307cb46e7f48379a186243cc2863d6f89141eebc';
 
-@ProviderFor(sidebarOrderMemory)
-final sidebarOrderMemoryProvider = SidebarOrderMemoryProvider._();
-
-final class SidebarOrderMemoryProvider
-    extends
-        $FunctionalProvider<
-          SidebarOrderMemory,
-          SidebarOrderMemory,
-          SidebarOrderMemory
-        >
-    with $Provider<SidebarOrderMemory> {
-  SidebarOrderMemoryProvider._()
-    : super(
-        from: null,
-        argument: null,
-        retry: null,
-        name: r'sidebarOrderMemoryProvider',
-        isAutoDispose: false,
-        dependencies: null,
-        $allTransitiveDependencies: null,
-      );
-
-  @override
-  String debugGetCreateSourceHash() => _$sidebarOrderMemoryHash();
-
-  @$internal
-  @override
-  $ProviderElement<SidebarOrderMemory> $createElement(
-    $ProviderPointer pointer,
-  ) => $ProviderElement(pointer);
-
-  @override
-  SidebarOrderMemory create(Ref ref) {
-    return sidebarOrderMemory(ref);
-  }
-
-  /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(SidebarOrderMemory value) {
-    return $ProviderOverride(
-      origin: this,
-      providerOverride: $SyncValueProvider<SidebarOrderMemory>(value),
-    );
-  }
-}
-
-String _$sidebarOrderMemoryHash() =>
-    r'63af5266267a090aad55563c87262c6ea27d6a5b';
-
 /// The sidebar row list, recomputed once per state change instead of once per
 /// widget rebuild.
 ///
@@ -268,7 +220,7 @@ final class WorkbenchSidebarRowsProvider
 }
 
 String _$workbenchSidebarRowsHash() =>
-    r'f549c71cd45c77050faa6ce3d2908407e9911a01';
+    r'9f8ecfca092c1ba351c67de8e473579701ca983e';
 
 /// Keeps the terminal runtime's pinned workspace in sync with the active one,
 /// so the memory budget never evicts a terminal in the workspace being worked

--- a/test/unit/workbench_agent_activity_listing_test.dart
+++ b/test/unit/workbench_agent_activity_listing_test.dart
@@ -1,0 +1,391 @@
+import 'package:alera/src/features/agent_status/domain/agent_status.dart';
+import 'package:alera/src/features/projects/domain/project.dart';
+import 'package:alera/src/features/workbench/application/workbench_listing.dart';
+import 'package:alera/src/features/workbench/application/workbench_state.dart';
+import 'package:alera/src/features/workbench/domain/workbench_view_prefs.dart';
+import 'package:alera/src/features/workbench/domain/workspace.dart';
+import 'package:alera/src/features/workbench/domain/workspace_tab_record.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+final DateTime _now = DateTime.utc(2026, 5, 1);
+
+Project _project(String id, String name, {int recencyOffset = 0}) {
+  return Project(
+    id: id,
+    name: name,
+    repoPath: '/repo/$id',
+    createdAt: _now,
+    updatedAt: _now.add(Duration(days: recencyOffset)),
+  );
+}
+
+Workspace _workspace(
+  String id,
+  String projectId,
+  String name, {
+  int recencyOffset = 0,
+  String? parentWorkspaceId,
+  bool isPinned = false,
+}) {
+  return Workspace(
+    id: id,
+    projectId: projectId,
+    name: name,
+    branch: id,
+    path: '/repo/$projectId/$id',
+    createdAt: _now,
+    updatedAt: _now.add(Duration(days: recencyOffset)),
+    kind: WorkspaceKind.linked,
+    status: WorkspaceStatus.active,
+    parentWorkspaceId: parentWorkspaceId,
+    isPinned: isPinned,
+  );
+}
+
+WorkspaceTabRecord _tab(String id, String workspaceId) {
+  return WorkspaceTabRecord(
+    id: id,
+    workspaceId: workspaceId,
+    kind: WorkspaceTabKind.terminal,
+    title: id,
+    createdAt: _now,
+    updatedAt: _now,
+  );
+}
+
+AgentStatusEntry _status(WorkspaceTabRecord tab, AgentStatusState state) {
+  return AgentStatusEntry(
+    terminalSessionId: tab.terminalSessionId,
+    workspaceId: tab.workspaceId,
+    tabId: tab.id,
+    agentType: AgentType.claude,
+    state: state,
+    prompt: state.name,
+    updatedAt: _now,
+    stateStartedAt: _now,
+  );
+}
+
+WorkbenchState _activityState(
+  WorkbenchViewPrefs prefs, {
+  String? activeWorkspaceId,
+}) {
+  final alera = _project('p-alera', 'alera');
+  final orca = _project('p-orca', 'orca');
+  final waiting = _workspace('w-waiting', alera.id, 'aaa-waiting');
+  final working = _workspace('w-working', alera.id, 'bbb-working');
+  final idle = _workspace('w-idle', orca.id, 'ccc-idle');
+  return WorkbenchState(
+    projects: <Project>[alera, orca],
+    workspacesByProject: <String, List<Workspace>>{
+      alera.id: <Workspace>[working, waiting],
+      orca.id: <Workspace>[idle],
+    },
+    tabsByWorkspace: <String, List<WorkspaceTabRecord>>{
+      waiting.id: <WorkspaceTabRecord>[_tab('t-w', waiting.id)],
+      working.id: <WorkspaceTabRecord>[_tab('t-x', working.id)],
+    },
+    viewPrefs: prefs,
+    activeWorkspaceId: activeWorkspaceId,
+    bootstrapped: true,
+  );
+}
+
+Map<String, AgentStatusEntry> _activityStatuses(WorkbenchState state) {
+  return <String, AgentStatusEntry>{
+    for (final tab in state.tabsByWorkspace.values.expand((tabs) => tabs))
+      tab.terminalSessionId: _status(
+        tab,
+        tab.workspaceId == 'w-waiting'
+            ? AgentStatusState.waiting
+            : AgentStatusState.working,
+      ),
+  };
+}
+
+List<String> _workspaceIds(List<WorkbenchSidebarRow> rows) {
+  return rows
+      .whereType<WorkbenchWorkspaceRow>()
+      .map((row) => row.workspace.id)
+      .toList();
+}
+
+void main() {
+  test('needs-you workspaces rank above working and inactive workspaces', () {
+    final prefs = WorkbenchViewPrefs.defaults.copyWith(
+      groupBy: WorkbenchGroupBy.none,
+      workspaceSort: WorkbenchSortBy.activity,
+    );
+    final state = _activityState(prefs);
+
+    expect(
+      _workspaceIds(
+        buildSidebarRows(
+          state,
+          agentStatuses: _activityStatuses(state),
+          now: _now,
+        ),
+      ),
+      <String>['w-waiting', 'w-working', 'w-idle'],
+    );
+  });
+
+  test('active project headers rank above inactive projects', () {
+    final prefs = WorkbenchViewPrefs.defaults.copyWith(
+      projectSort: WorkbenchSortBy.activity,
+    );
+    final state = _activityState(prefs);
+    final headers = buildSidebarRows(
+      state,
+      agentStatuses: _activityStatuses(state),
+      now: _now,
+    ).whereType<WorkbenchProjectHeaderRow>();
+
+    expect(headers.first.project.id, 'p-alera');
+  });
+
+  test('active projects rank by their most urgent workspace', () {
+    final prefs = WorkbenchViewPrefs.defaults.copyWith(
+      projectSort: WorkbenchSortBy.activity,
+    );
+    final alpha = _project('p-alpha', 'alpha');
+    final zeta = _project('p-zeta', 'zeta');
+    final working = _workspace('w-working', alpha.id, 'working');
+    final waiting = _workspace('w-waiting', zeta.id, 'waiting');
+    final workingTab = _tab('t-working', working.id);
+    final waitingTab = _tab('t-waiting', waiting.id);
+    final state = WorkbenchState(
+      projects: <Project>[alpha, zeta],
+      workspacesByProject: <String, List<Workspace>>{
+        alpha.id: <Workspace>[working],
+        zeta.id: <Workspace>[waiting],
+      },
+      tabsByWorkspace: <String, List<WorkspaceTabRecord>>{
+        working.id: <WorkspaceTabRecord>[workingTab],
+        waiting.id: <WorkspaceTabRecord>[waitingTab],
+      },
+      viewPrefs: prefs,
+      bootstrapped: true,
+    );
+    final statuses = <String, AgentStatusEntry>{
+      workingTab.terminalSessionId: _status(
+        workingTab,
+        AgentStatusState.working,
+      ),
+      waitingTab.terminalSessionId: _status(
+        waitingTab,
+        AgentStatusState.waiting,
+      ),
+    };
+
+    expect(
+      buildSidebarRows(
+        state,
+        agentStatuses: statuses,
+        now: _now,
+      ).whereType<WorkbenchProjectHeaderRow>().map((row) => row.project.id),
+      <String>['p-zeta', 'p-alpha'],
+    );
+  });
+
+  test('inactive projects sort alphabetically', () {
+    final prefs = WorkbenchViewPrefs.defaults.copyWith(
+      projectSort: WorkbenchSortBy.activity,
+    );
+    final zeta = _project('p-zeta', 'zeta', recencyOffset: 10);
+    final alpha = _project('p-alpha', 'alpha');
+    final state = WorkbenchState(
+      projects: <Project>[zeta, alpha],
+      workspacesByProject: <String, List<Workspace>>{
+        zeta.id: <Workspace>[_workspace('w-zeta', zeta.id, 'zeta')],
+        alpha.id: <Workspace>[_workspace('w-alpha', alpha.id, 'alpha')],
+      },
+      viewPrefs: prefs,
+      bootstrapped: true,
+    );
+
+    expect(
+      buildSidebarRows(
+        state,
+      ).whereType<WorkbenchProjectHeaderRow>().map((row) => row.project.id),
+      <String>['p-alpha', 'p-zeta'],
+    );
+  });
+
+  test('the selected workspace does not override strict activity order', () {
+    final prefs = WorkbenchViewPrefs.defaults.copyWith(
+      groupBy: WorkbenchGroupBy.none,
+      workspaceSort: WorkbenchSortBy.activity,
+    );
+    final state = _activityState(prefs, activeWorkspaceId: 'w-working');
+
+    expect(
+      _workspaceIds(
+        buildSidebarRows(
+          state,
+          agentStatuses: _activityStatuses(state),
+          now: _now,
+        ),
+      ),
+      <String>['w-waiting', 'w-working', 'w-idle'],
+    );
+  });
+
+  test('inactive workspaces ignore recency and sort alphabetically', () {
+    final prefs = WorkbenchViewPrefs.defaults.copyWith(
+      groupBy: WorkbenchGroupBy.none,
+      workspaceSort: WorkbenchSortBy.activity,
+    );
+    final project = _project('p-alera', 'alera');
+    final alpha = _workspace('w-a', project.id, 'aaa');
+    final beta = _workspace('w-b', project.id, 'bbb');
+    final state = WorkbenchState(
+      projects: <Project>[project],
+      workspacesByProject: <String, List<Workspace>>{
+        project.id: <Workspace>[alpha, beta],
+      },
+      viewPrefs: prefs,
+      bootstrapped: true,
+    );
+
+    expect(
+      _workspaceIds(
+        buildSidebarRows(
+          state,
+          lastActivityByWorkspaceId: <String, DateTime>{
+            beta.id: _now.add(const Duration(days: 1)),
+          },
+          now: _now,
+        ),
+      ),
+      <String>['w-a', 'w-b'],
+    );
+  });
+
+  test('an open terminal is active without a live agent status', () {
+    final prefs = WorkbenchViewPrefs.defaults.copyWith(
+      groupBy: WorkbenchGroupBy.none,
+      workspaceSort: WorkbenchSortBy.activity,
+    );
+    final project = _project('p-alera', 'alera');
+    final active = _workspace('w-active', project.id, 'zebra');
+    final inactive = _workspace('w-inactive', project.id, 'alpha');
+    final state = WorkbenchState(
+      projects: <Project>[project],
+      workspacesByProject: <String, List<Workspace>>{
+        project.id: <Workspace>[inactive, active],
+      },
+      tabsByWorkspace: <String, List<WorkspaceTabRecord>>{
+        active.id: <WorkspaceTabRecord>[_tab('t-active', active.id)],
+      },
+      viewPrefs: prefs,
+      bootstrapped: true,
+    );
+
+    expect(_workspaceIds(buildSidebarRows(state)), <String>[
+      'w-active',
+      'w-inactive',
+    ]);
+  });
+
+  test('global pinned section keeps active workspaces first', () {
+    final prefs = WorkbenchViewPrefs.defaults.copyWith(
+      workspaceSort: WorkbenchSortBy.activity,
+    );
+    final alpha = _project('p-alpha', 'alpha');
+    final zeta = _project('p-zeta', 'zeta');
+    final inactive = _workspace(
+      'w-inactive',
+      alpha.id,
+      'alpha',
+      isPinned: true,
+    );
+    final active = _workspace('w-active', zeta.id, 'zebra', isPinned: true);
+    final state = WorkbenchState(
+      projects: <Project>[alpha, zeta],
+      workspacesByProject: <String, List<Workspace>>{
+        alpha.id: <Workspace>[inactive],
+        zeta.id: <Workspace>[active],
+      },
+      tabsByWorkspace: <String, List<WorkspaceTabRecord>>{
+        active.id: <WorkspaceTabRecord>[_tab('t-active', active.id)],
+      },
+      viewPrefs: prefs,
+      bootstrapped: true,
+    );
+
+    expect(
+      buildSidebarRows(state)
+          .whereType<WorkbenchWorkspaceRow>()
+          .where((row) => row.isPinnedCopy)
+          .map((row) => row.workspace.id),
+      <String>['w-active', 'w-inactive'],
+    );
+  });
+
+  test('active descendants promote and rank their workspace trees', () {
+    final prefs = WorkbenchViewPrefs.defaults.copyWith(
+      groupBy: WorkbenchGroupBy.none,
+      workspaceSort: WorkbenchSortBy.activity,
+    );
+    final project = _project('p-tree', 'tree');
+    final workingRoot = _workspace('w-working-root', project.id, 'alpha-root');
+    final workingChild = _workspace(
+      'w-working-child',
+      project.id,
+      'working-child',
+      parentWorkspaceId: workingRoot.id,
+    );
+    final waitingRoot = _workspace('w-waiting-root', project.id, 'zeta-root');
+    final waitingChild = _workspace(
+      'w-waiting-child',
+      project.id,
+      'waiting-child',
+      parentWorkspaceId: waitingRoot.id,
+    );
+    final inactiveRoot = _workspace('w-inactive-root', project.id, 'beta-root');
+    final workingTab = _tab('t-working', workingChild.id);
+    final waitingTab = _tab('t-waiting', waitingChild.id);
+    final state = WorkbenchState(
+      projects: <Project>[project],
+      workspacesByProject: <String, List<Workspace>>{
+        project.id: <Workspace>[
+          workingRoot,
+          workingChild,
+          waitingRoot,
+          waitingChild,
+          inactiveRoot,
+        ],
+      },
+      tabsByWorkspace: <String, List<WorkspaceTabRecord>>{
+        workingChild.id: <WorkspaceTabRecord>[workingTab],
+        waitingChild.id: <WorkspaceTabRecord>[waitingTab],
+      },
+      viewPrefs: prefs,
+      bootstrapped: true,
+    );
+    final statuses = <String, AgentStatusEntry>{
+      workingTab.terminalSessionId: _status(
+        workingTab,
+        AgentStatusState.working,
+      ),
+      waitingTab.terminalSessionId: _status(
+        waitingTab,
+        AgentStatusState.waiting,
+      ),
+    };
+
+    expect(
+      _workspaceIds(
+        buildSidebarRows(state, agentStatuses: statuses, now: _now),
+      ),
+      <String>[
+        'w-waiting-root',
+        'w-waiting-child',
+        'w-working-root',
+        'w-working-child',
+        'w-inactive-root',
+      ],
+    );
+  });
+}

--- a/test/unit/workbench_agent_activity_sort_test.dart
+++ b/test/unit/workbench_agent_activity_sort_test.dart
@@ -112,15 +112,15 @@ void main() {
   group('compareByAgentActivity', () {
     test('lower class ranks first regardless of recency', () {
       final result = compareByAgentActivity(
-        aAttention: const WorkspaceAttention(
+        aActivity: AgentActivityRank(
           attentionClass: AgentAttentionClass.working,
+          activityAt: _now,
         ),
-        aFallback: _now,
         aName: 'a',
-        bAttention: const WorkspaceAttention(
+        bActivity: AgentActivityRank(
           attentionClass: AgentAttentionClass.needsYou,
+          activityAt: _now.subtract(const Duration(days: 1)),
         ),
-        bFallback: _now.subtract(const Duration(days: 1)),
         bName: 'b',
       );
       expect(result, greaterThan(0));
@@ -128,64 +128,91 @@ void main() {
 
     test('same class ranks by recency then name', () {
       final result = compareByAgentActivity(
-        aAttention: WorkspaceAttention(
+        aActivity: AgentActivityRank(
           attentionClass: AgentAttentionClass.done,
-          attentionAt: _now,
+          activityAt: _now,
         ),
-        aFallback: _now,
         aName: 'a',
-        bAttention: WorkspaceAttention(
+        bActivity: AgentActivityRank(
           attentionClass: AgentAttentionClass.done,
-          attentionAt: _now.subtract(const Duration(minutes: 1)),
+          activityAt: _now.subtract(const Duration(minutes: 1)),
         ),
-        bFallback: _now,
         bName: 'b',
       );
       expect(result, lessThan(0));
     });
 
-    test('idle entries fall back to the provided timestamp', () {
+    test(
+      'terminal activity ranks before an alphabetically earlier inactive',
+      () {
+        final result = compareByAgentActivity(
+          aActivity: AgentActivityRank(
+            attentionClass: AgentAttentionClass.idle,
+            activityAt: _now,
+          ),
+          aName: 'zebra',
+          bActivity: null,
+          bName: 'alpha',
+        );
+        expect(result, lessThan(0));
+      },
+    );
+
+    test('inactive entries sort alphabetically', () {
       final result = compareByAgentActivity(
-        aAttention: WorkspaceAttention.idle,
-        aFallback: _now.subtract(const Duration(days: 2)),
-        aName: 'a',
-        bAttention: WorkspaceAttention.idle,
-        bFallback: _now,
-        bName: 'b',
+        aActivity: null,
+        aName: 'zebra',
+        bActivity: null,
+        bName: 'alpha',
       );
       expect(result, greaterThan(0));
     });
   });
 
-  group('stabilizeActiveEntry', () {
-    test('re-inserts the active id at its previous index', () {
-      final stabilized = stabilizeActiveEntry<String>(
-        sorted: <String>['b', 'c', 'a'],
-        idOf: (id) => id,
-        previousOrder: <String>['a', 'b', 'c'],
-        activeId: 'a',
+  group('aggregateAgentActivityBySubtree', () {
+    test('promotes an ancestor using its best descendant activity', () {
+      final working = AgentActivityRank(
+        attentionClass: AgentAttentionClass.working,
+        activityAt: _now,
       );
-      expect(stabilized, <String>['a', 'b', 'c']);
+      final waiting = AgentActivityRank(
+        attentionClass: AgentAttentionClass.needsYou,
+        activityAt: _now.subtract(const Duration(minutes: 5)),
+      );
+      final ranks = aggregateAgentActivityBySubtree(
+        workspaces: <({String id, String? parentId})>[
+          (id: 'root', parentId: null),
+          (id: 'child', parentId: 'root'),
+          (id: 'grandchild', parentId: 'child'),
+        ],
+        directActivityByWorkspaceId: <String, AgentActivityRank?>{
+          'child': working,
+          'grandchild': waiting,
+        },
+      );
+
+      expect(ranks['root'], same(waiting));
+      expect(ranks['child'], same(waiting));
+      expect(ranks['grandchild'], same(waiting));
     });
 
-    test('leaves the order untouched without an active id', () {
-      final stabilized = stabilizeActiveEntry<String>(
-        sorted: <String>['b', 'a'],
-        idOf: (id) => id,
-        previousOrder: <String>['a', 'b'],
-        activeId: null,
+    test('terminates when parent relationships contain a cycle', () {
+      final activity = AgentActivityRank(
+        attentionClass: AgentAttentionClass.working,
+        activityAt: _now,
       );
-      expect(stabilized, <String>['b', 'a']);
-    });
+      final ranks = aggregateAgentActivityBySubtree(
+        workspaces: <({String id, String? parentId})>[
+          (id: 'a', parentId: 'b'),
+          (id: 'b', parentId: 'a'),
+        ],
+        directActivityByWorkspaceId: <String, AgentActivityRank?>{
+          'b': activity,
+        },
+      );
 
-    test('ignores an active id missing from the previous order', () {
-      final stabilized = stabilizeActiveEntry<String>(
-        sorted: <String>['b', 'a'],
-        idOf: (id) => id,
-        previousOrder: const <String>[],
-        activeId: 'a',
-      );
-      expect(stabilized, <String>['b', 'a']);
+      expect(ranks['a'], same(activity));
+      expect(ranks['b'], same(activity));
     });
   });
 }

--- a/test/unit/workbench_listing_test.dart
+++ b/test/unit/workbench_listing_test.dart
@@ -608,7 +608,7 @@ void main() {
       expect(headers.first.project.id, 'p-alera');
     });
 
-    test('the active workspace keeps its previous position', () {
+    test('the selected workspace does not override strict activity order', () {
       final prefs = WorkbenchViewPrefs.defaults.copyWith(
         groupBy: WorkbenchGroupBy.none,
         workspaceSort: WorkbenchSortBy.activity,
@@ -618,17 +618,15 @@ void main() {
         state,
         agentStatuses: activityStatuses(state),
         now: _t0,
-        // Previous render had the active workspace first.
-        previousWorkspaceOrder: <String>['w-working', 'w-waiting', 'w-idle'],
       );
       final ids = rows
           .whereType<WorkbenchWorkspaceRow>()
           .map((r) => r.workspace.id)
           .toList();
-      expect(ids.first, 'w-working');
+      expect(ids, <String>['w-waiting', 'w-working', 'w-idle']);
     });
 
-    test('idle workspaces fall back to the persisted activity timestamp', () {
+    test('inactive workspaces ignore recency and sort alphabetically', () {
       final prefs = WorkbenchViewPrefs.defaults.copyWith(
         groupBy: WorkbenchGroupBy.none,
         workspaceSort: WorkbenchSortBy.activity,
@@ -655,7 +653,7 @@ void main() {
           .whereType<WorkbenchWorkspaceRow>()
           .map((r) => r.workspace.id)
           .toList();
-      expect(ids, <String>['w-b', 'w-a']);
+      expect(ids, <String>['w-a', 'w-b']);
     });
   });
 


### PR DESCRIPTION
## Summary
- prioritize Agent Activity workspaces and projects that contain open terminal tabs
- preserve the existing activity ordering for active entries and sort inactive entries alphabetically
- propagate activity through workspace trees and add regression coverage

## Validation
- native asset preflight
- Dart formatting and maximum-line checks
- `flutter analyze`
- `CI=true flutter test --coverage --exclude-tags golden -r compact` (2,424 passed, 2 skipped)
- domain coverage: 100%
- `gh act` static passed; test matrix ran with golden 3/3, with the existing installer sudo assertion differing because act runs as root