### PR TITLE
fix: reposition project settings action

### DIFF
--- a/lib/src/features/workbench/presentation/project_workbench_workspace_actions.dart
+++ b/lib/src/features/workbench/presentation/project_workbench_workspace_actions.dart
@@ -28,11 +28,6 @@ List<PopupMenuEntry<String>> workspaceContextMenuEntries({
 }) {
   return <PopupMenuEntry<String>>[
     const AleraDropdownEntry<String>(
-      value: _openProjectSettingsAction,
-      leading: Icon(AleraIcons.settings, size: 16),
-      label: 'Open Project Settings',
-    ),
-    const AleraDropdownEntry<String>(
       value: _renameAction,
       leading: Icon(AleraIcons.edit, size: 16),
       label: 'Rename',
@@ -76,6 +71,11 @@ List<PopupMenuEntry<String>> workspaceContextMenuEntries({
         color: AleraTokens.foreground,
       ),
       label: 'Open in $fileManagerLabel',
+    ),
+    const AleraDropdownEntry<String>(
+      value: _openProjectSettingsAction,
+      leading: Icon(AleraIcons.settings, size: 16),
+      label: 'Open in Project Settings',
     ),
     const AleraDropdownEntry<String>(
       value: _copyPathAction,

--- a/test/unit/project_workbench_workspace_actions_test.dart
+++ b/test/unit/project_workbench_workspace_actions_test.dart
@@ -3,7 +3,7 @@ import 'package:alera/src/features/workbench/presentation/project_workbench_side
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  test('workspace context menu opens project settings', () {
+  test('workspace context menu places project settings with open actions', () {
     final entries = workspaceContextMenuEntries(
       fileManagerLabel: 'Files',
       hasClearParent: false,
@@ -15,7 +15,18 @@ void main() {
       entries.whereType<AleraDropdownEntry<String>>().map(
         (entry) => entry.label,
       ),
-      contains('Open Project Settings'),
+      <String>[
+        'Rename',
+        'Pin Workspace',
+        'Manage Tags',
+        'Set Parent Workspace',
+        'Open in Browser',
+        'Open in Files',
+        'Open in Project Settings',
+        'Copy Path',
+        'Sleep',
+        'Remove',
+      ],
     );
   });
 }

--- a/test/widget/alera_shell_page_workbench_test_cases.dart
+++ b/test/widget/alera_shell_page_workbench_test_cases.dart
@@ -325,6 +325,8 @@ void _registerAleraShellWorkbenchTests() {
     expect(find.text('Manage Tags'), findsOneWidget);
     expect(find.text('Set Parent Workspace'), findsOneWidget);
     expect(find.text('Open in Finder'), findsOneWidget);
+    expect(find.text('Open in Project Settings'), findsOneWidget);
+    expect(find.text('Open Project Settings'), findsNothing);
     expect(find.text('Copy Path'), findsOneWidget);
     expect(find.text('Sleep'), findsOneWidget);
     expect(find.text('Remove'), findsOneWidget);


### PR DESCRIPTION
## Summary
- move the workspace project settings action below the Open in actions
- rename it to Open in Project Settings

## Validation
- flutter analyze
- dart format --set-exit-if-changed lib test integration_test tool
- dart tool/quality/check_max_lines.dart
- flutter test --no-pub --reporter expanded test/unit/project_workbench_workspace_actions_test.dart
- flutter test --no-pub --reporter expanded test/widget/alera_shell_page_test.dart

The local gh act static job reached the composite setup action but could not initialize submodules in this linked worktree (`fatal: not a git repository: (null)`); hosted checks remain authoritative.