### PR TITLE
feat: clone agent profiles and select a default

### DIFF
--- a/lib/src/features/agent_profiles/application/agent_profile_providers.dart
+++ b/lib/src/features/agent_profiles/application/agent_profile_providers.dart
@@ -92,6 +92,18 @@ class AgentProfiles extends _$AgentProfiles {
     return saved;
   }
 
+  Future<AgentProfile> clone(AgentProfile source, {required String name}) {
+    return upsert(
+      name: name,
+      agentType: source.agentType,
+      launchMode: source.launchMode,
+      command: source.command,
+      managedConfig: <String, Object?>{...source.managedConfig},
+      description: source.description,
+      quotaGroup: source.quotaGroup,
+    );
+  }
+
   Future<void> remove(String profileId) async {
     await _repository.remove(profileId);
     _pendingUpserts.remove(profileId);

--- a/lib/src/features/agent_profiles/application/agent_profile_providers.g.dart
+++ b/lib/src/features/agent_profiles/application/agent_profile_providers.g.dart
@@ -132,7 +132,7 @@ final class AgentProfilesProvider
   AgentProfiles create() => AgentProfiles();
 }
 
-String _$agentProfilesHash() => r'46b3949764224c657894e7781bb17db37bb06518';
+String _$agentProfilesHash() => r'e796a7c453d8f6032af6298df73fe853865db00b';
 
 abstract class _$AgentProfiles extends $AsyncNotifier<List<AgentProfile>> {
   FutureOr<List<AgentProfile>> build();

--- a/lib/src/features/settings/application/settings_controller.dart
+++ b/lib/src/features/settings/application/settings_controller.dart
@@ -182,6 +182,19 @@ class SettingsController extends _$SettingsController {
     );
   }
 
+  Future<void> setDefaultAgentProfile(String? profileId) async {
+    final normalized = profileId?.trim();
+    final next = normalized == null || normalized.isEmpty ? null : normalized;
+    if (state.agents.defaultAgentProfileId == next) {
+      return;
+    }
+    await _save(
+      state.copyWith(
+        agents: state.agents.copyWith(defaultAgentProfileId: next),
+      ),
+    );
+  }
+
   Future<void> setAgentQuotaProviderEnabled({
     required String hostId,
     required AgentQuotaProviderId provider,

--- a/lib/src/features/settings/application/settings_controller.g.dart
+++ b/lib/src/features/settings/application/settings_controller.g.dart
@@ -42,7 +42,7 @@ final class SettingsControllerProvider
 }
 
 String _$settingsControllerHash() =>
-    r'35c1d8486dac86ec7b2e4f462222d9e576d31d6f';
+    r'755901931d6a7ec035cd932bdef3686eea811551';
 
 abstract class _$SettingsController extends $Notifier<AleraSettings> {
   AleraSettings build();

--- a/lib/src/features/settings/domain/alera_settings.dart
+++ b/lib/src/features/settings/domain/alera_settings.dart
@@ -275,6 +275,7 @@ class AgentSettings with AgentSettingsMappable {
     this.agentStatusNotificationsEnabled = false,
     this.agentStatusFinishedNotificationsEnabled = false,
     this.keepComputerAwakeWhileAgentsWork = false,
+    this.defaultAgentProfileId,
     this.quotas = AgentQuotaSettings.defaults,
   });
 
@@ -293,6 +294,9 @@ class AgentSettings with AgentSettingsMappable {
 
   /// Keep the local computer awake while local hook-reported agents are working.
   final bool keepComputerAwakeWhileAgentsWork;
+
+  /// Runtime profile selected for flows that need an initial agent choice.
+  final String? defaultAgentProfileId;
 
   /// Per-host quota providers, Claude CCS profiles, and environment names.
   final AgentQuotaSettings quotas;

--- a/lib/src/features/settings/domain/alera_settings.mapper.dart
+++ b/lib/src/features/settings/domain/alera_settings.mapper.dart
@@ -1444,6 +1444,13 @@ class AgentSettingsMapper extends ClassMapperBase<AgentSettings> {
         opt: true,
         def: false,
       );
+  static String? _$defaultAgentProfileId(AgentSettings v) =>
+      v.defaultAgentProfileId;
+  static const Field<AgentSettings, String> _f$defaultAgentProfileId = Field(
+    'defaultAgentProfileId',
+    _$defaultAgentProfileId,
+    opt: true,
+  );
   static AgentQuotaSettings _$quotas(AgentSettings v) => v.quotas;
   static const Field<AgentSettings, AgentQuotaSettings> _f$quotas = Field(
     'quotas',
@@ -1459,6 +1466,7 @@ class AgentSettingsMapper extends ClassMapperBase<AgentSettings> {
     #agentStatusFinishedNotificationsEnabled:
         _f$agentStatusFinishedNotificationsEnabled,
     #keepComputerAwakeWhileAgentsWork: _f$keepComputerAwakeWhileAgentsWork,
+    #defaultAgentProfileId: _f$defaultAgentProfileId,
     #quotas: _f$quotas,
   };
 
@@ -1474,6 +1482,7 @@ class AgentSettingsMapper extends ClassMapperBase<AgentSettings> {
       keepComputerAwakeWhileAgentsWork: data.dec(
         _f$keepComputerAwakeWhileAgentsWork,
       ),
+      defaultAgentProfileId: data.dec(_f$defaultAgentProfileId),
       quotas: data.dec(_f$quotas),
     );
   }
@@ -1553,6 +1562,7 @@ abstract class AgentSettingsCopyWith<$R, $In extends AgentSettings, $Out>
     bool? agentStatusNotificationsEnabled,
     bool? agentStatusFinishedNotificationsEnabled,
     bool? keepComputerAwakeWhileAgentsWork,
+    String? defaultAgentProfileId,
     AgentQuotaSettings? quotas,
   });
   AgentSettingsCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(Then<$Out2, $R2> t);
