### PR TITLE
fix: install and update all skills

### DIFF
--- a/lib/src/features/settings/presentation/panes/agents_pane.dart
+++ b/lib/src/features/settings/presentation/panes/agents_pane.dart
@@ -5,9 +5,10 @@ import 'package:alera/src/design_system/layout/alera_settings_group.dart';
 import 'package:alera/src/features/agent_status/domain/agent_status.dart';
 import 'package:alera/src/features/settings/domain/alera_settings.dart';
 import 'package:alera/src/features/settings/presentation/panes/alera_all_skills_control.dart';
+import 'package:alera/src/features/settings/presentation/panes/alera_computer_use_skill_control.dart';
+import 'package:alera/src/features/settings/presentation/panes/alera_emulator_skill_control.dart';
 import 'package:alera/src/features/settings/presentation/panes/agents_cli_skill_control.dart';
 import 'package:alera/src/features/settings/presentation/panes/alera_orchestration_skill_control.dart';
-import 'package:alera/src/features/settings/presentation/panes/alera_emulator_skill_control.dart';
 import 'package:alera/src/features/settings/presentation/rows/settings_rows.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -64,6 +65,13 @@ class AgentsSettingsPane extends ConsumerWidget {
                     'Install Or Update Orchestration And Reapply Selected Status Hooks.',
                 controlWidth: 360,
                 child: AleraOrchestrationSkillControl(),
+              ),
+              AleraSettingRow(
+                title: 'Alera Computer Use Skill',
+                description:
+                    'Install The Skill For Reading And Operating Desktop Applications.',
+                controlWidth: 360,
+                child: AleraComputerUseSkillControl(),
               ),
               AleraSettingRow(
                 title: 'Alera Emulator Skill',

--- a/lib/src/features/settings/presentation/panes/alera_computer_use_skill_control.dart
+++ b/lib/src/features/settings/presentation/panes/alera_computer_use_skill_control.dart
@@ -1,0 +1,32 @@
+import 'package:alera/src/app/providers.dart';
+import 'package:alera/src/features/settings/infra/alera_cli_skill_service.dart';
+import 'package:alera/src/features/settings/presentation/panes/alera_skill_install_control.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class AleraComputerUseSkillControl extends ConsumerWidget {
+  const AleraComputerUseSkillControl({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return AleraSkillInstallControl(
+      commandFor: (runner) => aleraCliSkillInstallCommand(
+        runner: runner,
+        skill: AleraAgentSkill.computerUse,
+      ),
+      install: (runner) async {
+        final result = await ref
+            .read(aleraCliSkillServiceProvider)
+            .installOrUpdate(
+              runner: runner,
+              skill: AleraAgentSkill.computerUse,
+            );
+        return AleraSkillInstallStatus(
+          result.summary,
+          detail: result.detail,
+          needsAttention: !result.succeeded,
+        );
+      },
+    );
+  }
+}

--- a/lib/src/features/settings/presentation/settings_search_entries.dart
+++ b/lib/src/features/settings/presentation/settings_search_entries.dart
@@ -128,6 +128,20 @@ const List<SettingsSearchEntry> agentsSearchEntries = <SettingsSearchEntry>[
     groupId: 'cliSkill',
   ),
   SettingsSearchEntry(
+    title: 'Alera Computer Use Skill',
+    description: 'Install Agent Instructions For Desktop Computer Use.',
+    keywords: <String>[
+      'computer use',
+      'desktop',
+      'accessibility',
+      'skill',
+      'agent',
+      'click',
+      'window',
+    ],
+    groupId: 'cliSkill',
+  ),
+  SettingsSearchEntry(
     title: 'Codex Hooks',
     description: 'Use Alera-managed Codex runtime hooks.',
     keywords: <String>['codex', 'agent', 'status', 'hooks'],

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1792,7 +1792,7 @@ packages:
     source: path
     version: "4.0.0"
   yaml:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: yaml
       sha256: b9da305ac7c39faa3f030eccd175340f968459dae4af175130b3fc47e40d76ce

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -77,6 +77,7 @@ dev_dependencies:
   riverpod_generator: ^4.0.4
   riverpod_lint: ^3.1.4
   url_launcher_platform_interface: ^2.3.2
+  yaml: ^3.1.3
 
 dependency_overrides:
   ghostty_vte:

--- a/skills/computer-use/SKILL.md
+++ b/skills/computer-use/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: computer-use
-description: Use when reading or operating local desktop application windows through Alera: listing apps and windows, reading a window's accessibility tree, clicking controls, writing values, or invoking accessibility actions. Also covers browser windows and webviews as desktop apps.
+description: >-
+  Use when reading or operating local desktop application windows through
+  Alera: listing apps and windows, reading a window's accessibility tree,
+  clicking controls, writing values, or invoking accessibility actions. Also
+  covers browser windows and webviews as desktop apps.
 metadata:
   version: 1
 ---

--- a/test/unit/alera_cli_skill_service_test.dart
+++ b/test/unit/alera_cli_skill_service_test.dart
@@ -58,6 +58,16 @@ void main() {
       );
     });
 
