### PR TITLE
fix: preserve dash-prefixed codex prompts

### DIFF
--- a/rust/alera-cli/src/terminal_host/orchestration/agent_prompt_injection.rs
+++ b/rust/alera-cli/src/terminal_host/orchestration/agent_prompt_injection.rs
@@ -97,11 +97,11 @@ mod tests {
 
     #[test]
     fn paste_wraps_sanitized_prompt() {
-        let paste = build_agent_prompt_paste_bytes("hello\nworld");
+        let paste = build_agent_prompt_paste_bytes("- Review memory\n- Implement it");
         assert!(paste.starts_with(BRACKETED_PASTE_START));
         assert!(paste.ends_with(BRACKETED_PASTE_END));
         let inner = &paste[BRACKETED_PASTE_START.len()..paste.len() - BRACKETED_PASTE_END.len()];
-        assert_eq!(inner, b"hello\nworld");
+        assert_eq!(inner, b"- Review memory\n- Implement it");
     }
 
     #[test]

--- a/rust/alera-cli/src/terminal_host/orchestration/agent_registry.rs
+++ b/rust/alera-cli/src/terminal_host/orchestration/agent_registry.rs
@@ -98,4 +98,20 @@ mod tests {
             .iter()
             .all(|adapter| !adapter.default_command.is_empty()));
     }
+
+    #[test]
+    fn only_codex_receives_its_initial_prompt_as_an_argument() {
+        let initial_argument_agents: Vec<_> = AGENT_ADAPTERS
+            .iter()
+            .filter(|adapter| {
+                adapter.startup_delivery == AgentStartupDelivery::InitialPromptArgument
+            })
+            .map(|adapter| adapter.agent_type)
+            .collect();
+        assert_eq!(initial_argument_agents, ["codex"]);
+        assert!(AGENT_ADAPTERS
+            .iter()
+            .filter(|adapter| adapter.agent_type != "codex")
+            .all(|adapter| adapter.startup_delivery == AgentStartupDelivery::ReadinessInjection));
+    }
 }

--- a/rust/alera-cli/src/terminal_host/orchestration/agent_startup_command.rs
+++ b/rust/alera-cli/src/terminal_host/orchestration/agent_startup_command.rs
@@ -5,12 +5,22 @@ enum ShellFamily {
     Cmd,
 }
 
