### PR TITLE
feat: install all alera skills together

### DIFF
--- a/lib/src/features/settings/infra/alera_all_skills_setup_service.dart
+++ b/lib/src/features/settings/infra/alera_all_skills_setup_service.dart
@@ -1,0 +1,130 @@
+import 'package:alera/src/features/agent_status/application/agent_hook_reconciliation_service.dart';
+import 'package:alera/src/features/settings/domain/alera_settings.dart';
+import 'package:alera/src/features/settings/infra/alera_cli_skill_service.dart';
+import 'package:alera/src/features/settings/infra/alera_orchestration_setup_service.dart';
+import 'package:logging/logging.dart';
+
+final Logger _log = Logger('AleraAllSkillsSetupService');
+
+class AleraSkillSetupOutcome {
+  const AleraSkillSetupOutcome({
+    required this.skill,
+    required this.succeeded,
+    required this.summary,
+    required this.detail,
+    required this.needsAttention,
+  });
+
+  final AleraAgentSkill skill;
+  final bool succeeded;
+  final String summary;
+  final String detail;
+  final bool needsAttention;
+}
+
+class AleraAllSkillsSetupResult {
+  const AleraAllSkillsSetupResult(this.outcomes);
+
+  final List<AleraSkillSetupOutcome> outcomes;
+
+  int get succeededCount =>
+      outcomes.where((outcome) => outcome.succeeded).length;
+
+  bool get succeeded => succeededCount == outcomes.length;
+
+  bool get needsAttention => outcomes.any((outcome) => outcome.needsAttention);
+
+  String get summary {
+    if (succeeded) {
+      final attention = needsAttention ? ' · Setup Needs Attention' : '';
+      return 'All ${outcomes.length} Alera Skills Installed / Updated$attention';
+    }
+    return '$succeededCount Of ${outcomes.length} Alera Skills Installed / Updated';
+  }
+
+  String get detail {
+    return outcomes
+        .map((outcome) {
+          final detail = outcome.detail.trim();
+          return <String>[
+            outcome.skill.name,
+            outcome.summary,
+            if (detail.isNotEmpty) detail,
+          ].join('\n');
+        })
+        .join('\n\n');
+  }
+}
+
+class AleraAllSkillsSetupService {
+  const AleraAllSkillsSetupService({
+    required this.skillService,
+    required this.hookReconciliationService,
+  });
+
+  final AleraCliSkillService skillService;
+  final AgentHookReconciler hookReconciliationService;
+
+  Future<AleraAllSkillsSetupResult> installOrUpdate({
+    required AgentStatusHookSettings hooks,
+    AleraCliSkillRunner runner = AleraCliSkillRunner.auto,
+  }) async {
+    final outcomes = <AleraSkillSetupOutcome>[];
+    for (final skill in AleraAgentSkill.values) {
+      try {
+        outcomes.add(
+          await _installSkill(skill: skill, hooks: hooks, runner: runner),
+        );
+      } catch (error, stackTrace) {
+        _log.warning(
+          '${skill.name} install failed before producing a result',
+          error,
+          stackTrace,
+        );
+        outcomes.add(
+          AleraSkillSetupOutcome(
+            skill: skill,
+            succeeded: false,
+            summary: 'Install Failed: $error',
+            detail: '$error',
+            needsAttention: true,
+          ),
+        );
+      }
+    }
+    return AleraAllSkillsSetupResult(
+      List<AleraSkillSetupOutcome>.unmodifiable(outcomes),
+    );
+  }
+
+  Future<AleraSkillSetupOutcome> _installSkill({
+    required AleraAgentSkill skill,
+    required AgentStatusHookSettings hooks,
+    required AleraCliSkillRunner runner,
+  }) async {
+    if (skill == AleraAgentSkill.orchestration) {
+      final result = await AleraOrchestrationSetupService(
+        skillService: skillService,
+        hookReconciliationService: hookReconciliationService,
+      ).installOrUpdate(hooks: hooks, runner: runner);
+      return AleraSkillSetupOutcome(
+        skill: skill,
+        succeeded: result.succeeded,
+        summary: result.summary,
+        detail: result.detail,
+        needsAttention: result.needsAttention,
+      );
+    }
+    final result = await skillService.installOrUpdate(
+      runner: runner,
+      skill: skill,
+    );
+    return AleraSkillSetupOutcome(
+      skill: skill,
+      succeeded: result.succeeded,
+      summary: result.summary,
+      detail: result.detail,
+      needsAttention: !result.succeeded,
+    );
+  }
+}

