### PR TITLE
fix: keep all skills actions on one row

### DIFF
--- a/lib/src/features/settings/presentation/panes/alera_all_skills_control.dart
+++ b/lib/src/features/settings/presentation/panes/alera_all_skills_control.dart
@@ -17,8 +17,6 @@ class AleraAllSkillsControl extends ConsumerWidget {
       commandFor: (runner) => aleraAllSkillsInstallCommand(runner: runner),
       runCommand: (context, request) =>
           showCommandTerminalDialog(context, ref, request),
-      installLabel: 'Install / Update All',
-      runningLabel: 'Running All',
       followUp: () async {
         final result =
             await AleraOrchestrationSetupService(

--- a/test/widget/agents_cli_skill_control_test.dart
+++ b/test/widget/agents_cli_skill_control_test.dart
@@ -247,7 +247,7 @@ void main() {
       ),
     );
 
-    await tester.tap(find.text('Install / Update All'));
+    await tester.tap(find.text('Install / Update'));
     await tester.pumpAndSettle();
 
     expect(find.text('Install All Alera Skills'), findsOneWidget);
@@ -265,6 +265,34 @@ void main() {
 
     expect(reconciler.settings?.codex, isTrue);
     expect(find.text('Selected Hooks Ready'), findsOneWidget);
+  });
+
+  testWidgets('all skills control keeps its three buttons on one row', (
+    tester,
+  ) async {
+    final fontLoader = FontLoader('Inter')
+      ..addFont(rootBundle.load('assets/fonts/Inter-Variable.ttf'));
+    await fontLoader.load();
+
+    await tester.pumpWidget(
+      ProviderScope(
+        child: MaterialApp(
+          theme: buildAleraDarkTheme(),
+          home: const Scaffold(
+            body: SizedBox(width: 360, child: AleraAllSkillsControl()),
+          ),
+        ),
+      ),
+    );
+
+    final outlinedButtons = find.byType(OutlinedButton);
+    final filledButton = find.byType(FilledButton);
+    expect(outlinedButtons, findsNWidgets(2));
+    expect(filledButton, findsOneWidget);
+
+    final runnerY = tester.getTopLeft(outlinedButtons.at(0)).dy;
+    expect(tester.getTopLeft(outlinedButtons.at(1)).dy, runnerY);
+    expect(tester.getTopLeft(filledButton).dy, runnerY);
   });
 
   testWidgets('all skills control copies without opening the terminal', (


### PR DESCRIPTION
## Summary

- Keep the All Skills action buttons on one row by using the same compact labels as individual skill controls.
- Add a widget regression test for the 360 px settings control width.

## Validation

- `dart format --set-exit-if-changed lib test integration_test tool`
- `dart tool/quality/check_max_lines.dart`
- `flutter analyze --no-pub`
- `flutter test --no-pub`

The local `gh act` PR workflow run was inconclusive because Docker could not authenticate to the runner image and act could not preserve the linked checkout as a Git repository. Native local gates above passed; hosted PR checks are required for merge.

