### PR TITLE
fix: isolate ai text reasoning by operation

### DIFF
--- a/lib/src/features/ai_text_generation/application/ai_text_generation_service.dart
+++ b/lib/src/features/ai_text_generation/application/ai_text_generation_service.dart
@@ -324,7 +324,8 @@ class CliAiTextGenerationService implements AiTextGenerationService {
       extraModels: discoveredModelsForAgent(settings, agent),
     );
     final thinking =
-        settings.thinkingForModel(model.id) ?? model.defaultThinkingLevel;
+        settings.thinkingForOperation(operation, model.id) ??
+        model.defaultThinkingLevel;
     if (spec.promptDelivery == AiPromptDelivery.argv &&
         utf8.encode(prompt).length > maxArgvPromptBytes) {
       throw AiTextGenerationException(

--- a/lib/src/features/ai_text_generation/domain/ai_text_generation_settings.dart
+++ b/lib/src/features/ai_text_generation/domain/ai_text_generation_settings.dart
@@ -109,6 +109,8 @@ class AiTextGenerationSettings with AiTextGenerationSettingsMappable {
     this.agent = AiTextGenerationAgent.codex,
     this.selectedModelByAgent = const <AiTextGenerationAgent, String>{},
     this.selectedThinkingByModel = const <String, String>{},
+    this.selectedThinkingByOperation =
+        const <AiTextGenerationOperation, Map<String, String>>{},
     this.discoveredModelsByAgent =
         const <AiTextGenerationAgent, List<AiTextDiscoveredModel>>{},
     this.discoveredDefaultModelByAgent =
@@ -124,6 +126,8 @@ class AiTextGenerationSettings with AiTextGenerationSettingsMappable {
   final AiTextGenerationAgent agent;
   final Map<AiTextGenerationAgent, String> selectedModelByAgent;
   final Map<String, String> selectedThinkingByModel;
+  final Map<AiTextGenerationOperation, Map<String, String>>
+  selectedThinkingByOperation;
   final Map<AiTextGenerationAgent, List<AiTextDiscoveredModel>>
   discoveredModelsByAgent;
   final Map<AiTextGenerationAgent, String> discoveredDefaultModelByAgent;
@@ -144,6 +148,21 @@ class AiTextGenerationSettings with AiTextGenerationSettingsMappable {
     }
     final value = selectedThinkingByModel[model]?.trim();
     return value == null || value.isEmpty ? null : value;
+  }
+
+  String? thinkingForOperation(
+    AiTextGenerationOperation operation,
+    String? model,
+  ) {
+    if (model == null || model.trim().isEmpty) {
+      return null;
+    }
+    final operationValue = selectedThinkingByOperation[operation]?[model]
+        ?.trim();
+    if (operationValue != null && operationValue.isNotEmpty) {
+      return operationValue;
+    }
+    return thinkingForModel(model);
   }
 
   String instructionsFor(AiTextGenerationOperation operation) {

--- a/lib/src/features/ai_text_generation/domain/ai_text_generation_settings.mapper.dart
+++ b/lib/src/features/ai_text_generation/domain/ai_text_generation_settings.mapper.dart
@@ -687,8 +687,8 @@ class AiTextGenerationSettingsMapper
         _instance = AiTextGenerationSettingsMapper._(),
       );
       AiTextGenerationAgentMapper.ensureInitialized();
-      AiTextDiscoveredModelMapper.ensureInitialized();
       AiTextGenerationOperationMapper.ensureInitialized();
+      AiTextDiscoveredModelMapper.ensureInitialized();
       AiTextGenerationPromptSettingsMapper.ensureInitialized();
     }
     return _instance!;
@@ -729,6 +729,19 @@ class AiTextGenerationSettingsMapper
     _$selectedThinkingByModel,
     opt: true,
     def: const <String, String>{},
+  );
+  static Map<AiTextGenerationOperation, Map<String, String>>
+  _$selectedThinkingByOperation(AiTextGenerationSettings v) =>
+      v.selectedThinkingByOperation;
+  static const Field<
+    AiTextGenerationSettings,
+    Map<AiTextGenerationOperation, Map<String, String>>
+  >
+  _f$selectedThinkingByOperation = Field(
+    'selectedThinkingByOperation',
+    _$selectedThinkingByOperation,
+    opt: true,
+    def: const <AiTextGenerationOperation, Map<String, String>>{},
   );
   static Map<AiTextGenerationAgent, List<AiTextDiscoveredModel>>
   _$discoveredModelsByAgent(AiTextGenerationSettings v) =>
@@ -803,6 +816,7 @@ class AiTextGenerationSettingsMapper
     #agent: _f$agent,
     #selectedModelByAgent: _f$selectedModelByAgent,
     #selectedThinkingByModel: _f$selectedThinkingByModel,
+    #selectedThinkingByOperation: _f$selectedThinkingByOperation,
     #discoveredModelsByAgent: _f$discoveredModelsByAgent,
     #discoveredDefaultModelByAgent: _f$discoveredDefaultModelByAgent,
     #customCommand: _f$customCommand,
@@ -817,6 +831,7 @@ class AiTextGenerationSettingsMapper
       agent: data.dec(_f$agent),
       selectedModelByAgent: data.dec(_f$selectedModelByAgent),
       selectedThinkingByModel: data.dec(_f$selectedThinkingByModel),
+      selectedThinkingByOperation: data.dec(_f$selectedThinkingByOperation),
       discoveredModelsByAgent: data.dec(_f$discoveredModelsByAgent),
       discoveredDefaultModelByAgent: data.dec(_f$discoveredDefaultModelByAgent),
       customCommand: data.dec(_f$customCommand),
@@ -907,6 +922,13 @@ abstract class AiTextGenerationSettingsCopyWith<
   get selectedThinkingByModel;
   MapCopyWith<
     $R,
+    AiTextGenerationOperation,
+    Map<String, String>,
+    ObjectCopyWith<$R, Map<String, String>, Map<String, String>>
+  >
+  get selectedThinkingByOperation;
+  MapCopyWith<
+    $R,
     AiTextGenerationAgent,
     List<AiTextDiscoveredModel>,
     ObjectCopyWith<$R, List<AiTextDiscoveredModel>, List<AiTextDiscoveredModel>>
@@ -942,6 +964,8 @@ abstract class AiTextGenerationSettingsCopyWith<
     AiTextGenerationAgent? agent,
     Map<AiTextGenerationAgent, String>? selectedModelByAgent,
     Map<String, String>? selectedThinkingByModel,
+    Map<AiTextGenerationOperation, Map<String, String>>?
+    selectedThinkingByOperation,
     Map<AiTextGenerationAgent, List<AiTextDiscoveredModel>>?
     discoveredModelsByAgent,
     Map<AiTextGenerationAgent, String>? discoveredDefaultModelByAgent,
@@ -983,6 +1007,18 @@ class _AiTextGenerationSettingsCopyWithImpl<$R, $Out>
     $value.selectedThinkingByModel,
     (v, t) => ObjectCopyWith(v, $identity, t),
     (v) => call(selectedThinkingByModel: v),
+  );
+  @override
+  MapCopyWith<
+    $R,
+    AiTextGenerationOperation,
+    Map<String, String>,
+    ObjectCopyWith<$R, Map<String, String>, Map<String, String>>
+  >
+  get selectedThinkingByOperation => MapCopyWith(
+    $value.selectedThinkingByOperation,
+    (v, t) => ObjectCopyWith(v, $identity, t),
+    (v) => call(selectedThinkingByOperation: v),
   );
   @override
   MapCopyWith<
