### PR TITLE
fix: open mobile updates in external browser

### DIFF
--- a/mobile/lib/src/features/updater/presentation/mobile_update_prompt.dart
+++ b/mobile/lib/src/features/updater/presentation/mobile_update_prompt.dart
@@ -20,7 +20,7 @@ class MobileUpdatePrompt extends ConsumerStatefulWidget {
     super.key,
     required this.child,
     this.copyLink = _copyToClipboard,
-    this.openUrl = launchUrl,
+    this.openUrl = _launchExternalBrowser,
   });
 
   final Widget child;
@@ -29,7 +29,7 @@ class MobileUpdatePrompt extends ConsumerStatefulWidget {
   final Future<void> Function(String link) copyLink;
 
   /// Injected so tests do not reach the platform's URL launcher.
-  final Future<bool> Function(Uri url, {LaunchMode mode}) openUrl;
+  final Future<bool> Function(Uri url) openUrl;
 
   @override
   ConsumerState<MobileUpdatePrompt> createState() => _MobileUpdatePromptState();
@@ -91,10 +91,7 @@ class _MobileUpdatePromptState extends ConsumerState<MobileUpdatePrompt> {
         ).showSnackBar(const SnackBar(content: Text('Download link copied.')));
         return;
       case _MobileUpdateAction.download:
-        final opened = await widget.openUrl(
-          release.apkUrl,
-          mode: LaunchMode.externalApplication,
-        );
+        final opened = await widget.openUrl(release.apkUrl);
         if (opened || !mounted) {
           return;
         }
@@ -170,4 +167,8 @@ class _MobileUpdateDialog extends StatelessWidget {
 
 Future<void> _copyToClipboard(String link) {
   return Clipboard.setData(ClipboardData(text: link));
+}
+
+Future<bool> _launchExternalBrowser(Uri url) {
+  return launchUrl(url, mode: LaunchMode.externalApplication);
 }

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -817,7 +817,7 @@ packages:
     source: hosted
     version: "3.1.6"
   plugin_platform_interface:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: plugin_platform_interface
       sha256: "4820fbfdb9478b1ebae27888254d445073732dae3d6ea81f0b7e06d5dedc3f02"
@@ -1206,7 +1206,7 @@ packages:
     source: hosted
     version: "3.2.5"
   url_launcher_platform_interface:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: url_launcher_platform_interface
       sha256: "552f8a1e663569be95a8190206a38187b531910283c3e982193e4f2733f01029"

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -67,8 +67,10 @@ dev_dependencies:
   flutter_lints: ^6.0.0
   flutter_launcher_icons: ^0.14.4
   flutter_native_splash: ^2.4.8
+  plugin_platform_interface: ^2.1.8
   riverpod_generator: ^4.0.4
   riverpod_lint: ^3.1.4
+  url_launcher_platform_interface: ^2.3.2
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/mobile/test/mobile_update_prompt_test.dart
+++ b/mobile/test/mobile_update_prompt_test.dart
@@ -4,7 +4,9 @@ import 'package:alera_mobile/src/features/updater/presentation/mobile_update_pro
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:url_launcher/url_launcher.dart';
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+import 'package:url_launcher_platform_interface/link.dart';
+import 'package:url_launcher_platform_interface/url_launcher_platform_interface.dart';
 
 final MobileRelease _release = MobileRelease(
   version: const MobileVersion(0, 10, 0),
@@ -19,24 +21,24 @@ Future<void> _pump(
   WidgetTester tester, {
   required MobileRelease? release,
   required List<String> copied,
-  required List<(Uri, LaunchMode)> opened,
-  bool openResult = true,
+  Future<bool> Function(Uri url)? openUrl,
 }) {
+  final prompt = openUrl == null
+      ? MobileUpdatePrompt(
+          copyLink: (link) async => copied.add(link),
+          child: const Scaffold(body: Text('Home')),
+        )
+      : MobileUpdatePrompt(
+          copyLink: (link) async => copied.add(link),
+          openUrl: openUrl,
+          child: const Scaffold(body: Text('Home')),
+        );
   return tester.pumpWidget(
     ProviderScope(
       overrides: [
         availableMobileUpdateProvider.overrideWith((ref) async => release),
       ],
-      child: MaterialApp(
-        home: MobileUpdatePrompt(
-          copyLink: (link) async => copied.add(link),
-          openUrl: (url, {mode = LaunchMode.platformDefault}) async {
-            opened.add((url, mode));
-            return openResult;
-          },
-          child: const Scaffold(body: Text('Home')),
-        ),
-      ),
+      child: MaterialApp(home: prompt),
     ),
   );
 }
@@ -46,8 +48,16 @@ void main() {
     tester,
   ) async {
     final copied = <String>[];
-    final opened = <(Uri, LaunchMode)>[];
-    await _pump(tester, release: _release, copied: copied, opened: opened);
+    final opened = <Uri>[];
+    await _pump(
+      tester,
+      release: _release,
+      copied: copied,
+      openUrl: (url) async {
+        opened.add(url);
+        return true;
+      },
+    );
     await tester.pumpAndSettle();
 
     expect(find.text('Update available'), findsOneWidget);
@@ -58,15 +68,34 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(copied, isEmpty);
-    expect(opened, <(Uri, LaunchMode)>[
-      (_release.apkUrl, LaunchMode.externalApplication),
+    expect(opened, <Uri>[_release.apkUrl]);
+  });
+
+  testWidgets('default download launcher requests an external application', (
+    tester,
+  ) async {
+    final previousPlatform = UrlLauncherPlatform.instance;
+    final fakePlatform = _RecordingUrlLauncherPlatform();
+    UrlLauncherPlatform.instance = fakePlatform;
+    addTearDown(() => UrlLauncherPlatform.instance = previousPlatform);
+
+    final copied = <String>[];
+    await _pump(tester, release: _release, copied: copied);
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Download'));
+    await tester.pumpAndSettle();
+
+    expect(fakePlatform.launchedUrls, <String>[_release.apkUrl.toString()]);
+    expect(fakePlatform.modes, <PreferredLaunchMode>[
+      PreferredLaunchMode.externalApplication,
     ]);
   });
 
   testWidgets('copies the apk link without opening it', (tester) async {
     final copied = <String>[];
-    final opened = <(Uri, LaunchMode)>[];
-    await _pump(tester, release: _release, copied: copied, opened: opened);
+    final opened = <Uri>[];
+    await _pump(tester, release: _release, copied: copied);
     await tester.pumpAndSettle();
 
     await tester.tap(find.text('Copy Link'));
@@ -79,8 +108,8 @@ void main() {
 
   testWidgets('declining opens nothing and does not ask again', (tester) async {
     final copied = <String>[];
-    final opened = <(Uri, LaunchMode)>[];
-    await _pump(tester, release: _release, copied: copied, opened: opened);
+    final opened = <Uri>[];
+    await _pump(tester, release: _release, copied: copied);
     await tester.pumpAndSettle();
 
     await tester.tap(find.text('Later'));
@@ -98,12 +127,28 @@ void main() {
 
   testWidgets('stays silent when the app is current', (tester) async {
     final copied = <String>[];
-    final opened = <(Uri, LaunchMode)>[];
-    await _pump(tester, release: null, copied: copied, opened: opened);
+    final opened = <Uri>[];
+    await _pump(tester, release: null, copied: copied);
     await tester.pumpAndSettle();
 
     expect(find.text('Update available'), findsNothing);
     expect(copied, isEmpty);
     expect(opened, isEmpty);
   });
+}
+
+class _RecordingUrlLauncherPlatform extends UrlLauncherPlatform
+    with MockPlatformInterfaceMixin {
+  final List<String> launchedUrls = <String>[];
+  final List<PreferredLaunchMode> modes = <PreferredLaunchMode>[];
+
+  @override
+  LinkDelegate? get linkDelegate => null;
+
+  @override
+  Future<bool> launchUrl(String url, LaunchOptions options) async {
+    launchedUrls.add(url);
+    modes.add(options.mode);
+    return true;
+  }
 }


### PR DESCRIPTION
## Summary

- Route mobile update downloads through an explicit external browser launcher.
- Verify that the default launcher sends `PreferredLaunchMode.externalApplication` to `url_launcher`.
- Declare the platform-interface packages used by the launcher boundary test.

## Root cause

`url_launcher` leaves `LaunchMode.platformDefault` up to the platform, and Android may use an in-app web view for HTTPS URLs. The update prompt now owns a default launcher that requests `LaunchMode.externalApplication`, which delegates the APK URL to Chrome or the device's external browser handler.

## Validation

- `dart format --set-exit-if-changed lib test`
- `flutter analyze`
- `flutter test` (202 tests passed)
- `flutter build apk --debug`
- `gh act pull_request -W .github/workflows/pr.yml -j mobile` attempted, but stopped before Flutter because `act` could not initialize the linked worktree submodule (`fatal: not a git repository: (null)`).
