### PR TITLE
fix: align remote host action buttons

### DIFF
--- a/lib/src/features/settings/presentation/panes/remote_host_editor.dart
+++ b/lib/src/features/settings/presentation/panes/remote_host_editor.dart
@@ -196,7 +196,10 @@ class RemoteHostEditor extends StatelessWidget {
                   spacing: AleraTokens.space8,
                   runSpacing: AleraTokens.space8,
                   children: <Widget>[
-                    ElevatedButton.icon(
+                    // The app theme styles FilledButton and gives enabled
+                    // buttons the click cursor; ElevatedButton falls back to
+                    // Material defaults here.
+                    FilledButton.icon(
                       onPressed: saving || bootstrapping ? null : onSave,
                       icon: Icon(saving ? AleraIcons.loading : AleraIcons.save),
                       label: const Text('Save'),

--- a/test/widget/remote_host_editor_test.dart
+++ b/test/widget/remote_host_editor_test.dart
@@ -1,0 +1,69 @@
+import 'package:alera/src/app/theme/alera_dark_theme.dart';
+import 'package:alera/src/features/remote_hosts/domain/ssh_target.dart';
+import 'package:alera/src/features/settings/presentation/panes/remote_host_editor.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('remote host save button uses the click cursor', (tester) async {
+    final aliasController = TextEditingController();
+    final hostController = TextEditingController();
+    final portController = TextEditingController(text: '22');
+    final usernameController = TextEditingController();
+    final installDirController = TextEditingController();
+    addTearDown(aliasController.dispose);
+    addTearDown(hostController.dispose);
+    addTearDown(portController.dispose);
+    addTearDown(usernameController.dispose);
+    addTearDown(installDirController.dispose);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: buildAleraDarkTheme(),
+        home: Scaffold(
+          body: RemoteHostEditor(
+            aliasController: aliasController,
+            hostController: hostController,
+            portController: portController,
+            usernameController: usernameController,
+            installDirController: installDirController,
+            platform: '',
+            arch: '',
+            authKind: SshAuthKind.agent,
+            hasSelection: false,
+            saving: false,
+            planning: false,
+            bootstrapping: false,
+            onPlatformChanged: (_) {},
+            onArchChanged: (_) {},
+            onAuthKindChanged: (_) {},
+            onSave: () {},
+            onRemove: null,
+            onPlan: null,
+            onBootstrap: null,
+            onCancel: null,
+          ),
+        ),
+      ),
+    );
+
+    final saveButton = find.widgetWithText(FilledButton, 'Save');
+    await tester.ensureVisible(saveButton);
+    await tester.pump();
+
+    final mouse = await tester.createGesture(
+      kind: PointerDeviceKind.mouse,
+      pointer: 1,
+    );
+    addTearDown(mouse.removePointer);
+    await mouse.addPointer(location: tester.getCenter(saveButton));
+    await tester.pump();
+
+    expect(
+      RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1),
+      SystemMouseCursors.click,
+    );
+  });
+}

--- a/test/widget/settings_dialog_interaction_test_cases.dart
+++ b/test/widget/settings_dialog_interaction_test_cases.dart
@@ -455,7 +455,7 @@ void _registerSettingsDialogAdvancedTests() {
     expect(runtimeClient.targets.single.host, 'new.example.com');
     expect(
       tester
-          .widget<ElevatedButton>(find.widgetWithText(ElevatedButton, 'Save'))
+          .widget<FilledButton>(find.widgetWithText(FilledButton, 'Save'))
           .onPressed,
       isNull,
     );
@@ -699,7 +699,7 @@ void _registerSettingsDialogAdvancedTests() {
     );
 
     await _enterRemoteHostText(tester, 'Host', 'second-edited.example.com');
-    final saveButton = find.widgetWithText(ElevatedButton, 'Save');
+    final saveButton = find.widgetWithText(FilledButton, 'Save');
     await tester.ensureVisible(saveButton);
     await tester.tap(saveButton);
     await tester.pumpAndSettle();
@@ -781,7 +781,7 @@ void _registerSettingsDialogAdvancedTests() {
 
     expect(find.text('Password'), findsOneWidget);
 
-    final saveButton = find.widgetWithText(ElevatedButton, 'Save');
+    final saveButton = find.widgetWithText(FilledButton, 'Save');
     await tester.ensureVisible(saveButton);
     await tester.tap(saveButton);
     await tester.pumpAndSettle();
@@ -812,7 +812,7 @@ void _registerSettingsDialogAdvancedTests() {
     await _selectRemoteHostsSection(tester);
 
     await _enterRemoteHostText(tester, 'Port', '2222a');
-    final saveButton = find.widgetWithText(ElevatedButton, 'Save');
+    final saveButton = find.widgetWithText(FilledButton, 'Save');
     await tester.ensureVisible(saveButton);
     await tester.tap(saveButton);
     await tester.pumpAndSettle();


### PR DESCRIPTION
## Summary
- Use the themed FilledButton for the Remote Hosts Save action.
- Add a widget regression test for the click cursor and update interaction finders.

## Validation
- `dart format --set-exit-if-changed lib test integration_test tool`
- `dart tool/quality/check_max_lines.dart`
- `flutter analyze`
- `flutter test`
- Remote Hosts interaction tests
- Remote Host cursor widget test
- Native Rust deferred-delivery regression cases

The local `gh act` run was attempted; its Docker runner failed with an exit 137 and an RWLayer error after the Rust test process was terminated, so hosted checks remain authoritative.