### PR TITLE
feat: test managed agent profile commands

### DIFF
--- a/lib/src/features/settings/presentation/panes/agent_profile_editor.dart
+++ b/lib/src/features/settings/presentation/panes/agent_profile_editor.dart
@@ -69,6 +69,10 @@ class AgentProfileEditor extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final managedCommandPreview = managedAgentCommandPreview(
+      adapter,
+      managedConfig,
+    );
     return SingleChildScrollView(
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -149,17 +153,40 @@ class AgentProfileEditor extends StatelessWidget {
                   commandController: commandController,
                 ),
               ] else
-                AleraSettingRow(
-                  title: 'Command Preview',
-                  description:
-                      'The Host Quotes These Arguments For The Actual Platform Shell.',
-                  controlWidth: 320,
-                  child: SelectableText(
-                    managedAgentCommandPreview(adapter, managedConfig),
-                    style: theme.textTheme.bodySmall?.copyWith(
-                      color: AleraTokens.foregroundMuted,
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: <Widget>[
+                    AleraSettingRow(
+                      title: 'Command Preview',
+                      description:
+                          'The Host Quotes These Arguments For The Actual Platform Shell.',
+                      controlWidth: 320,
+                      child: SelectableText(
+                        managedCommandPreview,
+                        style: theme.textTheme.bodySmall?.copyWith(
+                          color: AleraTokens.foregroundMuted,
+                        ),
+                      ),
                     ),
-                  ),
+                    Padding(
+                      padding: const EdgeInsets.only(
+                        left: AleraTokens.space12,
+                        right: AleraTokens.space12,
+                        top: AleraTokens.space8,
+                      ),
+                      child: Align(
+                        alignment: Alignment.centerRight,
+                        child: OutlinedButton.icon(
+                          onPressed:
+                              saving || managedCommandPreview.trim().isEmpty
+                              ? null
+                              : onTestCommand,
+                          icon: const Icon(AleraIcons.terminal, size: 16),
+                          label: const Text('Test Command'),
+                        ),
+                      ),
+                    ),
+                  ],
                 ),
             ],
           ),

--- a/lib/src/features/settings/presentation/panes/agent_profiles_pane.dart
+++ b/lib/src/features/settings/presentation/panes/agent_profiles_pane.dart
@@ -171,9 +171,7 @@ class _AgentProfilesSettingsPaneState
             onRemove: selectedProfile == null
                 ? null
                 : () => _removeProfile(selectedProfile),
-            onTestCommand: _launchMode == AgentProfileLaunchMode.command
-                ? () => unawaited(_testCommand())
-                : null,
+            onTestCommand: () => unawaited(_testCommand()),
           ),
         );
       },

