### PR TITLE
fix: allow deployer to read kms public keys

### DIFF
--- a/infra/bootstrap/github/main.tf
+++ b/infra/bootstrap/github/main.tf
@@ -3,6 +3,7 @@ locals {
   deployer_project_roles = toset([
     "roles/artifactregistry.admin",
     "roles/cloudkms.admin",
+    "roles/cloudkms.publicKeyViewer",
     "roles/firebase.admin",
     "roles/iam.serviceAccountAdmin",
     "roles/resourcemanager.projectIamAdmin",


### PR DESCRIPTION
## Summary
- grant the keyless production deployer the dedicated Cloud KMS public-key viewer role
- preserve the existing broader KMS administration role used by OpenTofu

## Validation
- `tofu fmt -check -recursive`
- `tofu validate`
- bootstrap apply: 1 IAM binding added
- post-apply bootstrap plan: no changes
