### PR TITLE
fix: close setup terminal after successful workspace setup

### DIFF
--- a/docs/worktree-setup-config.md
+++ b/docs/worktree-setup-config.md
@@ -46,11 +46,14 @@ The desktop and mobile apps do not hold the New Workspace UI open while the setu
 
 The Setup terminal runs a script the host generates. That script exists because the terminal hosts whatever interactive shell the user configured, and chaining with `&&` is not portable: PowerShell 5.1 rejects it at parse time and nushell removed it. Writing one command per line up front does not work either, since the later lines would be delivered to the standard input of the process the earlier line started. So the terminal runs a single portable line (`/bin/sh "<script>"`, or `cmd /d /c "<script>"` on Windows) and the script does the sequencing.
 
+For the Setup tab, the runtime adds the shell-specific wrapper needed to replace or exit the interactive shell after that line finishes, so the PTY exit code reflects the script result.
+
 Inside the Setup terminal:
 
 - the copy rules run first, through `alera workspace setup --id <workspace> --copies-only`, so their symlink and path-escape validation stays in Rust;
 - every `setup` command then runs in order, each preceded by an echoed `> <command>` marker, and **a failing command does not stop the ones after it** - the output is right there to read;
-- the script deletes itself when it finishes. A run interrupted before that leaves the script behind, and the host sweeps any leftovers the next time it starts.
+- the script deletes itself when it finishes and preserves a non-zero result if any copy or setup action failed. A run interrupted before that leaves the script behind, and the host sweeps any leftovers the next time it starts;
+- the host closes the **Setup** terminal after a successful run. If the run fails, the terminal remains open with its output so the problem can be inspected and rerun.
 
 The command is delivered once. After it is on its way the host drops it from the tab record, so restarting the terminal, the app, or the host leaves a clean shell rather than reinstalling dependencies.
 

--- a/lib/src/features/workbench/application/workbench_controller_tab_opening.dart
+++ b/lib/src/features/workbench/application/workbench_controller_tab_opening.dart
@@ -13,6 +13,7 @@ mixin _WorkbenchControllerTabOpening
     String? initialCommand,
     bool spawnOnCreate = false,
     bool initialCommandOnce = false,
+    bool autoCloseOnSuccess = false,
   }) async {
     try {
       final previousTabs = state.tabsFor(workspace.id);
@@ -23,6 +24,7 @@ mixin _WorkbenchControllerTabOpening
         initialCommand: initialCommand,
         spawnOnCreate: spawnOnCreate,
         initialCommandOnce: initialCommandOnce,
+        autoCloseOnSuccess: autoCloseOnSuccess,
       );
       final tabs = <WorkspaceTabRecord>[...previousTabs, tab];
       _setTabsForWorkspace(workspace.id, tabs);
@@ -59,6 +61,7 @@ mixin _WorkbenchControllerTabOpening
         initialCommand: command,
         spawnOnCreate: true,
         initialCommandOnce: true,
+        autoCloseOnSuccess: true,
       );
     } catch (error) {
       state = state.copyWith(error: error.toString());

--- a/lib/src/features/workbench/application/workbench_providers.dart
+++ b/lib/src/features/workbench/application/workbench_providers.dart
@@ -342,6 +342,9 @@ void terminalRuntimeExitCoordinator(Ref ref) {
         runtime.closeTab(event.tabId);
         return;
       }
+      if (event.autoCloseOnSuccess && event.exitCode != 0) {
+        return;
+      }
       await ref
           .read(workbenchControllerProvider.notifier)
           .closeWorkspaceTab(workspace: workspace, tabId: event.tabId);

--- a/lib/src/features/workbench/application/workspace_tab_service.dart
+++ b/lib/src/features/workbench/application/workspace_tab_service.dart
@@ -56,6 +56,7 @@ class WorkspaceTabService {
     String? initialCommand,
     bool spawnOnCreate = false,
     bool initialCommandOnce = false,
+    bool autoCloseOnSuccess = false,
   }) async {
     final existing = await _repository.listWorkspaceTabs(workspaceId);
     final tabId = _uuid.v4();
@@ -79,6 +80,8 @@ class WorkspaceTabService {
             workspaceTabInitialCommandOncePayloadKey: true,
         },
         if (spawnOnCreate) workspaceTabSpawnOnCreatePayloadKey: true,
+        if (autoCloseOnSuccess)
+          workspaceTabAutoCloseOnSuccessPayloadKey: true,
       },
     );
     await _repository.upsertWorkspaceTab(tab);

--- a/lib/src/features/workbench/application/workspace_tab_service.dart
+++ b/lib/src/features/workbench/application/workspace_tab_service.dart
@@ -80,8 +80,7 @@ class WorkspaceTabService {
             workspaceTabInitialCommandOncePayloadKey: true,
         },
         if (spawnOnCreate) workspaceTabSpawnOnCreatePayloadKey: true,
-        if (autoCloseOnSuccess)
-          workspaceTabAutoCloseOnSuccessPayloadKey: true,
+        if (autoCloseOnSuccess) workspaceTabAutoCloseOnSuccessPayloadKey: true,
       },
     );
     await _repository.upsertWorkspaceTab(tab);

--- a/lib/src/features/workbench/domain/workspace_tab_record.dart
+++ b/lib/src/features/workbench/domain/workspace_tab_record.dart
@@ -38,6 +38,7 @@ const String workspaceTabTerminalSessionIdPayloadKey = 'terminalSessionId';
 const String workspaceTabInitialCommandPayloadKey = 'initialCommand';
 const String workspaceTabInitialCommandOncePayloadKey = 'initialCommandOnce';
 const String workspaceTabSpawnOnCreatePayloadKey = 'spawnOnCreate';
+const String workspaceTabAutoCloseOnSuccessPayloadKey = 'autoCloseOnSuccess';
 const String workspaceTabFilePathPayloadKey = 'filePath';
 const String workspaceTabFileRolePayloadKey = 'fileRole';
 const String workspaceTabFileRoleMermanPreview = 'mermanPreview';
