### PR TITLE
perf(landing): defer offscreen rendering

### DIFF
--- a/landing/src/components/Agents.astro
+++ b/landing/src/components/Agents.astro
@@ -12,7 +12,7 @@ const agents = [
 ];
 ---
 
-<section id="agents" class="py-20 px-6 border-t border-border-subtle/50">
+<section id="agents" class="defer-offscreen-rendering py-20 px-6 border-t border-border-subtle/50">
   <div class="max-w-5xl mx-auto">
     <p class="text-center text-label-md text-foreground-faint uppercase tracking-widest font-mono mb-4">
       Works with every CLI agent

--- a/landing/src/components/CtaSection.astro
+++ b/landing/src/components/CtaSection.astro
@@ -6,7 +6,7 @@ const signingAttribution =
   'Free code signing provided by SignPath.io, certificate by SignPath Foundation';
 ---
 
-<section class="py-24 px-6">
+<section class="defer-offscreen-rendering py-24 px-6">
   <div class="max-w-2xl mx-auto text-center">
     <h2 class="text-headline-lg md:text-[32px] font-semibold tracking-tight text-foreground mb-4">
       Build with Alera today

--- a/landing/src/components/Faq.astro
+++ b/landing/src/components/Faq.astro
@@ -27,7 +27,7 @@ const faqs = [
 ];
 ---
 
-<section id="faq" class="py-24 px-6 border-t border-border-subtle/50">
+<section id="faq" class="defer-offscreen-rendering py-24 px-6 border-t border-border-subtle/50">
   <div class="max-w-3xl mx-auto">
     <div class="text-center mb-14">
       <p class="text-label-md text-foreground-faint uppercase tracking-widest font-mono mb-4">FAQ</p>

--- a/landing/src/components/Features.astro
+++ b/landing/src/components/Features.astro
@@ -48,7 +48,7 @@ const features = [
 ];
 ---
 
-<section id="features" class="py-24 px-6">
+<section id="features" class="defer-offscreen-rendering py-24 px-6">
   <div class="max-w-6xl mx-auto">
     <div class="text-center mb-16">
       <p class="text-label-md text-foreground-faint uppercase tracking-widest font-mono mb-4">Features</p>

--- a/landing/src/components/Footer.astro
+++ b/landing/src/components/Footer.astro
@@ -1,7 +1,7 @@
 ---
 ---
 
-<footer class="py-10 px-6 border-t border-border-subtle/50">
+<footer class="defer-offscreen-rendering py-10 px-6 border-t border-border-subtle/50">
   <div class="max-w-5xl mx-auto">
     <div class="flex flex-col md:flex-row items-center justify-between gap-6">
       <!-- Logo -->

--- a/landing/src/components/Roadmap.astro
+++ b/landing/src/components/Roadmap.astro
@@ -9,7 +9,7 @@ const items = [
 ];
 ---
 
-<section id="roadmap" class="py-24 px-6 border-t border-border-subtle/50">
+<section id="roadmap" class="defer-offscreen-rendering py-24 px-6 border-t border-border-subtle/50">
   <div class="max-w-5xl mx-auto">
     <div class="text-center mb-14">
       <p class="text-label-md text-foreground-faint uppercase tracking-widest font-mono mb-4">Roadmap</p>

--- a/landing/src/components/Stack.astro
+++ b/landing/src/components/Stack.astro
@@ -27,7 +27,7 @@ const stack = [
 ];
 ---
 
-<section id="stack" class="py-24 px-6 border-t border-border-subtle/50">
+<section id="stack" class="defer-offscreen-rendering py-24 px-6 border-t border-border-subtle/50">
   <div class="max-w-5xl mx-auto">
     <div class="text-center mb-14">
       <p class="text-label-md text-foreground-faint uppercase tracking-widest font-mono mb-4">Built on</p>

--- a/landing/src/components/Workflow.astro
+++ b/landing/src/components/Workflow.astro
@@ -18,7 +18,7 @@ const steps = [
 ];
 ---
 
-<section id="workflow" class="py-24 px-6 border-t border-border-subtle/50">
+<section id="workflow" class="defer-offscreen-rendering py-24 px-6 border-t border-border-subtle/50">
   <div class="max-w-5xl mx-auto">
     <div class="text-center mb-16">
       <p class="text-label-md text-foreground-faint uppercase tracking-widest font-mono mb-4">How it works</p>

--- a/landing/src/layouts/Layout.astro
+++ b/landing/src/layouts/Layout.astro
@@ -145,7 +145,35 @@ const jsonLd = articleJsonLd ?? softwareJsonLd;
     <meta name="twitter:image" content={ogImage} />
     <meta name="twitter:image:alt" content={ogImageAlt} />
 
-    <!-- Fonts are self-hosted; see the @font-face rules in styles/global.css -->
+    <!-- Preload the Latin fonts used on every route before the inline CSS is parsed. -->
+    <link
+      rel="preload"
+      href="/fonts/inter-400-latin.woff2"
+      as="font"
+      type="font/woff2"
+      crossorigin
+    />
+    <link
+      rel="preload"
+      href="/fonts/inter-500-latin.woff2"
+      as="font"
+      type="font/woff2"
+      crossorigin
+    />
+    <link
+      rel="preload"
+      href="/fonts/inter-600-latin.woff2"
+      as="font"
+      type="font/woff2"
+      crossorigin
+    />
+    <link
+      rel="preload"
+      href="/fonts/jetbrains-mono-500-latin.woff2"
+      as="font"
+      type="font/woff2"
+      crossorigin
+    />
 
     <!-- Structured data -->
     <script type="application/ld+json" set:html={JSON.stringify(jsonLd)} />

--- a/landing/src/styles/global.css
+++ b/landing/src/styles/global.css
@@ -273,6 +273,11 @@
   opacity: 0;
 }
 
+@utility defer-offscreen-rendering {
+  content-visibility: auto;
+  contain-intrinsic-size: auto 800px;
+}
+
 @utility hero-glow {
   /* Subtle breathing glow behind the hero. */
   background: radial-gradient(


### PR DESCRIPTION
Summary:
- preload the four critical Latin font files from the document head
- defer rendering for below-the-fold home sections with intrinsic sizing

Validation:
- `bun run build`
- generated-output audit: 20 HTML routes, inline CSS, 4 font preloads per route
- responsive Chrome screenshots and direct anchor navigation
- Chrome trace: initial layout objects 492 -> 85; forced layout 59.4 ms -> 29.0 ms

Notes:
- `gh act pull_request -W .github/workflows/landing.yml` could not start because Docker rejected the runner image authentication; no repository step failed.