### PR TITLE
feat: configure ai text agents and workspace prompt append

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -104,7 +104,9 @@ Terminal clipboard integration is explicit at the runtime boundary. Text takes p
 
 ## AI Text Generation
 
-AI Text generation delegates source-control copy to a user-installed agent CLI. Grok Build participates in the existing commit-message flow through `grok models` discovery and headless `--prompt-file` execution. Alera writes the generated prompt into a private temporary directory, disables Grok tools, subagents, memory, and web access for that invocation, and uses a disposable `GROK_HOME` containing temporary copies of the current authentication and configuration policy files. The directory, including Grok's automatically persisted session, is removed on success, failure, timeout, or cancellation. The default reasoning option leaves Grok's model-specific effort unchanged; explicit levels are forwarded with `--effort`.
+AI Text generation delegates source-control copy to a user-installed agent CLI. Settings define a global agent and model, while each supported prompt can independently override either value or inherit it. The runtime stores the portable execution settings so desktop and mobile workspace-identity generation resolve the same effective configuration.
+
+Grok Build participates in the existing commit-message flow through `grok models` discovery and headless `--prompt-file` execution. Alera writes the generated prompt into a private temporary directory, disables Grok tools, subagents, memory, and web access for that invocation, and uses a disposable `GROK_HOME` containing temporary copies of the current authentication and configuration policy files. The directory, including Grok's automatically persisted session, is removed on success, failure, timeout, or cancellation. The default reasoning option leaves Grok's model-specific effort unchanged; explicit levels are forwarded with `--effort`.
 
 ## Agent Hook Status
 

--- a/docs/worktree-setup-config.md
+++ b/docs/worktree-setup-config.md
@@ -20,6 +20,12 @@ setup = [
   "pnpm install",
   "make bootstrap"
 ]
