### PR TITLE
feat: add pinned workspace repeat option

### DIFF
--- a/lib/src/features/workbench/application/workbench_controller_view_prefs.dart
+++ b/lib/src/features/workbench/application/workbench_controller_view_prefs.dart
@@ -42,6 +42,13 @@ mixin _WorkbenchControllerViewPrefs
     _updateViewPrefs(state.viewPrefs.copyWith(workspaceKindFilter: filter));
   }
 
+  void setShowPinnedWorkspacesBelow(bool show) {
+    if (state.viewPrefs.showPinnedWorkspacesBelow == show) {
+      return;
+    }
+    _updateViewPrefs(state.viewPrefs.copyWith(showPinnedWorkspacesBelow: show));
+  }
+
   void toggleProjectFilter(String projectId) {
     final next = Set<String>.from(state.viewPrefs.selectedProjectIds);
     if (!next.add(projectId)) {

--- a/lib/src/features/workbench/application/workbench_listing.dart
+++ b/lib/src/features/workbench/application/workbench_listing.dart
@@ -96,6 +96,11 @@ List<WorkbenchSidebarRow> buildSidebarRows(
     return false;
   }
 
+  bool workspaceVisibleBelow(Project project, Workspace workspace) {
+    return workspaceVisible(project, workspace) &&
+        (prefs.showPinnedWorkspacesBelow || !workspace.isPinned);
+  }
+
   // The flat view mixes several projects, so pinning each project's main
   // worktree only applies to the name sort there; grouped mode pins it for
   // name and recent. Agent Activity never pins - urgency owns the order.
@@ -167,7 +172,8 @@ List<WorkbenchSidebarRow> buildSidebarRows(
   final filtersHideEmptyProjects =
       query.isNotEmpty ||
       prefs.selectedTagIds.isNotEmpty ||
-      prefs.workspaceKindFilter != WorkspaceKindFilter.all;
+      prefs.workspaceKindFilter != WorkspaceKindFilter.all ||
+      !prefs.showPinnedWorkspacesBelow;
 
   final pinnedRows = <WorkbenchSidebarRow>[];
   var pinnedWorkspaceCount = 0;
@@ -262,7 +268,7 @@ List<WorkbenchSidebarRow> buildSidebarRows(
         final workspaces = sortWorkspaces(
           state
               .workspacesFor(project.id)
-              .where((w) => workspaceVisible(project, w))
+              .where((w) => workspaceVisibleBelow(project, w))
               .toList(),
           pinMainOnRecent: true,
         );
@@ -293,7 +299,7 @@ List<WorkbenchSidebarRow> buildSidebarRows(
       final workspaces = <Workspace>[];
       for (final project in visibleProjects) {
         for (final workspace in state.workspacesFor(project.id)) {
-          if (!workspaceVisible(project, workspace)) {
+          if (!workspaceVisibleBelow(project, workspace)) {
             continue;
           }
           projectByWorkspaceId[workspace.id] = project;
@@ -302,8 +308,8 @@ List<WorkbenchSidebarRow> buildSidebarRows(
       }
       // The flat list only gets an "All" header when a pinned section sits
       // above it - without pins there is nothing to separate it from.
-      final hasPinnedSection = pinnedRows.isNotEmpty;
-      if (hasPinnedSection) {
+      final showAllSection = pinnedRows.isNotEmpty && workspaces.isNotEmpty;
+      if (showAllSection) {
         rows.add(
           WorkbenchAllHeaderRow(
             workspaceCount: workspaces.length,
@@ -311,7 +317,7 @@ List<WorkbenchSidebarRow> buildSidebarRows(
           ),
         );
       }
-      if (!hasPinnedSection || !prefs.allSectionCollapsed) {
+      if (!showAllSection || !prefs.allSectionCollapsed) {
         appendWorkspaceTreeRows(
           rows,
           workspaces: sortWorkspaces(workspaces, pinMainOnRecent: false),

--- a/lib/src/features/workbench/application/workbench_sidebar_rows.dart
+++ b/lib/src/features/workbench/application/workbench_sidebar_rows.dart
@@ -71,7 +71,7 @@ class WorkbenchPinnedHeaderRow extends WorkbenchSidebarRow {
 
 /// Header for the flat "All" section that follows the pinned section when the
 /// sidebar is not grouped by project. It marks where the pinned copies end
-/// and the full workspace list begins, and can collapse the whole list.
+/// and the regular workspace list begins, and can collapse the whole list.
 class WorkbenchAllHeaderRow extends WorkbenchSidebarRow {
   const WorkbenchAllHeaderRow({
     required this.workspaceCount,
@@ -118,8 +118,8 @@ class WorkbenchWorkspaceRow extends WorkbenchSidebarRow {
   final bool isPinnedCopy;
   final int indent;
 
-  // A pinned workspace also appears in the list below, so the section has to
-  // be part of the key or the two copies would share one element.
+  // A pinned workspace may also appear in the list below, so the section has
+  // to be part of the key or the two copies would share one element.
   @override
   String get key =>
       'workspace:${isPinnedCopy ? 'pinned' : 'all'}:${workspace.id}';

--- a/lib/src/features/workbench/domain/workbench_view_prefs.dart
+++ b/lib/src/features/workbench/domain/workbench_view_prefs.dart
@@ -40,6 +40,7 @@ class WorkbenchViewPrefs with WorkbenchViewPrefsMappable {
     this.collapsedParentWorkspaceIds = const <String>{},
     this.pinnedSectionCollapsed = false,
     this.allSectionCollapsed = false,
+    this.showPinnedWorkspacesBelow = true,
     this.sourceControlRootByWorkspaceId = const <String, String>{},
     this.rightSidebarVisible = true,
     this.rightSidebarWidth = 280,
@@ -83,6 +84,10 @@ class WorkbenchViewPrefs with WorkbenchViewPrefsMappable {
   /// collapsed.
   final bool allSectionCollapsed;
 
+  /// Whether pinned workspaces also appear in the regular project or "All"
+  /// sections below the dedicated pinned section.
+  final bool showPinnedWorkspacesBelow;
+
   /// Folder-workspace ids mapped to the workspace-relative Git folder that
   /// should back the Source Control tab.
   final Map<String, String> sourceControlRootByWorkspaceId;
@@ -116,6 +121,7 @@ class WorkbenchViewPrefs with WorkbenchViewPrefsMappable {
     collapsedParentWorkspaceIds: <String>{},
     pinnedSectionCollapsed: false,
     allSectionCollapsed: false,
+    showPinnedWorkspacesBelow: true,
     sourceControlRootByWorkspaceId: <String, String>{},
     rightSidebarVisible: true,
     rightSidebarWidth: 280,

--- a/lib/src/features/workbench/domain/workbench_view_prefs.mapper.dart
+++ b/lib/src/features/workbench/domain/workbench_view_prefs.mapper.dart
@@ -433,6 +433,15 @@ class WorkbenchViewPrefsMapper extends ClassMapperBase<WorkbenchViewPrefs> {
     opt: true,
     def: false,
   );
+  static bool _$showPinnedWorkspacesBelow(WorkbenchViewPrefs v) =>
+      v.showPinnedWorkspacesBelow;
+  static const Field<WorkbenchViewPrefs, bool> _f$showPinnedWorkspacesBelow =
+      Field(
+        'showPinnedWorkspacesBelow',
+        _$showPinnedWorkspacesBelow,
+        opt: true,
+        def: true,
+      );
   static Map<String, String> _$sourceControlRootByWorkspaceId(
     WorkbenchViewPrefs v,
   ) => v.sourceControlRootByWorkspaceId;
@@ -526,6 +535,7 @@ class WorkbenchViewPrefsMapper extends ClassMapperBase<WorkbenchViewPrefs> {
     #collapsedParentWorkspaceIds: _f$collapsedParentWorkspaceIds,
     #pinnedSectionCollapsed: _f$pinnedSectionCollapsed,
     #allSectionCollapsed: _f$allSectionCollapsed,
+    #showPinnedWorkspacesBelow: _f$showPinnedWorkspacesBelow,
     #sourceControlRootByWorkspaceId: _f$sourceControlRootByWorkspaceId,
     #rightSidebarVisible: _f$rightSidebarVisible,
     #rightSidebarWidth: _f$rightSidebarWidth,
@@ -549,6 +559,7 @@ class WorkbenchViewPrefsMapper extends ClassMapperBase<WorkbenchViewPrefs> {
       collapsedParentWorkspaceIds: data.dec(_f$collapsedParentWorkspaceIds),
       pinnedSectionCollapsed: data.dec(_f$pinnedSectionCollapsed),
       allSectionCollapsed: data.dec(_f$allSectionCollapsed),
+      showPinnedWorkspacesBelow: data.dec(_f$showPinnedWorkspacesBelow),
       sourceControlRootByWorkspaceId: data.dec(
         _f$sourceControlRootByWorkspaceId,
       ),
@@ -647,6 +658,7 @@ abstract class WorkbenchViewPrefsCopyWith<
     Set<String>? collapsedParentWorkspaceIds,
     bool? pinnedSectionCollapsed,
     bool? allSectionCollapsed,
+    bool? showPinnedWorkspacesBelow,
     Map<String, String>? sourceControlRootByWorkspaceId,
     bool? rightSidebarVisible,
     double? rightSidebarWidth,
@@ -689,6 +701,7 @@ class _WorkbenchViewPrefsCopyWithImpl<$R, $Out>
     Set<String>? collapsedParentWorkspaceIds,
     bool? pinnedSectionCollapsed,
     bool? allSectionCollapsed,
+    bool? showPinnedWorkspacesBelow,
     Map<String, String>? sourceControlRootByWorkspaceId,
     bool? rightSidebarVisible,
     double? rightSidebarWidth,
@@ -715,6 +728,8 @@ class _WorkbenchViewPrefsCopyWithImpl<$R, $Out>
         #pinnedSectionCollapsed: pinnedSectionCollapsed,
       if (allSectionCollapsed != null)
         #allSectionCollapsed: allSectionCollapsed,
+      if (showPinnedWorkspacesBelow != null)
+        #showPinnedWorkspacesBelow: showPinnedWorkspacesBelow,
       if (sourceControlRootByWorkspaceId != null)
         #sourceControlRootByWorkspaceId: sourceControlRootByWorkspaceId,
       if (rightSidebarVisible != null)
@@ -760,6 +775,10 @@ class _WorkbenchViewPrefsCopyWithImpl<$R, $Out>
     allSectionCollapsed: data.get(
       #allSectionCollapsed,
       or: $value.allSectionCollapsed,
+    ),
+    showPinnedWorkspacesBelow: data.get(
+      #showPinnedWorkspacesBelow,
+      or: $value.showPinnedWorkspacesBelow,
     ),
     sourceControlRootByWorkspaceId: data.get(
       #sourceControlRootByWorkspaceId,

--- a/lib/src/features/workbench/infra/runtime_workbench_view_prefs_repository.dart
+++ b/lib/src/features/workbench/infra/runtime_workbench_view_prefs_repository.dart
@@ -83,6 +83,7 @@ Map<String, Object?> _sharedJson(WorkbenchViewPrefs prefs) {
     'collapsedParentWorkspaceIds': prefs.collapsedParentWorkspaceIds.toList(),
     'pinnedSectionCollapsed': prefs.pinnedSectionCollapsed,
     'allSectionCollapsed': prefs.allSectionCollapsed,
+    'showPinnedWorkspacesBelow': prefs.showPinnedWorkspacesBelow,
     'workspaceKindFilter': prefs.workspaceKindFilter.name,
   };
 }
@@ -115,6 +116,9 @@ WorkbenchViewPrefs _mergeShared(
     ),
     pinnedSectionCollapsed: shared['pinnedSectionCollapsed'] == true,
     allSectionCollapsed: shared['allSectionCollapsed'] == true,
+    showPinnedWorkspacesBelow:
+        shared['showPinnedWorkspacesBelow'] as bool? ??
+        local.showPinnedWorkspacesBelow,
     workspaceKindFilter: _enumByName(
       WorkspaceKindFilter.values,
       shared['workspaceKindFilter'],

--- a/lib/src/features/workbench/presentation/widgets/workbench_view_options_menu.dart
+++ b/lib/src/features/workbench/presentation/widgets/workbench_view_options_menu.dart
@@ -5,6 +5,7 @@ import 'package:alera/src/design_system/buttons/alera_icon_button.dart';
 import 'package:alera/src/design_system/buttons/alera_segmented_button.dart';
 import 'package:alera/src/design_system/chips/alera_chip.dart';
 import 'package:alera/src/design_system/feedback/alera_status_dot.dart';
+import 'package:alera/src/design_system/forms/alera_checkbox.dart';
 import 'package:alera/src/design_system/forms/alera_text_field.dart';
 import 'package:alera/src/design_system/icons/alera_icons.dart';
 import 'package:alera/src/design_system/layout/alera_dialog.dart';
@@ -35,6 +36,8 @@ class WorkbenchViewOptionsButton extends ConsumerWidget {
         prefs.selectedTagIds.isNotEmpty ||
         prefs.workspaceKindFilter !=
             WorkbenchViewPrefs.defaults.workspaceKindFilter ||
+        prefs.showPinnedWorkspacesBelow !=
+            WorkbenchViewPrefs.defaults.showPinnedWorkspacesBelow ||
         prefs.groupBy != WorkbenchViewPrefs.defaults.groupBy ||
         prefs.projectSort != WorkbenchViewPrefs.defaults.projectSort ||
         prefs.workspaceSort != WorkbenchViewPrefs.defaults.workspaceSort;
@@ -281,6 +284,15 @@ class _WorkbenchViewOptionsPanelState
                   _WorkspaceKindSegmented(
                     value: prefs.workspaceKindFilter,
                     onChanged: controller.setWorkspaceKindFilter,
+                  ),
+                  const SizedBox(height: AleraTokens.space6),
+                  Align(
+                    alignment: Alignment.centerLeft,
+                    child: AleraCheckbox(
+                      value: prefs.showPinnedWorkspacesBelow,
+                      onChanged: controller.setShowPinnedWorkspacesBelow,
+                      label: 'Repeat Pinned Workspaces',
+                    ),
                   ),
                   const SizedBox(height: AleraTokens.space16),
                   const Divider(height: 1, color: AleraTokens.borderSubtle),

--- a/mobile/lib/src/features/workbench/application/mobile_view_prefs_controller.dart
+++ b/mobile/lib/src/features/workbench/application/mobile_view_prefs_controller.dart
@@ -53,6 +53,10 @@ class MobileViewPrefsController extends _$MobileViewPrefsController {
     return _update((prefs) => prefs.copyWith(workspaceKindFilter: value));
   }
 
+  Future<void> setShowPinnedWorkspacesBelow(bool show) {
+    return _update((prefs) => prefs.copyWith(showPinnedWorkspacesBelow: show));
+  }
+
   Future<void> setProjectFilter(Set<String> ids) {
     return _update((prefs) => prefs.copyWith(selectedProjectIds: ids));
   }

--- a/mobile/lib/src/features/workbench/application/mobile_view_prefs_controller.g.dart
+++ b/mobile/lib/src/features/workbench/application/mobile_view_prefs_controller.g.dart
@@ -52,7 +52,7 @@ final class MobileViewPrefsControllerProvider
 }
 
 String _$mobileViewPrefsControllerHash() =>
-    r'548876bd9ec823d2101eb95e884da68041fd1776';
+    r'3d6aa6e5caff7f2c5266bc8485a28952f7fe47cb';
 
 final class MobileViewPrefsControllerFamily extends $Family
     with

--- a/mobile/lib/src/features/workbench/application/mobile_workspace_rows.dart
+++ b/mobile/lib/src/features/workbench/application/mobile_workspace_rows.dart
@@ -48,8 +48,7 @@ class MobileWorkspaceEntryRow extends MobileWorkspaceRow {
 
   final WorkspaceTreeEntry entry;
 
-  /// True for the flat duplicate rendered inside the pinned section; the same
-  /// workspace still appears in its tree position below.
+  /// True for the flat copy rendered inside the pinned section.
   final bool isPinnedCopy;
 }
 
@@ -145,12 +144,18 @@ List<MobileWorkspaceRow> buildMobileWorkspaceRows({
     }
   }
 
+  final workspacesBelow = prefs.showPinnedWorkspacesBelow
+      ? visibleWorkspaces
+      : visibleWorkspaces
+            .where((workspace) => !workspace.isPinned)
+            .toList(growable: false);
+
   if (prefs.groupBy == MobileWorkspaceGroupBy.project) {
     final projectNames = <String, String>{
       for (final project in projects) project.id: project.name,
     };
     final byProject = <String, List<WorkspaceSummary>>{};
-    for (final workspace in visibleWorkspaces) {
+    for (final workspace in workspacesBelow) {
       byProject
           .putIfAbsent(workspace.projectId, () => <WorkspaceSummary>[])
           .add(workspace);
@@ -195,11 +200,11 @@ List<MobileWorkspaceRow> buildMobileWorkspaceRows({
   } else {
     // Without project grouping, "All" is only useful as a sibling of Pinned.
     // A lone All header just adds an extra collapse step.
-    final showAllHeader = pinned.isNotEmpty;
+    final showAllHeader = pinned.isNotEmpty && workspacesBelow.isNotEmpty;
     if (showAllHeader) {
       rows.add(
         MobileAllHeaderRow(
-          count: visibleWorkspaces.length,
+          count: workspacesBelow.length,
           collapsed: prefs.allSectionCollapsed,
         ),
       );
@@ -208,7 +213,7 @@ List<MobileWorkspaceRow> buildMobileWorkspaceRows({
       }
     }
     for (final entry in buildWorkspaceTree(
-      entries: visibleWorkspaces,
+      entries: workspacesBelow,
       collapsedParentIds: prefs.collapsedParentWorkspaceIds,
     )) {
       rows.add(MobileWorkspaceEntryRow(entry: entry));

--- a/mobile/lib/src/features/workbench/domain/mobile_view_prefs.dart
+++ b/mobile/lib/src/features/workbench/domain/mobile_view_prefs.dart
@@ -13,6 +13,7 @@ class MobileViewPrefs {
     this.groupBy = MobileWorkspaceGroupBy.project,
     this.pinnedSectionCollapsed = false,
     this.allSectionCollapsed = false,
+    this.showPinnedWorkspacesBelow = true,
     this.projectSort = MobileWorkbenchSortBy.name,
     this.workspaceSort = MobileWorkbenchSortBy.name,
     this.workspaceKindFilter = MobileWorkspaceKindFilter.all,
@@ -27,6 +28,7 @@ class MobileViewPrefs {
   final MobileWorkspaceGroupBy groupBy;
   final bool pinnedSectionCollapsed;
   final bool allSectionCollapsed;
+  final bool showPinnedWorkspacesBelow;
   final MobileWorkbenchSortBy projectSort;
   final MobileWorkbenchSortBy workspaceSort;
   final MobileWorkspaceKindFilter workspaceKindFilter;
@@ -41,6 +43,7 @@ class MobileViewPrefs {
     MobileWorkspaceGroupBy? groupBy,
     bool? pinnedSectionCollapsed,
     bool? allSectionCollapsed,
+    bool? showPinnedWorkspacesBelow,
     MobileWorkbenchSortBy? projectSort,
     MobileWorkbenchSortBy? workspaceSort,
     MobileWorkspaceKindFilter? workspaceKindFilter,
@@ -56,6 +59,8 @@ class MobileViewPrefs {
       pinnedSectionCollapsed:
           pinnedSectionCollapsed ?? this.pinnedSectionCollapsed,
       allSectionCollapsed: allSectionCollapsed ?? this.allSectionCollapsed,
+      showPinnedWorkspacesBelow:
+          showPinnedWorkspacesBelow ?? this.showPinnedWorkspacesBelow,
       projectSort: projectSort ?? this.projectSort,
       workspaceSort: workspaceSort ?? this.workspaceSort,
       workspaceKindFilter: workspaceKindFilter ?? this.workspaceKindFilter,
@@ -77,6 +82,8 @@ class MobileViewPrefs {
           : MobileWorkspaceGroupBy.project,
       pinnedSectionCollapsed: json['pinnedSectionCollapsed'] == true,
       allSectionCollapsed: json['allSectionCollapsed'] == true,
+      showPinnedWorkspacesBelow:
+          json['showPinnedWorkspacesBelow'] as bool? ?? true,
       projectSort: MobileWorkbenchSortBy.values.byName(
         json.optionalString('projectSort') ?? 'name',
       ),
@@ -107,6 +114,7 @@ class MobileViewPrefs {
       'groupBy': groupBy.name,
       'pinnedSectionCollapsed': pinnedSectionCollapsed,
       'allSectionCollapsed': allSectionCollapsed,
+      'showPinnedWorkspacesBelow': showPinnedWorkspacesBelow,
       'projectSort': projectSort.name,
       'workspaceSort': workspaceSort.name,
       'workspaceKindFilter': workspaceKindFilter.name,

--- a/mobile/lib/src/features/workbench/presentation/workspace_view_options_sheet.dart
+++ b/mobile/lib/src/features/workbench/presentation/workspace_view_options_sheet.dart
@@ -111,6 +111,12 @@ class _WorkspaceViewOptions extends ConsumerWidget {
                     ),
                   ],
             ),
+            SwitchListTile(
+              contentPadding: EdgeInsets.zero,
+              title: const Text('Repeat Pinned Workspaces'),
+              value: prefs.showPinnedWorkspacesBelow,
+              onChanged: controller.setShowPinnedWorkspacesBelow,
+            ),
             const SizedBox(height: AleraTokens.space16),
             const Divider(height: 1),
             const ListTile(

--- a/mobile/test/workspace_rows_test.dart
+++ b/mobile/test/workspace_rows_test.dart
@@ -189,6 +189,55 @@ void main() {
 
       expect(rows.whereType<MobileAllHeaderRow>(), hasLength(1));
     });
+
+    test('Can omit pinned workspaces from the list below', () {
+      final rows = buildMobileWorkspaceRows(
+        workspaces: <WorkspaceSummary>[
+          _workspace('a', project: 'p1'),
+          _workspace('b', project: 'p1', pinned: true),
+        ],
+        projects: <ProjectSummary>[_project('p1')],
+        prefs: const MobileViewPrefs(
+          groupBy: MobileWorkspaceGroupBy.none,
+          showPinnedWorkspacesBelow: false,
+        ),
+      );
+
+      expect((rows.first as MobilePinnedHeaderRow).count, 1);
+      expect(rows.whereType<MobileAllHeaderRow>().single.count, 1);
+      final entries = rows.whereType<MobileWorkspaceEntryRow>().toList();
+      expect(
+        entries.where((row) => row.entry.workspace.id == 'b'),
+        hasLength(1),
+      );
+      expect(
+        entries.firstWhere((row) => row.entry.workspace.id == 'b').isPinnedCopy,
+        isTrue,
+      );
+      expect(
+        entries
+            .where((row) => !row.isPinnedCopy)
+            .map((row) => row.entry.workspace.id),
+        <String>['a'],
+      );
+    });
+
+    test('Omits an empty All section when every workspace is pinned', () {
+      final rows = buildMobileWorkspaceRows(
+        workspaces: <WorkspaceSummary>[
+          _workspace('b', project: 'p1', pinned: true),
+        ],
+        projects: <ProjectSummary>[_project('p1')],
+        prefs: const MobileViewPrefs(
+          groupBy: MobileWorkspaceGroupBy.none,
+          showPinnedWorkspacesBelow: false,
+        ),
+      );
+
+      expect(rows.whereType<MobilePinnedHeaderRow>(), hasLength(1));
+      expect(rows.whereType<MobileAllHeaderRow>(), isEmpty);
+      expect(rows.whereType<MobileWorkspaceEntryRow>(), hasLength(1));
+    });
   });
 }
 

--- a/mobile/test/workspace_sidebar_snapshot_test.dart
+++ b/mobile/test/workspace_sidebar_snapshot_test.dart
@@ -1,7 +1,19 @@
 import 'package:alera_mobile/src/features/runtime/domain/workspace_sidebar_snapshot.dart';
+import 'package:alera_mobile/src/features/workbench/domain/mobile_view_prefs.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  test('View prefs preserve the pinned workspace display option', () {
+    final hidden = MobileViewPrefs.fromJson(<String, Object?>{
+      'showPinnedWorkspacesBelow': false,
+    });
+    final legacy = MobileViewPrefs.fromJson(const <String, Object?>{});
+
+    expect(hidden.showPinnedWorkspacesBelow, isFalse);
+    expect(hidden.toJson()['showPinnedWorkspacesBelow'], isFalse);
+    expect(legacy.showPinnedWorkspacesBelow, isTrue);
+  });
+
   test('Parses runtime terminal counts and full agent details', () {
     final snapshot = WorkspaceSidebarSnapshot.fromJson(<String, Object?>{
       'projects': <Object?>[],

--- a/rust/alera-core/src/runtime/workbench_shared_state_models.rs
+++ b/rust/alera-core/src/runtime/workbench_shared_state_models.rs
@@ -44,7 +44,13 @@ pub struct SharedWorkbenchViewPrefs {
     pub pinned_section_collapsed: bool,
     #[serde(default)]
     pub all_section_collapsed: bool,
+    #[serde(default = "default_true")]
+    pub show_pinned_workspaces_below: bool,
     pub workspace_kind_filter: SharedWorkspaceKindFilter,
+}
+
+fn default_true() -> bool {
+    true
 }
 
 impl Default for SharedWorkbenchViewPrefs {
@@ -59,6 +65,7 @@ impl Default for SharedWorkbenchViewPrefs {
             collapsed_parent_workspace_ids: Vec::new(),
             pinned_section_collapsed: false,
             all_section_collapsed: false,
+            show_pinned_workspaces_below: true,
             workspace_kind_filter: SharedWorkspaceKindFilter::All,
         }
     }

--- a/rust/alera-core/src/runtime/workbench_shared_state_store_tests.rs
+++ b/rust/alera-core/src/runtime/workbench_shared_state_store_tests.rs
@@ -11,6 +11,7 @@ async fn desktop_initializes_shared_prefs_and_mobile_rejects_stale_revision() {
     let store = RuntimeStore::open(dir.path()).await.unwrap();
     let prefs = SharedWorkbenchViewPrefs {
         workspace_sort: SharedWorkbenchSortBy::Activity,
+        show_pinned_workspaces_below: false,
         ..SharedWorkbenchViewPrefs::default()
     };
 
@@ -24,12 +25,26 @@ async fn desktop_initializes_shared_prefs_and_mobile_rejects_stale_revision() {
         .unwrap();
     assert!(desktop.desktop_initialized);
     assert_eq!(desktop.revision, 1);
+    assert!(!desktop.prefs.show_pinned_workspaces_below);
 
     let error = store
         .update_shared_workbench_view_prefs(prefs, Some(0), SharedWorkbenchPrefsWriter::Mobile)
         .await
         .unwrap_err();
     assert!(error.to_string().contains("changed on desktop"));
+}
+
+#[test]
+fn legacy_shared_view_prefs_show_pinned_workspaces_below() {
+    let mut encoded = serde_json::to_value(SharedWorkbenchViewPrefs::default()).unwrap();
+    encoded
+        .as_object_mut()
+        .unwrap()
+        .remove("showPinnedWorkspacesBelow");
+
+    let restored: SharedWorkbenchViewPrefs = serde_json::from_value(encoded).unwrap();
+
+    assert!(restored.show_pinned_workspaces_below);
 }
 
 #[tokio::test]

--- a/test/unit/workbench_pinned_listing_test.dart
+++ b/test/unit/workbench_pinned_listing_test.dart
@@ -102,6 +102,29 @@ void main() {
     expect(filteredRows.whereType<WorkbenchPinnedHeaderRow>(), isEmpty);
   });
 
+  test('can omit pinned workspaces from project sections below', () {
+    final prefs = WorkbenchViewPrefs.defaults.copyWith(
+      showPinnedWorkspacesBelow: false,
+    );
+    final rows = buildSidebarRows(_state(prefs: prefs));
+    final featureRows = rows
+        .whereType<WorkbenchWorkspaceRow>()
+        .where((row) => row.workspace.id == 'feature')
+        .toList();
+
+    expect(featureRows, hasLength(1));
+    expect(featureRows.single.isPinnedCopy, isTrue);
+    expect(
+      rows
+          .whereType<WorkbenchProjectHeaderRow>()
+          .firstWhere((row) => row.project.id == 'alera')
+          .workspaceCount,
+      1,
+    );
+    expect(workspaceOrderOfRows(rows), <String>['main', 'review']);
+    expect(countVisibleWorkspaces(_state(prefs: prefs)), 3);
+  });
+
   test('builds a tree from pinned workspaces only', () {
     final project = _project('alera');
     final parent = _workspace(
@@ -181,6 +204,56 @@ void main() {
             .toList();
         expect(regular, hasLength(3));
         expect(regular.every((row) => !row.isPinnedCopy), isTrue);
+      },
+    );
+
+    test('flat list can exclude pinned workspaces from All', () {
+      final prefs = WorkbenchViewPrefs.defaults.copyWith(
+        groupBy: WorkbenchGroupBy.none,
+        showPinnedWorkspacesBelow: false,
+      );
+      final rows = buildSidebarRows(_state(prefs: prefs));
+
+      expect(
+        rows.whereType<WorkbenchPinnedHeaderRow>().single.workspaceCount,
+        1,
+      );
+      expect(rows.whereType<WorkbenchAllHeaderRow>().single.workspaceCount, 2);
+      final entries = rows.whereType<WorkbenchWorkspaceRow>().toList();
+      expect(
+        entries.where((row) => row.workspace.id == 'feature'),
+        hasLength(1),
+      );
+      expect(workspaceOrderOfRows(rows), <String>['main', 'review']);
+    });
+
+    test(
+      'flat list omits an empty All section when every workspace is pinned',
+      () {
+        final prefs = WorkbenchViewPrefs.defaults.copyWith(
+          groupBy: WorkbenchGroupBy.none,
+          showPinnedWorkspacesBelow: false,
+        );
+        final project = _project('alera');
+        final pinned = _workspace(
+          'pinned',
+          project.id,
+          name: 'Pinned',
+          isPinned: true,
+        );
+        final rows = buildSidebarRows(
+          WorkbenchState(
+            projects: <Project>[project],
+            workspacesByProject: <String, List<Workspace>>{
+              project.id: <Workspace>[pinned],
+            },
+            viewPrefs: prefs,
+          ),
+        );
+
+        expect(rows.whereType<WorkbenchPinnedHeaderRow>(), hasLength(1));
+        expect(rows.whereType<WorkbenchAllHeaderRow>(), isEmpty);
+        expect(rows.whereType<WorkbenchWorkspaceRow>(), hasLength(1));
       },
     );
 

--- a/test/unit/workbench_view_prefs_test.dart
+++ b/test/unit/workbench_view_prefs_test.dart
@@ -14,6 +14,7 @@ void main() {
       expect(WorkbenchViewPrefs.defaults.expandedWorkspaceIds, isEmpty);
       expect(WorkbenchViewPrefs.defaults.selectedTagIds, isEmpty);
       expect(WorkbenchViewPrefs.defaults.collapsedParentWorkspaceIds, isEmpty);
+      expect(WorkbenchViewPrefs.defaults.showPinnedWorkspacesBelow, isTrue);
       expect(
         WorkbenchViewPrefs.defaults.sourceControlRootByWorkspaceId,
         isEmpty,
@@ -44,6 +45,7 @@ void main() {
         expandedWorkspaceIds: <String>{'w1'},
         selectedTagIds: <String>{'tag-1'},
         collapsedParentWorkspaceIds: <String>{'w-parent'},
+        showPinnedWorkspacesBelow: false,
         sourceControlRootByWorkspaceId: <String, String>{
           'w-folder': 'packages/app',
         },
@@ -64,6 +66,7 @@ void main() {
       expect(restored.expandedWorkspaceIds, <String>{'w1'});
       expect(restored.selectedTagIds, <String>{'tag-1'});
       expect(restored.collapsedParentWorkspaceIds, <String>{'w-parent'});
+      expect(restored.showPinnedWorkspacesBelow, isFalse);
       expect(restored.sourceControlRootByWorkspaceId, <String, String>{
         'w-folder': 'packages/app',
       });
@@ -111,6 +114,7 @@ void main() {
       expect(restored.collapsedParentWorkspaceIds, isEmpty);
       expect(restored.workspaceSort, WorkbenchSortBy.recent);
       expect(restored.workspaceKindFilter, WorkspaceKindFilter.all);
+      expect(restored.showPinnedWorkspacesBelow, isTrue);
     });
 
     test('round-trips the workspace kind filter', () {

--- a/test/widget/alera_shell_page_pinning_test_cases.dart
+++ b/test/widget/alera_shell_page_pinning_test_cases.dart
@@ -96,6 +96,37 @@ void _registerAleraShellPinningTests() {
     expect(find.text('Pinned'), findsNothing);
   });
 
+  testWidgets('view preference hides the regular pinned workspace copy', (
+    tester,
+  ) async {
+    final seeded = _linkedWorkbenchState();
+    final linked = seeded
+        .workspacesFor('project-1')[1]
+        .copyWith(isPinned: true);
+    await _pumpShell(
+      tester,
+      state: seeded.copyWith(
+        workspacesByProject: <String, List<Workspace>>{
+          'project-1': <Workspace>[
+            seeded.workspacesFor('project-1').first,
+            linked,
+          ],
+        },
+        viewPrefs: seeded.viewPrefs.copyWith(showPinnedWorkspacesBelow: false),
+      ),
+    );
+
+    expect(find.text('Feature login'), findsOneWidget);
+    expect(
+      find.byKey(const ValueKey<String>('workspace-row:pinned:workspace-2')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const ValueKey<String>('workspace-row:regular:workspace-2')),
+      findsNothing,
+    );
+  });
+
   testWidgets('flat grouping shows collapsible pinned and all sections', (
     tester,
   ) async {

--- a/test/widget/workbench_view_options_menu_test.dart
+++ b/test/widget/workbench_view_options_menu_test.dart
@@ -165,6 +165,30 @@ void main() {
       );
     });
 
+    testWidgets('toggles pinned workspace copies below the pinned section', (
+      tester,
+    ) async {
+      final controller = _ViewOptionsTestController(
+        WorkbenchState(projects: <Project>[_project('project-1', 'Alera')]),
+      );
+
+      await _pumpButton(tester, controller);
+      await tester.tap(_viewOptionsButton());
+      await tester.pumpAndSettle();
+
+      final option = find.text('Repeat Pinned Workspaces');
+      expect(option, findsOneWidget);
+      expect(controller.state.viewPrefs.showPinnedWorkspacesBelow, isTrue);
+
+      await tester.tap(option);
+      await tester.pumpAndSettle();
+      expect(controller.state.viewPrefs.showPinnedWorkspacesBelow, isFalse);
+
+      await tester.tap(find.byTooltip('Close'));
+      await tester.pumpAndSettle();
+      expect(_activeDot(), findsOneWidget);
+    });
+
     testWidgets('available project rows animate their hover state', (
       tester,
     ) async {
@@ -327,6 +351,13 @@ class _ViewOptionsTestController extends WorkbenchController {
   void setWorkspaceKindFilter(WorkspaceKindFilter filter) {
     state = state.copyWith(
       viewPrefs: state.viewPrefs.copyWith(workspaceKindFilter: filter),
+    );
+  }
+
+  @override
+  void setShowPinnedWorkspacesBelow(bool show) {
+    state = state.copyWith(
+      viewPrefs: state.viewPrefs.copyWith(showPinnedWorkspacesBelow: show),
     );
   }
 }


### PR DESCRIPTION
## Summary

- Add a `Repeat Pinned Workspaces` View Options toggle on desktop and mobile.
- Hide pinned workspaces from their regular sections when the toggle is disabled.
- Persist and synchronize the preference through the shared runtime state while preserving the current default behavior.

## Validation

- `dart format --set-exit-if-changed lib test integration_test tool`
- `dart tool/quality/check_max_lines.dart`
- `flutter analyze`
- Focused desktop tests: 100 passed
- Mobile `flutter analyze` and full `flutter test`: 186 passed
- `make rust-test`

## Notes

- Local `gh act` could not reach the relevant jobs because the linked workspace gitdir is not supported by its checkout emulation and the runner image registry rejected authentication. Hosted GitHub Actions checks are the merge authority.