### PR TITLE
feat: improve prompt workspace creation

### DIFF
--- a/lib/src/features/workbench/application/workbench_controller.dart
+++ b/lib/src/features/workbench/application/workbench_controller.dart
@@ -38,6 +38,7 @@ part 'workbench_controller_internals.dart';
 part 'workbench_controller_browser.dart';
 part 'workbench_controller_projects.dart';
 part 'workbench_controller_tab_opening.dart';
+part 'workbench_controller_workspace_creation.dart';
 part 'workbench_controller_tabs.dart';
 part 'workbench_controller_view_prefs.dart';
 part 'workbench_controller_sync.dart';
@@ -47,10 +48,11 @@ class WorkbenchController extends _$WorkbenchController
     with
         _WorkbenchControllerInternals,
         _WorkbenchControllerBrowser,
-        // Opening tabs comes first: creating a workspace opens its "Setup"
-        // terminal, so the projects mixin builds on this one.
         _WorkbenchControllerTabOpening,
         _WorkbenchControllerProjects,
+        // Creation builds on project selection and tab opening so the prompt
+        // flow can synchronize its agent before appending Setup.
+        _WorkbenchControllerWorkspaceCreation,
         _WorkbenchControllerTabs,
         _WorkbenchControllerViewPrefs,
         _WorkbenchControllerSync {

--- a/lib/src/features/workbench/application/workbench_controller_projects.dart
+++ b/lib/src/features/workbench/application/workbench_controller_projects.dart
@@ -125,66 +125,6 @@ mixin _WorkbenchControllerProjects
     }
   }
 
