### PR TITLE
fix: refresh terminal after restore

### DIFF
--- a/lib/src/features/workbench/presentation/terminal_runtime_restore_progress.dart
+++ b/lib/src/features/workbench/presentation/terminal_runtime_restore_progress.dart
@@ -7,6 +7,7 @@ part of 'terminal_runtime.dart';
 /// terminal.
 extension _TerminalRestoreProgressTracking on _XtermTerminalSessionHandle {
   void _beginRestore(int totalChars) {
+    _restoreGeneration += 1;
     _restoreTotalChars = totalChars;
     _restoreWrittenChars = 0;
     _restoreProgress.value = totalChars <= 0
@@ -29,18 +30,34 @@ extension _TerminalRestoreProgressTracking on _XtermTerminalSessionHandle {
     );
   }
 
-  /// Takes the restore overlay down.
+  /// Takes the restore overlay down and refreshes the rebuilt view next frame.
   ///
   /// Any path that empties the backlog without going through [_advanceRestore]
   /// has to call this, or the overlay covers the terminal for good: nothing
   /// else clears it short of another snapshot or disposal.
+  /// Restore and PTY generations cancel the pulse after replacement or exit.
   void _finishRestore() {
     if (_restoreTotalChars <= 0) {
       return;
     }
+    final restoreGeneration = _restoreGeneration;
+    final ptyGeneration = _activePtyGeneration;
     _restoreTotalChars = 0;
     _restoreWrittenChars = 0;
     _restoreProgress.value = null;
+    if (ptyGeneration == null) {
+      return;
+    }
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (_disposed ||
+          !_visible ||
+          _restoreGeneration != restoreGeneration ||
+          _activePtyGeneration != ptyGeneration ||
+          _restoreProgress.value != null) {
+        return;
+      }
+      unawaited(refreshRendering());
+    });
   }
 
   void _rebuildTerminalFromSnapshot(

--- a/lib/src/features/workbench/presentation/terminal_runtime_session_handle.dart
+++ b/lib/src/features/workbench/presentation/terminal_runtime_session_handle.dart
@@ -85,7 +85,7 @@ class _XtermTerminalSessionHandle extends TerminalSessionHandle {
   DateTime? _lastVisibleAt;
   final ValueNotifier<TerminalRestoreProgress?> _restoreProgress =
       ValueNotifier<TerminalRestoreProgress?>(null);
-  int _restoreTotalChars = 0, _restoreWrittenChars = 0;
+  int _restoreGeneration = 0, _restoreTotalChars = 0, _restoreWrittenChars = 0;
   bool _pendingInteractionModeReset = false;
   int _pointerInputCatchUpChars = 0;
   bool _pointerInputResumePending = false;

--- a/test/unit/terminal_runtime_xterm_widget_cases.dart
+++ b/test/unit/terminal_runtime_xterm_widget_cases.dart
@@ -60,6 +60,131 @@ void _registerXtermRuntimeWidgetTests() {
     },
   );
 
+  testWidgets('completed restore refreshes the measured viewport once', (
+    tester,
+  ) async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+    final fakeSession = _FakeTerminalPtySession();
+    final runtime = XtermTerminalRuntime(
+      ptySessionFactory: _FakeTerminalPtySessionFactory(
+        sessions: <_FakeTerminalPtySession>[fakeSession],
+      ),
+      shellLaunchesBuilder: () => <GhosttyTerminalShellLaunch>[
+        _launch('shell', shell: '/bin/sh'),
+      ],
+    );
+    addTearDown(runtime.dispose);
+    final session = runtime.sessionFor(workspace: _workspace(), tab: _tab());
+    final visibility = acquireTerminalVisibilityForTesting(session);
+    try {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AnimatedBuilder(
+              animation: session,
+              builder: (context, _) => session.buildView(),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+      await session.ensureStarted();
+      await tester.pump(const Duration(milliseconds: 200));
+      fakeSession.resizeCalls.clear();
+      fakeSession.writes.clear();
+
+      const marker = 'restored-tail-marker';
+      fakeSession.emitSnapshot(utf8.encode('$marker\r\n'));
+      await tester.idle();
+
+      while (pendingRestoreTerminalOutputCharsForTesting(session) > 0) {
+        flushTerminalOutputForTesting(session);
+      }
+      final bufferBeforeRefresh = terminalBufferTextForTesting(session);
+      expect(session.restoreProgress.value, isNull);
+      expect(bufferBeforeRefresh, contains(marker));
+      expect(fakeSession.resizeCalls, isEmpty);
+
+      await tester.pump();
+
+      expect(fakeSession.resizeCalls, hasLength(2));
+      expect(
+        fakeSession.resizeCalls.first.cols,
+        fakeSession.resizeCalls.last.cols - 1,
+      );
+      expect(
+        fakeSession.resizeCalls.first.rows,
+        fakeSession.resizeCalls.last.rows,
+      );
+      expect(terminalBufferTextForTesting(session), bufferBeforeRefresh);
+      expect(runtime.peekSession('tab-1'), same(session));
+      expect(fakeSession.writes, isEmpty);
+      expect(fakeSession.terminated, isFalse);
+    } finally {
+      visibility.dispose();
+      runtime.dispose();
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pump();
+      debugDefaultTargetPlatformOverride = null;
+    }
+  });
+
+  testWidgets('a replacement invalidates a pending restore refresh', (
+    tester,
+  ) async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+    final fakeSession = _FakeTerminalPtySession();
+    final runtime = XtermTerminalRuntime(
+      ptySessionFactory: _FakeTerminalPtySessionFactory(
+        sessions: <_FakeTerminalPtySession>[fakeSession],
+      ),
+      shellLaunchesBuilder: () => <GhosttyTerminalShellLaunch>[
+        _launch('shell', shell: '/bin/sh'),
+      ],
+    );
+    addTearDown(runtime.dispose);
+    final session = runtime.sessionFor(workspace: _workspace(), tab: _tab());
+    final visibility = acquireTerminalVisibilityForTesting(session);
+    try {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AnimatedBuilder(
+              animation: session,
+              builder: (context, _) => session.buildView(),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+      await session.ensureStarted();
+      await tester.pump(const Duration(milliseconds: 200));
+      fakeSession.resizeCalls.clear();
+
+      fakeSession.emitSnapshot(utf8.encode('superseded'));
+      await tester.idle();
+      flushTerminalOutputForTesting(session);
+      expect(session.restoreProgress.value, isNull);
+
+      fakeSession.emitSnapshot(utf8.encode('latest-tail-marker\r\n'));
+      await tester.idle();
+      expect(session.restoreProgress.value, isNotNull);
+      flushTerminalOutputForTesting(session);
+      expect(session.restoreProgress.value, isNull);
+      expect(fakeSession.resizeCalls, isEmpty);
+
+      await tester.pump();
+
+      expect(fakeSession.resizeCalls, hasLength(2));
+    } finally {
+      visibility.dispose();
+      runtime.dispose();
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pump();
+      debugDefaultTargetPlatformOverride = null;
+    }
+  });
+
   testWidgets(
     'build view supports deferred focus, direct input, and OSC updates',
     (tester) async {


### PR DESCRIPTION
## Summary

- refresh the rebuilt terminal viewport after a restore snapshot finishes
- cancel stale refresh pulses when a newer restore or PTY generation replaces the current one
- preserve the terminal session, process, buffer, and scrollback while forcing the existing redraw pulse

## Validation

- `flutter analyze`
- `dart tool/quality/check_max_lines.dart`
- 70 terminal runtime tests passed, excluding the two known real-adapter baseline failures
- 26 terminal surface widget tests passed
- `gh act pull_request -W .github/workflows/pr.yml` attempted; linked-worktree submodule initialization stopped before project execution with `fatal: not a git repository: (null)`, and two image pulls hit local Docker authentication errors