--- a/lib/src/features/settings/infra/alera_orchestration_setup_service.dart
+++ b/lib/src/features/settings/infra/alera_orchestration_setup_service.dart
@@ -22,6 +22,16 @@ class AleraOrchestrationSetupResult {
 
   bool get succeeded => skillResult.succeeded;
 
+  bool get needsAttention {
+    return !succeeded ||
+        hookError != null ||
+        hookStatuses.any(
+          (status) =>
+              status.state == ManagedAgentHookInstallState.error ||
+              status.state == ManagedAgentHookInstallState.partial,
+        );
+  }
+
   /// Forwarded so a failed orchestration setup exposes the same full installer
   /// output as the plain skill controls.
   String get detail => skillResult.detail;

--- a/lib/src/features/settings/presentation/panes/agents_pane.dart
+++ b/lib/src/features/settings/presentation/panes/agents_pane.dart
@@ -4,6 +4,7 @@ import 'package:alera/src/design_system/forms/alera_setting_row.dart';
 import 'package:alera/src/design_system/layout/alera_settings_group.dart';
 import 'package:alera/src/features/agent_status/domain/agent_status.dart';
 import 'package:alera/src/features/settings/domain/alera_settings.dart';
+import 'package:alera/src/features/settings/presentation/panes/alera_all_skills_control.dart';
 import 'package:alera/src/features/settings/presentation/panes/agents_cli_skill_control.dart';
 import 'package:alera/src/features/settings/presentation/panes/alera_orchestration_skill_control.dart';
 import 'package:alera/src/features/settings/presentation/panes/alera_emulator_skill_control.dart';
@@ -42,6 +43,13 @@ class AgentsSettingsPane extends ConsumerWidget {
                     'Register The Alera Command On PATH For Terminals And Agents.',
                 controlWidth: 360,
                 child: AleraCliRegistrationControl(),
+              ),
+              AleraSettingRow(
+                title: 'All Alera Skills',
+                description:
+                    'Install Or Update CLI, Orchestration, Computer Use, And Emulator Skills. Reapplies Selected Status Hooks.',
+                controlWidth: 360,
+                child: AleraAllSkillsControl(),
               ),
               AleraSettingRow(
                 title: 'Alera CLI Skill',

--- a/lib/src/features/settings/presentation/panes/alera_all_skills_control.dart
+++ b/lib/src/features/settings/presentation/panes/alera_all_skills_control.dart
@@ -1,0 +1,37 @@
+import 'package:alera/src/app/providers.dart';
+import 'package:alera/src/features/settings/infra/alera_all_skills_setup_service.dart';
+import 'package:alera/src/features/settings/presentation/panes/alera_skill_install_control.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class AleraAllSkillsControl extends ConsumerWidget {
+  const AleraAllSkillsControl({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return AleraSkillInstallControl(
+      installLabel: 'Install / Update All',
+      installingLabel: 'Installing All',
+      install: (runner) async {
+        final result =
+            await AleraAllSkillsSetupService(
+              skillService: ref.read(aleraCliSkillServiceProvider),
+              hookReconciliationService: ref.read(
+                agentHookReconciliationServiceProvider,
+              ),
+            ).installOrUpdate(
+              runner: runner,
+              hooks: ref
+                  .read(settingsControllerProvider)
+                  .agents
+                  .agentStatusHooks,
+            );
+        return AleraSkillInstallStatus(
+          result.summary,
+          detail: result.detail,
+          needsAttention: result.needsAttention,
+        );
+      },
+    );
+  }
+}

--- a/lib/src/features/settings/presentation/panes/alera_orchestration_skill_control.dart
+++ b/lib/src/features/settings/presentation/panes/alera_orchestration_skill_control.dart
@@ -1,5 +1,4 @@
 import 'package:alera/src/app/providers.dart';
-import 'package:alera/src/features/agent_status/infra/managed_agent_hook_installer.dart';
 import 'package:alera/src/features/settings/infra/alera_cli_skill_service.dart';
 import 'package:alera/src/features/settings/infra/alera_orchestration_setup_service.dart';
 import 'package:alera/src/features/settings/presentation/panes/alera_skill_install_control.dart';
@@ -30,14 +29,7 @@ class AleraOrchestrationSkillControl extends ConsumerWidget {
         return AleraSkillInstallStatus(
           result.summary,
           detail: result.detail,
-          needsAttention:
-              !result.succeeded ||
-              result.hookError != null ||
-              result.hookStatuses.any(
-                (status) =>
-                    status.state == ManagedAgentHookInstallState.error ||
-                    status.state == ManagedAgentHookInstallState.partial,
-              ),
+          needsAttention: result.needsAttention,
         );
       },
     );

--- a/lib/src/features/settings/presentation/panes/alera_skill_install_control.dart
+++ b/lib/src/features/settings/presentation/panes/alera_skill_install_control.dart
@@ -29,11 +29,15 @@ class AleraSkillInstallControl extends StatefulWidget {
   const AleraSkillInstallControl({
     super.key,
     required this.install,
-    required this.commandFor,
+    this.commandFor,
+    this.installLabel = 'Install / Update',
+    this.installingLabel = 'Installing',
   });
 
   final AleraSkillInstaller install;
-  final AleraSkillCommandBuilder commandFor;
+  final AleraSkillCommandBuilder? commandFor;
+  final String installLabel;
+  final String installingLabel;
 
   @override
   State<AleraSkillInstallControl> createState() =>
@@ -78,7 +82,7 @@ class _AleraSkillInstallControlState extends State<AleraSkillInstallControl> {
   }
 
   Future<void> _copyCommand() async {
-    await Clipboard.setData(ClipboardData(text: widget.commandFor(_runner)));
+    await Clipboard.setData(ClipboardData(text: widget.commandFor!(_runner)));
     if (mounted) {
       setState(() {
         _status = const AleraSkillInstallStatus('Install Command Copied');
@@ -134,14 +138,15 @@ class _AleraSkillInstallControlState extends State<AleraSkillInstallControl> {
                 ),
               ),
             ),
-            SizedBox(
-              height: kSupportControlHeight,
-              child: OutlinedButton.icon(
-                onPressed: _installing ? null : _copyCommand,
-                icon: const Icon(AleraIcons.copy, size: 16),
-                label: const Text('Copy'),
+            if (widget.commandFor != null)
+              SizedBox(
+                height: kSupportControlHeight,
+                child: OutlinedButton.icon(
+                  onPressed: _installing ? null : _copyCommand,
+                  icon: const Icon(AleraIcons.copy, size: 16),
+                  label: const Text('Copy'),
+                ),
               ),
-            ),
             if (status != null && status.detail.isNotEmpty)
               SizedBox(
                 height: kSupportControlHeight,
@@ -169,7 +174,9 @@ class _AleraSkillInstallControlState extends State<AleraSkillInstallControl> {
                         ),
                       )
                     : const Icon(AleraIcons.download, size: 16),
-                label: Text(_installing ? 'Installing' : 'Install / Update'),
+                label: Text(
+                  _installing ? widget.installingLabel : widget.installLabel,
+                ),
               ),
             ),
           ],

--- a/lib/src/features/settings/presentation/settings_search_entries.dart
+++ b/lib/src/features/settings/presentation/settings_search_entries.dart
@@ -95,6 +95,20 @@ applicationSearchEntries = <SettingsSearchEntry>[
 
 const List<SettingsSearchEntry> agentsSearchEntries = <SettingsSearchEntry>[
   SettingsSearchEntry(
+    title: 'All Alera Skills',
+    description: 'Install Or Update Every Alera Agent Skill.',
+    keywords: <String>[
+      'all',
+      'install',
+      'update',
+      'skills',
+      'computer use',
+      'emulator',
+      'orchestration',
+    ],
+    groupId: 'cliSkill',
+  ),
+  SettingsSearchEntry(
     title: 'Alera CLI Skill',
     description: 'Install agent instructions for the Alera CLI.',
     keywords: <String>['codex', 'skill', 'cli', 'agent', 'workspace'],

--- a/test/unit/alera_all_skills_setup_service_test.dart
+++ b/test/unit/alera_all_skills_setup_service_test.dart
@@ -1,0 +1,140 @@
+import 'package:alera/src/features/agent_status/application/agent_hook_reconciliation_service.dart';
+import 'package:alera/src/features/agent_status/domain/agent_status.dart';
+import 'package:alera/src/features/agent_status/infra/managed_agent_hook_installer.dart';
+import 'package:alera/src/features/settings/domain/alera_settings.dart';
+import 'package:alera/src/features/settings/infra/alera_all_skills_setup_service.dart';
+import 'package:alera/src/features/settings/infra/alera_cli_skill_service.dart';
+import 'package:alera/src/shared/infra/process/command_environment_resolver.dart';
+import 'package:alera/src/shared/infra/process/process_runner.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('installs every Alera skill and reapplies selected hooks', () async {
+    final skillService = _RecordingSkillService();
+    final hookReconciler = _RecordingHookReconciler();
+    const hooks = AgentStatusHookSettings(codex: true);
+    final result = await AleraAllSkillsSetupService(
+      skillService: skillService,
+      hookReconciliationService: hookReconciler,
+    ).installOrUpdate(hooks: hooks, runner: AleraCliSkillRunner.bunx);
+
+    expect(skillService.skills, AleraAgentSkill.values);
+    expect(skillService.runners, everyElement(AleraCliSkillRunner.bunx));
+    expect(hookReconciler.settings, hooks);
+    expect(result.succeeded, isTrue);
+    expect(result.needsAttention, isFalse);
+    expect(result.summary, 'All 4 Alera Skills Installed / Updated');
+    for (final skill in AleraAgentSkill.values) {
+      expect(result.detail, contains(skill.name));
+    }
+  });
+
+  test('continues installing remaining skills after one throws', () async {
+    final skillService = _RecordingSkillService(
+      throwingSkill: AleraAgentSkill.computerUse,
+    );
+    final result = await AleraAllSkillsSetupService(
+      skillService: skillService,
+      hookReconciliationService: _RecordingHookReconciler(),
+    ).installOrUpdate(hooks: const AgentStatusHookSettings());
+
+    expect(skillService.skills, AleraAgentSkill.values);
+    expect(result.succeeded, isFalse);
+    expect(result.needsAttention, isTrue);
+    expect(result.succeededCount, 3);
+    expect(result.summary, '3 Of 4 Alera Skills Installed / Updated');
+    expect(result.detail, contains('computer-use'));
+    expect(result.detail, contains('installer unavailable'));
+    expect(result.detail, contains('alera-emulator'));
+  });
+}
+
+class _RecordingSkillService extends AleraCliSkillService {
+  _RecordingSkillService({this.throwingSkill})
+    : super(
+        processRunner: _NoopProcessRunner(),
+        commandEnvironmentResolver: const _EmptyCommandEnvironmentResolver(),
+      );
+
+  final AleraAgentSkill? throwingSkill;
+  final List<AleraAgentSkill> skills = <AleraAgentSkill>[];
+  final List<AleraCliSkillRunner> runners = <AleraCliSkillRunner>[];
+
+  @override
+  Future<AleraCliSkillInstallResult> installOrUpdate({
+    AleraCliSkillRunner runner = AleraCliSkillRunner.auto,
+    AleraAgentSkill skill = AleraAgentSkill.cli,
+  }) async {
+    skills.add(skill);
+    runners.add(runner);
+    if (skill == throwingSkill) {
+      throw StateError('installer unavailable');
+    }
+    return AleraCliSkillInstallResult(
+      runner: runner,
+      skill: skill,
+      attempts: <AleraCliSkillInstallAttempt>[
+        AleraCliSkillInstallAttempt(
+          runner: runner == AleraCliSkillRunner.auto
+              ? AleraCliSkillRunner.npx
+              : runner,
+          exitCode: 0,
+          stdout: 'ok',
+          stderr: '',
+        ),
+      ],
+    );
+  }
+}
+
+class _RecordingHookReconciler implements AgentHookReconciler {
+  AgentStatusHookSettings? settings;
+
+  @override
+  Future<List<ManagedAgentHookInstallStatus>> reconcile(
+    AgentStatusHookSettings settings,
+  ) async {
+    this.settings = settings;
+    return <ManagedAgentHookInstallStatus>[
+      const ManagedAgentHookInstallStatus(
+        agentType: AgentType.codex,
+        state: ManagedAgentHookInstallState.installed,
+        configPath: '/tmp/codex',
+        managedHooksPresent: true,
+      ),
+    ];
+  }
+}
+
+class _NoopProcessRunner implements ProcessRunner {
+  @override
+  Future<ProcessRunOutput> run(
+    String executable,
+    List<String> arguments, {
+    String? workingDirectory,
+    Map<String, String>? environment,
+  }) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<StartedProcess> start(
+    String executable,
+    List<String> arguments, {
+    String? workingDirectory,
+    Map<String, String>? environment,
+  }) {
+    throw UnimplementedError();
+  }
+}
+
+class _EmptyCommandEnvironmentResolver implements CommandEnvironmentResolver {
+  const _EmptyCommandEnvironmentResolver();
+
+  @override
+  Future<Map<String, String>> environment() async => const <String, String>{};
+
+  @override
+  Future<Map<String, String>> environmentVariables(List<String> names) async =>
+      const <String, String>{};
+}

--- a/test/widget/agents_cli_skill_control_test.dart
+++ b/test/widget/agents_cli_skill_control_test.dart
@@ -8,6 +8,7 @@ import 'package:alera/src/features/agent_status/infra/managed_agent_hook_install
 import 'package:alera/src/features/settings/domain/alera_settings.dart';
 import 'package:alera/src/features/settings/infra/alera_cli_registration_service.dart';
 import 'package:alera/src/features/settings/infra/alera_cli_skill_service.dart';
+import 'package:alera/src/features/settings/presentation/panes/alera_all_skills_control.dart';
 import 'package:alera/src/features/settings/presentation/panes/alera_emulator_skill_control.dart';
 import 'package:alera/src/features/settings/presentation/panes/alera_orchestration_skill_control.dart';
 import 'package:alera/src/features/settings/presentation/panes/agents_cli_skill_control.dart';
@@ -188,6 +189,39 @@ void main() {
     expect(service.skill, AleraAgentSkill.emulator);
   });
 
+  testWidgets('all skills control installs every skill and reapplies hooks', (
+    tester,
+  ) async {
+    final service = _FakeAleraCliSkillService();
+    final reconciler = _FakeHookReconciler();
+    final settings = AleraSettings.defaults.copyWith(
+      agents: AleraSettings.defaults.agents.copyWith(
+        agentStatusHooks: const AgentStatusHookSettings(codex: true),
+      ),
+    );
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          aleraCliSkillServiceProvider.overrideWithValue(service),
+          agentHookReconciliationServiceProvider.overrideWithValue(reconciler),
+          settingsControllerProvider.overrideWithValue(settings),
+        ],
+        child: MaterialApp(
+          theme: buildAleraDarkTheme(),
+          home: const Scaffold(body: AleraAllSkillsControl()),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('Install / Update All'));
+    await tester.pumpAndSettle();
+
+    expect(service.skills, AleraAgentSkill.values);
+    expect(reconciler.settings?.codex, isTrue);
+    expect(find.text('All 4 Alera Skills Installed / Updated'), findsOneWidget);
+    expect(find.text('View Output'), findsOneWidget);
+  });
+
   testWidgets('a failed install exposes the untruncated output', (
     tester,
   ) async {
@@ -304,6 +338,7 @@ class _FakeAleraCliSkillService extends AleraCliSkillService {
   final AleraCliSkillInstallAttempt? failure;
   AleraCliSkillRunner? runner;
   AleraAgentSkill? skill;
+  final List<AleraAgentSkill> skills = <AleraAgentSkill>[];
 
   @override
   Future<AleraCliSkillInstallResult> installOrUpdate({
@@ -312,6 +347,7 @@ class _FakeAleraCliSkillService extends AleraCliSkillService {
   }) async {
     this.runner = runner;
     this.skill = skill;
+    skills.add(skill);
     final attemptRunner = runner == AleraCliSkillRunner.auto
         ? AleraCliSkillRunner.npx
         : runner;


### PR DESCRIPTION
## Summary

- add an All Alera Skills action in Settings > Agents
- install or update CLI, orchestration, computer-use, and emulator skills in one resilient sequence
- reapply selected status hooks and expose consolidated installer output

## Validation

- `flutter analyze`
- focused skill service and widget tests (26 passed)
- full non-golden suite (2 unrelated parallel flakes passed when rerun individually)
- `dart run tool/quality/check_max_lines.dart`
- dashboard goldens passed; design-system core differed by 0.01% locally on Flutter 3.44.4, so CI on pinned Flutter 3.44.8 is authoritative