### PR TITLE
feat: resize settings master detail panes

### DIFF
--- a/lib/src/app/theme/alera_tokens.dart
+++ b/lib/src/app/theme/alera_tokens.dart
@@ -23,6 +23,10 @@ abstract final class AleraTokens {
   static const double sidebarMaxWidth = 460.0;
   static const double sidebarDefaultWidth = 300.0;
   static const double sidebarCollapsedWidth = 52.0;
+  static const double masterDetailDefaultWidth = 240.0;
+  static const double masterDetailMinWidth = 180.0;
+  static const double masterDetailMaxWidth = 420.0;
+  static const double masterDetailMinDetailWidth = 240.0;
   static const double emptyStateMaxWidth = 520.0;
   static const double activityLogHeight = 160.0;
   static const double imageMaxWidth = 400.0;

--- a/lib/src/design_system/layout/alera_master_detail.dart
+++ b/lib/src/design_system/layout/alera_master_detail.dart
@@ -1,20 +1,24 @@
+import 'dart:math' as math;
+
 import 'package:alera/src/app/theme/alera_tokens.dart';
 import 'package:flutter/material.dart';
 
-/// Resource-management scaffold: a fixed-width master column (header with
+/// Resource-management scaffold: a resizable master column (header with
 /// title and optional action, then a scrollable list) beside an expanded
 /// detail area with its own scroll context.
 ///
-/// Used by settings resource panes (Projects, Remote Hosts) so entity CRUD
-/// screens share one layout.
-class AleraMasterDetail extends StatelessWidget {
+/// Used by settings resource panes (Projects, Remote Hosts, Agent Profiles)
+/// so entity CRUD screens share one layout.
+class AleraMasterDetail extends StatefulWidget {
   const AleraMasterDetail({
     super.key,
     required this.masterTitle,
     this.masterAction,
     required this.master,
     required this.detail,
-    this.masterWidth = 240,
+    this.masterWidth = AleraTokens.masterDetailDefaultWidth,
+    this.masterMinWidth = AleraTokens.masterDetailMinWidth,
+    this.masterMaxWidth = AleraTokens.masterDetailMaxWidth,
   });
 
   final String masterTitle;
@@ -22,48 +26,178 @@ class AleraMasterDetail extends StatelessWidget {
   final Widget master;
   final Widget detail;
   final double masterWidth;
+  final double masterMinWidth;
+  final double masterMaxWidth;
+
+  @override
+  State<AleraMasterDetail> createState() => _AleraMasterDetailState();
+}
+
+class _AleraMasterDetailState extends State<AleraMasterDetail> {
+  late double _masterWidth;
+
+  @override
+  void initState() {
+    super.initState();
+    _masterWidth = widget.masterWidth;
+  }
+
+  @override
+  void didUpdateWidget(AleraMasterDetail oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.masterWidth != oldWidget.masterWidth) {
+      _masterWidth = widget.masterWidth;
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    return Row(
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: <Widget>[
-        SizedBox(
-          width: masterWidth,
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: <Widget>[
-              Padding(
-                padding: const EdgeInsets.only(
-                  left: AleraTokens.space4,
-                  bottom: AleraTokens.space8,
-                ),
-                child: Row(
-                  children: <Widget>[
-                    Expanded(
-                      child: Text(
-                        masterTitle,
-                        style: theme.textTheme.titleSmall?.copyWith(
-                          color: AleraTokens.foreground,
-                          fontWeight: FontWeight.w600,
-                        ),
-                      ),
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final maximumMasterWidth = _maximumMasterWidth(constraints);
+        final masterWidth = _masterWidth
+            .clamp(widget.masterMinWidth, maximumMasterWidth)
+            .toDouble();
+        return Row(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: <Widget>[
+            SizedBox(
+              width: masterWidth,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: <Widget>[
+                  Padding(
+                    padding: const EdgeInsets.only(
+                      left: AleraTokens.space4,
+                      bottom: AleraTokens.space8,
                     ),
-                    ?masterAction,
-                  ],
+                    child: Row(
+                      children: <Widget>[
+                        Expanded(
+                          child: Text(
+                            widget.masterTitle,
+                            style: theme.textTheme.titleSmall?.copyWith(
+                              color: AleraTokens.foreground,
+                              fontWeight: FontWeight.w600,
+                            ),
+                          ),
+                        ),
+                        ?widget.masterAction,
+                      ],
+                    ),
+                  ),
+                  Expanded(child: widget.master),
+                ],
+              ),
+            ),
+            _MasterDetailResizeHandle(
+              currentWidth: masterWidth,
+              minWidth: widget.masterMinWidth,
+              maxWidth: maximumMasterWidth,
+              label: 'Resize ${widget.masterTitle} List',
+              onResize: (width) => setState(() {
+                _masterWidth = width;
+              }),
+            ),
+            Expanded(child: widget.detail),
+          ],
+        );
+      },
+    );
+  }
+
+  double _maximumMasterWidth(BoxConstraints constraints) {
+    if (!constraints.hasBoundedWidth) {
+      return widget.masterMaxWidth;
+    }
+    final availableWidth =
+        constraints.maxWidth -
+        _masterDetailHandleWidth -
+        AleraTokens.masterDetailMinDetailWidth;
+    return math.max(
+      widget.masterMinWidth,
+      math.min(widget.masterMaxWidth, availableWidth),
+    );
+  }
+}
+
+const double _masterDetailHandleWidth =
+    AleraTokens.space16 * 2 + AleraTokens.dividerExtent;
+
+class _MasterDetailResizeHandle extends StatefulWidget {
+  const _MasterDetailResizeHandle({
+    required this.currentWidth,
+    required this.minWidth,
+    required this.maxWidth,
+    required this.label,
+    required this.onResize,
+  });
+
+  final double currentWidth;
+  final double minWidth;
+  final double maxWidth;
+  final String label;
+  final ValueChanged<double> onResize;
+
+  @override
+  State<_MasterDetailResizeHandle> createState() =>
+      _MasterDetailResizeHandleState();
+}
+
+class _MasterDetailResizeHandleState extends State<_MasterDetailResizeHandle> {
+  bool _hovered = false;
+  bool _dragging = false;
+  double? _dragWidth;
+
+  @override
+  Widget build(BuildContext context) {
+    final emphasised = _hovered || _dragging;
+    return Semantics(
+      container: true,
+      label: widget.label,
+      child: MouseRegion(
+        cursor: SystemMouseCursors.resizeColumn,
+        onEnter: (_) => setState(() => _hovered = true),
+        onExit: (_) => setState(() => _hovered = false),
+        child: GestureDetector(
+          key: const ValueKey<String>('alera-master-detail-resize-handle'),
+          behavior: HitTestBehavior.translucent,
+          onHorizontalDragStart: (_) {
+            _dragWidth = widget.currentWidth;
+            setState(() => _dragging = true);
+          },
+          onHorizontalDragEnd: (_) => _stopDragging(),
+          onHorizontalDragCancel: _stopDragging,
+          onHorizontalDragUpdate: (details) {
+            final next = (_dragWidth ?? widget.currentWidth) + details.delta.dx;
+            final constrained = next.clamp(widget.minWidth, widget.maxWidth);
+            _dragWidth = constrained.toDouble();
+            widget.onResize(_dragWidth!);
+          },
+          child: SizedBox(
+            width: _masterDetailHandleWidth,
+            child: Center(
+              child: AnimatedContainer(
+                duration: AleraTokens.durationFast,
+                width: emphasised
+                    ? AleraTokens.space2
+                    : AleraTokens.dividerExtent,
+                decoration: BoxDecoration(
+                  color: emphasised
+                      ? AleraTokens.border
+                      : AleraTokens.borderSubtle,
                 ),
               ),
-              Expanded(child: master),
-            ],
+            ),
           ),
         ),
-        const Padding(
-          padding: EdgeInsets.symmetric(horizontal: AleraTokens.space16),
-          child: VerticalDivider(width: 1, color: AleraTokens.borderSubtle),
-        ),
-        Expanded(child: detail),
-      ],
+      ),
     );
+  }
+
+  void _stopDragging() {
+    _dragWidth = null;
+    setState(() => _dragging = false);
   }
 }

--- a/test/widget/alera_master_detail_test.dart
+++ b/test/widget/alera_master_detail_test.dart
@@ -1,0 +1,50 @@
+import 'package:alera/src/design_system/layout/alera_master_detail.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('master detail splitter moves within its width limits', (
+    tester,
+  ) async {
+    const masterKey = ValueKey<String>('master-detail-master');
+    const handleKey = ValueKey<String>('alera-master-detail-resize-handle');
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: SizedBox(
+          width: 800,
+          height: 320,
+          child: AleraMasterDetail(
+            masterTitle: 'Projects',
+            master: SizedBox(key: masterKey),
+            detail: const SizedBox(),
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.getSize(find.byKey(masterKey)).width, 240);
+
+    final handle = find.byKey(handleKey);
+    final dragRight = await tester.startGesture(tester.getCenter(handle));
+    await dragRight.moveBy(const Offset(64, 0));
+    await dragRight.up();
+    await tester.pumpAndSettle();
+
+    expect(tester.getSize(find.byKey(masterKey)).width, 304);
+
+    final dragPastMinimum = await tester.startGesture(tester.getCenter(handle));
+    await dragPastMinimum.moveBy(const Offset(-200, 0));
+    await dragPastMinimum.up();
+    await tester.pumpAndSettle();
+
+    expect(tester.getSize(find.byKey(masterKey)).width, 180);
+
+    final dragPastMaximum = await tester.startGesture(tester.getCenter(handle));
+    await dragPastMaximum.moveBy(const Offset(500, 0));
+    await dragPastMaximum.up();
+    await tester.pumpAndSettle();
+
+    expect(tester.getSize(find.byKey(masterKey)).width, 420);
+  });
+}


### PR DESCRIPTION
## Summary

- Make the shared settings master-detail divider draggable in Projects, Remote Hosts, and Agent Profiles.
- Clamp the master list width while keeping the detail pane usable and preserve the existing dark design tokens.
- Add widget coverage for drag updates and minimum/maximum widths.

## Validation

- `flutter analyze`
- `dart tool/quality/check_max_lines.dart`
- `dart format --set-exit-if-changed ...`
- `flutter test test/widget/alera_master_detail_test.dart test/widget/settings_dialog_test.dart test/widget/agent_profiles_pane_test.dart test/widget/sidebar_resize_handle_test.dart`
- `git diff --check`
- `gh act pull_request -W .github/workflows/pr.yml` was attempted; local emulation was blocked by linked-worktree submodule initialization, Docker image authentication, and a container resource failure. Hosted checks remain authoritative.

No documentation update is needed because this is an internal UI interaction change.