### PR TITLE
fix: show click cursor for saved agent profiles

### DIFF
--- a/lib/src/features/settings/presentation/panes/agent_profile_list_row.dart
+++ b/lib/src/features/settings/presentation/panes/agent_profile_list_row.dart
@@ -32,6 +32,7 @@ class AgentProfileListRow extends StatelessWidget {
       color: selected ? AleraTokens.accentSubtle : Colors.transparent,
       child: InkWell(
         onTap: onTap,
+        mouseCursor: SystemMouseCursors.click,
         child: Padding(
           padding: const EdgeInsets.all(AleraTokens.space12),
           child: Row(

--- a/test/widget/agent_profile_list_row_test.dart
+++ b/test/widget/agent_profile_list_row_test.dart
@@ -1,0 +1,45 @@
+import 'package:alera/src/features/agent_profiles/domain/agent_profile.dart';
+import 'package:alera/src/features/settings/presentation/panes/agent_profile_list_row.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('saved profile row shows the click cursor on hover', (
+    tester,
+  ) async {
+    final now = DateTime.utc(2026, 7, 30);
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: AgentProfileListRow(
+            profile: AgentProfile(
+              id: 'profile-1',
+              name: 'Codex',
+              agentType: 'codex',
+              command: 'codex',
+              createdAt: now,
+              updatedAt: now,
+            ),
+            selected: false,
+            onTap: () {},
+          ),
+        ),
+      ),
+    );
+
+    final mouse = await tester.createGesture(
+      kind: PointerDeviceKind.mouse,
+      pointer: 1,
+    );
+    addTearDown(mouse.removePointer);
+    await mouse.addPointer(location: tester.getCenter(find.text('Codex')));
+    await tester.pump();
+
+    expect(
+      RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1),
+      SystemMouseCursors.click,
+    );
+  });
+}


### PR DESCRIPTION
## Summary

- show the click cursor when hovering saved Agent Profile rows
- add a widget regression test that verifies the active mouse cursor

## Root Cause

The selectable row used an `InkWell` without an explicit mouse cursor, so desktop hover retained the basic cursor even though the row was clickable.

## Impact

Saved profiles now provide the expected desktop affordance without changing selection behavior.

## Validation

- `dart format --output=none --set-exit-if-changed lib test integration_test tool`
- `dart tool/quality/check_max_lines.dart`
- `flutter analyze --no-pub`
- `flutter test --no-pub test/widget/agent_profile_list_row_test.dart test/widget/agent_profile_editor_test.dart`

`gh act pull_request -W .github/workflows/pr.yml -j static` was attempted but Docker could not pull the runner image because its registry credentials were rejected before any repository step ran. GitHub-hosted checks remain authoritative.