### PR TITLE
feat: pin mobile terminal quick actions

### DIFF
--- a/mobile/lib/src/app/theme/alera_tokens.dart
+++ b/mobile/lib/src/app/theme/alera_tokens.dart
@@ -85,7 +85,7 @@ abstract final class AleraTokens {
 
   /// Matches desktop editor-like tab title max width.
   static const double tabTitleMaxWidthEditor = 180;
-  static const double accessoryBarHeight = 44;
+  static const double accessoryBarHeight = minTapTarget + spaceSm;
   static const int composeBarMaxLines = 4;
 
   static const Duration keyRepeatInterval = Duration(milliseconds: 90);

--- a/mobile/lib/src/design_system/icons/alera_icons.dart
+++ b/mobile/lib/src/design_system/icons/alera_icons.dart
@@ -30,6 +30,7 @@ abstract final class AleraIcons {
   static const IconData edit = LucideIcons.pencil;
   static const IconData delete = LucideIcons.trash2;
   static const IconData copy = LucideIcons.copy;
+  static const IconData paste = LucideIcons.clipboard;
   static const IconData refresh = LucideIcons.refreshCw;
   static const IconData loading = LucideIcons.loaderCircle;
   static const IconData link = LucideIcons.link;

--- a/mobile/lib/src/features/terminal/application/terminal_session_controller.dart
+++ b/mobile/lib/src/features/terminal/application/terminal_session_controller.dart
@@ -237,6 +237,24 @@ class TerminalSessionController extends _$TerminalSessionController {
     await client.writeTerminal(session.sessionId, bytes);
   }
 
+  /// Text from an explicit Paste action. It never submits the prompt, but it
+  /// uses bracketed paste when control characters or a large payload require
+  /// protection from the foreground line editor.
+  Future<void> pasteText(String text) async {
+    final session = await future;
+    final client = await ref.read(terminalClientProvider(hostId).future);
+    final delivery = TerminalComposeDelivery.forText(
+      text,
+      withEnter: false,
+      hostSupportsDeferredInput: client.supportsDeferredTerminalInput,
+    );
+    await client.writeTerminal(
+      session.sessionId,
+      delivery.bytes,
+      bracketedPaste: delivery.bracketedPaste,
+    );
+  }
+
   /// Compose-mode send. The prompt and its Enter become separate PTY writes
   /// when the host supports it, because an agent TUI reads a CR arriving inside
   /// an input burst as a literal newline instead of a submit.

--- a/mobile/lib/src/features/terminal/domain/terminal_accessory_key.dart
+++ b/mobile/lib/src/features/terminal/domain/terminal_accessory_key.dart
@@ -158,3 +158,10 @@ final Map<String, TerminalAccessoryKey> builtInTerminalAccessoryKeysById =
     <String, TerminalAccessoryKey>{
       for (final key in builtInTerminalAccessoryKeys) key.id: key,
     };
+
+/// Frequent navigation keys that stay visible while the configurable key list
+/// scrolls. Visibility still follows the saved accessory layout.
+const Set<String> pinnedTerminalAccessoryKeyIds = <String>{
+  'arrowUp',
+  'arrowDown',
+};

--- a/mobile/lib/src/features/terminal/presentation/terminal_accessory_bar.dart
+++ b/mobile/lib/src/features/terminal/presentation/terminal_accessory_bar.dart
@@ -1,29 +1,44 @@
 import 'dart:async';
 
 import 'package:alera_mobile/src/app/theme/alera_tokens.dart';
+import 'package:alera_mobile/src/design_system/icons/alera_icons.dart';
 import 'package:alera_mobile/src/features/terminal/domain/terminal_accessory_key.dart';
 import 'package:alera_mobile/src/features/terminal/domain/terminal_input_mode.dart';
 import 'package:flutter/material.dart';
 
-/// Quick-key strip shown above the keyboard in both input modes. Repeatable
-/// keys auto-repeat while long-pressed. Presentational: bytes flow out via
-/// [onKey], configuration lives with the caller.
+/// Quick-key strip shown above the keyboard in both input modes.
+///
+/// Paste and the visible vertical navigation keys stay pinned while the
+/// remaining user-configured keys scroll. Repeatable keys auto-repeat while
+/// long-pressed. Presentational: actions flow out via callbacks and
+/// configuration lives with the caller.
 class TerminalAccessoryBar extends StatelessWidget {
   const TerminalAccessoryBar({
     super.key,
     required this.keys,
     required this.inputMode,
     required this.onKey,
+    required this.onPaste,
     required this.onToggleMode,
   });
 
   final List<TerminalAccessoryKey> keys;
   final TerminalInputMode inputMode;
   final ValueChanged<List<int>> onKey;
+  final Future<void> Function() onPaste;
   final VoidCallback onToggleMode;
 
   @override
   Widget build(BuildContext context) {
+    final pinnedKeys = <TerminalAccessoryKey>[
+      for (final id in pinnedTerminalAccessoryKeyIds)
+        for (final key in keys)
+          if (key.id == id) key,
+    ];
+    final scrollingKeys = <TerminalAccessoryKey>[
+      for (final key in keys)
+        if (!pinnedTerminalAccessoryKeyIds.contains(key.id)) key,
+    ];
     return ColoredBox(
       color: AleraTokens.surface,
       child: SizedBox(
@@ -37,13 +52,42 @@ class TerminalAccessoryBar extends StatelessWidget {
                   horizontal: AleraTokens.spaceSm,
                   vertical: AleraTokens.spaceXs,
                 ),
-                itemCount: keys.length,
+                itemCount: scrollingKeys.length,
                 separatorBuilder: (_, _) =>
                     const SizedBox(width: AleraTokens.spaceXs),
                 itemBuilder: (context, index) {
-                  final key = keys[index];
+                  final key = scrollingKeys[index];
                   return _AccessoryKeyButton(accessoryKey: key, onKey: onKey);
                 },
+              ),
+            ),
+            Container(
+              decoration: const BoxDecoration(
+                color: AleraTokens.surfaceElevated,
+                border: Border(
+                  left: BorderSide(color: AleraTokens.borderSubtle),
+                ),
+              ),
+              padding: const EdgeInsets.symmetric(
+                vertical: AleraTokens.spaceXs,
+              ),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: <Widget>[
+                  _PriorityActionButton(
+                    tooltip: 'Paste Clipboard',
+                    icon: AleraIcons.paste,
+                    onPressed: onPaste,
+                  ),
+                  for (final key in pinnedKeys) ...<Widget>[
+                    const SizedBox(width: AleraTokens.space2),
+                    _AccessoryKeyButton(
+                      accessoryKey: key,
+                      onKey: onKey,
+                      pinned: true,
+                    ),
+                  ],
+                ],
               ),
             ),
             IconButton(
@@ -63,10 +107,15 @@ class TerminalAccessoryBar extends StatelessWidget {
 }
 
 class _AccessoryKeyButton extends StatefulWidget {
-  const _AccessoryKeyButton({required this.accessoryKey, required this.onKey});
+  const _AccessoryKeyButton({
+    required this.accessoryKey,
+    required this.onKey,
+    this.pinned = false,
+  });
 
   final TerminalAccessoryKey accessoryKey;
   final ValueChanged<List<int>> onKey;
+  final bool pinned;
 
   @override
   State<_AccessoryKeyButton> createState() => _AccessoryKeyButtonState();
@@ -74,6 +123,7 @@ class _AccessoryKeyButton extends StatefulWidget {
 
 class _AccessoryKeyButtonState extends State<_AccessoryKeyButton> {
   Timer? _repeatTimer;
+  bool _pressed = false;
 
   @override
   void dispose() {
@@ -82,6 +132,7 @@ class _AccessoryKeyButtonState extends State<_AccessoryKeyButton> {
   }
 
   void _startRepeat() {
+    _setPressed(true);
     widget.onKey(widget.accessoryKey.bytes);
     _repeatTimer = Timer.periodic(AleraTokens.keyRepeatInterval, (_) {
       widget.onKey(widget.accessoryKey.bytes);
@@ -91,16 +142,35 @@ class _AccessoryKeyButtonState extends State<_AccessoryKeyButton> {
   void _stopRepeat() {
     _repeatTimer?.cancel();
     _repeatTimer = null;
+    _setPressed(false);
+  }
+
+  void _setPressed(bool value) {
+    if (mounted && _pressed != value) {
+      setState(() => _pressed = value);
+    }
   }
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final child = Container(
-      padding: const EdgeInsets.symmetric(horizontal: AleraTokens.spaceMd),
+    final child = AnimatedContainer(
+      duration: AleraTokens.durationFast,
+      width: widget.pinned ? AleraTokens.minTapTarget : null,
+      constraints: const BoxConstraints(
+        minWidth: AleraTokens.minTapTarget,
+        minHeight: AleraTokens.minTapTarget,
+      ),
+      padding: widget.pinned
+          ? EdgeInsets.zero
+          : const EdgeInsets.symmetric(horizontal: AleraTokens.spaceMd),
       alignment: Alignment.center,
       decoration: BoxDecoration(
-        color: AleraTokens.surfaceVariant,
+        color: _pressed
+            ? AleraTokens.accentSubtle
+            : widget.pinned
+            ? AleraTokens.surfaceVariant
+            : AleraTokens.surfaceElevated,
         borderRadius: BorderRadius.circular(AleraTokens.radiusSm),
         border: Border.all(color: AleraTokens.borderSubtle),
       ),
@@ -112,21 +182,59 @@ class _AccessoryKeyButtonState extends State<_AccessoryKeyButton> {
       ),
     );
     return Semantics(
+      key: ValueKey<String>('terminal-accessory-${widget.accessoryKey.id}'),
       button: true,
       label: widget.accessoryKey.accessibilityLabel,
       child: widget.accessoryKey.repeatable
           ? GestureDetector(
               onTap: () => widget.onKey(widget.accessoryKey.bytes),
+              onTapDown: (_) => _setPressed(true),
+              onTapUp: (_) => _setPressed(false),
+              onTapCancel: () => _setPressed(false),
               onLongPressStart: (_) => _startRepeat(),
               onLongPressEnd: (_) => _stopRepeat(),
               onLongPressCancel: _stopRepeat,
               child: child,
             )
-          : InkWell(
-              borderRadius: BorderRadius.circular(AleraTokens.radiusSm),
-              onTap: () => widget.onKey(widget.accessoryKey.bytes),
-              child: child,
+          : Material(
+              color: Colors.transparent,
+              child: InkWell(
+                borderRadius: BorderRadius.circular(AleraTokens.radiusSm),
+                onTap: () => widget.onKey(widget.accessoryKey.bytes),
+                child: child,
+              ),
             ),
+    );
+  }
+}
+
+class _PriorityActionButton extends StatelessWidget {
+  const _PriorityActionButton({
+    required this.tooltip,
+    required this.icon,
+    required this.onPressed,
+  });
+
+  final String tooltip;
+  final IconData icon;
+  final Future<void> Function() onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox.square(
+      dimension: AleraTokens.minTapTarget,
+      child: IconButton(
+        tooltip: tooltip,
+        onPressed: () => unawaited(onPressed()),
+        style: IconButton.styleFrom(
+          backgroundColor: AleraTokens.accentSubtle,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(AleraTokens.radiusSm),
+            side: const BorderSide(color: AleraTokens.borderSubtle),
+          ),
+        ),
+        icon: Icon(icon),
+      ),
     );
   }
 }

--- a/mobile/lib/src/features/terminal/presentation/terminal_keys_settings_screen.dart
+++ b/mobile/lib/src/features/terminal/presentation/terminal_keys_settings_screen.dart
@@ -1,5 +1,6 @@
 import 'package:alera_mobile/src/app/theme/alera_tokens.dart';
 import 'package:alera_mobile/src/features/terminal/application/terminal_accessory_layout_controller.dart';
+import 'package:alera_mobile/src/features/terminal/domain/terminal_accessory_key.dart';
 import 'package:alera_mobile/src/features/terminal/domain/terminal_accessory_layout.dart';
 import 'package:alera_mobile/src/features/terminal/presentation/custom_key_dialog.dart';
 import 'package:flutter/material.dart';
@@ -82,6 +83,7 @@ class _KeyList extends StatelessWidget {
       itemBuilder: (context, index) {
         final key = keys[index];
         final isCustom = customIds.contains(key.id);
+        final isPinned = pinnedTerminalAccessoryKeyIds.contains(key.id);
         return SwitchListTile(
           key: ValueKey<String>(key.id),
           value: !layout.hiddenIds.contains(key.id),
@@ -90,12 +92,23 @@ class _KeyList extends StatelessWidget {
             key.label,
             style: const TextStyle(fontFamily: AleraTokens.monoFontFamily),
           ),
-          subtitle: Text(isCustom ? 'Custom Key' : key.accessibilityLabel),
+          subtitle: Text(
+            isCustom
+                ? 'Custom Key'
+                : isPinned
+                ? '${key.accessibilityLabel} - Pinned'
+                : key.accessibilityLabel,
+          ),
           secondary: isCustom
               ? IconButton(
                   tooltip: 'Delete Custom Key',
                   onPressed: () => controller.removeCustomKey(key.id),
                   icon: const Icon(Icons.delete_outline),
+                )
+              : isPinned
+              ? const Tooltip(
+                  message: 'Pinned Quick Key',
+                  child: Icon(Icons.push_pin_outlined),
                 )
               : ReorderableDragStartListener(
                   index: index,

--- a/mobile/lib/src/features/terminal/presentation/terminal_tab_view.dart
+++ b/mobile/lib/src/features/terminal/presentation/terminal_tab_view.dart
@@ -13,8 +13,10 @@ import 'package:alera_mobile/src/features/terminal/domain/terminal_input_mode.da
 import 'package:alera_mobile/src/features/terminal/presentation/terminal_accessory_bar.dart';
 import 'package:alera_mobile/src/features/terminal/presentation/terminal_compose_bar.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:alera_mobile/src/features/terminal/domain/terminal_output_batcher.dart';
+import 'package:logging/logging.dart';
 import 'package:xterm/xterm.dart';
 
 part 'terminal_tab_state_widgets.dart';
@@ -71,6 +73,7 @@ class _TerminalTabViewState extends ConsumerState<TerminalTabView> {
             keys: accessoryKeys,
             inputMode: inputMode,
             onKey: notifier.write,
+            onPaste: () => _pasteClipboard(notifier),
             onToggleMode: ref
                 .read(
                   terminalInputModeControllerProvider(widget.tabId).notifier,
@@ -113,6 +116,31 @@ class _TerminalTabViewState extends ConsumerState<TerminalTabView> {
         ),
       ],
     );
+  }
+
+  Future<void> _pasteClipboard(TerminalSessionController notifier) async {
+    try {
+      final data = await Clipboard.getData(Clipboard.kTextPlain);
+      final text = data?.text;
+      if (text == null || text.isEmpty) {
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(content: Text('Clipboard Has No Text')),
+          );
+        }
+        return;
+      }
+      await notifier.pasteText(text);
+    } catch (error, stackTrace) {
+      Logger(
+        'TerminalTabView',
+      ).warning('terminal clipboard paste failed', error, stackTrace);
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Could Not Paste Clipboard')),
+        );
+      }
+    }
   }
 
   Future<void> _refreshTerminal() async {

--- a/mobile/test/terminal_compose_send_test.dart
+++ b/mobile/test/terminal_compose_send_test.dart
@@ -83,6 +83,20 @@ void main() {
       ]),
     );
   });
+
+  test('Clipboard text is pasted without pressing Enter', () async {
+    final client = FakeTerminalClient()
+      ..tabs = <WorkspaceTabSummary>[fakeTab(id: 'tab-1', title: 'Terminal 1')];
+    final notifier = await _notifier(client);
+
+    await notifier.pasteText('first\nsecond');
+
+    expect(
+      client.calls,
+      contains('write session-tab-1 12 paste=true enter=false'),
+    );
+    expect(client.writes.single, utf8.encode('first\nsecond'));
+  });
 }
 
 Future<TerminalSessionController> _notifier(FakeTerminalClient client) async {

--- a/mobile/test/terminal_input_test.dart
+++ b/mobile/test/terminal_input_test.dart
@@ -44,6 +44,7 @@ void main() {
             ],
             inputMode: TerminalInputMode.compose,
             onKey: written.add,
+            onPaste: () async {},
             onToggleMode: () {},
           ),
         ),
@@ -59,6 +60,52 @@ void main() {
       <int>[0x1b, 0x5b, 0x5a],
       <int>[0x03],
     ]);
+  });
+
+  testWidgets('Paste and vertical arrows stay in the pinned command rail', (
+    tester,
+  ) async {
+    final written = <List<int>>[];
+    var pasteCount = 0;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Align(
+            alignment: Alignment.bottomCenter,
+            child: SizedBox(
+              width: 320,
+              child: TerminalAccessoryBar(
+                keys: builtInTerminalAccessoryKeys,
+                inputMode: TerminalInputMode.compose,
+                onKey: written.add,
+                onPaste: () async {
+                  pasteCount += 1;
+                },
+                onToggleMode: () {},
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.byTooltip('Paste Clipboard'));
+    final arrowUp = find.byKey(
+      const ValueKey<String>('terminal-accessory-arrowUp'),
+    );
+    final arrowDown = find.byKey(
+      const ValueKey<String>('terminal-accessory-arrowDown'),
+    );
+    await tester.tap(arrowUp);
+    await tester.tap(arrowDown);
+
+    expect(pasteCount, 1);
+    expect(written, <List<int>>[
+      <int>[0x1b, 0x5b, 0x41],
+      <int>[0x1b, 0x5b, 0x42],
+    ]);
+    expect(tester.getSize(arrowUp), const Size.square(48));
+    expect(tester.getSize(arrowDown), const Size.square(48));
   });
 
   testWidgets(

--- a/mobile/test/terminal_tab_view_test.dart
+++ b/mobile/test/terminal_tab_view_test.dart
@@ -1,5 +1,4 @@
 import 'dart:convert';
-import 'dart:typed_data';
 
 import 'package:alera_mobile/src/app/theme/alera_tokens.dart';
 import 'package:alera_mobile/src/features/runtime/domain/workspace_tab_summary.dart';
@@ -7,6 +6,7 @@ import 'package:alera_mobile/src/features/terminal/application/terminal_provider
 import 'package:alera_mobile/src/features/terminal/presentation/terminal_tab_view.dart';
 import 'package:alera_mobile/src/features/workbench/application/workbench_providers.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:xterm/xterm.dart';
@@ -104,6 +104,38 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(_terminalOf(tester), same(before));
+  });
+
+  testWidgets('Paste quick action writes clipboard text without Enter', (
+    tester,
+  ) async {
+    tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+      SystemChannels.platform,
+      (call) async {
+        if (call.method == 'Clipboard.getData') {
+          return <String, Object?>{'text': 'first\nsecond'};
+        }
+        return null;
+      },
+    );
+    addTearDown(
+      () => tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        SystemChannels.platform,
+        null,
+      ),
+    );
+    final client = FakeTerminalClient()
+      ..tabs = <WorkspaceTabSummary>[fakeTab(id: 'tab-1', title: 'Terminal 1')];
+    await _pumpTab(tester, client);
+
+    await tester.tap(find.byTooltip('Paste Clipboard'));
+    await tester.pumpAndSettle();
+
+    expect(client.writes.single, utf8.encode('first\nsecond'));
+    expect(
+      client.calls,
+      contains('write session-tab-1 12 paste=true enter=false'),
+    );
   });
 
   testWidgets('A resync snapshot replaces the emulator', (tester) async {


### PR DESCRIPTION
## Summary
- add a persistent Paste action to the mobile terminal quick-action bar
- pin Up and Down in a 48 dp command rail while keeping other quick keys scrollable and configurable
- preserve safe bracketed-paste delivery without submitting the terminal input

## Validation
- `flutter analyze` from `mobile/`
- `flutter test` from `mobile/` (178 tests)