@@ -1583,6 +1593,7 @@ class _AgentSettingsCopyWithImpl<$R, $Out>
     bool? agentStatusNotificationsEnabled,
     bool? agentStatusFinishedNotificationsEnabled,
     bool? keepComputerAwakeWhileAgentsWork,
+    Object? defaultAgentProfileId = $none,
     AgentQuotaSettings? quotas,
   }) => $apply(
     FieldCopyWithData({
@@ -1594,6 +1605,8 @@ class _AgentSettingsCopyWithImpl<$R, $Out>
             agentStatusFinishedNotificationsEnabled,
       if (keepComputerAwakeWhileAgentsWork != null)
         #keepComputerAwakeWhileAgentsWork: keepComputerAwakeWhileAgentsWork,
+      if (defaultAgentProfileId != $none)
+        #defaultAgentProfileId: defaultAgentProfileId,
       if (quotas != null) #quotas: quotas,
     }),
   );
@@ -1611,6 +1624,10 @@ class _AgentSettingsCopyWithImpl<$R, $Out>
     keepComputerAwakeWhileAgentsWork: data.get(
       #keepComputerAwakeWhileAgentsWork,
       or: $value.keepComputerAwakeWhileAgentsWork,
+    ),
+    defaultAgentProfileId: data.get(
+      #defaultAgentProfileId,
+      or: $value.defaultAgentProfileId,
     ),
     quotas: data.get(#quotas, or: $value.quotas),
   );

--- a/lib/src/features/settings/infra/runtime_settings_repository.dart
+++ b/lib/src/features/settings/infra/runtime_settings_repository.dart
@@ -34,6 +34,9 @@ class RuntimeSettingsRepository implements SettingsRepository {
               discoveredDefaultModelByAgent:
                   legacy.aiTextGeneration.discoveredDefaultModelByAgent,
             );
