### PR TITLE
fix: stabilize diagnostics startup and linux setup

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -11,6 +11,27 @@ Thanks for contributing to Alera.
 
 ## Local Setup
 
+On Ubuntu and Debian, install the native dependencies required by the Linux desktop build:
+
+```bash
+sudo apt-get update
+sudo apt-get install -y \
+  clang \
+  cmake \
+  ninja-build \
+  pkg-config \
+  libgtk-3-dev \
+  libwebkit2gtk-4.1-dev \
+  libjson-glib-dev \
+  libsecret-1-dev \
+  libsqlite3-dev \
+  libssl-dev \
+  libepoxy-dev \
+  libmpv-dev
+```
+
+These packages provide the compiler toolchain and the native browser, video, storage, and security libraries used by the desktop plugins.
+
 ```bash
 git submodule update --init third_party/xterm third_party/dart_terminal
 flutter pub get

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -16,6 +16,10 @@ import 'package:ghostty_vte_flutter/ghostty_vte_flutter.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 
 Future<void> main(List<String> args) async {
+  await runZonedGuarded<Future<void>>(_bootstrap, recordZoneError);
+}
+
+Future<void> _bootstrap() async {
   AleraPerformanceTrace.startStartup();
   WidgetsFlutterBinding.ensureInitialized();
   AleraPerformanceTrace.mark('widgets_initialized');
@@ -33,7 +37,7 @@ Future<void> main(List<String> args) async {
   await CrashReporting.run(
     enabled: false,
     release: 'alera@${packageInfo.version}+${packageInfo.buildNumber}',
-    appRunner: () => runZonedGuarded<Future<void>>(_startApp, recordZoneError),
+    appRunner: _startApp,
   );
 }
 

--- a/lib/src/features/diagnostics/application/diagnostics_providers.dart
+++ b/lib/src/features/diagnostics/application/diagnostics_providers.dart
@@ -5,6 +5,7 @@ import 'package:alera/src/features/settings/domain/alera_settings.dart';
 import 'package:alera/src/features/workbench/infra/terminal_host/terminal_host_client.dart';
 import 'package:alera/src/shared/infra/logging/app_logger.dart';
 import 'package:alera/src/shared/infra/runtime/runtime_host_providers.dart';
+import 'package:alera/src/shared/infra/storage/storage_providers.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:logging/logging.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -31,16 +32,16 @@ Level loggingLevelFor(DiagnosticsLogLevel level) {
 /// change so turning reporting off stops it immediately.
 @Riverpod(keepAlive: true)
 void diagnosticsSettingsApplier(Ref ref) {
-  DiagnosticsSettings diagnostics;
-  try {
-    diagnostics = ref.watch(
-      settingsControllerProvider.select((settings) => settings.diagnostics),
-    );
-  } on Object {
-    // Settings are unavailable, typically because the local database failed to
-    // open. Diagnostics must never be the reason the app cannot start: fall
-    // back to the safe defaults and let the shell show its own error.
-    diagnostics = DiagnosticsSettings.defaults;
+  var diagnostics = DiagnosticsSettings.defaults;
+  if (ref.watch(aleraDatabaseProvider).hasValue) {
+    try {
+      diagnostics = ref.watch(
+        settingsControllerProvider.select((settings) => settings.diagnostics),
+      );
+    } on Object {
+      // Diagnostics must never be the reason the app cannot start. Keep the safe
+      // defaults and let the shell surface the settings failure.
+    }
   }
   AppLogger.setLevel(loggingLevelFor(diagnostics.logLevel));
   CrashReporting.setEnabled(diagnostics.crashReportingEnabled);

--- a/lib/src/features/diagnostics/application/diagnostics_providers.g.dart
+++ b/lib/src/features/diagnostics/application/diagnostics_providers.g.dart
@@ -118,7 +118,7 @@ final class DiagnosticsSettingsApplierProvider
 }
 
 String _$diagnosticsSettingsApplierHash() =>
-    r'61dcab46e0664cec378a187adebaf4499627d7a2';
+    r'f1927dde79046309ef2c9f0fd7aeea494e3ffb87';
 
 /// Runtime facts for the bundle, read from a live host.
 ///

--- a/lib/src/features/diagnostics/infra/crash_reporting.dart
+++ b/lib/src/features/diagnostics/infra/crash_reporting.dart
@@ -68,7 +68,7 @@ abstract final class CrashReporting {
     options.beforeSend = (event, hint) async => filterEvent(event);
   }
 
-  /// Starts Sentry and runs [appRunner] inside it.
+  /// Starts Sentry and then runs [appRunner] in the caller's zone.
   ///
   /// Initialization happens regardless of the setting so the switch can be
   /// flipped later without a restart; nothing is transmitted while it is off.
@@ -78,15 +78,11 @@ abstract final class CrashReporting {
     required FutureOr<void> Function() appRunner,
   }) async {
     setEnabled(enabled);
-    if (_initialized) {
-      await appRunner();
-      return;
+    if (!_initialized) {
+      _initialized = true;
+      await Sentry.init((options) => _applyOptions(options, release));
     }
-    _initialized = true;
-    await Sentry.init(
-      (options) => _applyOptions(options, release),
-      appRunner: () async => appRunner(),
-    );
+    await appRunner();
   }
 
   /// Test seam so a suite can exercise the filter without a live client.

--- a/lib/src/shared/infra/logging/global_error_handlers.dart
+++ b/lib/src/shared/infra/logging/global_error_handlers.dart
@@ -1,5 +1,8 @@
+import 'dart:async';
+
 import 'package:alera/src/shared/infra/logging/app_logger.dart';
 import 'package:flutter/foundation.dart';
+import 'package:sentry/sentry.dart';
 
 /// Routes errors that never reach a `try`/`catch` into the log file.
 ///
@@ -14,6 +17,7 @@ void installGlobalErrorHandlers() {
       details.stack,
       context: 'FlutterError',
     );
+    _captureException(details.exception, details.stack);
     // Chain rather than replace so the console output and any test harness
     // expectations keep working.
     previousOnError?.call(details);
@@ -21,6 +25,7 @@ void installGlobalErrorHandlers() {
 
   PlatformDispatcher.instance.onError = (Object error, StackTrace stack) {
     AppLogger.recordError(error, stack, context: 'PlatformDispatcher');
+    _captureException(error, stack);
     // Returning true marks the error handled; it is already recorded.
     return true;
   };
@@ -32,4 +37,9 @@ void installGlobalErrorHandlers() {
 /// inside a zone-bound callback that never reaches the platform land here.
 void recordZoneError(Object error, StackTrace stack) {
   AppLogger.recordError(error, stack, context: 'Zone');
+  _captureException(error, stack);
+}
+
+void _captureException(Object error, StackTrace? stackTrace) {
+  unawaited(Sentry.captureException(error, stackTrace: stackTrace));
 }

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -10,6 +10,10 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 
 Future<void> main() async {
+  await runZonedGuarded<Future<void>>(_bootstrap, recordZoneError);
+}
+
+Future<void> _bootstrap() async {
   // The app used to start with no bootstrap at all, so nothing could be wired
   // before the first frame and no failure left a trace.
   WidgetsFlutterBinding.ensureInitialized();
@@ -22,9 +26,6 @@ Future<void> main() async {
   await CrashReporting.run(
     enabled: crashReportingEnabled,
     release: 'alera-mobile@${info.version}+${info.buildNumber}',
-    appRunner: () => runZonedGuarded<void>(
-      () => runApp(const ProviderScope(child: AleraMobileApp())),
-      recordZoneError,
-    ),
+    appRunner: () => runApp(const ProviderScope(child: AleraMobileApp())),
   );
 }

--- a/mobile/lib/src/core/logging/global_error_handlers.dart
+++ b/mobile/lib/src/core/logging/global_error_handlers.dart
@@ -1,5 +1,8 @@
+import 'dart:async';
+
 import 'package:alera_mobile/src/core/logging/mobile_logger.dart';
 import 'package:flutter/foundation.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
 
 /// Routes errors that never reach a `try`/`catch` into the log file.
 ///
@@ -25,4 +28,5 @@ void installGlobalErrorHandlers() {
 /// Records an error that escaped an async gap and reached the guarding zone.
 void recordZoneError(Object error, StackTrace stack) {
   MobileLogger.recordError(error, stack, context: 'Zone');
+  unawaited(Sentry.captureException(error, stackTrace: stack));
 }

--- a/mobile/lib/src/features/diagnostics/infra/crash_reporting.dart
+++ b/mobile/lib/src/features/diagnostics/infra/crash_reporting.dart
@@ -61,7 +61,7 @@ abstract final class CrashReporting {
     options.beforeSend = (event, hint) async => filterEvent(event);
   }
 
-  /// Starts Sentry and runs [appRunner] inside it.
+  /// Starts Sentry and then runs [appRunner] in the caller's zone.
   ///
   /// Initialization happens regardless of the setting so the switch can be
   /// flipped later without a restart; nothing is transmitted while it is off.
@@ -71,15 +71,11 @@ abstract final class CrashReporting {
     required FutureOr<void> Function() appRunner,
   }) async {
     setEnabled(enabled);
-    if (_initialized) {
-      await appRunner();
-      return;
+    if (!_initialized) {
+      _initialized = true;
+      await SentryFlutter.init((options) => _applyOptions(options, release));
     }
-    _initialized = true;
-    await SentryFlutter.init(
-      (options) => _applyOptions(options, release),
-      appRunner: () async => appRunner(),
-    );
+    await appRunner();
   }
 
   /// Test seam so a suite can exercise the filter without a live client.

--- a/readme.md
+++ b/readme.md
@@ -201,6 +201,8 @@ Current status: Linux packages are distributed through a repository whose metada
 
 Alera is a Flutter desktop app. You'll need a recent [Flutter SDK](https://docs.flutter.dev/get-started/install), a working Rust toolchain (`rustup`), and [Zig](https://ziglang.org/download/) 0.16.0. The Rust workspace under `rust/` provides both the native terminal-host sidecar (`alera-cli`) and the git layer (`alera_native`, compiled into the app through `flutter_rust_bridge`). Zig builds the vendored `ghostty_vte` terminal engine, which a checkout like this one compiles from its own submodule rather than downloading.
 
+Linux source builds also require system development packages. Install the [Ubuntu and Debian prerequisites](.github/CONTRIBUTING.md#local-setup) before running the app.
+
 ```bash
 git clone https://github.com/leynier/alera.git
 cd alera

