### PR TITLE
fix: detect agy models dynamically

### DIFF
--- a/lib/src/features/ai_text_generation/application/ai_text_generation_model_labels.dart
+++ b/lib/src/features/ai_text_generation/application/ai_text_generation_model_labels.dart
@@ -15,3 +15,28 @@ String labelFromModelId(String id) {
       })
       .join(' ');
 }
+
+String labelFromAgyModelId(String id) {
+  final effort = RegExp(
+    r'-(low|medium|high)$',
+    caseSensitive: false,
+  ).firstMatch(id);
+  final thinking = RegExp(r'-thinking$', caseSensitive: false).firstMatch(id);
+  final suffix = effort ?? thinking;
+  final baseId = suffix == null ? id : id.substring(0, suffix.start);
+  var label = labelFromModelId(baseId).replaceAllMapped(
+    RegExp(r'\b(\d+) (\d+)\b'),
+    (match) => '${match.group(1)}.${match.group(2)}',
+  );
+  if (label.contains(' Oss ')) {
+    label = label.replaceFirst(' Oss ', ' OSS ');
+  }
+  if (effort != null) {
+    final level = effort.group(1)!;
+    return '$label (${level[0].toUpperCase()}${level.substring(1).toLowerCase()})';
+  }
+  if (thinking != null) {
+    return '$label (Thinking)';
+  }
+  return label;
+}

--- a/lib/src/features/ai_text_generation/application/ai_text_generation_registry.dart
+++ b/lib/src/features/ai_text_generation/application/ai_text_generation_registry.dart
@@ -64,6 +64,7 @@ class AiTextAgentSpec {
     required this.models,
     required this.defaultModelId,
     required this.buildArgs,
+    this.modelCanInherit = false,
   });
 
   final AiTextGenerationAgent agent;