-  Future<WorkspaceCreationResult> createWorkspace({
-    required Project project,
-    required String sourceBranch,
-    required String newBranchName,
-    bool reuseExistingBranch = false,
-    String? name,
-    String? parentWorkspaceId,
-  }) async {
-    try {
-      final result = await _workspaceService.createLinkedWorkspace(
-        project: project,
-        sourceBranch: sourceBranch,
-        newBranchName: newBranchName,
-        reuseExistingBranch: reuseExistingBranch,
-        name: name,
-      );
-      _reconcileCreatedWorkspace(project, result.workspace);
-      await selectWorkspace(project: project, workspace: result.workspace);
-      await _openDeferredSetupTab(result);
-      final parentId = parentWorkspaceId?.trim();
-      if (parentId != null && parentId.isNotEmpty) {
-        try {
-          await _workspaceGraphRepository.linkWorkspaces(
-            parentWorkspaceId: parentId,
-            childWorkspaceId: result.workspace.id,
-          );
-        } catch (error) {
-          // The workspace itself was created successfully, so the failure is
-          // reported as a warning on the result instead of failing the flow.
-          state = state.copyWith(error: null);
-          return WorkspaceCreationResult(
-            workspace: result.workspace,
-            setupReport: result.setupReport,
-            parentLinkError: error.toString(),
-          );
-        }
-      }
-      state = state.copyWith(error: null);
-      return result;
-    } catch (error) {
-      state = state.copyWith(error: error.toString());
-      rethrow;
-    }
-  }
-
-  void _reconcileCreatedWorkspace(Project project, Workspace workspace) {
-    final workspaces = List<Workspace>.from(state.workspacesFor(project.id));
-    final index = workspaces.indexWhere((entry) => entry.id == workspace.id);
-    if (index == -1) {
-      workspaces.add(workspace);
-    } else {
-      workspaces[index] = workspace;
-    }
-    state = state.copyWith(
-      workspacesByProject: Map<String, List<Workspace>>.from(
-        state.workspacesByProject,
-      )..[project.id] = workspaces,
-    );
-  }
-
   Future<void> deleteWorkspace({
     required Project project,
     required Workspace workspace,
@@ -439,6 +379,18 @@ mixin _WorkbenchControllerProjects
   Future<void> selectWorkspace({
     required Project project,
     required Workspace workspace,
+  }) {
+    return _selectWorkspace(
+      project: project,
+      workspace: workspace,
+      ensureInitialTerminal: true,
+    );
+  }
+
+  Future<void> _selectWorkspace({
+    required Project project,
+    required Workspace workspace,
+    required bool ensureInitialTerminal,
   }) async {
     final prefs = state.viewPrefs;
     final nextPrefs = _viewPrefsForProjectContext(
@@ -455,7 +407,9 @@ mixin _WorkbenchControllerProjects
     if (!identical(nextPrefs, prefs)) {
       unawaited(_persistViewPrefs());
     }
-    await _workspaceTabService.ensureInitialTerminalTab(workspace.id);
+    if (ensureInitialTerminal) {
+      await _workspaceTabService.ensureInitialTerminalTab(workspace.id);
+    }
     final tabs = await _workspaceTabService.listTabs(workspace.id);
     _setTabsForWorkspace(workspace.id, tabs);
     final layout = await _ensureWorkbenchLayout(workspace.id, tabs);

--- a/lib/src/features/workbench/application/workbench_controller_workspace_creation.dart
+++ b/lib/src/features/workbench/application/workbench_controller_workspace_creation.dart
@@ -1,0 +1,153 @@
+part of 'workbench_controller.dart';
+
+/// Creates workspaces and initializes their first tabs.
+///
+/// Kept separate from project lifecycle actions because the From Prompt flow
+/// deliberately persists its agent terminal before the Setup terminal.
+mixin _WorkbenchControllerWorkspaceCreation
+    on
+        _$WorkbenchController,
+        _WorkbenchControllerInternals,
+        _WorkbenchControllerTabOpening,
+        _WorkbenchControllerProjects {
+  Future<WorkspaceCreationResult> createWorkspace({
+    required Project project,
+    required String sourceBranch,
+    required String newBranchName,
+    bool reuseExistingBranch = false,
+    String? name,
+    String? parentWorkspaceId,
+  }) {
+    return _createWorkspace(
+      project: project,
+      sourceBranch: sourceBranch,
+      newBranchName: newBranchName,
+      reuseExistingBranch: reuseExistingBranch,
+      name: name,
+      parentWorkspaceId: parentWorkspaceId,
+      initializeTabs: true,
+    );
+  }
+
+  /// Creates the workspace record for the From Prompt flow without opening a
+  /// blank terminal or the deferred Setup tab. The agent profile launch creates
+  /// its terminal first, then [completePromptWorkspaceCreation] synchronizes
+  /// that tab and appends Setup.
+  Future<WorkspaceCreationResult> createWorkspaceForPrompt({
+    required Project project,
+    required String sourceBranch,
+    required String newBranchName,
+    required String name,
+    String? parentWorkspaceId,
+  }) {
+    return _createWorkspace(
+      project: project,
+      sourceBranch: sourceBranch,
+      newBranchName: newBranchName,
+      reuseExistingBranch: false,
+      name: name,
+      parentWorkspaceId: parentWorkspaceId,
+      initializeTabs: false,
+    );
+  }
+
+  Future<WorkspaceCreationResult> _createWorkspace({
+    required Project project,
+    required String sourceBranch,
+    required String newBranchName,
+    required bool reuseExistingBranch,
+    required bool initializeTabs,
+    String? name,
+    String? parentWorkspaceId,
+  }) async {
+    try {
+      final result = await _workspaceService.createLinkedWorkspace(
+        project: project,
+        sourceBranch: sourceBranch,
+        newBranchName: newBranchName,
+        reuseExistingBranch: reuseExistingBranch,
+        name: name,
+      );
+      _reconcileCreatedWorkspace(project, result.workspace);
+      if (initializeTabs) {
+        await selectWorkspace(project: project, workspace: result.workspace);
+        await _openDeferredSetupTab(result);
+      }
+      final parentId = parentWorkspaceId?.trim();
+      if (parentId != null && parentId.isNotEmpty) {
+        try {
+          await _workspaceGraphRepository.linkWorkspaces(
+            parentWorkspaceId: parentId,
+            childWorkspaceId: result.workspace.id,
+          );
+        } catch (error) {
+          // The workspace itself was created successfully, so the failure is
+          // reported as a warning on the result instead of failing the flow.
+          state = state.copyWith(error: null);
+          return WorkspaceCreationResult(
+            workspace: result.workspace,
+            setupReport: result.setupReport,
+            parentLinkError: error.toString(),
+            deferredSetupCommand: result.deferredSetupCommand,
+          );
+        }
+      }
+      state = state.copyWith(error: null);
+      return result;
+    } catch (error) {
+      state = state.copyWith(error: error.toString());
+      rethrow;
+    }
+  }
+
+  /// Activates a workspace created from a prompt after the host has persisted
+  /// the agent tab, then appends Setup and restores focus to the agent.
+  Future<void> completePromptWorkspaceCreation({
+    required WorkspaceCreationResult creation,
+    String? agentTabId,
+  }) async {
+    final workspace = creation.workspace;
+    final project = state.projects
+        .where((candidate) => candidate.id == workspace.projectId)
+        .firstOrNull;
+    if (project == null) {
+      throw StateError('Workspace Project Not Found: ${workspace.projectId}');
+    }
+    final setupCommand = creation.deferredSetupCommand?.trim();
+    final expectsPromptTab =
+        agentTabId?.trim().isNotEmpty == true ||
+        (setupCommand != null && setupCommand.isNotEmpty);
+    await _selectWorkspace(
+      project: project,
+      workspace: workspace,
+      ensureInitialTerminal: !expectsPromptTab,
+    );
+    await _openDeferredSetupTab(creation);
+    final resolvedAgentTabId = agentTabId?.trim();
+    if (resolvedAgentTabId != null && resolvedAgentTabId.isNotEmpty) {
+      final groupId = state
+          .layoutFor(workspace.id)
+          ?.groupIdForTab(resolvedAgentTabId);
+      _setActiveTabInternal(
+        workspaceId: workspace.id,
+        tabId: resolvedAgentTabId,
+        groupId: groupId,
+      );
+    }
+  }
+
+  void _reconcileCreatedWorkspace(Project project, Workspace workspace) {
+    final workspaces = List<Workspace>.from(state.workspacesFor(project.id));
+    final index = workspaces.indexWhere((entry) => entry.id == workspace.id);
+    if (index == -1) {
+      workspaces.add(workspace);
+    } else {
+      workspaces[index] = workspace;
+    }
+    state = state.copyWith(
+      workspacesByProject: Map<String, List<Workspace>>.from(
+        state.workspacesByProject,
+      )..[project.id] = workspaces,
+    );
+  }
+}

--- a/lib/src/features/workbench/presentation/prompt_workspace_dialog.dart
+++ b/lib/src/features/workbench/presentation/prompt_workspace_dialog.dart
@@ -8,6 +8,7 @@ import 'package:alera/src/design_system/icons/alera_icons.dart';
 import 'package:alera/src/design_system/layout/alera_dialog.dart';
 import 'package:alera/src/features/agent_profiles/domain/agent_profile.dart';
 import 'package:alera/src/features/projects/domain/project.dart';
+import 'package:alera/src/features/workbench/domain/workspace.dart';
 import 'package:alera/src/features/workbench/domain/workspace_creation_result.dart';
 import 'package:alera/src/features/workbench/infra/prompt_workspace_runtime_client.dart';
 import 'package:flutter/material.dart';
@@ -37,6 +38,7 @@ class PromptWorkspaceDialog extends StatefulWidget {
     required this.loadBranches,
     required this.checkBranchExists,
     required this.workspaceBranches,
+    required this.parentWorkspaces,
     required this.generateIdentity,
     required this.cancelGeneration,
     required this.createWorkspace,
@@ -51,6 +53,7 @@ class PromptWorkspaceDialog extends StatefulWidget {
   final Future<bool> Function(Project project, String branchName)
   checkBranchExists;
   final Set<String> Function(Project project) workspaceBranches;
+  final List<Workspace> parentWorkspaces;
   final Future<GeneratedWorkspaceIdentity> Function({
     required String operationId,
     required String projectId,
@@ -63,6 +66,7 @@ class PromptWorkspaceDialog extends StatefulWidget {
     required String sourceBranch,
     required String newBranchName,
     required String name,
+    String? parentWorkspaceId,
   })
   createWorkspace;
   final Future<AgentProfileLaunchResult> Function({
@@ -83,6 +87,7 @@ class _PromptWorkspaceDialogState extends State<PromptWorkspaceDialog> {
   AgentProfile? _profile;
   List<String> _branches = const <String>[];
   String? _sourceBranch;
+  String? _selectedParentWorkspaceId;
   bool _loadingBranches = false;
   bool _working = false;
   String? _phase;
@@ -94,6 +99,7 @@ class _PromptWorkspaceDialogState extends State<PromptWorkspaceDialog> {
   void initState() {
     super.initState();
     _project = _initialProject();
+    _selectedParentWorkspaceId = _defaultParentWorkspaceId(_project);
     _profile = widget.agentProfiles.firstOrNull;
     final project = _project;
     if (project != null) {
@@ -162,6 +168,51 @@ class _PromptWorkspaceDialogState extends State<PromptWorkspaceDialog> {
     return branches.firstOrNull;
   }
 
+  List<Workspace> get _parentWorkspaces {
+    return <Workspace>[
+      for (final workspace in widget.parentWorkspaces)
+        if (workspace.isActive) workspace,
+    ];
+  }
+
+  String? _defaultParentWorkspaceId(Project? project) {
+    if (project == null) {
+      return null;
+    }
+    Workspace? firstProjectWorkspace;
+    for (final workspace in _parentWorkspaces) {
+      if (workspace.projectId != project.id) {
+        continue;
+      }
+      firstProjectWorkspace ??= workspace;
+      if (workspace.isMain) {
+        return workspace.id;
+      }
+    }
+    return firstProjectWorkspace?.id;
+  }
+
+  String _parentWorkspaceLabel(Workspace workspace) {
+    Project? project;
+    for (final candidate in widget.projects) {
+      if (candidate.id == workspace.projectId) {
+        project = candidate;
+        break;
+      }
+    }
+    final branch = workspace.branch?.trim();
+    final suffix = branch == null || branch.isEmpty ? '' : ' - $branch';
+    return '${project?.name ?? workspace.projectId} / ${workspace.name}$suffix';
+  }
+
+  void _selectProject(Project project) {
+    _update(() {
+      _project = project;
+      _selectedParentWorkspaceId = _defaultParentWorkspaceId(project);
+    });
+    unawaited(_loadBranches(project));
+  }
+
   Future<void> _submit() async {
     final project = _project;
     final profile = _profile;
@@ -223,6 +274,7 @@ class _PromptWorkspaceDialogState extends State<PromptWorkspaceDialog> {
             sourceBranch: sourceBranch,
             newBranchName: identity.branchName,
             name: identity.workspaceName,
+            parentWorkspaceId: _selectedParentWorkspaceId,
           );
           break;
         } catch (error) {

--- a/lib/src/features/workbench/presentation/prompt_workspace_dialog_form.dart
+++ b/lib/src/features/workbench/presentation/prompt_workspace_dialog_form.dart
@@ -31,10 +31,7 @@ extension _PromptWorkspaceDialogForm on _PromptWorkspaceDialogState {
               ],
               enabled: !_working && created == null,
               filterable: true,
-              onChanged: (project) {
-                _update(() => _project = project);
-                unawaited(_loadBranches(project));
-              },
+              onChanged: _selectProject,
             ),
             const SizedBox(height: AleraTokens.space12),
             AleraDropdownField<String>(
@@ -48,6 +45,27 @@ extension _PromptWorkspaceDialogForm on _PromptWorkspaceDialogState {
               enabled: !_working && !_loadingBranches && created == null,
               filterable: true,
               onChanged: (branch) => _update(() => _sourceBranch = branch),
+            ),
+            const SizedBox(height: AleraTokens.space12),
+            AleraDropdownField<String?>(
+              labelText: 'Parent Workspace',
+              value: _selectedParentWorkspaceId,
+              entries: <AleraDropdownFieldEntry<String?>>[
+                const AleraDropdownFieldEntry<String?>(
+                  value: null,
+                  label: 'No Parent',
+                ),
+                for (final workspace in _parentWorkspaces)
+                  AleraDropdownFieldEntry<String?>(
+                    value: workspace.id,
+                    label: _parentWorkspaceLabel(workspace),
+                  ),
+              ],
+              enabled: !_working && created == null,
+              filterable: true,
+              filterHintText: 'Search Workspaces',
+              onChanged: (workspaceId) =>
+                  _update(() => _selectedParentWorkspaceId = workspaceId),
             ),
             const SizedBox(height: AleraTokens.space12),
             AleraDropdownField<AgentProfile>(

--- a/lib/src/features/workbench/presentation/workbench_dialog_launchers.dart
+++ b/lib/src/features/workbench/presentation/workbench_dialog_launchers.dart
@@ -10,6 +10,7 @@ import 'package:alera/src/features/agent_profiles/domain/agent_profile.dart';
 import 'package:alera/src/features/projects/domain/project.dart';
 import 'package:alera/src/features/projects/presentation/add_project_dialog.dart';
 import 'package:alera/src/features/settings/presentation/settings_dialog.dart';
+import 'package:alera/src/features/workbench/domain/workspace.dart';
 import 'package:alera/src/features/workbench/domain/workspace_creation_result.dart';
 import 'package:alera/src/features/workbench/presentation/create_workspace_dialog.dart';
 import 'package:alera/src/features/workbench/infra/prompt_workspace_runtime_client.dart';
@@ -252,6 +253,9 @@ Future<void> showCreateWorkspaceFlow(
             .where((branch) => branch.isNotEmpty)
             .toSet();
       },
+      parentWorkspaces: <Workspace>[
+        for (final candidate in parentCandidates) candidate.workspace,
+      ],
       generateIdentity: runtime.generateIdentity,
       cancelGeneration: runtime.cancel,
       createWorkspace:
@@ -260,12 +264,14 @@ Future<void> showCreateWorkspaceFlow(
             required sourceBranch,
             required newBranchName,
             required name,
+            parentWorkspaceId,
           }) {
-            return controller.createWorkspace(
+            return controller.createWorkspaceForPrompt(
               project: project,
               sourceBranch: sourceBranch,
               newBranchName: newBranchName,
               name: name,
+              parentWorkspaceId: parentWorkspaceId,
             );
           },
       launchAgent: runtime.launchAgent,
@@ -340,9 +346,11 @@ Future<void> showCreateWorkspaceFlow(
     );
   } else {
     final creation = promptResult.creation;
-    final tabId = promptResult.agentTabId;
-    if (creation != null && tabId != null) {
-      controller.setActiveTab(workspaceId: creation.workspace.id, tabId: tabId);
+    if (creation != null) {
+      await controller.completePromptWorkspaceCreation(
+        creation: creation,
+        agentTabId: promptResult.agentTabId,
+      );
     }
   }
 

--- a/test/unit/workbench_controller_create_workspace_test_cases.dart
+++ b/test/unit/workbench_controller_create_workspace_test_cases.dart
@@ -123,6 +123,55 @@ void _registerWorkbenchControllerCreateWorkspaceTests() {
   );
 
   test(
+    'prompt creation opens the agent first and Setup second without a blank terminal',
+    () async {
+      await _harness.dispose();
+      _harness = _WorkbenchHarness(
+        const _ManagedWorkspaceRuntimeWithDeferredSetup(_setupCommand),
+      );
+      _controller = _harness._controller;
+      await _controller.bootstrap();
+      await _flushUntil(
+        () => _controller.state.workspacesFor(_harness.project.id).isNotEmpty,
+      );
+
+      final result = await _controller.createWorkspaceForPrompt(
+        project: _harness.project,
+        sourceBranch: 'main',
+        newBranchName: 'feature/prompt-terminal-order',
+        name: 'Prompt Terminal Order',
+      );
+
+      expect(_controller.state.tabsFor(result.workspace.id), isEmpty);
+      final now = DateTime.utc(2026, 5, 22, 4);
+      await _harness.workbenchRepository.upsertWorkspaceTab(
+        WorkspaceTabRecord(
+          id: 'agent-tab',
+          workspaceId: result.workspace.id,
+          title: 'Codex',
+          createdAt: now,
+          updatedAt: now,
+          payload: const <String, Object?>{
+            workspaceTabTerminalSessionIdPayloadKey: 'agent-tab',
+          },
+        ),
+      );
+
+      await _controller.completePromptWorkspaceCreation(
+        creation: result,
+        agentTabId: 'agent-tab',
+      );
+
+      final tabs = _controller.state.tabsFor(result.workspace.id);
+      expect(tabs.map((tab) => tab.title), <String>['Codex', 'Setup']);
+      expect(tabs.where((tab) => tab.title.startsWith('Terminal ')), isEmpty);
+      expect(tabs.last.initialCommand, _setupCommand);
+      expect(tabs.last.initialCommandOnce, isTrue);
+      expect(_controller.state.activeWorkspaceTab?.id, 'agent-tab');
+    },
+  );
+
+  test(
     'createWorkspace leaves the workspace with one terminal when nothing is deferred',
     () async {
       await _harness.dispose();

--- a/test/widget/prompt_workspace_dialog_test.dart
+++ b/test/widget/prompt_workspace_dialog_test.dart
@@ -4,6 +4,7 @@ import 'package:alera/src/features/workbench/domain/workspace.dart';
 import 'package:alera/src/features/workbench/domain/workspace_creation_result.dart';
 import 'package:alera/src/features/workbench/infra/prompt_workspace_runtime_client.dart';
 import 'package:alera/src/features/workbench/presentation/prompt_workspace_dialog.dart';
+import 'package:alera/src/design_system/forms/alera_dropdown_field.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -31,6 +32,7 @@ void main() {
     String? generatedPrompt;
     String? createdBranch;
     String? createdName;
+    String? createdParentWorkspaceId;
     String? launchedPrompt;
 
     await tester.pumpWidget(
@@ -47,6 +49,7 @@ void main() {
                     loadBranches: (_) async => <String>['main'],
                     checkBranchExists: (_, _) async => false,
                     workspaceBranches: (_) => const <String>{},
+                    parentWorkspaces: const <Workspace>[],
                     generateIdentity:
                         ({
                           required operationId,
@@ -66,9 +69,11 @@ void main() {
                           required sourceBranch,
                           required newBranchName,
                           required name,
+                          parentWorkspaceId,
                         }) async {
                           createdBranch = newBranchName;
                           createdName = name;
+                          createdParentWorkspaceId = parentWorkspaceId;
                           return WorkspaceCreationResult(
                             workspace: Workspace(
                               id: 'workspace-1',
@@ -122,8 +127,207 @@ void main() {
     expect(generatedPrompt, 'Build workspace creation');
     expect(createdBranch, 'feat/prompt-workspace');
     expect(createdName, 'Prompt Workspace');
+    expect(createdParentWorkspaceId, isNull);
     expect(launchedPrompt, 'Build workspace creation');
     expect(dialogResult?.creation?.workspace.id, 'workspace-1');
     expect(dialogResult?.agentTabId, 'tab-1');
   });
+
+  testWidgets(
+    'defaults the parent to the selected project main workspace and allows changing it',
+    (tester) async {
+      final now = DateTime.utc(2026, 7, 30);
+      final alera = Project(
+        id: 'project-alera',
+        name: 'Alera',
+        repoPath: '/repo/alera',
+        createdAt: now,
+        updatedAt: now,
+      );
+      final orca = Project(
+        id: 'project-orca',
+        name: 'Orca',
+        repoPath: '/repo/orca',
+        createdAt: now,
+        updatedAt: now,
+      );
+      final profile = AgentProfile(
+        id: 'profile-1',
+        name: 'Codex Builder',
+        agentType: 'codex',
+        command: 'codex',
+        createdAt: now,
+        updatedAt: now,
+      );
+      final aleraMain = _workspace(
+        id: 'alera-main',
+        projectId: alera.id,
+        name: 'Alera',
+        branch: 'main',
+        kind: WorkspaceKind.main,
+        now: now,
+      );
+      final orcaMain = _workspace(
+        id: 'orca-main',
+        projectId: orca.id,
+        name: 'Orca',
+        branch: 'main',
+        kind: WorkspaceKind.main,
+        now: now,
+      );
+      final orcaFeature = _workspace(
+        id: 'orca-feature',
+        projectId: orca.id,
+        name: 'Feature Workspace',
+        branch: 'feat/other',
+        kind: WorkspaceKind.linked,
+        now: now,
+      );
+      String? createdParentWorkspaceId;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (context) => Scaffold(
+              body: FilledButton(
+                onPressed: () {
+                  showDialog<PromptWorkspaceDialogResult>(
+                    context: context,
+                    builder: (_) => PromptWorkspaceDialog(
+                      projects: <Project>[alera, orca],
+                      agentProfiles: <AgentProfile>[profile],
+                      loadBranches: (_) async => <String>['main'],
+                      checkBranchExists: (_, _) async => false,
+                      workspaceBranches: (_) => const <String>{},
+                      parentWorkspaces: <Workspace>[
+                        aleraMain,
+                        orcaMain,
+                        orcaFeature,
+                      ],
+                      generateIdentity:
+                          ({
+                            required operationId,
+                            required projectId,
+                            required prompt,
+                          }) async => const GeneratedWorkspaceIdentity(
+                            workspaceName: 'Prompt Workspace',
+                            branchName: 'feat/prompt-workspace',
+                          ),
+                      cancelGeneration: (_) async {},
+                      createWorkspace:
+                          ({
+                            required project,
+                            required sourceBranch,
+                            required newBranchName,
+                            required name,
+                            parentWorkspaceId,
+                          }) async {
+                            createdParentWorkspaceId = parentWorkspaceId;
+                            return WorkspaceCreationResult(
+                              workspace: _workspace(
+                                id: 'created',
+                                projectId: project.id,
+                                name: name,
+                                branch: newBranchName,
+                                kind: WorkspaceKind.linked,
+                                now: now,
+                              ),
+                              setupReport: WorktreeSetupReport.empty,
+                            );
+                          },
+                      launchAgent:
+                          ({
+                            required workspaceId,
+                            required profileId,
+                            required prompt,
+                          }) async => const AgentProfileLaunchResult(
+                            tabId: 'tab-1',
+                            agentType: 'codex',
+                            profileId: 'profile-1',
+                          ),
+                    ),
+                  );
+                },
+                child: const Text('Open'),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+
+      AleraDropdownField<String?> parentField() {
+        return tester.widget<AleraDropdownField<String?>>(
+          find.byWidgetPredicate(
+            (widget) =>
+                widget is AleraDropdownField<String?> &&
+                widget.labelText == 'Parent Workspace',
+          ),
+        );
+      }
+
+      expect(parentField().value, aleraMain.id);
+      final projectField = tester.widget<AleraDropdownField<Project>>(
+        find.byWidgetPredicate(
+          (widget) =>
+              widget is AleraDropdownField<Project> &&
+              widget.labelText == 'Project',
+        ),
+      );
+      projectField.onChanged(orca);
+      await tester.pumpAndSettle();
+
+      expect(parentField().value, orcaMain.id);
+      expect(parentField().entries.map((entry) => entry.value), <String?>[
+        null,
+        aleraMain.id,
+        orcaMain.id,
+        orcaFeature.id,
+      ]);
+
+      parentField().onChanged(orcaFeature.id);
+      await tester.pump();
+      expect(parentField().value, orcaFeature.id);
+
+      parentField().onChanged(null);
+      await tester.pump();
+      expect(parentField().value, isNull);
+
+      parentField().onChanged(orcaFeature.id);
+      await tester.pump();
+      await tester.enterText(
+        find.widgetWithText(TextField, 'Initial Prompt'),
+        'Build another workspace',
+      );
+      final submit = find.text('Create And Start Agent');
+      await tester.ensureVisible(submit);
+      await tester.tap(submit);
+      await tester.pumpAndSettle();
+
+      expect(createdParentWorkspaceId, orcaFeature.id);
+    },
+  );
+}
+
+Workspace _workspace({
+  required String id,
+  required String projectId,
+  required String name,
+  required String branch,
+  required WorkspaceKind kind,
+  required DateTime now,
+}) {
+  return Workspace(
+    id: id,
+    projectId: projectId,
+    name: name,
+    branch: branch,
+    path: '/repo/$projectId/$id',
+    kind: kind,
+    status: WorkspaceStatus.active,
+    createdAt: now,
+    updatedAt: now,
+  );
 }


### PR DESCRIPTION
## Summary

- add a parent workspace selector to From Prompt, defaulting to the selected project's main workspace with options for another active workspace or no parent
- create the agent terminal before the deferred Setup terminal and avoid the blank initial terminal
- keep manual workspace creation behavior unchanged

## Root cause and impact

The generic workspace activation path always seeded `Terminal 1` and opened `Setup` before the runtime created the agent tab. The prompt flow now delays tab initialization until the agent tab exists, then appends Setup and restores focus to the agent.

## Validation

- `dart format --set-exit-if-changed` equivalent on changed files
- `dart tool/quality/check_max_lines.dart`
- `flutter analyze`
- 102 focused unit and widget tests
- `gh act pull_request -W .github/workflows/pr.yml -j static` attempted; local emulation stopped in submodule setup with `fatal: not a git repository: (null)` before product checks