### PR TITLE
fix: show update versions and restart app

### DIFF
--- a/lib/src/features/app_menu/presentation/app_menu_actions.dart
+++ b/lib/src/features/app_menu/presentation/app_menu_actions.dart
@@ -83,7 +83,8 @@ AleraToastTone _toastToneForUpdateStatus(AleraUpdateStatus status) {
     AleraUpdateStatus.error => AleraToastTone.error,
     AleraUpdateStatus.available ||
     AleraUpdateStatus.manualDownloadRequired ||
-    AleraUpdateStatus.downloaded => AleraToastTone.success,
+    AleraUpdateStatus.downloaded ||
+    AleraUpdateStatus.restartRequired => AleraToastTone.success,
     AleraUpdateStatus.idle ||
     AleraUpdateStatus.checking ||
     AleraUpdateStatus.notAvailable ||

--- a/lib/src/features/updater/application/update_controller.dart
+++ b/lib/src/features/updater/application/update_controller.dart
@@ -48,6 +48,8 @@ class AleraUpdateController extends _$AleraUpdateController {
           message: result.message ?? 'Alera is up to date.',
           latest: null,
           progress: 0,
+          currentVersion: result.currentVersion,
+          currentBuildNumber: result.currentBuildNumber,
         );
         return;
       }
@@ -63,6 +65,8 @@ class AleraUpdateController extends _$AleraUpdateController {
                 ? 'Update ${latest.version} is ready to install.'
                 : 'Update ${latest.version} is available for manual download.'),
         progress: 0,
+        currentVersion: result.currentVersion,
+        currentBuildNumber: result.currentBuildNumber,
       );
     } catch (error, stackTrace) {
       _log.warning('update check failed', error, stackTrace);
@@ -175,7 +179,38 @@ class AleraUpdateController extends _$AleraUpdateController {
     return _service.openDownloadPage(state.latest);
   }
 
-  Future<void> restartApp() {
-    return _service.restartApp();
+  void requireRestartAfterManualUpdate() {
+    if (state.latest == null || state.isBusy) {
+      return;
+    }
+    state = state.copyWith(
+      status: AleraUpdateStatus.restartRequired,
+      message: 'Restart Alera to load any update installed by the command.',
+      progress: 0,
+    );
+  }
+
+  Future<void> restartApp() async {
+    if (state.isBusy) {
+      return;
+    }
+    state = state.copyWith(
+      status: AleraUpdateStatus.applying,
+      message: 'Restarting Alera.',
+      progress: 0,
+    );
+    try {
+      await _service.restartApp();
+    } catch (error, stackTrace) {
+      _log.warning('app restart failed', error, stackTrace);
+      if (_disposed) {
+        return;
+      }
+      state = state.copyWith(
+        status: AleraUpdateStatus.error,
+        message: 'Alera could not restart: $error',
+        progress: 0,
+      );
+    }
   }
 }

--- a/lib/src/features/updater/application/update_controller.g.dart
+++ b/lib/src/features/updater/application/update_controller.g.dart
@@ -42,7 +42,7 @@ final class AleraUpdateControllerProvider
 }
 
 String _$aleraUpdateControllerHash() =>
-    r'8efaca010b75c193830802275d8196cdb60458e2';
+    r'15a59822591058452d4897fb283620287d80b509';
 
 abstract class _$AleraUpdateController extends $Notifier<AleraUpdateState> {
   AleraUpdateState build();

--- a/lib/src/features/updater/application/update_service.dart
+++ b/lib/src/features/updater/application/update_service.dart
@@ -6,11 +6,15 @@ class AleraUpdateCheckResult {
     this.latest,
     this.autoInstallAllowed = false,
     this.message,
+    this.currentVersion,
+    this.currentBuildNumber,
   });
 
   final AleraUpdateInfo? latest;
   final bool autoInstallAllowed;
   final String? message;