+      final defaultAgentProfileId = runtime.containsKey('defaultAgentProfileId')
+          ? _optionalRuntimeString(runtime['defaultAgentProfileId'])
+          : legacy.agents.defaultAgentProfileId;
       return legacy.copyWith(
         general: legacy.general.copyWith(
           workspaceDirectory: runtime['workspaceDirectory'] as String?,
@@ -45,6 +48,7 @@ class RuntimeSettingsRepository implements SettingsRepository {
               legacy.general.confirmWorkspaceRemoval,
         ),
         agents: legacy.agents.copyWith(
+          defaultAgentProfileId: defaultAgentProfileId,
           agentStatusHooks: AgentStatusHookSettings.fromJson(
             _asMap(runtime['agentStatusHooks']),
           ),
@@ -76,6 +80,7 @@ class RuntimeSettingsRepository implements SettingsRepository {
       'workspaceDirectory': settings.general.workspaceDirectory,
       'confirmProjectRemoval': settings.general.confirmProjectRemoval,
       'confirmWorkspaceRemoval': settings.general.confirmWorkspaceRemoval,
+      'defaultAgentProfileId': settings.agents.defaultAgentProfileId,
       'agentStatusHooks': settings.agents.agentStatusHooks.toMap(),
       'agentQuotas': settings.agents.quotas.forHost('local').toMap(),
       'aiTextGeneration': _runtimeAiTextSettings(settings.aiTextGeneration),
@@ -117,4 +122,14 @@ Map<String, Object?> _asMap(Object? value) {
     return Map<String, Object?>.from(value);
   }
   return const <String, Object?>{};
+}
+
+String? _optionalRuntimeString(Object? value) {
+  if (value is String) {
+    final trimmed = value.trim();
+    if (trimmed.isNotEmpty) {
+      return trimmed;
+    }
+  }
+  return null;
 }

--- a/lib/src/features/settings/presentation/panes/agent_profile_list_row.dart
+++ b/lib/src/features/settings/presentation/panes/agent_profile_list_row.dart
@@ -1,4 +1,6 @@
 import 'package:alera/src/app/theme/alera_tokens.dart';
+import 'package:alera/src/design_system/buttons/alera_icon_button.dart';
+import 'package:alera/src/design_system/icons/alera_icons.dart';
 import 'package:alera/src/features/agent_profiles/domain/agent_profile.dart';
 import 'package:alera/src/features/agent_profiles/domain/agent_profile_adapters.dart';
 import 'package:alera/src/features/agent_status/presentation/agent_identity_icon.dart';
@@ -12,11 +14,17 @@ class AgentProfileListRow extends StatelessWidget {
     required this.profile,
     required this.selected,
     required this.onTap,
+    this.isDefault = false,
+    this.onSetDefault,
+    this.onClone,
   });
 
   final AgentProfile profile;
   final bool selected;
   final VoidCallback onTap;
+  final bool isDefault;
+  final VoidCallback? onSetDefault;
+  final VoidCallback? onClone;
 
   @override
   Widget build(BuildContext context) {
@@ -77,6 +85,19 @@ class AgentProfileListRow extends StatelessWidget {
                     ),
                   ],
                 ),
+              ),
+              AleraIconButton(
+                tooltip: isDefault ? 'Default Agent Profile' : 'Set As Default',
+                icon: AleraIcons.star,
+                iconColor: isDefault
+                    ? AleraTokens.accent
+                    : AleraTokens.foregroundFaint,
+                onPressed: onSetDefault,
+              ),
+              AleraIconButton(
+                tooltip: 'Clone Profile',
+                icon: AleraIcons.duplicate,
+                onPressed: onClone,
               ),
             ],
           ),

--- a/lib/src/features/settings/presentation/panes/agent_profiles_pane.dart
+++ b/lib/src/features/settings/presentation/panes/agent_profiles_pane.dart
@@ -16,6 +16,7 @@ import 'package:alera/src/features/agent_profiles/domain/agent_profile.dart';
 import 'package:alera/src/features/agent_profiles/domain/agent_profile_adapters.dart';
 import 'package:alera/src/features/agent_profiles/domain/managed_agent_profile_options.dart';
 import 'package:alera/src/features/agent_status/domain/agent_status.dart';
+import 'package:alera/src/features/settings/application/settings_controller.dart';
 import 'package:alera/src/features/settings/presentation/panes/agent_profile_editor.dart';
 import 'package:alera/src/features/settings/presentation/panes/agent_profile_list_row.dart';
 import 'package:flutter/material.dart';
@@ -69,6 +70,10 @@ class _AgentProfilesSettingsPaneState
   @override
   Widget build(BuildContext context) {
     final profilesAsync = ref.watch(agentProfilesProvider);
+    final defaultAgentProfileId = ref
+        .watch(settingsControllerProvider)
+        .agents
+        .defaultAgentProfileId;
     return profilesAsync.when(
       loading: () => const Center(child: CircularProgressIndicator()),
       error: (error, _) => AleraEmptyState(
@@ -112,7 +117,16 @@ class _AgentProfilesSettingsPaneState
                         AgentProfileListRow(
                           profile: profile,
                           selected: profile.id == _selectedProfileId,
+                          isDefault: profile.id == defaultAgentProfileId,
                           onTap: () => _selectProfile(profile),
+                          onSetDefault:
+                              _saving || profile.id == defaultAgentProfileId
+                              ? null
+                              : () => unawaited(_setDefaultProfile(profile)),
+                          onClone: _saving
+                              ? null
+                              : () =>
+                                    unawaited(_cloneProfile(profile, profiles)),
                         ),
                     ],
                   ),
@@ -340,6 +354,12 @@ class _AgentProfilesSettingsPaneState
     });
     try {
       await ref.read(agentProfilesProvider.notifier).remove(profile.id);
+      if (ref.read(settingsControllerProvider).agents.defaultAgentProfileId ==
+          profile.id) {
+        await ref
+            .read(settingsControllerProvider.notifier)
+            .setDefaultAgentProfile(null);
+      }
       if (!mounted) {
         return;
       }
@@ -356,6 +376,87 @@ class _AgentProfilesSettingsPaneState
         _saving = false;
         _error = error.toString();
       });
