### PR TITLE
fix: guard terminal link row bounds

### DIFF
--- a/lib/src/features/workbench/presentation/terminal_link_resolver.dart
+++ b/lib/src/features/workbench/presentation/terminal_link_resolver.dart
@@ -1,3 +1,5 @@
+import 'dart:math' show min;
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:xterm/xterm.dart' as xterm;
@@ -262,9 +264,13 @@ final class _LogicalTerminalLine {
     final spans = <_CharacterCellSpan>[];
     for (var currentRow = startRow; currentRow <= endRow; currentRow += 1) {
       final line = buffer.lines[currentRow];
-      final segmentEnd = currentRow < endRow
-          ? buffer.viewWidth
-          : line.getTrimmedLength(buffer.viewWidth);
+      // A resize can leave a wrapped row shorter than the current viewport.
+      final segmentEnd = min(
+        line.length,
+        currentRow < endRow
+            ? buffer.viewWidth
+            : line.getTrimmedLength(buffer.viewWidth),
+      );
       for (var column = 0; column < segmentEnd; column += 1) {
         final codePoint = line.getCodePoint(column);
         final width = line.getWidth(column);

--- a/test/unit/terminal_link_resolver_test.dart
+++ b/test/unit/terminal_link_resolver_test.dart
@@ -56,6 +56,27 @@ void main() {
     expect(link.end.y, greaterThan(0));
   });
 
+  test('does not read beyond a short wrapped row after a resize', () {
+    final terminal = xterm.Terminal();
+    terminal.resize(516, 4);
+
+    final shortLine = xterm.BufferLine(128);
+    const url = 'https://example.com';
+    for (var index = 0; index < url.length; index += 1) {
+      shortLine.setCodePoint(index, url.codeUnitAt(index));
+    }
+    terminal.buffer.lines[0] = shortLine;
+    terminal.buffer.lines[1].isWrapped = true;
+
+    final link = resolveVisibleHttpLinkAt(
+      terminal: terminal,
+      offset: const xterm.CellOffset(1, 0),
+    );
+
+    expect(link, isNotNull);
+    expect(link!.uri, Uri.parse(url));
+  });
+
   test('ignores offsets outside visible urls and trims ] and } suffixes', () {
     final terminal = xterm.Terminal();
     terminal.resize(80, 24);


### PR DESCRIPTION
## Summary

- Bound visible terminal link scans by each xterm row's actual length.
- Add regression coverage for a short wrapped row after resize.

## Root Cause

A wrapped xterm row can temporarily retain a shorter backing buffer than the current viewport. Scanning through the viewport width indexed past that buffer and caused the Linux release `RangeError` reported by Sentry.

## Validation

- `flutter test test/unit/terminal_link_resolver_test.dart test/unit/xterm_regression_test.dart`
- `flutter test test/widget/terminal_surface_test.dart`
- `flutter analyze lib/src/features/workbench/presentation/terminal_link_resolver.dart test/unit/terminal_link_resolver_test.dart test/widget/terminal_surface_test.dart`
- `dart format` and `git diff --check`

`gh act pull_request -W .github/workflows/pr.yml` was also attempted; Flutter jobs hit the known linked-worktree submodule emulation error, and the local Rust container run hit unrelated permission/environment-only failures. Hosted GitHub checks remain authoritative.