--- a/lib/src/features/settings/presentation/panes/agent_profiles_pane_profile_actions.dart
+++ b/lib/src/features/settings/presentation/panes/agent_profiles_pane_profile_actions.dart
@@ -79,7 +79,11 @@ extension _AgentProfilesPaneProfileActions on _AgentProfilesSettingsPaneState {
   }
 
   Future<void> _testCommand() async {
-    final command = _commandController.text.trim();
+    final command =
+        (_launchMode == AgentProfileLaunchMode.managed
+                ? managedAgentCommandPreview(_adapter, _managedConfig)
+                : _commandController.text)
+            .trim();
     if (command.isEmpty) {
       _setPaneState(() => _error = 'Command is required.');
       return;

--- a/test/widget/agent_profile_editor_test.dart
+++ b/test/widget/agent_profile_editor_test.dart
@@ -88,6 +88,40 @@ void main() {
     expect(testCommandCalls, 1);
   });
 
+  testWidgets('managed mode offers to test the current command preview', (
+    tester,
+  ) async {
+    var testCommandCalls = 0;
+    await tester.pumpWidget(
+      _EditorHarness(
+        launchMode: AgentProfileLaunchMode.managed,
+        managedConfig: const <String, Object?>{'model': 'gpt-5.6-sol'},
+        onTestCommand: () => testCommandCalls++,
+      ),
+    );
+
+    await tester.tap(find.text('Test Command'));
+    await tester.pump();
+
+    expect(testCommandCalls, 1);
+  });
+
+  testWidgets('managed mode disables testing while saving', (tester) async {
+    var testCommandCalls = 0;
+    await tester.pumpWidget(
+      _EditorHarness(
+        launchMode: AgentProfileLaunchMode.managed,
+        managedConfig: const <String, Object?>{'model': 'gpt-5.6-sol'},
+        saving: true,
+        onTestCommand: () => testCommandCalls++,
+      ),
+    );
+
+    final testButton = find.widgetWithText(OutlinedButton, 'Test Command');
+    expect(tester.widget<OutlinedButton>(testButton).onPressed, isNull);
+    expect(testCommandCalls, 0);
+  });
+
   testWidgets('a Claude managed profile can route through a CCS profile', (
     tester,
   ) async {
@@ -163,12 +197,14 @@ class _EditorHarness extends StatefulWidget {
     required this.launchMode,
     this.adapter = AgentType.codex,
     this.managedConfig = const <String, Object?>{},
+    this.saving = false,
     this.onTestCommand,
   });
 
   final AgentProfileLaunchMode launchMode;
   final AgentType adapter;
   final Map<String, Object?> managedConfig;
+  final bool saving;
   final VoidCallback? onTestCommand;
 
   @override
@@ -219,7 +255,7 @@ class _EditorHarnessState extends State<_EditorHarness> {
             ],
             personas: const <ManagedAgentOption>[],
             hasSelection: true,
-            saving: false,
+            saving: widget.saving,
             onAdapterChanged: (_) {},
             onLaunchModeChanged: (_) {},
             onManagedConfigChanged: (_) {},

--- a/test/widget/agent_profiles_pane_test.dart
+++ b/test/widget/agent_profiles_pane_test.dart
@@ -2,6 +2,7 @@ import 'package:alera/src/app/providers.dart';
 import 'package:alera/src/app/theme/alera_dark_theme.dart';
 import 'package:alera/src/features/agent_profiles/application/agent_profile_providers.dart';
 import 'package:alera/src/features/agent_profiles/domain/agent_profile.dart';
+import 'package:alera/src/features/agent_status/domain/agent_status.dart';
 import 'package:alera/src/features/settings/domain/alera_settings.dart';
 import 'package:alera/src/features/settings/presentation/panes/agent_profiles_pane.dart';
 import 'package:flutter/material.dart';
@@ -11,35 +12,17 @@ import 'package:flutter_test/flutter_test.dart';
 import 'command_terminal_test_doubles.dart';
 
 void main() {
-  testWidgets('agent profile tests its command in the embedded terminal', (
+  testWidgets('command profile tests its command in the embedded terminal', (
     tester,
   ) async {
     final runtime = FakeCommandTerminalRuntime(running: false);
     addTearDown(runtime.dispose);
 
-    await tester.pumpWidget(
-      ProviderScope(
-        overrides: [
-          agentProfilesProvider.overrideWith(() => _TestAgentProfiles()),
-          settingsControllerProvider.overrideWith(
-            () => _TestSettingsController(),
-          ),
-          terminalRuntimeProvider.overrideWithValue(runtime),
-        ],
-        child: MaterialApp(
-          theme: buildAleraDarkTheme(),
-          home: const Scaffold(
-            body: SizedBox(
-              width: 1200,
-              height: 1000,
-              child: AgentProfilesSettingsPane(),
-            ),
-          ),
-        ),
-      ),
+    await _pumpPane(
+      tester,
+      runtime,
+      _profile(launchMode: AgentProfileLaunchMode.command),
     );
-    await tester.pump();
-    await tester.pump(const Duration(milliseconds: 100));
 
     await tester.tap(find.text('Test Command'));
     await tester.pumpAndSettle();
@@ -52,23 +35,94 @@ void main() {
 
     expect(runtime.closedTabIds, <String>[runtime.lastTab!.id]);
   });
+
+  testWidgets('managed profile tests its current command preview', (
+    tester,
+  ) async {
+    final runtime = FakeCommandTerminalRuntime(running: false);
+    addTearDown(runtime.dispose);
+
+    await _pumpPane(
+      tester,
+      runtime,
+      _profile(
+        adapter: AgentType.amp,
+        launchMode: AgentProfileLaunchMode.managed,
+        managedConfig: const <String, Object?>{'mode': 'ultra', 'fast': true},
+      ),
+    );
+
+    await tester.tap(find.text('Test Command'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Test Agent Profile'), findsOneWidget);
+    expect(runtime.lastTab?.initialCommand, 'amp --mode ultra --fast');
+
+    await tester.tap(find.text('Close'));
+    await tester.pumpAndSettle();
+
+    expect(runtime.closedTabIds, <String>[runtime.lastTab!.id]);
+  });
+}
+
+AgentProfile _profile({
+  required AgentProfileLaunchMode launchMode,
+  AgentType adapter = AgentType.codex,
+  Map<String, Object?> managedConfig = const <String, Object?>{},
+}) {
+  final now = DateTime.utc(2026, 8, 1);
+  return AgentProfile(
+    id: 'profile-1',
+    name: 'Codex Sol',
+    agentType: adapter.key,
+    command: launchMode == AgentProfileLaunchMode.command
+        ? 'codex --model gpt-5.6-sol'
+        : adapter.key,
+    launchMode: launchMode,
+    managedConfig: managedConfig,
+    createdAt: now,
+    updatedAt: now,
+  );
+}
+
+Future<void> _pumpPane(
+  WidgetTester tester,
+  FakeCommandTerminalRuntime runtime,
+  AgentProfile profile,
+) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        agentProfilesProvider.overrideWith(() => _TestAgentProfiles(profile)),
+        settingsControllerProvider.overrideWith(
+          () => _TestSettingsController(),
+        ),
+        terminalRuntimeProvider.overrideWithValue(runtime),
+      ],
+      child: MaterialApp(
+        theme: buildAleraDarkTheme(),
+        home: const Scaffold(
+          body: SizedBox(
+            width: 1200,
+            height: 1000,
+            child: AgentProfilesSettingsPane(),
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pump();
+  await tester.pump(const Duration(milliseconds: 100));
 }
 
 class _TestAgentProfiles extends AgentProfiles {
+  _TestAgentProfiles(this.profile);
+
+  final AgentProfile profile;
+
   @override
   Future<List<AgentProfile>> build() async {
-    final now = DateTime.utc(2026, 8, 1);
-    return <AgentProfile>[
-      AgentProfile(
-        id: 'profile-1',
-        name: 'Codex Sol',
-        agentType: 'codex',
-        command: 'codex --model gpt-5.6-sol',
-        launchMode: AgentProfileLaunchMode.command,
-        createdAt: now,
-        updatedAt: now,
-      ),
-    ];
+    return <AgentProfile>[profile];
   }
 }
 


### PR DESCRIPTION
## Summary

- Add Test Command to Managed agent profiles using the current command preview.
- Run the preview in the shared embedded command terminal without saving the profile or dispatching a task.
- Keep the button disabled while the profile is saving and when the preview is empty.
- Cover the editor action and the full Managed terminal lifecycle, including opening, initial command, and closing the tab.

## Validation

- `dart format --set-exit-if-changed lib test integration_test tool`
- `dart tool/quality/check_max_lines.dart`
- `flutter analyze`
- `flutter test --no-pub` - 2,545 tests passed.
- Focused profile and terminal tests - 52 tests passed before the final saving-state assertion, plus 11 editor tests after it.
- `gh act pull_request -W .github/workflows/pr.yml` was attempted; local emulation was blocked by missing Git metadata inside copied containers, Docker RWLayer/container errors, and exit code 137. Native gates and hosted checks remain authoritative.

No documentation update is needed for this UI-only extension.