@@ -1042,6 +1078,8 @@ class _AiTextGenerationSettingsCopyWithImpl<$R, $Out>
     AiTextGenerationAgent? agent,
     Map<AiTextGenerationAgent, String>? selectedModelByAgent,
     Map<String, String>? selectedThinkingByModel,
+    Map<AiTextGenerationOperation, Map<String, String>>?
+    selectedThinkingByOperation,
     Map<AiTextGenerationAgent, List<AiTextDiscoveredModel>>?
     discoveredModelsByAgent,
     Map<AiTextGenerationAgent, String>? discoveredDefaultModelByAgent,
@@ -1058,6 +1096,8 @@ class _AiTextGenerationSettingsCopyWithImpl<$R, $Out>
         #selectedModelByAgent: selectedModelByAgent,
       if (selectedThinkingByModel != null)
         #selectedThinkingByModel: selectedThinkingByModel,
+      if (selectedThinkingByOperation != null)
+        #selectedThinkingByOperation: selectedThinkingByOperation,
       if (discoveredModelsByAgent != null)
         #discoveredModelsByAgent: discoveredModelsByAgent,
       if (discoveredDefaultModelByAgent != null)
@@ -1081,6 +1121,10 @@ class _AiTextGenerationSettingsCopyWithImpl<$R, $Out>
     selectedThinkingByModel: data.get(
       #selectedThinkingByModel,
       or: $value.selectedThinkingByModel,
+    ),
+    selectedThinkingByOperation: data.get(
+      #selectedThinkingByOperation,
+      or: $value.selectedThinkingByOperation,
     ),
     discoveredModelsByAgent: data.get(
       #discoveredModelsByAgent,

--- a/lib/src/features/settings/infra/runtime_settings_repository.dart
+++ b/lib/src/features/settings/infra/runtime_settings_repository.dart
@@ -97,6 +97,10 @@ Map<String, Object?> _runtimeAiTextSettings(AiTextGenerationSettings settings) {
         entry.key.key: entry.value,
     },
     'selectedThinkingByModel': settings.selectedThinkingByModel,
+    'selectedThinkingByOperation': <String, Map<String, String>>{
+      for (final entry in settings.selectedThinkingByOperation.entries)
+        entry.key.key: entry.value,
+    },
     'customCommand': settings.customCommand,
     'instructionsByOperation': <String, String>{
       for (final entry in settings.instructionsByOperation.entries)

--- a/lib/src/features/settings/presentation/panes/ai_text_pane.dart
+++ b/lib/src/features/settings/presentation/panes/ai_text_pane.dart
@@ -204,15 +204,20 @@ class _AiTextSettingsPaneState extends ConsumerState<AiTextSettingsPane> {
         controlKey: '${operation.key}-reasoning',
         levels: model.thinkingLevels,
         value:
-            settings.thinkingForModel(model.id) ??
+            settings.thinkingForOperation(operation, model.id) ??
             model.defaultThinkingLevel ??
             model.thinkingLevels.first.id,
         onChanged: (value) => widget.onChanged(
           settings.copyWith(
-            selectedThinkingByModel: <String, String>{
-              ...settings.selectedThinkingByModel,
-              model.id: value,
-            },
+            selectedThinkingByOperation:
+                <AiTextGenerationOperation, Map<String, String>>{
+                  ...settings.selectedThinkingByOperation,
+                  operation: <String, String>{
+                    ...settings.selectedThinkingByOperation[operation] ??
+                        const <String, String>{},
+                    model.id: value,
+                  },
+                },
           ),
         ),
       ),

--- a/rust/alera-cli/src/terminal_host/server/ai_text_requests.rs
+++ b/rust/alera-cli/src/terminal_host/server/ai_text_requests.rs
@@ -169,8 +169,10 @@ fn plan_command(
         })
         .unwrap_or_else(|| default_model(agent));
     let thinking = settings
-        .selected_thinking_by_model
-        .get(model)
+        .selected_thinking_by_operation
+        .get(operation)
+        .and_then(|values| values.get(model))
+        .or_else(|| settings.selected_thinking_by_model.get(model))
         .map(String::as_str)
         .filter(|value| !value.trim().is_empty());
     let timeout = settings.timeout_seconds;

--- a/rust/alera-cli/src/terminal_host/server/ai_text_requests_tests.rs
+++ b/rust/alera-cli/src/terminal_host/server/ai_text_requests_tests.rs
@@ -30,3 +30,21 @@ fn prompt_settings_override_the_global_agent_and_model() {
         .windows(2)
         .any(|values| values == ["--mode", "rush"]));
 }
