### PR TITLE
fix: make workspace removal retry-safe

### DIFF
--- a/lib/src/features/workbench/application/workspace_service.dart
+++ b/lib/src/features/workbench/application/workspace_service.dart
@@ -13,6 +13,8 @@ import 'package:alera/src/shared/infra/git/git_worktree_entry.dart';
 import 'package:path/path.dart' as p;
 import 'package:uuid/uuid.dart';
 
+part 'workspace_service_removal.dart';
+
 class WorkspaceException implements Exception {
   WorkspaceException(this.message, {this.stderr});
 
@@ -322,56 +324,6 @@ class WorkspaceService {
       workspace: workspace,
       config: effective.config,
     );
-  }
-
-  Future<void> removeWorkspace({
-    required Project project,
-    required Workspace workspace,
-    required bool deleteBranch,
-  }) async {
-    if (workspace.isMain) {
-      throw WorkspaceException('The main workspace cannot be removed');
-    }
-    final shouldDeleteBranch = deleteBranch && !workspace.reusesExistingBranch;
-    final managedRuntime = _managedRuntime;
-    if (managedRuntime != null) {
-      await managedRuntime.removeWorkspace(
-        workspace: workspace,
-        deleteBranch: shouldDeleteBranch,
-      );
-      return;
-    }
-    try {
-      await _gitBackend.removeWorktree(
-        repoPath: project.repoPath,
-        path: workspace.path,
-        force: true,
-      );
-    } on GitException catch (error) {
-      throw WorkspaceException(
-        'git worktree remove failed',
-        stderr: error.context,
-      );
-    }
-    if (shouldDeleteBranch) {
-      final branch = workspace.branch;
-      if (branch == null || branch.isEmpty) {
-        throw WorkspaceException('Workspace Branch Is Required');
-      }
-      try {
-        await _gitBackend.deleteBranch(
-          repoPath: project.repoPath,
-          branch: branch,
-          force: true,
-        );
-      } on GitException catch (error) {
-        throw WorkspaceException(
-          'git branch -D $branch failed',
-          stderr: error.context,
-        );
-      }
-    }
-    await _repository.removeWorkspace(workspace.id, cascadeTabs: true);
   }
 
   Future<List<Workspace>> reconcile(Project project) async {

--- a/lib/src/features/workbench/application/workspace_service_removal.dart
+++ b/lib/src/features/workbench/application/workspace_service_removal.dart
@@ -1,0 +1,74 @@
+part of 'workspace_service.dart';
+
+extension WorkspaceServiceRemoval on WorkspaceService {
+  Future<void> removeWorkspace({
+    required Project project,
+    required Workspace workspace,
+    required bool deleteBranch,
+  }) async {
+    if (workspace.isMain) {
+      throw WorkspaceException('The main workspace cannot be removed');
+    }
+    final shouldDeleteBranch = deleteBranch && !workspace.reusesExistingBranch;
+    final managedRuntime = _managedRuntime;
+    if (managedRuntime != null) {
+      await managedRuntime.removeWorkspace(
+        workspace: workspace,
+        deleteBranch: shouldDeleteBranch,
+      );
+      return;
+    }
+    try {
+      await _gitBackend.removeWorktree(
+        repoPath: project.repoPath,
+        path: workspace.path,
+        force: true,
+      );
+    } on WorktreeNotFoundException catch (error) {
+      if (!await _filesystemEntryIsMissing(workspace.path)) {
+        throw WorkspaceException(
+          'git worktree remove failed',
+          stderr: error.context,
+        );
+      }
+    } on GitException catch (error) {
+      throw WorkspaceException(
+        'git worktree remove failed',
+        stderr: error.context,
+      );
+    }
+    if (shouldDeleteBranch) {
+      final branch = workspace.branch;
+      if (branch == null || branch.isEmpty) {
+        throw WorkspaceException('Workspace Branch Is Required');
+      }
+      try {
+        await _gitBackend.deleteBranch(
+          repoPath: project.repoPath,
+          branch: branch,
+          force: true,
+        );
+      } on BranchNotFoundException {
+        // The requested final state already exists.
+      } on GitException catch (error) {
+        throw WorkspaceException(
+          'git branch -D $branch failed',
+          stderr: error.context,
+        );
+      }
+    }
+    await _repository.removeWorkspace(workspace.id, cascadeTabs: true);
+  }
+
+  Future<bool> _filesystemEntryIsMissing(String path) async {
+    try {
+      return await FileSystemEntity.type(path, followLinks: false) ==
+          FileSystemEntityType.notFound;
+    } on FileSystemException catch (error) {
+      throw WorkspaceException(
+        'Could Not Inspect Workspace Path',
+        stderr: error.message,
+      );
+    }
+  }
+}

--- a/rust/alera-cli/src/main.rs
+++ b/rust/alera-cli/src/main.rs
@@ -15,6 +15,8 @@ mod emulator_commands;
 mod host_tools;
 mod login_shell_environment;
 mod managed_workspace;
+#[cfg(test)]
+mod managed_workspace_removal_tests;
 mod mobile_access;
 mod orchestration_command_summaries;
 mod orchestration_commands;

--- a/rust/alera-cli/src/managed_workspace.rs
+++ b/rust/alera-cli/src/managed_workspace.rs
@@ -6,7 +6,7 @@
 
 use std::path::{Path, PathBuf};
 
-use alera_core::git as core_git;
+use alera_core::git::{self as core_git, GitErrorKind};
 use alera_core::runtime::{
     Project, ProjectKind, RuntimeStore, Workspace, WorkspaceCreationResult, WorkspaceKind,
     WorkspaceStatus, LOCAL_HOST_ID,
@@ -221,8 +221,13 @@ pub async fn remove_managed_workspace(
         .find_project(&workspace.project_id)
         .await?
         .ok_or_else(|| anyhow!("Project not found: {}", workspace.project_id))?;
-    core_git::remove_worktree(&project.repo_path, &workspace.path, true)
-        .context("git worktree remove failed")?;
+    match core_git::remove_worktree(&project.repo_path, &workspace.path, true) {
+        Ok(()) => {}
+        Err(error)
+            if error.kind == GitErrorKind::WorktreeNotFound
+                && filesystem_entry_is_missing(&workspace.path)? => {}
+        Err(error) => return Err(error).context("git worktree remove failed"),
+    }
     let should_delete_branch = request
         .delete_branch
         .unwrap_or(!workspace.reuses_existing_branch);
@@ -232,11 +237,26 @@ pub async fn remove_managed_workspace(
             .as_deref()
             .filter(|branch| !branch.is_empty())
             .ok_or_else(|| anyhow!("Workspace Branch Is Required"))?;
-        core_git::delete_branch(&project.repo_path, branch, true)
-            .with_context(|| format!("git branch -D {branch} failed"))?;
+        match core_git::delete_branch(&project.repo_path, branch, true) {
+            Ok(()) => {}
+            Err(error) if error.kind == GitErrorKind::BranchNotFound => {}
+            Err(error) => {
+                return Err(error).with_context(|| format!("git branch -D {branch} failed"));
+            }
+        }
     }
     store.remove_workspace(&workspace.id, true).await?;
     Ok(workspace)
+}
+
+fn filesystem_entry_is_missing(path: &str) -> Result<bool> {
+    match std::fs::symlink_metadata(path) {
+        Ok(_) => Ok(false),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(true),
+        Err(error) => {
+            Err(error).with_context(|| format!("Could not inspect workspace path \"{path}\""))
+        }
+    }
 }
 
 fn require_trimmed(value: &str, message: &str) -> Result<String> {

--- a/rust/alera-cli/src/managed_workspace_removal_tests.rs
+++ b/rust/alera-cli/src/managed_workspace_removal_tests.rs
@@ -1,0 +1,193 @@
+use std::path::Path;
+use std::process::Command as StdCommand;
+
+use alera_core::runtime::{Project, ProjectKind, RuntimeStore};
+use chrono::Utc;
+
+use crate::managed_workspace::{
+    create_managed_workspace, remove_managed_workspace, ManagedWorkspaceCreateRequest,
+    ManagedWorkspaceRemoveRequest,
+};
+
+#[tokio::test]
+async fn recovers_when_worktree_and_branch_are_missing() {
+    let fixture = RemovalFixture::new("stale").await;
+    fixture.remove_worktree();
+    fixture.delete_branch();
+
+    let removed = fixture.remove_managed_workspace().await.unwrap();
+
+    assert_eq!(removed.id, fixture.workspace_id);
+    assert!(fixture.workspace_record().await.is_none());
+}
+
+#[tokio::test]
+async fn deletes_branch_after_worktree_was_removed() {
+    let fixture = RemovalFixture::new("retry").await;
+    fixture.remove_worktree();
+
+    fixture.remove_managed_workspace().await.unwrap();
+
+    assert!(!fixture.branch_exists());
+    assert!(fixture.workspace_record().await.is_none());
+}
+
+#[tokio::test]
+async fn keeps_branch_when_worktree_was_removed() {
+    let fixture = RemovalFixture::new("keep-branch").await;
+    fixture.remove_worktree();
+
+    fixture
+        .remove_managed_workspace_with(Some(false))
+        .await
+        .unwrap();
+
+    assert!(fixture.branch_exists());
+    assert!(fixture.workspace_record().await.is_none());
+}
+
+#[tokio::test]
+async fn preserves_unregistered_filesystem_entry() {
+    let fixture = RemovalFixture::new("occupied").await;
+    fixture.remove_worktree();
+    std::fs::create_dir_all(&fixture.worktree_path).unwrap();
+    let sentinel = fixture.worktree_path.join("keep.txt");
+    std::fs::write(&sentinel, "keep").unwrap();
+
+    let error = fixture.remove_managed_workspace().await.unwrap_err();
+
+    assert!(error.to_string().contains("git worktree remove failed"));
+    assert!(sentinel.exists());
+    assert!(fixture.workspace_record().await.is_some());
+    assert!(fixture.branch_exists());
+}
+
+struct RemovalFixture {
+    _root: tempfile::TempDir,
+    repo: std::path::PathBuf,
+    store: RuntimeStore,
+    worktree_path: std::path::PathBuf,
+    workspace_id: String,
+    branch: String,
+}
+
+impl RemovalFixture {
+    async fn new(suffix: &str) -> Self {
+        let root = tempfile::tempdir().unwrap();
+        let repo = root.path().join("repo");
+        std::fs::create_dir(&repo).unwrap();
+        init_git_repo(&repo);
+        let store = seed_project(root.path(), &repo).await;
+        let worktree_path = root.path().join("workspaces").join(suffix);
+        let workspace_id = format!("workspace-{suffix}");
+        let branch = format!("feature/{suffix}");
+        create_managed_workspace(
+            &store,
+            ManagedWorkspaceCreateRequest {
+                id: Some(workspace_id.clone()),
+                project_id: "project-1".to_string(),
+                name: Some(branch.clone()),
+                branch: branch.clone(),
+                source_branch: Some("main".to_string()),
+                reuse_existing_branch: false,
+                workspace_root: None,
+                path: Some(worktree_path.to_string_lossy().into_owned()),
+                parent_workspace_id: None,
+                defer_setup: false,
+                setup_script_directory: None,
+            },
+        )
+        .await
+        .unwrap();
+        Self {
+            _root: root,
+            repo,
+            store,
+            worktree_path,
+            workspace_id,
+            branch,
+        }
+    }
+
+    fn remove_worktree(&self) {
+        alera_core::git::remove_worktree(
+            &self.repo.to_string_lossy(),
+            &self.worktree_path.to_string_lossy(),
+            true,
+        )
+        .unwrap();
+    }
+
+    fn delete_branch(&self) {
+        alera_core::git::delete_branch(&self.repo.to_string_lossy(), &self.branch, true).unwrap();
+    }
+
+    fn branch_exists(&self) -> bool {
+        alera_core::git::branch_exists(&self.repo.to_string_lossy(), &self.branch).unwrap()
+    }
+
+    async fn workspace_record(&self) -> Option<alera_core::runtime::Workspace> {
+        self.store.find_workspace(&self.workspace_id).await.unwrap()
+    }
+
+    async fn remove_managed_workspace(&self) -> anyhow::Result<alera_core::runtime::Workspace> {
+        self.remove_managed_workspace_with(None).await
+    }
+
+    async fn remove_managed_workspace_with(
+        &self,
+        delete_branch: Option<bool>,
+    ) -> anyhow::Result<alera_core::runtime::Workspace> {
+        remove_managed_workspace(
+            &self.store,
+            ManagedWorkspaceRemoveRequest {
+                id: self.workspace_id.clone(),
+                delete_branch,
+            },
+        )
+        .await
+    }
+}
+
+async fn seed_project(root: &Path, repo: &Path) -> RuntimeStore {
+    let store = RuntimeStore::open(&root.join("runtime")).await.unwrap();
+    let now = Utc::now();
+    store
+        .upsert_project(Project {
+            id: "project-1".to_string(),
+            name: "Project".to_string(),
+            repo_path: repo.to_string_lossy().into_owned(),
+            created_at: now,
+            updated_at: now,
+            kind: ProjectKind::GitRepository,
+        })
+        .await
+        .unwrap();
+    store
+}
+
+fn init_git_repo(repo: &Path) {
+    run_git(repo, &["init"]);
+    run_git(repo, &["config", "user.email", "test@example.com"]);
+    run_git(repo, &["config", "user.name", "Test"]);
+    std::fs::write(repo.join("README.md"), "hello\n").unwrap();
+    run_git(repo, &["add", "README.md"]);
+    run_git(repo, &["commit", "-m", "initial"]);
+    run_git(repo, &["branch", "-M", "main"]);
+}
+
+#[allow(clippy::disallowed_methods)]
+fn run_git(repo: &Path, args: &[&str]) {
+    let output = StdCommand::new("git")
+        .args(args)
+        .current_dir(repo)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "git {} failed\nstdout:\n{}\nstderr:\n{}",
+        args.join(" "),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}

--- a/test/unit/fake_git_backend.dart
+++ b/test/unit/fake_git_backend.dart
@@ -63,9 +63,11 @@ class FakeGitBackend
 
   /// Worktree paths whose [removeWorktree] should fail.
   final Set<String> failingWorktreeRemovePaths = <String>{};
+  GitException? removeWorktreeError;
 
   /// Branch names whose [deleteBranch] should fail.
   final Set<String> failingBranchDeletes = <String>{};
+  GitException? deleteBranchError;
 
   /// When set, [clone] throws [cloneError].
   bool cloneFails = false;
@@ -228,6 +230,10 @@ class FakeGitBackend
     if (failingWorktreeRemovePaths.contains(path)) {
       throw const GitInternalException('remove failed');
     }
+    final error = removeWorktreeError;
+    if (error != null) {
+      throw error;
+    }
   }
 
   @override
@@ -245,6 +251,10 @@ class FakeGitBackend
     );
     if (failingBranchDeletes.contains(branch)) {
       throw const GitInternalException('delete failed');
+    }
+    final error = deleteBranchError;
+    if (error != null) {
+      throw error;
     }
   }
 