-pub fn command_with_initial_prompt(command: &str, prompt: &str, shell: &str) -> String {
+// Codex parses a leading dash in its positional prompt as another option unless
+// the standard option terminator appears first.
+const CODEX_OPTION_TERMINATOR: &str = "--";
+
+pub fn codex_command_with_initial_prompt(command: &str, prompt: &str, shell: &str) -> String {
     format!(
-        "{} {}",
+        "{} {} {}",
         command.trim(),
+        CODEX_OPTION_TERMINATOR,
         quote_argument(prompt, shell_family(shell))
     )
+}
+
+pub fn append_codex_initial_prompt_argument(arguments: &mut Vec<String>, prompt: String) {
+    arguments.push(CODEX_OPTION_TERMINATOR.to_string());
+    arguments.push(prompt);
 }
 
 fn shell_family(shell: &str) -> ShellFamily {
@@ -42,26 +52,51 @@ mod tests {
     use super::*;
 
     #[test]
-    fn quotes_posix_prompt_without_shell_expansion() {
+    fn terminates_posix_options_before_a_dash_prefixed_prompt() {
         assert_eq!(
-            command_with_initial_prompt("codex", "read $HOME and it's ready", "/bin/zsh"),
-            "codex 'read $HOME and it'\"'\"'s ready'"
+            codex_command_with_initial_prompt(
+                "codex --search",
+                "- Review $HOME\n- It's ready",
+                "/bin/zsh"
+            ),
+            "codex --search -- '- Review $HOME\n- It'\"'\"'s ready'"
         );
     }
 
     #[test]
-    fn quotes_powershell_prompt() {
+    fn terminates_powershell_options_before_a_dash_prefixed_prompt() {
         assert_eq!(
-            command_with_initial_prompt("codex", "it's ready", "pwsh.exe"),
-            "codex 'it''s ready'"
+            codex_command_with_initial_prompt(
+                "codex --search",
+                "- Review memory\n- It's ready",
+                "pwsh.exe"
+            ),
+            "codex --search -- '- Review memory\n- It''s ready'"
         );
     }
 
     #[test]
-    fn quotes_cmd_prompt() {
+    fn terminates_cmd_options_before_a_dash_prefixed_prompt() {
         assert_eq!(
-            command_with_initial_prompt("codex", "read \"context\"", "C:\\Windows\\cmd.exe"),
-            "codex \"read \"\"context\"\"\""
+            codex_command_with_initial_prompt(
+                "codex --search",
+                "- Review \"context\"\n- Implement memory",
+                "C:\\Windows\\cmd.exe"
+            ),
+            "codex --search -- \"- Review \"\"context\"\"\n- Implement memory\""
+        );
+    }
+
+    #[test]
+    fn appends_the_option_terminator_before_a_managed_prompt() {
+        let mut arguments = vec!["--search".to_string()];
+        append_codex_initial_prompt_argument(
+            &mut arguments,
+            "- Review memory\n- Implement it".to_string(),
+        );
+        assert_eq!(
+            arguments,
+            ["--search", "--", "- Review memory\n- Implement it"]
         );
     }
 }

--- a/rust/alera-cli/src/terminal_host/orchestration/managed_agent_launch_tests.rs
+++ b/rust/alera-cli/src/terminal_host/orchestration/managed_agent_launch_tests.rs
@@ -111,3 +111,24 @@ fn rendering_quotes_each_token_for_supported_shell_families() {
         "\"agy\" \"--model\" \"Gemini 3.5 Flash (High)\" \"it's ready\""
     );
 }
+
+#[test]
+fn codex_managed_prompt_follows_the_option_terminator_on_every_shell() {
+    let mut launch = build_managed_agent_launch("codex", &json!({"webSearch": true})).unwrap();
+    crate::terminal_host::orchestration::agent_startup_command::append_codex_initial_prompt_argument(
+        &mut launch.arguments,
+        "- Review why it's pending\n- Implement memory".to_string(),
+    );
+    assert_eq!(
+        render_managed_launch(&launch, "/bin/zsh"),
+        "'codex' '--search' '--' '- Review why it'\"'\"'s pending\n- Implement memory'"
+    );
+    assert_eq!(
+        render_managed_launch(&launch, "pwsh.exe"),
+        "'codex' '--search' '--' '- Review why it''s pending\n- Implement memory'"
+    );
+    assert_eq!(
+        render_managed_launch(&launch, "cmd.exe"),
+        "\"codex\" \"--search\" \"--\" \"- Review why it's pending\n- Implement memory\""
+    );
+}

--- a/rust/alera-cli/src/terminal_host/server/terminal_spawn.rs
+++ b/rust/alera-cli/src/terminal_host/server/terminal_spawn.rs
@@ -119,7 +119,10 @@ impl ServerActor {
         let managed_launch = initial_managed_agent_launch(tab)?;
         let command = if let Some(mut launch) = managed_launch {
             if let Some(prompt) = initial_prompt(tab) {
-                launch.arguments.push(prompt);
+                crate::terminal_host::orchestration::agent_startup_command::append_codex_initial_prompt_argument(
+                    &mut launch.arguments,
+                    prompt,
+                );
             }
             Some(
                 crate::terminal_host::orchestration::managed_agent_launch::render_managed_launch(
@@ -131,7 +134,7 @@ impl ServerActor {
             initial_command(tab).map(|command| {
                 initial_prompt(tab)
                     .map(|prompt| {
-                        crate::terminal_host::orchestration::agent_startup_command::command_with_initial_prompt(
+                        crate::terminal_host::orchestration::agent_startup_command::codex_command_with_initial_prompt(
                             &command,
                             &prompt,
                             &default_launch.interactive_shell,


### PR DESCRIPTION
## Summary

- add Codex's `--` option terminator before prompts launched from New Workspace
- cover command and managed profiles across POSIX, PowerShell, and CMD
- keep readiness-injected prompts unchanged for the other agent adapters

## Root cause

Codex received the New Workspace prompt as its final positional argument without an option terminator, so a prompt beginning with `-` was parsed as another CLI option.

## Validation

- `make rust-test`
- focused startup, adapter, managed-launch, and prompt-injection tests
- local `gh act` Rust job attempted; blocked by an act/Docker action-copy emulation error (`path escapes from parent`) before workflow execution