### PR TITLE
fix: add card spacing to test command buttons

### DIFF
--- a/lib/src/features/settings/presentation/panes/agent_profile_editor.dart
+++ b/lib/src/features/settings/presentation/panes/agent_profile_editor.dart
@@ -126,6 +126,7 @@ class AgentProfileEditor extends StatelessWidget {
                       left: AleraTokens.space12,
                       right: AleraTokens.space12,
                       top: AleraTokens.space8,
+                      bottom: AleraTokens.space12,
                     ),
                     child: Align(
                       alignment: Alignment.centerRight,
@@ -173,6 +174,7 @@ class AgentProfileEditor extends StatelessWidget {
                         left: AleraTokens.space12,
                         right: AleraTokens.space12,
                         top: AleraTokens.space8,
+                        bottom: AleraTokens.space12,
                       ),
                       child: Align(
                         alignment: Alignment.centerRight,

--- a/test/widget/agent_profile_editor_test.dart
+++ b/test/widget/agent_profile_editor_test.dart
@@ -1,3 +1,4 @@
+import 'package:alera/src/app/theme/alera_tokens.dart';
 import 'package:alera/src/features/agent_profiles/domain/agent_profile.dart';
 import 'package:alera/src/features/agent_profiles/domain/managed_agent_profile_options.dart';
 import 'package:alera/src/features/agent_status/domain/agent_status.dart';
@@ -88,6 +89,21 @@ void main() {
     expect(testCommandCalls, 1);
   });
 
+  testWidgets('command mode gives the test button room inside its card', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      const _EditorHarness(launchMode: AgentProfileLaunchMode.command),
+    );
+
+    final actionPadding = _testCommandActionPadding(tester);
+
+    expect(
+      actionPadding.resolve(TextDirection.ltr).bottom,
+      AleraTokens.space12,
+    );
+  });
+
   testWidgets('managed mode offers to test the current command preview', (
     tester,
   ) async {
@@ -104,6 +120,24 @@ void main() {
     await tester.pump();
 
     expect(testCommandCalls, 1);
+  });
+
+  testWidgets('managed mode gives the test button room inside its card', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _EditorHarness(
+        launchMode: AgentProfileLaunchMode.managed,
+        managedConfig: const <String, Object?>{'model': 'gpt-5.6-sol'},
+      ),
+    );
+
+    final actionPadding = _testCommandActionPadding(tester);
+
+    expect(
+      actionPadding.resolve(TextDirection.ltr).bottom,
+      AleraTokens.space12,
+    );
   });
 
   testWidgets('managed mode disables testing while saving', (tester) async {
@@ -190,6 +224,12 @@ void main() {
       findsOneWidget,
     );
   });
+}
+
+EdgeInsetsGeometry _testCommandActionPadding(WidgetTester tester) {
+  final button = find.widgetWithText(OutlinedButton, 'Test Command');
+  final buttonElement = tester.element(button);
+  return buttonElement.findAncestorWidgetOfExactType<Padding>()!.padding;
 }
 
 class _EditorHarness extends StatefulWidget {


### PR DESCRIPTION
## Summary
- add token-based bottom spacing to `Test Command` actions in both command and managed agent profile cards
- cover the card spacing contract in widget tests

## Validation
- `dart format --set-exit-if-changed lib test integration_test tool`
- `dart tool/quality/check_max_lines.dart`
- `flutter analyze`
- four CI-style Flutter test shards
- `make rust-test`
- local `gh act` attempted; linked-worktree checkout and Docker image authentication limited emulation, so hosted checks remain authoritative