+  final String? currentVersion;
+  final String? currentBuildNumber;
 }
 
 abstract class AleraUpdateService {

--- a/lib/src/features/updater/domain/alera_update.dart
+++ b/lib/src/features/updater/domain/alera_update.dart
@@ -256,6 +256,7 @@ enum AleraUpdateStatus {
   downloading,
   applying,
   downloaded,
+  restartRequired,
   error,
 }
 
@@ -306,6 +307,8 @@ class AleraUpdateState with AleraUpdateStateMappable {
     this.latest,
     this.message,
     this.progress = 0,
+    this.currentVersion,
+    this.currentBuildNumber,
   });
 
   factory AleraUpdateState.idle(AleraUpdateConfig config) {
@@ -320,6 +323,8 @@ class AleraUpdateState with AleraUpdateStateMappable {
   final AleraUpdateInfo? latest;
   final String? message;
   final double progress;
+  final String? currentVersion;
+  final String? currentBuildNumber;
 
   bool get isBusy {
     return status == AleraUpdateStatus.checking ||

--- a/lib/src/features/updater/domain/alera_update.mapper.dart
+++ b/lib/src/features/updater/domain/alera_update.mapper.dart
@@ -89,6 +89,8 @@ class AleraUpdateStatusMapper extends EnumMapper<AleraUpdateStatus> {
         return AleraUpdateStatus.applying;
       case r'downloaded':
         return AleraUpdateStatus.downloaded;
+      case r'restartRequired':
+        return AleraUpdateStatus.restartRequired;
       case r'error':
         return AleraUpdateStatus.error;
       default:
@@ -115,6 +117,8 @@ class AleraUpdateStatusMapper extends EnumMapper<AleraUpdateStatus> {
         return r'applying';
       case AleraUpdateStatus.downloaded:
         return r'downloaded';
+      case AleraUpdateStatus.restartRequired:
+        return r'restartRequired';
       case AleraUpdateStatus.error:
         return r'error';
     }
@@ -661,6 +665,19 @@ class AleraUpdateStateMapper extends ClassMapperBase<AleraUpdateState> {
     opt: true,
     def: 0,
   );
+  static String? _$currentVersion(AleraUpdateState v) => v.currentVersion;
+  static const Field<AleraUpdateState, String> _f$currentVersion = Field(
+    'currentVersion',
+    _$currentVersion,
+    opt: true,
+  );
+  static String? _$currentBuildNumber(AleraUpdateState v) =>
+      v.currentBuildNumber;
+  static const Field<AleraUpdateState, String> _f$currentBuildNumber = Field(
+    'currentBuildNumber',
+    _$currentBuildNumber,
+    opt: true,
+  );
 
   @override
   final MappableFields<AleraUpdateState> fields = const {
@@ -669,6 +686,8 @@ class AleraUpdateStateMapper extends ClassMapperBase<AleraUpdateState> {
     #latest: _f$latest,
     #message: _f$message,
     #progress: _f$progress,
+    #currentVersion: _f$currentVersion,
+    #currentBuildNumber: _f$currentBuildNumber,
   };
 
   static AleraUpdateState _instantiate(DecodingData data) {
@@ -678,6 +697,8 @@ class AleraUpdateStateMapper extends ClassMapperBase<AleraUpdateState> {
       latest: data.dec(_f$latest),
       message: data.dec(_f$message),
       progress: data.dec(_f$progress),
+      currentVersion: data.dec(_f$currentVersion),
+      currentBuildNumber: data.dec(_f$currentBuildNumber),
     );
   }
 
@@ -752,6 +773,8 @@ abstract class AleraUpdateStateCopyWith<$R, $In extends AleraUpdateState, $Out>
     AleraUpdateInfo? latest,
     String? message,
     double? progress,
+    String? currentVersion,
+    String? currentBuildNumber,
   });
   AleraUpdateStateCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(
     Then<$Out2, $R2> t,
@@ -779,6 +802,8 @@ class _AleraUpdateStateCopyWithImpl<$R, $Out>
     Object? latest = $none,
     Object? message = $none,
     double? progress,
+    Object? currentVersion = $none,
+    Object? currentBuildNumber = $none,
   }) => $apply(
     FieldCopyWithData({
       if (status != null) #status: status,
@@ -786,6 +811,8 @@ class _AleraUpdateStateCopyWithImpl<$R, $Out>
       if (latest != $none) #latest: latest,
       if (message != $none) #message: message,
       if (progress != null) #progress: progress,
+      if (currentVersion != $none) #currentVersion: currentVersion,
+      if (currentBuildNumber != $none) #currentBuildNumber: currentBuildNumber,
     }),
   );
   @override
@@ -795,6 +822,11 @@ class _AleraUpdateStateCopyWithImpl<$R, $Out>
     latest: data.get(#latest, or: $value.latest),
     message: data.get(#message, or: $value.message),
     progress: data.get(#progress, or: $value.progress),
+    currentVersion: data.get(#currentVersion, or: $value.currentVersion),
+    currentBuildNumber: data.get(
+      #currentBuildNumber,
+      or: $value.currentBuildNumber,
+    ),
   );
 
   @override

--- a/lib/src/features/updater/infra/app_restart_launcher.dart
+++ b/lib/src/features/updater/infra/app_restart_launcher.dart
@@ -1,0 +1,181 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:alera/src/shared/infra/process/process_runner.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+
+typedef AppRestartDirectory = Future<Directory> Function();
+typedef AleraAppExit = FutureOr<void> Function();
+
+abstract interface class AleraAppRestarter {
+  Future<void> restart();
+}
+
+/// Relaunches Alera after the current process has fully stopped.
+///
+/// A system-shell helper owns the handoff so Windows can release the running
+/// executable before it is opened again and every platform avoids briefly
+/// running two app instances against the same state.
+class AppRestartLauncher implements AleraAppRestarter {
+  AppRestartLauncher({
+    required this.processRunner,
+    String? platform,
+    String? resolvedExecutable,
+    int? processId,
+    AleraAppExit? exitApp,
+    AppRestartDirectory? restartDirectory,
+    this.handoffTimeout = const Duration(seconds: 30),
+  }) : _platform = platform ?? Platform.operatingSystem,
+       _resolvedExecutable = resolvedExecutable ?? Platform.resolvedExecutable,
+       _processId = processId ?? pid,
+       _exitApp = exitApp ?? _exitCurrentApp,
+       _restartDirectory = restartDirectory ?? _defaultRestartDirectory;
+
+  final ProcessRunner processRunner;
+  final String _platform;
+  final String _resolvedExecutable;
+  final int _processId;
+  final AleraAppExit _exitApp;
+  final AppRestartDirectory _restartDirectory;
+  final Duration handoffTimeout;
+
+  @override
+  Future<void> restart() async {
+    final script = _restartScriptFor(_platform);
+    final directory = await _restartDirectory();
+    await directory.create(recursive: true);
+    final scriptFile = File(p.join(directory.path, script.fileName));
+    await scriptFile.writeAsString(script.contents);
+    final handoffFile = File(p.join(directory.path, 'restart.ready'));
+    if (await handoffFile.exists()) {
+      await handoffFile.delete();
+    }
+    final logPath = p.join(directory.path, 'app-restart.log');
+    final child = await processRunner.start(script.executable, <String>[
+      ...script.arguments,
+      scriptFile.path,
+      '$_processId',
+      handoffFile.path,
+      logPath,
+      _platform,
+      _resolvedExecutable,
+    ], workingDirectory: directory.path);
+
+    unawaited(child.stdout.drain<void>());
+    unawaited(child.stderr.drain<void>());
+    var helperExited = false;
+    unawaited(
+      child.exitCode.then(
+        (_) => helperExited = true,
+        onError: (Object _, StackTrace _) => helperExited = true,
+      ),
+    );
+
+    final deadline = DateTime.now().add(handoffTimeout);
+    while (DateTime.now().isBefore(deadline)) {
+      if (await handoffFile.exists()) {
+        await _exitApp();
+        return;
+      }
+      if (helperExited) {
+        throw StateError('The app restart helper exited before it was ready.');
+      }
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+    }
+    child.kill();
+    throw TimeoutException(
+      'The app restart helper did not start in time.',
+      handoffTimeout,
+    );
+  }
+}
+
+class _AppRestartScript {
+  const _AppRestartScript({
+    required this.fileName,
+    required this.contents,
+    required this.executable,
+    required this.arguments,
+  });
+
+  final String fileName;
+  final String contents;
+  final String executable;
+  final List<String> arguments;
+}
+
+_AppRestartScript _restartScriptFor(String platform) {
+  return switch (platform) {
+    'linux' || 'macos' => const _AppRestartScript(
+      fileName: 'restart-alera.sh',
+      contents: _unixRestartScript,
+      executable: '/bin/sh',
+      arguments: <String>[],
+    ),
+    'windows' => const _AppRestartScript(
+      fileName: 'restart-alera.ps1',
+      contents: _windowsRestartScript,
+      executable: 'powershell.exe',
+      arguments: <String>[
+        '-NoProfile',
+        '-NonInteractive',
+        '-ExecutionPolicy',
+        'Bypass',
+        '-File',
+      ],
+    ),
+    _ => throw UnsupportedError('App restart is not supported on $platform.'),
+  };
+}
+
+const String _unixRestartScript = r'''#!/bin/sh
+set -u
+
+parent_pid="$1"
+handoff_file="$2"
+log_file="$3"
+platform="$4"
+app_bin="$5"
+
+printf 'ready\n' >"$handoff_file"
+while kill -0 "$parent_pid" 2>/dev/null; do
+  sleep 1
+done
+
+if [ "$platform" = "macos" ]; then
+  /usr/bin/open -b dev.leynier.alera >>"$log_file" 2>&1 ||
+    /usr/bin/open -a Alera >>"$log_file" 2>&1
+elif [ -x "$app_bin" ]; then
+  "$app_bin" >>"$log_file" 2>&1 &
+else
+  printf 'Alera was not found at %s\n' "$app_bin" >"$log_file"
+fi
+''';
+
+const String _windowsRestartScript = r'''param(
+  [int]$ParentPid,
+  [string]$HandoffFile,
+  [string]$LogFile,
+  [string]$Platform,
+  [string]$AleraPath
+)
+
+Set-Content -LiteralPath $HandoffFile -Value 'ready'
+while (Get-Process -Id $ParentPid -ErrorAction SilentlyContinue) {
+  Start-Sleep -Milliseconds 250
+}
+
+if (Test-Path -LiteralPath $AleraPath -PathType Leaf) {
+  Start-Process -FilePath $AleraPath
+} else {
+  Set-Content -LiteralPath $LogFile -Value "Alera was not found at $AleraPath"
+}
+''';
+
+Future<Directory> _defaultRestartDirectory() async {
+  final support = await getApplicationSupportDirectory();
+  return Directory(p.join(support.path, 'app-restart'));
+}
+
+Never _exitCurrentApp() => exit(0);

--- a/lib/src/features/updater/infra/desktop_update_service.dart
+++ b/lib/src/features/updater/infra/desktop_update_service.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:alera/src/features/updater/application/update_service.dart';
 import 'package:alera/src/features/updater/domain/alera_update.dart';
 import 'package:alera/src/features/updater/domain/package_install_method.dart';
+import 'package:alera/src/features/updater/infra/app_restart_launcher.dart';
 import 'package:alera/src/features/updater/infra/desktop_updater_backend.dart';
 import 'package:alera/src/features/updater/infra/linux_update_package.dart';
 import 'package:alera/src/features/updater/infra/package_manager_update_launcher.dart';
@@ -29,6 +30,7 @@ class DesktopAleraUpdateService implements AleraUpdateService {
     AleraAppExit? exitApp,
     PackageManagerInstall? packageInstall,
     PackageManagerUpdateLauncher? packageManagerLauncher,
+    AleraAppRestarter? appRestarter,
   }) : config = config ?? AleraUpdateConfig.fromEnvironment(),
        _loadPackageInfo = loadPackageInfo ?? PackageInfo.fromPlatform,
        _launchUrl = launchUrl ?? _launchExternalUrl,
@@ -36,16 +38,27 @@ class DesktopAleraUpdateService implements AleraUpdateService {
        _loadLinuxInstallerKind =
            loadLinuxInstallerKind ?? loadDesktopLinuxInstallerKind,
        _backend = backend ?? DesktopUpdaterBackend() {
+    final runner = processRunner ?? const RustProcessRunner();
+    final executable = resolvedExecutable ?? Platform.resolvedExecutable;
     _packageInstall =
         packageInstall ??
         packageManagerInstallFromExecutablePath(
           platform: _platform,
-          executablePath: resolvedExecutable ?? Platform.resolvedExecutable,
+          executablePath: executable,
         );
     _packageManagerLauncher =
         packageManagerLauncher ??
         PackageManagerUpdateLauncher(
-          processRunner: processRunner ?? const RustProcessRunner(),
+          processRunner: runner,
+          processId: processId,
+          exitApp: exitApp,
+        );
+    _appRestarter =
+        appRestarter ??
+        AppRestartLauncher(
+          processRunner: runner,
+          platform: _platform,
+          resolvedExecutable: executable,
           processId: processId,
           exitApp: exitApp,
         );
@@ -73,6 +86,7 @@ class DesktopAleraUpdateService implements AleraUpdateService {
   final AleraDesktopUpdaterBackend _backend;
   late final PackageManagerInstall _packageInstall;
   late final PackageManagerUpdateLauncher _packageManagerLauncher;
+  late final AleraAppRestarter _appRestarter;
   DesktopUpdaterReleaseCandidate? _activeCandidate;
   AleraUpdateInfo? _activeUpdate;
   String? _stagingPath;
@@ -110,13 +124,19 @@ class DesktopAleraUpdateService implements AleraUpdateService {
       );
     } on DesktopUpdateIndexNotFound {
       _clearSelection();
-      return const AleraUpdateCheckResult(
+      return AleraUpdateCheckResult(
         message: 'No update index is published yet.',
+        currentVersion: packageInfo.version,
+        currentBuildNumber: packageInfo.buildNumber,
       );
     }
     if (candidate == null) {
       _clearSelection();
-      return const AleraUpdateCheckResult(message: 'Alera is up to date.');
+      return AleraUpdateCheckResult(
+        message: 'Alera is up to date.',
+        currentVersion: packageInfo.version,
+        currentBuildNumber: packageInfo.buildNumber,
+      );
     }
 
     final update = await _toAleraUpdate(candidate);
@@ -134,6 +154,8 @@ class DesktopAleraUpdateService implements AleraUpdateService {
         latest: update,
         autoInstallAllowed: true,
         message: 'Update ${update.version} is ready to install.',
+        currentVersion: packageInfo.version,
+        currentBuildNumber: packageInfo.buildNumber,
       );
     }
 
@@ -144,6 +166,8 @@ class DesktopAleraUpdateService implements AleraUpdateService {
         update: update,
         packageInstall: _packageInstall,
       ),
+      currentVersion: packageInfo.version,
+      currentBuildNumber: packageInfo.buildNumber,
     );
   }
 
@@ -205,7 +229,8 @@ class DesktopAleraUpdateService implements AleraUpdateService {
   Future<void> restartApp() async {
     final stagingPath = _stagingPath;
     if (stagingPath == null || stagingPath.isEmpty) {
-      throw StateError('No verified update is ready to install.');
+      await _appRestarter.restart();
+      return;
     }
     await _backend.install(
       stagingPath: stagingPath,

--- a/lib/src/features/updater/infra/package_manager_update_launcher.dart
+++ b/lib/src/features/updater/infra/package_manager_update_launcher.dart
@@ -3,12 +3,12 @@ import 'dart:io';
 
 import 'package:alera/src/features/updater/domain/package_install_method.dart';
 import 'package:alera/src/features/updater/domain/package_manager_upgrade_script.dart';
+import 'package:alera/src/features/updater/infra/app_restart_launcher.dart';
 import 'package:alera/src/shared/infra/process/process_runner.dart';
 import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
 
 typedef PackageManagerUpgradeDirectory = Future<Directory> Function();
-typedef AleraAppExit = FutureOr<void> Function();
 
 /// Runs the package manager's own upgrade and brings Alera back.
 ///

--- a/lib/src/features/updater/presentation/update_settings_section.dart
+++ b/lib/src/features/updater/presentation/update_settings_section.dart
@@ -25,6 +25,7 @@ class UpdateSettingsSection extends ConsumerWidget {
     final packageInstall = ref.watch(packageManagerInstallProvider);
     final needsManualPath =
         state.status == AleraUpdateStatus.manualDownloadRequired ||
+        state.status == AleraUpdateStatus.restartRequired ||
         (state.status == AleraUpdateStatus.error && state.latest != null);
     final upgradeCommand = needsManualPath
         ? packageManagerUpgradeCommand(
@@ -35,7 +36,10 @@ class UpdateSettingsSection extends ConsumerWidget {
         : null;
     final managerLabel = packageManagerLabel(packageInstall.method);
     final canRunUpgrade =
-        needsManualPath && packageInstall.canRunUpgrade && !state.isBusy;
+        needsManualPath &&
+        state.status != AleraUpdateStatus.restartRequired &&
+        packageInstall.canRunUpgrade &&
+        !state.isBusy;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: <Widget>[
@@ -103,7 +107,11 @@ class UpdateSettingsSection extends ConsumerWidget {
                 runSpacing: AleraTokens.space8,
                 children: <Widget>[
                   OutlinedButton.icon(
-                    onPressed: state.isBusy ? null : controller.checkForUpdates,
+                    onPressed:
+                        state.isBusy ||
+                            state.status == AleraUpdateStatus.restartRequired
+                        ? null
+                        : controller.checkForUpdates,
                     icon: const Icon(AleraIcons.refresh, size: 16),
                     label: Text(
                       state.status == AleraUpdateStatus.checking
@@ -132,6 +140,12 @@ class UpdateSettingsSection extends ConsumerWidget {
                       onPressed: controller.installLatest,
                       icon: const Icon(AleraIcons.download, size: 16),
                       label: const Text('Install Update'),
+                    ),
+                  if (state.status == AleraUpdateStatus.restartRequired)
+                    FilledButton.icon(
+                      onPressed: controller.restartApp,
+                      icon: const Icon(AleraIcons.restart, size: 16),
+                      label: const Text('Restart Alera'),
                     ),
                   if (state.status == AleraUpdateStatus.error &&
                       state.latest != null &&
@@ -176,7 +190,9 @@ class _UpgradeCommand extends ConsumerWidget {
     if (!context.mounted) {
       return;
     }
-    await ref.read(aleraUpdateControllerProvider.notifier).checkForUpdates();
+    ref
+        .read(aleraUpdateControllerProvider.notifier)
+        .requireRestartAfterManualUpdate();
   }
 
   @override
@@ -213,6 +229,8 @@ class _UpdateStatusCopy extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final latest = state.latest;
+    final currentVersion = state.currentVersion?.trim();
+    final currentBuildNumber = state.currentBuildNumber?.trim();
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: <Widget>[
@@ -223,10 +241,29 @@ class _UpdateStatusCopy extends StatelessWidget {
             fontWeight: FontWeight.w500,
           ),
         ),
+        if (currentVersion != null && currentVersion.isNotEmpty) ...<Widget>[
+          const SizedBox(height: AleraTokens.space4),
+          Text(
+            _versionLabel(
+              prefix: 'Current Version',
+              version: currentVersion,
+              buildNumber: currentBuildNumber,
+            ),
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: AleraTokens.foregroundMuted,
+            ),
+          ),
+        ],
         if (latest != null) ...<Widget>[
           const SizedBox(height: AleraTokens.space4),
           Text(
-            'Version ${latest.version} - Build ${latest.shortVersion}',
+            _versionLabel(
+              prefix: 'Update Version',
+              version: latest.version,
+              buildNumber: latest.shortVersion > 0
+                  ? '${latest.shortVersion}'
+                  : null,
+            ),
             style: theme.textTheme.bodySmall?.copyWith(
               color: AleraTokens.foregroundMuted,
             ),
@@ -255,15 +292,28 @@ class _UpdateStatusCopy extends StatelessWidget {
       AleraUpdateStatus.downloading => 'Downloading Update',
       AleraUpdateStatus.applying => 'Installing Update',
       AleraUpdateStatus.downloaded => 'Restarting Alera',
+      AleraUpdateStatus.restartRequired => 'Restart Alera',
       AleraUpdateStatus.error => 'Update Failed',
     };
   }
+}
+
+String _versionLabel({
+  required String prefix,
+  required String version,
+  String? buildNumber,
+}) {
+  final build = buildNumber?.trim();
+  return build == null || build.isEmpty
+      ? '$prefix $version'
+      : '$prefix $version (Build $build)';
 }
 
 Color _colorForStatus(AleraUpdateStatus status) {
   return switch (status) {
     AleraUpdateStatus.error => AleraTokens.error,
     AleraUpdateStatus.downloaded => AleraTokens.success,
+    AleraUpdateStatus.restartRequired => AleraTokens.info,
     AleraUpdateStatus.available ||
     AleraUpdateStatus.manualDownloadRequired ||
     AleraUpdateStatus.downloading ||
@@ -281,6 +331,7 @@ IconData _iconForStatus(AleraUpdateStatus status) {
     AleraUpdateStatus.downloading => AleraIcons.downloading,
     AleraUpdateStatus.applying => AleraIcons.sync,
     AleraUpdateStatus.downloaded => AleraIcons.check,
+    AleraUpdateStatus.restartRequired => AleraIcons.restart,
     AleraUpdateStatus.error => AleraIcons.error,
     AleraUpdateStatus.idle => AleraIcons.info,
   };

--- a/test/unit/alera_update_test.dart
+++ b/test/unit/alera_update_test.dart
@@ -227,6 +227,7 @@ void main() {
         AleraUpdateStatus.downloading,
         AleraUpdateStatus.applying,
         AleraUpdateStatus.downloaded,
+        AleraUpdateStatus.restartRequired,
         AleraUpdateStatus.error,
       ]);
     });
@@ -256,6 +257,8 @@ void main() {
         latest: _update,
         message: 'Update is ready.',
         progress: 0.4,
+        currentVersion: '0.1.1',
+        currentBuildNumber: '2',
       );
 
       final updated = state.copyWith(
@@ -263,6 +266,8 @@ void main() {
         latest: null,
         message: null,
         progress: 0,
+        currentVersion: null,
+        currentBuildNumber: null,
       );
 
       expect(updated.status, AleraUpdateStatus.checking);
@@ -270,6 +275,8 @@ void main() {
       expect(updated.latest, isNull);
       expect(updated.message, isNull);
       expect(updated.progress, 0);
+      expect(updated.currentVersion, isNull);
+      expect(updated.currentBuildNumber, isNull);
     });
 
     test('idle state starts non-busy and keeps the provided config', () {
@@ -290,6 +297,8 @@ void main() {
         latest: _update,
         message: 'Download the latest release manually.',
         progress: 0,
+        currentVersion: '0.1.1',
+        currentBuildNumber: '2',
       );
 
       final restored = AleraUpdateState.fromJson(
@@ -298,6 +307,8 @@ void main() {
 
       expect(restored, state);
       expect(restored.latest, _update);
+      expect(restored.currentVersion, '0.1.1');
+      expect(restored.currentBuildNumber, '2');
     });
 
     test('isBusy is true while checking or downloading', () {

--- a/test/unit/app_restart_launcher_test.dart
+++ b/test/unit/app_restart_launcher_test.dart
@@ -1,0 +1,171 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:alera/src/features/updater/infra/app_restart_launcher.dart';
+import 'package:alera/src/shared/infra/process/process_runner.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+
+void main() {
+  late Directory directory;
+
+  setUp(() {
+    directory = Directory.systemTemp.createTempSync('alera-app-restart');
+  });
+
+  tearDown(() {
+    if (directory.existsSync()) {
+      directory.deleteSync(recursive: true);
+    }
+  });
+
+  for (final testCase
+      in <
+        ({
+          String platform,
+          String executable,
+          String scriptName,
+          String scriptFragment,
+        })
+      >[
+        (
+          platform: 'linux',
+          executable: '/bin/sh',
+          scriptName: 'restart-alera.sh',
+          scriptFragment: r'"$app_bin"',
+        ),
+        (
+          platform: 'macos',
+          executable: '/bin/sh',
+          scriptName: 'restart-alera.sh',
+          scriptFragment: '/usr/bin/open -b dev.leynier.alera',
+        ),
+        (
+          platform: 'windows',
+          executable: 'powershell.exe',
+          scriptName: 'restart-alera.ps1',
+          scriptFragment: r'Start-Process -FilePath $AleraPath',
+        ),
+      ]) {
+    test('hands a ${testCase.platform} restart off before exiting', () async {
+      final runner = _RecordingProcessRunner()..writeHandoffOnStart = true;
+      var exits = 0;
+      final launcher = AppRestartLauncher(
+        processRunner: runner,
+        platform: testCase.platform,
+        resolvedExecutable: '/installed/alera',
+        processId: 4242,
+        exitApp: () => exits += 1,
+        restartDirectory: () async => directory,
+      );
+
+      await launcher.restart();
+
+      expect(exits, 1);
+      expect(runner.starts, hasLength(1));
+      final invocation = runner.starts.single;
+      expect(invocation.executable, testCase.executable);
+      expect(invocation.arguments, contains('4242'));
+      expect(invocation.arguments, contains(testCase.platform));
+      expect(invocation.arguments.last, '/installed/alera');
+      final scriptPath = invocation.arguments.firstWhere(
+        (argument) => argument.endsWith(testCase.scriptName),
+      );
+      expect(File(scriptPath).existsSync(), isTrue);
+      expect(
+        File(scriptPath).readAsStringSync(),
+        contains(testCase.scriptFragment),
+      );
+    });
+  }
+
+  test('discards a stale handoff marker', () async {
+    final runner = _RecordingProcessRunner();
+    File(p.join(directory.path, 'restart.ready')).writeAsStringSync('ready');
+    var exits = 0;
+    final launcher = AppRestartLauncher(
+      processRunner: runner,
+      platform: 'linux',
+      resolvedExecutable: '/installed/alera',
+      processId: 4242,
+      exitApp: () => exits += 1,
+      restartDirectory: () async => directory,
+      handoffTimeout: const Duration(milliseconds: 200),
+    );
+
+    await expectLater(launcher.restart(), throwsA(isA<TimeoutException>()));
+
+    expect(exits, 0);
+    expect(runner.killed, isTrue);
+  });
+
+  test('keeps Alera open when the helper exits before handoff', () async {
+    final runner = _RecordingProcessRunner()..helperExitCode = 1;
+    var exits = 0;
+    final launcher = AppRestartLauncher(
+      processRunner: runner,
+      platform: 'linux',
+      resolvedExecutable: '/installed/alera',
+      processId: 4242,
+      exitApp: () => exits += 1,
+      restartDirectory: () async => directory,
+    );
+
+    await expectLater(launcher.restart(), throwsA(isA<StateError>()));
+
+    expect(exits, 0);
+  });
+}
+
+class _RecordingProcessRunner implements ProcessRunner {
+  final List<_Invocation> starts = <_Invocation>[];
+  bool writeHandoffOnStart = false;
+  bool killed = false;
+  int? helperExitCode;
+
+  @override
+  Future<ProcessRunOutput> run(
+    String executable,
+    List<String> arguments, {
+    String? workingDirectory,
+    Map<String, String>? environment,
+  }) async {
+    return const ProcessRunOutput(exitCode: 0, stdout: '', stderr: '');
+  }
+
+  @override
+  Future<StartedProcess> start(
+    String executable,
+    List<String> arguments, {
+    String? workingDirectory,
+    Map<String, String>? environment,
+  }) async {
+    starts.add(_Invocation(executable, arguments));
+    if (writeHandoffOnStart) {
+      final handoff = arguments.firstWhere(
+        (argument) => argument.endsWith('restart.ready'),
+      );
+      await File(handoff).writeAsString('ready');
+    }
+    return StartedProcess(
+      stdinWrite: (_) {},
+      stdout: const Stream<List<int>>.empty(),
+      stderr: const Stream<List<int>>.empty(),
+      pid: 12,
+      exitCode: helperExitCode == null
+          ? Completer<int>().future
+          : Future<int>.value(helperExitCode),
+      kill: ([dynamic signal]) {
+        killed = true;
+        return true;
+      },
+    );
+  }
+}
+
+class _Invocation {
+  const _Invocation(this.executable, this.arguments);
+
+  final String executable;
+  final List<String> arguments;
+}

--- a/test/unit/desktop_update_service_test.dart
+++ b/test/unit/desktop_update_service_test.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:alera/src/features/updater/domain/alera_update.dart';
 import 'package:alera/src/features/updater/domain/package_install_method.dart';
+import 'package:alera/src/features/updater/infra/app_restart_launcher.dart';
 import 'package:alera/src/features/updater/infra/desktop_update_service.dart';
 import 'package:alera/src/features/updater/infra/desktop_updater_backend.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -47,6 +48,8 @@ void main() {
         expect(result.latest?.installerKind, 'zip');
         expect(result.autoInstallAllowed, isTrue);
         expect(result.message, 'Update 1.2.3 is ready to install.');
+        expect(result.currentVersion, '1.0.0');
+        expect(result.currentBuildNumber, '1');
         expect(backend.lastCheck?.archiveUrl, _config().archiveUrl);
         expect(backend.lastCheck?.channel, 'stable');
         expect(backend.lastCheck?.currentVersion, '1.0.0');
@@ -90,6 +93,7 @@ void main() {
         'No update index is published yet.',
       );
       expect((await current.checkForUpdates()).message, 'Alera is up to date.');
+      expect((await current.checkForUpdates()).currentVersion, '1.0.0');
     });
 
     test('propagates update metadata failures', () async {
@@ -231,11 +235,13 @@ void main() {
         platform: 'macos',
         backend: _FakeDesktopUpdaterBackend(candidate: _candidate()),
       );
+      final appRestarter = _FakeAppRestarter();
       final enabled = DesktopAleraUpdateService(
         config: _config(autoInstallEnabled: true),
         loadPackageInfo: () async => _packageInfo('1'),
         platform: 'macos',
         backend: _FakeDesktopUpdaterBackend(candidate: _candidate()),
+        appRestarter: appRestarter,
       );
 
       await expectLater(disabled.installUpdate(_update()), throwsStateError);
@@ -244,7 +250,8 @@ void main() {
         enabled.installUpdate(_update(version: '9.0.0')),
         throwsStateError,
       );
-      await expectLater(enabled.restartApp(), throwsStateError);
+      await enabled.restartApp();
+      expect(appRestarter.restartCalls, 1);
     });
 
     test('opens release pages and reports launcher refusal', () async {
@@ -365,6 +372,15 @@ class _FakeDesktopUpdaterBackend implements AleraDesktopUpdaterBackend {
   @override
   void dispose() {
     disposed = true;
+  }
+}
+
+class _FakeAppRestarter implements AleraAppRestarter {
+  int restartCalls = 0;
+
+  @override
+  Future<void> restart() async {
+    restartCalls += 1;
   }
 }
 

--- a/test/unit/update_controller_test.dart
+++ b/test/unit/update_controller_test.dart
@@ -68,6 +68,8 @@ void main() {
         result: AleraUpdateCheckResult(
           latest: _update,
           autoInstallAllowed: true,
+          currentVersion: '0.1.0',
+          currentBuildNumber: '1',
         ),
       );
       final container = ProviderContainer(
@@ -81,6 +83,14 @@ void main() {
       expect(
         container.read(aleraUpdateControllerProvider).status,
         AleraUpdateStatus.available,
+      );
+      expect(
+        container.read(aleraUpdateControllerProvider).currentVersion,
+        '0.1.0',
+      );
+      expect(
+        container.read(aleraUpdateControllerProvider).currentBuildNumber,
+        '1',
       );
     });
 
@@ -341,6 +351,42 @@ void main() {
       await controller.restartApp();
 
       expect(service.restartCalls, 1);
+    });
+
+    test('manual command completion exposes the restart state', () async {
+      final service = _FakeUpdateService(
+        result: AleraUpdateCheckResult(latest: _update),
+      );
+      final container = ProviderContainer(
+        overrides: [aleraUpdateServiceProvider.overrideWithValue(service)],
+      );
+      addTearDown(container.dispose);
+      final controller = container.read(aleraUpdateControllerProvider.notifier);
+
+      await controller.checkForUpdates();
+      controller.requireRestartAfterManualUpdate();
+
+      final state = container.read(aleraUpdateControllerProvider);
+      expect(state.status, AleraUpdateStatus.restartRequired);
+      expect(state.message, contains('Restart Alera'));
+      expect(state.latest, _update);
+    });
+
+    test('restartApp reports a relaunch failure', () async {
+      final service = _FakeUpdateService(
+        restartError: StateError('relaunch unavailable'),
+      );
+      final container = ProviderContainer(
+        overrides: [aleraUpdateServiceProvider.overrideWithValue(service)],
+      );
+      addTearDown(container.dispose);
+      final controller = container.read(aleraUpdateControllerProvider.notifier);
+
+      await controller.restartApp();
+
+      final state = container.read(aleraUpdateControllerProvider);
+      expect(state.status, AleraUpdateStatus.error);
+      expect(state.message, contains('relaunch unavailable'));
     });
   });
 }

--- a/test/widget/update_settings_section_test.dart
+++ b/test/widget/update_settings_section_test.dart
@@ -59,7 +59,7 @@ void main() {
       expect(copied, <String>[_debUpgradeCommand]);
     });
 
-    testWidgets('runs the upgrade command in a terminal and rechecks after', (
+    testWidgets('runs the upgrade command and offers to restart after', (
       tester,
     ) async {
       final runtime = FakeCommandTerminalRuntime(running: false);
@@ -81,11 +81,14 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(runtime.closedTabIds, <String>[runtime.lastTab!.id]);
-      expect(
-        controller.checkForUpdatesCalls,
-        1,
-        reason: 'the section has to reflect whatever the upgrade left behind',
-      );
+      expect(controller.checkForUpdatesCalls, 0);
+      expect(controller.requireRestartCalls, 1);
+      expect(find.text('Restart Alera'), findsWidgets);
+
+      await tester.tap(find.widgetWithText(FilledButton, 'Restart Alera'));
+      await tester.pump();
+
+      expect(controller.restartAppCalls, 1);
     });
 
     testWidgets(
@@ -110,13 +113,14 @@ void main() {
         controller.setState(
           _state(
             status: AleraUpdateStatus.notAvailable,
-            latest: _latest(),
             message: 'Alera is up to date.',
+            currentVersion: '1.0.0',
+            currentBuildNumber: '100',
           ),
         );
         await tester.pump();
         expect(find.text('No Update Available'), findsOneWidget);
-        expect(find.text('Version 1.2.3 - Build 123'), findsOneWidget);
+        expect(find.text('Current Version 1.0.0 (Build 100)'), findsOneWidget);
         expect(find.text('Alera is up to date.'), findsOneWidget);
 
         controller.setState(
@@ -124,10 +128,14 @@ void main() {
             status: AleraUpdateStatus.manualDownloadRequired,
             latest: _latest(),
             message: 'Manual download required.',
+            currentVersion: '1.0.0',
+            currentBuildNumber: '100',
           ),
         );
         await tester.pump();
         expect(find.text('Manual Update Available'), findsOneWidget);
+        expect(find.text('Current Version 1.0.0 (Build 100)'), findsOneWidget);
+        expect(find.text('Update Version 1.2.3 (Build 123)'), findsOneWidget);
         expect(find.text('Download Manually'), findsOneWidget);
 
         controller.setState(
@@ -263,6 +271,8 @@ AleraUpdateState _state({
   AleraUpdateInfo? latest,
   String? message,
   double progress = 0,
+  String? currentVersion,
+  String? currentBuildNumber,
 }) {
   return AleraUpdateState(
     status: status,
@@ -270,6 +280,8 @@ AleraUpdateState _state({
     latest: latest,
     message: message,
     progress: progress,
+    currentVersion: currentVersion,
+    currentBuildNumber: currentBuildNumber,
   );
 }
 
@@ -304,6 +316,7 @@ class _FakeUpdateController extends AleraUpdateController {
   int installLatestCalls = 0;
   int openDownloadPageCalls = 0;
   int restartAppCalls = 0;
+  int requireRestartCalls = 0;
 
   @override
   AleraUpdateState build() => _seed;
@@ -325,6 +338,12 @@ class _FakeUpdateController extends AleraUpdateController {
   @override
   Future<void> openDownloadPage() async {
     openDownloadPageCalls += 1;
+  }
+
+  @override
+  void requireRestartAfterManualUpdate() {
+    requireRestartCalls += 1;
+    state = state.copyWith(status: AleraUpdateStatus.restartRequired);
   }
 
   @override


### PR DESCRIPTION
## Summary

- show the running and target app versions separately in update settings
- offer an explicit restart after a package-manager command finishes
- relaunch Alera safely through a platform-specific helper on Linux, macOS, and Windows

## Root cause

The updater state only retained the release candidate, so the UI could not distinguish the running version from the update target. The manual command flow then rechecked from the still-running old binary instead of offering a restart.

## Validation

- `dart format --set-exit-if-changed lib test integration_test tool`
- `dart tool/quality/check_max_lines.dart`
- `flutter analyze`
- 131 updater and adjacent tests
- `git diff --check`

`gh act pull_request -W .github/workflows/pr.yml -j static` was attempted but stopped before product steps because the linked workspace gitdir is not resolvable inside the act container (`fatal: not a git repository: (null)`). Hosted GitHub checks remain authoritative.