### PR TITLE
fix: run all skill installs in embedded terminal

### DIFF
--- a/lib/src/features/settings/infra/alera_cli_skill_service.dart
+++ b/lib/src/features/settings/infra/alera_cli_skill_service.dart
@@ -50,6 +50,28 @@ String aleraCliSkillInstallCommand({
   return '$npxCommand || ${_installCommandFor(AleraCliSkillRunner.bunx, skill)}';
 }
 
+/// Builds the one-line command used by the settings action that installs every
+/// bundled skill in the user's interactive shell.
+///
+/// A semicolon keeps the commands independent so one failed skill does not
+/// prevent the remaining skills from running, and it is accepted by the
+/// supported interactive shells. The command remains one line because it is
+/// typed into a live PTY and is also offered for copying.
+String aleraAllSkillsInstallCommand({
+  AleraCliSkillRunner runner = AleraCliSkillRunner.npx,
+  String? operatingSystem,
+}) {
+  return AleraAgentSkill.values
+      .map(
+        (skill) => aleraCliSkillInstallCommand(
+          runner: runner,
+          skill: skill,
+          operatingSystem: operatingSystem,
+        ),
+      )
+      .join('; ');
+}
+
 /// Windows PowerShell 5.1 has no `||` separator, and pasting a multi-line block
 /// into its console runs each line as it arrives, so this stays one line.
 /// `Get-Command` beats a `$LASTEXITCODE` chain because a missing `npx` raises

--- a/lib/src/features/settings/presentation/panes/alera_all_skills_control.dart
+++ b/lib/src/features/settings/presentation/panes/alera_all_skills_control.dart
@@ -1,6 +1,9 @@
 import 'package:alera/src/app/providers.dart';
-import 'package:alera/src/features/settings/infra/alera_all_skills_setup_service.dart';
+import 'package:alera/src/features/command_terminal/presentation/command_terminal_launcher.dart';
+import 'package:alera/src/features/settings/infra/alera_cli_skill_service.dart';
+import 'package:alera/src/features/settings/infra/alera_orchestration_setup_service.dart';
 import 'package:alera/src/features/settings/presentation/panes/alera_skill_install_control.dart';
+import 'package:alera/src/features/settings/presentation/panes/alera_skill_terminal_install_control.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -9,26 +12,25 @@ class AleraAllSkillsControl extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    return AleraSkillInstallControl(
+    return AleraSkillTerminalInstallControl(
+      dialogTitle: 'Install All Alera Skills',
+      commandFor: (runner) => aleraAllSkillsInstallCommand(runner: runner),
+      runCommand: (context, request) =>
+          showCommandTerminalDialog(context, ref, request),
       installLabel: 'Install / Update All',
-      installingLabel: 'Installing All',
-      install: (runner) async {
+      runningLabel: 'Running All',
+      followUp: () async {
         final result =
-            await AleraAllSkillsSetupService(
+            await AleraOrchestrationSetupService(
               skillService: ref.read(aleraCliSkillServiceProvider),
               hookReconciliationService: ref.read(
                 agentHookReconciliationServiceProvider,
               ),
-            ).installOrUpdate(
-              runner: runner,
-              hooks: ref
-                  .read(settingsControllerProvider)
-                  .agents
-                  .agentStatusHooks,
+            ).reconcileHooks(
+              ref.read(settingsControllerProvider).agents.agentStatusHooks,
             );
         return AleraSkillInstallStatus(
           result.summary,
-          detail: result.detail,
           needsAttention: result.needsAttention,
         );
       },

--- a/lib/src/features/settings/presentation/panes/alera_skill_terminal_install_control.dart
+++ b/lib/src/features/settings/presentation/panes/alera_skill_terminal_install_control.dart
@@ -6,6 +6,7 @@ import 'package:alera/src/features/settings/infra/alera_cli_skill_service.dart';
 import 'package:alera/src/features/settings/presentation/panes/alera_skill_install_control.dart';
 import 'package:alera/src/features/settings/presentation/panes/application_support_section.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 typedef AleraSkillTerminalRunner =
     Future<void> Function(BuildContext context, CommandTerminalRequest request);
@@ -21,7 +22,8 @@ typedef AleraSkillTerminalFollowUp =
 /// The installer resolves `npx` out of the user's interactive shell, which is
 /// where it actually is, and anything it asks for has somewhere to be answered.
 /// There is no `View Output` here because the output is no longer something
-/// that happens offscreen and gets shown afterwards.
+/// that happens offscreen and gets shown afterwards. The external Copy action
+/// remains available for users who want to run the command themselves.
 class AleraSkillTerminalInstallControl extends StatefulWidget {
   const AleraSkillTerminalInstallControl({
     super.key,
@@ -52,6 +54,15 @@ class _AleraSkillTerminalInstallControlState
   bool _running = false;
   AleraSkillInstallStatus? _status;
   AleraCliSkillRunner _runner = AleraCliSkillRunner.auto;
+
+  Future<void> _copyCommand() async {
+    await Clipboard.setData(ClipboardData(text: widget.commandFor(_runner)));
+    if (mounted) {
+      setState(
+        () => _status = const AleraSkillInstallStatus('Install Command Copied'),
+      );
+    }
+  }
 
   Future<void> _run() async {
     if (_running) {
@@ -142,6 +153,14 @@ class _AleraSkillTerminalInstallControlState
                   icon: const Icon(AleraIcons.chevronDown, size: 16),
                   label: Text(_runner.label),
                 ),
+              ),
+            ),
+            SizedBox(
+              height: kSupportControlHeight,
+              child: OutlinedButton.icon(
+                onPressed: _running ? null : _copyCommand,
+                icon: const Icon(AleraIcons.copy, size: 16),
+                label: const Text('Copy'),
               ),
             ),
             SizedBox(

--- a/test/unit/alera_cli_skill_service_test.dart
+++ b/test/unit/alera_cli_skill_service_test.dart
@@ -30,6 +30,33 @@ void main() {
       expect(command, isNot(contains('\n')));
     });
 
+    test('builds one independent command for every bundled skill', () {
+      final command = aleraAllSkillsInstallCommand(
+        runner: AleraCliSkillRunner.bunx,
+        operatingSystem: 'linux',
+      );
+
+      expect(command.split('; '), <String>[
+        for (final skill in AleraAgentSkill.values)
+          'bunx skills add https://github.com/leynier/alera --skill ${skill.name} --global',
+      ]);
+      expect(command, isNot(contains('\n')));
+    });
+
+    test('keeps the all-skills auto command single-line on windows', () {
+      final command = aleraAllSkillsInstallCommand(
+        runner: AleraCliSkillRunner.auto,
+        operatingSystem: 'windows',
+      );
+
+      expect(command, isNot(contains('||')));
+      expect(command, isNot(contains('\n')));
+      expect(
+        RegExp(r'if \(Get-Command npx').allMatches(command),
+        hasLength(AleraAgentSkill.values.length),
+      );
+    });
+
     test('keeps explicit runners unwrapped on windows', () {
       expect(
         aleraCliSkillInstallCommand(

--- a/test/widget/agents_cli_skill_control_test.dart
+++ b/test/widget/agents_cli_skill_control_test.dart
@@ -28,6 +28,19 @@ void main() {
     tester,
   ) async {
     final runtime = FakeCommandTerminalRuntime(running: false);
+    String? clipboardText;
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(SystemChannels.platform, (call) async {
+          if (call.method == 'Clipboard.setData') {
+            final arguments = call.arguments as Map<dynamic, dynamic>;
+            clipboardText = arguments['text'] as String?;
+          }
+          return null;
+        });
+    addTearDown(() {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(SystemChannels.platform, null);
+    });
     await tester.pumpWidget(
       ProviderScope(
         overrides: [terminalRuntimeProvider.overrideWithValue(runtime)],
@@ -42,6 +55,11 @@ void main() {
         ),
       ),
     );
+
+    await tester.tap(find.text('Copy'));
+    await tester.pump();
+    expect(clipboardText, contains('--skill alera-cli --global'));
+    expect(runtime.lastTab, isNull);
 
     final mouse = await tester.createGesture(
       kind: PointerDeviceKind.mouse,
@@ -65,6 +83,14 @@ void main() {
     await tester.tap(find.text('bunx').last);
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 250));
+
+    await tester.tap(find.text('Copy'));
+    await tester.pump();
+    expect(
+      clipboardText,
+      'bunx skills add https://github.com/leynier/alera --skill alera-cli --global',
+    );
+    expect(runtime.lastTab, isNull);
 
     await tester.tap(find.text('Install / Update'));
     await tester.pumpAndSettle();
@@ -195,9 +221,10 @@ void main() {
     expect(runtime.lastTab?.initialCommand, contains('--skill computer-use'));
   });
 
-  testWidgets('all skills control installs every skill and reapplies hooks', (
+  testWidgets('all skills control runs every skill in the embedded terminal', (
     tester,
   ) async {
+    final runtime = FakeCommandTerminalRuntime(running: false);
     final service = _FakeAleraCliSkillService();
     final reconciler = _FakeHookReconciler();
     final settings = AleraSettings.defaults.copyWith(
@@ -208,6 +235,7 @@ void main() {
     await tester.pumpWidget(
       ProviderScope(
         overrides: [
+          terminalRuntimeProvider.overrideWithValue(runtime),
           aleraCliSkillServiceProvider.overrideWithValue(service),
           agentHookReconciliationServiceProvider.overrideWithValue(reconciler),
           settingsControllerProvider.overrideWithValue(settings),
@@ -222,13 +250,24 @@ void main() {
     await tester.tap(find.text('Install / Update All'));
     await tester.pumpAndSettle();
 
-    expect(service.skills, AleraAgentSkill.values);
+    expect(find.text('Install All Alera Skills'), findsOneWidget);
+    final command = runtime.lastTab?.initialCommand;
+    expect(command, isNotNull);
+    for (final skill in AleraAgentSkill.values) {
+      expect(command, contains('--skill ${skill.name} --global'));
+    }
+    expect(command, isNot(contains('\n')));
+    expect(service.skills, isEmpty);
+    expect(reconciler.settings, isNull);
+
+    await tester.tap(find.text('Close'));
+    await tester.pumpAndSettle();
+
     expect(reconciler.settings?.codex, isTrue);
-    expect(find.text('All 4 Alera Skills Installed / Updated'), findsOneWidget);
-    expect(find.text('View Output'), findsOneWidget);
+    expect(find.text('Selected Hooks Ready'), findsOneWidget);
   });
 
-  testWidgets('a failed install exposes the untruncated output', (
+  testWidgets('all skills control copies without opening the terminal', (
     tester,
   ) async {
     String? clipboardText;
@@ -244,68 +283,25 @@ void main() {
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
           .setMockMethodCallHandler(SystemChannels.platform, null);
     });
-    const missingModule = "Error: Cannot find module 'C:\\shim\\npx-cli.js'";
-    final service = _FakeAleraCliSkillService(
-      failure: const AleraCliSkillInstallAttempt(
-        runner: AleraCliSkillRunner.npx,
-        exitCode: 1,
-        stdout: 'npm warn exec downloading skills',
-        stderr:
-            'node:internal/modules/cjs/loader:1424\n'
-            '        throw err;\n'
-            '$missingModule',
-      ),
-    );
-    // The all-skills control is the one that still installs in process, because
-    // it is more than one command and also reconciles hooks in Dart.
+    final runtime = FakeCommandTerminalRuntime(running: false);
     await tester.pumpWidget(
       ProviderScope(
-        overrides: [
-          aleraCliSkillServiceProvider.overrideWithValue(service),
-          agentHookReconciliationServiceProvider.overrideWithValue(
-            _FakeHookReconciler(),
-          ),
-          settingsControllerProvider.overrideWithValue(AleraSettings.defaults),
-        ],
+        overrides: [terminalRuntimeProvider.overrideWithValue(runtime)],
         child: MaterialApp(
           theme: buildAleraDarkTheme(),
-          home: const Scaffold(
-            body: Align(
-              alignment: Alignment.topLeft,
-              child: AleraAllSkillsControl(),
-            ),
-          ),
+          home: const Scaffold(body: AleraAllSkillsControl()),
         ),
       ),
     );
 
-    expect(find.text('View Output'), findsNothing);
-
-    await tester.tap(find.text('Install / Update All'));
-    await tester.pumpAndSettle();
-
-    expect(
-      find.textContaining('0 Of 4 Alera Skills Installed / Updated'),
-      findsOneWidget,
-      reason: 'the row shows a one-line summary',
-    );
-
-    await tester.tap(find.text('View Output'));
-    await tester.pumpAndSettle();
-
-    // The line that names the failure is the third one, and the settings row
-    // can never show it.
-    expect(find.textContaining(missingModule), findsOneWidget);
-    expect(
-      find.textContaining('npm warn exec downloading skills'),
-      findsOneWidget,
-    );
-
-    await tester.tap(find.text('Copy Output'));
+    await tester.tap(find.text('Copy'));
     await tester.pump();
 
-    expect(clipboardText, contains(missingModule));
-    expect(clipboardText, contains('npm warn exec downloading skills'));
+    expect(clipboardText, isNotNull);
+    for (final skill in AleraAgentSkill.values) {
+      expect(clipboardText, contains('--skill ${skill.name} --global'));
+    }
+    expect(runtime.lastTab, isNull);
   });
 
   testWidgets('registration control surfaces install failures', (tester) async {
@@ -342,15 +338,12 @@ void main() {
 }
 
 class _FakeAleraCliSkillService extends AleraCliSkillService {
-  _FakeAleraCliSkillService({this.failure})
+  _FakeAleraCliSkillService()
     : super(
         processRunner: _NoopProcessRunner(),
         commandEnvironmentResolver: const _FakeCommandEnvironmentResolver(),
       );
 
-  final AleraCliSkillInstallAttempt? failure;
-  AleraCliSkillRunner? runner;
-  AleraAgentSkill? skill;
   final List<AleraAgentSkill> skills = <AleraAgentSkill>[];
 
   @override
@@ -358,8 +351,6 @@ class _FakeAleraCliSkillService extends AleraCliSkillService {
     AleraCliSkillRunner runner = AleraCliSkillRunner.auto,
     AleraAgentSkill skill = AleraAgentSkill.cli,
   }) async {
-    this.runner = runner;
-    this.skill = skill;
     skills.add(skill);
     final attemptRunner = runner == AleraCliSkillRunner.auto
         ? AleraCliSkillRunner.npx
@@ -368,13 +359,12 @@ class _FakeAleraCliSkillService extends AleraCliSkillService {
       runner: runner,
       skill: skill,
       attempts: <AleraCliSkillInstallAttempt>[
-        failure ??
-            AleraCliSkillInstallAttempt(
-              runner: attemptRunner,
-              exitCode: 0,
-              stdout: 'ok',
-              stderr: '',
-            ),
+        AleraCliSkillInstallAttempt(
+          runner: attemptRunner,
+          exitCode: 0,
+          stdout: 'ok',
+          stderr: '',
+        ),
       ],
     );
   }


### PR DESCRIPTION
## Summary

- Run the Install / Update All Skills action in the embedded terminal as one portable command.
- Restore the external Copy action without opening or executing the terminal.
- Keep selected status-hook reconciliation after the terminal flow.

## Validation

- `flutter analyze`
- `flutter test test/unit/alera_cli_skill_service_test.dart test/widget/agents_cli_skill_control_test.dart test/unit/alera_all_skills_setup_service_test.dart`
- `gh act pull_request -W .github/workflows/pr.yml` was attempted but could not execute the workflow gates in this linked worktree because submodule setup failed with `fatal: not a git repository: (null)`; native checks passed.