### PR TITLE
fix(landing): resolve pagespeed findings

### DIFF
--- a/landing/astro.config.mjs
+++ b/landing/astro.config.mjs
@@ -5,6 +5,9 @@ import tailwindcss from '@tailwindcss/vite';
 export default defineConfig({
   site: 'https://alera.build',
   output: 'static',
+  build: {
+    inlineStylesheets: 'always',
+  },
   integrations: [sitemap()],
   vite: {
     plugins: [tailwindcss()],

--- a/landing/src/components/Footer.astro
+++ b/landing/src/components/Footer.astro
@@ -6,7 +6,7 @@
     <div class="flex flex-col md:flex-row items-center justify-between gap-6">
       <!-- Logo -->
       <a href="/" class="flex items-center gap-2.5">
-        <img src="/logo.png" alt="Alera" class="h-4 w-auto opacity-60 hover:opacity-80 transition-opacity duration-fast" />
+        <img src="/logo.svg" alt="Alera" width="16" height="16" class="h-4 w-4 invert opacity-60 hover:opacity-80 transition-opacity duration-fast" />
         <span class="text-body-md font-semibold text-foreground-faint tracking-tight">Alera</span>
       </a>
 

--- a/landing/src/components/Navbar.astro
+++ b/landing/src/components/Navbar.astro
@@ -5,7 +5,7 @@ const repo = 'leynier/alera';
 <header class="fixed top-0 left-0 right-0 z-50 border-b border-border-subtle/50 bg-bg/70 backdrop-blur-xl">
   <nav class="max-w-6xl mx-auto px-6 h-14 flex items-center justify-between gap-6">
     <a href="/" class="flex items-center gap-2.5 group shrink-0">
-      <img src="/logo.png" alt="Alera" class="h-5 w-auto opacity-90 group-hover:opacity-100 transition-opacity duration-fast" />
+      <img src="/logo.svg" alt="Alera" width="20" height="20" class="h-5 w-5 invert opacity-90 group-hover:opacity-100 transition-opacity duration-fast" />
       <span class="text-sm font-semibold text-foreground tracking-tight">Alera</span>
     </a>
 

--- a/landing/src/components/TrustDocument.astro
+++ b/landing/src/components/TrustDocument.astro
@@ -12,7 +12,7 @@ const { eyebrow, title, summary, updated } = Astro.props;
 <header class="border-b border-border-subtle/70">
   <nav class="mx-auto flex h-14 max-w-5xl items-center justify-between gap-6 px-6" aria-label="Legal">
     <a href="/" class="group flex shrink-0 items-center gap-2.5">
-      <img src="/logo.png" alt="Alera" class="h-5 w-auto opacity-90 transition-opacity duration-fast group-hover:opacity-100" />
+      <img src="/logo.svg" alt="Alera" width="20" height="20" class="h-5 w-5 invert opacity-90 transition-opacity duration-fast group-hover:opacity-100" />
       <span class="text-sm font-semibold tracking-tight text-foreground">Alera</span>
     </a>
     <div class="flex items-center gap-4 text-body-md text-foreground-faint sm:gap-6">

--- a/landing/src/styles/global.css
+++ b/landing/src/styles/global.css
@@ -136,7 +136,7 @@
   --color-on-accent: #101010;
   --color-foreground: #f5f5f5;
   --color-foreground-muted: #a1a1a1;
-  --color-foreground-faint: #606060;
+  --color-foreground-faint: #8c8c8c;
   --color-success: #22c55e;
   --color-error: #f87171;
   --color-on-error: #2c0d0d;


### PR DESCRIPTION
## Summary

- raise faint-text contrast while preserving the dark visual hierarchy
- replace rendered PNG logos with explicitly sized SVGs
- inline Astro stylesheets to remove the render-blocking CSS request

## Validation

- `cd landing && bun run build` (19 routes)
- local Lighthouse mobile: accessibility 100, contrast passed, sized images passed, render-blocking requests passed, image delivery passed, TBT 0 ms, CLS 0, total 233 KiB
- inspected home at 412 px and 1335 px, blog/download/legal mobile layouts, and `prefers-reduced-motion`
- `gh act pull_request -W .github/workflows/landing.yml -j build` could not start because Docker rejected the `act` runner image pull with `authentication required`; hosted CI remains authoritative

## AI Review Report

Reviewed the scoped diff for visual parity, generated HTML structure, all 19 routes, font discovery, CSS output, responsive layout, and reduced-motion behavior. The SVG needed the existing dark-theme inversion to retain the white logo appearance.

## Security Audit

No input handling, command execution, auth, secrets, dependencies, or runtime APIs changed.