+
+[new_workspace]
+prompt_append = """
+Follow the project's contributor instructions.
+Run the focused tests before finishing.
+"""
 ```
 
 `copy` entries copy files or directories from the main project checkout into the new linked workspace. `to` defaults to `from`, and `overwrite` defaults to `false`.
@@ -27,6 +33,12 @@ setup = [
 `setup` commands run sequentially from the new linked workspace root. When they run inline (see below) they stop on the first non-zero exit code.
 
 Paths are repo-relative literal paths. Absolute paths and `..` escapes are rejected. Globs and custom command environments are not part of v1.
+
+## New Workspace Prompt Append
+
+`new_workspace.prompt_append` is optional project-specific text added to the initial prompt immediately before Alera starts the selected agent profile from the **New Workspace** flow. Alera separates the user prompt and the configured text with a blank line. It does not send this append text through AI Text and does not use it to generate the workspace name or branch.
+
+Like the worktree settings, this value can be stored in `alera.toml` or edited under **Settings > Projects**. A UI override replaces the complete repository config for that project, including this value.
 
 ## Where the setup runs
 

--- a/lib/src/features/ai_text_generation/application/ai_text_generation_service.dart
+++ b/lib/src/features/ai_text_generation/application/ai_text_generation_service.dart
@@ -97,7 +97,12 @@ class CliAiTextGenerationService implements AiTextGenerationService {
         throw const AiTextGenerationCanceledException();
       }
       final environment = await commandEnvironmentResolver.environment();
-      plan = await _planCommand(request.settings, prompt, environment);
+      plan = await _planCommand(
+        request.settings,
+        request.operation,
+        prompt,
+        environment,
+      );
       if (_canceled.contains(key)) {
         throw const AiTextGenerationCanceledException();
       }
@@ -298,23 +303,25 @@ class CliAiTextGenerationService implements AiTextGenerationService {
 
   Future<_AiTextCommandPlan> _planCommand(
     AiTextGenerationSettings settings,
+    AiTextGenerationOperation operation,
     String prompt,
     Map<String, String> environment,
   ) async {
-    if (settings.agent == AiTextGenerationAgent.custom) {
+    final agent = settings.agentFor(operation);
+    if (agent == AiTextGenerationAgent.custom) {
       return _planCustomCommand(settings.customCommand, prompt);
     }
-    final spec = aiTextAgentSpecs[settings.agent];
+    final spec = aiTextAgentSpecs[agent];
     if (spec == null) {
       throw AiTextGenerationException(
-        '${settings.agent.label} does not support AI text generation.',
+        '${agent.label} does not support AI text generation.',
       );
     }
     final model = modelForAgent(
-      settings.agent,
-      settings.modelFor(settings.agent) ??
-          defaultModelIdForAgent(settings.agent, settings),
-      extraModels: discoveredModelsForAgent(settings, settings.agent),
+      agent,
+      settings.modelForOperation(operation) ??
+          defaultModelIdForAgent(agent, settings),
+      extraModels: discoveredModelsForAgent(settings, agent),
     );
     final thinking =
         settings.thinkingForModel(model.id) ?? model.defaultThinkingLevel;
@@ -337,7 +344,7 @@ class CliAiTextGenerationService implements AiTextGenerationService {
         );
         await promptFile.writeAsString(prompt, flush: true);
         deliveredPrompt = promptFile.path;
-        if (settings.agent == AiTextGenerationAgent.grok) {
+        if (agent == AiTextGenerationAgent.grok) {
           final grokHome = Directory(p.join(promptDirectory.path, 'grok-home'));
           await grokHome.create();
           await _copyGrokRuntimeConfiguration(grokHome, environment);

--- a/lib/src/features/ai_text_generation/domain/ai_text_generation_settings.dart
+++ b/lib/src/features/ai_text_generation/domain/ai_text_generation_settings.dart
@@ -90,6 +90,19 @@ class AiTextDiscoveredModel with AiTextDiscoveredModelMappable {
 }
 
 @MappableClass()
+class AiTextGenerationPromptSettings
+    with AiTextGenerationPromptSettingsMappable {
+  const AiTextGenerationPromptSettings({this.agent, this.model});
+
+  final AiTextGenerationAgent? agent;
+  final String? model;
+
+  bool get inheritsAgent => agent == null;
+
+  bool get inheritsModel => model == null || model!.trim().isEmpty;
+}
+
+@MappableClass()
 class AiTextGenerationSettings with AiTextGenerationSettingsMappable {
   const AiTextGenerationSettings({
     this.enabled = true,
@@ -102,6 +115,8 @@ class AiTextGenerationSettings with AiTextGenerationSettingsMappable {
         const <AiTextGenerationAgent, String>{},
     this.customCommand = '',
     this.instructionsByOperation = const <AiTextGenerationOperation, String>{},
+    this.promptSettingsByOperation =
+        const <AiTextGenerationOperation, AiTextGenerationPromptSettings>{},
     this.timeoutSeconds = 120,
   });
 
@@ -114,6 +129,8 @@ class AiTextGenerationSettings with AiTextGenerationSettingsMappable {
   final Map<AiTextGenerationAgent, String> discoveredDefaultModelByAgent;
   final String customCommand;
   final Map<AiTextGenerationOperation, String> instructionsByOperation;
+  final Map<AiTextGenerationOperation, AiTextGenerationPromptSettings>
+  promptSettingsByOperation;
   final int timeoutSeconds;
 
   String? modelFor(AiTextGenerationAgent agent) {
@@ -131,6 +148,26 @@ class AiTextGenerationSettings with AiTextGenerationSettingsMappable {
 
   String instructionsFor(AiTextGenerationOperation operation) {
     return instructionsByOperation[operation]?.trim() ?? '';
+  }
+
+  AiTextGenerationPromptSettings promptSettingsFor(
+    AiTextGenerationOperation operation,
+  ) {
+    return promptSettingsByOperation[operation] ??
+        const AiTextGenerationPromptSettings();
+  }
+
+  AiTextGenerationAgent agentFor(AiTextGenerationOperation operation) {
+    return promptSettingsFor(operation).agent ?? agent;
+  }
+
+  String? modelForOperation(AiTextGenerationOperation operation) {
+    final promptSettings = promptSettingsFor(operation);
+    final override = promptSettings.model?.trim();
+    if (override != null && override.isNotEmpty) {
+      return override;
+    }
+    return modelFor(agentFor(operation));
   }
 
   List<AiTextDiscoveredModel> discoveredModelsFor(AiTextGenerationAgent agent) {

--- a/lib/src/features/ai_text_generation/domain/ai_text_generation_settings.mapper.dart
+++ b/lib/src/features/ai_text_generation/domain/ai_text_generation_settings.mapper.dart
@@ -509,6 +509,173 @@ class _AiTextDiscoveredModelCopyWithImpl<$R, $Out>
       _AiTextDiscoveredModelCopyWithImpl<$R2, $Out2>($value, $cast, t);
 }
 
+class AiTextGenerationPromptSettingsMapper
+    extends ClassMapperBase<AiTextGenerationPromptSettings> {
+  AiTextGenerationPromptSettingsMapper._();
+
+  static AiTextGenerationPromptSettingsMapper? _instance;
+  static AiTextGenerationPromptSettingsMapper ensureInitialized() {
+    if (_instance == null) {
+      MapperContainer.globals.use(
+        _instance = AiTextGenerationPromptSettingsMapper._(),
+      );
+      AiTextGenerationAgentMapper.ensureInitialized();
+    }
+    return _instance!;
+  }
+
+  @override
+  final String id = 'AiTextGenerationPromptSettings';
+
+  static AiTextGenerationAgent? _$agent(AiTextGenerationPromptSettings v) =>
+      v.agent;
+  static const Field<AiTextGenerationPromptSettings, AiTextGenerationAgent>
+  _f$agent = Field('agent', _$agent, opt: true);
+  static String? _$model(AiTextGenerationPromptSettings v) => v.model;
+  static const Field<AiTextGenerationPromptSettings, String> _f$model = Field(
+    'model',
+    _$model,
+    opt: true,
+  );
+
+  @override
+  final MappableFields<AiTextGenerationPromptSettings> fields = const {
+    #agent: _f$agent,
+    #model: _f$model,
+  };
+
+  static AiTextGenerationPromptSettings _instantiate(DecodingData data) {
+    return AiTextGenerationPromptSettings(
+      agent: data.dec(_f$agent),
+      model: data.dec(_f$model),
+    );
+  }
+
+  @override
+  final Function instantiate = _instantiate;
+
+  static AiTextGenerationPromptSettings fromMap(Map<String, dynamic> map) {
+    return ensureInitialized().decodeMap<AiTextGenerationPromptSettings>(map);
+  }
+
+  static AiTextGenerationPromptSettings fromJson(String json) {
+    return ensureInitialized().decodeJson<AiTextGenerationPromptSettings>(json);
+  }
+}
+
+mixin AiTextGenerationPromptSettingsMappable {
+  String toJson() {
+    return AiTextGenerationPromptSettingsMapper.ensureInitialized()
+        .encodeJson<AiTextGenerationPromptSettings>(
+          this as AiTextGenerationPromptSettings,
+        );
+  }
+
+  Map<String, dynamic> toMap() {
+    return AiTextGenerationPromptSettingsMapper.ensureInitialized()
+        .encodeMap<AiTextGenerationPromptSettings>(
+          this as AiTextGenerationPromptSettings,
+        );
+  }
+
+  AiTextGenerationPromptSettingsCopyWith<
+    AiTextGenerationPromptSettings,
+    AiTextGenerationPromptSettings,
+    AiTextGenerationPromptSettings
+  >
+  get copyWith =>
+      _AiTextGenerationPromptSettingsCopyWithImpl<
+        AiTextGenerationPromptSettings,
+        AiTextGenerationPromptSettings
+      >(this as AiTextGenerationPromptSettings, $identity, $identity);
+  @override
+  String toString() {
+    return AiTextGenerationPromptSettingsMapper.ensureInitialized()
+        .stringifyValue(this as AiTextGenerationPromptSettings);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return AiTextGenerationPromptSettingsMapper.ensureInitialized().equalsValue(
+      this as AiTextGenerationPromptSettings,
+      other,
+    );
+  }
+
+  @override
+  int get hashCode {
+    return AiTextGenerationPromptSettingsMapper.ensureInitialized().hashValue(
+      this as AiTextGenerationPromptSettings,
+    );
+  }
+}
+
+extension AiTextGenerationPromptSettingsValueCopy<$R, $Out>
+    on ObjectCopyWith<$R, AiTextGenerationPromptSettings, $Out> {
+  AiTextGenerationPromptSettingsCopyWith<
+    $R,
+    AiTextGenerationPromptSettings,
+    $Out
+  >
+  get $asAiTextGenerationPromptSettings => $base.as(
+    (v, t, t2) =>
+        _AiTextGenerationPromptSettingsCopyWithImpl<$R, $Out>(v, t, t2),
+  );
+}
+
+abstract class AiTextGenerationPromptSettingsCopyWith<
+  $R,
+  $In extends AiTextGenerationPromptSettings,
+  $Out
+>
+    implements ClassCopyWith<$R, $In, $Out> {
+  $R call({AiTextGenerationAgent? agent, String? model});
+  AiTextGenerationPromptSettingsCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(
+    Then<$Out2, $R2> t,
+  );
+}
+
+class _AiTextGenerationPromptSettingsCopyWithImpl<$R, $Out>
+    extends ClassCopyWithBase<$R, AiTextGenerationPromptSettings, $Out>
+    implements
+        AiTextGenerationPromptSettingsCopyWith<
+          $R,
+          AiTextGenerationPromptSettings,
+          $Out
+        > {
+  _AiTextGenerationPromptSettingsCopyWithImpl(
+    super.value,
+    super.then,
+    super.then2,
+  );
+
+  @override
+  late final ClassMapperBase<AiTextGenerationPromptSettings> $mapper =
+      AiTextGenerationPromptSettingsMapper.ensureInitialized();
+  @override
+  $R call({Object? agent = $none, Object? model = $none}) => $apply(
+    FieldCopyWithData({
+      if (agent != $none) #agent: agent,
+      if (model != $none) #model: model,
+    }),
+  );
+  @override
+  AiTextGenerationPromptSettings $make(CopyWithData data) =>
+      AiTextGenerationPromptSettings(
+        agent: data.get(#agent, or: $value.agent),
+        model: data.get(#model, or: $value.model),
+      );
+
+  @override
+  AiTextGenerationPromptSettingsCopyWith<
+    $R2,
+    AiTextGenerationPromptSettings,
+    $Out2
+  >
+  $chain<$R2, $Out2>(Then<$Out2, $R2> t) =>
+      _AiTextGenerationPromptSettingsCopyWithImpl<$R2, $Out2>($value, $cast, t);
+}
+
 class AiTextGenerationSettingsMapper
     extends ClassMapperBase<AiTextGenerationSettings> {
   AiTextGenerationSettingsMapper._();
@@ -522,6 +689,7 @@ class AiTextGenerationSettingsMapper
       AiTextGenerationAgentMapper.ensureInitialized();
       AiTextDiscoveredModelMapper.ensureInitialized();
       AiTextGenerationOperationMapper.ensureInitialized();
+      AiTextGenerationPromptSettingsMapper.ensureInitialized();
     }
     return _instance!;
   }
@@ -608,6 +776,19 @@ class AiTextGenerationSettingsMapper
     opt: true,
     def: const <AiTextGenerationOperation, String>{},
   );
+  static Map<AiTextGenerationOperation, AiTextGenerationPromptSettings>
+  _$promptSettingsByOperation(AiTextGenerationSettings v) =>
+      v.promptSettingsByOperation;
+  static const Field<
+    AiTextGenerationSettings,
+    Map<AiTextGenerationOperation, AiTextGenerationPromptSettings>
+  >
+  _f$promptSettingsByOperation = Field(
+    'promptSettingsByOperation',
+    _$promptSettingsByOperation,
+    opt: true,
+    def: const <AiTextGenerationOperation, AiTextGenerationPromptSettings>{},
+  );
   static int _$timeoutSeconds(AiTextGenerationSettings v) => v.timeoutSeconds;
   static const Field<AiTextGenerationSettings, int> _f$timeoutSeconds = Field(
     'timeoutSeconds',
@@ -626,6 +807,7 @@ class AiTextGenerationSettingsMapper
     #discoveredDefaultModelByAgent: _f$discoveredDefaultModelByAgent,
     #customCommand: _f$customCommand,
     #instructionsByOperation: _f$instructionsByOperation,
+    #promptSettingsByOperation: _f$promptSettingsByOperation,
     #timeoutSeconds: _f$timeoutSeconds,
   };
 
@@ -639,6 +821,7 @@ class AiTextGenerationSettingsMapper
       discoveredDefaultModelByAgent: data.dec(_f$discoveredDefaultModelByAgent),
       customCommand: data.dec(_f$customCommand),
       instructionsByOperation: data.dec(_f$instructionsByOperation),
+      promptSettingsByOperation: data.dec(_f$promptSettingsByOperation),
       timeoutSeconds: data.dec(_f$timeoutSeconds),
     );
   }
@@ -743,6 +926,17 @@ abstract class AiTextGenerationSettingsCopyWith<
     ObjectCopyWith<$R, String, String>
   >
   get instructionsByOperation;
+  MapCopyWith<
+    $R,
+    AiTextGenerationOperation,
+    AiTextGenerationPromptSettings,
+    AiTextGenerationPromptSettingsCopyWith<
+      $R,
+      AiTextGenerationPromptSettings,
+      AiTextGenerationPromptSettings
+    >
+  >
+  get promptSettingsByOperation;
   $R call({
     bool? enabled,
     AiTextGenerationAgent? agent,
@@ -753,6 +947,8 @@ abstract class AiTextGenerationSettingsCopyWith<
     Map<AiTextGenerationAgent, String>? discoveredDefaultModelByAgent,
     String? customCommand,
     Map<AiTextGenerationOperation, String>? instructionsByOperation,
+    Map<AiTextGenerationOperation, AiTextGenerationPromptSettings>?
+    promptSettingsByOperation,
     int? timeoutSeconds,
   });
   AiTextGenerationSettingsCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(
@@ -825,6 +1021,22 @@ class _AiTextGenerationSettingsCopyWithImpl<$R, $Out>
     (v) => call(instructionsByOperation: v),
   );
   @override
+  MapCopyWith<
+    $R,
+    AiTextGenerationOperation,
+    AiTextGenerationPromptSettings,
+    AiTextGenerationPromptSettingsCopyWith<
+      $R,
+      AiTextGenerationPromptSettings,
+      AiTextGenerationPromptSettings
+    >
+  >
+  get promptSettingsByOperation => MapCopyWith(
+    $value.promptSettingsByOperation,
+    (v, t) => v.copyWith.$chain(t),
+    (v) => call(promptSettingsByOperation: v),
+  );
+  @override
   $R call({
     bool? enabled,
     AiTextGenerationAgent? agent,
@@ -835,6 +1047,8 @@ class _AiTextGenerationSettingsCopyWithImpl<$R, $Out>
     Map<AiTextGenerationAgent, String>? discoveredDefaultModelByAgent,
     String? customCommand,
     Map<AiTextGenerationOperation, String>? instructionsByOperation,
+    Map<AiTextGenerationOperation, AiTextGenerationPromptSettings>?
+    promptSettingsByOperation,
     int? timeoutSeconds,
   }) => $apply(
     FieldCopyWithData({
@@ -851,6 +1065,8 @@ class _AiTextGenerationSettingsCopyWithImpl<$R, $Out>
       if (customCommand != null) #customCommand: customCommand,
       if (instructionsByOperation != null)
         #instructionsByOperation: instructionsByOperation,
+      if (promptSettingsByOperation != null)
+        #promptSettingsByOperation: promptSettingsByOperation,
       if (timeoutSeconds != null) #timeoutSeconds: timeoutSeconds,
     }),
   );
@@ -878,6 +1094,10 @@ class _AiTextGenerationSettingsCopyWithImpl<$R, $Out>
     instructionsByOperation: data.get(
       #instructionsByOperation,
       or: $value.instructionsByOperation,
+    ),
+    promptSettingsByOperation: data.get(
+      #promptSettingsByOperation,
+      or: $value.promptSettingsByOperation,
     ),
     timeoutSeconds: data.get(#timeoutSeconds, or: $value.timeoutSeconds),
   );

--- a/lib/src/features/projects/domain/project_config.dart
+++ b/lib/src/features/projects/domain/project_config.dart
@@ -7,21 +7,35 @@ part 'project_config.mapper.dart';
 class ProjectConfig with ProjectConfigMappable {
   const ProjectConfig({
     this.worktree = WorktreeSetupConfig.defaults,
+    this.newWorkspace = NewWorkspaceConfig.defaults,
     this.gitHostingProvider,
   });
 
   final WorktreeSetupConfig worktree;
+  final NewWorkspaceConfig newWorkspace;
 
   /// Overrides auto-detection of the git hosting provider for this project.
   /// Null means auto-detect from the repository's remote.
   final GitHostingProvider? gitHostingProvider;
 
-  bool get isEmpty => worktree.isEmpty && gitHostingProvider == null;
+  bool get isEmpty =>
+      worktree.isEmpty && newWorkspace.isEmpty && gitHostingProvider == null;
 
   static const ProjectConfig empty = ProjectConfig();
 
   factory ProjectConfig.fromJson(Map<String, Object?> json) =>
       ProjectConfigMapper.fromMap(Map<String, dynamic>.from(json));
+}
+
+@MappableClass()
+class NewWorkspaceConfig with NewWorkspaceConfigMappable {
+  const NewWorkspaceConfig({this.promptAppend = ''});
+
+  final String promptAppend;
+
+  bool get isEmpty => promptAppend.trim().isEmpty;
+
+  static const NewWorkspaceConfig defaults = NewWorkspaceConfig();
 }
 
 @MappableClass()

--- a/lib/src/features/projects/domain/project_config.mapper.dart
+++ b/lib/src/features/projects/domain/project_config.mapper.dart
@@ -16,6 +16,7 @@ class ProjectConfigMapper extends ClassMapperBase<ProjectConfig> {
     if (_instance == null) {
       MapperContainer.globals.use(_instance = ProjectConfigMapper._());
       WorktreeSetupConfigMapper.ensureInitialized();
+      NewWorkspaceConfigMapper.ensureInitialized();
       GitHostingProviderMapper.ensureInitialized();
     }
     return _instance!;
@@ -31,6 +32,13 @@ class ProjectConfigMapper extends ClassMapperBase<ProjectConfig> {
     opt: true,
     def: WorktreeSetupConfig.defaults,
   );
+  static NewWorkspaceConfig _$newWorkspace(ProjectConfig v) => v.newWorkspace;
+  static const Field<ProjectConfig, NewWorkspaceConfig> _f$newWorkspace = Field(
+    'newWorkspace',
+    _$newWorkspace,
+    opt: true,
+    def: NewWorkspaceConfig.defaults,
+  );
   static GitHostingProvider? _$gitHostingProvider(ProjectConfig v) =>
       v.gitHostingProvider;
   static const Field<ProjectConfig, GitHostingProvider> _f$gitHostingProvider =
@@ -39,12 +47,14 @@ class ProjectConfigMapper extends ClassMapperBase<ProjectConfig> {
   @override
   final MappableFields<ProjectConfig> fields = const {
     #worktree: _f$worktree,
+    #newWorkspace: _f$newWorkspace,
     #gitHostingProvider: _f$gitHostingProvider,
   };
 
   static ProjectConfig _instantiate(DecodingData data) {
     return ProjectConfig(
       worktree: data.dec(_f$worktree),
+      newWorkspace: data.dec(_f$newWorkspace),
       gitHostingProvider: data.dec(_f$gitHostingProvider),
     );
   }
@@ -113,8 +123,11 @@ abstract class ProjectConfigCopyWith<$R, $In extends ProjectConfig, $Out>
     implements ClassCopyWith<$R, $In, $Out> {
   WorktreeSetupConfigCopyWith<$R, WorktreeSetupConfig, WorktreeSetupConfig>
   get worktree;
+  NewWorkspaceConfigCopyWith<$R, NewWorkspaceConfig, NewWorkspaceConfig>
+  get newWorkspace;
   $R call({
     WorktreeSetupConfig? worktree,
+    NewWorkspaceConfig? newWorkspace,
     GitHostingProvider? gitHostingProvider,
   });
   ProjectConfigCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(Then<$Out2, $R2> t);
@@ -132,18 +145,25 @@ class _ProjectConfigCopyWithImpl<$R, $Out>
   WorktreeSetupConfigCopyWith<$R, WorktreeSetupConfig, WorktreeSetupConfig>
   get worktree => $value.worktree.copyWith.$chain((v) => call(worktree: v));
   @override
+  NewWorkspaceConfigCopyWith<$R, NewWorkspaceConfig, NewWorkspaceConfig>
+  get newWorkspace =>
+      $value.newWorkspace.copyWith.$chain((v) => call(newWorkspace: v));
+  @override
   $R call({
     WorktreeSetupConfig? worktree,
+    NewWorkspaceConfig? newWorkspace,
     Object? gitHostingProvider = $none,
   }) => $apply(
     FieldCopyWithData({
       if (worktree != null) #worktree: worktree,
+      if (newWorkspace != null) #newWorkspace: newWorkspace,
       if (gitHostingProvider != $none) #gitHostingProvider: gitHostingProvider,
     }),
   );
   @override
   ProjectConfig $make(CopyWithData data) => ProjectConfig(
     worktree: data.get(#worktree, or: $value.worktree),
+    newWorkspace: data.get(#newWorkspace, or: $value.newWorkspace),
     gitHostingProvider: data.get(
       #gitHostingProvider,
       or: $value.gitHostingProvider,
@@ -463,5 +483,136 @@ class _WorktreeCopyRuleCopyWithImpl<$R, $Out>
   WorktreeCopyRuleCopyWith<$R2, WorktreeCopyRule, $Out2> $chain<$R2, $Out2>(
     Then<$Out2, $R2> t,
   ) => _WorktreeCopyRuleCopyWithImpl<$R2, $Out2>($value, $cast, t);
+}
+
+class NewWorkspaceConfigMapper extends ClassMapperBase<NewWorkspaceConfig> {
+  NewWorkspaceConfigMapper._();
+
+  static NewWorkspaceConfigMapper? _instance;
+  static NewWorkspaceConfigMapper ensureInitialized() {
+    if (_instance == null) {
+      MapperContainer.globals.use(_instance = NewWorkspaceConfigMapper._());
+    }
+    return _instance!;
+  }
+
+  @override
+  final String id = 'NewWorkspaceConfig';
+
+  static String _$promptAppend(NewWorkspaceConfig v) => v.promptAppend;
+  static const Field<NewWorkspaceConfig, String> _f$promptAppend = Field(
+    'promptAppend',
+    _$promptAppend,
+    opt: true,
+    def: '',
+  );
+
+  @override
+  final MappableFields<NewWorkspaceConfig> fields = const {
+    #promptAppend: _f$promptAppend,
+  };
+
+  static NewWorkspaceConfig _instantiate(DecodingData data) {
+    return NewWorkspaceConfig(promptAppend: data.dec(_f$promptAppend));
+  }
+
+  @override
+  final Function instantiate = _instantiate;
+
+  static NewWorkspaceConfig fromMap(Map<String, dynamic> map) {
+    return ensureInitialized().decodeMap<NewWorkspaceConfig>(map);
+  }
+
+  static NewWorkspaceConfig fromJson(String json) {
+    return ensureInitialized().decodeJson<NewWorkspaceConfig>(json);
+  }
+}
+
+mixin NewWorkspaceConfigMappable {
+  String toJson() {
+    return NewWorkspaceConfigMapper.ensureInitialized()
+        .encodeJson<NewWorkspaceConfig>(this as NewWorkspaceConfig);
+  }
+
+  Map<String, dynamic> toMap() {
+    return NewWorkspaceConfigMapper.ensureInitialized()
+        .encodeMap<NewWorkspaceConfig>(this as NewWorkspaceConfig);
+  }
+
+  NewWorkspaceConfigCopyWith<
+    NewWorkspaceConfig,
+    NewWorkspaceConfig,
+    NewWorkspaceConfig
+  >
+  get copyWith =>
+      _NewWorkspaceConfigCopyWithImpl<NewWorkspaceConfig, NewWorkspaceConfig>(
+        this as NewWorkspaceConfig,
+        $identity,
+        $identity,
+      );
+  @override
+  String toString() {
+    return NewWorkspaceConfigMapper.ensureInitialized().stringifyValue(
+      this as NewWorkspaceConfig,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return NewWorkspaceConfigMapper.ensureInitialized().equalsValue(
+      this as NewWorkspaceConfig,
+      other,
+    );
+  }
+
+  @override
+  int get hashCode {
+    return NewWorkspaceConfigMapper.ensureInitialized().hashValue(
+      this as NewWorkspaceConfig,
+    );
+  }
+}
+
+extension NewWorkspaceConfigValueCopy<$R, $Out>
+    on ObjectCopyWith<$R, NewWorkspaceConfig, $Out> {
+  NewWorkspaceConfigCopyWith<$R, NewWorkspaceConfig, $Out>
+  get $asNewWorkspaceConfig => $base.as(
+    (v, t, t2) => _NewWorkspaceConfigCopyWithImpl<$R, $Out>(v, t, t2),
+  );
+}
+
+abstract class NewWorkspaceConfigCopyWith<
+  $R,
+  $In extends NewWorkspaceConfig,
+  $Out
+>
+    implements ClassCopyWith<$R, $In, $Out> {
+  $R call({String? promptAppend});
+  NewWorkspaceConfigCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(
+    Then<$Out2, $R2> t,
+  );
+}
+
+class _NewWorkspaceConfigCopyWithImpl<$R, $Out>
+    extends ClassCopyWithBase<$R, NewWorkspaceConfig, $Out>
+    implements NewWorkspaceConfigCopyWith<$R, NewWorkspaceConfig, $Out> {
+  _NewWorkspaceConfigCopyWithImpl(super.value, super.then, super.then2);
+
+  @override
+  late final ClassMapperBase<NewWorkspaceConfig> $mapper =
+      NewWorkspaceConfigMapper.ensureInitialized();
+  @override
+  $R call({String? promptAppend}) => $apply(
+    FieldCopyWithData({if (promptAppend != null) #promptAppend: promptAppend}),
+  );
+  @override
+  NewWorkspaceConfig $make(CopyWithData data) => NewWorkspaceConfig(
+    promptAppend: data.get(#promptAppend, or: $value.promptAppend),
+  );
+
+  @override
+  NewWorkspaceConfigCopyWith<$R2, NewWorkspaceConfig, $Out2> $chain<$R2, $Out2>(
+    Then<$Out2, $R2> t,
+  ) => _NewWorkspaceConfigCopyWithImpl<$R2, $Out2>($value, $cast, t);
 }
 

--- a/lib/src/features/projects/infra/project_config_toml_file_store.dart
+++ b/lib/src/features/projects/infra/project_config_toml_file_store.dart
@@ -45,9 +45,13 @@ ProjectConfig parseProjectConfigToml(String contents) {
   }
   final root = Map<String, Object?>.from(decoded);
   final provider = _gitHostingProviderFrom(root['git_hosting_provider']);
+  final newWorkspace = _newWorkspaceConfigFrom(root['new_workspace']);
   final worktreeValue = root['worktree'];
   if (worktreeValue == null) {
-    return ProjectConfig(gitHostingProvider: provider);
+    return ProjectConfig(
+      newWorkspace: newWorkspace,
+      gitHostingProvider: provider,
+    );
   }
   if (worktreeValue is! Map) {
     throw ProjectConfigException('alera.toml [worktree] must be a table');
@@ -58,8 +62,29 @@ ProjectConfig parseProjectConfigToml(String contents) {
   final setup = _setupCommandsFrom(worktree['setup']);
   return ProjectConfig(
     worktree: WorktreeSetupConfig(copy: copyRules, setup: setup),
+    newWorkspace: newWorkspace,
     gitHostingProvider: provider,
   );
+}
+
+NewWorkspaceConfig _newWorkspaceConfigFrom(Object? value) {
+  if (value == null) {
+    return NewWorkspaceConfig.defaults;
+  }
+  if (value is! Map) {
+    throw ProjectConfigException('alera.toml [new_workspace] must be a table');
+  }
+  final table = Map<String, Object?>.from(value);
+  final promptAppend = table['prompt_append'];
+  if (promptAppend == null) {
+    return NewWorkspaceConfig.defaults;
+  }
+  if (promptAppend is! String) {
+    throw ProjectConfigException(
+      'new_workspace.prompt_append must be a string',
+    );
+  }
+  return NewWorkspaceConfig(promptAppend: promptAppend.trim());
 }
 
 GitHostingProvider? _gitHostingProviderFrom(Object? value) {

--- a/lib/src/features/settings/infra/runtime_settings_repository.dart
+++ b/lib/src/features/settings/infra/runtime_settings_repository.dart
@@ -97,6 +97,14 @@ Map<String, Object?> _runtimeAiTextSettings(AiTextGenerationSettings settings) {
       for (final entry in settings.instructionsByOperation.entries)
         entry.key.key: entry.value,
     },
+    'promptSettingsByOperation': <String, Map<String, Object?>>{
+      for (final entry in settings.promptSettingsByOperation.entries)
+        entry.key.key: <String, Object?>{
+          if (entry.value.agent != null) 'agent': entry.value.agent!.key,
+          if (entry.value.model?.trim().isNotEmpty == true)
+            'model': entry.value.model!.trim(),
+        },
+    },
     'timeoutSeconds': settings.timeoutSeconds,
   };
 }

--- a/lib/src/features/settings/presentation/panes/ai_text_pane.dart
+++ b/lib/src/features/settings/presentation/panes/ai_text_pane.dart
@@ -28,6 +28,13 @@ class AiTextSettingsPane extends ConsumerStatefulWidget {
 }
 
 class _AiTextSettingsPaneState extends ConsumerState<AiTextSettingsPane> {
+  static const List<AiTextGenerationOperation> _configuredOperations =
+      <AiTextGenerationOperation>[
+        AiTextGenerationOperation.commitMessage,
+        AiTextGenerationOperation.pullRequestDetails,
+        AiTextGenerationOperation.workspaceIdentity,
+      ];
+
   final Map<AiTextGenerationAgent, _AiTextModelDiscoveryState> _discovery =
       <AiTextGenerationAgent, _AiTextModelDiscoveryState>{};
   final Set<AiTextGenerationAgent> _autoDiscovered = <AiTextGenerationAgent>{};
@@ -36,7 +43,7 @@ class _AiTextSettingsPaneState extends ConsumerState<AiTextSettingsPane> {
   void initState() {
     super.initState();
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      _autoDiscoverActiveAgent();
+      _autoDiscoverConfiguredAgents();
     });
   }
 
@@ -44,9 +51,11 @@ class _AiTextSettingsPaneState extends ConsumerState<AiTextSettingsPane> {
   void didUpdateWidget(covariant AiTextSettingsPane oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.settings.agent != widget.settings.agent ||
-        oldWidget.settings.enabled != widget.settings.enabled) {
+        oldWidget.settings.enabled != widget.settings.enabled ||
+        oldWidget.settings.promptSettingsByOperation !=
+            widget.settings.promptSettingsByOperation) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
-        _autoDiscoverActiveAgent();
+        _autoDiscoverConfiguredAgents();
       });
     }
   }
@@ -86,7 +95,7 @@ class _AiTextSettingsPaneState extends ConsumerState<AiTextSettingsPane> {
               AiTextAgentRow(
                 value: agent,
                 onChanged: (value) =>
-                    widget.onChanged(settings.copyWith(agent: value)),
+                    widget.onChanged(_withGlobalAgent(settings, value)),
               ),
               if (agent == AiTextGenerationAgent.custom)
                 SettingsTextRow(
@@ -134,6 +143,34 @@ class _AiTextSettingsPaneState extends ConsumerState<AiTextSettingsPane> {
                     ),
                   ),
                 ),
+              if (agent != AiTextGenerationAgent.custom &&
+                  _configuredOperations.any(
+                    (operation) =>
+                        settings.agentFor(operation) ==
+                        AiTextGenerationAgent.custom,
+                  ))
+                SettingsTextRow(
+                  title: 'Custom Command',
+                  description:
+                      'Used By Prompts That Override The Global Agent With Custom Command.',
+                  value: settings.customCommand,
+                  hintText: 'llm --system commit-message',
+                  onChanged: (value) =>
+                      widget.onChanged(settings.copyWith(customCommand: value)),
+                ),
+            ],
+          ),
+        ),
+        const SizedBox(height: AleraTokens.space16),
+        KeyedSubtree(
+          key: widget.groupKeys['promptOverrides'],
+          child: AleraSettingsGroup(
+            title: 'Prompt Overrides',
+            description:
+                'Choose A Different Agent Or Model Per Prompt, Or Inherit The Global Selection.',
+            children: <Widget>[
+              for (final operation in _configuredOperations)
+                ..._promptOverrideRows(settings, operation),
             ],
           ),
         ),
@@ -196,11 +233,105 @@ class _AiTextSettingsPaneState extends ConsumerState<AiTextSettingsPane> {
     );
   }
 
-  void _autoDiscoverActiveAgent() {
+  List<Widget> _promptOverrideRows(
+    AiTextGenerationSettings settings,
+    AiTextGenerationOperation operation,
+  ) {
+    final promptSettings = settings.promptSettingsFor(operation);
+    final agent = settings.agentFor(operation);
+    final inheritedModel = modelForAgent(
+      agent,
+      settings.modelFor(agent) ?? defaultModelIdForAgent(agent, settings),
+      extraModels: discoveredModelsForAgent(settings, agent),
+    );
+    final spec = aiTextAgentSpecs[agent];
+    final discovery = _discovery[agent] ?? const _AiTextModelDiscoveryState();
+    return <Widget>[
+      AiTextPromptAgentRow(
+        operation: operation,
+        globalAgent: settings.agent,
+        value: promptSettings.agent,
+        onChanged: (agent) {
+          final previousAgent = settings.agentFor(operation);
+          final nextAgent = agent ?? settings.agent;
+          _updatePromptSettings(
+            settings,
+            operation,
+            AiTextGenerationPromptSettings(
+              agent: agent,
+              model: previousAgent == nextAgent ? promptSettings.model : null,
+            ),
+          );
+        },
+      ),
+      if (agent != AiTextGenerationAgent.custom)
+        AiTextPromptModelRow(
+          operation: operation,
+          agent: agent,
+          models: modelsForAgent(agent, settings),
+          inheritedModel: inheritedModel,
+          value: promptSettings.model,
+          discovering: discovery.loading,
+          discoveryError: discovery.error,
+          onRefreshModels: spec?.modelsCommand == null
+              ? null
+              : () => unawaited(_discoverModels(agent)),
+          onChanged: (model) {
+            _updatePromptSettings(
+              settings,
+              operation,
+              AiTextGenerationPromptSettings(
+                agent: promptSettings.agent,
+                model: model,
+              ),
+            );
+          },
+        ),
+    ];
+  }
+
+  void _updatePromptSettings(
+    AiTextGenerationSettings settings,
+    AiTextGenerationOperation operation,
+    AiTextGenerationPromptSettings promptSettings,
+  ) {
+    final updated = <AiTextGenerationOperation, AiTextGenerationPromptSettings>{
+      ...settings.promptSettingsByOperation,
+    };
+    if (promptSettings.inheritsAgent && promptSettings.inheritsModel) {
+      updated.remove(operation);
+    } else {
+      updated[operation] = promptSettings;
+    }
+    widget.onChanged(settings.copyWith(promptSettingsByOperation: updated));
+  }
+
+  AiTextGenerationSettings _withGlobalAgent(
+    AiTextGenerationSettings settings,
+    AiTextGenerationAgent agent,
+  ) {
+    final updated = <AiTextGenerationOperation, AiTextGenerationPromptSettings>{
+      for (final entry in settings.promptSettingsByOperation.entries)
+        if (entry.value.agent != null) entry.key: entry.value,
+    };
+    return settings.copyWith(agent: agent, promptSettingsByOperation: updated);
+  }
+
+  void _autoDiscoverConfiguredAgents() {
     if (!mounted || !widget.settings.enabled) {
       return;
     }
-    final agent = widget.settings.agent;
+    final agents = <AiTextGenerationAgent>{
+      widget.settings.agent,
+      for (final operation in _configuredOperations)
+        widget.settings.agentFor(operation),
+    };
+    for (final agent in agents) {
+      _autoDiscoverAgent(agent);
+    }
+  }
+
+  void _autoDiscoverAgent(AiTextGenerationAgent agent) {
     final spec = aiTextAgentSpecs[agent];
     if (spec?.modelsCommand == null ||
         _autoDiscovered.contains(agent) ||

--- a/lib/src/features/settings/presentation/panes/ai_text_setting_rows.dart
+++ b/lib/src/features/settings/presentation/panes/ai_text_setting_rows.dart
@@ -143,6 +143,121 @@ class AiTextThinkingRow extends StatelessWidget {
   }
 }
 
+class AiTextPromptAgentRow extends StatelessWidget {
+  const AiTextPromptAgentRow({
+    super.key,
+    required this.operation,
+    required this.globalAgent,
+    required this.value,
+    required this.onChanged,
+  });
+
+  final AiTextGenerationOperation operation;
+  final AiTextGenerationAgent globalAgent;
+  final AiTextGenerationAgent? value;
+  final ValueChanged<AiTextGenerationAgent?> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return AleraSettingRow(
+      title: '${operation.label} Agent',
+      description: 'Override The Global Agent For This Prompt.',
+      child: AleraDropdownField<AiTextGenerationAgent?>(
+        key: ValueKey<String>(
+          'ai-text-${operation.key}-agent-${value?.key ?? 'global'}',
+        ),
+        value: value,
+        entries: <AleraDropdownFieldEntry<AiTextGenerationAgent?>>[
+          AleraDropdownFieldEntry<AiTextGenerationAgent?>(
+            value: null,
+            label: 'Global (${globalAgent.label})',
+          ),
+          for (final agent in AiTextGenerationAgent.values)
+            AleraDropdownFieldEntry<AiTextGenerationAgent?>(
+              value: agent,
+              label: agent.label,
+            ),
+        ],
+        onChanged: onChanged,
+      ),
+    );
+  }
+}
+
+class AiTextPromptModelRow extends StatelessWidget {
+  const AiTextPromptModelRow({
+    super.key,
+    required this.operation,
+    required this.agent,
+    required this.models,
+    required this.inheritedModel,
+    required this.value,
+    required this.discovering,
+    required this.discoveryError,
+    required this.onRefreshModels,
+    required this.onChanged,
+  });
+
+  final AiTextGenerationOperation operation;
+  final AiTextGenerationAgent agent;
+  final List<AiTextModel> models;
+  final AiTextModel inheritedModel;
+  final String? value;
+  final bool discovering;
+  final String? discoveryError;
+  final VoidCallback? onRefreshModels;
+  final ValueChanged<String?> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final selected = value?.trim();
+    final entries = <AiTextModel>[
+      ...models,
+      if (selected != null &&
+          selected.isNotEmpty &&
+          !models.any((model) => model.id == selected))
+        modelForAgent(agent, selected),
+    ];
+    return AleraSettingRow(
+      title: '${operation.label} Model',
+      description:
+          discoveryError ?? 'Override The Global Model For This Prompt.',
+      child: Row(
+        children: <Widget>[
+          Expanded(
+            child: AleraDropdownField<String?>(
+              key: ValueKey<String>(
+                'ai-text-${operation.key}-model-${selected ?? 'global'}',
+              ),
+              value: selected == null || selected.isEmpty ? null : selected,
+              entries: <AleraDropdownFieldEntry<String?>>[
+                AleraDropdownFieldEntry<String?>(
+                  value: null,
+                  label: 'Global (${inheritedModel.label})',
+                ),
+                for (final model in entries)
+                  AleraDropdownFieldEntry<String?>(
+                    value: model.id,
+                    label: model.label,
+                  ),
+              ],
+              onChanged: onChanged,
+            ),
+          ),
+          if (onRefreshModels != null) ...<Widget>[
+            const SizedBox(width: AleraTokens.space8),
+            AleraIconButton(
+              tooltip: 'Refresh Models',
+              icon: discovering ? AleraIcons.sync : AleraIcons.refresh,
+              onPressed: discovering ? null : onRefreshModels,
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
 class InstructionSettingRow extends StatefulWidget {
   const InstructionSettingRow({
     super.key,

--- a/lib/src/features/settings/presentation/panes/project_config_editor.dart
+++ b/lib/src/features/settings/presentation/panes/project_config_editor.dart
@@ -18,6 +18,8 @@ class ProjectConfigEditor extends StatelessWidget {
     required this.sourceLabel,
     required this.copyRules,
     required this.setupCommands,
+    required this.promptAppend,
+    required this.onPromptAppendChanged,
     required this.saveError,
     required this.saving,
     required this.updateCopyRule,
@@ -38,6 +40,8 @@ class ProjectConfigEditor extends StatelessWidget {
   final String? sourceError;
   final List<EditableCopyRule> copyRules;
   final List<String> setupCommands;
+  final String promptAppend;
+  final ValueChanged<String> onPromptAppendChanged;
   final GitHostingProvider? gitHostingProvider;
   final ValueChanged<GitHostingProvider?> onGitHostingProviderChanged;
   final String? saveError;
@@ -80,6 +84,25 @@ class ProjectConfigEditor extends StatelessWidget {
                   ),
                 ),
               ),
+          ],
+        ),
+        const SizedBox(height: AleraTokens.space16),
+        AleraSettingsGroup(
+          title: 'New Workspace',
+          description:
+              'Project Instructions Appended To Prompts That Start An Agent.',
+          children: <Widget>[
+            Padding(
+              padding: const EdgeInsets.all(AleraTokens.space16),
+              child: _ProjectConfigTextField(
+                value: promptAppend,
+                labelText: 'Prompt Append',
+                hintText: 'Add Project-Specific Agent Instructions',
+                minLines: 3,
+                maxLines: 6,
+                onChanged: onPromptAppendChanged,
+              ),
+            ),
           ],
         ),
         const SizedBox(height: AleraTokens.space16),
@@ -309,12 +332,16 @@ class _ProjectConfigTextField extends StatefulWidget {
     required this.onChanged,
     this.labelText,
     this.hintText,
+    this.minLines,
+    this.maxLines = 1,
   });
 
   final String value;
   final ValueChanged<String> onChanged;
   final String? labelText;
   final String? hintText;
+  final int? minLines;
+  final int? maxLines;
 
   @override
   State<_ProjectConfigTextField> createState() =>
@@ -350,6 +377,8 @@ class _ProjectConfigTextFieldState extends State<_ProjectConfigTextField> {
       controller: _controller,
       labelText: widget.labelText,
       hintText: widget.hintText,
+      minLines: widget.minLines,
+      maxLines: widget.maxLines,
       onChanged: widget.onChanged,
     );
   }
@@ -443,6 +472,8 @@ String projectConfigSignature(ProjectConfig config) {
   }
   buffer
     ..write('\u{1d}')
-    ..write(config.gitHostingProvider?.name ?? '');
+    ..write(config.gitHostingProvider?.name ?? '')
+    ..write('\u{1d}')
+    ..write(config.newWorkspace.promptAppend);
   return buffer.toString();
 }

--- a/lib/src/features/settings/presentation/panes/project_config_editor_loader.dart
+++ b/lib/src/features/settings/presentation/panes/project_config_editor_loader.dart
@@ -19,6 +19,7 @@ class ProjectConfigEditorLoader extends StatelessWidget {
     required this.updateSetupCommand,
     required this.removeSetupCommand,
     required this.addSetupCommand,
+    required this.onPromptAppendChanged,
     required this.saveOverride,
     required this.useRepoFile,
     required this.onGitHostingProviderChanged,
@@ -32,6 +33,7 @@ class ProjectConfigEditorLoader extends StatelessWidget {
   final ({
     List<EditableCopyRule> copyRules,
     List<String> setupCommands,
+    String promptAppend,
     GitHostingProvider? gitHostingProvider,
   })
   Function({required Project project, required ProjectConfig config})
@@ -43,6 +45,7 @@ class ProjectConfigEditorLoader extends StatelessWidget {
   final void Function(int index, String command) updateSetupCommand;
   final ValueChanged<int> removeSetupCommand;
   final VoidCallback addSetupCommand;
+  final ValueChanged<String> onPromptAppendChanged;
   final Future<void> Function(Project project) saveOverride;
   final Future<void> Function()? useRepoFile;
 
@@ -58,6 +61,8 @@ class ProjectConfigEditorLoader extends StatelessWidget {
         onGitHostingProviderChanged: onGitHostingProviderChanged,
         copyRules: editorState.copyRules,
         setupCommands: editorState.setupCommands,
+        promptAppend: editorState.promptAppend,
+        onPromptAppendChanged: onPromptAppendChanged,
         saveError: saveError,
         saving: saving,
         updateCopyRule: updateCopyRule,
@@ -91,6 +96,8 @@ class ProjectConfigEditorLoader extends StatelessWidget {
             onGitHostingProviderChanged: onGitHostingProviderChanged,
             copyRules: editorState.copyRules,
             setupCommands: editorState.setupCommands,
+            promptAppend: editorState.promptAppend,
+            onPromptAppendChanged: onPromptAppendChanged,
             saveError: saveError,
             saving: saving,
             updateCopyRule: updateCopyRule,
@@ -113,6 +120,8 @@ class ProjectConfigEditorLoader extends StatelessWidget {
           onGitHostingProviderChanged: onGitHostingProviderChanged,
           copyRules: editorState.copyRules,
           setupCommands: editorState.setupCommands,
+          promptAppend: editorState.promptAppend,
+          onPromptAppendChanged: onPromptAppendChanged,
           saveError: saveError,
           saving: saving,
           updateCopyRule: updateCopyRule,

--- a/lib/src/features/settings/presentation/panes/projects_pane.dart
+++ b/lib/src/features/settings/presentation/panes/projects_pane.dart
@@ -28,6 +28,7 @@ class _ProjectSettingsPaneState extends ConsumerState<ProjectSettingsPane> {
   String? _seedSignature;
   List<EditableCopyRule> _copyRules = const <EditableCopyRule>[];
   List<String> _setupCommands = const <String>[];
+  String _promptAppend = '';
   GitHostingProvider? _gitHostingProvider;
   final Map<String, Future<ProjectConfig?>> _repoConfigFutures =
       <String, Future<ProjectConfig?>>{};
@@ -85,6 +86,7 @@ class _ProjectSettingsPaneState extends ConsumerState<ProjectSettingsPane> {
                   updateSetupCommand: _updateSetupCommand,
                   removeSetupCommand: _removeSetupCommand,
                   addSetupCommand: _addSetupCommand,
+                  onPromptAppendChanged: _setPromptAppend,
                   saveOverride: _saveOverride,
                   useRepoFile: overrides.containsKey(selected.id)
                       ? () => _useRepoFile(selected)
@@ -120,6 +122,7 @@ class _ProjectSettingsPaneState extends ConsumerState<ProjectSettingsPane> {
   ({
     List<EditableCopyRule> copyRules,
     List<String> setupCommands,
+    String promptAppend,
     GitHostingProvider? gitHostingProvider,
   })
   _seedEditor({required Project project, required ProjectConfig config}) {
@@ -128,6 +131,7 @@ class _ProjectSettingsPaneState extends ConsumerState<ProjectSettingsPane> {
       return (
         copyRules: _copyRules,
         setupCommands: _setupCommands,
+        promptAppend: _promptAppend,
         gitHostingProvider: _gitHostingProvider,
       );
     }
@@ -142,17 +146,23 @@ class _ProjectSettingsPaneState extends ConsumerState<ProjectSettingsPane> {
         ),
     ];
     _setupCommands = <String>[...config.worktree.setup];
+    _promptAppend = config.newWorkspace.promptAppend;
     _gitHostingProvider = config.gitHostingProvider;
     _saveError = null;
     return (
       copyRules: _copyRules,
       setupCommands: _setupCommands,
+      promptAppend: _promptAppend,
       gitHostingProvider: _gitHostingProvider,
     );
   }
 
   void _setGitHostingProvider(GitHostingProvider? provider) {
     setState(() => _gitHostingProvider = provider);
+  }
+
+  void _setPromptAppend(String value) {
+    setState(() => _promptAppend = value);
   }
 
   void _updateCopyRule(int index, EditableCopyRule rule) {
@@ -250,6 +260,7 @@ class _ProjectSettingsPaneState extends ConsumerState<ProjectSettingsPane> {
         _seedSignature = null;
         _copyRules = const <EditableCopyRule>[];
         _setupCommands = const <String>[];
+        _promptAppend = '';
         _repoConfigFutures.remove(project.id);
       });
     } catch (error) {
@@ -300,6 +311,7 @@ class _ProjectSettingsPaneState extends ConsumerState<ProjectSettingsPane> {
             if (command.trim().isNotEmpty) command.trim(),
         ],
       ),
+      newWorkspace: NewWorkspaceConfig(promptAppend: _promptAppend.trim()),
       gitHostingProvider: _gitHostingProvider,
     );
   }

--- a/lib/src/features/settings/presentation/settings_dialog.dart
+++ b/lib/src/features/settings/presentation/settings_dialog.dart
@@ -168,6 +168,7 @@ class _SettingsDialogState extends ConsumerState<SettingsDialog> {
     ];
     const aiTextGroups = <SettingsGroupSpec>[
       SettingsGroupSpec(id: 'generation', title: 'Generation'),
+      SettingsGroupSpec(id: 'promptOverrides', title: 'Prompt Overrides'),
       SettingsGroupSpec(id: 'instructions', title: 'Instructions'),
     ];
     const terminalGroups = <SettingsGroupSpec>[

--- a/lib/src/features/settings/presentation/settings_search_entries.dart
+++ b/lib/src/features/settings/presentation/settings_search_entries.dart
@@ -418,4 +418,17 @@ const List<SettingsSearchEntry> aiTextSearchEntries = <SettingsSearchEntry>[
     ],
     groupId: 'instructions',
   ),
+  SettingsSearchEntry(
+    title: 'AI Text Prompt Overrides',
+    description: 'Choose An Agent Or Model For Each Generated Text Prompt.',
+    keywords: <String>[
+      'prompt',
+      'agent',
+      'model',
+      'inherit',
+      'global',
+      'workspace identity',
+    ],
+    groupId: 'promptOverrides',
+  ),
 ];

--- a/lib/src/features/settings/presentation/settings_search_entries_resources.dart
+++ b/lib/src/features/settings/presentation/settings_search_entries_resources.dart
@@ -6,7 +6,8 @@ import 'package:alera/src/features/settings/presentation/settings_sections.dart'
 const List<SettingsSearchEntry> projectSearchEntries = <SettingsSearchEntry>[
   SettingsSearchEntry(
     title: 'Project Worktree Setup',
-    description: 'Copy Files And Run Setup Commands For Linked Workspaces.',
+    description:
+        'Configure Copy Rules, Setup Commands, And New Workspace Prompts.',
     keywords: <String>[
       'project',
       'repo',
@@ -14,6 +15,10 @@ const List<SettingsSearchEntry> projectSearchEntries = <SettingsSearchEntry>[
       'workspace',
       'copy',
       'setup',
+      'prompt',
+      'append',
+      'agent instructions',
+      'new workspace',
       'alera.toml',
     ],
   ),

--- a/mobile/lib/src/features/projects/domain/project_management_models.dart
+++ b/mobile/lib/src/features/projects/domain/project_management_models.dart
@@ -188,15 +188,18 @@ class MobileProjectConfig {
   const MobileProjectConfig({
     this.copyRules = const <ProjectConfigCopyRule>[],
     this.setupCommands = const <String>[],
+    this.promptAppend = '',
     this.gitHostingProvider,
   });
 
   final List<ProjectConfigCopyRule> copyRules;
   final List<String> setupCommands;
+  final String promptAppend;
   final String? gitHostingProvider;
 
   factory MobileProjectConfig.fromJson(Map<String, Object?> json) {
     final worktree = asJsonMap(json['worktree']);
+    final newWorkspace = asJsonMap(json['newWorkspace']);
     return MobileProjectConfig(
       copyRules: <ProjectConfigCopyRule>[
         for (final item
@@ -204,6 +207,7 @@ class MobileProjectConfig {
           ProjectConfigCopyRule.fromJson(asJsonMap(item)),
       ],
       setupCommands: worktree.stringList('setup'),
+      promptAppend: newWorkspace.optionalString('promptAppend') ?? '',
       gitHostingProvider: json.optionalString('gitHostingProvider'),
     );
   }
@@ -215,6 +219,7 @@ class MobileProjectConfig {
       ],
       'setup': setupCommands,
     },
+    'newWorkspace': <String, Object?>{'promptAppend': promptAppend.trim()},
     if (gitHostingProvider != null) 'gitHostingProvider': gitHostingProvider,
   };
 }

--- a/mobile/lib/src/features/projects/presentation/project_setup_screen.dart
+++ b/mobile/lib/src/features/projects/presentation/project_setup_screen.dart
@@ -22,6 +22,7 @@ class ProjectSetupScreen extends ConsumerStatefulWidget {
 class _ProjectSetupScreenState extends ConsumerState<ProjectSetupScreen> {
   final List<_CopyRuleDraft> _copyRules = <_CopyRuleDraft>[];
   final TextEditingController _commandsController = TextEditingController();
+  final TextEditingController _promptAppendController = TextEditingController();
   String? _provider;
   String _origin = 'none';
   String? _loadError;
@@ -40,6 +41,7 @@ class _ProjectSetupScreenState extends ConsumerState<ProjectSetupScreen> {
       rule.dispose();
     }
     _commandsController.dispose();
+    _promptAppendController.dispose();
     super.dispose();
   }
 
@@ -57,6 +59,7 @@ class _ProjectSetupScreenState extends ConsumerState<ProjectSetupScreen> {
         ..clear()
         ..addAll(effective.config.copyRules.map(_CopyRuleDraft.fromRule));
       _commandsController.text = effective.config.setupCommands.join('\n');
+      _promptAppendController.text = effective.config.promptAppend;
       setState(() {
         _provider = effective.config.gitHostingProvider;
         _origin = effective.origin;
@@ -141,6 +144,7 @@ class _ProjectSetupScreenState extends ConsumerState<ProjectSetupScreen> {
           .map((value) => value.trim())
           .where((value) => value.isNotEmpty)
           .toList(growable: false),
+      promptAppend: _promptAppendController.text.trim(),
       gitHostingProvider: _provider,
     );
   }
@@ -208,6 +212,20 @@ class _ProjectSetupScreenState extends ConsumerState<ProjectSetupScreen> {
                       DropdownMenuItem(value: 'gitlab', child: Text('GitLab')),
                     ],
                     onChanged: (value) => setState(() => _provider = value),
+                  ),
+                  const SizedBox(height: AleraTokens.spaceXl),
+                  Text(
+                    'New Workspace Prompt Append',
+                    style: Theme.of(context).textTheme.titleMedium,
+                  ),
+                  const SizedBox(height: AleraTokens.spaceSm),
+                  TextField(
+                    controller: _promptAppendController,
+                    minLines: 3,
+                    maxLines: 6,
+                    decoration: const InputDecoration(
+                      hintText: 'Add Project-Specific Agent Instructions',
+                    ),
                   ),
                   const SizedBox(height: AleraTokens.spaceXl),
                   Row(

--- a/mobile/test/project_management_models_test.dart
+++ b/mobile/test/project_management_models_test.dart
@@ -1,0 +1,22 @@
+import 'package:alera_mobile/src/features/projects/domain/project_management_models.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('round-trips New Workspace prompt append', () {
+    const config = MobileProjectConfig(
+      promptAppend: 'Follow The Project Conventions.',
+    );
+
+    final restored = MobileProjectConfig.fromJson(config.toJson());
+
+    expect(restored.promptAppend, 'Follow The Project Conventions.');
+  });
+
+  test('defaults New Workspace prompt append for older payloads', () {
+    final config = MobileProjectConfig.fromJson(<String, Object?>{
+      'worktree': <String, Object?>{},
+    });
+
+    expect(config.promptAppend, isEmpty);
+  });
+}

--- a/rust/alera-cli/src/project_config_toml.rs
+++ b/rust/alera-cli/src/project_config_toml.rs
@@ -3,7 +3,7 @@
 //! Split out of `worktree_setup.rs`, which keeps the execution side: applying
 //! the copy rules and running the setup commands.
 
-use alera_core::runtime::{ProjectConfig, WorktreeCopyRule};
+use alera_core::runtime::{NewWorkspaceConfig, ProjectConfig, WorktreeCopyRule};
 use anyhow::{anyhow, bail, Context, Result};
 
 pub(crate) fn parse_project_config_toml(contents: &str) -> Result<ProjectConfig> {
@@ -12,8 +12,10 @@ pub(crate) fn parse_project_config_toml(contents: &str) -> Result<ProjectConfig>
         bail!("alera.toml must contain a table");
     };
     let git_hosting_provider = parse_git_hosting_provider(root.get("git_hosting_provider"))?;
+    let new_workspace = parse_new_workspace_config(root.get("new_workspace"))?;
     let Some(worktree) = root.get("worktree") else {
         return Ok(ProjectConfig {
+            new_workspace,
             git_hosting_provider,
             ..ProjectConfig::default()
         });
@@ -25,8 +27,30 @@ pub(crate) fn parse_project_config_toml(contents: &str) -> Result<ProjectConfig>
     let setup = parse_setup_commands(worktree.get("setup"))?;
     Ok(ProjectConfig {
         worktree: alera_core::runtime::WorktreeSetupConfig { copy, setup },
+        new_workspace,
         git_hosting_provider,
     })
+}
+
+fn parse_new_workspace_config(value: Option<&toml::Value>) -> Result<NewWorkspaceConfig> {
+    let Some(value) = value else {
+        return Ok(NewWorkspaceConfig::default());
+    };
+    let Some(table) = value.as_table() else {
+        bail!("alera.toml [new_workspace] must be a table");
+    };
+    let prompt_append = table
+        .get("prompt_append")
+        .map(|value| {
+            value
+                .as_str()
+                .map(str::trim)
+                .map(str::to_string)
+                .ok_or_else(|| anyhow!("new_workspace.prompt_append must be a string"))
+        })
+        .transpose()?
+        .unwrap_or_default();
+    Ok(NewWorkspaceConfig { prompt_append })
 }
 
 fn parse_git_hosting_provider(value: Option<&toml::Value>) -> Result<Option<String>> {
@@ -161,5 +185,23 @@ mod tests {
         let config =
             parse_project_config_toml("git_hosting_provider = \"githubEnterprise\"").unwrap();
         assert_eq!(config.git_hosting_provider.as_deref(), Some("github"));
+    }
+
+    #[test]
+    fn project_config_reads_new_workspace_prompt_append() {
+        let config = parse_project_config_toml(
+            r#"
+[new_workspace]
+prompt_append = """
+Run The Focused Tests.
+Preserve Existing APIs.
+"""
+"#,
+        )
+        .unwrap();
+        assert_eq!(
+            config.new_workspace.prompt_append,
+            "Run The Focused Tests.\nPreserve Existing APIs."
+        );
     }
 }

--- a/rust/alera-cli/src/terminal_host/server/agent_profile_launch_requests.rs
+++ b/rust/alera-cli/src/terminal_host/server/agent_profile_launch_requests.rs
@@ -24,6 +24,21 @@ impl ServerActor {
                 "Workspace is not active: {workspace_id}"
             )));
         }
+        let effective_config = crate::project_management::effective_project_config(
+            &self.runtime_store,
+            &workspace.project_id,
+        )
+        .await
+        .map_err(|error| HostError::state(error.to_string()))?;
+        if let Some(error) = effective_config.error {
+            return Err(HostError::state(format!(
+                "Could not load project configuration: {error}"
+            )));
+        }
+        let prompt = append_project_prompt(
+            &prompt,
+            &effective_config.config.new_workspace.prompt_append,
+        );
         let profile = self
             .runtime_store
             .find_agent_profile(&profile_id)
@@ -135,5 +150,34 @@ impl ServerActor {
             tracing::error!(tab_id = %tab_id, "failed to clear pending agent prompt: {error}");
         }
         self.broadcast_workspace_tabs_changed(Some(&workspace_id));
+    }
+}
+
+fn append_project_prompt(prompt: &str, prompt_append: &str) -> String {
+    let prompt_append = prompt_append.trim();
+    if prompt_append.is_empty() {
+        return prompt.to_string();
+    }
+    format!("{}\n\n{prompt_append}", prompt.trim())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::append_project_prompt;
+
+    #[test]
+    fn appends_project_instructions_with_a_paragraph_boundary() {
+        assert_eq!(
+            append_project_prompt("Build The Feature", "Run Focused Tests"),
+            "Build The Feature\n\nRun Focused Tests"
+        );
+    }
+
+    #[test]
+    fn leaves_the_prompt_unchanged_without_project_instructions() {
+        assert_eq!(
+            append_project_prompt("Build The Feature", "  "),
+            "Build The Feature"
+        );
     }
 }

--- a/rust/alera-cli/src/terminal_host/server/ai_text_requests.rs
+++ b/rust/alera-cli/src/terminal_host/server/ai_text_requests.rs
@@ -139,7 +139,7 @@ async fn generate_workspace_identity(
             .map(String::as_str)
             .unwrap_or_default(),
     );
-    let plan = plan_command(&settings, &prompt)?;
+    let plan = plan_command(&settings, "workspaceIdentity", &prompt)?;
     let timeout_seconds = settings.timeout_seconds;
     let result = run_command(plan, working_directory, timeout_seconds, cancel_rx).await?;
     parse_workspace_identity(&result)
@@ -147,24 +147,34 @@ async fn generate_workspace_identity(
 
 fn plan_command(
     settings: &RuntimeAiTextGenerationSettings,
+    operation: &str,
     prompt: &str,
 ) -> HostResult<AiTextCommandPlan> {
-    if settings.agent == "custom" {
+    let prompt_settings = settings.prompt_settings_by_operation.get(operation);
+    let agent = prompt_settings
+        .and_then(|value| value.agent.as_deref())
+        .unwrap_or(&settings.agent);
+    if agent == "custom" {
         return plan_custom_command(&settings.custom_command, prompt);
     }
-    let model = settings
-        .selected_model_by_agent
-        .get(&settings.agent)
-        .map(String::as_str)
+    let model = prompt_settings
+        .and_then(|value| value.model.as_deref())
         .filter(|value| !value.trim().is_empty())
-        .unwrap_or_else(|| default_model(&settings.agent));
+        .or_else(|| {
+            settings
+                .selected_model_by_agent
+                .get(agent)
+                .map(String::as_str)
+                .filter(|value| !value.trim().is_empty())
+        })
+        .unwrap_or_else(|| default_model(agent));
     let thinking = settings
         .selected_thinking_by_model
         .get(model)
         .map(String::as_str)
         .filter(|value| !value.trim().is_empty());
     let timeout = settings.timeout_seconds;
-    let (binary, arguments, stdin_payload, label) = match settings.agent.as_str() {
+    let (binary, arguments, stdin_payload, label) = match agent {
         "claude" => (
             "claude",
             vec![

--- a/rust/alera-cli/src/terminal_host/server/ai_text_requests_tests.rs
+++ b/rust/alera-cli/src/terminal_host/server/ai_text_requests_tests.rs
@@ -7,3 +7,26 @@ fn custom_command_uses_stdin_without_placeholder() {
     assert_eq!(plan.arguments, ["--quiet"]);
     assert_eq!(plan.stdin_payload.as_deref(), Some("hello"));
 }
+
+#[test]
+fn prompt_settings_override_the_global_agent_and_model() {
+    let settings = RuntimeAiTextGenerationSettings {
+        agent: "codex".to_string(),
+        prompt_settings_by_operation: HashMap::from([(
+            "workspaceIdentity".to_string(),
+            alera_core::runtime::RuntimeAiTextPromptSettings {
+                agent: Some("amp".to_string()),
+                model: Some("rush".to_string()),
+            },
+        )]),
+        ..RuntimeAiTextGenerationSettings::default()
+    };
+
+    let plan = plan_command(&settings, "workspaceIdentity", "hello").unwrap();
+
+    assert_eq!(plan.binary, "amp");
+    assert!(plan
+        .arguments
+        .windows(2)
+        .any(|values| values == ["--mode", "rush"]));
+}

--- a/rust/alera-cli/src/terminal_host/server/host_service_requests.rs
+++ b/rust/alera-cli/src/terminal_host/server/host_service_requests.rs
@@ -253,7 +253,27 @@ fn validate_ai_text_generation_settings(
     if !AGENTS.contains(&settings.agent.trim()) {
         return Err(HostError::format("aiTextGeneration.agent is unsupported."));
     }
-    if settings.agent.trim() == "custom" && settings.custom_command.trim().is_empty() {
+    if settings
+        .prompt_settings_by_operation
+        .values()
+        .filter_map(|prompt| prompt.agent.as_deref())
+        .any(|agent| !AGENTS.contains(&agent.trim()))
+    {
+        return Err(HostError::format(
+            "aiTextGeneration prompt agent is unsupported.",
+        ));
+    }
+    let uses_custom_agent = settings.agent.trim() == "custom"
+        || settings
+            .prompt_settings_by_operation
+            .values()
+            .any(|prompt| {
+                prompt
+                    .agent
+                    .as_deref()
+                    .is_some_and(|agent| agent.trim() == "custom")
+            });
+    if uses_custom_agent && settings.custom_command.trim().is_empty() {
         return Err(HostError::format(
             "aiTextGeneration.customCommand is required for the custom agent.",
         ));

--- a/rust/alera-core/src/runtime/models.rs
+++ b/rust/alera-core/src/runtime/models.rs
@@ -387,6 +387,8 @@ pub struct ProjectConfigRecord {
 pub struct ProjectConfig {
     #[serde(default)]
     pub worktree: WorktreeSetupConfig,
+    #[serde(default)]
+    pub new_workspace: NewWorkspaceConfig,
     // Opaque provider override string (e.g. "github", "azureDevops") set by the
     // Dart client; round-tripped so it survives config upserts. Null/absent
     // means auto-detect.
@@ -398,8 +400,16 @@ impl ProjectConfig {
     pub fn is_empty(&self) -> bool {
         self.worktree.copy.is_empty()
             && self.worktree.setup.is_empty()
+            && self.new_workspace.prompt_append.trim().is_empty()
             && self.git_hosting_provider.is_none()
     }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct NewWorkspaceConfig {
+    #[serde(default)]
+    pub prompt_append: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]

--- a/rust/alera-core/src/runtime/settings_models.rs
+++ b/rust/alera-core/src/runtime/settings_models.rs
@@ -75,8 +75,19 @@ pub struct RuntimeAiTextGenerationSettings {
     pub custom_command: String,
     #[serde(default)]
     pub instructions_by_operation: HashMap<String, String>,
+    #[serde(default)]
+    pub prompt_settings_by_operation: HashMap<String, RuntimeAiTextPromptSettings>,
     #[serde(default = "default_ai_text_timeout")]
     pub timeout_seconds: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct RuntimeAiTextPromptSettings {
+    #[serde(default)]
+    pub agent: Option<String>,
+    #[serde(default)]
+    pub model: Option<String>,
 }
 
 impl Default for RuntimeAiTextGenerationSettings {
@@ -88,6 +99,7 @@ impl Default for RuntimeAiTextGenerationSettings {
             selected_thinking_by_model: HashMap::new(),
             custom_command: String::new(),
             instructions_by_operation: HashMap::new(),
+            prompt_settings_by_operation: HashMap::new(),
             timeout_seconds: default_ai_text_timeout(),
         }
     }
@@ -100,6 +112,23 @@ impl RuntimeAiTextGenerationSettings {
         self.selected_model_by_agent = normalized_string_map(self.selected_model_by_agent);
         self.selected_thinking_by_model = normalized_string_map(self.selected_thinking_by_model);
         self.instructions_by_operation = normalized_string_map(self.instructions_by_operation);
+        self.prompt_settings_by_operation = self
+            .prompt_settings_by_operation
+            .into_iter()
+            .filter_map(|(operation, settings)| {
+                let operation = operation.trim().to_string();
+                let agent = settings
+                    .agent
+                    .map(|value| value.trim().to_ascii_lowercase())
+                    .filter(|value| !value.is_empty());
+                let model = settings
+                    .model
+                    .map(|value| value.trim().to_string())
+                    .filter(|value| !value.is_empty());
+                (!operation.is_empty() && (agent.is_some() || model.is_some()))
+                    .then_some((operation, RuntimeAiTextPromptSettings { agent, model }))
+            })
+            .collect();
         self.timeout_seconds = self.timeout_seconds.clamp(10, 600);
         self
     }

--- a/rust/src/api/process_tests.rs
+++ b/rust/src/api/process_tests.rs
@@ -119,6 +119,10 @@ fn run_uses_the_requested_working_directory() {
 fn run_adds_the_requested_environment() {
     let mut environment = std::collections::HashMap::new();
     environment.insert("GIT_AUTHOR_NAME".to_string(), "Alera Test".to_string());
+    environment.insert(
+        "GIT_AUTHOR_EMAIL".to_string(),
+        "alera-test@example.com".to_string(),
+    );
 
     let result = process_run(
         "git".to_string(),
@@ -129,7 +133,9 @@ fn run_adds_the_requested_environment() {
     .expect("git var runs");
 
     assert!(
-        result.stdout.starts_with("Alera Test"),
+        result
+            .stdout
+            .starts_with("Alera Test <alera-test@example.com>"),
         "stdout: {}",
         result.stdout
     );

--- a/test/unit/ai_text_generation_prompt_override_test_cases.dart
+++ b/test/unit/ai_text_generation_prompt_override_test_cases.dart
@@ -1,0 +1,45 @@
+part of 'ai_text_generation_service_test.dart';
+
+void _registerAiTextPromptOverrideTests() {
+  test('uses the agent and model configured for the prompt', () async {
+    final git = FakeGitBackend()
+      ..gitRepositoryStateResult = const GitRepositoryState(
+        branch: 'feature/prompt-agent',
+      )
+      ..gitStatusResult = const GitStatusResult(
+        entries: <GitChangeEntry>[
+          GitChangeEntry(
+            path: 'lib/foo.dart',
+            area: GitChangeArea.staged,
+            status: GitChangeStatus.modified,
+          ),
+        ],
+      );
+    final runner = _FakeProcessRunner(stdout: 'fix: use prompt agent\n');
+    final service = CliAiTextGenerationService(
+      gitBackend: git,
+      processRunner: runner,
+    );
+
+    await service.generate(
+      const AiTextGenerationRequest(
+        operation: AiTextGenerationOperation.commitMessage,
+        workspacePath: '/repo',
+        settings: AiTextGenerationSettings(
+          agent: AiTextGenerationAgent.agy,
+          promptSettingsByOperation:
+              <AiTextGenerationOperation, AiTextGenerationPromptSettings>{
+                AiTextGenerationOperation.commitMessage:
+                    AiTextGenerationPromptSettings(
+                      agent: AiTextGenerationAgent.amp,
+                      model: 'rush',
+                    ),
+              },
+        ),
+      ),
+    );
+
+    expect(runner.executable, 'amp');
+    expect(runner.arguments, containsAll(<String>['--mode', 'rush']));
+  });
+}

--- a/test/unit/ai_text_generation_service_test.dart
+++ b/test/unit/ai_text_generation_service_test.dart
@@ -15,11 +15,13 @@ import 'package:flutter_test/flutter_test.dart';
 import 'fake_git_backend.dart';
 
 part 'ai_text_generation_grok_test_cases.dart';
+part 'ai_text_generation_prompt_override_test_cases.dart';
 part 'ai_text_generation_test_harness.dart';
 
 void main() {
   group('AI text generation', () {
     _registerGrokAiTextGenerationTests();
+    _registerAiTextPromptOverrideTests();
 
     test('builds commit prompts with staged context and instructions', () {
       final prompt = buildCommitMessagePrompt(

--- a/test/unit/ai_text_generation_settings_test.dart
+++ b/test/unit/ai_text_generation_settings_test.dart
@@ -47,8 +47,69 @@ void main() {
       selectedModelByAgent: <AiTextGenerationAgent, String>{
         AiTextGenerationAgent.codex: 'gpt-5',
       },
+      promptSettingsByOperation:
+          <AiTextGenerationOperation, AiTextGenerationPromptSettings>{
+            AiTextGenerationOperation.commitMessage:
+                AiTextGenerationPromptSettings(
+                  agent: AiTextGenerationAgent.claude,
+                  model: 'opus',
+                ),
+          },
     );
 
     expect(AiTextGenerationSettings.fromJson(settings.toMap()), settings);
+  });
+
+  test('resolves prompt agent and model overrides independently', () {
+    const settings = AiTextGenerationSettings(
+      agent: AiTextGenerationAgent.codex,
+      selectedModelByAgent: <AiTextGenerationAgent, String>{
+        AiTextGenerationAgent.codex: 'gpt-global',
+        AiTextGenerationAgent.claude: 'sonnet',
+      },
+      promptSettingsByOperation:
+          <AiTextGenerationOperation, AiTextGenerationPromptSettings>{
+            AiTextGenerationOperation.commitMessage:
+                AiTextGenerationPromptSettings(
+                  agent: AiTextGenerationAgent.claude,
+                ),
+            AiTextGenerationOperation.pullRequestDetails:
+                AiTextGenerationPromptSettings(model: 'gpt-pull-request'),
+          },
+    );
+
+    expect(
+      settings.agentFor(AiTextGenerationOperation.commitMessage),
+      AiTextGenerationAgent.claude,
+    );
+    expect(
+      settings.modelForOperation(AiTextGenerationOperation.commitMessage),
+      'sonnet',
+    );
+    expect(
+      settings.agentFor(AiTextGenerationOperation.pullRequestDetails),
+      AiTextGenerationAgent.codex,
+    );
+    expect(
+      settings.modelForOperation(AiTextGenerationOperation.pullRequestDetails),
+      'gpt-pull-request',
+    );
+    expect(
+      settings.modelForOperation(AiTextGenerationOperation.workspaceIdentity),
+      'gpt-global',
+    );
+  });
+
+  test('reports whether prompt settings inherit each global value', () {
+    const inherited = AiTextGenerationPromptSettings(model: '  ');
+    const overridden = AiTextGenerationPromptSettings(
+      agent: AiTextGenerationAgent.claude,
+      model: 'sonnet',
+    );
+
+    expect(inherited.inheritsAgent, isTrue);
+    expect(inherited.inheritsModel, isTrue);
+    expect(overridden.inheritsAgent, isFalse);
+    expect(overridden.inheritsModel, isFalse);
   });
 }

--- a/test/unit/project_config_git_hosting_provider_test.dart
+++ b/test/unit/project_config_git_hosting_provider_test.dart
@@ -48,5 +48,21 @@ void main() {
         GitHostingProvider.gitlab,
       );
     });
+
+    test('round-trips New Workspace prompt append through JSON', () {
+      const config = ProjectConfig(
+        newWorkspace: NewWorkspaceConfig(
+          promptAppend: 'Follow The Project Conventions.',
+        ),
+      );
+
+      final restored = ProjectConfig.fromJson(config.toMap());
+
+      expect(
+        restored.newWorkspace.promptAppend,
+        'Follow The Project Conventions.',
+      );
+      expect(restored.isEmpty, isFalse);
+    });
   });
 }

--- a/test/unit/project_config_toml_file_store_test.dart
+++ b/test/unit/project_config_toml_file_store_test.dart
@@ -46,6 +46,32 @@ setup = ["pnpm install", "make bootstrap"]
       expect(config.worktree.setup, <String>['pnpm install', 'make bootstrap']);
     });
 
+    test('parses New Workspace prompt append instructions', () {
+      final config = parseProjectConfigToml('''
+[new_workspace]
+prompt_append = """
+Run The Focused Tests.
+Preserve Existing APIs.
+"""
+''');
+
+      expect(
+        config.newWorkspace.promptAppend,
+        'Run The Focused Tests.\nPreserve Existing APIs.',
+      );
+      expect(config.isEmpty, isFalse);
+    });
+
+    test('rejects a non-string New Workspace prompt append', () {
+      expect(
+        () => parseProjectConfigToml('''
+[new_workspace]
+prompt_append = ["invalid"]
+'''),
+        throwsA(isA<ProjectConfigException>()),
+      );
+    });
+
     test('returns empty config when the worktree table is absent', () {
       final config = parseProjectConfigToml('title = "Alera"');
 

--- a/test/unit/runtime_settings_repository_test.dart
+++ b/test/unit/runtime_settings_repository_test.dart
@@ -23,6 +23,7 @@ void main() {
       expect(payload['aiTextGeneration'], isA<Map<String, Object?>>());
       final aiText = payload['aiTextGeneration']! as Map<String, Object?>;
       expect(aiText['agent'], 'codex');
+      expect(aiText['promptSettingsByOperation'], isA<Map<String, Object?>>());
       expect(aiText, isNot(contains('discoveredModelsByAgent')));
       expect(
         (payload['agentQuotas']! as Map<String, Object?>)['enabledProviders'],
@@ -108,6 +109,12 @@ void main() {
           'instructionsByOperation': <String, String>{
             'workspaceIdentity': 'Use feature branches.',
           },
+          'promptSettingsByOperation': <String, Object?>{
+            'workspaceIdentity': <String, Object?>{
+              'agent': 'claude',
+              'model': 'opus',
+            },
+          },
           'timeoutSeconds': 180,
         },
       };
@@ -124,6 +131,18 @@ void main() {
           AiTextGenerationOperation.workspaceIdentity,
         ),
         'Use feature branches.',
+      );
+      expect(
+        loaded.aiTextGeneration.agentFor(
+          AiTextGenerationOperation.workspaceIdentity,
+        ),
+        AiTextGenerationAgent.claude,
+      );
+      expect(
+        loaded.aiTextGeneration.modelForOperation(
+          AiTextGenerationOperation.workspaceIdentity,
+        ),
+        'opus',
       );
       expect(
         loaded.aiTextGeneration


### PR DESCRIPTION
## Summary

- allow each AI Text prompt to override its agent and model independently while inheriting global defaults when unset
- add project-level New Workspace prompt append configuration through `alera.toml` and desktop/mobile settings overrides
- apply the append only when launching the New Workspace agent, with shared runtime validation and documentation

## Validation

- `flutter pub run build_runner build -d`
- `dart format --set-exit-if-changed` and max-lines ratchet
- `flutter analyze` for desktop and mobile
- root Flutter suite: 2,485 passed, 2 expected skips
- mobile Flutter suite: 199 passed
- domain coverage: 100.00% (2823/2823)
- `make rust-test`
- `git diff --check`

## Notes

`gh act pull_request -W .github/workflows/pr.yml` was attempted, but local emulation could not run the complete workflow because Docker image authentication and linked-worktree Git metadata failed before project steps. GitHub-hosted checks remain authoritative.