### PR TITLE
ci: add batched mergify merge queue

### DIFF
--- a/.github/workflows/cloud.yml
+++ b/.github/workflows/cloud.yml
@@ -134,3 +134,31 @@ jobs:
       - name: Test Plan Guard
         working-directory: tool/cloud
         run: python3 -m unittest -v test_validate_tofu_plan.py
+
+  cloud-ready:
+    name: cloud-ready
+    if: always()
+    needs:
+      - backend
+      - edge
+      - infrastructure
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Require cloud checks
+        shell: bash
+        env:
+          BACKEND_RESULT: ${{ needs.backend.result }}
+          EDGE_RESULT: ${{ needs.edge.result }}
+          INFRASTRUCTURE_RESULT: ${{ needs.infrastructure.result }}
+        run: |
+          set -euo pipefail
+          failed=0
+          for result_name in BACKEND_RESULT EDGE_RESULT INFRASTRUCTURE_RESULT; do
+            result="${!result_name}"
+            if [ "$result" != "success" ]; then
+              echo "::error::${result_name} was ${result}"
+              failed=1
+            fi
+          done
+          exit "$failed"

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -1,17 +1,13 @@
 name: Desktop Builds
 
 on:
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
+  workflow_call:
   workflow_dispatch:
 
 # A newer commit makes the checks for the previous one irrelevant, and superseded
 # runs otherwise keep saturating the runner pool for the whole repository.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: desktop-builds-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/landing.yml
+++ b/.github/workflows/landing.yml
@@ -36,3 +36,22 @@ jobs:
 
       - name: Build
         run: bun run build
+
+  landing-ready:
+    name: landing-ready
+    if: always()
+    needs:
+      - build
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Require landing checks
+        shell: bash
+        env:
+          BUILD_RESULT: ${{ needs.build.result }}
+        run: |
+          set -euo pipefail
+          if [ "$BUILD_RESULT" != "success" ]; then
+            echo "::error::BUILD_RESULT was ${BUILD_RESULT}"
+            exit 1
+          fi

