### PR TITLE
feat: select linux reveals and paste terminal file drops

### DIFF
--- a/lib/src/features/workbench/application/workspace_folder_opener.dart
+++ b/lib/src/features/workbench/application/workspace_folder_opener.dart
@@ -140,6 +140,7 @@ class WorkspaceFolderOpener {
       case WorkspaceFolderPlatform.linux:
         final target = _fileManagerTargetForReveal(path);
         return <_WorkspaceFolderOpenCommand>[
+          _showItemsCommand(path),
           _WorkspaceFolderOpenCommand('xdg-open', <String>[target]),
           _WorkspaceFolderOpenCommand('gio', <String>['open', target]),
         ];
@@ -156,6 +157,25 @@ class WorkspaceFolderOpener {
         ? path
         : File(path).parent.path;
   }
+}
+
+/// FreeDesktop FileManager1.ShowItems selects the path in the session file
+/// manager (Nautilus, Dolphin, ...). The GVariant array is one argv token so
+/// ProcessRunner shell-quoting leaves it intact for `gdbus`.
+_WorkspaceFolderOpenCommand _showItemsCommand(String path) {
+  final uri = Uri.file(path).toString();
+  return _WorkspaceFolderOpenCommand('gdbus', <String>[
+    'call',
+    '--session',
+    '--dest',
+    'org.freedesktop.FileManager1',
+    '--object-path',
+    '/org/freedesktop/FileManager1',
+    '--method',
+    'org.freedesktop.FileManager1.ShowItems',
+    "['$uri']",
+    '',
+  ]);
 }
 
 WorkspaceFolderPlatform currentWorkspaceFolderPlatform() {

--- a/lib/src/features/workbench/domain/terminal_path_paste.dart
+++ b/lib/src/features/workbench/domain/terminal_path_paste.dart
@@ -1,0 +1,27 @@
+import 'package:alera/src/features/workbench/domain/terminal_image_paste.dart';
+
+final RegExp _terminalPathWhitespace = RegExp(r'\s');
+
+/// Formats one absolute path for pasting into a terminal PTY.
+///
+/// Bare path when there is no whitespace; otherwise POSIX single-quoted, with a
+/// trailing space so multiple drops stay separated (Jean / native-terminal style).
+String formatPathForTerminalPaste(String path) {
+  final sanitized = sanitizeTerminalImagePastePath(path.trim());
+  if (sanitized.isEmpty) {
+    return '';
+  }
+  if (!_terminalPathWhitespace.hasMatch(sanitized)) {
+    return '$sanitized ';
+  }
+  return "'${sanitized.replaceAll("'", "'\\''")}' ";
+}
+
+/// Formats several absolute paths for a single terminal paste.
+String formatPathsForTerminalPaste(Iterable<String> paths) {
+  final buffer = StringBuffer();
+  for (final path in paths) {
+    buffer.write(formatPathForTerminalPaste(path));
+  }
+  return buffer.toString();
+}

--- a/lib/src/features/workbench/presentation/terminal_file_drop.dart
+++ b/lib/src/features/workbench/presentation/terminal_file_drop.dart
@@ -1,0 +1,15 @@
+import 'package:alera/src/features/workbench/domain/terminal_path_paste.dart';
+import 'package:alera/src/features/workbench/presentation/terminal_runtime.dart';
+
+/// Pastes absolute OS paths into [session] after a file/folder drop.
+void handleTerminalOsFileDrop({
+  required TerminalSessionHandle session,
+  required Iterable<String> paths,
+}) {
+  final text = formatPathsForTerminalPaste(paths);
+  if (text.isEmpty) {
+    return;
+  }
+  session.pasteText(text);
+  session.requestFocus();
+}

--- a/lib/src/features/workbench/presentation/terminal_runtime.dart
+++ b/lib/src/features/workbench/presentation/terminal_runtime.dart
@@ -113,6 +113,11 @@ abstract class TerminalSessionHandle extends ChangeNotifier {
   /// Moves keyboard focus to this terminal's text input so subsequent
   /// keypresses are routed to its PTY instead of any sidebar control.
   void requestFocus();
+
+  /// Inserts [text] as if the user pasted it (bracketed paste when enabled).
+  ///
+  /// Default is a no-op so test doubles stay source-compatible.
+  void pasteText(String text) {}
 }
 
 enum TerminalSessionOperation { starting, reconnecting, restarting }

--- a/lib/src/features/workbench/presentation/terminal_runtime_clipboard.dart
+++ b/lib/src/features/workbench/presentation/terminal_runtime_clipboard.dart
@@ -27,6 +27,13 @@ void _handleTerminalPrivateOsc(
   handle._osc8LinkTracker.handlePrivateOsc(code, args);
 }
 
+void _pasteTerminalText(_XtermTerminalSessionHandle handle, String text) {
+  if (handle._disposed || text.isEmpty) {
+    return;
+  }
+  handle._terminal.paste(text);
+}
+
 Future<void> _pasteTerminalClipboard(_XtermTerminalSessionHandle handle) async {
   String? text;
   try {
@@ -38,7 +45,7 @@ Future<void> _pasteTerminalClipboard(_XtermTerminalSessionHandle handle) async {
     return;
   }
   if (text != null && text.isNotEmpty) {
-    handle._terminal.paste(text);
+    _pasteTerminalText(handle, text);
     return;
   }
   try {

--- a/lib/src/features/workbench/presentation/terminal_runtime_session_handle.dart
+++ b/lib/src/features/workbench/presentation/terminal_runtime_session_handle.dart
@@ -639,6 +639,14 @@ class _XtermTerminalSessionHandle extends TerminalSessionHandle {
   }
 
   @override
+  void pasteText(String text) {
+    if (_disposed || text.isEmpty) {
+      return;
+    }
+    _terminal.paste(text);
+  }
+
+  @override
   void dispose({bool terminatePty = true}) {
     _disposed = true;
     _startAttempt += 1;

--- a/lib/src/features/workbench/presentation/terminal_runtime_session_handle.dart
+++ b/lib/src/features/workbench/presentation/terminal_runtime_session_handle.dart
@@ -639,12 +639,7 @@ class _XtermTerminalSessionHandle extends TerminalSessionHandle {
   }
 
   @override
-  void pasteText(String text) {
-    if (_disposed || text.isEmpty) {
-      return;
-    }
-    _terminal.paste(text);
-  }
+  void pasteText(String text) => _pasteTerminalText(this, text);
 
   @override
   void dispose({bool terminatePty = true}) {

--- a/lib/src/features/workbench/presentation/terminal_surface.dart
+++ b/lib/src/features/workbench/presentation/terminal_surface.dart
@@ -8,7 +8,9 @@ import 'package:alera/src/features/keyboard/application/keybinding_resolver.dart
 import 'package:alera/src/features/keyboard/application/keyboard_command_dispatcher.dart';
 import 'package:alera/src/features/keyboard/domain/key_chord.dart';
 import 'package:alera/src/features/keyboard/domain/keyboard_action.dart';
+import 'package:alera/src/features/workbench/presentation/terminal_file_drop.dart';
 import 'package:alera/src/features/workbench/presentation/terminal_runtime.dart';
+import 'package:desktop_drop/desktop_drop.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -115,60 +117,69 @@ class _TerminalSurfaceState extends ConsumerState<TerminalSurface> {
           _ => null,
         };
         final operation = error == null ? widget.session.operation : null;
-        return Stack(
-          children: <Widget>[
-            Positioned.fill(
-              child: error == null
-                  ? DecoratedBox(
-                      decoration: const BoxDecoration(color: AleraTokens.bg),
-                      child: widget.session.buildView(
-                        autofocus: widget.autofocus,
-                        onKeyEvent: _handleTerminalKey,
+        return DropTarget(
+          enable: error == null,
+          onDragDone: (details) {
+            handleTerminalOsFileDrop(
+              session: widget.session,
+              paths: details.files.map((file) => file.path),
+            );
+          },
+          child: Stack(
+            children: <Widget>[
+              Positioned.fill(
+                child: error == null
+                    ? DecoratedBox(
+                        decoration: const BoxDecoration(color: AleraTokens.bg),
+                        child: widget.session.buildView(
+                          autofocus: widget.autofocus,
+                          onKeyEvent: _handleTerminalKey,
+                        ),
+                      )
+                    : _TerminalErrorState(
+                        message: error,
+                        onReconnect: widget.session.reconnect,
+                        onRestart: widget.session.canRestart
+                            ? () => _confirmRestart(context)
+                            : null,
                       ),
-                    )
-                  : _TerminalErrorState(
-                      message: error,
-                      onReconnect: widget.session.reconnect,
-                      onRestart: widget.session.canRestart
-                          ? () => _confirmRestart(context)
-                          : null,
-                    ),
-            ),
-            if (operation != null)
-              Positioned.fill(
-                child: _TerminalOperationState(operation: operation),
               ),
-            // Restoring an evicted terminal replays its whole scrollback over
-            // several frames. The corner spinner does not read as a wait that
-            // long, so cover the area until the history is back.
-            if (error == null)
-              Positioned.fill(
-                child: ValueListenableBuilder<TerminalRestoreProgress?>(
-                  valueListenable: widget.session.restoreProgress,
-                  builder: (context, progress, _) {
-                    if (progress == null) {
-                      return const SizedBox.shrink();
-                    }
-                    return _TerminalRestoreState(progress: progress);
-                  },
+              if (operation != null)
+                Positioned.fill(
+                  child: _TerminalOperationState(operation: operation),
+                ),
+              // Restoring an evicted terminal replays its whole scrollback over
+              // several frames. The corner spinner does not read as a wait that
+              // long, so cover the area until the history is back.
+              if (error == null)
+                Positioned.fill(
+                  child: ValueListenableBuilder<TerminalRestoreProgress?>(
+                    valueListenable: widget.session.restoreProgress,
+                    builder: (context, progress, _) {
+                      if (progress == null) {
+                        return const SizedBox.shrink();
+                      }
+                      return _TerminalRestoreState(progress: progress);
+                    },
+                  ),
+                ),
+              Positioned(
+                top: AleraTokens.space4,
+                right: AleraTokens.space4,
+                child: AleraIconButton(
+                  tooltip: _refreshing
+                      ? 'Refreshing Terminal'
+                      : 'Refresh Terminal',
+                  icon: _refreshing ? AleraIcons.loading : AleraIcons.refresh,
+                  backgroundColor: AleraTokens.surfaceElevated,
+                  borderColor: AleraTokens.borderSubtle,
+                  onPressed: _refreshing
+                      ? null
+                      : () => unawaited(_refreshTerminal()),
                 ),
               ),
-            Positioned(
-              top: AleraTokens.space4,
-              right: AleraTokens.space4,
-              child: AleraIconButton(
-                tooltip: _refreshing
-                    ? 'Refreshing Terminal'
-                    : 'Refresh Terminal',
-                icon: _refreshing ? AleraIcons.loading : AleraIcons.refresh,
-                backgroundColor: AleraTokens.surfaceElevated,
-                borderColor: AleraTokens.borderSubtle,
-                onPressed: _refreshing
-                    ? null
-                    : () => unawaited(_refreshTerminal()),
-              ),
-            ),
-          ],
+            ],
+          ),
         );
       },
     );

--- a/lib/src/features/workbench/presentation/workspace_explorer.dart
+++ b/lib/src/features/workbench/presentation/workspace_explorer.dart
@@ -164,6 +164,7 @@ class _WorkspaceExplorerState extends ConsumerState<WorkspaceExplorer> {
                       expanderGap: 0,
                       expanderBuilder: _buildExpander,
                       contextMenuDelegate: _ExplorerMenuDelegate(
+                        fileManagerLabel: _folderOpener.fileManagerLabel,
                         canFocusSourceControlFolders:
                             widget.onFocusSourceControlFolder != null,
                         isFocusedSourceControlRoot: (node) {

--- a/lib/src/features/workbench/presentation/workspace_explorer_widgets.dart
+++ b/lib/src/features/workbench/presentation/workspace_explorer_widgets.dart
@@ -251,12 +251,14 @@ class _ExplorerNameDialogState extends State<_ExplorerNameDialog> {
 
 class _ExplorerMenuDelegate extends tree.ContextMenuDelegate {
   const _ExplorerMenuDelegate({
+    required this.fileManagerLabel,
     required this.canFocusSourceControlFolders,
     required this.isFocusedSourceControlRoot,
     required this.onMenuOpening,
     required this.onAction,
   });
 
+  final String fileManagerLabel;
   final bool canFocusSourceControlFolders;
   final bool Function(tree.VisibleNode node) isFocusedSourceControlRoot;
   final VoidCallback onMenuOpening;
@@ -328,10 +330,10 @@ class _ExplorerMenuDelegate extends tree.ContextMenuDelegate {
             label: 'Duplicate',
             leading: Icon(AleraIcons.duplicate, size: 16),
           ),
-          const AleraDropdownEntry<_ExplorerAction>(
+          AleraDropdownEntry<_ExplorerAction>(
             value: _ExplorerAction.reveal,
-            label: 'Reveal in Finder',
-            leading: Icon(AleraIcons.external, size: 16),
+            label: 'Reveal in $fileManagerLabel',
+            leading: const Icon(AleraIcons.external, size: 16),
           ),
           const PopupMenuDivider(height: AleraTokens.space8),
           const AleraDropdownEntry<_ExplorerAction>(

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -7,6 +7,7 @@
 #include "generated_plugin_registrant.h"
 
 #include <alera_browser/alera_browser_plugin.h>
+#include <desktop_drop/desktop_drop_plugin.h>
 #include <desktop_updater/desktop_updater_plugin.h>
 #include <file_selector_linux/file_selector_plugin.h>
 #include <media_kit_libs_linux/media_kit_libs_linux_plugin.h>
@@ -19,6 +20,9 @@ void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) alera_browser_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "AleraBrowserPlugin");
   alera_browser_plugin_register_with_registrar(alera_browser_registrar);
+  g_autoptr(FlPluginRegistrar) desktop_drop_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "DesktopDropPlugin");
+  desktop_drop_plugin_register_with_registrar(desktop_drop_registrar);
   g_autoptr(FlPluginRegistrar) desktop_updater_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "DesktopUpdaterPlugin");
   desktop_updater_plugin_register_with_registrar(desktop_updater_registrar);

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -4,6 +4,7 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   alera_browser
+  desktop_drop
   desktop_updater
   file_selector_linux
   media_kit_libs_linux

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -7,6 +7,7 @@ import Foundation
 
 import alera_browser
 import cryptography_flutter_plus
+import desktop_drop
 import desktop_updater
 import file_selector_macos
 import flutter_local_notifications
@@ -21,6 +22,7 @@ import window_manager
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   AleraBrowserPlugin.register(with: registry.registrar(forPlugin: "AleraBrowserPlugin"))
   CryptographyFlutterPlugin.register(with: registry.registrar(forPlugin: "CryptographyFlutterPlugin"))
+  DesktopDropPlugin.register(with: registry.registrar(forPlugin: "DesktopDropPlugin"))
   DesktopUpdaterPlugin.register(with: registry.registrar(forPlugin: "DesktopUpdaterPlugin"))
   FileSelectorPlugin.register(with: registry.registrar(forPlugin: "FileSelectorPlugin"))
   FlutterLocalNotificationsPlugin.register(with: registry.registrar(forPlugin: "FlutterLocalNotificationsPlugin"))

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -327,6 +327,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.12"
+  desktop_drop:
+    dependency: "direct main"
+    description:
+      name: desktop_drop
+      sha256: aa1e797255bfbc76f9eb5aa4f61e5b68dbf69962ab1be6495816d2f251bc0d1f
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.1"
   desktop_updater:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -33,6 +33,7 @@ dependencies:
   wakelock_plus: ^1.5.0
   riverpod_annotation: ^4.0.2
   dart_mappable: ^4.8.0
+  desktop_drop: ^0.7.1
   drift: ^2.33.0
   meta: ^1.18.0
   sqlite3: ^3.3.1

--- a/roadmap.md
+++ b/roadmap.md
@@ -52,7 +52,7 @@ Comprehensive feature roadmap for Alera. Each feature is scored on two axes:
 | Code edition with LSP support | 5 | 5 | Partial | In-app editor via `code_forge` with syntax themes, find, undo/redo, save/dirty state; no language server protocol yet |
 | Markdown editor | 4 | 3 | Planned | WYSIWYG markdown editing with toolbar, slash menu, code blocks, tables, mermaid |
 | Markdown viewer | 2 | 3 | Shipped | View rendered markdown files in workspace tabs |
-| Open in with other softwares | 2 | 4 | Partial | Open workspace/folder in OS file manager and open repository in browser; no VS Code / Cursor / Zed / custom editor launcher yet |
+| Open in with other softwares | 2 | 4 | Partial | Open workspace/folder in OS file manager (Linux selects via FileManager1.ShowItems with parent-folder fallback) and open repository in browser; no VS Code / Cursor / Zed / custom editor launcher yet |
 | Autosave | 2 | 4 | Planned | Automatic file saving with configurable behavior |
 | Editor scroll restore | 1 | 3 | Planned | Persist and restore scroll position across sessions |
 | External file watch | 2 | 4 | Partial | Explorer and source-control file watches are live; editor reloads/conflicts on external disk changes; no full prompt-to-reload product surface yet |
@@ -127,7 +127,7 @@ Comprehensive feature roadmap for Alera. Each feature is scored on two axes:
 | Workspace cleanup dialog | 2 | 3 | Planned | Bulk cleanup of stale worktrees |
 | Status bar | 2 | 4 | Partial | Agent quota status bar ships separately; no general SSH/ports/resources/disk status bar yet |
 | UI zoom controls | 1 | 3 | Planned | Zoom in/out/reset for the entire UI |
-| Global file drop | 2 | 3 | Planned | Drag files from OS into the app |
+| Global file drop | 2 | 3 | Partial | Terminal OS drop pastes absolute paths; explorer/editor/composer drops still planned |
 
 ---
 

--- a/test/unit/terminal_file_drop_test.dart
+++ b/test/unit/terminal_file_drop_test.dart
@@ -1,0 +1,90 @@
+import 'package:alera/src/features/workbench/presentation/terminal_file_drop.dart';
+import 'package:alera/src/features/workbench/presentation/terminal_runtime.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('pastes formatted paths and requests focus', () {
+    final session = _CapturingTerminalSessionHandle();
+
+    handleTerminalOsFileDrop(
+      session: session,
+      paths: <String>['/tmp/foo', '/tmp/my file'],
+    );
+
+    expect(session.pasted, <String>["/tmp/foo '/tmp/my file' "]);
+    expect(session.focusRequests, 1);
+  });
+
+  test('ignores empty path lists', () {
+    final session = _CapturingTerminalSessionHandle();
+
+    handleTerminalOsFileDrop(session: session, paths: <String>['', '  ']);
+
+    expect(session.pasted, isEmpty);
+    expect(session.focusRequests, 0);
+  });
+}
+
+class _CapturingTerminalSessionHandle extends TerminalSessionHandle {
+  final List<String> pasted = <String>[];
+  int focusRequests = 0;
+  final ValueNotifier<String> _title = ValueNotifier<String>('Terminal');
+
+  @override
+  String get tabId => 'tab';
+
+  @override
+  String get workspaceId => 'workspace';
+
+  @override
+  String get displayTitle => 'Terminal';
+
+  @override
+  ValueListenable<String> get titleListenable => _title;
+
+  @override
+  bool get isRunning => true;
+
+  @override
+  bool get isStarting => false;
+
+  @override
+  String? get errorMessage => null;
+
+  @override
+  Future<void> ensureStarted() async {}
+
+  @override
+  Future<void> restart() async {}
+
+  @override
+  TerminalVisibilityLease acquireVisibility() =>
+      const NoopTerminalVisibilityLease();
+
+  @override
+  Widget buildView({
+    Key? key,
+    bool autofocus = false,
+    FocusOnKeyEventCallback? onKeyEvent,
+  }) {
+    return const SizedBox.shrink();
+  }
+
+  @override
+  void requestFocus() {
+    focusRequests += 1;
+  }
+
+  @override
+  void pasteText(String text) {
+    pasted.add(text);
+  }
+
+  @override
+  void dispose() {
+    _title.dispose();
+    super.dispose();
+  }
+}

--- a/test/unit/terminal_path_paste_test.dart
+++ b/test/unit/terminal_path_paste_test.dart
@@ -1,0 +1,52 @@
+import 'package:alera/src/features/workbench/domain/terminal_path_paste.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('formatPathForTerminalPaste', () {
+    test('keeps bare paths unquoted and trailing-spaced', () {
+      expect(formatPathForTerminalPaste('/tmp/foo'), '/tmp/foo ');
+    });
+
+    test('single-quotes paths that contain whitespace', () {
+      expect(formatPathForTerminalPaste('/tmp/my file'), "'/tmp/my file' ");
+    });
+
+    test('quotes and escapes single quotes only when whitespace is present', () {
+      // Jean-style: no whitespace means bare path, even with apostrophes.
+      expect(formatPathForTerminalPaste("/tmp/it's"), "/tmp/it's ");
+      expect(
+        formatPathForTerminalPaste("/tmp/it's a file"),
+        "'/tmp/it'\\''s a file' ",
+      );
+    });
+
+    test('sanitizes ESC before quoting', () {
+      expect(formatPathForTerminalPaste('/tmp/\x1bsecret'), '/tmp/␛secret ');
+    });
+
+    test('trims surrounding whitespace before formatting', () {
+      expect(formatPathForTerminalPaste('  /tmp/foo  '), '/tmp/foo ');
+    });
+
+    test('returns empty for blank input', () {
+      expect(formatPathForTerminalPaste('   '), '');
+    });
+  });
+
+  group('formatPathsForTerminalPaste', () {
+    test('joins multiple paths in order', () {
+      expect(
+        formatPathsForTerminalPaste(<String>['/a', '/b c', "/d'e", "/x y'z"]),
+        "/a '/b c' /d'e '/x y'\\''z' ",
+      );
+    });
+
+    test('skips blank entries', () {
+      expect(formatPathsForTerminalPaste(<String>['', '  ', '/ok']), '/ok ');
+    });
+
+    test('returns empty for an empty iterable', () {
+      expect(formatPathsForTerminalPaste(const <String>[]), '');
+    });
+  });
+}

--- a/test/unit/terminal_path_paste_test.dart
+++ b/test/unit/terminal_path_paste_test.dart
@@ -11,14 +11,17 @@ void main() {
       expect(formatPathForTerminalPaste('/tmp/my file'), "'/tmp/my file' ");
     });
 
-    test('quotes and escapes single quotes only when whitespace is present', () {
-      // Jean-style: no whitespace means bare path, even with apostrophes.
-      expect(formatPathForTerminalPaste("/tmp/it's"), "/tmp/it's ");
-      expect(
-        formatPathForTerminalPaste("/tmp/it's a file"),
-        "'/tmp/it'\\''s a file' ",
-      );
-    });
+    test(
+      'quotes and escapes single quotes only when whitespace is present',
+      () {
+        // Jean-style: no whitespace means bare path, even with apostrophes.
+        expect(formatPathForTerminalPaste("/tmp/it's"), "/tmp/it's ");
+        expect(
+          formatPathForTerminalPaste("/tmp/it's a file"),
+          "'/tmp/it'\\''s a file' ",
+        );
+      },
+    );
 
     test('sanitizes ESC before quoting', () {
       expect(formatPathForTerminalPaste('/tmp/\x1bsecret'), '/tmp/␛secret ');

--- a/test/unit/workspace_folder_opener_test.dart
+++ b/test/unit/workspace_folder_opener_test.dart
@@ -112,7 +112,7 @@ void main() {
     ]);
   });
 
-  test('reveals the parent folder on Linux for files', () async {
+  test('reveals an item via FileManager1.ShowItems on Linux', () async {
     final processRunner = _FakeProcessRunner();
     final directory = await Directory.systemTemp.createTemp(
       'alera-reveal-item-',
@@ -133,9 +133,60 @@ void main() {
 
     expect(result.ok, isTrue);
     expect(processRunner.calls, <_ProcessCall>[
-      _ProcessCall('xdg-open', <String>[directory.path]),
+      _ProcessCall('gdbus', <String>[
+        'call',
+        '--session',
+        '--dest',
+        'org.freedesktop.FileManager1',
+        '--object-path',
+        '/org/freedesktop/FileManager1',
+        '--method',
+        'org.freedesktop.FileManager1.ShowItems',
+        "['${Uri.file(file.path)}']",
+        '',
+      ]),
     ]);
   });
+
+  test(
+    'falls back to the parent folder on Linux when ShowItems fails',
+    () async {
+      final processRunner = _FakeProcessRunner(exitCodes: <int>[1, 0]);
+      final directory = await Directory.systemTemp.createTemp(
+        'alera-reveal-item-',
+      );
+      final file = File('${directory.path}/note.txt');
+      await file.writeAsString('note');
+      addTearDown(() async {
+        if (await directory.exists()) {
+          await directory.delete(recursive: true);
+        }
+      });
+      final opener = WorkspaceFolderOpener(
+        processRunner: processRunner,
+        platform: WorkspaceFolderPlatform.linux,
+      );
+
+      final result = await opener.reveal(file.path);
+
+      expect(result.ok, isTrue);
+      expect(processRunner.calls, <_ProcessCall>[
+        _ProcessCall('gdbus', <String>[
+          'call',
+          '--session',
+          '--dest',
+          'org.freedesktop.FileManager1',
+          '--object-path',
+          '/org/freedesktop/FileManager1',
+          '--method',
+          'org.freedesktop.FileManager1.ShowItems',
+          "['${Uri.file(file.path)}']",
+          '',
+        ]),
+        _ProcessCall('xdg-open', <String>[directory.path]),
+      ]);
+    },
+  );
 
   test('falls back to gio on Linux when xdg-open fails', () async {
     final processRunner = _FakeProcessRunner(exitCodes: <int>[1, 0]);

--- a/test/widget/workspace_explorer_test.dart
+++ b/test/widget/workspace_explorer_test.dart
@@ -1234,7 +1234,11 @@ void _appendProjectedChild(
 }
 
 class _FakeWorkspaceFolderOpener extends WorkspaceFolderOpener {
-  _FakeWorkspaceFolderOpener() : super(processRunner: _NoopProcessRunner());
+  _FakeWorkspaceFolderOpener()
+    : super(
+        processRunner: _NoopProcessRunner(),
+        platform: WorkspaceFolderPlatform.macos,
+      );
 
   final List<String> revealedPaths = <String>[];
 

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -7,6 +7,7 @@
 #include "generated_plugin_registrant.h"
 
 #include <alera_browser/alera_browser_plugin_c_api.h>
+#include <desktop_drop/desktop_drop_plugin.h>
 #include <desktop_updater/desktop_updater_plugin_c_api.h>
 #include <file_selector_windows/file_selector_windows.h>
 #include <media_kit_libs_windows_video/media_kit_libs_windows_video_plugin_c_api.h>
@@ -18,6 +19,8 @@
 void RegisterPlugins(flutter::PluginRegistry* registry) {
   AleraBrowserPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("AleraBrowserPluginCApi"));
+  DesktopDropPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("DesktopDropPlugin"));
   DesktopUpdaterPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("DesktopUpdaterPluginCApi"));
   FileSelectorWindowsRegisterWithRegistrar(

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -4,6 +4,7 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   alera_browser
+  desktop_drop
   desktop_updater
   file_selector_windows
   media_kit_libs_windows_video


### PR DESCRIPTION
## Summary
- Linux reveal uses FreeDesktop `FileManager1.ShowItems` via `gdbus`, with the existing parent-folder `xdg-open` / `gio` fallback
- Explorer context menu label is platform-aware (`Reveal in Finder` / `Explorer` / `File Manager`)
- OS file and folder drops on the terminal paste absolute paths into the PTY (Jean-style quoting, trailing spaces)

## Test plan
- [x] `flutter test test/unit/workspace_folder_opener_test.dart test/unit/terminal_path_paste_test.dart test/unit/terminal_file_drop_test.dart test/widget/workspace_explorer_test.dart`
- [x] `flutter analyze` on touched files
- [ ] Manual Linux: reveal a file selects it in the file manager
- [ ] Manual: drag files/folders onto a terminal pastes absolute paths