--- a/test/unit/workspace_service_removal_test_cases.dart
+++ b/test/unit/workspace_service_removal_test_cases.dart
@@ -150,6 +150,98 @@ void _registerWorkspaceServiceRemovalTests() {
     );
   });
 
+  test(
+    'removeWorkspace removes stale metadata when worktree and branch are missing',
+    () async {
+      gitBackend.sourceBranches = <String>['main'];
+      final linkedWorkspace = (await service.createLinkedWorkspace(
+        project: project,
+        sourceBranch: 'main',
+        newBranchName: 'feature/stale',
+      )).workspace;
+      gitBackend.removeWorktreeError = WorktreeNotFoundException(
+        linkedWorkspace.path,
+      );
+      gitBackend.deleteBranchError = const BranchNotFoundException(
+        'feature/stale',
+      );
+
+      await service.removeWorkspace(
+        project: project,
+        workspace: linkedWorkspace,
+        deleteBranch: true,
+      );
+
+      expect(
+        repository.workspaces.any(
+          (workspace) => workspace.id == linkedWorkspace.id,
+        ),
+        isFalse,
+      );
+    },
+  );
+
+  test('removeWorkspace preserves an unregistered filesystem entry', () async {
+    gitBackend.sourceBranches = <String>['main'];
+    final linkedWorkspace = (await service.createLinkedWorkspace(
+      project: project,
+      sourceBranch: 'main',
+      newBranchName: 'feature/occupied',
+    )).workspace;
+    final sentinel = File(p.join(linkedWorkspace.path, 'keep.txt'));
+    sentinel.createSync(recursive: true);
+    sentinel.writeAsStringSync('keep');
+    gitBackend.removeWorktreeError = WorktreeNotFoundException(
+      linkedWorkspace.path,
+    );
+
+    await expectLater(
+      service.removeWorkspace(
+        project: project,
+        workspace: linkedWorkspace,
+        deleteBranch: true,
+      ),
+      throwsA(isA<WorkspaceException>()),
+    );
+
+    expect(sentinel.existsSync(), isTrue);
+    expect(
+      repository.workspaces.any(
+        (workspace) => workspace.id == linkedWorkspace.id,
+      ),
+      isTrue,
+    );
+    expect(
+      gitBackend.calls.any((call) => call.method == 'deleteBranch'),
+      isFalse,
+    );
+  });
+
+  test('removeWorkspace accepts an already deleted branch', () async {
+    gitBackend.sourceBranches = <String>['main'];
+    final linkedWorkspace = (await service.createLinkedWorkspace(
+      project: project,
+      sourceBranch: 'main',
+      newBranchName: 'feature/missing-branch',
+    )).workspace;
+    gitBackend.deleteBranchError = const BranchNotFoundException(
+      'feature/missing-branch',
+    );
+
+    await service.removeWorkspace(
+      project: project,
+      workspace: linkedWorkspace,
+      deleteBranch: true,
+    );
+
+    expect(
+      repository.workspaces.any(
+        (workspace) => workspace.id == linkedWorkspace.id,
+      ),
+      isFalse,
+    );
+  });
+
   test('removeWorkspace surfaces git branch deletion failures', () async {
     gitBackend.sourceBranches = <String>['main'];
     final linkedWorkspace = (await service.createLinkedWorkspace(


### PR DESCRIPTION
## Summary
- treat already-removed worktree and branch metadata as a successful retry
- refuse cleanup when any filesystem entry still occupies the workspace path
- preserve branch retention policy and add Rust and Dart regressions
- move removal orchestration into a focused part file to satisfy the max-lines gate

## Validation
- `make rust-test`
- `puro -e v3_44_8 flutter analyze`
- `CI=true puro -e v3_44_8 flutter test --coverage --exclude-tags golden -r compact`
- domain coverage: 100.00% (2720/2720)
- `puro -e v3_44_8 dart tool/quality/check_max_lines.dart`

## Notes
- `gh act pull_request -W .github/workflows/pr.yml` was attempted. Flutter jobs hit the linked-worktree submodule emulation limitation (`fatal: not a git repository: (null)`), and the root container changed permission-sensitive Rust test behavior. Native validation above is green; hosted CI is authoritative.
- No documentation change is needed because this only hardens internal recovery semantics and does not change a user-facing or public API contract.