--- a/test/unit/crash_reporting_test.dart
+++ b/test/unit/crash_reporting_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:alera/src/features/diagnostics/infra/crash_reporting.dart';
 import 'package:alera/src/shared/infra/logging/log_redaction.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -93,5 +95,22 @@ void main() {
       CrashReporting.filterEvent(SentryEvent(message: SentryMessage('b'))),
       isNull,
     );
+  });
+
+  test('runs the app callback in the caller zone', () async {
+    final callerZone = Zone.current;
+    late Zone appZone;
+
+    try {
+      await CrashReporting.run(
+        enabled: false,
+        release: 'alera@test',
+        appRunner: () => appZone = Zone.current,
+      );
+    } finally {
+      await Sentry.close();
+    }
+
+    expect(appZone, same(callerZone));
   });
 }

--- a/test/unit/diagnostics_providers_test.dart
+++ b/test/unit/diagnostics_providers_test.dart
@@ -1,0 +1,52 @@
+import 'dart:async';
+
+import 'package:alera/src/features/diagnostics/application/diagnostics_providers.dart';
+import 'package:alera/src/features/settings/application/runtime_settings_changes.dart';
+import 'package:alera/src/features/settings/application/settings_providers.dart';
+import 'package:alera/src/features/settings/application/settings_repository.dart';
+import 'package:alera/src/features/settings/domain/alera_settings.dart';
+import 'package:alera/src/shared/infra/storage/drift_database.dart';
+import 'package:alera/src/shared/infra/storage/storage_providers.dart';
+import 'package:drift/native.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('waits for the database before reading settings', () async {
+    final databaseCompleter = Completer<AleraDatabase>();
+    final database = AleraDatabase(executor: NativeDatabase.memory());
+    var repositoryCreated = false;
+    final container = ProviderContainer(
+      overrides: [
+        aleraDatabaseProvider.overrideWith((ref) => databaseCompleter.future),
+        settingsRepositoryProvider.overrideWith((ref) {
+          repositoryCreated = true;
+          return _FakeSettingsRepository();
+        }),
+        runtimeSettingsChangesProvider.overrideWith(
+          (ref) => const Stream<void>.empty(),
+        ),
+      ],
+    );
+
+    container.read(diagnosticsSettingsApplierProvider);
+    expect(repositoryCreated, isFalse);
+
+    databaseCompleter.complete(database);
+    await container.read(aleraDatabaseProvider.future);
+    container.read(diagnosticsSettingsApplierProvider);
+
+    expect(repositoryCreated, isTrue);
+
+    container.dispose();
+    await database.close();
+  });
+}
+
+final class _FakeSettingsRepository implements SettingsRepository {
+  @override
+  Future<AleraSettings> load() async => AleraSettings.defaults;
+
+  @override
+  Future<void> save(AleraSettings settings) async {}
+}


### PR DESCRIPTION
## Summary

- keep Flutter binding initialization and `runApp` in the same guarded zone on desktop and mobile
- delay diagnostics settings reads until the database is ready
- preserve global Sentry capture and add regression coverage
- document the Ubuntu and Debian native packages required by `make app-debug`

## Root cause

The diagnostics bootstrap introduced a nested Sentry zone after Flutter binding initialization, which triggered `Zone mismatch`. It also read settings synchronously while the database provider was still loading, which triggered `AsyncValueIsLoadingException`.

## Validation

- `make app-debug`
- `flutter analyze`
- `CI=true flutter test --coverage --exclude-tags golden` (2,459 passed, 2 skipped)
- `dart run tool/quality/coverage_report.dart --input coverage/lcov.info --min-lines 100 --worst 25` (100%)
- mobile `flutter analyze` and `flutter test` (154 passed)
- `cargo test --manifest-path rust/Cargo.toml -p alera_native --lib` (169 passed)
- desktop and mobile format checks
- max-lines ratchet

## Notes

`gh act pull_request -W .github/workflows/pr.yml` was attempted locally. The linked worktree and root container semantics caused emulation-only failures, so GitHub-hosted checks remain authoritative.