+    }
+  }
+
+  Future<void> _setDefaultProfile(AgentProfile profile) async {
+    setState(() {
+      _saving = true;
+      _error = null;
+    });
+    try {
+      await ref
+          .read(settingsControllerProvider.notifier)
+          .setDefaultAgentProfile(profile.id);
+      if (!mounted) {
+        return;
+      }
+      setState(() => _saving = false);
+      AleraToast.show(
+        context,
+        message: 'Default Agent Profile Updated',
+        tone: AleraToastTone.success,
+      );
+    } catch (error) {
+      if (mounted) {
+        setState(() {
+          _saving = false;
+          _error = error.toString();
+        });
+      }
+    }
+  }
+
+  Future<void> _cloneProfile(
+    AgentProfile source,
+    List<AgentProfile> profiles,
+  ) async {
+    setState(() {
+      _saving = true;
+      _error = null;
+    });
+    try {
+      final cloned = await ref
+          .read(agentProfilesProvider.notifier)
+          .clone(source, name: _cloneName(source, profiles));
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _saving = false;
+        _creatingNew = false;
+        _selectedProfileId = cloned.id;
+        _seededSignature = null;
+      });
+      AleraToast.show(
+        context,
+        message: 'Agent Profile Cloned',
+        tone: AleraToastTone.success,
+      );
+    } catch (error) {
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _saving = false;
+        _error = error.toString();
+      });
+    }
+  }
+
+  String _cloneName(AgentProfile source, List<AgentProfile> profiles) {
+    final base = '${source.name.trim()} Copy';
+    final names = <String>{
+      for (final profile in profiles) profile.name.trim().toLowerCase(),
+    };
+    if (!names.contains(base.toLowerCase())) {
+      return base;
+    }
+    for (var suffix = 2; ; suffix++) {
+      final candidate = '$base $suffix';
+      if (!names.contains(candidate.toLowerCase())) {
+        return candidate;
+      }
     }
   }
 

--- a/lib/src/features/workbench/presentation/prompt_workspace_dialog.dart
+++ b/lib/src/features/workbench/presentation/prompt_workspace_dialog.dart
@@ -48,6 +48,7 @@ class PromptWorkspaceDialog extends StatefulWidget {
     required this.createWorkspace,
     required this.launchAgent,
     this.initialProject,
+    this.defaultAgentProfileId,
     this.onCreateAnother,
   });
 
@@ -80,6 +81,7 @@ class PromptWorkspaceDialog extends StatefulWidget {
     required String prompt,
   })
   launchAgent;
