### PR TITLE
feat: align mobile prompt workspace creation

### DIFF
--- a/mobile/lib/src/design_system/forms/alera_dropdown_field.dart
+++ b/mobile/lib/src/design_system/forms/alera_dropdown_field.dart
@@ -1,4 +1,5 @@
 import 'package:alera_mobile/src/app/theme/alera_tokens.dart';
+import 'package:alera_mobile/src/design_system/forms/alera_search_field.dart';
 import 'package:alera_mobile/src/design_system/icons/alera_icons.dart';
 import 'package:alera_mobile/src/design_system/menus/alera_dropdown_entry.dart';
 import 'package:flutter/material.dart';
@@ -30,6 +31,8 @@ class AleraDropdownField<T> extends StatelessWidget {
     this.hintText,
     this.labelText,
     this.enabled = true,
+    this.filterable = false,
+    this.filterHintText = 'Search',
   });
 
   final T? value;
@@ -38,10 +41,31 @@ class AleraDropdownField<T> extends StatelessWidget {
   final String? hintText;
   final String? labelText;
   final bool enabled;
+  final bool filterable;
+  final String filterHintText;
 
   static const double _height = 34;
 
   Future<void> _openMenu(BuildContext context) async {
+    if (filterable) {
+      final selectedIndex = await showDialog<int>(
+        context: context,
+        builder: (_) => _AleraDropdownSearchDialog<T>(
+          title: labelText,
+          hintText: filterHintText,
+          entries: entries,
+          selectedValue: value,
+        ),
+      );
+      if (selectedIndex == null) {
+        return;
+      }
+      final selected = entries[selectedIndex].value;
+      if (selected != value) {
+        onChanged(selected);
+      }
+      return;
+    }
     final box = context.findRenderObject()! as RenderBox;
     final overlay =
         Overlay.of(context).context.findRenderObject()! as RenderBox;
@@ -184,6 +208,97 @@ class AleraDropdownField<T> extends StatelessWidget {
         const SizedBox(height: AleraTokens.space4),
         field,
       ],
+    );
+  }
+}
+
+class _AleraDropdownSearchDialog<T> extends StatefulWidget {
+  const _AleraDropdownSearchDialog({
+    required this.title,
+    required this.hintText,
+    required this.entries,
+    required this.selectedValue,
+  });
+
+  final String? title;
+  final String hintText;
+  final List<AleraDropdownFieldEntry<T>> entries;
+  final T? selectedValue;
+
+  @override
+  State<_AleraDropdownSearchDialog<T>> createState() =>
+      _AleraDropdownSearchDialogState<T>();
+}
+
+class _AleraDropdownSearchDialogState<T>
+    extends State<_AleraDropdownSearchDialog<T>> {
+  String _query = '';
+
+  List<int> get _visibleIndexes {
+    final query = _query.trim().toLowerCase();
+    return <int>[
+      for (final entry in widget.entries.asMap().entries)
+        if (query.isEmpty || entry.value.label.toLowerCase().contains(query))
+          entry.key,
+    ];
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final indexes = _visibleIndexes;
+    return Dialog(
+      child: ConstrainedBox(
+        constraints: BoxConstraints(
+          minWidth: 280,
+          maxWidth: 520,
+          maxHeight: MediaQuery.sizeOf(context).height * 0.7,
+        ),
+        child: Padding(
+          padding: const EdgeInsets.all(AleraTokens.space16),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: <Widget>[
+              Text(
+                widget.title ?? 'Select',
+                style: Theme.of(context).textTheme.titleMedium,
+              ),
+              const SizedBox(height: AleraTokens.space12),
+              AleraSearchField(
+                hintText: widget.hintText,
+                autofocus: true,
+                onChanged: (value) => setState(() => _query = value),
+              ),
+              const SizedBox(height: AleraTokens.space8),
+              Flexible(
+                child: indexes.isEmpty
+                    ? const Center(child: Text('No Results'))
+                    : ListView.builder(
+                        shrinkWrap: true,
+                        itemCount: indexes.length,
+                        itemBuilder: (context, visibleIndex) {
+                          final index = indexes[visibleIndex];
+                          final entry = widget.entries[index];
+                          return ListTile(
+                            dense: true,
+                            enabled: entry.enabled,
+                            selected: entry.value == widget.selectedValue,
+                            leading: entry.leading,
+                            title: Text(
+                              entry.label,
+                              overflow: TextOverflow.ellipsis,
+                            ),
+                            onTap: entry.enabled
+                                ? () => Navigator.of(context).pop(index)
+                                : null,
+                          );
+                        },
+                      ),
+              ),
+            ],
+          ),
+        ),
+      ),
     );
   }
 }

--- a/mobile/lib/src/features/runtime/domain/project_summary.dart
+++ b/mobile/lib/src/features/runtime/domain/project_summary.dart
@@ -15,6 +15,8 @@ class ProjectSummary {
   final String kind;
   final DateTime? updatedAt;
 
+  bool get supportsLinkedWorkspaces => kind == 'gitRepository';
+
   factory ProjectSummary.fromJson(Map<String, Object?> json) {
     return ProjectSummary(
       id: json.requiredString('id'),

--- a/mobile/lib/src/features/runtime/domain/workspace_creation_result.dart
+++ b/mobile/lib/src/features/runtime/domain/workspace_creation_result.dart
@@ -33,12 +33,14 @@ class WorkspaceCreationResult {
     required this.steps,
     this.deferredSetupCommand,
     this.setupLaunchError,
+    this.parentLinkError,
   });
 
   final WorkspaceSummary workspace;
   final List<WorkspaceSetupStep> steps;
   final String? deferredSetupCommand;
   final String? setupLaunchError;
+  final String? parentLinkError;
 
   bool get hasDeferredSetup =>
       deferredSetupCommand != null && deferredSetupCommand!.trim().isNotEmpty;
@@ -52,6 +54,17 @@ class WorkspaceCreationResult {
       steps: steps,
       deferredSetupCommand: deferredSetupCommand,
       setupLaunchError: error.toString(),
+      parentLinkError: parentLinkError,
+    );
+  }
+
+  WorkspaceCreationResult withParentLinkError(Object error) {
+    return WorkspaceCreationResult(
+      workspace: workspace,
+      steps: steps,
+      deferredSetupCommand: deferredSetupCommand,
+      setupLaunchError: setupLaunchError,
+      parentLinkError: error.toString(),
     );
   }
 
@@ -63,6 +76,7 @@ class WorkspaceCreationResult {
           if (item is Map) WorkspaceSetupStep.fromJson(asJsonMap(item)),
       ],
       deferredSetupCommand: json.optionalString('deferredSetupCommand'),
+      parentLinkError: json.optionalString('parentLinkError'),
     );
   }
 }