@@ -201,6 +202,11 @@ class WorkspaceTabRecord with WorkspaceTabRecordMappable {
   /// appears, without waiting for the tab to become visible.
   bool get spawnOnCreate =>
       payload[workspaceTabSpawnOnCreatePayloadKey] == true;
+
+  /// Whether a terminal whose one-shot command exits successfully should be
+  /// removed automatically. Failed commands stay visible for inspection.
+  bool get autoCloseOnSuccess =>
+      payload[workspaceTabAutoCloseOnSuccessPayloadKey] == true;
 
   String? get filePath {
     final value = payload[workspaceTabFilePathPayloadKey];

--- a/lib/src/features/workbench/presentation/terminal_runtime.dart
+++ b/lib/src/features/workbench/presentation/terminal_runtime.dart
@@ -200,11 +200,13 @@ final class TerminalRuntimeExitEvent {
     required this.workspaceId,
     required this.tabId,
     required this.exitCode,
+    this.autoCloseOnSuccess = false,
   });
 
   final String workspaceId;
   final String tabId;
   final int exitCode;
+  final bool autoCloseOnSuccess;
 }
 
 abstract interface class TerminalPtySessionFactory {

--- a/lib/src/features/workbench/presentation/terminal_runtime_session_handle.dart
+++ b/lib/src/features/workbench/presentation/terminal_runtime_session_handle.dart
@@ -101,7 +101,6 @@ class _XtermTerminalSessionHandle extends TerminalSessionHandle {
   String get terminalSessionId => _tab.terminalSessionId;
 
   @override
-  @override
   ValueListenable<String> get titleListenable => _titleNotifier;
 
   @override

--- a/lib/src/features/workbench/presentation/terminal_runtime_session_handle.dart
+++ b/lib/src/features/workbench/presentation/terminal_runtime_session_handle.dart
@@ -515,6 +515,7 @@ class _XtermTerminalSessionHandle extends TerminalSessionHandle {
           workspaceId: workspaceId,
           tabId: tabId,
           exitCode: exitCode,
+          autoCloseOnSuccess: _tab.autoCloseOnSuccess,
         ),
       );
     }

--- a/mobile/lib/src/features/runtime/domain/runtime_client_surfaces.dart
+++ b/mobile/lib/src/features/runtime/domain/runtime_client_surfaces.dart
@@ -79,6 +79,7 @@ abstract interface class MobileTerminalClient {
     String? title,
     int cols,
     int rows,
+    bool autoCloseOnSuccess = false,
   });
   Future<MobileTerminalSession> attachTerminal(
     String tabId, {

--- a/mobile/lib/src/features/runtime/infra/mobile_runtime_terminal_requests.dart
+++ b/mobile/lib/src/features/runtime/infra/mobile_runtime_terminal_requests.dart
@@ -36,12 +36,14 @@ mixin MobileRuntimeTerminalRequests {
     String? title,
     int cols = defaultTerminalCols,
     int rows = defaultTerminalRows,
+    bool autoCloseOnSuccess = false,
   }) async {
     final payload = await requestMap('terminal.create', <String, Object?>{
       'workspaceId': workspaceId,
       'title': title ?? 'Mobile Terminal',
       'cols': cols,
       'rows': rows,
+      if (autoCloseOnSuccess) 'autoCloseOnSuccess': true,
     });
     return MobileTerminalSession.fromJson(payload);
   }

--- a/mobile/lib/src/features/workbench/application/deferred_workspace_setup_launcher.dart
+++ b/mobile/lib/src/features/workbench/application/deferred_workspace_setup_launcher.dart
@@ -21,11 +21,13 @@ Future<WorkspaceCreationResult> launchDeferredWorkspaceSetup(
     session = await client.createTerminal(
       creation.workspace.id,
       title: 'Setup',
+      autoCloseOnSuccess: true,
     );
     final supportsDeferredInput = client.supportsDeferredTerminalInput;
+    final startupCommand = _autoCloseSetupCommand(command);
     await client.writeTerminal(
       session.attachment.sessionId,
-      utf8.encode(supportsDeferredInput ? command : '$command\r'),
+      utf8.encode(supportsDeferredInput ? startupCommand : '$startupCommand\r'),
       deferredEnter: supportsDeferredInput,
     );
     return creation;
@@ -50,4 +52,14 @@ Future<WorkspaceCreationResult> launchDeferredWorkspaceSetup(
       }
     }
   }
+}
+
+String _autoCloseSetupCommand(String command) {
+  if (command.startsWith('/bin/sh ')) {
+    return 'exec $command';
+  }
+  if (command.startsWith('cmd ')) {
+    return '$command & exit /b';
+  }
+  return command;
 }

