### PR TITLE
feat: paste images into prompt workspaces

### DIFF
--- a/lib/src/design_system/forms/alera_text_field.dart
+++ b/lib/src/design_system/forms/alera_text_field.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:alera/src/app/theme/alera_tokens.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -27,6 +29,7 @@ class AleraTextField extends StatelessWidget {
     this.onSubmitted,
     this.onEditingComplete,
     this.onTap,
+    this.onPaste,
     this.autofocus = false,
     this.dense = false,
     this.denseHeight = defaultDenseHeight,
@@ -51,6 +54,12 @@ class AleraTextField extends StatelessWidget {
   final ValueChanged<String>? onSubmitted;
   final VoidCallback? onEditingComplete;
   final VoidCallback? onTap;
+
+  /// Handles a paste before the default text action runs.
+  ///
+  /// Return `true` when the callback consumed the clipboard. Returning
+  /// `false` preserves Flutter's normal text-paste behavior.
+  final Future<bool> Function()? onPaste;
   final bool autofocus;
   final bool dense;
   final double denseHeight;
@@ -70,7 +79,7 @@ class AleraTextField extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     if (!dense) {
-      return TextField(
+      final field = TextField(
         controller: controller,
         focusNode: focusNode,
         autofocus: autofocus,
@@ -81,6 +90,7 @@ class AleraTextField extends StatelessWidget {
         onSubmitted: onSubmitted,
         onEditingComplete: onEditingComplete,
         onTap: onTap,
+        contextMenuBuilder: onPaste == null ? null : _buildContextMenu,
         readOnly: readOnly,
         enabled: enabled,
         minLines: minLines,
@@ -93,9 +103,10 @@ class AleraTextField extends StatelessWidget {
           suffixIcon: suffix,
         ),
       );
+      return _withPasteAction(field);
     }
 
-    return SizedBox(
+    final field = SizedBox(
       height: denseHeight,
       child: TextField(
         controller: controller,
@@ -107,6 +118,7 @@ class AleraTextField extends StatelessWidget {
         onSubmitted: onSubmitted,
         onEditingComplete: onEditingComplete,
         onTap: onTap,
+        contextMenuBuilder: onPaste == null ? null : _buildContextMenu,
         readOnly: readOnly,
         enabled: enabled,
         minLines: minLines,
@@ -158,10 +170,93 @@ class AleraTextField extends StatelessWidget {
         ),
       ),
     );
+    return _withPasteAction(field);
+  }
+
+  Widget _withPasteAction(Widget field) {
+    final paste = onPaste;
+    if (paste == null) {
+      return field;
+    }
+    return Actions(
+      actions: <Type, Action<Intent>>{
+        PasteTextIntent: _ClipboardAwarePasteAction(paste),
+      },
+      child: field,
+    );
+  }
+
+  Widget _buildContextMenu(
+    BuildContext context,
+    EditableTextState editableTextState,
+  ) {
+    final items = List<ContextMenuButtonItem>.from(
+      editableTextState.contextMenuButtonItems,
+    );
+    final pasteItem = ContextMenuButtonItem(
+      onPressed: () {
+        unawaited(_pasteFromContextMenu(editableTextState));
+      },
+      type: ContextMenuButtonType.paste,
+    );
+    final pasteIndex = items.indexWhere(
+      (item) => item.type == ContextMenuButtonType.paste,
+    );
+    if (pasteIndex >= 0) {
+      items[pasteIndex] = pasteItem;
+    } else {
+      final selectAllIndex = items.indexWhere(
+        (item) => item.type == ContextMenuButtonType.selectAll,
+      );
+      items.insert(
+        selectAllIndex >= 0 ? selectAllIndex : items.length,
+        pasteItem,
+      );
+    }
+    return AdaptiveTextSelectionToolbar.buttonItems(
+      anchors: editableTextState.contextMenuAnchors,
+      buttonItems: items,
+    );
+  }
+
+  Future<void> _pasteFromContextMenu(
+    EditableTextState editableTextState,
+  ) async {
+    final paste = onPaste;
+    if (paste == null || await paste()) {
+      return;
+    }
+    await editableTextState.pasteText(SelectionChangedCause.toolbar);
   }
 
   OutlineInputBorder _denseBorder(Color color) => OutlineInputBorder(
     borderRadius: BorderRadius.circular(AleraTokens.radiusLg),
     borderSide: BorderSide(color: color),
   );
+}
+
+final class _ClipboardAwarePasteAction extends Action<PasteTextIntent> {
+  _ClipboardAwarePasteAction(this._onPaste);
+
+  final Future<bool> Function() _onPaste;
+
+  @override
+  bool get isActionEnabled => callingAction?.isActionEnabled ?? true;
+
+  @override
+  Object? invoke(PasteTextIntent intent) {
+    final defaultAction = callingAction;
+    unawaited(_invokePaste(intent, defaultAction));
+    return null;
+  }
+
+  Future<void> _invokePaste(
+    PasteTextIntent intent,
+    Action<PasteTextIntent>? defaultAction,
+  ) async {
+    if (await _onPaste()) {
+      return;
+    }
+    defaultAction?.invoke(intent);
+  }
 }

--- a/lib/src/features/workbench/infra/prompt_workspace_clipboard.dart
+++ b/lib/src/features/workbench/infra/prompt_workspace_clipboard.dart
@@ -1,0 +1,22 @@
+import 'package:alera/src/features/workbench/infra/terminal_clipboard.dart';
+
+/// Clipboard operations needed by the desktop prompt workspace flow.
+abstract interface class PromptWorkspaceClipboard {
+  Future<String?> readText();
+
+  Future<String?> saveImageAsTempFile();
+}
+
+final class NativePromptWorkspaceClipboard implements PromptWorkspaceClipboard {
+  const NativePromptWorkspaceClipboard({
+    this._clipboard = const NativeTerminalClipboard(),
+  });
+
+  final TerminalClipboard _clipboard;
+
+  @override
+  Future<String?> readText() => _clipboard.readText();
+
+  @override
+  Future<String?> saveImageAsTempFile() => _clipboard.saveImageAsTempFile();
+}

--- a/lib/src/features/workbench/presentation/prompt_workspace_dialog.dart
+++ b/lib/src/features/workbench/presentation/prompt_workspace_dialog.dart
@@ -13,11 +13,14 @@ import 'package:alera/src/features/projects/domain/project_selection_order.dart'
 import 'package:alera/src/features/workbench/domain/workspace.dart';
 import 'package:alera/src/features/workbench/domain/workspace_creation_result.dart';
 import 'package:alera/src/features/workbench/domain/workspace_parent_selection_order.dart';
+import 'package:alera/src/features/workbench/domain/terminal_image_paste.dart';
+import 'package:alera/src/features/workbench/infra/prompt_workspace_clipboard.dart';
 import 'package:alera/src/features/workbench/infra/prompt_workspace_runtime_client.dart';
 import 'package:flutter/material.dart';
 import 'package:uuid/uuid.dart';
 
 part 'prompt_workspace_dialog_form.dart';
+part 'prompt_workspace_dialog_clipboard.dart';
 part 'prompt_workspace_dialog_selection_order.dart';
 
 enum NewWorkspaceMode { fromPrompt, manual }
@@ -47,6 +50,7 @@ class PromptWorkspaceDialog extends StatefulWidget {
     required this.cancelGeneration,
     required this.createWorkspace,
     required this.launchAgent,
+    this.clipboard = const NativePromptWorkspaceClipboard(),
     this.initialProject,
     this.defaultAgentProfileId,
     this.onCreateAnother,
@@ -81,6 +85,7 @@ class PromptWorkspaceDialog extends StatefulWidget {
     required String prompt,
   })
   launchAgent;
+  final PromptWorkspaceClipboard clipboard;
   final String? defaultAgentProfileId;
   final Future<void> Function({
     required WorkspaceCreationResult creation,
@@ -177,20 +182,6 @@ class _PromptWorkspaceDialogState extends State<PromptWorkspaceDialog> {
         });
       }
     }
-  }
-
-  String? _defaultBranch(List<String> branches) {
-    for (final preferred in const <String>[
-      'main',
-      'origin/main',
-      'master',
-      'origin/master',
-    ]) {
-      if (branches.contains(preferred)) {
-        return preferred;
-      }
-    }
-    return branches.firstOrNull;
   }
 
   String? _defaultParentWorkspaceId(Project? project) {

--- a/lib/src/features/workbench/presentation/prompt_workspace_dialog_clipboard.dart
+++ b/lib/src/features/workbench/presentation/prompt_workspace_dialog_clipboard.dart
@@ -1,0 +1,44 @@
+part of 'prompt_workspace_dialog.dart';
+
+extension _PromptWorkspaceDialogClipboard on _PromptWorkspaceDialogState {
+  Future<bool> _pastePromptClipboard() async {
+    String? clipboardText;
+    try {
+      clipboardText = await widget.clipboard.readText();
+    } catch (_) {
+      // Image-only clipboards can reject text reads on some platforms.
+    }
+    if (clipboardText != null && clipboardText.isNotEmpty) {
+      return false;
+    }
+    try {
+      final imagePath = await widget.clipboard.saveImageAsTempFile();
+      if (!mounted || imagePath == null || imagePath.isEmpty) {
+        return false;
+      }
+      final value = _promptController.value;
+      final selection = _validPromptSelection(value);
+      _promptController.value = value.replaced(
+        selection,
+        sanitizeTerminalImagePastePath(imagePath),
+      );
+      _update(() => _error = null);
+      return true;
+    } catch (_) {
+      if (mounted) {
+        _update(() => _error = 'Could Not Paste Clipboard Image.');
+      }
+      return true;
+    }
+  }
+
+  TextSelection _validPromptSelection(TextEditingValue value) {
+    final selection = value.selection;
+    if (selection.isValid &&
+        selection.start <= value.text.length &&
+        selection.end <= value.text.length) {
+      return selection;
+    }
+    return TextSelection.collapsed(offset: value.text.length);
+  }
+}

--- a/lib/src/features/workbench/presentation/prompt_workspace_dialog_form.dart
+++ b/lib/src/features/workbench/presentation/prompt_workspace_dialog_form.dart
@@ -12,11 +12,13 @@ extension _PromptWorkspaceDialogForm on _PromptWorkspaceDialogState {
             AleraTextField(
               controller: _promptController,
               labelText: 'Initial Prompt',
-              hintText: 'Describe What The Agent Should Build',
+              hintText:
+                  'Describe What The Agent Should Build Or Paste An Image',
               minLines: 4,
               maxLines: 8,
               autofocus: true,
               enabled: !_working && created == null,
+              onPaste: _pastePromptClipboard,
             ),
             const SizedBox(height: AleraTokens.space16),
             AleraDropdownField<Project>(

--- a/lib/src/features/workbench/presentation/prompt_workspace_dialog_selection_order.dart
+++ b/lib/src/features/workbench/presentation/prompt_workspace_dialog_selection_order.dart
@@ -1,6 +1,20 @@
 part of 'prompt_workspace_dialog.dart';
 
 extension _PromptWorkspaceDialogSelectionOrder on _PromptWorkspaceDialogState {
+  String? _defaultBranch(List<String> branches) {
+    for (final preferred in const <String>[
+      'main',
+      'origin/main',
+      'master',
+      'origin/master',
+    ]) {
+      if (branches.contains(preferred)) {
+        return preferred;
+      }
+    }
+    return branches.firstOrNull;
+  }
+
   List<Project> get _orderedProjects =>
       sortProjectsForSelection(widget.projects);
 

--- a/test/widget/prompt_workspace_dialog_clipboard_test_cases.dart
+++ b/test/widget/prompt_workspace_dialog_clipboard_test_cases.dart
@@ -1,0 +1,146 @@
+part of 'prompt_workspace_dialog_test.dart';
+
+void _registerPromptWorkspaceClipboardTests() {
+  testWidgets('pastes an image path into the prompt at the caret', (
+    tester,
+  ) async {
+    final now = DateTime.utc(2026, 7, 30);
+    final project = _project(id: 'project-1', name: 'Alera', now: now);
+    final profile = _profile(id: 'profile-1', name: 'Codex Builder', now: now);
+    final clipboard = _FakePromptWorkspaceClipboard(
+      imagePath: '/tmp/alera-paste-\x1b.png',
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: PromptWorkspaceDialog(
+          projects: <Project>[project],
+          agentProfiles: <AgentProfile>[profile],
+          loadBranches: (_) async => <String>['main'],
+          checkBranchExists: (_, _) async => false,
+          workspaceBranches: (_) => const <String>{},
+          parentWorkspaces: const <Workspace>[],
+          generateIdentity:
+              ({
+                required operationId,
+                required projectId,
+                required prompt,
+              }) async => const GeneratedWorkspaceIdentity(
+                workspaceName: 'Prompt Workspace',
+                branchName: 'feat/prompt-workspace',
+              ),
+          cancelGeneration: (_) async {},
+          createWorkspace:
+              ({
+                required project,
+                required sourceBranch,
+                required newBranchName,
+                required name,
+                parentWorkspaceId,
+              }) async => WorkspaceCreationResult(
+                workspace: _workspace(
+                  id: 'workspace-1',
+                  projectId: project.id,
+                  name: name,
+                  branch: newBranchName,
+                  kind: WorkspaceKind.linked,
+                  now: now,
+                ),
+                setupReport: WorktreeSetupReport.empty,
+              ),
+          launchAgent:
+              ({
+                required workspaceId,
+                required profileId,
+                required prompt,
+              }) async => const AgentProfileLaunchResult(
+                tabId: 'tab-1',
+                agentType: 'codex',
+                profileId: 'profile-1',
+              ),
+          clipboard: clipboard,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final promptField = find.widgetWithText(TextField, 'Initial Prompt');
+    await tester.enterText(promptField, 'Review this ');
+    final focusContext = tester.binding.focusManager.primaryFocus?.context;
+    expect(focusContext, isNotNull);
+    Actions.invoke(
+      focusContext!,
+      const PasteTextIntent(SelectionChangedCause.keyboard),
+    );
+    await tester.pump();
+    await tester.pump();
+
+    expect(
+      tester.widget<TextField>(promptField).controller?.text,
+      'Review this /tmp/alera-paste-\u241b.png',
+    );
+    expect(clipboard.imageReads, 1);
+  });
+
+  testWidgets('keeps the default text paste when no image is available', (
+    tester,
+  ) async {
+    tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+      SystemChannels.platform,
+      (call) async {
+        if (call.method == 'Clipboard.getData') {
+          return <String, Object?>{'text': 'from clipboard'};
+        }
+        return null;
+      },
+    );
+    addTearDown(
+      () => tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        SystemChannels.platform,
+        null,
+      ),
+    );
+    final controller = TextEditingController(text: 'Before ');
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: AleraTextField(
+            controller: controller,
+            onPaste: () async => false,
+          ),
+        ),
+      ),
+    );
+    await tester.tap(find.byType(TextField));
+    controller.selection = TextSelection.collapsed(
+      offset: controller.text.length,
+    );
+    final focusContext = tester.binding.focusManager.primaryFocus?.context;
+    expect(focusContext, isNotNull);
+    Actions.invoke(
+      focusContext!,
+      const PasteTextIntent(SelectionChangedCause.keyboard),
+    );
+    await tester.pump();
+    await tester.pumpAndSettle();
+
+    expect(controller.text, 'Before from clipboard');
+  });
+}
+
+final class _FakePromptWorkspaceClipboard implements PromptWorkspaceClipboard {
+  _FakePromptWorkspaceClipboard({this.imagePath});
+
+  final String? imagePath;
+  int imageReads = 0;
+
+  @override
+  Future<String?> readText() async => null;
+
+  @override
+  Future<String?> saveImageAsTempFile() async {
+    imageReads += 1;
+    return imagePath;
+  }
+}

--- a/test/widget/prompt_workspace_dialog_test.dart
+++ b/test/widget/prompt_workspace_dialog_test.dart
@@ -2,13 +2,20 @@ import 'package:alera/src/features/agent_profiles/domain/agent_profile.dart';
 import 'package:alera/src/features/projects/domain/project.dart';
 import 'package:alera/src/features/workbench/domain/workspace.dart';
 import 'package:alera/src/features/workbench/domain/workspace_creation_result.dart';
+import 'package:alera/src/features/workbench/infra/prompt_workspace_clipboard.dart';
 import 'package:alera/src/features/workbench/infra/prompt_workspace_runtime_client.dart';
 import 'package:alera/src/features/workbench/presentation/prompt_workspace_dialog.dart';
 import 'package:alera/src/design_system/forms/alera_dropdown_field.dart';
+import 'package:alera/src/design_system/forms/alera_text_field.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+part 'prompt_workspace_dialog_clipboard_test_cases.dart';
+
 void main() {
+  _registerPromptWorkspaceClipboardTests();
+
   testWidgets('creates an AI-named workspace and launches the profile', (
     tester,
   ) async {


### PR DESCRIPTION
Summary:
- Support image clipboard paste in the desktop New Workspace From Prompt field.
- Preserve text paste behavior and insert sanitized local image paths at the caret.
- Reuse the existing native clipboard image tempfile flow and cover keyboard paste plus fallback behavior with widget tests.

Validation:
- dart format --set-exit-if-changed lib test integration_test tool
- dart tool/quality/check_max_lines.dart
- flutter analyze
- flutter test --coverage --exclude-tags golden
- dart tool/quality/coverage_report.dart --input coverage/lcov.info --min-lines 100 --worst 25
- (cd mobile && flutter analyze && flutter test)

Notes:
- Mobile remains text-only because the current mobile prompt/runtime flow has no compatible image-transfer protocol.
- Local gh act was attempted, but its checkout/native-container emulation was not authoritative; hosted checks will be used for the PR.