--- a/mobile/lib/src/features/runtime/domain/workspace_sidebar_snapshot.dart
+++ b/mobile/lib/src/features/runtime/domain/workspace_sidebar_snapshot.dart
@@ -78,6 +78,7 @@ class WorkspaceSidebarSnapshot {
     required this.activity,
     required this.viewPrefs,
     required this.confirmWorkspaceRemoval,
+    this.defaultAgentProfileId,
     this.agentPresence = const <AgentPresenceSummary>[],
     this.terminalTabCountByWorkspaceId = const <String, int>{},
   });
@@ -88,6 +89,7 @@ class WorkspaceSidebarSnapshot {
   final Map<String, DateTime> activity;
   final MobileViewPrefs viewPrefs;
   final bool confirmWorkspaceRemoval;
+  final String? defaultAgentProfileId;
   final List<AgentPresenceSummary> agentPresence;
   final Map<String, int> terminalTabCountByWorkspaceId;
 
@@ -119,6 +121,9 @@ class WorkspaceSidebarSnapshot {
       viewPrefs: MobileViewPrefs.fromRecordJson(json.mapValue('viewPrefs')),
       confirmWorkspaceRemoval:
           json.mapValue('runtimeSettings')['confirmWorkspaceRemoval'] != false,
+      defaultAgentProfileId: json
+          .mapValue('runtimeSettings')
+          .optionalString('defaultAgentProfileId'),
       agentPresence: <AgentPresenceSummary>[
         for (final item in json.objectList('agentPresence'))
           AgentPresenceSummary.fromJson(asJsonMap(item)),

--- a/mobile/lib/src/features/workbench/application/prompt_workspace_controller.dart
+++ b/mobile/lib/src/features/workbench/application/prompt_workspace_controller.dart
@@ -70,13 +70,18 @@ class PromptWorkspaceState {
 @riverpod
 class PromptWorkspaceController extends _$PromptWorkspaceController {
   String? _activeOperationId;
+  String? _defaultAgentProfileId;
 
   @override
   PromptWorkspaceState build(String hostId) {
     return const PromptWorkspaceState();
   }
 
-  Future<void> selectProject(String projectId) async {
+  Future<void> selectProject(
+    String projectId, {
+    String? defaultAgentProfileId,
+  }) async {
+    _defaultAgentProfileId = defaultAgentProfileId;
     state = state.copyWith(
       projectId: projectId,
       branches: const <String>[],
@@ -104,7 +109,7 @@ class PromptWorkspaceController extends _$PromptWorkspaceController {
         branches: branches,
         sourceBranch: _defaultBranch(branches),
         profiles: profiles,
-        profileId: state.profileId ?? profiles.firstOrNull?.id,
+        profileId: state.profileId ?? _preferredProfileId(profiles),
         loading: false,
       );
     } on Object catch (error) {
@@ -128,6 +133,7 @@ class PromptWorkspaceController extends _$PromptWorkspaceController {
   Future<void> create({
     required String prompt,
     required Set<String> workspaceBranches,
+    String? parentWorkspaceId,
   }) async {
     final projectId = state.projectId;
     final sourceBranch = state.sourceBranch;
@@ -187,14 +193,16 @@ class PromptWorkspaceController extends _$PromptWorkspaceController {
             name: identity.workspaceName,
           );
           creation = created;
-          if (created.hasDeferredSetup) {
-            final terminalClient = await ref.read(
-              terminalClientProvider(hostId).future,
-            );
-            creation = await launchDeferredWorkspaceSetup(
-              terminalClient,
-              created,
-            );
+          final parentId = parentWorkspaceId?.trim();
+          if (parentId != null && parentId.isNotEmpty) {
+            try {
+              await client.linkWorkspaces(
+                parentWorkspaceId: parentId,
+                childWorkspaceId: created.workspace.id,
+              );
+            } on Object catch (error) {
+              creation = created.withParentLinkError(error);
+            }
           }
           break;
         } on Object catch (error) {
@@ -217,7 +225,19 @@ class PromptWorkspaceController extends _$PromptWorkspaceController {
         profileId: profileId,
         prompt: prompt.trim(),
       );
+      var completedCreation = creation;
+      if (creation.hasDeferredSetup) {
+        state = state.copyWith(phase: 'Starting Setup');
+        final terminalClient = await ref.read(
+          terminalClientProvider(hostId).future,
+        );
+        completedCreation = await launchDeferredWorkspaceSetup(
+          terminalClient,
+          creation,
+        );
+      }
       state = state.copyWith(
+        creation: completedCreation,
         loading: false,
         agentTabId: launch.tabId,
         clearPhase: true,
@@ -249,7 +269,19 @@ class PromptWorkspaceController extends _$PromptWorkspaceController {
         profileId: profileId,
         prompt: prompt.trim(),
       );
+      var completedCreation = creation;
+      if (creation.hasDeferredSetup) {
+        state = state.copyWith(phase: 'Starting Setup');
+        final terminalClient = await ref.read(
+          terminalClientProvider(hostId).future,
+        );
+        completedCreation = await launchDeferredWorkspaceSetup(
+          terminalClient,
+          creation,
+        );
+      }
       state = state.copyWith(
+        creation: completedCreation,
         loading: false,
         agentTabId: launch.tabId,
         clearPhase: true,
@@ -294,6 +326,18 @@ class PromptWorkspaceController extends _$PromptWorkspaceController {
       }
     }
     return branches.firstOrNull;
+  }
+
+  String? _preferredProfileId(List<AgentProfileSummary> profiles) {
+    final defaultId = _defaultAgentProfileId;
+    if (defaultId != null) {
+      for (final profile in profiles) {
+        if (profile.id == defaultId) {
+          return profile.id;
+        }
+      }
+    }
+    return profiles.firstOrNull?.id;
   }
 
   bool _looksLikeCollision(Object error) {

--- a/mobile/lib/src/features/workbench/application/workspace_list_controller.dart
+++ b/mobile/lib/src/features/workbench/application/workspace_list_controller.dart
@@ -27,10 +27,12 @@ class WorkspaceListData {
     required this.workspaces,
     required this.projects,
     required this.supportsMutations,
+    this.supportsPromptWorkspaceCreation = true,
     required this.tags,
     required this.activity,
     required this.confirmWorkspaceRemoval,
     required this.agentPresence,
+    this.defaultAgentProfileId,
     this.terminalTabCountByWorkspaceId = const <String, int>{},
   });
 
@@ -40,10 +42,12 @@ class WorkspaceListData {
   /// False against runtimes that predate the mobile mutation allowlist; the
   /// UI hides mutating actions in that case.
   final bool supportsMutations;
+  final bool supportsPromptWorkspaceCreation;
   final List<WorkspaceTagSummary> tags;
   final Map<String, DateTime> activity;
   final bool confirmWorkspaceRemoval;
   final List<AgentPresenceSummary> agentPresence;
+  final String? defaultAgentProfileId;
   final Map<String, int> terminalTabCountByWorkspaceId;
 
   WorkspaceSummary? workspaceById(String id) {
@@ -77,10 +81,12 @@ class WorkspaceListController extends _$WorkspaceListController {
       workspaces: snapshot.workspaces,
       projects: snapshot.projects,
       supportsMutations: client.supportsWorkspaceMutations,
+      supportsPromptWorkspaceCreation: client.supportsPromptWorkspaceCreation,
       tags: snapshot.tags,
       activity: snapshot.activity,
       confirmWorkspaceRemoval: snapshot.confirmWorkspaceRemoval,
       agentPresence: snapshot.agentPresence,
+      defaultAgentProfileId: snapshot.defaultAgentProfileId,
       terminalTabCountByWorkspaceId: snapshot.terminalTabCountByWorkspaceId,
     );
   }
@@ -133,7 +139,6 @@ class WorkspaceListController extends _$WorkspaceListController {
         sourceBranch: sourceBranch,
         reuseExistingBranch: reuseExistingBranch,
         name: name,
-        parentWorkspaceId: parentWorkspaceId,
       );
       var result = creation;
       if (creation.hasDeferredSetup) {
@@ -141,6 +146,17 @@ class WorkspaceListController extends _$WorkspaceListController {
           terminalClientProvider(hostId).future,
         );
         result = await launchDeferredWorkspaceSetup(terminalClient, creation);
+      }
+      final parentId = parentWorkspaceId?.trim();
+      if (parentId != null && parentId.isNotEmpty) {
+        try {
+          await client.linkWorkspaces(
+            parentWorkspaceId: parentId,
+            childWorkspaceId: creation.workspace.id,
+          );
+        } on Object catch (error) {
+          result = result.withParentLinkError(error);
+        }
       }
       ref.invalidateSelf();
       return result;

--- a/mobile/lib/src/features/workbench/presentation/create_workspace_manual.dart
+++ b/mobile/lib/src/features/workbench/presentation/create_workspace_manual.dart
@@ -5,23 +5,21 @@ extension _CreateWorkspaceManualForm on _CreateWorkspaceScreenState {
     return ListView(
       padding: AleraTokens.pagePadding,
       children: <Widget>[
-        DropdownButtonFormField<String>(
-          initialValue: _projectId,
-          decoration: const InputDecoration(labelText: 'Project'),
-          items: <DropdownMenuItem<String>>[
+        AleraDropdownField<String>(
+          value: _projectId,
+          labelText: 'Project',
+          hintText: 'Select Project',
+          entries: <AleraDropdownFieldEntry<String>>[
             for (final project in _orderedProjects)
-              DropdownMenuItem<String>(
+              AleraDropdownFieldEntry<String>(
                 value: project.id,
-                child: Text(project.name, overflow: TextOverflow.ellipsis),
+                label: project.name,
               ),
           ],
-          onChanged: _creating
-              ? null
-              : (value) {
-                  if (value != null) {
-                    _selectProject(value);
-                  }
-                },
+          enabled: !_creating,
+          filterable: true,
+          filterHintText: 'Search Projects',
+          onChanged: _selectProject,
         ),
         const SizedBox(height: AleraTokens.spaceLg),
         TextField(
@@ -51,23 +49,22 @@ extension _CreateWorkspaceManualForm on _CreateWorkspaceScreenState {
           if (_loadingBranches)
             const Center(child: CircularProgressIndicator())
           else
-            DropdownButtonFormField<String>(
-              initialValue: _sourceBranch,
-              decoration: const InputDecoration(labelText: 'Source Branch'),
-              items: <DropdownMenuItem<String>>[
+            AleraDropdownField<String>(
+              value: _sourceBranch,
+              labelText: 'Source Branch',
+              hintText: _loadingBranches ? 'Loading Branches' : 'Select Branch',
+              entries: <AleraDropdownFieldEntry<String>>[
                 for (final branch in _branches)
-                  DropdownMenuItem<String>(
-                    value: branch,
-                    child: Text(branch, overflow: TextOverflow.ellipsis),
-                  ),
+                  AleraDropdownFieldEntry<String>(value: branch, label: branch),
               ],
-              onChanged: _creating
-                  ? null
-                  : (value) {
-                      _update(() {
-                        _sourceBranch = value;
-                      });
-                    },
+              enabled: !_creating && !_loadingBranches,
+              filterable: true,
+              filterHintText: 'Search Branches',
+              onChanged: (value) {
+                _update(() {
+                  _sourceBranch = value;
+                });
+              },
             ),
         ],
         const SizedBox(height: AleraTokens.spaceLg),
@@ -79,28 +76,29 @@ extension _CreateWorkspaceManualForm on _CreateWorkspaceScreenState {
           ),
         ),
         const SizedBox(height: AleraTokens.spaceLg),
-        DropdownButtonFormField<String?>(
-          initialValue: _parentWorkspaceId,
-          decoration: const InputDecoration(labelText: 'Parent Workspace'),
-          items: <DropdownMenuItem<String?>>[
-            const DropdownMenuItem<String?>(
+        AleraDropdownField<String?>(
+          value: _parentWorkspaceId,
+          labelText: 'Parent Workspace',
+          hintText: 'Select Parent Workspace',
+          entries: <AleraDropdownFieldEntry<String?>>[
+            const AleraDropdownFieldEntry<String?>(
               value: null,
-              child: Text('No Parent'),
+              label: 'No Parent',
             ),
             for (final workspace in _orderedParentWorkspaces)
-              if (workspace.projectId == _projectId)
-                DropdownMenuItem<String?>(
-                  value: workspace.id,
-                  child: Text(workspace.name, overflow: TextOverflow.ellipsis),
-                ),
+              AleraDropdownFieldEntry<String?>(
+                value: workspace.id,
+                label: _parentWorkspaceLabel(workspace),
+              ),
           ],
-          onChanged: _creating
-              ? null
-              : (value) {
-                  _update(() {
-                    _parentWorkspaceId = value;
-                  });
-                },
+          enabled: !_creating,
+          filterable: true,
+          filterHintText: 'Search Workspaces',
+          onChanged: (value) {
+            _update(() {
+              _parentWorkspaceId = value;
+            });
+          },
         ),
         if (_error != null) ...<Widget>[
           const SizedBox(height: AleraTokens.spaceMd),

--- a/mobile/lib/src/features/workbench/presentation/create_workspace_prompt.dart
+++ b/mobile/lib/src/features/workbench/presentation/create_workspace_prompt.dart
@@ -1,0 +1,230 @@
+part of 'create_workspace_screen.dart';
+
+extension _CreateWorkspacePromptForm on _CreateWorkspaceScreenState {
+  Widget _buildPromptForm(BuildContext context) {
+    final promptState = ref.watch(
+      promptWorkspaceControllerProvider(widget.hostId),
+    );
+    final controller = ref.read(
+      promptWorkspaceControllerProvider(widget.hostId).notifier,
+    );
+    final created = promptState.creation;
+    return ListView(
+      padding: AleraTokens.pagePadding,
+      children: <Widget>[
+        TextField(
+          controller: _prompt,
+          enabled: !promptState.loading && created == null,
+          minLines: 4,
+          maxLines: 8,
+          decoration: const InputDecoration(
+            labelText: 'Initial Prompt',
+            hintText: 'Describe What The Agent Should Build',
+            alignLabelWithHint: true,
+          ),
+        ),
+        const SizedBox(height: AleraTokens.spaceLg),
+        AleraDropdownField<String>(
+          value: promptState.projectId,
+          labelText: 'Project',
+          hintText: 'Select Project',
+          entries: <AleraDropdownFieldEntry<String>>[
+            for (final project in _orderedProjects)
+              AleraDropdownFieldEntry<String>(
+                value: project.id,
+                label: project.name,
+              ),
+          ],
+          enabled: !promptState.loading && created == null,
+          filterable: true,
+          filterHintText: 'Search Projects',
+          onChanged: (value) => _selectPromptProject(value, controller),
+        ),
+        const SizedBox(height: AleraTokens.spaceLg),
+        AleraDropdownField<String>(
+          key: ValueKey<String?>(
+            'prompt-source-${promptState.projectId}-${promptState.sourceBranch}',
+          ),
+          value: promptState.sourceBranch,
+          labelText: 'Source Branch',
+          hintText: promptState.loading ? 'Loading Branches' : 'Select Branch',
+          entries: <AleraDropdownFieldEntry<String>>[
+            for (final branch in promptState.branches)
+              AleraDropdownFieldEntry<String>(value: branch, label: branch),
+          ],
+          enabled: !promptState.loading && created == null,
+          filterable: true,
+          filterHintText: 'Search Branches',
+          onChanged: controller.selectSourceBranch,
+        ),
+        const SizedBox(height: AleraTokens.spaceLg),
+        AleraDropdownField<String?>(
+          key: ValueKey<String?>(
+            'prompt-parent-${promptState.projectId}-$_promptParentWorkspaceId',
+          ),
+          value: _promptParentWorkspaceId,
+          labelText: 'Parent Workspace',
+          hintText: 'Select Parent Workspace',
+          entries: <AleraDropdownFieldEntry<String?>>[
+            const AleraDropdownFieldEntry<String?>(
+              value: null,
+              label: 'No Parent',
+            ),
+            for (final workspace in _parentWorkspacesFor(promptState.projectId))
+              AleraDropdownFieldEntry<String?>(
+                value: workspace.id,
+                label: _parentWorkspaceLabel(workspace),
+              ),
+          ],
+          enabled: !promptState.loading && created == null,
+          filterable: true,
+          filterHintText: 'Search Workspaces',
+          onChanged: (value) {
+            _update(() => _promptParentWorkspaceId = value);
+          },
+        ),
+        const SizedBox(height: AleraTokens.spaceLg),
+        AleraDropdownField<String>(
+          key: ValueKey<String?>('prompt-profile-${promptState.profileId}'),
+          value: promptState.profileId,
+          labelText: 'Agent Profile',
+          hintText: promptState.profiles.isEmpty
+              ? 'Create An Agent Profile In Desktop Settings'
+              : 'Select Agent Profile',
+          entries: <AleraDropdownFieldEntry<String>>[
+            for (final profile in promptState.profiles)
+              AleraDropdownFieldEntry<String>(
+                value: profile.id,
+                label: profile.name,
+              ),
+          ],
+          enabled: !promptState.loading && created == null,
+          filterable: true,
+          filterHintText: 'Search Agent Profiles',
+          onChanged: controller.selectProfile,
+        ),
+        if (promptState.error != null) ...<Widget>[
+          const SizedBox(height: AleraTokens.spaceMd),
+          Text(
+            promptState.error!,
+            style: TextStyle(color: Theme.of(context).colorScheme.error),
+          ),
+        ],
+        const SizedBox(height: AleraTokens.spaceMd),
+        CheckboxListTile(
+          contentPadding: EdgeInsets.zero,
+          controlAffinity: ListTileControlAffinity.leading,
+          value: _createAnother,
+          onChanged: promptState.loading || created != null
+              ? null
+              : (value) {
+                  _update(() => _createAnother = value ?? false);
+                },
+          title: const Text('Create Another'),
+          subtitle: const Text('Keep This Screen Open After Creation'),
+        ),
+        const SizedBox(height: AleraTokens.spaceXl),
+        if (promptState.loading)
+          Row(
+            children: <Widget>[
+              const SizedBox.square(
+                dimension: AleraTokens.spaceLg,
+                child: CircularProgressIndicator(
+                  strokeWidth: AleraTokens.strokeSm,
+                ),
+              ),
+              const SizedBox(width: AleraTokens.spaceMd),
+              Expanded(child: Text(promptState.phase ?? 'Working')),
+              if (promptState.phase == 'Generating Workspace Identity')
+                TextButton(
+                  onPressed: controller.cancelGeneration,
+                  child: const Text('Cancel'),
+                ),
+            ],
+          )
+        else if (created != null)
+          Row(
+            children: <Widget>[
+              Expanded(
+                child: OutlinedButton(
+                  onPressed: () => _openWorkspace(created),
+                  child: const Text('Open Workspace'),
+                ),
+              ),
+              const SizedBox(width: AleraTokens.spaceMd),
+              Expanded(
+                child: FilledButton(
+                  onPressed: () => _retryPromptAgent(controller),
+                  child: const Text('Retry Agent'),
+                ),
+              ),
+            ],
+          )
+        else
+          FilledButton.icon(
+            onPressed:
+                promptState.projectId == null ||
+                    promptState.sourceBranch == null ||
+                    promptState.profileId == null
+                ? null
+                : () => _createFromPrompt(controller),
+            icon: const Icon(Icons.smart_toy_outlined),
+            label: const Text('Create And Start Agent'),
+          ),
+      ],
+    );
+  }
+
+  Future<void> _createFromPrompt(PromptWorkspaceController controller) async {
+    final selectedProjectId = ref
+        .read(promptWorkspaceControllerProvider(widget.hostId))
+        .projectId;
+    final workspaceBranches = <String>{
+      for (final workspace in widget.workspaces)
+        if (workspace.status == 'active' &&
+            workspace.projectId == selectedProjectId &&
+            workspace.branch != null &&
+            workspace.branch!.trim().isNotEmpty)
+          workspace.branch!.trim(),
+    };
+    await controller.create(
+      prompt: _prompt.text,
+      workspaceBranches: workspaceBranches,
+      parentWorkspaceId: _promptParentWorkspaceId,
+    );
+    if (!mounted) {
+      return;
+    }
+    final state = ref.read(promptWorkspaceControllerProvider(widget.hostId));
+    final creation = state.creation;
+    final tabId = state.agentTabId;
+    if (creation != null && tabId != null) {
+      if (_createAnother) {
+        _showCreationMessage(creation);
+        _prompt.clear();
+        controller.resetForAnother();
+      } else {
+        _openWorkspace(creation, tabId: tabId);
+      }
+    }
+  }
+
+  Future<void> _retryPromptAgent(PromptWorkspaceController controller) async {
+    await controller.retryAgent(_prompt.text);
+    if (!mounted) {
+      return;
+    }
+    final state = ref.read(promptWorkspaceControllerProvider(widget.hostId));
+    final creation = state.creation;
+    final tabId = state.agentTabId;
+    if (creation != null && tabId != null) {
+      if (_createAnother) {
+        _showCreationMessage(creation);
+        _prompt.clear();
+        controller.resetForAnother();
+      } else {
+        _openWorkspace(creation, tabId: tabId);
+      }
+    }
+  }
+}

--- a/mobile/lib/src/features/workbench/presentation/create_workspace_screen.dart
+++ b/mobile/lib/src/features/workbench/presentation/create_workspace_screen.dart
@@ -1,4 +1,5 @@
 import 'package:alera_mobile/src/app/theme/alera_tokens.dart';
+import 'package:alera_mobile/src/design_system/forms/alera_dropdown_field.dart';
 import 'package:alera_mobile/src/features/runtime/domain/project_selection_order.dart';
 import 'package:alera_mobile/src/features/runtime/domain/project_summary.dart';
 import 'package:alera_mobile/src/features/runtime/domain/workspace_creation_result.dart';
@@ -12,6 +13,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 part 'create_workspace_manual.dart';
+part 'create_workspace_prompt.dart';
 
 class CreateWorkspaceScreen extends ConsumerStatefulWidget {
   const CreateWorkspaceScreen({
@@ -19,11 +21,15 @@ class CreateWorkspaceScreen extends ConsumerStatefulWidget {
     required this.hostId,
     required this.projects,
     required this.workspaces,
+    this.defaultAgentProfileId,
+    this.supportsPromptWorkspaceCreation = true,
   });
 
   final String hostId;
   final List<ProjectSummary> projects;
   final List<WorkspaceSummary> workspaces;
+  final String? defaultAgentProfileId;
+  final bool supportsPromptWorkspaceCreation;
 
   @override
   ConsumerState<CreateWorkspaceScreen> createState() =>
@@ -39,52 +45,99 @@ class _CreateWorkspaceScreenState extends ConsumerState<CreateWorkspaceScreen> {
   List<String> _branches = const <String>[];
   String? _sourceBranch;
   String? _parentWorkspaceId;
+  String? _promptParentWorkspaceId;
   bool _reuseExistingBranch = false;
   bool _createAnother = false;
   bool _loadingBranches = false;
   bool _creating = false;
   String? _error;
 
-  List<ProjectSummary> get _orderedProjects =>
-      sortProjectsForSelection(widget.projects);
+  List<ProjectSummary> get _orderedProjects => sortProjectsForSelection(
+    widget.projects.where((project) => project.supportsLinkedWorkspaces),
+  );
 
-  List<WorkspaceSummary> get _orderedParentWorkspaces {
+  List<WorkspaceSummary> get _orderedParentWorkspaces =>
+      _parentWorkspacesFor(_projectId);
+
+  List<WorkspaceSummary> _parentWorkspacesFor(String? preferredProjectId) {
     final projectNameById = <String, String>{
       for (final project in widget.projects) project.id: project.name,
     };
-    return <WorkspaceSummary>[...widget.workspaces]..sort(
-      (left, right) => compareWorkspaceParentSelectionKeys(
-        (
-          isDefault: left.isMain,
-          projectId: left.projectId,
-          projectName: projectNameById[left.projectId] ?? left.projectId,
-          workspaceId: left.id,
-          workspaceName: left.name,
+    return <WorkspaceSummary>[...widget.workspaces]
+        .where((workspace) => workspace.status == 'active')
+        .toList(growable: false)
+      ..sort(
+        (left, right) => compareWorkspaceParentSelectionKeys(
+          (
+            isDefault: left.isMain,
+            projectId: left.projectId,
+            projectName: projectNameById[left.projectId] ?? left.projectId,
+            workspaceId: left.id,
+            workspaceName: left.name,
+          ),
+          (
+            isDefault: right.isMain,
+            projectId: right.projectId,
+            projectName: projectNameById[right.projectId] ?? right.projectId,
+            workspaceId: right.id,
+            workspaceName: right.name,
+          ),
+          preferredProjectId: preferredProjectId,
         ),
-        (
-          isDefault: right.isMain,
-          projectId: right.projectId,
-          projectName: projectNameById[right.projectId] ?? right.projectId,
-          workspaceId: right.id,
-          workspaceName: right.name,
-        ),
-        preferredProjectId: _projectId,
-      ),
-    );
+      );
+  }
+
+  String? _defaultParentWorkspaceId(String? projectId) {
+    if (projectId == null) {
+      return null;
+    }
+    final candidates = _parentWorkspacesFor(projectId);
+    for (final workspace in candidates) {
+      if (workspace.projectId == projectId && workspace.isMain) {
+        return workspace.id;
+      }
+    }
+    for (final workspace in candidates) {
+      if (workspace.projectId == projectId) {
+        return workspace.id;
+      }
+    }
+    return null;
+  }
+
+  String _parentWorkspaceLabel(WorkspaceSummary workspace) {
+    String? projectName;
+    for (final project in widget.projects) {
+      if (project.id == workspace.projectId) {
+        projectName = project.name;
+        break;
+      }
+    }
+    final branch = workspace.branch?.trim();
+    final suffix = branch == null || branch.isEmpty ? '' : ' - $branch';
+    return '${projectName ?? workspace.projectId} / ${workspace.name}$suffix';
   }
 
   @override
   void initState() {
     super.initState();
+    _fromPrompt = widget.supportsPromptWorkspaceCreation;
     if (_orderedProjects.length == 1) {
       _selectProject(_orderedProjects.single.id);
     }
     final initialPromptProject = _orderedProjects.firstOrNull;
-    if (initialPromptProject != null) {
+    if (widget.supportsPromptWorkspaceCreation &&
+        initialPromptProject != null) {
+      _promptParentWorkspaceId = _defaultParentWorkspaceId(
+        initialPromptProject.id,
+      );
       Future<void>.microtask(
         () => ref
             .read(promptWorkspaceControllerProvider(widget.hostId).notifier)
-            .selectProject(initialPromptProject.id),
+            .selectProject(
+              initialPromptProject.id,
+              defaultAgentProfileId: widget.defaultAgentProfileId,
+            ),
       );
     }
   }
@@ -98,6 +151,19 @@ class _CreateWorkspaceScreenState extends ConsumerState<CreateWorkspaceScreen> {
   }
 
   void _update(VoidCallback update) => setState(update);
+
+  void _selectPromptProject(
+    String projectId,
+    PromptWorkspaceController controller,
+  ) {
+    setState(() {
+      _promptParentWorkspaceId = _defaultParentWorkspaceId(projectId);
+    });
+    controller.selectProject(
+      projectId,
+      defaultAgentProfileId: widget.defaultAgentProfileId,
+    );
+  }
 
   Future<void> _selectProject(String projectId) async {
     setState(() {
@@ -202,6 +268,8 @@ class _CreateWorkspaceScreenState extends ConsumerState<CreateWorkspaceScreen> {
         ? 'Workspace Created, But Setup Could Not Start'
         : creation.hasSetupWarnings
         ? 'Workspace Created With Setup Warnings'
+        : creation.parentLinkError != null
+        ? 'Workspace Created, But Parent Link Failed'
         : 'Workspace Created';
     ScaffoldMessenger.of(
       context,
@@ -210,6 +278,30 @@ class _CreateWorkspaceScreenState extends ConsumerState<CreateWorkspaceScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final promptState = widget.supportsPromptWorkspaceCreation
+        ? ref.watch(promptWorkspaceControllerProvider(widget.hostId))
+        : const PromptWorkspaceState();
+    final modeLocked = _creating || promptState.loading;
+    final segments = widget.supportsPromptWorkspaceCreation
+        ? const <ButtonSegment<bool>>[
+            ButtonSegment<bool>(
+              value: true,
+              label: Text('From Prompt'),
+              icon: Icon(Icons.smart_toy_outlined),
+            ),
+            ButtonSegment<bool>(
+              value: false,
+              label: Text('Manual'),
+              icon: Icon(Icons.account_tree_outlined),
+            ),
+          ]
+        : const <ButtonSegment<bool>>[
+            ButtonSegment<bool>(
+              value: false,
+              label: Text('Manual'),
+              icon: Icon(Icons.account_tree_outlined),
+            ),
+          ];
     return Scaffold(
       appBar: AppBar(title: const Text('New Workspace')),
       body: SafeArea(
@@ -224,22 +316,15 @@ class _CreateWorkspaceScreenState extends ConsumerState<CreateWorkspaceScreen> {
               ),
               child: SegmentedButton<bool>(
                 showSelectedIcon: false,
-                segments: const <ButtonSegment<bool>>[
-                  ButtonSegment<bool>(
-                    value: true,
-                    label: Text('From Prompt'),
-                    icon: Icon(Icons.smart_toy_outlined),
-                  ),
-                  ButtonSegment<bool>(
-                    value: false,
-                    label: Text('Manual'),
-                    icon: Icon(Icons.account_tree_outlined),
-                  ),
-                ],
+                segments: segments,
                 selected: <bool>{_fromPrompt},
-                onSelectionChanged: (selection) {
-                  setState(() => _fromPrompt = selection.first);
-                },
+                onSelectionChanged: modeLocked
+                    ? null
+                    : (selection) {
+                        if (selection.isNotEmpty) {
+                          setState(() => _fromPrompt = selection.first);
+                        }
+                      },
               ),
             ),
             Expanded(
@@ -251,211 +336,6 @@ class _CreateWorkspaceScreenState extends ConsumerState<CreateWorkspaceScreen> {
         ),
       ),
     );
-  }
-
-  Widget _buildPromptForm(BuildContext context) {
-    final promptState = ref.watch(
-      promptWorkspaceControllerProvider(widget.hostId),
-    );
-    final controller = ref.read(
-      promptWorkspaceControllerProvider(widget.hostId).notifier,
-    );
-    final created = promptState.creation;
-    return ListView(
-      padding: AleraTokens.pagePadding,
-      children: <Widget>[
-        TextField(
-          controller: _prompt,
-          enabled: !promptState.loading && created == null,
-          minLines: 4,
-          maxLines: 8,
-          decoration: const InputDecoration(
-            labelText: 'Initial Prompt',
-            hintText: 'Describe What The Agent Should Build',
-            alignLabelWithHint: true,
-          ),
-        ),
-        const SizedBox(height: AleraTokens.spaceLg),
-        DropdownButtonFormField<String>(
-          initialValue: promptState.projectId,
-          decoration: const InputDecoration(labelText: 'Project'),
-          items: <DropdownMenuItem<String>>[
-            for (final project in _orderedProjects)
-              DropdownMenuItem<String>(
-                value: project.id,
-                child: Text(project.name, overflow: TextOverflow.ellipsis),
-              ),
-          ],
-          onChanged: promptState.loading || created != null
-              ? null
-              : (value) {
-                  if (value != null) {
-                    controller.selectProject(value);
-                  }
-                },
-        ),
-        const SizedBox(height: AleraTokens.spaceLg),
-        DropdownButtonFormField<String>(
-          key: ValueKey<String?>(
-            'prompt-source-${promptState.projectId}-${promptState.sourceBranch}',
-          ),
-          initialValue: promptState.sourceBranch,
-          decoration: const InputDecoration(labelText: 'Source Branch'),
-          items: <DropdownMenuItem<String>>[
-            for (final branch in promptState.branches)
-              DropdownMenuItem<String>(
-                value: branch,
-                child: Text(branch, overflow: TextOverflow.ellipsis),
-              ),
-          ],
-          onChanged: promptState.loading || created != null
-              ? null
-              : (value) {
-                  if (value != null) {
-                    controller.selectSourceBranch(value);
-                  }
-                },
-        ),
-        const SizedBox(height: AleraTokens.spaceLg),
-        DropdownButtonFormField<String>(
-          key: ValueKey<String?>('prompt-profile-${promptState.profileId}'),
-          initialValue: promptState.profileId,
-          decoration: InputDecoration(
-            labelText: 'Agent Profile',
-            helperText: promptState.profiles.isEmpty
-                ? 'Create An Agent Profile In Desktop Settings'
-                : null,
-          ),
-          items: <DropdownMenuItem<String>>[
-            for (final profile in promptState.profiles)
-              DropdownMenuItem<String>(
-                value: profile.id,
-                child: Text(profile.name, overflow: TextOverflow.ellipsis),
-              ),
-          ],
-          onChanged: promptState.loading || created != null
-              ? null
-              : (value) {
-                  if (value != null) {
-                    controller.selectProfile(value);
-                  }
-                },
-        ),
-        if (promptState.error != null) ...<Widget>[
-          const SizedBox(height: AleraTokens.spaceMd),
-          Text(
-            promptState.error!,
-            style: TextStyle(color: Theme.of(context).colorScheme.error),
-          ),
-        ],
-        const SizedBox(height: AleraTokens.spaceMd),
-        CheckboxListTile(
-          contentPadding: EdgeInsets.zero,
-          controlAffinity: ListTileControlAffinity.leading,
-          value: _createAnother,
-          onChanged: promptState.loading || created != null
-              ? null
-              : (value) {
-                  setState(() => _createAnother = value ?? false);
-                },
-          title: const Text('Create Another'),
-          subtitle: const Text('Keep This Screen Open After Creation'),
-        ),
-        const SizedBox(height: AleraTokens.spaceXl),
-        if (promptState.loading)
-          Row(
-            children: <Widget>[
-              const SizedBox.square(
-                dimension: AleraTokens.spaceLg,
-                child: CircularProgressIndicator(
-                  strokeWidth: AleraTokens.strokeSm,
-                ),
-              ),
-              const SizedBox(width: AleraTokens.spaceMd),
-              Expanded(child: Text(promptState.phase ?? 'Working')),
-              if (promptState.phase == 'Generating Workspace Identity')
-                TextButton(
-                  onPressed: controller.cancelGeneration,
-                  child: const Text('Cancel'),
-                ),
-            ],
-          )
-        else if (created != null)
-          Row(
-            children: <Widget>[
-              Expanded(
-                child: OutlinedButton(
-                  onPressed: () => _openWorkspace(created),
-                  child: const Text('Open Workspace'),
-                ),
-              ),
-              const SizedBox(width: AleraTokens.spaceMd),
-              Expanded(
-                child: FilledButton(
-                  onPressed: () => _retryPromptAgent(controller),
-                  child: const Text('Retry Agent'),
-                ),
-              ),
-            ],
-          )
-        else
-          FilledButton.icon(
-            onPressed:
-                promptState.projectId == null ||
-                    promptState.sourceBranch == null ||
-                    promptState.profileId == null
-                ? null
-                : () => _createFromPrompt(controller),
-            icon: const Icon(Icons.smart_toy_outlined),
-            label: const Text('Create And Start Agent'),
-          ),
-      ],
-    );
-  }
-
-  Future<void> _createFromPrompt(PromptWorkspaceController controller) async {
-    final workspaceBranches = <String>{
-      for (final workspace in widget.workspaces)
-        if (workspace.branch != null) workspace.branch!,
-    };
-    await controller.create(
-      prompt: _prompt.text,
-      workspaceBranches: workspaceBranches,
-    );
-    if (!mounted) {
-      return;
-    }
-    final state = ref.read(promptWorkspaceControllerProvider(widget.hostId));
-    final creation = state.creation;
-    final tabId = state.agentTabId;
-    if (creation != null && tabId != null) {
-      if (_createAnother) {
-        _showCreationMessage(creation);
-        _prompt.clear();
-        controller.resetForAnother();
-      } else {
-        _openWorkspace(creation, tabId: tabId);
-      }
-    }
-  }
-
-  Future<void> _retryPromptAgent(PromptWorkspaceController controller) async {
-    await controller.retryAgent(_prompt.text);
-    if (!mounted) {
-      return;
-    }
-    final state = ref.read(promptWorkspaceControllerProvider(widget.hostId));
-    final creation = state.creation;
-    final tabId = state.agentTabId;
-    if (creation != null && tabId != null) {
-      if (_createAnother) {
-        _showCreationMessage(creation);
-        _prompt.clear();
-        controller.resetForAnother();
-      } else {
-        _openWorkspace(creation, tabId: tabId);
-      }
-    }
   }
 
   void _openWorkspace(WorkspaceCreationResult creation, {String? tabId}) {

--- a/mobile/lib/src/features/workbench/presentation/runtime_workspaces_screen.dart
+++ b/mobile/lib/src/features/workbench/presentation/runtime_workspaces_screen.dart
@@ -162,6 +162,9 @@ class RuntimeWorkspacesScreen extends ConsumerWidget {
                       hostId: host.id,
                       projects: data.value!.projects,
                       workspaces: data.value!.workspaces,
+                      defaultAgentProfileId: data.value!.defaultAgentProfileId,
+                      supportsPromptWorkspaceCreation:
+                          data.value!.supportsPromptWorkspaceCreation,
                     ),
                   ),
                 );

--- a/mobile/test/create_workspace_screen_test.dart
+++ b/mobile/test/create_workspace_screen_test.dart
@@ -1,4 +1,5 @@
 import 'package:alera_mobile/src/features/runtime/domain/project_summary.dart';
+import 'package:alera_mobile/src/features/runtime/domain/workspace_summary.dart';
 import 'package:alera_mobile/src/features/terminal/application/terminal_providers.dart';
 import 'package:alera_mobile/src/features/workbench/application/workbench_providers.dart';
 import 'package:alera_mobile/src/features/workbench/presentation/create_workspace_screen.dart';
@@ -118,9 +119,21 @@ void main() {
     );
     await tester.ensureVisible(find.text('Create Another'));
     await tester.tap(find.text('Create Another'));
-    await tester.drag(find.byType(ListView), const Offset(0, -300));
-    await tester.pumpAndSettle();
-    await tester.tap(find.text('Create And Start Agent'));
+    final scrollState = tester.state<ScrollableState>(
+      find.byType(Scrollable).first,
+    );
+    scrollState.position.jumpTo(scrollState.position.maxScrollExtent);
+    await tester.pump();
+    final targetElement = tester.element(find.text('Create And Start Agent'));
+    final targetScrollState = targetElement
+        .findAncestorStateOfType<ScrollableState>();
+    if (targetScrollState != null) {
+      targetScrollState.position.jumpTo(
+        targetScrollState.position.maxScrollExtent,
+      );
+    }
+    await tester.pump();
+    await tester.tap(find.byType(FilledButton));
     for (var attempt = 0; attempt < 100; attempt += 1) {
       if (client.calls.any((call) => call.startsWith('launchAgentProfile'))) {
         break;
@@ -144,5 +157,70 @@ void main() {
           ?.text,
       isEmpty,
     );
+  });
+
+  testWidgets('Prompt exposes a configurable cross-project Parent', (
+    tester,
+  ) async {
+    final client = FakeTerminalClient()
+      ..projectBranches = const <String>['main'];
+    addTearDown(client.dispose);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          workspaceClientProvider('host-1').overrideWith((ref) async => client),
+          terminalClientProvider('host-1').overrideWith((ref) async => client),
+        ],
+        child: MaterialApp(
+          home: CreateWorkspaceScreen(
+            hostId: 'host-1',
+            projects: const <ProjectSummary>[
+              ProjectSummary(
+                id: 'project-1',
+                name: 'Alera',
+                repoPath: '/repo/alera',
+              ),
+              ProjectSummary(
+                id: 'folder-1',
+                name: 'Notes',
+                repoPath: '/notes',
+                kind: 'folder',
+              ),
+            ],
+            workspaces: const <WorkspaceSummary>[
+              WorkspaceSummary(
+                id: 'main-1',
+                projectId: 'project-1',
+                name: 'Main',
+                path: '/workspaces/alera',
+                branch: 'main',
+                kind: 'main',
+              ),
+              WorkspaceSummary(
+                id: 'notes-1',
+                projectId: 'folder-1',
+                name: 'Shared',
+                path: '/workspaces/notes',
+                branch: 'feature/shared',
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Alera / Main - main'), findsOneWidget);
+    await tester.tap(find.text('Alera / Main - main'));
+    await tester.pumpAndSettle();
+    expect(find.text('Notes / Shared - feature/shared'), findsOneWidget);
+    await tester.tap(find.text('Notes / Shared - feature/shared'));
+    await tester.pumpAndSettle();
+    expect(find.text('Notes / Shared - feature/shared'), findsOneWidget);
+
+    await tester.tap(find.text('Alera'));
+    await tester.pumpAndSettle();
+    expect(find.text('Notes'), findsNothing);
   });
 }

--- a/mobile/test/prompt_workspace_controller_test.dart
+++ b/mobile/test/prompt_workspace_controller_test.dart
@@ -1,3 +1,5 @@
+import 'package:alera_mobile/src/features/runtime/domain/agent_profile_summary.dart';
+import 'package:alera_mobile/src/features/terminal/application/terminal_providers.dart';
 import 'package:alera_mobile/src/features/workbench/application/prompt_workspace_controller.dart';
 import 'package:alera_mobile/src/features/workbench/application/workbench_providers.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -48,6 +50,69 @@ void main() {
           'launchAgentProfile created profile-1 Add offline support',
         ]),
       );
+    },
+  );
+
+  test(
+    'Uses the configured profile, links the parent, and starts Setup after Agent',
+    () async {
+      final client = FakeTerminalClient()
+        ..projectBranches = const <String>['main']
+        ..agentProfiles = const <AgentProfileSummary>[
+          AgentProfileSummary(
+            id: 'profile-1',
+            name: 'Codex',
+            agentType: 'codex',
+          ),
+          AgentProfileSummary(
+            id: 'profile-2',
+            name: 'Claude Code',
+            agentType: 'claude',
+          ),
+        ]
+        ..deferredSetupCommand = '/bin/sh "/runtime/setup.sh"'
+        ..linkError = StateError('Parent link rejected');
+      final container = ProviderContainer(
+        overrides: [
+          workspaceClientProvider('host-1').overrideWith((ref) async => client),
+          terminalClientProvider('host-1').overrideWith((ref) async => client),
+        ],
+      );
+      addTearDown(container.dispose);
+      addTearDown(client.dispose);
+      final subscription = container.listen(
+        promptWorkspaceControllerProvider('host-1'),
+        (_, _) {},
+      );
+      addTearDown(subscription.close);
+      final controller = container.read(
+        promptWorkspaceControllerProvider('host-1').notifier,
+      );
+
+      await controller.selectProject(
+        'project-1',
+        defaultAgentProfileId: 'profile-2',
+      );
+      expect(
+        container.read(promptWorkspaceControllerProvider('host-1')).profileId,
+        'profile-2',
+      );
+
+      await controller.create(
+        prompt: 'Add offline support',
+        workspaceBranches: const <String>{},
+        parentWorkspaceId: 'parent-1',
+      );
+      final state = container.read(promptWorkspaceControllerProvider('host-1'));
+
+      expect(state.creation?.parentLinkError, contains('Parent link rejected'));
+      final agentIndex = client.calls.indexOf(
+        'launchAgentProfile created profile-2 Add offline support',
+      );
+      final setupIndex = client.calls.indexOf('create created Setup');
+      expect(agentIndex, greaterThanOrEqualTo(0));
+      expect(setupIndex, greaterThan(agentIndex));
+      expect(client.calls, contains('link parent-1 created'));
     },
   );
 }

--- a/mobile/test/support/fake_terminal_client.dart
+++ b/mobile/test/support/fake_terminal_client.dart
@@ -60,6 +60,7 @@ class FakeTerminalClient
         branchName: 'feat/generated-workspace',
       );
   String? deferredSetupCommand;
+  Object? linkError;
   int _createdTabs = 0;
 
   void emitEvent(String name) {
@@ -332,6 +333,10 @@ class FakeTerminalClient
     required String childWorkspaceId,
   }) async {
     calls.add('link $parentWorkspaceId $childWorkspaceId');
+    final error = linkError;
+    if (error != null) {
+      throw error;
+    }
   }
 
   @override

--- a/mobile/test/workspace_list_controller_test.dart
+++ b/mobile/test/workspace_list_controller_test.dart
@@ -64,7 +64,8 @@ void main() {
       parentWorkspaceId: 'b',
     );
     expect(result.workspace.id, 'created');
-    expect(client.calls, contains('create p1 feature/x main b'));
+    expect(client.calls, contains('create p1 feature/x main null'));
+    expect(client.calls, contains('link b created'));
   });
 
   test('Cascade preview returns the subtree ids', () async {
@@ -109,6 +110,7 @@ class _FakeWorkspaceClient implements MobileWorkspaceClient {
   final StreamController<MobileRuntimeEvent> _events =
       StreamController<MobileRuntimeEvent>.broadcast();
   final List<String> calls = <String>[];
+  Object? linkError;
   List<WorkspaceSummary> workspaces = <WorkspaceSummary>[_workspace('a')];
   List<String> cascadeIds = <String>['a'];
 
@@ -224,6 +226,10 @@ class _FakeWorkspaceClient implements MobileWorkspaceClient {
     required String childWorkspaceId,
   }) async {
     calls.add('link $parentWorkspaceId $childWorkspaceId');
+    final error = linkError;
+    if (error != null) {
+      throw error;
+    }
   }
 
   @override


### PR DESCRIPTION
## Summary

- align mobile New Workspace From Prompt with desktop workspace selection and creation behavior
- add searchable Project, Source Branch, Parent Workspace, and Agent Profile selectors
- default Parent to the current project's main workspace while allowing active cross-project parents
- honor the configured default Agent Profile and start Agent before deferred Setup
- preserve created workspaces when parent linking fails and surface the warning
- filter folder projects from linked-workspace creation and keep mode switching locked while creation is active
- apply the same parent and searchable selection behavior to manual creation

## Validation

- flutter analyze
- flutter test
- gh act pull_request -W .github/workflows/pr.yml -j mobile (blocked by act's linked-worktree submodule checkout: fatal: not a git repository: (null)); native mobile checks passed