### PR TITLE
feat: add mobile update link actions

### DIFF
--- a/mobile/lib/src/features/updater/presentation/mobile_update_prompt.dart
+++ b/mobile/lib/src/features/updater/presentation/mobile_update_prompt.dart
@@ -1,9 +1,13 @@
-import 'package:alera_mobile/src/design_system/layout/alera_confirm_dialog.dart';
+import 'package:alera_mobile/src/app/theme/alera_tokens.dart';
+import 'package:alera_mobile/src/design_system/layout/alera_dialog.dart';
 import 'package:alera_mobile/src/features/updater/application/mobile_update_providers.dart';
 import 'package:alera_mobile/src/features/updater/domain/mobile_release.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:url_launcher/url_launcher.dart';
+
+enum _MobileUpdateAction { copyLink, download }
 
 /// Offers the newest Android build once per launch.
 ///
@@ -15,13 +19,17 @@ class MobileUpdatePrompt extends ConsumerStatefulWidget {
   const MobileUpdatePrompt({
     super.key,
     required this.child,
-    this.openUrl = _launchExternally,
+    this.copyLink = _copyToClipboard,
+    this.openUrl = launchUrl,
   });
 
   final Widget child;
 
+  /// Injected so tests do not reach the platform clipboard.
+  final Future<void> Function(String link) copyLink;
+
   /// Injected so tests do not reach the platform's URL launcher.
-  final Future<bool> Function(Uri url) openUrl;
+  final Future<bool> Function(Uri url, {LaunchMode mode}) openUrl;
 
   @override
   ConsumerState<MobileUpdatePrompt> createState() => _MobileUpdatePromptState();
@@ -64,31 +72,102 @@ class _MobileUpdatePromptState extends ConsumerState<MobileUpdatePrompt> {
   }
 
   Future<void> _ask(MobileRelease release) async {
-    final accepted = await showDialog<bool>(
+    final action = await showDialog<_MobileUpdateAction>(
       context: context,
-      builder: (context) => AleraConfirmDialog(
-        title: 'Update Available',
-        message:
-            'Alera ${release.version} is available. '
-            'Downloading opens the APK in your browser, and Android asks to '
-            'install it.',
-        confirmLabel: 'Download',
-        cancelLabel: 'Later',
-      ),
+      builder: (context) =>
+          _MobileUpdateDialog(version: release.version.toString()),
     );
-    if (accepted != true || !mounted) {
+    if (!mounted) {
       return;
     }
-    final opened = await widget.openUrl(release.apkUrl);
-    if (opened || !mounted) {
-      return;
+    switch (action) {
+      case _MobileUpdateAction.copyLink:
+        await widget.copyLink(release.apkUrl.toString());
+        if (!mounted) {
+          return;
+        }
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(const SnackBar(content: Text('Download Link Copied.')));
+        return;
+      case _MobileUpdateAction.download:
+        final opened = await widget.openUrl(
+          release.apkUrl,
+          mode: LaunchMode.externalApplication,
+        );
+        if (opened || !mounted) {
+          return;
+        }
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Could Not Open The Download.')),
+        );
+        return;
+      case null:
+        return;
     }
-    ScaffoldMessenger.of(context).showSnackBar(
-      const SnackBar(content: Text('Could not open the download.')),
+  }
+}
+
+class _MobileUpdateDialog extends StatelessWidget {
+  const _MobileUpdateDialog({required this.version});
+
+  final String version;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return AleraDialog(
+      maxWidth: 420,
+      child: Padding(
+        padding: const EdgeInsets.all(AleraTokens.space20),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Text('Update Available', style: theme.textTheme.titleMedium),
+            const SizedBox(height: AleraTokens.space12),
+            Text(
+              'Alera $version is available. Downloading opens the APK in your '
+              'browser, and Android asks to install it.',
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: AleraTokens.foregroundMuted,
+              ),
+            ),
+            const SizedBox(height: AleraTokens.space20),
+            SizedBox(
+              width: double.infinity,
+              child: OutlinedButton(
+                onPressed: () =>
+                    Navigator.of(context).pop(_MobileUpdateAction.copyLink),
+                child: const Text('Copy Link'),
+              ),
+            ),
+            const SizedBox(height: AleraTokens.space8),
+            Row(
+              children: <Widget>[
+                Expanded(
+                  child: TextButton(
+                    onPressed: () => Navigator.of(context).pop(),
+                    child: const Text('Later'),
+                  ),
+                ),
+                const SizedBox(width: AleraTokens.space8),
+                Expanded(
+                  child: FilledButton(
+                    onPressed: () =>
+                        Navigator.of(context).pop(_MobileUpdateAction.download),
+                    child: const Text('Download'),
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
     );
   }
 }
 
-Future<bool> _launchExternally(Uri url) {
-  return launchUrl(url, mode: LaunchMode.externalApplication);
+Future<void> _copyToClipboard(String link) {
+  return Clipboard.setData(ClipboardData(text: link));
 }

--- a/mobile/test/mobile_update_prompt_test.dart
+++ b/mobile/test/mobile_update_prompt_test.dart
@@ -4,6 +4,7 @@ import 'package:alera_mobile/src/features/updater/presentation/mobile_update_pro
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 final MobileRelease _release = MobileRelease(
   version: const MobileVersion(0, 10, 0),
@@ -17,7 +18,9 @@ final MobileRelease _release = MobileRelease(
 Future<void> _pump(
   WidgetTester tester, {
   required MobileRelease? release,
-  required List<Uri> opened,
+  required List<String> copied,
+  required List<(Uri, LaunchMode)> opened,
+  bool openResult = true,
 }) {
   return tester.pumpWidget(
     ProviderScope(
@@ -26,9 +29,10 @@ Future<void> _pump(
       ],
       child: MaterialApp(
         home: MobileUpdatePrompt(
-          openUrl: (url) async {
-            opened.add(url);
-            return true;
+          copyLink: (link) async => copied.add(link),
+          openUrl: (url, {mode = LaunchMode.platformDefault}) async {
+            opened.add((url, mode));
+            return openResult;
           },
           child: const Scaffold(body: Text('Home')),
         ),
@@ -41,27 +45,48 @@ void main() {
   testWidgets('offers the universal apk when a newer release exists', (
     tester,
   ) async {
-    final opened = <Uri>[];
-    await _pump(tester, release: _release, opened: opened);
+    final copied = <String>[];
+    final opened = <(Uri, LaunchMode)>[];
+    await _pump(tester, release: _release, copied: copied, opened: opened);
     await tester.pumpAndSettle();
 
     expect(find.text('Update Available'), findsOneWidget);
     expect(find.textContaining('0.10.0'), findsOneWidget);
+    expect(find.text('Copy Link'), findsOneWidget);
 
     await tester.tap(find.text('Download'));
     await tester.pumpAndSettle();
 
-    expect(opened, <Uri>[_release.apkUrl]);
+    expect(copied, isEmpty);
+    expect(opened, <(Uri, LaunchMode)>[
+      (_release.apkUrl, LaunchMode.externalApplication),
+    ]);
+  });
+
+  testWidgets('copies the apk link without opening it', (tester) async {
+    final copied = <String>[];
+    final opened = <(Uri, LaunchMode)>[];
+    await _pump(tester, release: _release, copied: copied, opened: opened);
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Copy Link'));
+    await tester.pumpAndSettle();
+
+    expect(copied, <String>[_release.apkUrl.toString()]);
+    expect(opened, isEmpty);
+    expect(find.text('Download Link Copied.'), findsOneWidget);
   });
 
   testWidgets('declining opens nothing and does not ask again', (tester) async {
-    final opened = <Uri>[];
-    await _pump(tester, release: _release, opened: opened);
+    final copied = <String>[];
+    final opened = <(Uri, LaunchMode)>[];
+    await _pump(tester, release: _release, copied: copied, opened: opened);
     await tester.pumpAndSettle();
 
     await tester.tap(find.text('Later'));
     await tester.pumpAndSettle();
 
+    expect(copied, isEmpty);
     expect(opened, isEmpty);
     expect(find.text('Update Available'), findsNothing);
 
@@ -72,11 +97,13 @@ void main() {
   });
 
   testWidgets('stays silent when the app is current', (tester) async {
-    final opened = <Uri>[];
-    await _pump(tester, release: null, opened: opened);
+    final copied = <String>[];
+    final opened = <(Uri, LaunchMode)>[];
+    await _pump(tester, release: null, copied: copied, opened: opened);
     await tester.pumpAndSettle();
 
     expect(find.text('Update Available'), findsNothing);
+    expect(copied, isEmpty);
     expect(opened, isEmpty);
   });
 }


### PR DESCRIPTION
## Summary
- add a Copy Link action to the mobile update prompt
- force APK downloads to use the external browser
- cover clipboard and external launch behavior with widget tests

## Validation
- `dart format --set-exit-if-changed lib test`
- `flutter analyze`
- `flutter test` (183 tests)