### PR TITLE
fix: detect stale runtime host builds

### DIFF
--- a/lib/src/features/runtime_host/application/runtime_host_lifecycle_service.dart
+++ b/lib/src/features/runtime_host/application/runtime_host_lifecycle_service.dart
@@ -107,7 +107,7 @@ final class RuntimeHostLifecycleService {
     await _client.ensureStarted(config: _readConfig());
   }
 
-  Future<void> stop({
+  Future<bool> stop({
     bool force = false,
     RuntimeHostForceConfirm? confirmForce,
   }) async {
@@ -123,19 +123,25 @@ final class RuntimeHostLifecycleService {
         confirmLabel: 'Force Stop',
       );
       if (!confirmed) {
-        return;
+        return false;
       }
       await _client.shutdownRuntime(force: true);
     }
     await _waitUntilStopped();
+    return true;
   }
 
-  Future<void> updateIfNewer({RuntimeHostForceConfirm? confirmForce}) async {
+  Future<void> updateIfAvailable({
+    RuntimeHostForceConfirm? confirmForce,
+  }) async {
     final status = await loadStatus();
     if (!status.updateAvailable) {
       return;
     }
-    await stop(confirmForce: confirmForce);
+    final stopped = await stop(confirmForce: confirmForce);
+    if (!stopped) {
+      return;
+    }
     await start();
   }
 

--- a/lib/src/features/runtime_host/domain/runtime_host_status.dart
+++ b/lib/src/features/runtime_host/domain/runtime_host_status.dart
@@ -24,13 +24,41 @@ final class RuntimeHostStatusSnapshot {
   final int activeAgents;
   final String? error;
 
+  bool get hasBuildMismatch {
+    final runningVersion = runtimeHostVersion;
+    if (!running ||
+        runningVersion == null ||
+        runningVersion.isEmpty ||
+        compareRuntimeHostVersions(bundledVersion, runningVersion) != 0) {
+      return false;
+    }
+    final bundledBuild = _knownRuntimeHostCommit(bundledCommit);
+    final runningBuild = _knownRuntimeHostCommit(runtimeHostCommit);
+    return bundledBuild != null &&
+        runningBuild != null &&
+        bundledBuild != runningBuild;
+  }
+
   bool get updateAvailable {
     final runningVersion = runtimeHostVersion;
     if (!running || runningVersion == null || runningVersion.isEmpty) {
       return false;
     }
-    return isRuntimeHostVersionNewer(bundledVersion, runningVersion);
+    final versionComparison = compareRuntimeHostVersions(
+      bundledVersion,
+      runningVersion,
+    );
+    return versionComparison > 0 ||
+        (versionComparison == 0 && hasBuildMismatch);
   }
+}
+
+String? _knownRuntimeHostCommit(String? value) {
+  final commit = value?.trim();
+  if (commit == null || commit.isEmpty || commit.toLowerCase() == 'unknown') {
+    return null;
+  }
+  return commit;
 }
 
 final class RuntimeHostShutdownResult {

--- a/lib/src/features/runtime_host/presentation/runtime_host_status_bar.dart
+++ b/lib/src/features/runtime_host/presentation/runtime_host_status_bar.dart
@@ -59,7 +59,7 @@ class _RuntimeHostStatusBarControlState
           _runAction((confirm) async {
             await ref
                 .read(runtimeHostLifecycleServiceProvider)
-                .updateIfNewer(confirmForce: confirm);
+                .updateIfAvailable(confirmForce: confirm);
             ref.invalidate(runtimeHostStatusProvider);
           }),
         ),

--- a/lib/src/features/runtime_host/presentation/runtime_host_status_panel.dart
+++ b/lib/src/features/runtime_host/presentation/runtime_host_status_panel.dart
@@ -134,6 +134,16 @@ class RuntimeHostStatusPanel extends StatelessWidget {
                   label: 'Bundled Version',
                   value: runtimeHostVersionLabel(status?.bundledVersion),
                 ),
+                if (status?.hasBuildMismatch == true) ...<Widget>[
+                  _StatusRow(
+                    label: 'Host Build',
+                    value: _runtimeHostBuildLabel(status?.runtimeHostCommit),
+                  ),
+                  _StatusRow(
+                    label: 'Bundled Build',
+                    value: _runtimeHostBuildLabel(status?.bundledCommit),
+                  ),
+                ],
                 if (status?.persistent == true)
                   const _StatusRow(label: 'Lifecycle', value: 'Persistent'),
                 _StatusRow(
@@ -266,6 +276,14 @@ String runtimeHostVersionLabel(String? version) {
     return '-';
   }
   return value.startsWith('v') || value.startsWith('V') ? value : 'v$value';
+}
+
+String _runtimeHostBuildLabel(String? commit) {
+  final value = commit?.trim() ?? '';
+  if (value.isEmpty) {
+    return '-';
+  }
+  return value.length <= 7 ? value : value.substring(0, 7);
 }
 
 Color _chipColor(RuntimeHostStatusSnapshot? snapshot, {required bool loading}) {

--- a/test/unit/runtime_host_lifecycle_service_test.dart
+++ b/test/unit/runtime_host_lifecycle_service_test.dart
@@ -225,7 +225,7 @@ void main() {
       expect(client.shutdownCalls, <bool>[false, true]);
     });
 
-    test('updateIfNewer stops and starts when bundled is newer', () async {
+    test('updateIfAvailable stops and starts when bundled is newer', () async {
       final client = _FakeRuntimeClient(
         status: <String, Object?>{'runtimeHostVersion': '1.2.0'},
       );
@@ -238,9 +238,91 @@ void main() {
         shutdownSettleTimeout: const Duration(milliseconds: 50),
       );
 
-      await service.updateIfNewer();
+      await service.updateIfAvailable();
 
       expect(client.shutdownCalls, <bool>[false]);
+      expect(client.ensureStartedCalls, 1);
+    });
+
+    test('updateIfAvailable replaces a different same-version build', () async {
+      final client = _FakeRuntimeClient(
+        status: <String, Object?>{
+          'runtimeHostVersion': '0.1.0',
+          'runtimeHostCommit': '1032e34',
+        },
+      );
+      final service = RuntimeHostLifecycleService(
+        client: client,
+        bundledVersionProbe: _FakeBundledProbe(
+          const BundledSidecarVersion(version: '0.1.0', commit: '9d848d7'),
+        ),
+        readConfig: () => TerminalHostConfig.defaults,
+        shutdownSettleTimeout: const Duration(milliseconds: 50),
+      );
+
+      await service.updateIfAvailable();
+
+      expect(client.shutdownCalls, <bool>[false]);
+      expect(client.ensureStartedCalls, 1);
+    });
+
+    test('updateIfAvailable preserves a busy host when declined', () async {
+      final client = _FakeRuntimeClient(
+        status: <String, Object?>{
+          'runtimeHostVersion': '0.1.0',
+          'runtimeHostCommit': 'old',
+        },
+        busyOnSoftStop: true,
+      );
+      final service = RuntimeHostLifecycleService(
+        client: client,
+        bundledVersionProbe: _FakeBundledProbe(
+          const BundledSidecarVersion(version: '0.1.0', commit: 'new'),
+        ),
+        readConfig: () => TerminalHostConfig.defaults,
+      );
+
+      await service.updateIfAvailable(
+        confirmForce:
+            ({
+              required String title,
+              required String message,
+              required String confirmLabel,
+            }) async => false,
+      );
+
+      expect(client.shutdownCalls, <bool>[false]);
+      expect(client.ensureStartedCalls, 0);
+      expect(await client.probeRuntimeStatus(), isNotNull);
+    });
+
+    test('updateIfAvailable force replaces a confirmed busy host', () async {
+      final client = _FakeRuntimeClient(
+        status: <String, Object?>{
+          'runtimeHostVersion': '0.1.0',
+          'runtimeHostCommit': 'old',
+        },
+        busyOnSoftStop: true,
+      );
+      final service = RuntimeHostLifecycleService(
+        client: client,
+        bundledVersionProbe: _FakeBundledProbe(
+          const BundledSidecarVersion(version: '0.1.0', commit: 'new'),
+        ),
+        readConfig: () => TerminalHostConfig.defaults,
+        shutdownSettleTimeout: const Duration(milliseconds: 50),
+      );
+
+      await service.updateIfAvailable(
+        confirmForce:
+            ({
+              required String title,
+              required String message,
+              required String confirmLabel,
+            }) async => true,
+      );
+
+      expect(client.shutdownCalls, <bool>[false, true]);
       expect(client.ensureStartedCalls, 1);
     });
 

--- a/test/unit/runtime_host_version_test.dart
+++ b/test/unit/runtime_host_version_test.dart
@@ -38,7 +38,7 @@ void main() {
   });
 
   group('RuntimeHostStatusSnapshot.updateAvailable', () {
-    test('is true only when bundled is strictly newer than running', () {
+    test('uses version ordering before commit identity', () {
       expect(
         const RuntimeHostStatusSnapshot(
           running: true,
@@ -52,6 +52,8 @@ void main() {
           running: true,
           bundledVersion: '1.2.3',
           runtimeHostVersion: '1.2.3',
+          bundledCommit: 'same',
+          runtimeHostCommit: 'same',
         ).updateAvailable,
         isFalse,
       );
@@ -60,6 +62,8 @@ void main() {
           running: true,
           bundledVersion: '1.2.0',
           runtimeHostVersion: '1.2.3',
+          bundledCommit: 'bundled',
+          runtimeHostCommit: 'running',
         ).updateAvailable,
         isFalse,
       );
@@ -84,6 +88,62 @@ void main() {
           running: true,
           bundledVersion: '1.3.0',
         ).updateAvailable,
+        isFalse,
+      );
+    });
+
+    test('detects different known builds at the same version', () {
+      const mismatch = RuntimeHostStatusSnapshot(
+        running: true,
+        bundledVersion: '0.1.0',
+        bundledCommit: '9d848d7',
+        runtimeHostVersion: '0.1.0',
+        runtimeHostCommit: '1032e34',
+      );
+      expect(mismatch.hasBuildMismatch, isTrue);
+      expect(mismatch.updateAvailable, isTrue);
+
+      for (final bundledCommit in <String?>[null, '', 'unknown', ' UNKNOWN ']) {
+        final unknownBuild = RuntimeHostStatusSnapshot(
+          running: true,
+          bundledVersion: '0.1.0',
+          bundledCommit: bundledCommit,
+          runtimeHostVersion: '0.1.0',
+          runtimeHostCommit: '1032e34',
+        );
+        expect(unknownBuild.hasBuildMismatch, isFalse);
+        expect(unknownBuild.updateAvailable, isFalse);
+      }
+    });
+
+    test('build mismatch requires a running host at the same version', () {
+      expect(
+        const RuntimeHostStatusSnapshot(
+          running: false,
+          bundledVersion: '0.1.0',
+          bundledCommit: 'bundled',
+          runtimeHostVersion: '0.1.0',
+          runtimeHostCommit: 'running',
+        ).hasBuildMismatch,
+        isFalse,
+      );
+      expect(
+        const RuntimeHostStatusSnapshot(
+          running: true,
+          bundledVersion: '0.1.0',
+          bundledCommit: 'bundled',
+          runtimeHostCommit: 'running',
+        ).hasBuildMismatch,
+        isFalse,
+      );
+      expect(
+        const RuntimeHostStatusSnapshot(
+          running: true,
+          bundledVersion: '0.2.0',
+          bundledCommit: 'bundled',
+          runtimeHostVersion: '0.1.0',
+          runtimeHostCommit: 'running',
+        ).hasBuildMismatch,
         isFalse,
       );
     });

--- a/test/widget/runtime_host_status_panel_test.dart
+++ b/test/widget/runtime_host_status_panel_test.dart
@@ -82,6 +82,30 @@ void main() {
     );
   });
 
+  testWidgets('different same-version builds advertise a runtime update', (
+    tester,
+  ) async {
+    const snapshot = RuntimeHostStatusSnapshot(
+      running: true,
+      bundledVersion: '0.1.0',
+      bundledCommit: '9d848d7b67d4',
+      runtimeHostVersion: '0.1.0',
+      runtimeHostCommit: '1032e34432f5',
+    );
+
+    await tester.pumpWidget(_wrapChip(snapshot));
+
+    expect(find.text('Update Available'), findsOneWidget);
+
+    await tester.pumpWidget(_wrapPanel(snapshot));
+
+    expect(find.text('Host Build'), findsOneWidget);
+    expect(find.text('1032e34'), findsOneWidget);
+    expect(find.text('Bundled Build'), findsOneWidget);
+    expect(find.text('9d848d7'), findsOneWidget);
+    expect(find.widgetWithText(FilledButton, 'Update Runtime'), findsOneWidget);
+  });
+
   testWidgets('the longest label keeps a gap before its value', (tester) async {
     await tester.pumpWidget(
       _wrapPanel(


### PR DESCRIPTION
## Summary

- detect bundled runtime builds that differ from a live host even when both report the same semantic version
- surface the running and bundled build commits in the runtime status panel
- preserve a busy runtime when the user cancels a forced replacement

## Root cause

The detached runtime host survived an app update. Both the old host and the newly bundled sidecar reported version `0.1.0`, so version-only update detection reused the old host. That host predates deferred workspace setup and therefore ran setup inline instead of opening the `Setup` terminal.

## Validation

- native asset preflight
- `dart format --set-exit-if-changed lib test integration_test tool`
- `dart tool/quality/check_max_lines.dart`
- `flutter analyze`
- focused runtime lifecycle, status UI, repository, and workspace controller tests: 117 passed
- full CI-mode Flutter suite: 2,463 passed, 2 expected skips
- maintained domain coverage: 100% (2734/2734)

## Notes

`gh act pull_request -W .github/workflows/pr.yml` could not validate the project locally because linked-worktree submodule initialization failed with `fatal: not a git repository: (null)`; two jobs also hit Docker image authentication before setup. Hosted GitHub checks remain authoritative.