### PR TITLE
fix: align mobile agent activity sort

### DIFF
--- a/mobile/lib/src/features/workbench/application/mobile_agent_activity_sort.dart
+++ b/mobile/lib/src/features/workbench/application/mobile_agent_activity_sort.dart
@@ -15,6 +15,16 @@ class MobileWorkspaceAttention {
   final DateTime? at;
 }
 
+class MobileAgentActivityRank {
+  const MobileAgentActivityRank({
+    required this.attentionClass,
+    required this.activityAt,
+  });
+
+  final MobileAgentAttentionClass attentionClass;
+  final DateTime activityAt;
+}
+
 MobileWorkspaceAttention mobileWorkspaceAttention({
   required String workspaceId,
   required Iterable<AgentPresenceSummary> statuses,
@@ -42,22 +52,95 @@ MobileWorkspaceAttention mobileWorkspaceAttention({
   return best;
 }
 
-int compareMobileAgentActivity({
-  required MobileWorkspaceAttention leftAttention,
-  required DateTime leftFallback,
-  required String leftName,
-  required MobileWorkspaceAttention rightAttention,
-  required DateTime rightFallback,
-  required String rightName,
+MobileAgentActivityRank mobileAgentActivityRank({
+  required MobileWorkspaceAttention attention,
+  required DateTime fallback,
 }) {
-  final byClass = leftAttention.attentionClass.index.compareTo(
-    rightAttention.attentionClass.index,
+  return MobileAgentActivityRank(
+    attentionClass: attention.attentionClass,
+    activityAt: attention.at ?? fallback,
+  );
+}
+
+int compareMobileAgentActivityRanks(
+  MobileAgentActivityRank left,
+  MobileAgentActivityRank right,
+) {
+  final byClass = left.attentionClass.index.compareTo(
+    right.attentionClass.index,
   );
   if (byClass != 0) return byClass;
-  final byTime = (rightAttention.at ?? rightFallback).compareTo(
-    leftAttention.at ?? leftFallback,
+  return right.activityAt.compareTo(left.activityAt);
+}
+
+MobileAgentActivityRank? bestMobileAgentActivityRank(
+  MobileAgentActivityRank? current,
+  MobileAgentActivityRank? candidate,
+) {
+  if (current == null) return candidate;
+  if (candidate == null) return current;
+  return compareMobileAgentActivityRanks(candidate, current) < 0
+      ? candidate
+      : current;
+}
+
+Map<String, MobileAgentActivityRank?> aggregateMobileAgentActivityBySubtree({
+  required Iterable<({String id, String? parentId})> workspaces,
+  required Map<String, MobileAgentActivityRank?> directActivityByWorkspaceId,
+}) {
+  final entries = workspaces.toList(growable: false);
+  final ids = <String>{for (final entry in entries) entry.id};
+  final childrenByParentId = <String, List<String>>{};
+  for (final entry in entries) {
+    final parentId = entry.parentId;
+    if (parentId == null || parentId == entry.id || !ids.contains(parentId)) {
+      continue;
+    }
+    childrenByParentId.putIfAbsent(parentId, () => <String>[]).add(entry.id);
+  }
+
+  final aggregateById = <String, MobileAgentActivityRank?>{};
+  final visiting = <String>{};
+
+  MobileAgentActivityRank? visit(String workspaceId) {
+    final cached = aggregateById[workspaceId];
+    if (cached != null || aggregateById.containsKey(workspaceId)) {
+      return cached;
+    }
+    if (!visiting.add(workspaceId)) {
+      return directActivityByWorkspaceId[workspaceId];
+    }
+    var best = directActivityByWorkspaceId[workspaceId];
+    for (final childId in childrenByParentId[workspaceId] ?? const <String>[]) {
+      best = bestMobileAgentActivityRank(best, visit(childId));
+    }
+    visiting.remove(workspaceId);
+    aggregateById[workspaceId] = best;
+    return best;
+  }
+
+  for (final entry in entries) {
+    visit(entry.id);
+  }
+  return aggregateById;
+}
+
+int compareMobileAgentActivity({
+  required MobileAgentActivityRank? leftActivity,
+  required String leftName,
+  required MobileAgentActivityRank? rightActivity,
+  required String rightName,
+}) {
+  if (leftActivity == null || rightActivity == null) {
+    if (leftActivity != null) return -1;
+    if (rightActivity != null) return 1;
+    return leftName.toLowerCase().compareTo(rightName.toLowerCase());
+  }
+  final byActivity = compareMobileAgentActivityRanks(
+    leftActivity,
+    rightActivity,
   );
-  if (byTime != 0) return byTime;
+  if (byActivity != 0) return byActivity;
   return leftName.toLowerCase().compareTo(rightName.toLowerCase());
 }
 

--- a/mobile/lib/src/features/workbench/application/mobile_workspace_rows.dart
+++ b/mobile/lib/src/features/workbench/application/mobile_workspace_rows.dart
@@ -59,6 +59,7 @@ List<MobileWorkspaceRow> buildMobileWorkspaceRows({
   required MobileViewPrefs prefs,
   Map<String, DateTime> activity = const <String, DateTime>{},
   List<AgentPresenceSummary> agentPresence = const <AgentPresenceSummary>[],
+  Map<String, int> terminalTabCountByWorkspaceId = const <String, int>{},
   String searchQuery = '',
   DateTime? now,
 }) {
@@ -80,24 +81,41 @@ List<MobileWorkspaceRow> buildMobileWorkspaceRows({
     );
   }
 
-  final visibleWorkspaces =
-      <WorkspaceSummary>[
-        for (final workspace in workspaces)
-          if (_matchesFilters(
-                workspace,
-                projectById[workspace.projectId],
-                prefs,
-              ) &&
-              _matchesSearch(
-                workspace,
-                projectById[workspace.projectId],
-                normalizedQuery,
-              ))
+  final visibleWorkspaces = <WorkspaceSummary>[
+    for (final workspace in workspaces)
+      if (_matchesFilters(workspace, projectById[workspace.projectId], prefs) &&
+          _matchesSearch(
             workspace,
-      ]..sort(
-        (left, right) =>
-            _compareWorkspaces(left, right, prefs, activity, attentionOf),
-      );
+            projectById[workspace.projectId],
+            normalizedQuery,
+          ))
+        workspace,
+  ];
+  final workspacesWithAgentPresence = <String>{
+    for (final status in agentPresence) status.workspaceId,
+  };
+  final directActivityByWorkspaceId = <String, MobileAgentActivityRank?>{
+    for (final workspace in visibleWorkspaces)
+      workspace.id:
+          (terminalTabCountByWorkspaceId[workspace.id] ?? 0) > 0 ||
+              workspacesWithAgentPresence.contains(workspace.id)
+          ? mobileAgentActivityRank(
+              attention: attentionOf(workspace),
+              fallback:
+                  activity[workspace.id] ?? workspace.updatedAt ?? DateTime(0),
+            )
+          : null,
+  };
+  final subtreeActivityByWorkspaceId = aggregateMobileAgentActivityBySubtree(
+    workspaces: visibleWorkspaces.map(
+      (workspace) => (id: workspace.id, parentId: workspace.parentWorkspaceId),
+    ),
+    directActivityByWorkspaceId: directActivityByWorkspaceId,
+  );
+  visibleWorkspaces.sort(
+    (left, right) =>
+        _compareWorkspaces(left, right, prefs, subtreeActivityByWorkspaceId),
+  );
 
   final pinned = <WorkspaceSummary>[
     for (final workspace in visibleWorkspaces)
@@ -150,8 +168,7 @@ List<MobileWorkspaceRow> buildMobileWorkspaceRows({
             byProject[left] ?? const <WorkspaceSummary>[],
             byProject[right] ?? const <WorkspaceSummary>[],
             prefs,
-            activity,
-            attentionOf,
+            directActivityByWorkspaceId,
           ),
         );
     for (final projectId in orderedProjectIds) {
@@ -242,8 +259,7 @@ int _compareWorkspaces(
   WorkspaceSummary left,
   WorkspaceSummary right,
   MobileViewPrefs prefs,
-  Map<String, DateTime> activity,
-  MobileWorkspaceAttention Function(WorkspaceSummary) attentionOf,
+  Map<String, MobileAgentActivityRank?> activityByWorkspaceId,
 ) {
   if (prefs.workspaceSort == MobileWorkbenchSortBy.name &&
       left.isMain != right.isMain) {
@@ -263,11 +279,9 @@ int _compareWorkspaces(
       left.updatedAt,
     ),
     MobileWorkbenchSortBy.activity => compareMobileAgentActivity(
-      leftAttention: attentionOf(left),
-      leftFallback: activity[left.id] ?? left.updatedAt ?? DateTime(0),
+      leftActivity: activityByWorkspaceId[left.id],
       leftName: left.name,
-      rightAttention: attentionOf(right),
-      rightFallback: activity[right.id] ?? right.updatedAt ?? DateTime(0),
+      rightActivity: activityByWorkspaceId[right.id],
       rightName: right.name,
     ),
   };
@@ -280,8 +294,7 @@ int _compareProjects(
   List<WorkspaceSummary> leftWorkspaces,
   List<WorkspaceSummary> rightWorkspaces,
   MobileViewPrefs prefs,
-  Map<String, DateTime> activity,
-  MobileWorkspaceAttention Function(WorkspaceSummary) attentionOf,
+  Map<String, MobileAgentActivityRank?> activityByWorkspaceId,
 ) {
   final order = switch (prefs.projectSort) {
     MobileWorkbenchSortBy.name => (left?.name ?? '').toLowerCase().compareTo(
@@ -296,8 +309,7 @@ int _compareProjects(
       leftWorkspaces,
       right,
       rightWorkspaces,
-      activity,
-      attentionOf,
+      activityByWorkspaceId,
     ),
   };
   return order != 0 ? order : (left?.name ?? '').compareTo(right?.name ?? '');
@@ -308,51 +320,33 @@ int _compareProjectActivity(
   List<WorkspaceSummary> leftWorkspaces,
   ProjectSummary? right,
   List<WorkspaceSummary> rightWorkspaces,
-  Map<String, DateTime> activity,
-  MobileWorkspaceAttention Function(WorkspaceSummary) attentionOf,
+  Map<String, MobileAgentActivityRank?> activityByWorkspaceId,
 ) {
-  final leftRank = _projectActivityRank(
-    left,
-    leftWorkspaces,
-    activity,
-    attentionOf,
-  );
+  final leftRank = _projectActivityRank(leftWorkspaces, activityByWorkspaceId);
   final rightRank = _projectActivityRank(
-    right,
     rightWorkspaces,
-    activity,
-    attentionOf,
+    activityByWorkspaceId,
   );
-  final byClass = leftRank.attention.attentionClass.index.compareTo(
-    rightRank.attention.attentionClass.index,
+  return compareMobileAgentActivity(
+    leftActivity: leftRank,
+    leftName: left?.name ?? '',
+    rightActivity: rightRank,
+    rightName: right?.name ?? '',
   );
-  if (byClass != 0) return byClass;
-  return rightRank.at.compareTo(leftRank.at);
 }
 
-({MobileWorkspaceAttention attention, DateTime at}) _projectActivityRank(
-  ProjectSummary? project,
+MobileAgentActivityRank? _projectActivityRank(
   List<WorkspaceSummary> workspaces,
-  Map<String, DateTime> activity,
-  MobileWorkspaceAttention Function(WorkspaceSummary) attentionOf,
+  Map<String, MobileAgentActivityRank?> activityByWorkspaceId,
 ) {
-  var best = MobileWorkspaceAttention.idle;
-  var bestAt = project?.updatedAt ?? DateTime(0);
+  MobileAgentActivityRank? best;
   for (final workspace in workspaces) {
-    final candidate = attentionOf(workspace);
-    final candidateAt =
-        candidate.at ??
-        activity[workspace.id] ??
-        workspace.updatedAt ??
-        DateTime(0);
-    if (candidate.attentionClass.index < best.attentionClass.index ||
-        (candidate.attentionClass == best.attentionClass &&
-            candidateAt.isAfter(bestAt))) {
-      best = candidate;
-      bestAt = candidateAt;
-    }
+    best = bestMobileAgentActivityRank(
+      best,
+      activityByWorkspaceId[workspace.id],
+    );
   }
-  return (attention: best, at: bestAt);
+  return best;
 }
 
 int _compareDates(DateTime? left, DateTime? right) {

--- a/mobile/lib/src/features/workbench/presentation/runtime_workspaces_screen.dart
+++ b/mobile/lib/src/features/workbench/presentation/runtime_workspaces_screen.dart
@@ -241,6 +241,7 @@ class _WorkspaceListBody extends ConsumerWidget {
       prefs: prefs,
       activity: data.activity,
       agentPresence: data.agentPresence,
+      terminalTabCountByWorkspaceId: data.terminalTabCountByWorkspaceId,
       searchQuery: ref.watch(workspaceSearchControllerProvider(hostId)),
     );
     final prefsController = ref.read(

--- a/mobile/test/mobile_workspace_rows_test.dart
+++ b/mobile/test/mobile_workspace_rows_test.dart
@@ -1,3 +1,4 @@
+import 'package:alera_mobile/src/features/runtime/domain/project_summary.dart';
 import 'package:alera_mobile/src/features/runtime/domain/workspace_sidebar_snapshot.dart';
 import 'package:alera_mobile/src/features/runtime/domain/workspace_summary.dart';
 import 'package:alera_mobile/src/features/workbench/application/mobile_workspace_rows.dart';
@@ -5,14 +6,36 @@ import 'package:alera_mobile/src/features/workbench/domain/mobile_view_prefs.dar
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  test('Activity sort matches desktop urgency before shared recency', () {
+  test('Activity sort ranks terminals first and inactive names last', () {
     final now = DateTime.utc(2026, 7, 18, 12);
     final rows = buildMobileWorkspaceRows(
       workspaces: <WorkspaceSummary>[
-        _workspace('idle', now.subtract(const Duration(minutes: 1))),
-        _workspace('working', now.subtract(const Duration(minutes: 4))),
-        _workspace('done', now.subtract(const Duration(minutes: 3))),
-        _workspace('waiting', now.subtract(const Duration(minutes: 2))),
+        _workspace('inactive-zebra', now, name: 'zebra'),
+        _workspace(
+          'idle-terminal',
+          now.subtract(const Duration(minutes: 1)),
+          name: 'idle',
+        ),
+        _workspace(
+          'working',
+          now.subtract(const Duration(minutes: 4)),
+          name: 'working',
+        ),
+        _workspace(
+          'done',
+          now.subtract(const Duration(minutes: 3)),
+          name: 'done',
+        ),
+        _workspace(
+          'waiting',
+          now.subtract(const Duration(minutes: 2)),
+          name: 'waiting',
+        ),
+        _workspace(
+          'inactive-alpha',
+          now.subtract(const Duration(days: 1)),
+          name: 'alpha',
+        ),
       ],
       projects: const [],
       prefs: const MobileViewPrefs(
@@ -20,7 +43,8 @@ void main() {
         workspaceSort: MobileWorkbenchSortBy.activity,
       ),
       activity: <String, DateTime>{
-        'idle': now,
+        'inactive-zebra': now,
+        'idle-terminal': now.subtract(const Duration(minutes: 1)),
         'working': now.subtract(const Duration(minutes: 4)),
         'done': now.subtract(const Duration(minutes: 3)),
         'waiting': now.subtract(const Duration(minutes: 2)),
@@ -38,13 +62,21 @@ void main() {
           now.subtract(const Duration(minutes: 2)),
         ),
       ],
+      terminalTabCountByWorkspaceId: const <String, int>{'idle-terminal': 1},
       now: now,
     );
 
-    expect(_workspaceIds(rows), <String>['waiting', 'done', 'working', 'idle']);
+    expect(_workspaceIds(rows), <String>[
+      'waiting',
+      'done',
+      'working',
+      'idle-terminal',
+      'inactive-alpha',
+      'inactive-zebra',
+    ]);
   });
 
-  test('Stale presence falls back to shared activity', () {
+  test('Stale presence keeps its terminal ahead of inactive workspaces', () {
     final now = DateTime.utc(2026, 7, 18, 12);
     final rows = buildMobileWorkspaceRows(
       workspaces: <WorkspaceSummary>[
@@ -63,16 +95,111 @@ void main() {
       now: now,
     );
 
-    expect(_workspaceIds(rows), <String>['recent', 'stale']);
+    expect(_workspaceIds(rows), <String>['stale', 'recent']);
+  });
+
+  test('An open terminal is active without live agent presence', () {
+    final now = DateTime.utc(2026, 7, 18, 12);
+    final rows = buildMobileWorkspaceRows(
+      workspaces: <WorkspaceSummary>[
+        _workspace('inactive', now, name: 'alpha'),
+        _workspace(
+          'terminal',
+          now.subtract(const Duration(days: 1)),
+          name: 'zebra',
+        ),
+      ],
+      projects: const [],
+      prefs: const MobileViewPrefs(
+        groupBy: MobileWorkspaceGroupBy.none,
+        workspaceSort: MobileWorkbenchSortBy.activity,
+      ),
+      terminalTabCountByWorkspaceId: const <String, int>{'terminal': 1},
+      now: now,
+    );
+
+    expect(_workspaceIds(rows), <String>['terminal', 'inactive']);
+  });
+
+  test('Inactive projects sort alphabetically after active projects', () {
+    final now = DateTime.utc(2026, 7, 18, 12);
+    final rows = buildMobileWorkspaceRows(
+      workspaces: <WorkspaceSummary>[
+        _workspace('active', now, projectId: 'p-zeta'),
+        _workspace('inactive-zeta', now, projectId: 'p-charlie'),
+        _workspace('inactive-alpha', now, projectId: 'p-alpha'),
+      ],
+      projects: <ProjectSummary>[
+        _project('p-charlie', 'Charlie', now),
+        _project('p-zeta', 'Zeta', now.subtract(const Duration(days: 1))),
+        _project('p-alpha', 'Alpha', now.subtract(const Duration(days: 2))),
+      ],
+      prefs: const MobileViewPrefs(projectSort: MobileWorkbenchSortBy.activity),
+      terminalTabCountByWorkspaceId: const <String, int>{'active': 1},
+      now: now,
+    );
+
+    expect(
+      rows
+          .whereType<MobileProjectHeaderRow>()
+          .map((row) => row.projectId)
+          .toList(),
+      <String>['p-zeta', 'p-alpha', 'p-charlie'],
+    );
+  });
+
+  test('An active descendant promotes its workspace tree', () {
+    final now = DateTime.utc(2026, 7, 18, 12);
+    final rows = buildMobileWorkspaceRows(
+      workspaces: <WorkspaceSummary>[
+        _workspace('inactive-root', now, name: 'alpha-root'),
+        _workspace('active-root', now, name: 'zeta-root'),
+        _workspace(
+          'active-child',
+          now,
+          name: 'active-child',
+          parentWorkspaceId: 'active-root',
+        ),
+      ],
+      projects: const [],
+      prefs: const MobileViewPrefs(
+        groupBy: MobileWorkspaceGroupBy.none,
+        workspaceSort: MobileWorkbenchSortBy.activity,
+      ),
+      terminalTabCountByWorkspaceId: const <String, int>{'active-child': 1},
+      now: now,
+    );
+
+    expect(_workspaceIds(rows), <String>[
+      'active-root',
+      'active-child',
+      'inactive-root',
+    ]);
   });
 }
 
-WorkspaceSummary _workspace(String id, DateTime updatedAt) {
+WorkspaceSummary _workspace(
+  String id,
+  DateTime updatedAt, {
+  String? name,
+  String projectId = 'project',
+  String? parentWorkspaceId,
+}) {
   return WorkspaceSummary(
     id: id,
-    projectId: 'project',
-    name: id,
+    projectId: projectId,
+    name: name ?? id,
     path: '/tmp/$id',
+    parentWorkspaceId: parentWorkspaceId,
+    updatedAt: updatedAt,
+  );
+}
+
+ProjectSummary _project(String id, String name, DateTime updatedAt) {
+  return ProjectSummary(
+    id: id,
+    name: name,
+    repoPath: '/tmp/$id',
     updatedAt: updatedAt,
   );
 }


### PR DESCRIPTION
## Summary

- rank mobile workspaces with terminal activity before fully inactive workspaces
- sort fully inactive workspaces and projects alphabetically
- promote workspace trees when a descendant has agent activity
- use terminal tab counts so an open terminal remains active without live agent presence

## Root cause

Mobile treated every workspace as an idle activity entry and fell back to timestamps, so fully inactive rows were ordered by recency instead of by name.

## Validation

- `flutter analyze` from `mobile/`
- `flutter test` from `mobile/` (178 tests passed)