### PR TITLE
fix: harden terminal host disconnect and buffer writes

### DIFF
--- a/lib/src/features/workbench/infra/terminal_host/terminal_host_client.dart
+++ b/lib/src/features/workbench/infra/terminal_host/terminal_host_client.dart
@@ -27,6 +27,15 @@ part 'terminal_host_client_session_events.dart';
 part 'terminal_host_client_socket_reader.dart';
 part 'terminal_host_control_file.dart';
 
+StateError _terminalHostConnectionClosedError(Object? error) {
+  final reason = error?.toString();
+  return StateError(
+    reason == null || reason.isEmpty
+        ? 'Terminal host connection closed.'
+        : 'Terminal host connection closed: $reason',
+  );
+}
+
 final class SocketTerminalHostClient
     with _TerminalHostClientHeartbeat, _TerminalHostClientSessionEvents
     implements TerminalHostClient, RuntimeHostClient {
@@ -675,10 +684,9 @@ final class SocketTerminalHostClient
     if (connection.isClosed) {
       return;
     }
+    final closedError = _terminalHostConnectionClosedError(error);
     _stopHeartbeatFor(connection);
-    connection.completeAuthenticationError(
-      StateError('Terminal host connection closed: $error'),
-    );
+    connection.completeAuthenticationError(closedError);
     final wasTerminalConnection = identical(_terminalConnection, connection);
     if (wasTerminalConnection) {
       _terminalConnection = null;
@@ -687,9 +695,7 @@ final class SocketTerminalHostClient
       _terminalLineSub = null;
     }
     if (wasTerminalConnection && !_disposed) {
-      _emitConnectionError(
-        StateError('Terminal host connection closed: $error'),
-      );
+      _emitConnectionError(closedError);
     }
     if (identical(_runtimeConnection, connection)) {
       _runtimeConnection = null;
@@ -705,15 +711,13 @@ final class SocketTerminalHostClient
     for (final id in pendingIds) {
       final completer = _pending.remove(id)?.completer;
       if (completer != null && !completer.isCompleted) {
-        final closedError = StateError(
-          _disposed
-              ? 'Terminal host client is disposed.'
-              : 'Terminal host connection closed: $error',
+        final pendingError = StateError(
+          _disposed ? 'Terminal host client is disposed.' : closedError.message,
         );
         // Attach a sink before completeError so orphaned RPCs do not become
         // unhandled async errors during ProviderScope / test teardown.
         unawaited(completer.future.catchError((Object _) => null));
-        completer.completeError(closedError);
+        completer.completeError(pendingError);
       }
     }
   }

--- a/test/unit/terminal_host_client_resilience_cases.dart
+++ b/test/unit/terminal_host_client_resilience_cases.dart
@@ -102,6 +102,49 @@ void _registerTerminalHostClientResilienceTests() {
     );
   });
 
+  test(
+    'clean socket closure reports a stable error without a null reason',
+    () async {
+      final tempDir = await Directory.systemTemp.createTemp(
+        'alera-host-client-clean-close-',
+      );
+      addTearDown(() async {
+        if (await tempDir.exists()) {
+          await tempDir.delete(recursive: true);
+        }
+      });
+      final server = await _TerminalHostTestServer.start();
+      addTearDown(server.dispose);
+      await _writeControlFile(
+        tempDir: tempDir,
+        port: server.port,
+        token: 'existing-token',
+      );
+      final client = SocketTerminalHostClient(
+        launcher: _NoopTerminalHostLauncher(),
+        applicationSupportDirectory: () async => tempDir,
+      );
+      addTearDown(client.dispose);
+      final sessionError = client
+          .eventsForSession('session-1')
+          .where((event) => event is TerminalHostErrorEvent)
+          .cast<TerminalHostErrorEvent>()
+          .first;
+
+      await client.write(sessionId: 'session-1', bytes: const <int>[1]);
+      server.closeClient();
+
+      expect(
+        (await sessionError).error,
+        isA<StateError>().having(
+          (error) => error.message,
+          'message',
+          'Terminal host connection closed.',
+        ),
+      );
+    },
+  );
+
   test('waits for authenticated hello before sending requests', () async {
     final tempDir = await Directory.systemTemp.createTemp(
       'alera-host-client-authentication-',

--- a/test/unit/terminal_host_test_server.dart
+++ b/test/unit/terminal_host_test_server.dart
@@ -176,6 +176,10 @@ final class _TerminalHostTestServer {
     });
   }
 
+  void closeClient() {
+    _client?.destroy();
+  }
+
   Future<void> dispose() async {
     await _sub?.cancel();
     _client?.destroy();

--- a/test/unit/xterm_regression_test.dart
+++ b/test/unit/xterm_regression_test.dart
@@ -156,4 +156,13 @@ void main() {
       expect(terminal.buffer.lines[7].toString(), isEmpty);
     },
   );
+
+  test('xterm repairs a stale row before writing past its capacity', () {
+    final terminal = Terminal()..resize(680, 24);
+    terminal.mainBuffer.lines[0] = BufferLine(80);
+
+    terminal.write('\x1b[1;171Hx');
+
+    expect(terminal.mainBuffer.lines[0].length, terminal.viewWidth);
+  });
 }


### PR DESCRIPTION
## Summary

- Normalize terminal-host disconnect errors so clean socket EOFs no longer surface as `Terminal host connection closed: null`.
- Repair stale xterm buffer rows before writes so a widened viewport cannot call `BufferLine.setCell` beyond the row capacity.
- Update the pinned `xterm.dart` submodule to the fix commit.

## Validation

- `flutter analyze`
- `flutter test test/unit/terminal_host_client_test.dart test/unit/xterm_regression_test.dart -r compact`
- `flutter test test/unit/terminal_host_pty_session_test.dart test/unit/terminal_host_pty_remint_test.dart -r compact`
- `git diff --check`

The xterm regression test reproduces the stale-row failure reported alongside this issue and verifies the row is repaired to the viewport width.