### PR TITLE
fix: preserve prompt workspace selections

### DIFF
--- a/lib/src/features/workbench/presentation/prompt_workspace_dialog.dart
+++ b/lib/src/features/workbench/presentation/prompt_workspace_dialog.dart
@@ -387,7 +387,6 @@ class _PromptWorkspaceDialogState extends State<PromptWorkspaceDialog> {
       _phase = null;
       _error = null;
       _created = null;
-      _selectedParentWorkspaceId = null;
     });
   }
 

--- a/test/widget/prompt_workspace_dialog_test.dart
+++ b/test/widget/prompt_workspace_dialog_test.dart
@@ -253,11 +253,10 @@ void main() {
       );
     }
 
-    field<Project>('Project').onChanged(project);
     field<String>('Source Branch').onChanged('release');
-    await tester.pump();
     field<String?>('Parent Workspace').onChanged(featureWorkspace.id);
     field<AgentProfile>('Agent Profile').onChanged(alternateProfile);
+    await tester.pump();
 
     await tester.enterText(
       find.widgetWithText(TextField, 'Initial Prompt'),

--- a/test/widget/prompt_workspace_dialog_test.dart
+++ b/test/widget/prompt_workspace_dialog_test.dart
@@ -158,14 +158,6 @@ void main() {
       createdAt: now,
       updatedAt: now,
     );
-    final mainWorkspace = _workspace(
-      id: 'workspace-main',
-      projectId: project.id,
-      name: 'Alera',
-      branch: 'main',
-      kind: WorkspaceKind.main,
-      now: now,
-    );
     final featureWorkspace = _workspace(
       id: 'workspace-feature',
       projectId: project.id,
@@ -190,10 +182,7 @@ void main() {
                     loadBranches: (_) async => <String>['main', 'release'],
                     checkBranchExists: (_, _) async => false,
                     workspaceBranches: (_) => const <String>{},
-                    parentWorkspaces: <Workspace>[
-                      mainWorkspace,
-                      featureWorkspace,
-                    ],
+                    parentWorkspaces: <Workspace>[featureWorkspace],
                     generateIdentity:
                         ({
                           required operationId,
@@ -255,53 +244,20 @@ void main() {
     await tester.tap(find.text('Open'));
     await tester.pumpAndSettle();
 
-    AleraDropdownField<Project> projectField() {
-      return tester.widget<AleraDropdownField<Project>>(
+    AleraDropdownField<T> field<T>(String label) {
+      return tester.widget<AleraDropdownField<T>>(
         find.byWidgetPredicate(
           (widget) =>
-              widget is AleraDropdownField<Project> &&
-              widget.labelText == 'Project',
+              widget is AleraDropdownField<T> && widget.labelText == label,
         ),
       );
     }
 
-    AleraDropdownField<String> sourceBranchField() {
-      return tester.widget<AleraDropdownField<String>>(
-        find.byWidgetPredicate(
-          (widget) =>
-              widget is AleraDropdownField<String> &&
-              widget.labelText == 'Source Branch',
-        ),
-      );
-    }
-
-    AleraDropdownField<String?> parentWorkspaceField() {
-      return tester.widget<AleraDropdownField<String?>>(
-        find.byWidgetPredicate(
-          (widget) =>
-              widget is AleraDropdownField<String?> &&
-              widget.labelText == 'Parent Workspace',
-        ),
-      );
-    }
-
-    AleraDropdownField<AgentProfile> agentProfileField() {
-      return tester.widget<AleraDropdownField<AgentProfile>>(
-        find.byWidgetPredicate(
-          (widget) =>
-              widget is AleraDropdownField<AgentProfile> &&
-              widget.labelText == 'Agent Profile',
-        ),
-      );
-    }
-
-    expect(projectField().value, project);
-    sourceBranchField().onChanged('release');
+    field<Project>('Project').onChanged(project);
+    field<String>('Source Branch').onChanged('release');
     await tester.pump();
-    parentWorkspaceField().onChanged(featureWorkspace.id);
-    await tester.pump();
-    agentProfileField().onChanged(alternateProfile);
-    await tester.pump();
+    field<String?>('Parent Workspace').onChanged(featureWorkspace.id);
+    field<AgentProfile>('Agent Profile').onChanged(alternateProfile);
 
     await tester.enterText(
       find.widgetWithText(TextField, 'Initial Prompt'),
@@ -328,10 +284,10 @@ void main() {
       isEmpty,
     );
     expect(find.text('Create Another'), findsOneWidget);
-    expect(projectField().value, project);
-    expect(sourceBranchField().value, 'release');
-    expect(parentWorkspaceField().value, featureWorkspace.id);
-    expect(agentProfileField().value, alternateProfile);
+    expect(field<Project>('Project').value, project);
+    expect(field<String>('Source Branch').value, 'release');
+    expect(field<String?>('Parent Workspace').value, featureWorkspace.id);
+    expect(field<AgentProfile>('Agent Profile').value, alternateProfile);
   });
 
   testWidgets(

--- a/test/widget/prompt_workspace_dialog_test.dart
+++ b/test/widget/prompt_workspace_dialog_test.dart
@@ -133,9 +133,7 @@ void main() {
     expect(dialogResult?.agentTabId, 'tab-1');
   });
 
-  testWidgets('Create Another keeps the prompt dialog open and resets it', (
-    tester,
-  ) async {
+  testWidgets('Create Another preserves selections', (tester) async {
     final now = DateTime.utc(2026, 7, 30);
     final project = Project(
       id: 'project-1',
@@ -152,6 +150,30 @@ void main() {
       createdAt: now,
       updatedAt: now,
     );
+    final alternateProfile = AgentProfile(
+      id: 'profile-2',
+      name: 'Codex Reviewer',
+      agentType: 'codex',
+      command: 'codex',
+      createdAt: now,
+      updatedAt: now,
+    );
+    final mainWorkspace = _workspace(
+      id: 'workspace-main',
+      projectId: project.id,
+      name: 'Alera',
+      branch: 'main',
+      kind: WorkspaceKind.main,
+      now: now,
+    );
+    final featureWorkspace = _workspace(
+      id: 'workspace-feature',
+      projectId: project.id,
+      name: 'Feature Workspace',
+      branch: 'feat/parent',
+      kind: WorkspaceKind.linked,
+      now: now,
+    );
     var createAnotherCallbacks = 0;
 
     await tester.pumpWidget(
@@ -164,11 +186,14 @@ void main() {
                   context: context,
                   builder: (_) => PromptWorkspaceDialog(
                     projects: <Project>[project],
-                    agentProfiles: <AgentProfile>[profile],
-                    loadBranches: (_) async => <String>['main'],
+                    agentProfiles: <AgentProfile>[profile, alternateProfile],
+                    loadBranches: (_) async => <String>['main', 'release'],
                     checkBranchExists: (_, _) async => false,
                     workspaceBranches: (_) => const <String>{},
-                    parentWorkspaces: const <Workspace>[],
+                    parentWorkspaces: <Workspace>[
+                      mainWorkspace,
+                      featureWorkspace,
+                    ],
                     generateIdentity:
                         ({
                           required operationId,
@@ -229,6 +254,55 @@ void main() {
 
     await tester.tap(find.text('Open'));
     await tester.pumpAndSettle();
+
+    AleraDropdownField<Project> projectField() {
+      return tester.widget<AleraDropdownField<Project>>(
+        find.byWidgetPredicate(
+          (widget) =>
+              widget is AleraDropdownField<Project> &&
+              widget.labelText == 'Project',
+        ),
+      );
+    }
+
+    AleraDropdownField<String> sourceBranchField() {
+      return tester.widget<AleraDropdownField<String>>(
+        find.byWidgetPredicate(
+          (widget) =>
+              widget is AleraDropdownField<String> &&
+              widget.labelText == 'Source Branch',
+        ),
+      );
+    }
+
+    AleraDropdownField<String?> parentWorkspaceField() {
+      return tester.widget<AleraDropdownField<String?>>(
+        find.byWidgetPredicate(
+          (widget) =>
+              widget is AleraDropdownField<String?> &&
+              widget.labelText == 'Parent Workspace',
+        ),
+      );
+    }
+
+    AleraDropdownField<AgentProfile> agentProfileField() {
+      return tester.widget<AleraDropdownField<AgentProfile>>(
+        find.byWidgetPredicate(
+          (widget) =>
+              widget is AleraDropdownField<AgentProfile> &&
+              widget.labelText == 'Agent Profile',
+        ),
+      );
+    }
+
+    expect(projectField().value, project);
+    sourceBranchField().onChanged('release');
+    await tester.pump();
+    parentWorkspaceField().onChanged(featureWorkspace.id);
+    await tester.pump();
+    agentProfileField().onChanged(alternateProfile);
+    await tester.pump();
+
     await tester.enterText(
       find.widgetWithText(TextField, 'Initial Prompt'),
       'Build the first workspace',
@@ -254,6 +328,10 @@ void main() {
       isEmpty,
     );
     expect(find.text('Create Another'), findsOneWidget);
+    expect(projectField().value, project);
+    expect(sourceBranchField().value, 'release');
+    expect(parentWorkspaceField().value, featureWorkspace.id);
+    expect(agentProfileField().value, alternateProfile);
   });
 
   testWidgets(

--- a/test/widget/prompt_workspace_dialog_test.dart
+++ b/test/widget/prompt_workspace_dialog_test.dart
@@ -13,21 +13,8 @@ void main() {
     tester,
   ) async {
     final now = DateTime.utc(2026, 7, 29);
-    final project = Project(
-      id: 'project-1',
-      name: 'Alera',
-      repoPath: '/repo/alera',
-      createdAt: now,
-      updatedAt: now,
-    );
-    final profile = AgentProfile(
-      id: 'profile-1',
-      name: 'Codex Builder',
-      agentType: 'codex',
-      command: 'codex',
-      createdAt: now,
-      updatedAt: now,
-    );
+    final project = _project(id: 'project-1', name: 'Alera', now: now);
+    final profile = _profile(id: 'profile-1', name: 'Codex Builder', now: now);
     PromptWorkspaceDialogResult? dialogResult;
     String? generatedPrompt;
     String? createdBranch;
@@ -135,28 +122,12 @@ void main() {
 
   testWidgets('Create Another preserves selections', (tester) async {
     final now = DateTime.utc(2026, 7, 30);
-    final project = Project(
-      id: 'project-1',
-      name: 'Alera',
-      repoPath: '/repo/alera',
-      createdAt: now,
-      updatedAt: now,
-    );
-    final profile = AgentProfile(
-      id: 'profile-1',
-      name: 'Codex Builder',
-      agentType: 'codex',
-      command: 'codex',
-      createdAt: now,
-      updatedAt: now,
-    );
-    final alternateProfile = AgentProfile(
+    final project = _project(id: 'project-1', name: 'Alera', now: now);
+    final profile = _profile(id: 'profile-1', name: 'Codex Builder', now: now);
+    final alternateProfile = _profile(
       id: 'profile-2',
       name: 'Codex Reviewer',
-      agentType: 'codex',
-      command: 'codex',
-      createdAt: now,
-      updatedAt: now,
+      now: now,
     );
     final featureWorkspace = _workspace(
       id: 'workspace-feature',
@@ -293,27 +264,12 @@ void main() {
     'defaults the parent to the selected project main workspace and allows changing it',
     (tester) async {
       final now = DateTime.utc(2026, 7, 30);
-      final alera = Project(
-        id: 'project-alera',
-        name: 'Alera',
-        repoPath: '/repo/alera',
-        createdAt: now,
-        updatedAt: now,
-      );
-      final orca = Project(
-        id: 'project-orca',
-        name: 'Orca',
-        repoPath: '/repo/orca',
-        createdAt: now,
-        updatedAt: now,
-      );
-      final profile = AgentProfile(
+      final alera = _project(id: 'project-alera', name: 'Alera', now: now);
+      final orca = _project(id: 'project-orca', name: 'Orca', now: now);
+      final profile = _profile(
         id: 'profile-1',
         name: 'Codex Builder',
-        agentType: 'codex',
-        command: 'codex',
-        createdAt: now,
-        updatedAt: now,
+        now: now,
       );
       final aleraMain = _workspace(
         id: 'alera-main',
@@ -468,6 +424,35 @@ void main() {
 
       expect(createdParentWorkspaceId, orcaFeature.id);
     },
+  );
+}
+
+Project _project({
+  required String id,
+  required String name,
+  required DateTime now,
+}) {
+  return Project(
+    id: id,
+    name: name,
+    repoPath: '/repo/${name.toLowerCase()}',
+    createdAt: now,
+    updatedAt: now,
+  );
+}
+
+AgentProfile _profile({
+  required String id,
+  required String name,
+  required DateTime now,
+}) {
+  return AgentProfile(
+    id: id,
+    name: name,
+    agentType: 'codex',
+    command: 'codex',
+    createdAt: now,
+    updatedAt: now,
   );
 }
 


### PR DESCRIPTION
## Summary

- Preserve Project, Source Branch, Parent Workspace, and Agent Profile when `Create Another` resets the prompt workspace form.
- Continue clearing the prompt and transient creation state for the next workspace.

## Root Cause

`PromptWorkspaceDialog._finishCreation` explicitly reset `_selectedParentWorkspaceId` to `null` after a successful `Create Another` flow. The other selections already remained in the dialog state.

## Validation

- `flutter test test/widget/prompt_workspace_dialog_test.dart` - passed (3 tests)
- `dart analyze lib/src/features/workbench/presentation/prompt_workspace_dialog.dart test/widget/prompt_workspace_dialog_test.dart` - passed
- `git diff --check` - passed
- `gh act pull_request -W .github/workflows/pr.yml` - attempted; local emulation was blocked by Docker registry authentication and linked-worktree action checkout limitations, not by a product test failure.