+
+#[test]
+fn operation_reasoning_overrides_global_reasoning() {
+    let settings = RuntimeAiTextGenerationSettings {
+        selected_thinking_by_model: HashMap::from([("gpt-5.5".to_string(), "low".to_string())]),
+        selected_thinking_by_operation: HashMap::from([(
+            "workspaceIdentity".to_string(),
+            HashMap::from([("gpt-5.5".to_string(), "high".to_string())]),
+        )]),
+        ..RuntimeAiTextGenerationSettings::default()
+    };
+
+    let workspace_plan = plan_command(&settings, "workspaceIdentity", "hello").unwrap();
+    assert!(workspace_plan
+        .arguments
+        .windows(2)
+        .any(|values| values == ["-c", "model_reasoning_effort=high"]));
+}

--- a/rust/alera-core/src/runtime/settings_models.rs
+++ b/rust/alera-core/src/runtime/settings_models.rs
@@ -75,6 +75,8 @@ pub struct RuntimeAiTextGenerationSettings {
     #[serde(default)]
     pub selected_thinking_by_model: HashMap<String, String>,
     #[serde(default)]
+    pub selected_thinking_by_operation: HashMap<String, HashMap<String, String>>,
+    #[serde(default)]
     pub custom_command: String,
     #[serde(default)]
     pub instructions_by_operation: HashMap<String, String>,
@@ -100,6 +102,7 @@ impl Default for RuntimeAiTextGenerationSettings {
             agent: default_ai_text_agent(),
             selected_model_by_agent: HashMap::new(),
             selected_thinking_by_model: HashMap::new(),
+            selected_thinking_by_operation: HashMap::new(),
             custom_command: String::new(),
             instructions_by_operation: HashMap::new(),
             prompt_settings_by_operation: HashMap::new(),
@@ -114,6 +117,15 @@ impl RuntimeAiTextGenerationSettings {
         self.custom_command = self.custom_command.trim().to_string();
         self.selected_model_by_agent = normalized_string_map(self.selected_model_by_agent);
         self.selected_thinking_by_model = normalized_string_map(self.selected_thinking_by_model);
+        self.selected_thinking_by_operation = self
+            .selected_thinking_by_operation
+            .into_iter()
+            .filter_map(|(operation, values)| {
+                let operation = operation.trim().to_string();
+                let values = normalized_string_map(values);
+                (!operation.is_empty() && !values.is_empty()).then_some((operation, values))
+            })
+            .collect();
         self.instructions_by_operation = normalized_string_map(self.instructions_by_operation);
         self.prompt_settings_by_operation = self
             .prompt_settings_by_operation

--- a/test/unit/ai_text_generation_grok_test_cases.dart
+++ b/test/unit/ai_text_generation_grok_test_cases.dart
@@ -114,6 +114,33 @@ Available models:
     expect(runner.arguments, containsAllInOrder(<String>['--effort', 'high']));
   });
 
+  test('passes the reasoning effort configured for the operation', () async {
+    final git = _grokGitBackend();
+    final runner = _FakeProcessRunner(stdout: 'fix: use operation effort\n');
+    final service = CliAiTextGenerationService(
+      gitBackend: git,
+      processRunner: runner,
+    );
+
+    await service.generate(
+      const AiTextGenerationRequest(
+        operation: AiTextGenerationOperation.commitMessage,
+        workspacePath: '/repo',
+        settings: AiTextGenerationSettings(
+          agent: AiTextGenerationAgent.grok,
+          selectedThinkingByOperation:
+              <AiTextGenerationOperation, Map<String, String>>{
+                AiTextGenerationOperation.commitMessage: <String, String>{
+                  'grok-4.5': 'high',
+                },
+              },
+        ),
+      ),
+    );
+
+    expect(runner.arguments, containsAllInOrder(<String>['--effort', 'high']));
+  });
+
   test('removes the Grok Build prompt file after CLI failure', () async {
     final runner = _FakeProcessRunner(
       stdout: '',

--- a/test/unit/ai_text_generation_settings_test.dart
+++ b/test/unit/ai_text_generation_settings_test.dart
@@ -47,6 +47,12 @@ void main() {
       selectedModelByAgent: <AiTextGenerationAgent, String>{
         AiTextGenerationAgent.codex: 'gpt-5',
       },
+      selectedThinkingByOperation:
+          <AiTextGenerationOperation, Map<String, String>>{
+            AiTextGenerationOperation.commitMessage: <String, String>{
+              'gpt-5': 'high',
+            },
+          },
       promptSettingsByOperation:
           <AiTextGenerationOperation, AiTextGenerationPromptSettings>{
             AiTextGenerationOperation.commitMessage:
@@ -97,6 +103,33 @@ void main() {
     expect(
       settings.modelForOperation(AiTextGenerationOperation.workspaceIdentity),
       'gpt-global',
+    );
+  });
+
+  test('keeps operation reasoning overrides isolated with global fallback', () {
+    const settings = AiTextGenerationSettings(
+      selectedThinkingByModel: <String, String>{'gpt-5.5': 'low'},
+      selectedThinkingByOperation:
+          <AiTextGenerationOperation, Map<String, String>>{
+            AiTextGenerationOperation.commitMessage: <String, String>{
+              'gpt-5.5': 'high',
+            },
+          },
+    );
+
+    expect(
+      settings.thinkingForOperation(
+        AiTextGenerationOperation.commitMessage,
+        'gpt-5.5',
+      ),
+      'high',
+    );
+    expect(
+      settings.thinkingForOperation(
+        AiTextGenerationOperation.pullRequestDetails,
+        'gpt-5.5',
+      ),
+      'low',
     );
   });
 

--- a/test/unit/runtime_settings_repository_test.dart
+++ b/test/unit/runtime_settings_repository_test.dart
@@ -15,7 +15,18 @@ void main() {
         legacyRepository: _MemorySettingsRepository(),
       );
 
-      await repository.save(AleraSettings.defaults);
+      await repository.save(
+        AleraSettings.defaults.copyWith(
+          aiTextGeneration: const AiTextGenerationSettings(
+            selectedThinkingByOperation:
+                <AiTextGenerationOperation, Map<String, String>>{
+                  AiTextGenerationOperation.commitMessage: <String, String>{
+                    'gpt-5.5': 'high',
+                  },
+                },
+          ),
+        ),
+      );
 
       final payload = client.payloads['runtimeSettings.update']!.single;
       expect(payload['agentStatusHooks'], isA<Map<String, Object?>>());
@@ -25,6 +36,9 @@ void main() {
       final aiText = payload['aiTextGeneration']! as Map<String, Object?>;
       expect(aiText['agent'], 'codex');
       expect(aiText['promptSettingsByOperation'], isA<Map<String, Object?>>());
+      expect(aiText['selectedThinkingByOperation'], <String, Object?>{
+        'commitMessage': <String, String>{'gpt-5.5': 'high'},
+      });
       expect(aiText, isNot(contains('discoveredModelsByAgent')));
       expect(
         (payload['agentQuotas']! as Map<String, Object?>)['enabledProviders'],
@@ -131,6 +145,9 @@ void main() {
           'enabled': true,
           'agent': 'claude',
           'selectedModelByAgent': <String, String>{'claude': 'opus'},
+          'selectedThinkingByOperation': <String, Object?>{
+            'workspaceIdentity': <String, String>{'opus': 'high'},
+          },
           'instructionsByOperation': <String, String>{
             'workspaceIdentity': 'Use feature branches.',
           },
@@ -168,6 +185,13 @@ void main() {
           AiTextGenerationOperation.workspaceIdentity,
         ),
         'opus',
+      );
+      expect(
+        loaded.aiTextGeneration.thinkingForOperation(
+          AiTextGenerationOperation.workspaceIdentity,
+          'opus',
+        ),
+        'high',
       );
       expect(
         loaded.aiTextGeneration

--- a/test/widget/settings_dialog_ai_text_test_cases.dart
+++ b/test/widget/settings_dialog_ai_text_test_cases.dart
@@ -1,0 +1,50 @@
+part of 'settings_dialog_test.dart';
+
+void _registerSettingsDialogAiTextTests() {
+  testWidgets('keeps AI Text reasoning selections isolated per operation', (
+    tester,
+  ) async {
+    final container = await _pumpSettingsDialog(tester);
+    await tester.tap(find.text('AI Text').first);
+    await tester.pump();
+
+    final commitReasoning = find.byKey(
+      const ValueKey<String>('ai-text-commitMessage-reasoning-low'),
+    );
+    await tester.ensureVisible(commitReasoning);
+    await tester.tap(commitReasoning);
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('High').last);
+    await tester.pump(const Duration(milliseconds: 50));
+
+    final settings = container
+        .read(settingsControllerProvider)
+        .aiTextGeneration;
+    expect(
+      settings.selectedThinkingByOperation[AiTextGenerationOperation
+          .commitMessage]?['gpt-5.5'],
+      'high',
+    );
+    expect(
+      settings.thinkingForOperation(
+        AiTextGenerationOperation.commitMessage,
+        'gpt-5.5',
+      ),
+      'high',
+    );
+    expect(
+      settings.thinkingForOperation(
+        AiTextGenerationOperation.pullRequestDetails,
+        'gpt-5.5',
+      ),
+      isNull,
+    );
+    expect(settings.thinkingForModel('gpt-5.5'), isNull);
+    expect(
+      find.byKey(
+        const ValueKey<String>('ai-text-pullRequestDetails-reasoning-low'),
+      ),
+      findsOneWidget,
+    );
+  });
+}

--- a/test/widget/settings_dialog_core_test_cases.dart
+++ b/test/widget/settings_dialog_core_test_cases.dart
@@ -432,52 +432,6 @@ void _registerSettingsDialogCoreTests() {
     );
   });
 
-  testWidgets('keeps AI Text reasoning selections isolated per operation', (
-    tester,
-  ) async {
-    final container = await pumpSettingsDialogLocal(tester);
-    await selectAiTextSectionLocal(tester);
-
-    final commitReasoning = find.byKey(
-      const ValueKey<String>('ai-text-commitMessage-reasoning-low'),
-    );
-    await tester.ensureVisible(commitReasoning);
-    await tester.tap(commitReasoning);
-    await tester.pumpAndSettle();
-    await tester.tap(find.text('High').last);
-    await tester.pump(const Duration(milliseconds: 50));
-
-    final settings = container
-        .read(settingsControllerProvider)
-        .aiTextGeneration;
-    expect(
-      settings.selectedThinkingByOperation[AiTextGenerationOperation
-          .commitMessage]?['gpt-5.5'],
-      'high',
-    );
-    expect(
-      settings.thinkingForOperation(
-        AiTextGenerationOperation.commitMessage,
-        'gpt-5.5',
-      ),
-      'high',
-    );
-    expect(
-      settings.thinkingForOperation(
-        AiTextGenerationOperation.pullRequestDetails,
-        'gpt-5.5',
-      ),
-      isNull,
-    );
-    expect(settings.thinkingForModel('gpt-5.5'), isNull);
-    expect(
-      find.byKey(
-        const ValueKey<String>('ai-text-pullRequestDetails-reasoning-low'),
-      ),
-      findsOneWidget,
-    );
-  });
-
   testWidgets('edits and resets terminal settings', (tester) async {
     final container = await pumpSettingsDialogLocal(tester);
     await selectTerminalSectionLocal(tester);

--- a/test/widget/settings_dialog_core_test_cases.dart
+++ b/test/widget/settings_dialog_core_test_cases.dart
@@ -432,6 +432,52 @@ void _registerSettingsDialogCoreTests() {
     );
   });
 
+  testWidgets('keeps AI Text reasoning selections isolated per operation', (
+    tester,
+  ) async {
+    final container = await pumpSettingsDialogLocal(tester);
+    await selectAiTextSectionLocal(tester);
+
+    final commitReasoning = find.byKey(
+      const ValueKey<String>('ai-text-commitMessage-reasoning-low'),
+    );
+    await tester.ensureVisible(commitReasoning);
+    await tester.tap(commitReasoning);
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('High').last);
+    await tester.pump(const Duration(milliseconds: 50));
+
+    final settings = container
+        .read(settingsControllerProvider)
+        .aiTextGeneration;
+    expect(
+      settings.selectedThinkingByOperation[AiTextGenerationOperation
+          .commitMessage]?['gpt-5.5'],
+      'high',
+    );
+    expect(
+      settings.thinkingForOperation(
+        AiTextGenerationOperation.commitMessage,
+        'gpt-5.5',
+      ),
+      'high',
+    );
+    expect(
+      settings.thinkingForOperation(
+        AiTextGenerationOperation.pullRequestDetails,
+        'gpt-5.5',
+      ),
+      isNull,
+    );
+    expect(settings.thinkingForModel('gpt-5.5'), isNull);
+    expect(
+      find.byKey(
+        const ValueKey<String>('ai-text-pullRequestDetails-reasoning-low'),
+      ),
+      findsOneWidget,
+    );
+  });
+
   testWidgets('edits and resets terminal settings', (tester) async {
     final container = await pumpSettingsDialogLocal(tester);
     await selectTerminalSectionLocal(tester);

--- a/test/widget/settings_dialog_test.dart
+++ b/test/widget/settings_dialog_test.dart
@@ -46,6 +46,7 @@ import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 import '../unit/fake_project_config.dart';
 
 part 'settings_dialog_core_test_cases.dart';
+part 'settings_dialog_ai_text_test_cases.dart';
 part 'settings_dialog_quota_test_cases.dart';
 part 'settings_dialog_terminal_test_cases.dart';
 part 'settings_dialog_interaction_test_cases.dart';
@@ -110,6 +111,7 @@ Future<void> _selectTerminalSection(WidgetTester tester) async {
 
 void main() {
   _registerSettingsDialogCoreTests();
+  _registerSettingsDialogAiTextTests();
   _registerSettingsDialogQuotaTests();
   _registerSettingsDialogTerminalTests();
   _registerSettingsDialogAdvancedTests();


### PR DESCRIPTION
## Summary
- isolate Effort/Thinking selections per AI Text operation
- preserve global model reasoning as the fallback for operation-specific settings
- propagate operation-specific reasoning through local CLI and runtime host paths

## Root Cause
All operation controls wrote to the model-only `selectedThinkingByModel` map, so operations using the same model shared one selection.

## Validation
- `flutter analyze`
- focused Flutter unit and widget tests
- `cargo test --manifest-path rust/Cargo.toml -p alera-cli ai_text_requests -- --nocapture`
- `cargo fmt --manifest-path rust/Cargo.toml --all -- --check`
- local `gh act` Rust job passed; other local emulation jobs were blocked by Docker registry authentication and linked-worktree submodule metadata