--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -1,0 +1,108 @@
+name: Merge Queue
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  golden:
+    name: queue golden
+    if: startsWith(github.head_ref, 'mergify/merge-queue/')
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          submodules: false
+
+      - name: Setup Flutter workspace
+        uses: ./.github/actions/setup-flutter-workspace
+        with:
+          linux-toolchain: 'false'
+
+      - name: Golden tests
+        run: flutter test test/golden
+
+  desktop_e2e_linux:
+    name: queue desktop e2e linux
+    if: startsWith(github.head_ref, 'mergify/merge-queue/')
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          submodules: false
+
+      - name: Setup Flutter workspace
+        uses: ./.github/actions/setup-flutter-workspace
+        with:
+          xvfb: 'true'
+          enable-linux-desktop: 'true'
+          rust: 'true'
+
+      # One invocation per file on purpose: `flutter test integration_test`
+      # launches the app once and fails to start it again for the second suite
+      # ("Unable to start the app on the device"), so a directory run can only
+      # ever hold one desktop integration test.
+      - name: Desktop E2E
+        run: |
+          set -euo pipefail
+          for suite in integration_test/*_test.dart; do
+            echo "::group::${suite}"
+            xvfb-run -a flutter test "${suite}" -d linux -r github
+            echo "::endgroup::"
+          done
+
+      - name: Report sccache statistics
+        if: always()
+        run: |
+          {
+            echo "### sccache desktop E2E"
+            echo '```text'
+            sccache --show-stats || true
+            echo '```'
+          } | tee -a "$GITHUB_STEP_SUMMARY"
+
+  desktop_builds:
+    name: queue desktop builds
+    if: startsWith(github.head_ref, 'mergify/merge-queue/')
+    uses: ./.github/workflows/desktop-build.yml
+
+  queue_ready:
+    name: queue-ready
+    if: ${{ always() && startsWith(github.head_ref, 'mergify/merge-queue/') }}
+    needs:
+      - golden
+      - desktop_e2e_linux
+      - desktop_builds
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Require queue checks
+        shell: bash
+        env:
+          GOLDEN_RESULT: ${{ needs.golden.result }}
+          DESKTOP_E2E_RESULT: ${{ needs.desktop_e2e_linux.result }}
+          DESKTOP_BUILDS_RESULT: ${{ needs.desktop_builds.result }}
+        run: |
+          set -euo pipefail
+          failed=0
+          for result_name in GOLDEN_RESULT DESKTOP_E2E_RESULT DESKTOP_BUILDS_RESULT; do
+            result="${!result_name}"
+            if [ "$result" != "success" ]; then
+              echo "::error::${result_name} was ${result}"
+              failed=1
+            fi
+          done
+          exit "$failed"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -66,8 +66,6 @@ jobs:
             shard: '2'
           - name: shard 3
             shard: '3'
-          - name: golden
-            shard: golden
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -88,10 +86,6 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          if [ "${{ matrix.shard }}" = "golden" ]; then
-            flutter test test/golden
-            exit 0
-          fi
           mapfile -t files < <(dart tool/ci/select_test_shard.dart --total ${{ env.TEST_SHARDS }} --index "${{ matrix.shard }}" --skip test/golden)
           # Process substitution swallows the selector's exit code, and an empty
           # list would make flutter test silently run everything instead.
@@ -103,7 +97,6 @@ jobs:
           flutter test --coverage --coverage-path "coverage/lcov-shard-${{ matrix.shard }}.info" "${files[@]}"
 
       - name: Upload shard coverage
-        if: matrix.shard != 'golden'
         uses: actions/upload-artifact@v7
         with:
           name: coverage-shard-${{ matrix.shard }}
@@ -169,48 +162,6 @@ jobs:
       - name: Test
         run: flutter test
 
-  desktop-e2e-linux:
-    runs-on: ubuntu-latest
-    timeout-minutes: 35
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-        with:
-          submodules: false
-
-      - name: Setup Flutter workspace
-        uses: ./.github/actions/setup-flutter-workspace
-        with:
-          xvfb: 'true'
-          enable-linux-desktop: 'true'
-          rust: 'true'
-
-      # One invocation per file on purpose: `flutter test integration_test`
-      # launches the app once and fails to start it again for the second suite
-      # ("Unable to start the app on the device"), so a directory run can only
-      # ever hold one desktop integration test.
-      - name: Desktop E2E
-        run: |
-          set -euo pipefail
-          for suite in integration_test/*_test.dart; do
-            echo "::group::${suite}"
-            xvfb-run -a flutter test "${suite}" -d linux -r github
-            echo "::endgroup::"
-          done
-
-      - name: Report sccache statistics
-        if: always()
-        run: |
-          {
-            echo "### sccache desktop E2E"
-            echo '```text'
-            sccache --show-stats || true
-            echo '```'
-          } | tee -a "$GITHUB_STEP_SUMMARY"
-
-  # Split out of desktop-e2e-linux: the smoke run takes about as long as the
-  # integration tests themselves and is continue-on-error, so it can never fail
-  # a pull request, yet it was what made that job the critical path.
   rust:
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -247,3 +198,35 @@ jobs:
             sccache --show-stats || true
             echo '```'
           } | tee -a "$GITHUB_STEP_SUMMARY"
+
+  pr-ready:
+    name: pr-ready
+    if: always()
+    needs:
+      - static
+      - test
+      - coverage
+      - mobile
+      - rust
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Require fast checks
+        shell: bash
+        env:
+          STATIC_RESULT: ${{ needs.static.result }}
+          TEST_RESULT: ${{ needs.test.result }}
+          COVERAGE_RESULT: ${{ needs.coverage.result }}
+          MOBILE_RESULT: ${{ needs.mobile.result }}
+          RUST_RESULT: ${{ needs.rust.result }}
+        run: |
+          set -euo pipefail
+          failed=0
+          for result_name in STATIC_RESULT TEST_RESULT COVERAGE_RESULT MOBILE_RESULT RUST_RESULT; do
+            result="${!result_name}"
+            if [ "$result" != "success" ]; then
+              echo "::error::${result_name} was ${result}"
+              failed=1
+            fi
+          done
+          exit "$failed"

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,47 @@
+merge_queue:
+  mode: serial
+  max_parallel_checks: 1
+  queue_controls_comment: true
+  reset_on_external_merge: always
+  skip_intermediate_results: false
+
+commands_restrictions:
+  queue:
+    conditions:
+      - sender = leynier
+  dequeue:
+    conditions:
+      - sender = leynier
+  requeue:
+    conditions:
+      - sender = leynier
+
+queue_rules:
+  - name: default
+    queue_branch_prefix: mergify/merge-queue/
+    batch_size:
+      min: 2
+      max: 4
+    batch_max_wait_time: 60 min
+    max_checks_retries: 0
+    merge_method: squash
+    queue_conditions:
+      - base = main
+      - -draft
+      - -conflict
+      - check-success = @github-actions/pr-ready
+      - or:
+          - '-files ~= ^(cloud/|edge/|infra/|tool/cloud/|\.github/workflows/(cloud-deploy|cloud)\.yml$)'
+          - check-success = @github-actions/cloud-ready
+      - or:
+          - '-files ~= ^(landing/|\.github/workflows/landing\.yml$)'
+          - check-success = @github-actions/landing-ready
+    merge_conditions:
+      - check-success = @github-actions/pr-ready
+      - check-success = @github-actions/queue-ready
+      - or:
+          - '-files ~= ^(cloud/|edge/|infra/|tool/cloud/|\.github/workflows/(cloud-deploy|cloud)\.yml$)'
+          - check-success = @github-actions/cloud-ready
+      - or:
+          - '-files ~= ^(landing/|\.github/workflows/landing\.yml$)'
+          - check-success = @github-actions/landing-ready


### PR DESCRIPTION
Summary:
- keep fast coverage checks on normal pull requests behind pr-ready
- run golden, desktop E2E, and desktop builds only on Mergify queue branches
- batch 2-4 pull requests with a 60 minute maximum wait and Leynier-only queue commands

Validation:
- Mergify CLI configuration validation
- actionlint and YAML parsing
- gh act DAG and branch-filter dry-runs
- full gh act execution blocked by linked-workspace git metadata before product steps

Risk:
- main remains unprotected so Cut Release can continue pushing release commits and tags directly
- hosted CI and an initial two-PR queue trial remain authoritative