--- a/mobile/test/deferred_workspace_setup_launcher_test.dart
+++ b/mobile/test/deferred_workspace_setup_launcher_test.dart
@@ -27,10 +27,14 @@ void main() {
     expect(result.setupLaunchError, isNull);
     expect(client.calls, <String>[
       'create workspace-1 Setup',
-      'write session-created-1 27 paste=false enter=true',
+      'write session-created-1 32 paste=false enter=true',
       'detach session-created-1',
     ]);
-    expect(utf8.decode(client.writes.single), '/bin/sh "/runtime/setup.sh"');
+    expect(
+      utf8.decode(client.writes.single),
+      'exec /bin/sh "/runtime/setup.sh"',
+    );
+    expect(client.tabs.single.payload['autoCloseOnSuccess'], isTrue);
   });
 
   test('Falls back to an inline carriage return for an older host', () async {
@@ -51,7 +55,7 @@ void main() {
 
     expect(
       utf8.decode(client.writes.single),
-      'cmd /d /c "C:\\runtime\\setup.cmd"\r',
+      'cmd /d /c "C:\\runtime\\setup.cmd" & exit /b\r',
     );
     expect(client.calls, contains('detach session-created-1'));
   });

--- a/mobile/test/support/fake_terminal_client.dart
+++ b/mobile/test/support/fake_terminal_client.dart
@@ -17,6 +17,7 @@ WorkspaceTabSummary fakeTab({
   String workspaceId = 'workspace-1',
   String? runtimeTitle,
   bool manualTitle = false,
+  bool autoCloseOnSuccess = false,
 }) {
   return WorkspaceTabSummary(
     id: id,
@@ -26,6 +27,7 @@ WorkspaceTabSummary fakeTab({
     payload: <String, Object?>{
       'terminalSessionId': 'session-$id',
       if (manualTitle) 'manualTitle': true,
+      if (autoCloseOnSuccess) 'autoCloseOnSuccess': true,
     },
     runtimeTitle: runtimeTitle,
   );
@@ -175,6 +177,7 @@ class FakeTerminalClient
     String? title,
     int cols = defaultTerminalCols,
     int rows = defaultTerminalRows,
+    bool autoCloseOnSuccess = false,
   }) async {
     calls.add('create $workspaceId $title');
     _createdTabs += 1;
@@ -182,6 +185,7 @@ class FakeTerminalClient
       id: 'created-$_createdTabs',
       title: title ?? 'Terminal',
       workspaceId: workspaceId,
+      autoCloseOnSuccess: autoCloseOnSuccess,
     );
     tabs = <WorkspaceTabSummary>[...tabs, tab];
     return MobileTerminalSession(

--- a/rust/alera-cli/src/terminal_host/server.rs
+++ b/rust/alera-cli/src/terminal_host/server.rs
@@ -117,6 +117,7 @@ mod terminal_input_requests;
 mod terminal_launch_defaults;
 mod terminal_session_requests;
 mod terminal_spawn;
+mod terminal_startup_commands;
 mod workspace_pinning;
 mod workspace_sidebar_requests;
 

--- a/rust/alera-cli/src/terminal_host/server/mobile_terminal_requests.rs
+++ b/rust/alera-cli/src/terminal_host/server/mobile_terminal_requests.rs
@@ -101,6 +101,15 @@ impl ServerActor {
         let title =
             optional_string_key(payload, "title").unwrap_or_else(|| "Mobile Terminal".into());
         let now = Utc::now();
+        let auto_close_on_success =
+            payload.get("autoCloseOnSuccess").and_then(Value::as_bool) == Some(true);
+        let mut tab_payload = json!({
+            "terminalSessionId": session_id,
+            "source": "mobile",
+        });
+        if auto_close_on_success {
+            tab_payload["autoCloseOnSuccess"] = Value::Bool(true);
+        }
         let tab = WorkspaceTabRecord {
             id: tab_id.clone(),
             workspace_id: workspace.id.clone(),
@@ -108,10 +117,7 @@ impl ServerActor {
             title,
             created_at: now,
             updated_at: now,
-            payload: json!({
-                "terminalSessionId": session_id,
-                "source": "mobile",
-            }),
+            payload: tab_payload,
         };
         let tab = self
             .runtime_store

--- a/rust/alera-cli/src/terminal_host/server/pty_events.rs
+++ b/rust/alera-cli/src/terminal_host/server/pty_events.rs
@@ -1,3 +1,4 @@
+use super::terminal_spawn::auto_closes_on_success;
 use super::*;
 use crate::terminal_host::session::PtyEvent;
 
@@ -218,11 +219,14 @@ impl ServerActor {
         self.queue_terminal_exit_push(&session_id, Some(exit_code))
             .await;
         let reason = format!("terminal exited with code {exit_code}");
+        let keep_failed_setup =
+            exit_code != 0 && self.should_keep_failed_setup_terminal(&session_id).await;
         let keep_failed_spawn = self.should_keep_failed_owned_spawn(&session_id).await;
         self.cleanup_orchestration_for_closed_session(&session_id, &reason)
             .await;
         let keep_failed_spawn =
             keep_failed_spawn && self.make_failed_owned_spawn_inert(&session_id).await;
+        let keep_terminal = keep_failed_setup || keep_failed_spawn;
         self.flush_all_output(&session_id);
         let broadcast = self.sessions.get_mut(&session_id).and_then(|session| {
             let payload = session.handle_exit(exit_code)?;
@@ -231,7 +235,7 @@ impl ServerActor {
         });
         if let Some((frame, clients)) = broadcast {
             self.broadcast(&clients, frame);
-            if keep_failed_spawn {
+            if keep_terminal {
                 self.immediate_checkpoint(&session_id).await;
             } else {
                 match self.remove_terminal_session_tab(&session_id).await {
@@ -248,6 +252,24 @@ impl ServerActor {
             }
         }
         self.schedule_shutdown_if_idle();
+    }
+
+    async fn should_keep_failed_setup_terminal(&self, session_id: &str) -> bool {
+        let Some(tab_id) = self
+            .sessions
+            .get(session_id)
+            .map(|session| session.tab_id.as_str())
+        else {
+            return false;
+        };
+        match self.runtime_store.find_workspace_tab(tab_id).await {
+            Ok(Some(tab)) => auto_closes_on_success(&tab),
+            Ok(None) => false,
+            Err(error) => {
+                tracing::error!("failed to inspect setup terminal {tab_id} after exit: {error}");
+                true
+            }
+        }
     }
 
     pub(super) async fn remove_terminal_session_tab(

--- a/rust/alera-cli/src/terminal_host/server/pty_events.rs
+++ b/rust/alera-cli/src/terminal_host/server/pty_events.rs
@@ -1,4 +1,4 @@
-use super::terminal_spawn::auto_closes_on_success;
+use super::terminal_startup_commands::auto_closes_on_success;
 use super::*;
 use crate::terminal_host::session::PtyEvent;
 

--- a/rust/alera-cli/src/terminal_host/server/terminal_spawn.rs
+++ b/rust/alera-cli/src/terminal_host/server/terminal_spawn.rs
@@ -8,6 +8,11 @@ use crate::terminal_host::session::{PtyWriteCompletion, Session};
 
 use super::pty_event_forwarder::forward_pty_event;
 use super::terminal_launch_defaults::default_terminal_launch;
+use super::terminal_startup_commands::{
+    auto_close_setup_command, auto_closes_on_success, delivers_initial_command_once,
+    delivers_initial_prompt_once, initial_command, initial_managed_agent_launch, initial_prompt,
+    pending_agent_type, terminal_session_id,
+};
 use super::{ServerActor, ServerCommand};
 
 const DEFAULT_TERMINAL_COLS: u16 = 80;
@@ -404,114 +409,4 @@ impl ServerActor {
 fn spawns_on_create(tab: &WorkspaceTabRecord) -> bool {
     tab.kind == "terminal"
         && tab.payload.get("spawnOnCreate").and_then(Value::as_bool) == Some(true)
-}
-
-fn terminal_session_id(tab: &WorkspaceTabRecord) -> String {
-    tab.payload
-        .get("terminalSessionId")
-        .and_then(Value::as_str)
-        .filter(|value| !value.is_empty())
-        .unwrap_or(&tab.id)
-        .to_string()
-}
-
-fn initial_command(tab: &WorkspaceTabRecord) -> Option<String> {
-    tab.payload
-        .get("initialCommand")
-        .and_then(Value::as_str)
-        .filter(|value| !value.is_empty())
-        .map(str::to_string)
-}
-
-pub(super) fn auto_closes_on_success(tab: &WorkspaceTabRecord) -> bool {
-    tab.payload
-        .get("autoCloseOnSuccess")
-        .and_then(Value::as_bool)
-        == Some(true)
-}
-
-pub(super) fn auto_close_setup_command(command: &str, interactive_shell: &str) -> String {
-    let executable = interactive_shell
-        .rsplit(['/', '\\'])
-        .next()
-        .unwrap_or(interactive_shell)
-        .to_ascii_lowercase();
-    match executable.as_str() {
-        "cmd" | "cmd.exe" => format!("{command} & exit /b"),
-        "powershell" | "powershell.exe" | "pwsh" | "pwsh.exe" => {
-            format!("& {{ {command} }}; exit $LASTEXITCODE")
-        }
-        _ => format!("exec {command}"),
-    }
-}
-
-fn initial_managed_agent_launch(
-    tab: &WorkspaceTabRecord,
-) -> HostResult<Option<crate::terminal_host::orchestration::managed_agent_launch::ManagedAgentLaunch>>
-{
-    tab.payload
-        .get("initialManagedAgentLaunch")
-        .filter(|value| !value.is_null())
-        .cloned()
-        .map(serde_json::from_value)
-        .transpose()
-        .map_err(|error| HostError::format(format!("invalid managed agent launch: {error}")))
-}
-
-fn delivers_initial_command_once(tab: &WorkspaceTabRecord) -> bool {
-    tab.payload
-        .get("initialCommandOnce")
-        .and_then(Value::as_bool)
-        == Some(true)
-}
-
-fn delivers_initial_prompt_once(tab: &WorkspaceTabRecord) -> bool {
-    tab.payload
-        .get("initialPromptOnce")
-        .and_then(Value::as_bool)
-        == Some(true)
-}
-
-fn initial_prompt(tab: &WorkspaceTabRecord) -> Option<String> {
-    tab.payload
-        .get("initialPrompt")
-        .and_then(Value::as_str)
-        .filter(|value| !value.is_empty())
-        .map(str::to_string)
-}
-
-fn pending_agent_type(tab: &WorkspaceTabRecord) -> Option<&str> {
-    tab.payload
-        .pointer("/pendingAgentPrompt/agent")
-        .and_then(Value::as_str)
-        .filter(|value| !value.is_empty())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn setup_command_replaces_posix_shell() {
-        assert_eq!(
-            auto_close_setup_command("/bin/sh \"/tmp/setup.sh\"", "/bin/zsh"),
-            "exec /bin/sh \"/tmp/setup.sh\""
-        );
-    }
-
-    #[test]
-    fn setup_command_preserves_cmd_exit_status() {
-        assert_eq!(
-            auto_close_setup_command("cmd /d /c \"C:\\\\setup.cmd\"", "cmd.exe"),
-            "cmd /d /c \"C:\\\\setup.cmd\" & exit /b"
-        );
-    }
-
-    #[test]
-    fn setup_command_preserves_powershell_exit_status() {
-        assert_eq!(
-            auto_close_setup_command("cmd /d /c \"C:\\\\setup.cmd\"", "pwsh.exe"),
-            "& { cmd /d /c \"C:\\\\setup.cmd\" }; exit $LASTEXITCODE"
-        );
-    }
 }

--- a/rust/alera-cli/src/terminal_host/server/terminal_spawn.rs
+++ b/rust/alera-cli/src/terminal_host/server/terminal_spawn.rs
@@ -132,7 +132,7 @@ impl ServerActor {
             )
         } else {
             initial_command(tab).map(|command| {
-                initial_prompt(tab)
+                let command = initial_prompt(tab)
                     .map(|prompt| {
                         crate::terminal_host::orchestration::agent_startup_command::codex_command_with_initial_prompt(
                             &command,
@@ -140,7 +140,12 @@ impl ServerActor {
                             &default_launch.interactive_shell,
                         )
                     })
-                    .unwrap_or(command)
+                    .unwrap_or(command);
+                if auto_closes_on_success(tab) {
+                    auto_close_setup_command(&command, &default_launch.interactive_shell)
+                } else {
+                    command
+                }
             })
         };
         if let Some(command) = command {
@@ -418,6 +423,28 @@ fn initial_command(tab: &WorkspaceTabRecord) -> Option<String> {
         .map(str::to_string)
 }
 
+pub(super) fn auto_closes_on_success(tab: &WorkspaceTabRecord) -> bool {
+    tab.payload
+        .get("autoCloseOnSuccess")
+        .and_then(Value::as_bool)
+        == Some(true)
+}
+
+pub(super) fn auto_close_setup_command(command: &str, interactive_shell: &str) -> String {
+    let executable = interactive_shell
+        .rsplit(['/', '\\'])
+        .next()
+        .unwrap_or(interactive_shell)
+        .to_ascii_lowercase();
+    match executable.as_str() {
+        "cmd" | "cmd.exe" => format!("{command} & exit /b"),
+        "powershell" | "powershell.exe" | "pwsh" | "pwsh.exe" => {
+            format!("& {{ {command} }}; exit $LASTEXITCODE")
+        }
+        _ => format!("exec {command}"),
+    }
+}
+
 fn initial_managed_agent_launch(
     tab: &WorkspaceTabRecord,
 ) -> HostResult<Option<crate::terminal_host::orchestration::managed_agent_launch::ManagedAgentLaunch>>
@@ -458,4 +485,33 @@ fn pending_agent_type(tab: &WorkspaceTabRecord) -> Option<&str> {
         .pointer("/pendingAgentPrompt/agent")
         .and_then(Value::as_str)
         .filter(|value| !value.is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn setup_command_replaces_posix_shell() {
+        assert_eq!(
+            auto_close_setup_command("/bin/sh \"/tmp/setup.sh\"", "/bin/zsh"),
+            "exec /bin/sh \"/tmp/setup.sh\""
+        );
+    }
+
+    #[test]
+    fn setup_command_preserves_cmd_exit_status() {
+        assert_eq!(
+            auto_close_setup_command("cmd /d /c \"C:\\\\setup.cmd\"", "cmd.exe"),
+            "cmd /d /c \"C:\\\\setup.cmd\" & exit /b"
+        );
+    }
+
+    #[test]
+    fn setup_command_preserves_powershell_exit_status() {
+        assert_eq!(
+            auto_close_setup_command("cmd /d /c \"C:\\\\setup.cmd\"", "pwsh.exe"),
+            "& { cmd /d /c \"C:\\\\setup.cmd\" }; exit $LASTEXITCODE"
+        );
+    }
 }

--- a/rust/alera-cli/src/terminal_host/server/terminal_startup_commands.rs
+++ b/rust/alera-cli/src/terminal_host/server/terminal_startup_commands.rs
@@ -1,0 +1,114 @@
+use alera_core::runtime::WorkspaceTabRecord;
+use serde_json::Value;
+
+use crate::terminal_host::host_error::{HostError, HostResult};
+
+pub(super) fn terminal_session_id(tab: &WorkspaceTabRecord) -> String {
+    tab.payload
+        .get("terminalSessionId")
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(&tab.id)
+        .to_string()
+}
+
+pub(super) fn initial_command(tab: &WorkspaceTabRecord) -> Option<String> {
+    tab.payload
+        .get("initialCommand")
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+}
+
+pub(super) fn auto_closes_on_success(tab: &WorkspaceTabRecord) -> bool {
+    tab.payload
+        .get("autoCloseOnSuccess")
+        .and_then(Value::as_bool)
+        == Some(true)
+}
+
+pub(super) fn auto_close_setup_command(command: &str, interactive_shell: &str) -> String {
+    let executable = interactive_shell
+        .rsplit(['/', '\\'])
+        .next()
+        .unwrap_or(interactive_shell)
+        .to_ascii_lowercase();
+    match executable.as_str() {
+        "cmd" | "cmd.exe" => format!("{command} & exit /b"),
+        "powershell" | "powershell.exe" | "pwsh" | "pwsh.exe" => {
+            format!("& {{ {command} }}; exit $LASTEXITCODE")
+        }
+        _ => format!("exec {command}"),
+    }
+}
+
+pub(super) fn initial_managed_agent_launch(
+    tab: &WorkspaceTabRecord,
+) -> HostResult<Option<crate::terminal_host::orchestration::managed_agent_launch::ManagedAgentLaunch>>
+{
+    tab.payload
+        .get("initialManagedAgentLaunch")
+        .filter(|value| !value.is_null())
+        .cloned()
+        .map(serde_json::from_value)
+        .transpose()
+        .map_err(|error| HostError::format(format!("invalid managed agent launch: {error}")))
+}
+
+pub(super) fn delivers_initial_command_once(tab: &WorkspaceTabRecord) -> bool {
+    tab.payload
+        .get("initialCommandOnce")
+        .and_then(Value::as_bool)
+        == Some(true)
+}
+
+pub(super) fn delivers_initial_prompt_once(tab: &WorkspaceTabRecord) -> bool {
+    tab.payload
+        .get("initialPromptOnce")
+        .and_then(Value::as_bool)
+        == Some(true)
+}
+
+pub(super) fn initial_prompt(tab: &WorkspaceTabRecord) -> Option<String> {
+    tab.payload
+        .get("initialPrompt")
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+}
+
+pub(super) fn pending_agent_type(tab: &WorkspaceTabRecord) -> Option<&str> {
+    tab.payload
+        .pointer("/pendingAgentPrompt/agent")
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn setup_command_replaces_posix_shell() {
+        assert_eq!(
+            auto_close_setup_command("/bin/sh \"/tmp/setup.sh\"", "/bin/zsh"),
+            "exec /bin/sh \"/tmp/setup.sh\""
+        );
+    }
+
+    #[test]
+    fn setup_command_preserves_cmd_exit_status() {
+        assert_eq!(
+            auto_close_setup_command("cmd /d /c \"C:\\\\setup.cmd\"", "cmd.exe"),
+            "cmd /d /c \"C:\\\\setup.cmd\" & exit /b"
+        );
+    }
+
+    #[test]
+    fn setup_command_preserves_powershell_exit_status() {
+        assert_eq!(
+            auto_close_setup_command("cmd /d /c \"C:\\\\setup.cmd\"", "pwsh.exe"),
+            "& { cmd /d /c \"C:\\\\setup.cmd\" }; exit $LASTEXITCODE"
+        );
+    }
+}

--- a/rust/alera-cli/src/worktree_setup_script.rs
+++ b/rust/alera-cli/src/worktree_setup_script.rs
@@ -111,12 +111,16 @@ fn posix_script(
     copies: bool,
 ) -> String {
     let mut script = String::from("#!/bin/sh\n");
+    script.push_str("alera_setup_status=0\n");
     if copies {
         script.push_str(&format!(
             "{} workspace setup --id {} --copies-only\n",
             posix_quote(&alera_executable.display().to_string()),
             posix_quote(workspace_id),
         ));
+        script.push_str("if [ \"$?\" -ne 0 ]; then\n");
+        script.push_str("  alera_setup_status=1\n");
+        script.push_str("fi\n");
     }
     script.push_str(&format!("cd {} || exit 1\n", posix_quote(workspace_path)));
     for command in commands {
@@ -124,9 +128,13 @@ fn posix_script(
         script.push_str(&format!("echo {}\n", posix_quote(&format!("> {command}"))));
         script.push_str(command);
         script.push('\n');
+        script.push_str("if [ \"$?\" -ne 0 ]; then\n");
+        script.push_str("  alera_setup_status=1\n");
+        script.push_str("fi\n");
     }
     // Last line on purpose: unlink is safe while the fd stays open.
     script.push_str("rm -f -- \"$0\"\n");
+    script.push_str("exit \"$alera_setup_status\"\n");
     script
 }
 
@@ -138,22 +146,27 @@ fn windows_script(
     copies: bool,
 ) -> String {
     let mut script = String::from("@echo off\r\n");
+    script.push_str("set \"ALERA_SETUP_STATUS=0\"\r\n");
     if copies {
         script.push_str(&format!(
             "\"{}\" workspace setup --id \"{}\" --copies-only\r\n",
             alera_executable.display(),
             workspace_id,
         ));
+        script.push_str("if errorlevel 1 set \"ALERA_SETUP_STATUS=1\"\r\n");
     }
     script.push_str(&format!("cd /d \"{workspace_path}\"\r\n"));
+    script.push_str("if errorlevel 1 exit /b 1\r\n");
     for command in commands {
         script.push_str(&format!("echo {}\r\n", cmd_echo_marker(command)));
         script.push_str(command);
         script.push_str("\r\n");
+        script.push_str("if errorlevel 1 set \"ALERA_SETUP_STATUS=1\"\r\n");
     }
     // Last line on purpose: cmd re-reads the file by offset, so deleting it
     // earlier would truncate the run.
     script.push_str("del /q \"%~f0\"\r\n");
+    script.push_str("exit /b %ALERA_SETUP_STATUS%\r\n");
     script
 }
 
@@ -243,9 +256,14 @@ mod tests {
             script.contains("echo '> pnpm build'\npnpm build\n"),
             "{script}"
         );
+        assert!(script.contains("alera_setup_status=0\n"), "{script}");
+        assert!(script.contains("if [ \"$?\" -ne 0 ]; then\n"), "{script}");
         assert!(!script.contains("&&"), "{script}");
         assert!(!script.contains("set -e"), "{script}");
-        assert!(script.ends_with("rm -f -- \"$0\"\n"), "{script}");
+        assert!(
+            script.ends_with("rm -f -- \"$0\"\nexit \"$alera_setup_status\"\n"),
+            "{script}"
+        );
     }
 
     #[test]
@@ -293,8 +311,20 @@ mod tests {
             script.contains("echo ^> pnpm install\r\npnpm install\r\n"),
             "{script}"
         );
+        assert!(
+            script.contains("set \"ALERA_SETUP_STATUS=0\"\r\n"),
+            "{script}"
+        );
+        assert!(
+            script.contains("if errorlevel 1 set \"ALERA_SETUP_STATUS=1\"\r\n"),
+            "{script}"
+        );
+        assert!(script.contains("if errorlevel 1 exit /b 1\r\n"), "{script}");
         assert!(!script.contains("&&"), "{script}");
-        assert!(script.ends_with("del /q \"%~f0\"\r\n"), "{script}");
+        assert!(
+            script.ends_with("del /q \"%~f0\"\r\nexit /b %ALERA_SETUP_STATUS%\r\n"),
+            "{script}"
+        );
     }
 
     #[test]

--- a/rust/alera-cli/tests/terminal_host_headless_runtime/startup_command_cases.rs
+++ b/rust/alera-cli/tests/terminal_host_headless_runtime/startup_command_cases.rs
@@ -60,3 +60,89 @@ fn one_shot_initial_command_is_dropped_after_the_first_delivery() {
     assert_eq!(found["payload"]["payload"].get("initialCommand"), None);
     assert_eq!(std::fs::read_to_string(&marker).unwrap(), "X");
 }
+
+#[test]
+#[cfg(unix)]
+fn auto_close_setup_tab_removes_success_and_keeps_failure() {
+    let dir = tempfile::tempdir().unwrap();
+    let token = "setup-auto-close-token";
+    let (_guard, port) = spawn_host(dir.path(), token);
+    let (mut writer, mut reader) = connect(port, token);
+
+    send(
+        &mut writer,
+        json!({
+            "id": 1,
+            "type": "workspace.upsert",
+            "payload": workspace_payload("setup-workspace", dir.path())
+        }),
+    );
+    assert_eq!(read_response(&mut reader, 1)["ok"], json!(true));
+
+    send(
+        &mut writer,
+        json!({"id": 2, "type": "tab.upsert", "payload": {
+            "id": "successful-setup-tab", "workspaceId": "setup-workspace",
+            "kind": "terminal", "title": "Setup",
+            "createdAt": "2026-07-19T00:00:00Z",
+            "updatedAt": "2026-07-19T00:00:00Z", "payload": {
+                "terminalSessionId": "successful-setup-session",
+                "initialCommand": "/bin/sh -c 'exit 0'",
+                "initialCommandOnce": true,
+                "spawnOnCreate": true,
+                "autoCloseOnSuccess": true
+            }
+        }}),
+    );
+    assert_eq!(read_response(&mut reader, 2)["ok"], json!(true));
+
+    wait_for_tab_state(&mut writer, &mut reader, 3, "successful-setup-tab", false);
+
+    send(
+        &mut writer,
+        json!({"id": 4, "type": "tab.upsert", "payload": {
+            "id": "failed-setup-tab", "workspaceId": "setup-workspace",
+            "kind": "terminal", "title": "Setup",
+            "createdAt": "2026-07-19T00:00:00Z",
+            "updatedAt": "2026-07-19T00:00:00Z", "payload": {
+                "terminalSessionId": "failed-setup-session",
+                "initialCommand": "/bin/sh -c 'exit 7'",
+                "initialCommandOnce": true,
+                "spawnOnCreate": true,
+                "autoCloseOnSuccess": true
+            }
+        }}),
+    );
+    assert_eq!(read_response(&mut reader, 4)["ok"], json!(true));
+
+    let found = wait_for_tab_state(&mut writer, &mut reader, 5, "failed-setup-tab", true);
+    assert_eq!(found["payload"]["payload"].get("initialCommand"), None);
+}
+
+#[cfg(unix)]
+fn wait_for_tab_state(
+    writer: &mut std::net::TcpStream,
+    reader: &mut std::io::BufReader<std::net::TcpStream>,
+    mut request_id: i64,
+    tab_id: &str,
+    expected_present: bool,
+) -> serde_json::Value {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        send(
+            writer,
+            json!({"id": request_id, "type": "tab.find", "payload": {"id": tab_id}}),
+        );
+        let response = read_response(reader, request_id);
+        let present = !response["payload"].is_null();
+        if present == expected_present {
+            return response;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "unexpected tab state for {tab_id}"
+        );
+        request_id += 1;
+        std::thread::sleep(Duration::from_millis(25));
+    }
+}

--- a/test/unit/app_providers_test.dart
+++ b/test/unit/app_providers_test.dart
@@ -973,6 +973,63 @@ void main() {
       },
     );
 
+    test('exit coordinator keeps a failed auto-close setup tab visible', () async {
+      final runtime = _FakeTerminalRuntime();
+      final now = DateTime.utc(2026, 8, 1);
+      final workspace = Workspace(
+        id: 'workspace-1',
+        projectId: 'project-1',
+        name: 'Workspace',
+        path: '/tmp/workspace',
+        createdAt: now,
+        updatedAt: now,
+        kind: WorkspaceKind.linked,
+        status: WorkspaceStatus.active,
+      );
+      final setupTab = WorkspaceTabRecord(
+        id: 'setup-tab',
+        workspaceId: workspace.id,
+        title: 'Setup',
+        createdAt: now,
+        updatedAt: now,
+        payload: const <String, Object?>{
+          workspaceTabAutoCloseOnSuccessPayloadKey: true,
+        },
+      );
+      final container = ProviderContainer(
+        overrides: [
+          terminalRuntimeProvider.overrideWith((ref) => runtime),
+          workbenchControllerProvider.overrideWithValue(
+            WorkbenchState(
+              workspacesByProject: <String, List<Workspace>>{
+                workspace.projectId: <Workspace>[workspace],
+              },
+              tabsByWorkspace: <String, List<WorkspaceTabRecord>>{
+                workspace.id: <WorkspaceTabRecord>[setupTab],
+              },
+            ),
+          ),
+        ],
+      );
+      addTearDown(() {
+        runtime.dispose();
+        container.dispose();
+      });
+
+      container.read(terminalRuntimeExitCoordinatorProvider);
+      runtime.emitExit(
+        const TerminalRuntimeExitEvent(
+          workspaceId: 'workspace-1',
+          tabId: 'setup-tab',
+          exitCode: 1,
+          autoCloseOnSuccess: true,
+        ),
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      expect(runtime.closedTabIds, isEmpty);
+    });
+
     test('exit coordinator leaves command terminal sessions alone', () async {
       final runtime = _FakeTerminalRuntime();
       final container = ProviderContainer(

--- a/test/unit/app_providers_test.dart
+++ b/test/unit/app_providers_test.dart
@@ -973,62 +973,65 @@ void main() {
       },
     );
 
-    test('exit coordinator keeps a failed auto-close setup tab visible', () async {
-      final runtime = _FakeTerminalRuntime();
-      final now = DateTime.utc(2026, 8, 1);
-      final workspace = Workspace(
-        id: 'workspace-1',
-        projectId: 'project-1',
-        name: 'Workspace',
-        path: '/tmp/workspace',
-        createdAt: now,
-        updatedAt: now,
-        kind: WorkspaceKind.linked,
-        status: WorkspaceStatus.active,
-      );
-      final setupTab = WorkspaceTabRecord(
-        id: 'setup-tab',
-        workspaceId: workspace.id,
-        title: 'Setup',
-        createdAt: now,
-        updatedAt: now,
-        payload: const <String, Object?>{
-          workspaceTabAutoCloseOnSuccessPayloadKey: true,
-        },
-      );
-      final container = ProviderContainer(
-        overrides: [
-          terminalRuntimeProvider.overrideWith((ref) => runtime),
-          workbenchControllerProvider.overrideWithValue(
-            WorkbenchState(
-              workspacesByProject: <String, List<Workspace>>{
-                workspace.projectId: <Workspace>[workspace],
-              },
-              tabsByWorkspace: <String, List<WorkspaceTabRecord>>{
-                workspace.id: <WorkspaceTabRecord>[setupTab],
-              },
+    test(
+      'exit coordinator keeps a failed auto-close setup tab visible',
+      () async {
+        final runtime = _FakeTerminalRuntime();
+        final now = DateTime.utc(2026, 8, 1);
+        final workspace = Workspace(
+          id: 'workspace-1',
+          projectId: 'project-1',
+          name: 'Workspace',
+          path: '/tmp/workspace',
+          createdAt: now,
+          updatedAt: now,
+          kind: WorkspaceKind.linked,
+          status: WorkspaceStatus.active,
+        );
+        final setupTab = WorkspaceTabRecord(
+          id: 'setup-tab',
+          workspaceId: workspace.id,
+          title: 'Setup',
+          createdAt: now,
+          updatedAt: now,
+          payload: const <String, Object?>{
+            workspaceTabAutoCloseOnSuccessPayloadKey: true,
+          },
+        );
+        final container = ProviderContainer(
+          overrides: [
+            terminalRuntimeProvider.overrideWith((ref) => runtime),
+            workbenchControllerProvider.overrideWithValue(
+              WorkbenchState(
+                workspacesByProject: <String, List<Workspace>>{
+                  workspace.projectId: <Workspace>[workspace],
+                },
+                tabsByWorkspace: <String, List<WorkspaceTabRecord>>{
+                  workspace.id: <WorkspaceTabRecord>[setupTab],
+                },
+              ),
             ),
+          ],
+        );
+        addTearDown(() {
+          runtime.dispose();
+          container.dispose();
+        });
+
+        container.read(terminalRuntimeExitCoordinatorProvider);
+        runtime.emitExit(
+          const TerminalRuntimeExitEvent(
+            workspaceId: 'workspace-1',
+            tabId: 'setup-tab',
+            exitCode: 1,
+            autoCloseOnSuccess: true,
           ),
-        ],
-      );
-      addTearDown(() {
-        runtime.dispose();
-        container.dispose();
-      });
+        );
+        await Future<void>.delayed(Duration.zero);
 
-      container.read(terminalRuntimeExitCoordinatorProvider);
-      runtime.emitExit(
-        const TerminalRuntimeExitEvent(
-          workspaceId: 'workspace-1',
-          tabId: 'setup-tab',
-          exitCode: 1,
-          autoCloseOnSuccess: true,
-        ),
-      );
-      await Future<void>.delayed(Duration.zero);
-
-      expect(runtime.closedTabIds, isEmpty);
-    });
+        expect(runtime.closedTabIds, isEmpty);
+      },
+    );
 
     test('exit coordinator leaves command terminal sessions alone', () async {
       final runtime = _FakeTerminalRuntime();

--- a/test/unit/workbench_controller_create_workspace_test_cases.dart
+++ b/test/unit/workbench_controller_create_workspace_test_cases.dart
@@ -117,6 +117,7 @@ void _registerWorkbenchControllerCreateWorkspaceTests() {
       expect(setup.initialCommand, _setupCommand);
       expect(setup.initialCommandOnce, isTrue);
       expect(setup.spawnOnCreate, isTrue);
+      expect(setup.autoCloseOnSuccess, isTrue);
       expect(_controller.state.activeWorkspaceTab?.title, 'Setup');
       expect(_controller.state.error, isNull);
     },
@@ -167,6 +168,7 @@ void _registerWorkbenchControllerCreateWorkspaceTests() {
       expect(tabs.where((tab) => tab.title.startsWith('Terminal ')), isEmpty);
       expect(tabs.last.initialCommand, _setupCommand);
       expect(tabs.last.initialCommandOnce, isTrue);
+      expect(tabs.last.autoCloseOnSuccess, isTrue);
       expect(_controller.state.activeWorkspaceTab?.id, 'agent-tab');
     },
   );

--- a/test/unit/workspace_tab_record_test.dart
+++ b/test/unit/workspace_tab_record_test.dart
@@ -68,7 +68,7 @@ void main() {
     expect(bound.terminalSessionId, 'session-2');
   });
 
-  test('spawnOnCreate reflects the terminal payload flag', () {
+  test('terminal lifecycle flags reflect their payload values', () {
     final now = DateTime.utc(2026, 5, 25);
     final regular = WorkspaceTabRecord(
       id: 'tab-1',
@@ -85,11 +85,14 @@ void main() {
       updatedAt: now,
       payload: const <String, Object?>{
         workspaceTabSpawnOnCreatePayloadKey: true,
+        workspaceTabAutoCloseOnSuccessPayloadKey: true,
       },
     );
 
     expect(regular.spawnOnCreate, isFalse);
+    expect(regular.autoCloseOnSuccess, isFalse);
     expect(eager.spawnOnCreate, isTrue);
+    expect(eager.autoCloseOnSuccess, isTrue);
   });
 
   test(

--- a/test/unit/workspace_tab_service_test.dart
+++ b/test/unit/workspace_tab_service_test.dart
@@ -73,6 +73,7 @@ void main() {
         initialCommand: '  /bin/sh "/run/alera/worktree-setup-ws.sh"  ',
         spawnOnCreate: true,
         initialCommandOnce: true,
+        autoCloseOnSuccess: true,
       );
 
       expect(tab.title, 'Setup');
@@ -81,6 +82,7 @@ void main() {
       expect(tab.initialCommand, '/bin/sh "/run/alera/worktree-setup-ws.sh"');
       expect(tab.initialCommandOnce, isTrue);
       expect(tab.spawnOnCreate, isTrue);
+      expect(tab.autoCloseOnSuccess, isTrue);
       expect(repository.tabs.single.title, 'Setup');
     });
 
@@ -100,6 +102,7 @@ void main() {
         expect(tab.initialCommand, isNull);
         expect(tab.initialCommandOnce, isFalse);
         expect(tab.spawnOnCreate, isFalse);
+        expect(tab.autoCloseOnSuccess, isFalse);
       },
     );
 

--- a/test/widget/alera_shell_page_test_harness.dart
+++ b/test/widget/alera_shell_page_test_harness.dart
@@ -155,6 +155,7 @@ class _ShellTestWorkbenchController extends WorkbenchController {
     String? initialCommand,
     bool spawnOnCreate = false,
     bool initialCommandOnce = false,
+    bool autoCloseOnSuccess = false,
   }) async {
     final tabs = state.tabsFor(workspace.id);
     final tab = _newTerminalTab(workspace.id, tabs.length + 1);

--- a/test/widget/keyboard_command_dispatcher_test_harness.dart
+++ b/test/widget/keyboard_command_dispatcher_test_harness.dart
@@ -86,6 +86,7 @@ class _DispatcherTestWorkbenchController extends WorkbenchController {
     String? initialCommand,
     bool spawnOnCreate = false,
     bool initialCommandOnce = false,
+    bool autoCloseOnSuccess = false,
   }) async {
     createdTerminalWorkspaceIds.add(workspace.id);
     final tab = createdTab ?? _tab(id: 'tab-new');


### PR DESCRIPTION
## Summary

- Mark deferred Setup terminals for success-only auto-close.
- Preserve setup failures and their output by propagating the real shell exit code.
- Keep desktop and mobile behavior aligned without changing normal terminal lifecycle.

## Validation

- `flutter analyze` passed for desktop and mobile.
- Targeted Flutter tests passed for desktop and mobile.
- `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` passed.
- The new headless runtime test verifies success removes the Setup tab and failure keeps it visible.

Local `gh act` was attempted; its full emulation is limited by container registry/submodule behavior, so native gates and hosted checks remain authoritative.