+  final String? defaultAgentProfileId;
   final Future<void> Function({
     required WorkspaceCreationResult creation,
     required String agentTabId,
@@ -111,7 +113,7 @@ class _PromptWorkspaceDialogState extends State<PromptWorkspaceDialog> {
     super.initState();
     _project = _initialProject();
     _selectedParentWorkspaceId = _defaultParentWorkspaceId(_project);
-    _profile = widget.agentProfiles.firstOrNull;
+    _profile = _defaultAgentProfile();
     final project = _project;
     if (project != null) {
       unawaited(_loadBranches(project));
@@ -125,6 +127,18 @@ class _PromptWorkspaceDialogState extends State<PromptWorkspaceDialog> {
   }
 
   void _update(VoidCallback update) => setState(update);
+
+  AgentProfile? _defaultAgentProfile() {
+    final defaultId = widget.defaultAgentProfileId;
+    if (defaultId != null) {
+      for (final profile in widget.agentProfiles) {
+        if (profile.id == defaultId) {
+          return profile;
+        }
+      }
+    }
+    return widget.agentProfiles.firstOrNull;
+  }
 
   Project? _initialProject() {
     final preferred = widget.initialProject;

--- a/lib/src/features/workbench/presentation/workbench_dialog_launchers.dart
+++ b/lib/src/features/workbench/presentation/workbench_dialog_launchers.dart
@@ -237,6 +237,10 @@ Future<void> showCreateWorkspaceFlow(
     builder: (_) => PromptWorkspaceDialog(
       projects: projects,
       agentProfiles: profiles,
+      defaultAgentProfileId: ref
+          .read(settingsControllerProvider)
+          .agents
+          .defaultAgentProfileId,
       initialProject: resolvedInitialProject,
       loadBranches: controller.listSourceBranches,
       checkBranchExists: (project, branchName) {

--- a/rust/alera-cli/src/terminal_host/server/declared_catalog_requests.rs
+++ b/rust/alera-cli/src/terminal_host/server/declared_catalog_requests.rs
@@ -97,6 +97,7 @@ impl ServerActor {
             .map_err(|error| HostError::state(error.to_string()))?;
         if removed {
             self.broadcast_authenticated(event("agentProfilesChanged", json!({})));
+            self.broadcast_authenticated(event("runtimeSettingsChanged", json!({})));
         }
         Ok(json!({ "removed": removed }))
     }

--- a/rust/alera-cli/src/terminal_host/server/host_service_requests.rs
+++ b/rust/alera-cli/src/terminal_host/server/host_service_requests.rs
@@ -51,6 +51,22 @@ impl ServerActor {
                     .await,
             )?;
         }
+        if let Some(value) = payload.get("defaultAgentProfileId") {
+            let profile_id = match value {
+                Value::String(value) => Some(value.as_str()),
+                Value::Null => None,
+                _ => {
+                    return Err(HostError::format(
+                        "defaultAgentProfileId must be a string or null.",
+                    ))
+                }
+            };
+            runtime_value(
+                self.runtime_store
+                    .set_default_agent_profile_id(profile_id)
+                    .await,
+            )?;
+        }
         if let Some(value) = payload.get("agentStatusHooks") {
             let settings = serde_json::from_value(value.clone()).map_err(|_| {
                 HostError::format("agentStatusHooks must contain boolean agent switches.")

--- a/rust/alera-cli/src/terminal_host/server/requests.rs
+++ b/rust/alera-cli/src/terminal_host/server/requests.rs
@@ -699,10 +699,11 @@ impl ServerActor {
             }
             "mobile.runtimeSettings.update" => {
                 self.require_auth(client_id)?;
-                const ALLOWED: [&str; 6] = [
+                const ALLOWED: [&str; 7] = [
                     "workspaceDirectory",
                     "confirmProjectRemoval",
                     "confirmWorkspaceRemoval",
+                    "defaultAgentProfileId",
                     "agentStatusHooks",
                     "agentQuotas",
                     "mobilePushNotifications",

--- a/rust/alera-cli/tests/orchestration_conformance/agent_profiles.rs
+++ b/rust/alera-cli/tests/orchestration_conformance/agent_profiles.rs
@@ -185,6 +185,54 @@ fn agent_profile_upsert_rejects_a_duplicate_name() {
 }
 
 #[test]
+fn default_agent_profile_is_stored_and_cleared_with_the_profile() {
+    let host = start_host();
+    let (mut writer, mut reader) = connect(host.port);
+    handshake(&mut writer, &mut reader, &host.token);
+
+    let created = request(
+        &mut writer,
+        &mut reader,
+        222,
+        "agentProfile.upsert",
+        json!({"name": "Codex Sol", "agentType": "codex", "command": "codex"}),
+    );
+    assert_eq!(created["ok"], json!(true));
+    let profile_id = payload(&created)["id"].as_str().unwrap().to_string();
+
+    let updated = request(
+        &mut writer,
+        &mut reader,
+        223,
+        "runtimeSettings.update",
+        json!({"defaultAgentProfileId": profile_id}),
+    );
+    assert_eq!(updated["ok"], json!(true), "update rejected: {updated}");
+    assert_eq!(
+        payload(&updated)["defaultAgentProfileId"],
+        json!(profile_id)
+    );
+
+    let removed = request(
+        &mut writer,
+        &mut reader,
+        224,
+        "agentProfile.remove",
+        json!({"id": profile_id}),
+    );
+    assert_eq!(removed["ok"], json!(true));
+
+    let settings = request(
+        &mut writer,
+        &mut reader,
+        225,
+        "runtimeSettings.get",
+        json!({}),
+    );
+    assert_eq!(payload(&settings)["defaultAgentProfileId"], Value::Null);
+}
+
+#[test]
 fn command_agent_profile_upsert_requires_a_name_and_command() {
     let host = start_host();
     let (mut writer, mut reader) = connect(host.port);

--- a/rust/alera-core/src/runtime/agent_profile_store.rs
+++ b/rust/alera-core/src/runtime/agent_profile_store.rs
@@ -101,7 +101,11 @@ impl RuntimeStore {
             .bind(profile_id)
             .execute(self.pool())
             .await?;
-        Ok(result.rows_affected() > 0)
+        let removed = result.rows_affected() > 0;
+        if removed && self.default_agent_profile_id().await?.as_deref() == Some(profile_id) {
+            self.set_default_agent_profile_id(None).await?;
+        }
+        Ok(removed)
     }
 }
 

--- a/rust/alera-core/src/runtime/settings_models.rs
+++ b/rust/alera-core/src/runtime/settings_models.rs
@@ -11,6 +11,8 @@ pub struct RuntimeSettings {
     #[serde(default = "default_true")]
     pub confirm_workspace_removal: bool,
     #[serde(default)]
+    pub default_agent_profile_id: Option<String>,
+    #[serde(default)]
     pub agent_status_hooks: RuntimeAgentStatusHookSettings,
     #[serde(default)]
     pub agent_quotas: RuntimeAgentQuotaSettings,
@@ -26,6 +28,7 @@ impl Default for RuntimeSettings {
             workspace_directory: None,
             confirm_project_removal: true,
             confirm_workspace_removal: true,
+            default_agent_profile_id: None,
             agent_status_hooks: RuntimeAgentStatusHookSettings::default(),
             agent_quotas: RuntimeAgentQuotaSettings::default(),
             mobile_push_notifications: RuntimeMobilePushSettings::default(),

--- a/rust/alera-core/src/runtime/settings_store.rs
+++ b/rust/alera-core/src/runtime/settings_store.rs
@@ -11,6 +11,7 @@ impl RuntimeStore {
             workspace_directory: self.get_workspace_directory().await?,
             confirm_project_removal: self.confirm_project_removal().await?,
             confirm_workspace_removal: self.confirm_workspace_removal().await?,
+            default_agent_profile_id: self.default_agent_profile_id().await?,
             agent_status_hooks: self.agent_status_hook_settings().await?,
             agent_quotas: self.agent_quota_settings().await?,
             mobile_push_notifications: self.mobile_push_settings().await?,
@@ -123,6 +124,33 @@ impl RuntimeStore {
             .await?
             .and_then(|value| value.parse::<bool>().ok())
             .unwrap_or(true))
+    }
+
+    pub async fn default_agent_profile_id(&self) -> Result<Option<String>> {
+        Ok(self
+            .get_metadata("settings.agents.defaultAgentProfileId")
+            .await?
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty()))
+    }
+
+    pub async fn set_default_agent_profile_id(
+        &self,
+        profile_id: Option<&str>,
+    ) -> Result<RuntimeSettings> {
+        match profile_id.map(str::trim).filter(|value| !value.is_empty()) {
+            Some(value) => {
+                self.set_metadata("settings.agents.defaultAgentProfileId", value)
+                    .await?;
+            }
+            None => {
+                sqlx::query("DELETE FROM runtimeMetadata WHERE key = ?")
+                    .bind("settings.agents.defaultAgentProfileId")
+                    .execute(self.pool())
+                    .await?;
+            }
+        }
+        self.runtime_settings().await
     }
 
     pub async fn confirm_project_removal(&self) -> Result<bool> {

--- a/rust/alera-core/src/runtime/workbench_shared_state_store_tests.rs
+++ b/rust/alera-core/src/runtime/workbench_shared_state_store_tests.rs
@@ -104,6 +104,36 @@ async fn portable_settings_round_trip_project_confirmation_and_empty_quotas() {
 }
 
 #[tokio::test]
+async fn default_agent_profile_setting_round_trips_and_clears() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = RuntimeStore::open(dir.path()).await.unwrap();
+
+    store
+        .set_default_agent_profile_id(Some("  prof_codex  "))
+        .await
+        .unwrap();
+    assert_eq!(
+        store
+            .runtime_settings()
+            .await
+            .unwrap()
+            .default_agent_profile_id
+            .as_deref(),
+        Some("prof_codex")
+    );
+
+    store.set_default_agent_profile_id(None).await.unwrap();
+    assert_eq!(
+        store
+            .runtime_settings()
+            .await
+            .unwrap()
+            .default_agent_profile_id,
+        None
+    );
+}
+
+#[tokio::test]
 async fn tab_rename_preserves_payload_and_marks_manual_title() {
     let dir = tempfile::tempdir().unwrap();
     let store = RuntimeStore::open(dir.path()).await.unwrap();

--- a/test/unit/alera_settings_test.dart
+++ b/test/unit/alera_settings_test.dart
@@ -57,6 +57,7 @@ void main() {
       expect(agents.agentStatusHooks.anyEnabled, isFalse);
       expect(agents.agentStatusNotificationsEnabled, isFalse);
       expect(agents.keepComputerAwakeWhileAgentsWork, isFalse);
+      expect(agents.defaultAgentProfileId, isNull);
     });
 
     test('editor defaults match current editor behavior', () {
@@ -112,6 +113,7 @@ void main() {
         },
         'agentStatusNotificationsEnabled': true,
         'keepComputerAwakeWhileAgentsWork': true,
+        'defaultAgentProfileId': 'prof_1',
       });
 
       expect(overrides.foreground, '#ffffff');
@@ -128,6 +130,7 @@ void main() {
       expect(agents.agentStatusHooks.amp, isTrue);
       expect(agents.agentStatusNotificationsEnabled, isTrue);
       expect(agents.keepComputerAwakeWhileAgentsWork, isTrue);
+      expect(agents.defaultAgentProfileId, 'prof_1');
 
       final hooks = AgentStatusHookSettings.fromJson(<String, Object?>{
         'claude': true,
@@ -157,6 +160,7 @@ void main() {
           ),
           agentStatusNotificationsEnabled: true,
           keepComputerAwakeWhileAgentsWork: true,
+          defaultAgentProfileId: 'prof_1',
         ),
         editor: EditorSettings(
           tabSize: 2,
@@ -220,6 +224,7 @@ void main() {
       expect(restored.agents.agentStatusHooks.grok, isTrue);
       expect(restored.agents.agentStatusNotificationsEnabled, isTrue);
       expect(restored.agents.keepComputerAwakeWhileAgentsWork, isTrue);
+      expect(restored.agents.defaultAgentProfileId, 'prof_1');
       expect(restored.editor.tabSize, 2);
       expect(restored.editor.themeName, EditorSyntaxThemeNames.nord);
       expect(restored.aiTextGeneration.agent, AiTextGenerationAgent.agy);

--- a/test/unit/runtime_agent_profile_repository_test.dart
+++ b/test/unit/runtime_agent_profile_repository_test.dart
@@ -202,6 +202,50 @@ void main() {
       expect(payload['quotaGroup'], 'codex-personal');
     });
 
+    test('controller clone reuses all profile fields without its id', () async {
+      final client = _FakeRuntimeHostClient();
+      client.responses['agentProfile.upsert'] = <String, Object?>{
+        ..._profilePayload('prof_2', 'Codex Sol Copy'),
+        'description': 'Backend implementation',
+        'quotaGroup': 'codex-personal',
+      };
+      final repository = RuntimeAgentProfileRepository(client);
+      final container = ProviderContainer(
+        overrides: [
+          agentProfileRepositoryProvider.overrideWithValue(repository),
+        ],
+      );
+      addTearDown(() {
+        container.dispose();
+        client.close();
+      });
+      client.responses['agentProfile.list'] = <String, Object?>{
+        'items': <Object?>[],
+      };
+      await container.read(agentProfilesProvider.future);
+
+      final source = AgentProfile(
+        id: 'prof_1',
+        name: 'Codex Sol',
+        agentType: 'codex',
+        command: 'codex --model sol',
+        description: 'Backend implementation',
+        quotaGroup: 'codex-personal',
+        createdAt: DateTime.utc(2026, 7),
+        updatedAt: DateTime.utc(2026, 7),
+      );
+      await container
+          .read(agentProfilesProvider.notifier)
+          .clone(source, name: 'Codex Sol Copy');
+
+      final payload = client.payloads['agentProfile.upsert']!.single;
+      expect(payload.containsKey('id'), isFalse);
+      expect(payload['name'], 'Codex Sol Copy');
+      expect(payload['command'], 'codex --model sol');
+      expect(payload['description'], 'Backend implementation');
+      expect(payload['quotaGroup'], 'codex-personal');
+    });
+
     test('managed upsert sends structured config and no raw command', () async {
       final client = _FakeRuntimeHostClient();
       client.responses['status.get'] = <String, Object?>{

--- a/test/unit/runtime_settings_repository_test.dart
+++ b/test/unit/runtime_settings_repository_test.dart
@@ -20,6 +20,7 @@ void main() {
       final payload = client.payloads['runtimeSettings.update']!.single;
       expect(payload['agentStatusHooks'], isA<Map<String, Object?>>());
       expect(payload['agentQuotas'], isA<Map<String, Object?>>());
+      expect(payload['defaultAgentProfileId'], isNull);
       expect(payload['aiTextGeneration'], isA<Map<String, Object?>>());
       final aiText = payload['aiTextGeneration']! as Map<String, Object?>;
       expect(aiText['agent'], 'codex');
@@ -59,6 +60,7 @@ void main() {
       final client = _RecordingRuntimeHostClient();
       client.responses['runtimeSettings.get'] = <String, Object?>{
         'workspaceDirectory': '/tmp/workspaces',
+        'defaultAgentProfileId': 'prof_2',
         'agentQuotas': <String, Object?>{
           'enabledProviders': <String>['claude', 'codex'],
           'claudeDefaultEnabled': false,
@@ -72,6 +74,7 @@ void main() {
       final loaded = await repository.load();
       final local = loaded.agents.quotas.forHost('local');
 
+      expect(loaded.agents.defaultAgentProfileId, 'prof_2');
       expect(local.enabledProviders, <AgentQuotaProviderId>[
         AgentQuotaProviderId.claude,
         AgentQuotaProviderId.codex,
@@ -81,6 +84,28 @@ void main() {
       expect(local.unpinnedQuotaKeys, <String>['codex', 'claude:leynierdev']);
     },
   );
+
+  test('save sends the selected default agent profile', () async {
+    final client = _RecordingRuntimeHostClient();
+    final repository = RuntimeSettingsRepository(
+      client: client,
+      legacyRepository: _MemorySettingsRepository(),
+    );
+    final settings = AleraSettings.defaults.copyWith(
+      agents: AleraSettings.defaults.agents.copyWith(
+        defaultAgentProfileId: 'prof_2',
+      ),
+    );
+
+    await repository.save(settings);
+
+    expect(
+      client
+          .payloads['runtimeSettings.update']!
+          .single['defaultAgentProfileId'],
+      'prof_2',
+    );
+  });
 
   test(
     'load combines shared AI Text execution settings with local discovery',

--- a/test/unit/settings_controller_test.dart
+++ b/test/unit/settings_controller_test.dart
@@ -276,6 +276,32 @@ void main() {
       },
     );
 
+    test('persists the default agent profile', () async {
+      final db = AleraDatabase(executor: NativeDatabase.memory());
+      addTearDown(db.close);
+      final repository = DriftSettingsRepository(db);
+      final container = ProviderContainer(
+        overrides: [settingsRepositoryProvider.overrideWithValue(repository)],
+      );
+      addTearDown(container.dispose);
+      final controller = container.read(settingsControllerProvider.notifier);
+      await controller.load();
+
+      await controller.setDefaultAgentProfile(' profile-1 ');
+
+      expect(
+        container.read(settingsControllerProvider).agents.defaultAgentProfileId,
+        'profile-1',
+      );
+      expect(
+        (await repository.load()).agents.defaultAgentProfileId,
+        'profile-1',
+      );
+
+      await controller.setDefaultAgentProfile('   ');
+      expect((await repository.load()).agents.defaultAgentProfileId, isNull);
+    });
+
     test('applyBindingChanges reassigns a chord atomically', () async {
       final db = AleraDatabase(executor: NativeDatabase.memory());
       addTearDown(db.close);

--- a/test/widget/prompt_workspace_dialog_test.dart
+++ b/test/widget/prompt_workspace_dialog_test.dart
@@ -28,12 +28,21 @@ void main() {
       createdAt: now,
       updatedAt: now,
     );
+    final preferredProfile = AgentProfile(
+      id: 'profile-2',
+      name: 'Claude Reviewer',
+      agentType: 'claude',
+      command: 'claude',
+      createdAt: now,
+      updatedAt: now,
+    );
     PromptWorkspaceDialogResult? dialogResult;
     String? generatedPrompt;
     String? createdBranch;
     String? createdName;
     String? createdParentWorkspaceId;
     String? launchedPrompt;
+    String? launchedProfileId;
 
     await tester.pumpWidget(
       MaterialApp(
@@ -45,7 +54,8 @@ void main() {
                   context: context,
                   builder: (_) => PromptWorkspaceDialog(
                     projects: <Project>[project],
-                    agentProfiles: <AgentProfile>[profile],
+                    agentProfiles: <AgentProfile>[profile, preferredProfile],
+                    defaultAgentProfileId: preferredProfile.id,
                     loadBranches: (_) async => <String>['main'],
                     checkBranchExists: (_, _) async => false,
                     workspaceBranches: (_) => const <String>{},
@@ -97,10 +107,11 @@ void main() {
                           required prompt,
                         }) async {
                           launchedPrompt = prompt;
-                          return const AgentProfileLaunchResult(
+                          launchedProfileId = profileId;
+                          return AgentProfileLaunchResult(
                             tabId: 'tab-1',
-                            agentType: 'codex',
-                            profileId: 'profile-1',
+                            agentType: preferredProfile.agentType,
+                            profileId: profileId,
                           );
                         },
                   ),
@@ -129,6 +140,7 @@ void main() {
     expect(createdName, 'Prompt Workspace');
     expect(createdParentWorkspaceId, isNull);
     expect(launchedPrompt, 'Build workspace creation');
+    expect(launchedProfileId, preferredProfile.id);
     expect(dialogResult?.creation?.workspace.id, 'workspace-1');
     expect(dialogResult?.agentTabId, 'tab-1');
   });


### PR DESCRIPTION
## Summary
- add cloning for existing Agent Profiles with host-generated IDs
- persist and expose a default Agent Profile selection
- use the selected default in New Workspace From Prompt
- clear the default when its profile is removed

## Validation
- `flutter analyze`
- `flutter pub run build_runner build -d`
- `cargo fmt --check`
- `cargo clippy --manifest-path rust/Cargo.toml -p alera-cli --test orchestration_conformance -- -D warnings`
- `cargo test --manifest-path rust/Cargo.toml -p alera-core --features runtime`
- focused orchestration conformance test

The local `gh act` run was attempted but is limited by the linked worktree and Docker registry authentication; hosted checks remain authoritative.