### PR TITLE
fix: run cloud rollback after skipped checks

### DIFF
--- a/.github/workflows/cloud-deploy.yml
+++ b/.github/workflows/cloud-deploy.yml
@@ -131,6 +131,7 @@ jobs:
   deploy:
     name: Deploy Production
     needs: gates
+    if: ${{ always() && needs.gates.result == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
     permissions:
@@ -179,7 +180,7 @@ jobs:
 
       - name: Setup Docker Buildx
         if: ${{ env.DEPLOY_MODE != 'rollback' }}
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Install Edge Dependencies
         working-directory: edge

--- a/.github/workflows/cloud.yml
+++ b/.github/workflows/cloud.yml
@@ -12,6 +12,7 @@ on:
       - 'edge/**'
       - 'infra/**'
       - 'tool/cloud/**'
+      - '.github/workflows/cloud-deploy.yml'
       - '.github/workflows/cloud.yml'
   workflow_dispatch:
 


### PR DESCRIPTION
## Summary
- make the deployment job explicitly depend on the successful production gate so rollback mode can skip reusable checks without skipping deployment
- update the pinned Buildx action to the official Node 24 release

## Validation
- `actionlint .github/workflows/cloud-deploy.yml`
- observed rollback-mode authorization and gates succeed while the deployment job was skipped before this fix