+    test('builds the computer use skill command', () {
+      expect(
+        aleraCliSkillInstallCommand(
+          runner: AleraCliSkillRunner.bunx,
+          skill: AleraAgentSkill.computerUse,
+        ),
+        'bunx skills add https://github.com/leynier/alera --skill computer-use --global',
+      );
+    });
+
     test('builds the emulator skill command', () {
       expect(
         aleraCliSkillInstallCommand(

--- a/test/unit/alera_skill_manifest_test.dart
+++ b/test/unit/alera_skill_manifest_test.dart
@@ -1,0 +1,42 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+import 'package:yaml/yaml.dart';
+
+void main() {
+  test('every bundled skill has a valid manifest', () {
+    final skillFiles =
+        Directory('skills')
+            .listSync()
+            .whereType<Directory>()
+            .map((directory) => File(p.join(directory.path, 'SKILL.md')))
+            .where((file) => file.existsSync())
+            .toList()
+          ..sort((left, right) => left.path.compareTo(right.path));
+
+    expect(skillFiles, isNotEmpty);
+    for (final file in skillFiles) {
+      final contents = file.readAsStringSync();
+      final frontmatter = RegExp(
+        r'^---\r?\n(.*?)\r?\n---(?:\r?\n|$)',
+        dotAll: true,
+      ).firstMatch(contents);
+      expect(frontmatter, isNotNull, reason: '${file.path} needs frontmatter');
+
+      final manifest = loadYaml(frontmatter!.group(1)!, sourceUrl: file.uri);
+      expect(manifest, isA<YamlMap>(), reason: file.path);
+      final values = manifest as YamlMap;
+      expect(
+        values['name'],
+        p.basename(file.parent.path),
+        reason: '${file.path} must match its directory name',
+      );
+      expect(
+        values['description'],
+        isA<String>().having((value) => value.trim(), 'value', isNotEmpty),
+        reason: '${file.path} needs a description',
+      );
+    }
+  });
+}

--- a/test/unit/settings_search_entries_test.dart
+++ b/test/unit/settings_search_entries_test.dart
@@ -12,6 +12,15 @@ void main() {
     expect(entry.groupId, 'cliSkill');
   });
 
+  test('computer use skill is searchable in the agents skill group', () {
+    final entry = agentsSearchEntries.singleWhere(
+      (candidate) => candidate.title == 'Alera Computer Use Skill',
+    );
+
+    expect(entry.matches('accessibility'), isTrue);
+    expect(entry.groupId, 'cliSkill');
+  });
+
   test('Grok Build hooks are searchable in the hooks group', () {
     final entry = agentsSearchEntries.singleWhere(
       (candidate) => candidate.title == 'Grok Build Hooks',

--- a/test/widget/agents_cli_skill_control_test.dart
+++ b/test/widget/agents_cli_skill_control_test.dart
@@ -9,6 +9,7 @@ import 'package:alera/src/features/settings/domain/alera_settings.dart';
 import 'package:alera/src/features/settings/infra/alera_cli_registration_service.dart';
 import 'package:alera/src/features/settings/infra/alera_cli_skill_service.dart';
 import 'package:alera/src/features/settings/presentation/panes/alera_all_skills_control.dart';
+import 'package:alera/src/features/settings/presentation/panes/alera_computer_use_skill_control.dart';
 import 'package:alera/src/features/settings/presentation/panes/alera_emulator_skill_control.dart';
 import 'package:alera/src/features/settings/presentation/panes/alera_orchestration_skill_control.dart';
 import 'package:alera/src/features/settings/presentation/panes/agents_cli_skill_control.dart';
@@ -187,6 +188,27 @@ void main() {
     await tester.pump();
 
     expect(service.skill, AleraAgentSkill.emulator);
+  });
+
+  testWidgets('computer use control installs the computer use skill', (
+    tester,
+  ) async {
+    final service = _FakeAleraCliSkillService();
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [aleraCliSkillServiceProvider.overrideWithValue(service)],
+        child: MaterialApp(
+          theme: buildAleraDarkTheme(),
+          home: const Scaffold(body: AleraComputerUseSkillControl()),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('Install / Update'));
+    await tester.pump();
+    await tester.pump();
+
+    expect(service.skill, AleraAgentSkill.computerUse);
   });
 
   testWidgets('all skills control installs every skill and reapplies hooks', (


### PR DESCRIPTION
## Summary

- fix the `computer-use` skill manifest so `skills` discovers all four bundled skills
- add an individual Computer Use skill installer to Settings
- validate every bundled `SKILL.md` frontmatter and cover the new command, search entry, and UI flow

## Validation

- `bunx skills add . --list` (4 skills found)
- `dart format --set-exit-if-changed lib test integration_test tool`
- `dart tool/quality/check_max_lines.dart`
- `flutter analyze`
- native asset preflight
- `CI=true flutter test --coverage --exclude-tags golden -r compact` (2,466 passed, 2 expected skips)
- maintained-domain coverage: 100.00% (2779/2779)

## Notes

- `gh act pull_request -W .github/workflows/pr.yml -j static` was attempted, but linked-worktree gitdir emulation failed during submodule initialization before product checks ran. Hosted GitHub checks remain authoritative.