### PR TITLE
fix: prevent terminal reflow buffer overflow

### DIFF
--- a/test/unit/xterm_regression_test.dart
+++ b/test/unit/xterm_regression_test.dart
@@ -39,6 +39,26 @@ void main() {
     terminal.resize(2, 4);
   });
 
+  test('xterm keeps reflowed scrollback aligned after a circular trim', () {
+    final terminal = Terminal(maxLines: 100);
+
+    terminal.resize(10, 3);
+    for (var i = 0; i < 20; i++) {
+      terminal.write('line $i\r\n');
+    }
+    terminal
+      ..write('\x1b[?25l')
+      ..resize(10, 8)
+      ..write('\x1b[?25h')
+      ..resize(808, 8);
+
+    for (var i = 0; i < terminal.buffer.lines.length; i++) {
+      expect(terminal.buffer.lines[i].length, 808);
+    }
+    terminal.setCursor(807, terminal.buffer.lines.length - 1);
+    expect(() => terminal.write('x'), returnsNormally);
+  });
+
   test(
     'xterm handles line feeds at the bottom of a scroll region after resize',
     () {


### PR DESCRIPTION
## Summary

- Fix xterm circular-buffer reflow alignment after scrollback trims.
- Keep reflowed rows aligned with the current terminal width.
- Add regression coverage for the 808-column resize that triggered issue ALERA-DESKTOP-APP-1.

## Root Cause

After a circular buffer trim, reflow results were adopted using the previous physical start index and the buffer origin was reset only afterward. This exposed stale rows with the wrong width, allowing a later terminal write to index past the row length.

## Validation

- flutter analyze
- flutter test test/unit/xterm_regression_test.dart
- flutter test test/src/utils/circular_buffer_test.dart (from third_party/xterm)
- dart format --output=none --set-exit-if-changed test/unit/xterm_regression_test.dart
- git diff --check

The xterm fix is published in the fork branch fix/reflow-circular-trim and referenced by this PR's submodule commit.