### PR TITLE
feat: open project settings from workspace menus

### DIFF
--- a/lib/src/features/settings/presentation/panes/projects_pane.dart
+++ b/lib/src/features/settings/presentation/panes/projects_pane.dart
@@ -15,7 +15,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 class ProjectSettingsPane extends ConsumerStatefulWidget {
-  const ProjectSettingsPane({super.key});
+  const ProjectSettingsPane({super.key, this.initialProjectId});
+
+  final String? initialProjectId;
 
   @override
   ConsumerState<ProjectSettingsPane> createState() =>
@@ -34,6 +36,12 @@ class _ProjectSettingsPaneState extends ConsumerState<ProjectSettingsPane> {
       <String, Future<ProjectConfig?>>{};
   String? _saveError;
   bool _saving = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _selectedProjectId = widget.initialProjectId;
+  }
 
   @override
   Widget build(BuildContext context) {

--- a/lib/src/features/settings/presentation/settings_dialog.dart
+++ b/lib/src/features/settings/presentation/settings_dialog.dart
@@ -37,7 +37,14 @@ const double _kDialogMinHeight = 560;
 const double _kDialogMaxHeight = 1280;
 
 class SettingsDialog extends ConsumerStatefulWidget {
-  const SettingsDialog({super.key});
+  const SettingsDialog({
+    super.key,
+    this.initialSectionId = 'application',
+    this.initialProjectId,
+  });
+
+  final String initialSectionId;
+  final String? initialProjectId;
 
   @override
   ConsumerState<SettingsDialog> createState() => _SettingsDialogState();
@@ -54,6 +61,7 @@ class _SettingsDialogState extends ConsumerState<SettingsDialog> {
   @override
   void initState() {
     super.initState();
+    _activeSectionId = widget.initialSectionId;
     _searchController.addListener(() {
       final next = _searchController.text.trim().toLowerCase();
       if (next != _query) {
@@ -313,7 +321,8 @@ class _SettingsDialogState extends ConsumerState<SettingsDialog> {
         icon: AleraIcons.folderSpecial,
         entries: projectSearchEntries,
         navGroup: SettingsNavGroup.resources,
-        builder: (_) => const ProjectSettingsPane(),
+        builder: (_) =>
+            ProjectSettingsPane(initialProjectId: widget.initialProjectId),
       ),
       SettingsSectionData(
         id: 'mobileDevices',

--- a/lib/src/features/workbench/presentation/project_workbench_sidebar_actions.dart
+++ b/lib/src/features/workbench/presentation/project_workbench_sidebar_actions.dart
@@ -17,6 +17,12 @@ mixin _ProjectWorkbenchSidebarActions
 
   Future<void> _openSettings() => openSettingsDialog(context);
 
+  Future<void> _openProjectSettings(Project project) => openSettingsDialog(
+    context,
+    initialSectionId: 'projects',
+    initialProjectId: project.id,
+  );
+
   Future<void> _createWorkspace(Project? initialProject) {
     return showCreateWorkspaceFlow(
       context,

--- a/lib/src/features/workbench/presentation/project_workbench_sidebar_body.dart
+++ b/lib/src/features/workbench/presentation/project_workbench_sidebar_body.dart
@@ -11,6 +11,7 @@ class _SidebarBody extends StatelessWidget {
     required this.onOpenWorkspaceInBrowser,
     required this.onSleepWorkspace,
     required this.onCreateWorkspace,
+    required this.onOpenProjectSettings,
     required this.onDeleteWorkspace,
     required this.onRenameProject,
     required this.onRemoveProject,
@@ -34,6 +35,7 @@ class _SidebarBody extends StatelessWidget {
   final Future<void> Function(Workspace workspace) onOpenWorkspaceInBrowser;
   final Future<void> Function(Workspace workspace) onSleepWorkspace;
   final Future<void> Function(Project project) onCreateWorkspace;
+  final Future<void> Function(Project project) onOpenProjectSettings;
   final Future<void> Function(Project project, Workspace workspace)
   onDeleteWorkspace;
   final Future<void> Function(Project project) onRenameProject;
@@ -104,6 +106,8 @@ class _SidebarBody extends StatelessWidget {
           onCreateWorkspace: row.project.supportsLinkedWorkspaces
               ? () => onCreateWorkspace(row.project)
               : null,
+          onOpenProjectSettings: () =>
+              unawaited(onOpenProjectSettings(row.project)),
           onRenameProject: () => onRenameProject(row.project),
           onRemoveProject: () => onRemoveProject(row.project),
         ),
@@ -136,6 +140,8 @@ class _SidebarBody extends StatelessWidget {
           onCopyPath: () => unawaited(onCopyWorkspacePath(row.workspace)),
           onOpenInBrowser: () =>
               unawaited(onOpenWorkspaceInBrowser(row.workspace)),
+          onOpenProjectSettings: () =>
+              unawaited(onOpenProjectSettings(row.project)),
           onSleep: () => onSleepWorkspace(row.workspace),
           onToggleExpanded: () =>
               controller.toggleWorkspaceExpanded(row.workspace.id),
@@ -299,6 +305,7 @@ class _ProjectHeaderTile extends StatefulWidget {
     required this.workspaceCount,
     required this.onToggle,
     required this.onCreateWorkspace,
+    required this.onOpenProjectSettings,
     required this.onRenameProject,
     required this.onRemoveProject,
   });
@@ -308,6 +315,7 @@ class _ProjectHeaderTile extends StatefulWidget {
   final int workspaceCount;
   final VoidCallback onToggle;
   final VoidCallback? onCreateWorkspace;
+  final VoidCallback onOpenProjectSettings;
   final VoidCallback onRenameProject;
   final VoidCallback onRemoveProject;
 
@@ -331,6 +339,11 @@ class _ProjectHeaderTileState extends State<_ProjectHeaderTile> {
         Offset.zero & overlay.size,
       ),
       items: <PopupMenuEntry<String>>[
+        const AleraDropdownEntry<String>(
+          value: _openProjectSettingsAction,
+          leading: Icon(AleraIcons.settings, size: 16),
+          label: 'Open Project Settings',
+        ),
         const AleraDropdownEntry<String>(
           value: 'rename',
           leading: Icon(AleraIcons.edit, size: 16),
@@ -356,7 +369,9 @@ class _ProjectHeaderTileState extends State<_ProjectHeaderTile> {
         ),
       ],
     );
-    if (selected == 'rename') {
+    if (selected == _openProjectSettingsAction) {
+      widget.onOpenProjectSettings();
+    } else if (selected == 'rename') {
       widget.onRenameProject();
     } else if (selected == 'new-workspace') {
       widget.onCreateWorkspace?.call();

--- a/lib/src/features/workbench/presentation/project_workbench_sidebar_shell.dart
+++ b/lib/src/features/workbench/presentation/project_workbench_sidebar_shell.dart
@@ -112,6 +112,7 @@ class _ProjectWorkbenchSidebarState
                                     openWorkspaceInBrowser,
                                 onSleepWorkspace: sleepWorkspace,
                                 onCreateWorkspace: _createWorkspace,
+                                onOpenProjectSettings: _openProjectSettings,
                                 onDeleteWorkspace: _deleteWorkspace,
                                 onRenameProject: _renameProject,
                                 onRemoveProject: _removeProject,

--- a/lib/src/features/workbench/presentation/project_workbench_workspace_actions.dart
+++ b/lib/src/features/workbench/presentation/project_workbench_workspace_actions.dart
@@ -6,6 +6,7 @@ part of 'project_workbench_sidebar.dart';
 /// library-private and consumed only by the sidebar parts.
 
 const String _renameAction = 'rename';
+const String _openProjectSettingsAction = 'open-project-settings';
 const String _openFolderAction = 'open-folder';
 const String _copyPathAction = 'copy-path';
 const String _openInBrowserAction = 'open-in-browser';
@@ -26,6 +27,11 @@ List<PopupMenuEntry<String>> workspaceContextMenuEntries({
   required bool isPinned,
 }) {
   return <PopupMenuEntry<String>>[
+    const AleraDropdownEntry<String>(
+      value: _openProjectSettingsAction,
+      leading: Icon(AleraIcons.settings, size: 16),
+      label: 'Open Project Settings',
+    ),
     const AleraDropdownEntry<String>(
       value: _renameAction,
       leading: Icon(AleraIcons.edit, size: 16),

--- a/lib/src/features/workbench/presentation/project_workbench_workspace_rows.dart
+++ b/lib/src/features/workbench/presentation/project_workbench_workspace_rows.dart
@@ -17,6 +17,7 @@ class _WorkspaceRow extends StatefulWidget {
     required this.onOpenFolder,
     required this.onCopyPath,
     required this.onOpenInBrowser,
+    required this.onOpenProjectSettings,
     required this.onSleep,
     required this.onToggleExpanded,
     required this.fileManagerLabel,
@@ -52,6 +53,7 @@ class _WorkspaceRow extends StatefulWidget {
   final VoidCallback onOpenFolder;
   final VoidCallback onCopyPath;
   final VoidCallback onOpenInBrowser;
+  final VoidCallback onOpenProjectSettings;
   final VoidCallback onSleep;
   final VoidCallback onToggleExpanded;
   final String fileManagerLabel;
@@ -95,7 +97,9 @@ class _WorkspaceRowState extends State<_WorkspaceRow> {
       ),
     );
 
-    if (selected == _renameAction) {
+    if (selected == _openProjectSettingsAction) {
+      widget.onOpenProjectSettings();
+    } else if (selected == _renameAction) {
       widget.onRename();
     } else if (selected == _togglePinAction) {
       widget.onSetPinned();

--- a/lib/src/features/workbench/presentation/workbench_dialog_launchers.dart
+++ b/lib/src/features/workbench/presentation/workbench_dialog_launchers.dart
@@ -26,10 +26,17 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 /// Extracted so both the sidebar controls and the keyboard command dispatcher
 /// trigger the exact same behavior (dialogs, clone progress, toasts).
 
-Future<void> openSettingsDialog(BuildContext context) {
+Future<void> openSettingsDialog(
+  BuildContext context, {
+  String initialSectionId = 'application',
+  String? initialProjectId,
+}) {
   return showDialog<void>(
     context: context,
-    builder: (_) => const SettingsDialog(),
+    builder: (_) => SettingsDialog(
+      initialSectionId: initialSectionId,
+      initialProjectId: initialProjectId,
+    ),
   );
 }
 

--- a/test/unit/project_workbench_workspace_actions_test.dart
+++ b/test/unit/project_workbench_workspace_actions_test.dart
@@ -1,0 +1,21 @@
+import 'package:alera/src/design_system/menus/alera_dropdown_entry.dart';
+import 'package:alera/src/features/workbench/presentation/project_workbench_sidebar.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('workspace context menu opens project settings', () {
+    final entries = workspaceContextMenuEntries(
+      fileManagerLabel: 'Files',
+      hasClearParent: false,
+      canRemove: true,
+      isPinned: false,
+    );
+
+    expect(
+      entries.whereType<AleraDropdownEntry<String>>().map(
+        (entry) => entry.label,
+      ),
+      contains('Open Project Settings'),
+    );
+  });
+}

--- a/test/widget/settings_dialog_core_test_cases.dart
+++ b/test/widget/settings_dialog_core_test_cases.dart
@@ -8,8 +8,6 @@ void _registerSettingsDialogCoreTests() {
     Size surfaceSize = const Size(1200, 900),
     SystemFontService? fontService,
     AiTextModelDiscoveryService? modelDiscoveryService,
-    String initialSectionId = 'application',
-    String? initialProjectId,
     List<dynamic> extraOverrides = const <dynamic>[],
   }) async {
     await tester.binding.setSurfaceSize(surfaceSize);
@@ -46,10 +44,7 @@ void _registerSettingsDialogCoreTests() {
         container: container,
         child: MaterialApp(
           theme: buildAleraDarkTheme(),
-          home: SettingsDialog(
-            initialSectionId: initialSectionId,
-            initialProjectId: initialProjectId,
-          ),
+          home: const SettingsDialog(),
         ),
       ),
     );
@@ -185,51 +180,6 @@ void _registerSettingsDialogCoreTests() {
     expect(saved.worktree.copy.single.to, '.env.local');
     expect(saved.worktree.copy.single.overwrite, isTrue);
     expect(saved.worktree.setup, <String>['pnpm install']);
-  });
-
-  testWidgets('opens project settings with the requested project selected', (
-    tester,
-  ) async {
-    final projects = <Project>[
-      Project(
-        id: 'project-1',
-        name: 'First Project',
-        repoPath: '/repo/first',
-        createdAt: DateTime.utc(2026, 6, 27),
-        updatedAt: DateTime.utc(2026, 6, 27),
-      ),
-      Project(
-        id: 'project-2',
-        name: 'Second Project',
-        repoPath: '/repo/second',
-        createdAt: DateTime.utc(2026, 6, 27),
-        updatedAt: DateTime.utc(2026, 6, 27),
-      ),
-    ];
-    final configRepository = FakeProjectConfigRepository();
-    addTearDown(configRepository.dispose);
-    final configService = ProjectConfigService(
-      repository: configRepository,
-      fileStore: FakeProjectConfigFileStore(),
-      now: () => DateTime.utc(2026, 6, 27),
-    );
-
-    await pumpSettingsDialogLocal(
-      tester,
-      initialSectionId: 'projects',
-      initialProjectId: 'project-2',
-      extraOverrides: <dynamic>[
-        projectRepositoryProvider.overrideWithValue(
-          _FakeProjectRepository(projects),
-        ),
-        projectConfigServiceProvider.overrideWithValue(configService),
-      ],
-    );
-    await tester.pumpAndSettle();
-
-    expect(find.text('Projects'), findsWidgets);
-    expect(find.text('/repo/second'), findsOneWidget);
-    expect(find.text('/repo/first'), findsNothing);
   });
 
   testWidgets('clears dirty project setup edits when using repo file', (

--- a/test/widget/settings_dialog_core_test_cases.dart
+++ b/test/widget/settings_dialog_core_test_cases.dart
@@ -8,6 +8,8 @@ void _registerSettingsDialogCoreTests() {
     Size surfaceSize = const Size(1200, 900),
     SystemFontService? fontService,
     AiTextModelDiscoveryService? modelDiscoveryService,
+    String initialSectionId = 'application',
+    String? initialProjectId,
     List<dynamic> extraOverrides = const <dynamic>[],
   }) async {
     await tester.binding.setSurfaceSize(surfaceSize);
@@ -44,7 +46,10 @@ void _registerSettingsDialogCoreTests() {
         container: container,
         child: MaterialApp(
           theme: buildAleraDarkTheme(),
-          home: const SettingsDialog(),
+          home: SettingsDialog(
+            initialSectionId: initialSectionId,
+            initialProjectId: initialProjectId,
+          ),
         ),
       ),
     );
@@ -180,6 +185,51 @@ void _registerSettingsDialogCoreTests() {
     expect(saved.worktree.copy.single.to, '.env.local');
     expect(saved.worktree.copy.single.overwrite, isTrue);
     expect(saved.worktree.setup, <String>['pnpm install']);
+  });
+
+  testWidgets('opens project settings with the requested project selected', (
+    tester,
+  ) async {
+    final projects = <Project>[
+      Project(
+        id: 'project-1',
+        name: 'First Project',
+        repoPath: '/repo/first',
+        createdAt: DateTime.utc(2026, 6, 27),
+        updatedAt: DateTime.utc(2026, 6, 27),
+      ),
+      Project(
+        id: 'project-2',
+        name: 'Second Project',
+        repoPath: '/repo/second',
+        createdAt: DateTime.utc(2026, 6, 27),
+        updatedAt: DateTime.utc(2026, 6, 27),
+      ),
+    ];
+    final configRepository = FakeProjectConfigRepository();
+    addTearDown(configRepository.dispose);
+    final configService = ProjectConfigService(
+      repository: configRepository,
+      fileStore: FakeProjectConfigFileStore(),
+      now: () => DateTime.utc(2026, 6, 27),
+    );
+
+    await pumpSettingsDialogLocal(
+      tester,
+      initialSectionId: 'projects',
+      initialProjectId: 'project-2',
+      extraOverrides: <dynamic>[
+        projectRepositoryProvider.overrideWithValue(
+          _FakeProjectRepository(projects),
+        ),
+        projectConfigServiceProvider.overrideWithValue(configService),
+      ],
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Projects'), findsWidgets);
+    expect(find.text('/repo/second'), findsOneWidget);
+    expect(find.text('/repo/first'), findsNothing);
   });
 
   testWidgets('clears dirty project setup edits when using repo file', (

--- a/test/widget/settings_dialog_project_test_cases.dart
+++ b/test/widget/settings_dialog_project_test_cases.dart
@@ -1,0 +1,48 @@
+part of 'settings_dialog_test.dart';
+
+void _registerSettingsDialogProjectTests() {
+  testWidgets('opens project settings with the requested project selected', (
+    tester,
+  ) async {
+    final projects = <Project>[
+      Project(
+        id: 'project-1',
+        name: 'First Project',
+        repoPath: '/repo/first',
+        createdAt: DateTime.utc(2026, 6, 27),
+        updatedAt: DateTime.utc(2026, 6, 27),
+      ),
+      Project(
+        id: 'project-2',
+        name: 'Second Project',
+        repoPath: '/repo/second',
+        createdAt: DateTime.utc(2026, 6, 27),
+        updatedAt: DateTime.utc(2026, 6, 27),
+      ),
+    ];
+    final configRepository = FakeProjectConfigRepository();
+    addTearDown(configRepository.dispose);
+    final configService = ProjectConfigService(
+      repository: configRepository,
+      fileStore: FakeProjectConfigFileStore(),
+      now: () => DateTime.utc(2026, 6, 27),
+    );
+
+    await _pumpSettingsDialog(
+      tester,
+      initialSectionId: 'projects',
+      initialProjectId: 'project-2',
+      extraOverrides: <dynamic>[
+        projectRepositoryProvider.overrideWithValue(
+          _FakeProjectRepository(projects),
+        ),
+        projectConfigServiceProvider.overrideWithValue(configService),
+      ],
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Projects'), findsWidgets);
+    expect(find.text('/repo/second'), findsOneWidget);
+    expect(find.text('/repo/first'), findsNothing);
+  });
+}

--- a/test/widget/settings_dialog_test.dart
+++ b/test/widget/settings_dialog_test.dart
@@ -46,6 +46,7 @@ import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 import '../unit/fake_project_config.dart';
 
 part 'settings_dialog_core_test_cases.dart';
+part 'settings_dialog_project_test_cases.dart';
 part 'settings_dialog_ai_text_test_cases.dart';
 part 'settings_dialog_quota_test_cases.dart';
 part 'settings_dialog_terminal_test_cases.dart';
@@ -59,6 +60,8 @@ Future<ProviderContainer> _pumpSettingsDialog(
   Size surfaceSize = const Size(1200, 900),
   SystemFontService? fontService,
   AiTextModelDiscoveryService? modelDiscoveryService,
+  String initialSectionId = 'application',
+  String? initialProjectId,
   List<dynamic> extraOverrides = const <dynamic>[],
 }) async {
   await tester.binding.setSurfaceSize(surfaceSize);
@@ -95,7 +98,10 @@ Future<ProviderContainer> _pumpSettingsDialog(
       container: container,
       child: MaterialApp(
         theme: buildAleraDarkTheme(),
-        home: const SettingsDialog(),
+        home: SettingsDialog(
+          initialSectionId: initialSectionId,
+          initialProjectId: initialProjectId,
+        ),
       ),
     ),
   );
@@ -111,6 +117,7 @@ Future<void> _selectTerminalSection(WidgetTester tester) async {
 
 void main() {
   _registerSettingsDialogCoreTests();
+  _registerSettingsDialogProjectTests();
   _registerSettingsDialogAiTextTests();
   _registerSettingsDialogQuotaTests();
   _registerSettingsDialogTerminalTests();


### PR DESCRIPTION
## summary

- Add Open Project Settings to workspace and project context menus.
- Open the Projects settings section and preselect the originating project.

## validation

- dart format --set-exit-if-changed lib test integration_test tool
- flutter analyze --no-pub
- flutter test --no-pub
- focused settings, sidebar, and menu tests
- gh act pull_request -W .github/workflows/pr.yml attempted; local container emulation was limited by checkout, image authentication, and root-permission behavior

## notes

- No generated Riverpod, Drift, or dart_mappable surfaces changed.