@@ -72,7 +73,8 @@ class AiTextAgentSpec {
   final List<String>? modelsCommand;
   final List<AiTextModel> Function(String stdout) parseModels;
   final List<AiTextModel> models;
-  final String defaultModelId;
+  final String? defaultModelId;
+  final bool modelCanInherit;
   final List<String> Function({
     required String prompt,
     required String model,
@@ -267,22 +269,10 @@ aiTextAgentSpecs = <AiTextGenerationAgent, AiTextAgentSpec>{
     binary: 'agy',
     promptDelivery: AiPromptDelivery.stdin,
     modelsCommand: const <String>['models'],
-    parseModels: parseLineModels,
-    models: const <AiTextModel>[
-      AiTextModel(
-        id: 'Gemini 3.5 Flash (Medium)',
-        label: 'Gemini 3.5 Flash (Medium)',
-      ),
-      AiTextModel(
-        id: 'Gemini 3.5 Flash (High)',
-        label: 'Gemini 3.5 Flash (High)',
-      ),
-      AiTextModel(
-        id: 'Gemini 3.5 Flash (Low)',
-        label: 'Gemini 3.5 Flash (Low)',
-      ),
-    ],
-    defaultModelId: 'Gemini 3.5 Flash (Medium)',
+    parseModels: parseAgyModels,
+    models: const <AiTextModel>[],
+    defaultModelId: null,
+    modelCanInherit: true,
     buildArgs:
         ({
           required model,
@@ -294,8 +284,7 @@ aiTextAgentSpecs = <AiTextGenerationAgent, AiTextAgentSpec>{
           '--sandbox',
           '--print-timeout',
           '${timeoutSeconds}s',
-          '--model',
-          model,
+          if (model.trim().isNotEmpty) ...<String>['--model', model],
         ],
   ),
   AiTextGenerationAgent.opencode: AiTextAgentSpec(
@@ -424,6 +413,7 @@ List<AiTextModel> modelsForAgent(
     return const <AiTextModel>[];
   }
   return _uniqueModels(<AiTextModel>[
+    if (spec.modelCanInherit) const AiTextModel(id: '', label: 'Agent Default'),
     ...discoveredModelsForAgent(settings, agent),
     ...spec.models,
   ]);
@@ -437,11 +427,13 @@ String defaultModelIdForAgent(
   if (spec == null) {
     return 'custom';
   }
-  final discoveredDefault = settings.discoveredDefaultModelFor(agent);
-  if (discoveredDefault != null) {
-    return discoveredDefault;
+  if (!spec.modelCanInherit) {
+    final discoveredDefault = settings.discoveredDefaultModelFor(agent);
+    if (discoveredDefault != null) {
+      return discoveredDefault;
+    }
   }
-  return spec.defaultModelId;
+  return spec.defaultModelId ?? '';
 }
 
 AiTextModel modelForAgent(
@@ -455,7 +447,10 @@ AiTextModel modelForAgent(
   }
   final id = modelId?.trim().isNotEmpty == true
       ? modelId!.trim()
-      : spec.defaultModelId;
+      : spec.defaultModelId ?? '';
+  if (id.isEmpty && spec.modelCanInherit) {
+    return const AiTextModel(id: '', label: 'Agent Default');
+  }
   return <AiTextModel>[...extraModels, ...spec.models].firstWhere(
     (model) => model.id == id,
     orElse: () => AiTextModel(id: id, label: labelFromModelId(id)),
@@ -469,6 +464,22 @@ List<AiTextModel> parseLineModels(String stdout) {
         .map((line) => line.trim())
         .where((line) => line.isNotEmpty)
         .map((line) => AiTextModel(id: line, label: labelFromModelId(line)))
+        .toList(growable: false),
+  );
+}
+
+List<AiTextModel> parseAgyModels(String stdout) {
+  return _uniqueModels(
+    stdout
+        .split(RegExp(r'\r?\n'))
+        .map((line) => line.trim())
+        .map((line) => line.replaceFirst(RegExp(r'^[*-]\s+'), ''))
+        .where(
+          (line) =>
+              line.isNotEmpty &&
+              !line.toLowerCase().startsWith('available model'),
+        )
+        .map((line) => AiTextModel(id: line, label: labelFromAgyModelId(line)))
         .toList(growable: false),
   );
 }

--- a/lib/src/features/ai_text_generation/application/ai_text_model_discovery_service.dart
+++ b/lib/src/features/ai_text_generation/application/ai_text_model_discovery_service.dart
@@ -21,7 +21,7 @@ class AiTextModelDiscoveryResult {
   final bool success;
   final AiTextGenerationAgent agent;
   final List<AiTextModel> models;
-  final String defaultModelId;
+  final String? defaultModelId;
   final String? error;
 }
 
@@ -149,8 +149,11 @@ class CliAiTextModelDiscoveryService implements AiTextModelDiscoveryService {
       );
     }
     final defaultModelId =
-        models.any((model) => model.id == spec.defaultModelId)
+        spec.defaultModelId != null &&
+            models.any((model) => model.id == spec.defaultModelId)
         ? spec.defaultModelId
+        : spec.modelCanInherit
+        ? null
         : models.first.id;
     return AiTextModelDiscoveryResult(
       success: true,

--- a/lib/src/features/settings/presentation/panes/ai_text_pane.dart
+++ b/lib/src/features/settings/presentation/panes/ai_text_pane.dart
@@ -118,14 +118,19 @@ class _AiTextSettingsPaneState extends ConsumerState<AiTextSettingsPane> {
                   onRefreshModels: canDiscoverModels
                       ? () => unawaited(_discoverModels(agent))
                       : null,
-                  onChanged: (value) => widget.onChanged(
-                    settings.copyWith(
-                      selectedModelByAgent: <AiTextGenerationAgent, String>{
-                        ...settings.selectedModelByAgent,
-                        agent: value,
-                      },
-                    ),
-                  ),
+                  onChanged: (value) {
+                    final selectedModels = <AiTextGenerationAgent, String>{
+                      ...settings.selectedModelByAgent,
+                    };
+                    if (value.trim().isEmpty) {
+                      selectedModels.remove(agent);
+                    } else {
+                      selectedModels[agent] = value;
+                    }
+                    widget.onChanged(
+                      settings.copyWith(selectedModelByAgent: selectedModels),
+                    );
+                  },
                 ),
               if (thinkingLevels.isNotEmpty)
                 AiTextThinkingRow(
@@ -378,6 +383,14 @@ class _AiTextSettingsPaneState extends ConsumerState<AiTextSettingsPane> {
       return;
     }
     final latest = widget.settings;
+    final discoveredDefaults = <AiTextGenerationAgent, String>{
+      ...latest.discoveredDefaultModelByAgent,
+    };
+    if (result.defaultModelId == null) {
+      discoveredDefaults.remove(agent);
+    } else {
+      discoveredDefaults[agent] = result.defaultModelId!;
+    }
     widget.onChanged(
       latest.copyWith(
         discoveredModelsByAgent:
@@ -387,10 +400,7 @@ class _AiTextSettingsPaneState extends ConsumerState<AiTextSettingsPane> {
                 for (final model in result.models) model.toDiscovered(),
               ],
             },
-        discoveredDefaultModelByAgent: <AiTextGenerationAgent, String>{
-          ...latest.discoveredDefaultModelByAgent,
-          agent: result.defaultModelId,
-        },
+        discoveredDefaultModelByAgent: discoveredDefaults,
       ),
     );
     setState(() {

--- a/rust/alera-cli/src/terminal_host/server/ai_text_requests.rs
+++ b/rust/alera-cli/src/terminal_host/server/ai_text_requests.rs
@@ -157,7 +157,7 @@ fn plan_command(
     if agent == "custom" {
         return plan_custom_command(&settings.custom_command, prompt);
     }
-    let model = prompt_settings
+    let selected_model = prompt_settings
         .and_then(|value| value.model.as_deref())
         .filter(|value| !value.trim().is_empty())
         .or_else(|| {
@@ -166,8 +166,8 @@ fn plan_command(
                 .get(agent)
                 .map(String::as_str)
                 .filter(|value| !value.trim().is_empty())
-        })
-        .unwrap_or_else(|| default_model(agent));
+        });
+    let model = selected_model.unwrap_or_else(|| default_model(agent));
     let thinking = settings
         .selected_thinking_by_model
         .get(model)
@@ -260,19 +260,18 @@ fn plan_command(
             None,
             "Cursor",
         ),
-        "agy" => (
-            "agy",
-            vec![
+        "agy" => {
+            let mut arguments = vec![
                 "--print".to_string(),
                 "--sandbox".to_string(),
                 "--print-timeout".to_string(),
                 format!("{timeout}s"),
-                "--model".to_string(),
-                model.to_string(),
-            ],
-            Some(prompt.to_string()),
-            "Antigravity",
-        ),
+            ];
+            if selected_model.is_some() {
+                arguments.extend(["--model".to_string(), model.to_string()]);
+            }
+            ("agy", arguments, Some(prompt.to_string()), "Antigravity")
+        }
         "opencode" => (
             "opencode",
             vec![
@@ -483,7 +482,8 @@ fn default_model(agent: &str) -> &'static str {
         "codex" => "gpt-5.5",
         "copilot" => "gpt-5.4",
         "cursor" => "auto",
-        "agy" => "Gemini 3.5 Flash (Medium)",
+        // An empty model lets AGY use its own configured/default model.
+        "agy" => "",
         "opencode" => "opencode/deepseek-v4-flash-free",
         "pi" => "github-copilot/gpt-5.4-mini",
         "amp" => "smart",

--- a/rust/alera-cli/src/terminal_host/server/ai_text_requests_tests.rs
+++ b/rust/alera-cli/src/terminal_host/server/ai_text_requests_tests.rs
@@ -30,3 +30,42 @@ fn prompt_settings_override_the_global_agent_and_model() {
         .windows(2)
         .any(|values| values == ["--mode", "rush"]));
 }
+
+#[test]
+fn agy_inherits_its_configured_model_without_forcing_a_stale_default() {
+    let settings = RuntimeAiTextGenerationSettings {
+        agent: "agy".to_string(),
+        ..RuntimeAiTextGenerationSettings::default()
+    };
+
+    let plan = plan_command(&settings, "workspaceIdentity", "hello").unwrap();
+
+    assert_eq!(plan.binary, "agy");
+    assert!(!plan.arguments.iter().any(|argument| argument == "--model"));
+}
+
+#[test]
+fn agy_passes_an_explicit_discovered_model_unchanged() {
+    let settings = RuntimeAiTextGenerationSettings {
+        agent: "agy".to_string(),
+        selected_model_by_agent: HashMap::from([(
+            "agy".to_string(),
+            "gemini-3.1-pro-low".to_string(),
+        )]),
+        ..RuntimeAiTextGenerationSettings::default()
+    };
+
+    let plan = plan_command(&settings, "workspaceIdentity", "hello").unwrap();
+
+    assert_eq!(
+        plan.arguments,
+        [
+            "--print",
+            "--sandbox",
+            "--print-timeout",
+            "120s",
+            "--model",
+            "gemini-3.1-pro-low",
+        ]
+    );
+}

--- a/test/unit/ai_text_generation_agy_test_cases.dart
+++ b/test/unit/ai_text_generation_agy_test_cases.dart
@@ -1,0 +1,151 @@
+part of 'ai_text_generation_service_test.dart';
+
+void _registerAgyAiTextGenerationTests() {
+  test('parses agy model output as exact ids with readable labels', () {
+    final models = parseAgyModels('''
+Available models:
+- gemini-3.6-flash-high
+gemini-3.1-pro-low
+claude-opus-4-6-thinking
+Gemini 3.5 Flash (Medium)
+''');
+
+    expect(models.map((model) => model.id), <String>[
+      'gemini-3.6-flash-high',
+      'gemini-3.1-pro-low',
+      'claude-opus-4-6-thinking',
+      'Gemini 3.5 Flash (Medium)',
+    ]);
+    expect(models.map((model) => model.label), <String>[
+      'Gemini 3.6 Flash (High)',
+      'Gemini 3.1 Pro (Low)',
+      'Claude Opus 4.6 (Thinking)',
+      'Gemini 3.5 Flash (Medium)',
+    ]);
+  });
+
+  test(
+    'generates commit message with agy using its configured model',
+    () async {
+      final git = FakeGitBackend()
+        ..gitRepositoryStateResult = const GitRepositoryState(
+          branch: 'feature/ai-text',
+        )
+        ..gitStatusResult = const GitStatusResult(
+          entries: <GitChangeEntry>[
+            GitChangeEntry(
+              path: 'lib/foo.dart',
+              area: GitChangeArea.staged,
+              status: GitChangeStatus.modified,
+              added: 2,
+              removed: 1,
+            ),
+          ],
+        )
+        ..gitDiffResult = const GitDiffResult(
+          files: <GitDiffFile>[
+            GitDiffFile(
+              path: 'lib/foo.dart',
+              area: GitChangeArea.staged,
+              status: GitChangeStatus.modified,
+              lines: <GitDiffLine>[GitDiffLine.addition('+new line')],
+            ),
+          ],
+        );
+      final runner = _FakeProcessRunner(stdout: 'feat: add ai text\n');
+      final service = CliAiTextGenerationService(
+        gitBackend: git,
+        processRunner: runner,
+      );
+
+      final result = await service.generate(
+        const AiTextGenerationRequest(
+          operation: AiTextGenerationOperation.commitMessage,
+          workspacePath: '/repo',
+          settings: AiTextGenerationSettings(agent: AiTextGenerationAgent.agy),
+        ),
+      );
+
+      expect(result.text, 'feat: add ai text');
+      expect(runner.executable, 'agy');
+      expect(runner.arguments, containsAll(<String>['--print', '--sandbox']));
+      expect(runner.arguments, isNot(contains('--model')));
+      expect(runner.stdinText, contains('feature/ai-text'));
+      expect(runner.stdinClosed, isTrue);
+    },
+  );
+
+  test('passes an explicit agy model id unchanged', () async {
+    final git = FakeGitBackend()
+      ..gitRepositoryStateResult = const GitRepositoryState(
+        branch: 'feature/ai-text',
+      )
+      ..gitStatusResult = const GitStatusResult(
+        entries: <GitChangeEntry>[
+          GitChangeEntry(
+            path: 'lib/foo.dart',
+            area: GitChangeArea.staged,
+            status: GitChangeStatus.modified,
+          ),
+        ],
+      );
+    final runner = _FakeProcessRunner(stdout: 'feat: add ai text\n');
+    final service = CliAiTextGenerationService(
+      gitBackend: git,
+      processRunner: runner,
+    );
+
+    await service.generate(
+      const AiTextGenerationRequest(
+        operation: AiTextGenerationOperation.commitMessage,
+        workspacePath: '/repo',
+        settings: AiTextGenerationSettings(
+          agent: AiTextGenerationAgent.agy,
+          selectedModelByAgent: <AiTextGenerationAgent, String>{
+            AiTextGenerationAgent.agy: 'gemini-3.1-pro-low',
+          },
+        ),
+      ),
+    );
+
+    expect(
+      runner.arguments,
+      containsAll(<String>['--model', 'gemini-3.1-pro-low']),
+    );
+  });
+
+  test('discovers dynamic models through the agent CLI', () async {
+    final runner = _FakeProcessRunner(
+      stdout: '''
+gemini-3.6-flash-high
+gemini-3.1-pro-low
+''',
+    );
+    final service = CliAiTextModelDiscoveryService(processRunner: runner);
+
+    final result = await service.discover(AiTextGenerationAgent.agy);
+
+    expect(result.success, isTrue);
+    expect(result.defaultModelId, isNull);
+    expect(result.models.map((model) => model.id), <String>[
+      'gemini-3.6-flash-high',
+      'gemini-3.1-pro-low',
+    ]);
+    expect(runner.executable, 'agy');
+    expect(runner.arguments, <String>['models']);
+  });
+
+  test('discovers dynamic models with resolved command environment', () async {
+    final runner = _FakeProcessRunner(stdout: 'gemini-3.6-flash-high\n');
+    final service = CliAiTextModelDiscoveryService(
+      processRunner: runner,
+      commandEnvironmentResolver: const _FakeCommandEnvironmentResolver(
+        value: <String, String>{'PATH': '/shell/bin:/usr/bin'},
+      ),
+    );
+
+    await service.discover(AiTextGenerationAgent.agy);
+
+    expect(runner.environment, containsPair('PATH', '/shell/bin:/usr/bin'));
+  });
+}

--- a/test/unit/ai_text_generation_service_test.dart
+++ b/test/unit/ai_text_generation_service_test.dart
@@ -15,12 +15,14 @@ import 'package:flutter_test/flutter_test.dart';
 import 'fake_git_backend.dart';
 
 part 'ai_text_generation_grok_test_cases.dart';
+part 'ai_text_generation_agy_test_cases.dart';
 part 'ai_text_generation_prompt_override_test_cases.dart';
 part 'ai_text_generation_test_harness.dart';
 
 void main() {
   group('AI text generation', () {
     _registerGrokAiTextGenerationTests();
+    _registerAgyAiTextGenerationTests();
     _registerAiTextPromptOverrideTests();
 
     test('builds commit prompts with staged context and instructions', () {
@@ -85,66 +87,6 @@ Body line.
 
       expect(message.split('\n').first.length, 72);
       expect(message, contains('Body line.'));
-    });
-
-    test('parses agy model output as verbatim model ids', () {
-      final models = parseLineModels('''
-Gemini 3.5 Flash (Medium)
-Claude Sonnet 4.6 (Thinking)
-''');
-
-      expect(models.map((model) => model.id), <String>[
-        'Gemini 3.5 Flash (Medium)',
-        'Claude Sonnet 4.6 (Thinking)',
-      ]);
-    });
-
-    test('generates commit message with agy using stdin print mode', () async {
-      final git = FakeGitBackend()
-        ..gitRepositoryStateResult = const GitRepositoryState(
-          branch: 'feature/ai-text',
-        )
-        ..gitStatusResult = const GitStatusResult(
-          entries: <GitChangeEntry>[
-            GitChangeEntry(
-              path: 'lib/foo.dart',
-              area: GitChangeArea.staged,
-              status: GitChangeStatus.modified,
-              added: 2,
-              removed: 1,
-            ),
-          ],
-        )
-        ..gitDiffResult = const GitDiffResult(
-          files: <GitDiffFile>[
-            GitDiffFile(
-              path: 'lib/foo.dart',
-              area: GitChangeArea.staged,
-              status: GitChangeStatus.modified,
-              lines: <GitDiffLine>[GitDiffLine.addition('+new line')],
-            ),
-          ],
-        );
-      final runner = _FakeProcessRunner(stdout: 'feat: add ai text\n');
-      final service = CliAiTextGenerationService(
-        gitBackend: git,
-        processRunner: runner,
-      );
-
-      final result = await service.generate(
-        const AiTextGenerationRequest(
-          operation: AiTextGenerationOperation.commitMessage,
-          workspacePath: '/repo',
-          settings: AiTextGenerationSettings(agent: AiTextGenerationAgent.agy),
-        ),
-      );
-
-      expect(result.text, 'feat: add ai text');
-      expect(runner.executable, 'agy');
-      expect(runner.arguments, containsAll(<String>['--print', '--sandbox']));
-      expect(runner.arguments, contains('Gemini 3.5 Flash (Medium)'));
-      expect(runner.stdinText, contains('feature/ai-text'));
-      expect(runner.stdinClosed, isTrue);
     });
 
     test('generates pull request details from base range context', () async {
@@ -346,46 +288,6 @@ Claude Sonnet 4.6 (Thinking)
       expect(runner.stdinText, contains('lib/large.dart'));
       expect(runner.stdinClosed, isTrue);
     });
-
-    test('discovers dynamic models through the agent CLI', () async {
-      final runner = _FakeProcessRunner(
-        stdout: '''
-Gemini 3.5 Flash (Medium)
-Claude Sonnet 4.6 (Thinking)
-''',
-      );
-      final service = CliAiTextModelDiscoveryService(processRunner: runner);
-
-      final result = await service.discover(AiTextGenerationAgent.agy);
-
-      expect(result.success, isTrue);
-      expect(result.defaultModelId, 'Gemini 3.5 Flash (Medium)');
-      expect(result.models.map((model) => model.id), <String>[
-        'Gemini 3.5 Flash (Medium)',
-        'Claude Sonnet 4.6 (Thinking)',
-      ]);
-      expect(runner.executable, 'agy');
-      expect(runner.arguments, <String>['models']);
-    });
-
-    test(
-      'discovers dynamic models with resolved command environment',
-      () async {
-        final runner = _FakeProcessRunner(
-          stdout: 'Gemini 3.5 Flash (Medium)\n',
-        );
-        final service = CliAiTextModelDiscoveryService(
-          processRunner: runner,
-          commandEnvironmentResolver: const _FakeCommandEnvironmentResolver(
-            value: <String, String>{'PATH': '/shell/bin:/usr/bin'},
-          ),
-        );
-
-        await service.discover(AiTextGenerationAgent.agy);
-
-        expect(runner.environment, containsPair('PATH', '/shell/bin:/usr/bin'));
-      },
-    );
 
     test('discovers pi models from stderr on successful exit', () async {
       final runner = _FakeProcessRunner(


### PR DESCRIPTION
## Summary

- Discover AGY model IDs from `agy models`, preserving exact IDs and readable labels.
- Represent AGY's provider default/inherit state instead of selecting the first discovered model.
- Keep the runtime host from forcing a stale `--model` and cover inherited and explicit model paths.

## Validation

- `flutter analyze`
- `flutter test test/unit/ai_text_generation_service_test.dart`
- `flutter test test/widget/settings_dialog_test.dart`
- `dart format --set-exit-if-changed lib test integration_test tool`
- `dart tool/quality/check_max_lines.dart`
- `make rust-test`

The local `gh act` emulation could not complete because its checkout/container setup failed before running the project jobs; native gates above passed and hosted checks remain authoritative.