### PR TITLE
fix: reattach mobile terminal on foreground

### DIFF
--- a/mobile/lib/src/features/terminal/application/terminal_session_controller.dart
+++ b/mobile/lib/src/features/terminal/application/terminal_session_controller.dart
@@ -1,11 +1,13 @@
 import 'dart:async';
 
+import 'package:alera_mobile/src/app/lifecycle/app_lifecycle_controller.dart';
 import 'package:alera_mobile/src/core/json_payload_fields.dart';
-import 'package:alera_mobile/src/features/runtime/domain/workspace_tab_summary.dart';
 import 'package:alera_mobile/src/features/runtime/application/host_connection_controller.dart';
+import 'package:alera_mobile/src/features/runtime/domain/workspace_tab_summary.dart';
 import 'package:alera_mobile/src/features/runtime/infra/mobile_runtime_client.dart';
 import 'package:alera_mobile/src/features/terminal/application/terminal_providers.dart';
 import 'package:alera_mobile/src/features/terminal/domain/terminal_compose_delivery.dart';
+import 'package:flutter/widgets.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'terminal_session_controller.g.dart';
@@ -73,12 +75,28 @@ class TerminalSessionController extends _$TerminalSessionController {
           break;
       }
     });
+    ref.listen(appLifecycleControllerProvider, _handleLifecycleChange);
     final client = await ref.read(terminalClientProvider(hostId).future);
     // The runtime restarts exited sessions under the same handle during
     // attach, so a single attach always yields a usable session.
     final session = await client.attachTerminal(tabId);
     _registerCleanup();
     return _bindSession(client, session);
+  }
+
+  void _handleLifecycleChange(
+    AppLifecycleState? previous,
+    AppLifecycleState next,
+  ) {
+    if (next != AppLifecycleState.resumed ||
+        previous == AppLifecycleState.resumed ||
+        _desktopReclaimed) {
+      return;
+    }
+    final client = _client;
+    if (client != null) {
+      unawaited(_recoverWithClient(client, showStartingState: true));
+    }
   }
 
   void _registerCleanup() {
@@ -148,7 +166,10 @@ class TerminalSessionController extends _$TerminalSessionController {
     );
   }
 
-  Future<void> _recoverWithClient(MobileTerminalClient client) async {
+  Future<void> _recoverWithClient(
+    MobileTerminalClient client, {
+    bool showStartingState = false,
+  }) async {
     if (_recovering) {
       _pendingRecoveryClient = client;
       return;
@@ -158,7 +179,10 @@ class TerminalSessionController extends _$TerminalSessionController {
     try {
       while (!_desktopReclaimed) {
         _pendingRecoveryClient = null;
-        state = const AsyncLoading<TerminalTabSession>(progress: 0.25);
+        state = showStartingState
+            ? const AsyncLoading<TerminalTabSession>()
+            : const AsyncLoading<TerminalTabSession>(progress: 0.25);
+        showStartingState = false;
         try {
           final session = await nextClient.attachTerminal(
             tabId,

--- a/mobile/lib/src/features/terminal/application/terminal_session_controller.g.dart
+++ b/mobile/lib/src/features/terminal/application/terminal_session_controller.g.dart
@@ -53,7 +53,7 @@ final class TerminalSessionControllerProvider
 }
 
 String _$terminalSessionControllerHash() =>
-    r'86e04571f9420da1212177404d9fcd91d98e85f9';
+    r'f9967bf8150b4ab850418773b6fbb38c3695e691';
 
 final class TerminalSessionControllerFamily extends $Family
     with

--- a/mobile/test/tabs_controller_test.dart
+++ b/mobile/test/tabs_controller_test.dart
@@ -1,11 +1,13 @@
 import 'dart:async';
 import 'dart:typed_data';
 
+import 'package:alera_mobile/src/app/lifecycle/app_lifecycle_controller.dart';
 import 'package:alera_mobile/src/features/runtime/domain/workspace_tab_summary.dart';
 import 'package:alera_mobile/src/features/terminal/application/tabs_controller.dart';
 import 'package:alera_mobile/src/features/terminal/application/terminal_providers.dart';
 import 'package:alera_mobile/src/features/terminal/application/terminal_session_controller.dart';
 import 'package:alera_mobile/src/features/workbench/application/workbench_providers.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -308,6 +310,55 @@ void main() {
     );
   });
 
+  test(
+    'Open session starts again when the app returns to foreground',
+    () async {
+      final client = FakeTerminalClient()
+        ..tabs = <WorkspaceTabSummary>[
+          fakeTab(id: 'tab-1', title: 'Terminal 1'),
+        ];
+      final lifecycle = _TestAppLifecycleController(AppLifecycleState.resumed);
+      final container = _container(client, lifecycle: lifecycle);
+      final subscription = container.listen(
+        terminalSessionControllerProvider('host-1', 'tab-1'),
+        (_, _) {},
+      );
+      addTearDown(subscription.close);
+      await container.read(
+        terminalSessionControllerProvider('host-1', 'tab-1').future,
+      );
+      final notifier = container.read(
+        terminalSessionControllerProvider('host-1', 'tab-1').notifier,
+      );
+      await notifier.resize(48, 22);
+      final foregroundAttach = Completer<void>();
+      client.attachCompletion = foregroundAttach.future;
+
+      lifecycle.setLifecycleState(AppLifecycleState.inactive);
+      expect(client.attachments, hasLength(1));
+      lifecycle.setLifecycleState(AppLifecycleState.resumed);
+      await _waitUntil(() => client.attachments.length == 2);
+
+      expect(client.attachments.last, (tabId: 'tab-1', cols: 48, rows: 22));
+      expect(
+        container.read(terminalSessionControllerProvider('host-1', 'tab-1')),
+        isA<AsyncLoading<TerminalTabSession>>().having(
+          (value) => value.progress,
+          'progress',
+          isNull,
+        ),
+      );
+      expect(client.calls, isNot(contains('restart tab-1')));
+
+      foregroundAttach.complete();
+      await _waitUntil(
+        () => container
+            .read(terminalSessionControllerProvider('host-1', 'tab-1'))
+            .hasValue,
+      );
+    },
+  );
+
   test('Session automatically reattaches when the client changes', () async {
     final firstClient = FakeTerminalClient()
       ..tabs = <WorkspaceTabSummary>[fakeTab(id: 'tab-1', title: 'Terminal 1')];
@@ -433,11 +484,16 @@ void main() {
   );
 }
 
-ProviderContainer _container(FakeTerminalClient client) {
+ProviderContainer _container(
+  FakeTerminalClient client, {
+  AppLifecycleController? lifecycle,
+}) {
   final container = ProviderContainer(
     overrides: [
       terminalClientProvider('host-1').overrideWith((ref) async => client),
       workspaceClientProvider('host-1').overrideWith((ref) async => client),
+      if (lifecycle != null)
+        appLifecycleControllerProvider.overrideWith(() => lifecycle),
     ],
   );
   addTearDown(container.dispose);
@@ -448,6 +504,19 @@ ProviderContainer _container(FakeTerminalClient client) {
   );
   addTearDown(subscription.close);
   return container;
+}
+
+class _TestAppLifecycleController extends AppLifecycleController {
+  _TestAppLifecycleController(this.initialState);
+
+  final AppLifecycleState initialState;
+
+  @override
+  AppLifecycleState build() => initialState;
+
+  void setLifecycleState(AppLifecycleState next) {
+    state = next;
+  }
 }
 
 Future<void> _waitUntil(bool Function() condition) async {

--- a/mobile/test/tabs_controller_test.dart
+++ b/mobile/test/tabs_controller_test.dart
@@ -1,13 +1,11 @@
 import 'dart:async';
 import 'dart:typed_data';
 
-import 'package:alera_mobile/src/app/lifecycle/app_lifecycle_controller.dart';
 import 'package:alera_mobile/src/features/runtime/domain/workspace_tab_summary.dart';
 import 'package:alera_mobile/src/features/terminal/application/tabs_controller.dart';
 import 'package:alera_mobile/src/features/terminal/application/terminal_providers.dart';
 import 'package:alera_mobile/src/features/terminal/application/terminal_session_controller.dart';
 import 'package:alera_mobile/src/features/workbench/application/workbench_providers.dart';
-import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -310,55 +308,6 @@ void main() {
     );
   });
 
-  test(
-    'Open session starts again when the app returns to foreground',
-    () async {
-      final client = FakeTerminalClient()
-        ..tabs = <WorkspaceTabSummary>[
-          fakeTab(id: 'tab-1', title: 'Terminal 1'),
-        ];
-      final lifecycle = _TestAppLifecycleController(AppLifecycleState.resumed);
-      final container = _container(client, lifecycle: lifecycle);
-      final subscription = container.listen(
-        terminalSessionControllerProvider('host-1', 'tab-1'),
-        (_, _) {},
-      );
-      addTearDown(subscription.close);
-      await container.read(
-        terminalSessionControllerProvider('host-1', 'tab-1').future,
-      );
-      final notifier = container.read(
-        terminalSessionControllerProvider('host-1', 'tab-1').notifier,
-      );
-      await notifier.resize(48, 22);
-      final foregroundAttach = Completer<void>();
-      client.attachCompletion = foregroundAttach.future;
-
-      lifecycle.setLifecycleState(AppLifecycleState.inactive);
-      expect(client.attachments, hasLength(1));
-      lifecycle.setLifecycleState(AppLifecycleState.resumed);
-      await _waitUntil(() => client.attachments.length == 2);
-
-      expect(client.attachments.last, (tabId: 'tab-1', cols: 48, rows: 22));
-      expect(
-        container.read(terminalSessionControllerProvider('host-1', 'tab-1')),
-        isA<AsyncLoading<TerminalTabSession>>().having(
-          (value) => value.progress,
-          'progress',
-          isNull,
-        ),
-      );
-      expect(client.calls, isNot(contains('restart tab-1')));
-
-      foregroundAttach.complete();
-      await _waitUntil(
-        () => container
-            .read(terminalSessionControllerProvider('host-1', 'tab-1'))
-            .hasValue,
-      );
-    },
-  );
-
   test('Session automatically reattaches when the client changes', () async {
     final firstClient = FakeTerminalClient()
       ..tabs = <WorkspaceTabSummary>[fakeTab(id: 'tab-1', title: 'Terminal 1')];
@@ -484,16 +433,11 @@ void main() {
   );
 }
 
-ProviderContainer _container(
-  FakeTerminalClient client, {
-  AppLifecycleController? lifecycle,
-}) {
+ProviderContainer _container(FakeTerminalClient client) {
   final container = ProviderContainer(
     overrides: [
       terminalClientProvider('host-1').overrideWith((ref) async => client),
       workspaceClientProvider('host-1').overrideWith((ref) async => client),
-      if (lifecycle != null)
-        appLifecycleControllerProvider.overrideWith(() => lifecycle),
     ],
   );
   addTearDown(container.dispose);
@@ -504,19 +448,6 @@ ProviderContainer _container(
   );
   addTearDown(subscription.close);
   return container;
-}
-
-class _TestAppLifecycleController extends AppLifecycleController {
-  _TestAppLifecycleController(this.initialState);
-
-  final AppLifecycleState initialState;
-
-  @override
-  AppLifecycleState build() => initialState;
-
-  void setLifecycleState(AppLifecycleState next) {
-    state = next;
-  }
 }
 
 Future<void> _waitUntil(bool Function() condition) async {

--- a/mobile/test/terminal_session_lifecycle_test.dart
+++ b/mobile/test/terminal_session_lifecycle_test.dart
@@ -1,0 +1,92 @@
+import 'dart:async';
+
+import 'package:alera_mobile/src/app/lifecycle/app_lifecycle_controller.dart';
+import 'package:alera_mobile/src/features/runtime/domain/workspace_tab_summary.dart';
+import 'package:alera_mobile/src/features/terminal/application/terminal_providers.dart';
+import 'package:alera_mobile/src/features/terminal/application/terminal_session_controller.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'support/fake_terminal_client.dart';
+
+void main() {
+  test(
+    'Open session starts again when the app returns to foreground',
+    () async {
+      final client = FakeTerminalClient()
+        ..tabs = <WorkspaceTabSummary>[
+          fakeTab(id: 'tab-1', title: 'Terminal 1'),
+        ];
+      final lifecycle = _TestAppLifecycleController(AppLifecycleState.resumed);
+      final container = ProviderContainer(
+        overrides: [
+          terminalClientProvider('host-1').overrideWith((ref) async => client),
+          appLifecycleControllerProvider.overrideWith(() => lifecycle),
+        ],
+      );
+      addTearDown(container.dispose);
+      addTearDown(client.dispose);
+      final subscription = container.listen(
+        terminalSessionControllerProvider('host-1', 'tab-1'),
+        (_, _) {},
+      );
+      addTearDown(subscription.close);
+      await container.read(
+        terminalSessionControllerProvider('host-1', 'tab-1').future,
+      );
+      final notifier = container.read(
+        terminalSessionControllerProvider('host-1', 'tab-1').notifier,
+      );
+      await notifier.resize(48, 22);
+      final foregroundAttach = Completer<void>();
+      client.attachCompletion = foregroundAttach.future;
+
+      lifecycle.setLifecycleState(AppLifecycleState.inactive);
+      expect(client.attachments, hasLength(1));
+      lifecycle.setLifecycleState(AppLifecycleState.resumed);
+      await _waitUntil(() => client.attachments.length == 2);
+
+      expect(client.attachments.last, (tabId: 'tab-1', cols: 48, rows: 22));
+      expect(
+        container.read(terminalSessionControllerProvider('host-1', 'tab-1')),
+        isA<AsyncLoading<TerminalTabSession>>().having(
+          (value) => value.progress,
+          'progress',
+          isNull,
+        ),
+      );
+      expect(client.calls, isNot(contains('restart tab-1')));
+
+      foregroundAttach.complete();
+      await _waitUntil(
+        () => container
+            .read(terminalSessionControllerProvider('host-1', 'tab-1'))
+            .hasValue,
+      );
+    },
+  );
+}
+
+class _TestAppLifecycleController extends AppLifecycleController {
+  _TestAppLifecycleController(this.initialState);
+
+  final AppLifecycleState initialState;
+
+  @override
+  AppLifecycleState build() => initialState;
+
+  void setLifecycleState(AppLifecycleState next) {
+    state = next;
+  }
+}
+
+Future<void> _waitUntil(bool Function() condition) async {
+  final deadline = DateTime.now().add(const Duration(seconds: 5));
+  while (!condition()) {
+    if (DateTime.now().isAfter(deadline)) {
+      throw TimeoutException('Condition was not reached.');
+    }
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+  }
+}


### PR DESCRIPTION
## Summary

- reattach the currently open mobile terminal when the app returns to the foreground
- reuse the existing attach flow and current viewport dimensions so the runtime can restart an exited session and resynchronize the terminal
- keep the existing host status probe for transport recovery

## Root cause

Foreground resume only probed the runtime connection with `mobileStatus()`. It did not repeat the `attachTerminal(tabId)` action used by the Starting Terminal flow, so an open terminal was not reclaimed or resynchronized after the app resumed.

## Validation

- `dart format --set-exit-if-changed lib test`
- `flutter analyze`
- `flutter test` (176 tests)
