### PR TITLE
feat: add agent profile custom prompts

### DIFF
--- a/docs/orchestration.md
+++ b/docs/orchestration.md
@@ -35,7 +35,7 @@ alera orchestration run-stop --id <run-id> [--cancel-active] --reason "Stopped b
 
 ## Agent Profile Catalog
 
-An agent profile is a user-declared launch configuration a run can dispatch to. Each profile carries a unique name, an adapter type from the built-in registry, a launch mode, a free-text description used as a routing signal, and an optional quota group. Profiles are user configuration, not run state: they live in the runtime schema next to `sshTargets`, so resetting orchestration state never destroys them.
+An agent profile is a user-declared launch configuration a run can dispatch to. Each profile carries a unique name, an adapter type from the built-in registry, a launch mode, a custom prompt, a free-text description used as a routing signal, and an optional quota group. Profiles are user configuration, not run state: they live in the runtime schema next to `sshTargets`, so resetting orchestration state never destroys them.
 
 ```bash
 alera orchestration agent-profiles --json
@@ -54,6 +54,8 @@ A managed Claude profile can also pass `--allow-dangerously-skip-permissions` th
 A managed Claude profile may also carry an optional `ccsProfile`. When it is set, the launch replaces the executable with `ccs` and passes the profile as its first positional argument, followed by the same Claude flags, because that is the switcher's own contract (`ccs <profile> [claude-args...]`). The value must be a single name that does not start with a dash: it is positional, so a dash-prefixed value would be read as an option of the switcher itself. Only the Claude adapter accepts the key; the host rejects it anywhere else. Note that `ccs` points `CLAUDE_CONFIG_DIR` at its own profile directory, which is where Alera installs the Claude agent-status hooks, so a session launched through a CCS profile reports status only if that profile inherits those hooks.
 
 Command mode also has to say where the dispatched prompt goes, because the user writes the whole launch line there. That follows the adapter's `startup_delivery`: Codex receives the prompt as one quoted argument after the option terminator, and every other adapter launches bare and has the prompt typed in once it reports readiness. The editor states which of the two applies and, for the argument form, previews the resulting line.
+
+The profile's Custom Prompt is added after the prompt supplied by New Workspace or `orchestration agent-spawn`, when it is non-empty. The project's `new_workspace.prompt_append` is added last, so every delivered prompt has the order user prompt, profile instructions, then project instructions, with blank lines between non-empty sections.
 
 The quota group declares which profiles drain the same usage bucket. Alera never measures, predicts, or verifies quota here; the grouping is an assertion the user makes, and its only purpose is to let a later fallback prefer a candidate from a different bucket.
 

--- a/docs/worktree-setup-config.md
+++ b/docs/worktree-setup-config.md
@@ -36,7 +36,7 @@ Paths are repo-relative literal paths. Absolute paths and `..` escapes are rejec
 
 ## New Workspace Prompt Append
 
-`new_workspace.prompt_append` is optional project-specific text added to the initial prompt immediately before Alera starts the selected agent profile from the **New Workspace** flow. Alera separates the user prompt and the configured text with a blank line. It does not send this append text through AI Text and does not use it to generate the workspace name or branch.
+`new_workspace.prompt_append` is optional project-specific text added last to the prompt before Alera starts the selected agent profile from the **New Workspace** flow. When the profile has a Custom Prompt, the delivered order is the user prompt, the profile prompt, then this project prompt, with blank lines between non-empty sections. Alera does not send this append text through AI Text and does not use it to generate the workspace name or branch.
 
 Like the worktree settings, this value can be stored in `alera.toml` or edited under **Settings > Projects**. A UI override replaces the complete repository config for that project, including this value.
 

--- a/lib/src/features/agent_profiles/application/agent_profile_providers.dart
+++ b/lib/src/features/agent_profiles/application/agent_profile_providers.dart
@@ -73,6 +73,7 @@ class AgentProfiles extends _$AgentProfiles {
     required AgentProfileLaunchMode launchMode,
     String command = '',
     Map<String, Object?> managedConfig = const <String, Object?>{},
+    String customPrompt = '',
     String description = '',
     String? quotaGroup,
   }) async {
@@ -83,6 +84,7 @@ class AgentProfiles extends _$AgentProfiles {
       launchMode: launchMode,
       command: command,
       managedConfig: managedConfig,
+      customPrompt: customPrompt,
       description: description,
       quotaGroup: quotaGroup,
     );
@@ -99,6 +101,7 @@ class AgentProfiles extends _$AgentProfiles {
       launchMode: source.launchMode,
       command: source.command,
       managedConfig: <String, Object?>{...source.managedConfig},
+      customPrompt: source.customPrompt,
       description: source.description,
       quotaGroup: source.quotaGroup,
     );
@@ -151,6 +154,7 @@ class AgentProfiles extends _$AgentProfiles {
         left.command == right.command &&
         left.launchMode == right.launchMode &&
         _sameConfig(left.managedConfig, right.managedConfig) &&
+        left.customPrompt == right.customPrompt &&
         left.description == right.description &&
         left.quotaGroup == right.quotaGroup;
   }

--- a/lib/src/features/agent_profiles/application/agent_profile_providers.g.dart
+++ b/lib/src/features/agent_profiles/application/agent_profile_providers.g.dart
@@ -132,7 +132,7 @@ final class AgentProfilesProvider
   AgentProfiles create() => AgentProfiles();
 }
 
-String _$agentProfilesHash() => r'e796a7c453d8f6032af6298df73fe853865db00b';
+String _$agentProfilesHash() => r'9c691a7318d661f8193afc9343c32943ab0230a5';
 
 abstract class _$AgentProfiles extends $AsyncNotifier<List<AgentProfile>> {
   FutureOr<List<AgentProfile>> build();

--- a/lib/src/features/agent_profiles/domain/agent_profile.dart
+++ b/lib/src/features/agent_profiles/domain/agent_profile.dart
@@ -26,6 +26,7 @@ class AgentProfile {
     this.quotaGroup,
     this.launchMode = AgentProfileLaunchMode.command,
     this.managedConfig = const <String, Object?>{},
+    this.customPrompt = '',
   });
 
   factory AgentProfile.fromJson(Map<String, Object?> json) {
@@ -36,6 +37,7 @@ class AgentProfile {
       command: _requiredString(json, 'command'),
       launchMode: AgentProfileLaunchMode.fromJson(json['launchMode']),
       managedConfig: _jsonObject(json['managedConfig']),
+      customPrompt: _optionalString(json['customPrompt']) ?? '',
       description: _optionalString(json['description']) ?? '',
       quotaGroup: _optionalString(json['quotaGroup']),
       createdAt: _dateTime(json['createdAt']),
@@ -57,6 +59,10 @@ class AgentProfile {
 
   /// Adapter-specific overrides. Missing keys mean the CLI's own default.
   final Map<String, Object?> managedConfig;
+
+  /// Instructions appended after a dispatched prompt and before project-level
+  /// instructions.
+  final String customPrompt;
 
   /// Free-form routing signal the orchestrator reads when choosing a profile
   /// for a stage.
@@ -80,6 +86,7 @@ class AgentProfile {
       'managedConfig': launchMode == AgentProfileLaunchMode.managed
           ? managedConfig
           : null,
+      'customPrompt': customPrompt,
       'description': description,
       'quotaGroup': quotaGroup,
       'createdAt': createdAt.toUtc().toIso8601String(),
@@ -93,6 +100,7 @@ class AgentProfile {
     String? command,
     AgentProfileLaunchMode? launchMode,
     Map<String, Object?>? managedConfig,
+    String? customPrompt,
     String? description,
     String? quotaGroup,
     bool clearQuotaGroup = false,
@@ -104,6 +112,7 @@ class AgentProfile {
       command: command ?? this.command,
       launchMode: launchMode ?? this.launchMode,
       managedConfig: managedConfig ?? this.managedConfig,
+      customPrompt: customPrompt ?? this.customPrompt,
       description: description ?? this.description,
       quotaGroup: clearQuotaGroup ? null : (quotaGroup ?? this.quotaGroup),
       createdAt: createdAt,

--- a/lib/src/features/agent_profiles/infra/runtime_agent_profile_repository.dart
+++ b/lib/src/features/agent_profiles/infra/runtime_agent_profile_repository.dart
@@ -41,6 +41,7 @@ class RuntimeAgentProfileRepository {
     required AgentProfileLaunchMode launchMode,
     String command = '',
     Map<String, Object?> managedConfig = const <String, Object?>{},
+    String customPrompt = '',
     String description = '',
     String? quotaGroup,
   }) async {
@@ -58,6 +59,7 @@ class RuntimeAgentProfileRepository {
         'launchMode': launchMode.name,
         if (launchMode == AgentProfileLaunchMode.managed)
           'managedConfig': managedConfig,
+        'customPrompt': customPrompt,
         'description': description,
         'quotaGroup': quotaGroup,
       },

--- a/lib/src/features/settings/presentation/panes/agent_profile_editor.dart
+++ b/lib/src/features/settings/presentation/panes/agent_profile_editor.dart
@@ -19,6 +19,7 @@ class AgentProfileEditor extends StatelessWidget {
     super.key,
     required this.nameController,
     required this.commandController,
+    required this.customPromptController,
     required this.descriptionController,
     required this.quotaGroupController,
     required this.adapter,
@@ -44,6 +45,7 @@ class AgentProfileEditor extends StatelessWidget {
 
   final TextEditingController nameController;
   final TextEditingController commandController;
+  final TextEditingController customPromptController;
   final TextEditingController descriptionController;
   final TextEditingController quotaGroupController;
   final AgentType adapter;
@@ -190,6 +192,18 @@ class AgentProfileEditor extends StatelessWidget {
                     ),
                   ],
                 ),
+              Padding(
+                padding: const EdgeInsets.all(AleraTokens.space12),
+                child: AleraTextField(
+                  controller: customPromptController,
+                  labelText: 'Custom Prompt',
+                  hintText: 'Optional instructions for every dispatched task',
+                  prefixIcon: AleraIcons.agent,
+                  minLines: 3,
+                  maxLines: 8,
+                  enabled: !saving,
+                ),
+              ),
             ],
           ),
           const SizedBox(height: AleraTokens.space16),

--- a/lib/src/features/settings/presentation/panes/agent_profiles_pane.dart
+++ b/lib/src/features/settings/presentation/panes/agent_profiles_pane.dart
@@ -39,6 +39,7 @@ class _AgentProfilesSettingsPaneState
     extends ConsumerState<AgentProfilesSettingsPane> {
   final TextEditingController _nameController = TextEditingController();
   final TextEditingController _commandController = TextEditingController();
+  final TextEditingController _customPromptController = TextEditingController();
   final TextEditingController _descriptionController = TextEditingController();
   final TextEditingController _quotaGroupController = TextEditingController();
   String? _selectedProfileId;
@@ -65,6 +66,7 @@ class _AgentProfilesSettingsPaneState
   void dispose() {
     _nameController.dispose();
     _commandController.dispose();
+    _customPromptController.dispose();
     _descriptionController.dispose();
     _quotaGroupController.dispose();
     super.dispose();
@@ -137,6 +139,7 @@ class _AgentProfilesSettingsPaneState
           detail: AgentProfileEditor(
             nameController: _nameController,
             commandController: _commandController,
+            customPromptController: _customPromptController,
             descriptionController: _descriptionController,
             quotaGroupController: _quotaGroupController,
             adapter: _adapter,
@@ -202,6 +205,7 @@ class _AgentProfilesSettingsPaneState
       profile.command,
       profile.launchMode.name,
       jsonEncode(profile.managedConfig),
+      profile.customPrompt,
       profile.description,
       profile.quotaGroup ?? '',
     ].join('|');
@@ -211,6 +215,7 @@ class _AgentProfilesSettingsPaneState
     _seededSignature = signature;
     _nameController.text = profile.name;
     _commandController.text = profile.command;
+    _customPromptController.text = profile.customPrompt;
     _descriptionController.text = profile.description;
     _quotaGroupController.text = profile.quotaGroup ?? '';
     _adapter = agentProfileAdapterFromKey(profile.agentType) ?? AgentType.codex;
@@ -228,6 +233,7 @@ class _AgentProfilesSettingsPaneState
     _seededSignature = null;
     _selectedProfileId = null;
     _nameController.clear();
+    _customPromptController.clear();
     _descriptionController.clear();
     _quotaGroupController.clear();
     _adapter = AgentType.codex;

--- a/lib/src/features/settings/presentation/panes/agent_profiles_pane_profile_actions.dart
+++ b/lib/src/features/settings/presentation/panes/agent_profiles_pane_profile_actions.dart
@@ -50,6 +50,7 @@ extension _AgentProfilesPaneProfileActions on _AgentProfilesSettingsPaneState {
             launchMode: _launchMode,
             command: command,
             managedConfig: _managedConfig,
+            customPrompt: _customPromptController.text.trim(),
             description: _descriptionController.text.trim(),
             quotaGroup: quotaGroup.isEmpty ? null : quotaGroup,
           );

--- a/rust/alera-cli/src/terminal_host/server.rs
+++ b/rust/alera-cli/src/terminal_host/server.rs
@@ -54,6 +54,7 @@ mod account_requests_tests;
 mod actor_test_harness;
 mod agent_hook_events;
 mod agent_profile_launch_requests;
+mod agent_prompt_composition;
 mod ai_text_grok_plan;
 mod ai_text_requests;
 mod ai_text_workspace_identity;

--- a/rust/alera-cli/src/terminal_host/server/agent_profile_launch_requests.rs
+++ b/rust/alera-cli/src/terminal_host/server/agent_profile_launch_requests.rs
@@ -4,6 +4,7 @@ use serde_json::{json, Value};
 use crate::terminal_host::host_error::{HostError, HostResult};
 use crate::terminal_host::orchestration::agent_registry::{adapter_for, AgentStartupDelivery};
 
+use super::agent_prompt_composition::compose_agent_prompt;
 use super::host_service_requests::required_non_blank;
 use super::orchestration_profile_spawn::launch_for_profile;
 use super::ServerActor;
@@ -35,16 +36,17 @@ impl ServerActor {
                 "Could not load project configuration: {error}"
             )));
         }
-        let prompt = append_project_prompt(
-            &prompt,
-            &effective_config.config.new_workspace.prompt_append,
-        );
         let profile = self
             .runtime_store
             .find_agent_profile(&profile_id)
             .await
             .map_err(|error| HostError::state(error.to_string()))?
             .ok_or_else(|| HostError::state(format!("Agent profile not found: {profile_id}")))?;
+        let prompt = compose_agent_prompt(
+            &prompt,
+            &profile.custom_prompt,
+            &effective_config.config.new_workspace.prompt_append,
+        );
         let adapter = adapter_for(&profile.agent_type).ok_or_else(|| {
             HostError::format(format!("Unsupported agent type: {}", profile.agent_type))
         })?;
@@ -150,34 +152,5 @@ impl ServerActor {
             tracing::error!(tab_id = %tab_id, "failed to clear pending agent prompt: {error}");
         }
         self.broadcast_workspace_tabs_changed(Some(&workspace_id));
-    }
-}
-
-fn append_project_prompt(prompt: &str, prompt_append: &str) -> String {
-    let prompt_append = prompt_append.trim();
-    if prompt_append.is_empty() {
-        return prompt.to_string();
-    }
-    format!("{}\n\n{prompt_append}", prompt.trim())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::append_project_prompt;
-
-    #[test]
-    fn appends_project_instructions_with_a_paragraph_boundary() {
-        assert_eq!(
-            append_project_prompt("Build The Feature", "Run Focused Tests"),
-            "Build The Feature\n\nRun Focused Tests"
-        );
-    }
-
-    #[test]
-    fn leaves_the_prompt_unchanged_without_project_instructions() {
-        assert_eq!(
-            append_project_prompt("Build The Feature", "  "),
-            "Build The Feature"
-        );
     }
 }

--- a/rust/alera-cli/src/terminal_host/server/agent_prompt_composition.rs
+++ b/rust/alera-cli/src/terminal_host/server/agent_prompt_composition.rs
@@ -1,0 +1,127 @@
+use alera_core::runtime::OrchestrationTask;
+use serde_json::Value;
+
+use crate::terminal_host::host_error::{HostError, HostResult};
+
+use super::ServerActor;
+
+/// Combines the prompt supplied for one launch with profile and project
+/// instructions while keeping each source in its configured order.
+pub(super) fn compose_agent_prompt(
+    prompt: &str,
+    profile_prompt: &str,
+    project_prompt: &str,
+) -> String {
+    [prompt, profile_prompt, project_prompt]
+        .into_iter()
+        .map(str::trim)
+        .filter(|part| !part.is_empty())
+        .collect::<Vec<_>>()
+        .join("\n\n")
+}
+
+impl ServerActor {
+    pub(super) async fn compose_profile_prompt_for_workspace(
+        &self,
+        workspace_id: &str,
+        prompt: &str,
+        profile_name: Option<&str>,
+    ) -> HostResult<String> {
+        let Some(profile_name) = profile_name else {
+            return Ok(prompt.to_string());
+        };
+        let Some(profile) = self
+            .runtime_store
+            .agent_profile_by_name(profile_name)
+            .await
+            .map_err(|error| HostError::state(error.to_string()))?
+        else {
+            return Ok(prompt.to_string());
+        };
+        let project_prompt = match self
+            .runtime_store
+            .find_workspace(workspace_id)
+            .await
+            .map_err(|error| HostError::state(error.to_string()))?
+        {
+            Some(workspace) => {
+                let effective_config = crate::project_management::effective_project_config(
+                    &self.runtime_store,
+                    &workspace.project_id,
+                )
+                .await
+                .map_err(|error| HostError::state(error.to_string()))?;
+                if let Some(error) = effective_config.error {
+                    return Err(HostError::state(format!(
+                        "Could not load project configuration: {error}"
+                    )));
+                }
+                effective_config.config.new_workspace.prompt_append
+            }
+            None => String::new(),
+        };
+        Ok(compose_agent_prompt(
+            prompt,
+            &profile.custom_prompt,
+            &project_prompt,
+        ))
+    }
+
+    pub(super) async fn compose_orchestration_task_prompt(
+        &self,
+        task: &mut Option<OrchestrationTask>,
+        profile_name: Option<&str>,
+    ) -> HostResult<()> {
+        if let Some(task) = task.as_mut() {
+            let workspace_id = task.workspace_id.clone();
+            let task_spec = task.spec.clone();
+            task.spec = self
+                .compose_profile_prompt_for_workspace(&workspace_id, &task_spec, profile_name)
+                .await?;
+        }
+        Ok(())
+    }
+
+    pub(super) async fn compose_orchestration_prompt(
+        &self,
+        task: &OrchestrationTask,
+        prompt: &str,
+        payload: &Value,
+    ) -> HostResult<(Option<String>, String)> {
+        let profile_name =
+            super::orchestration_validation::optional_string(payload, "agentProfile");
+        let effective_prompt = self
+            .compose_profile_prompt_for_workspace(
+                &task.workspace_id,
+                prompt,
+                profile_name.as_deref(),
+            )
+            .await?;
+        Ok((profile_name, effective_prompt))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::compose_agent_prompt;
+
+    #[test]
+    fn preserves_prompt_profile_project_order() {
+        assert_eq!(
+            compose_agent_prompt(
+                "Build The Feature",
+                "Use The Repository Style",
+                "Run The Tests"
+            ),
+            "Build The Feature\n\nUse The Repository Style\n\nRun The Tests"
+        );
+    }
+
+    #[test]
+    fn skips_blank_sources_and_trims_boundaries() {
+        assert_eq!(
+            compose_agent_prompt("  Build The Feature  ", "  ", "  Run The Tests  "),
+            "Build The Feature\n\nRun The Tests"
+        );
+    }
+}

--- a/rust/alera-cli/src/terminal_host/server/coordinator_requests.rs
+++ b/rust/alera-cli/src/terminal_host/server/coordinator_requests.rs
@@ -736,6 +736,9 @@ impl ServerActor {
         else {
             return Ok(false);
         };
+        let (profile_name, profile_quota_group, effective_spec) = self
+            .coordinator_profile_prompt_for_task(&task, &stripped_spec)
+            .await?;
         let gates = self
             .runtime_store
             .list_orchestration_gates(Some(task_id), Some(OrchestrationGateStatus::Resolved))
@@ -763,6 +766,13 @@ impl ServerActor {
                 "keep-open",
             )
             .await?;
+        self.runtime_store
+            .set_orchestration_dispatch_profile(
+                &dispatch.id,
+                profile_name.as_deref(),
+                profile_quota_group.as_deref(),
+            )
+            .await?;
         self.orchestration_activity_last_recorded.remove(handle);
         if let Err(error) = self.install_dispatch_context(handle, &dispatch.id, &context_token) {
             self.runtime_store
@@ -773,7 +783,7 @@ impl ServerActor {
         let preamble = build_dispatch_preamble(&PreambleParams {
             task_id,
             dispatch_id: &dispatch.id,
-            task_spec: &stripped_spec,
+            task_spec: &effective_spec,
             coordinator_handle: config
                 .coordinator_handle
                 .as_deref()

--- a/rust/alera-cli/src/terminal_host/server/declared_catalog_requests.rs
+++ b/rust/alera-cli/src/terminal_host/server/declared_catalog_requests.rs
@@ -143,6 +143,7 @@ fn profile_from_payload(payload: &Value) -> HostResult<AgentProfile> {
         command,
         launch_mode,
         managed_config,
+        custom_prompt: optional_profile_string(payload, "customPrompt").unwrap_or_default(),
         description: optional_profile_string(payload, "description").unwrap_or_default(),
         quota_group: optional_profile_string(payload, "quotaGroup"),
         created_at: now,
@@ -183,6 +184,20 @@ mod tests {
         assert_eq!(profile.launch_mode, AgentProfileLaunchMode::Command);
         assert_eq!(profile.command, "codex --search");
         assert_eq!(profile.managed_config, None);
+        assert_eq!(profile.custom_prompt, "");
+    }
+
+    #[test]
+    fn profile_payload_trims_custom_prompt() {
+        let profile = profile_from_payload(&json!({
+            "name": "Codex",
+            "agentType": "codex",
+            "command": "codex --search",
+            "customPrompt": "  Keep The Changes Focused  "
+        }))
+        .unwrap();
+
+        assert_eq!(profile.custom_prompt, "Keep The Changes Focused");
     }
 
     #[test]

--- a/rust/alera-cli/src/terminal_host/server/orchestration_profile_spawn.rs
+++ b/rust/alera-cli/src/terminal_host/server/orchestration_profile_spawn.rs
@@ -1,7 +1,9 @@
 //! Resolving which agent profile runs a task, and picking the next candidate
 //! when an earlier one failed to start.
 
-use alera_core::runtime::{AgentProfile, AgentProfileLaunchMode, OrchestrationPolicyStatus};
+use alera_core::runtime::{
+    AgentProfile, AgentProfileLaunchMode, OrchestrationPolicyStatus, OrchestrationTask,
+};
 use serde_json::Value;
 
 use crate::terminal_host::host_error::{HostError, HostResult};
@@ -149,6 +151,31 @@ impl ServerActor {
             .await
             .ok()??;
         launch_for_profile(&profile).ok()
+    }
+
+    pub(super) async fn coordinator_profile_prompt_for_task(
+        &mut self,
+        task: &OrchestrationTask,
+        prompt: &str,
+    ) -> anyhow::Result<(Option<String>, Option<String>, String)> {
+        let profile_name = self.coordinator_profile_for_task(task).await;
+        let profile_quota_group = if let Some(profile_name) = profile_name.as_deref() {
+            self.runtime_store
+                .agent_profile_by_name(profile_name)
+                .await?
+                .and_then(|profile| profile.quota_group)
+        } else {
+            None
+        };
+        let effective_prompt = self
+            .compose_profile_prompt_for_workspace(
+                &task.workspace_id,
+                prompt,
+                profile_name.as_deref(),
+            )
+            .await
+            .map_err(|error| anyhow::anyhow!(error.to_string()))?;
+        Ok((profile_name, profile_quota_group, effective_prompt))
     }
 
     async fn quota_group_for(&mut self, profile_name: &str) -> HostResult<Option<String>> {

--- a/rust/alera-cli/src/terminal_host/server/orchestration_requests.rs
+++ b/rust/alera-cli/src/terminal_host/server/orchestration_requests.rs
@@ -1047,6 +1047,9 @@ impl ServerActor {
             .map_err(state_error)?
             .ok_or_else(|| HostError::state(format!("orchestration task not found: {task_id}")))?;
         let (_allow_stale, stripped_spec) = parse_allow_stale_base_from_spec(&task.spec);
+        let (profile_name, effective_spec) = self
+            .compose_orchestration_prompt(&task, &stripped_spec, payload)
+            .await?;
         if from != task.coordinator_handle {
             return Err(HostError::state(format!(
                 "coordinator ownership conflict: task is owned by {}, not {from}",
@@ -1061,7 +1064,7 @@ impl ServerActor {
             let preamble = build_dispatch_preamble(&PreambleParams {
                 task_id: &task_id,
                 dispatch_id: "ctx_dryrun",
-                task_spec: &stripped_spec,
+                task_spec: &effective_spec,
                 coordinator_handle: &from,
                 base_drift: None,
                 gate_resolution: gate_resolution.as_ref(),
@@ -1135,7 +1138,7 @@ impl ServerActor {
         self.runtime_store
             .set_orchestration_dispatch_profile(
                 &dispatch.id,
-                optional_string(payload, "agentProfile").as_deref(),
+                profile_name.as_deref(),
                 optional_string(payload, "agentQuotaGroup").as_deref(),
             )
             .await
@@ -1165,7 +1168,7 @@ impl ServerActor {
         let preamble = build_dispatch_preamble(&PreambleParams {
             task_id: &task_id,
             dispatch_id: &dispatch.id,
-            task_spec: &stripped_spec,
+            task_spec: &effective_spec,
             coordinator_handle: &from,
             base_drift: None,
             gate_resolution: gate_resolution.as_ref(),
@@ -1370,6 +1373,8 @@ impl ServerActor {
             }
             base_drift = stored_drift;
         }
+        self.compose_orchestration_task_prompt(&mut task, dispatch.agent_profile.as_deref())
+            .await?;
         let gate_resolution = self.latest_resolved_gate(&dispatch.task_id).await?;
         let worker_instructions = build_worker_contract(
             &dispatch.coordinator_handle,

--- a/rust/alera-core/src/runtime/agent_profile_models.rs
+++ b/rust/alera-core/src/runtime/agent_profile_models.rs
@@ -54,6 +54,10 @@ pub struct AgentProfile {
     pub launch_mode: AgentProfileLaunchMode,
     #[serde(default)]
     pub managed_config: Option<Value>,
+    /// Instructions appended after a dispatched prompt and before project
+    /// instructions.
+    #[serde(default)]
+    pub custom_prompt: String,
     #[serde(default)]
     pub description: String,
     /// Profiles sharing a group drain the same usage bucket. Alera never

--- a/rust/alera-core/src/runtime/agent_profile_store.rs
+++ b/rust/alera-core/src/runtime/agent_profile_store.rs
@@ -8,7 +8,7 @@ use super::{
 };
 
 const PROFILE_COLUMNS: &str =
-    "id, name, agentType, command, launchMode, managedConfig, description, quotaGroup, createdAt, updatedAt";
+    "id, name, agentType, command, launchMode, managedConfig, customPrompt, description, quotaGroup, createdAt, updatedAt";
 
 impl RuntimeStore {
     pub async fn list_agent_profiles(&self) -> Result<Vec<AgentProfile>> {
@@ -62,11 +62,12 @@ impl RuntimeStore {
         let now = format_timestamp(Utc::now());
         sqlx::query(
             "INSERT INTO agentProfiles \
-             (id, name, agentType, command, launchMode, managedConfig, description, quotaGroup, createdAt, updatedAt) \
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?) \
+             (id, name, agentType, command, launchMode, managedConfig, customPrompt, description, quotaGroup, createdAt, updatedAt) \
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) \
              ON CONFLICT(id) DO UPDATE SET \
              name = excluded.name, agentType = excluded.agentType, command = excluded.command, \
              launchMode = excluded.launchMode, managedConfig = excluded.managedConfig, \
+             customPrompt = excluded.customPrompt, \
              description = excluded.description, quotaGroup = excluded.quotaGroup, \
              updatedAt = excluded.updatedAt",
         )
@@ -82,6 +83,7 @@ impl RuntimeStore {
                 .map(serde_json::to_string)
                 .transpose()?,
         )
+        .bind(&profile.custom_prompt)
         .bind(&profile.description)
         .bind(&profile.quota_group)
         .bind(format_timestamp(profile.created_at))
@@ -114,6 +116,7 @@ fn normalize_agent_profile(mut profile: AgentProfile) -> Result<AgentProfile> {
     profile.name = profile.name.trim().to_string();
     profile.agent_type = profile.agent_type.trim().to_string();
     profile.command = profile.command.trim().to_string();
+    profile.custom_prompt = profile.custom_prompt.trim().to_string();
     profile.description = profile.description.trim().to_string();
     profile.quota_group = profile
         .quota_group
@@ -172,6 +175,7 @@ fn agent_profile_from_row(row: sqlx::sqlite::SqliteRow) -> Result<AgentProfile> 
             .try_get::<Option<String>, _>("managedConfig")?
             .map(|value| serde_json::from_str(&value))
             .transpose()?,
+        custom_prompt: row.try_get("customPrompt")?,
         description: row.try_get("description")?,
         quota_group: row.try_get("quotaGroup")?,
         created_at: parse_timestamp(row.try_get::<String, _>("createdAt")?.as_str()),

--- a/rust/alera-core/src/runtime/agent_profile_store_tests.rs
+++ b/rust/alera-core/src/runtime/agent_profile_store_tests.rs
@@ -19,6 +19,7 @@ fn profile(id: &str, name: &str) -> AgentProfile {
         command: "codex".to_string(),
         launch_mode: AgentProfileLaunchMode::Command,
         managed_config: None,
+        custom_prompt: String::new(),
         description: String::new(),
         quota_group: None,
         created_at: now,
@@ -98,12 +99,14 @@ async fn trims_fields_and_drops_a_blank_quota_group() {
     let (_dir, store) = store().await;
     let mut raw = profile("prof_a", "  Codex Sol  ");
     raw.command = "  codex  ".to_string();
+    raw.custom_prompt = "  Always Explain The Tradeoffs  ".to_string();
     raw.description = "  Backend work  ".to_string();
     raw.quota_group = Some("   ".to_string());
 
     let stored = store.upsert_agent_profile(raw).await.unwrap();
     assert_eq!(stored.name, "Codex Sol");
     assert_eq!(stored.command, "codex");
+    assert_eq!(stored.custom_prompt, "Always Explain The Tradeoffs");
     assert_eq!(stored.description, "Backend work");
     assert_eq!(stored.quota_group, None);
 }
@@ -194,6 +197,7 @@ async fn migrates_existing_profiles_to_command_mode() {
     assert_eq!(profile.launch_mode, AgentProfileLaunchMode::Command);
     assert_eq!(profile.command, "codex --search");
     assert_eq!(profile.managed_config, None);
+    assert_eq!(profile.custom_prompt, "");
 }
 
 #[tokio::test]

--- a/rust/alera-core/src/runtime/runtime_schema.rs
+++ b/rust/alera-core/src/runtime/runtime_schema.rs
@@ -118,6 +118,7 @@ pub(super) const RUNTIME_SCHEMA: &[&str] = &[
         command TEXT NOT NULL,
         launchMode TEXT NOT NULL DEFAULT 'command',
         managedConfig TEXT,
+        customPrompt TEXT NOT NULL DEFAULT '',
         description TEXT NOT NULL DEFAULT '',
         quotaGroup TEXT,
         createdAt TEXT NOT NULL,

--- a/rust/alera-core/src/runtime/store.rs
+++ b/rust/alera-core/src/runtime/store.rs
@@ -125,6 +125,8 @@ impl RuntimeStore {
         .await?;
         self.ensure_column("agentProfiles", "managedConfig", "TEXT")
             .await?;
+        self.ensure_column("agentProfiles", "customPrompt", "TEXT NOT NULL DEFAULT ''")
+            .await?;
         // Orchestration tables are created idempotently above, but CREATE TABLE
         // IF NOT EXISTS is a no-op on an existing database, so every column
         // added after the v2 rebuild must also be backfilled here.

--- a/test/unit/runtime_agent_profile_repository_test.dart
+++ b/test/unit/runtime_agent_profile_repository_test.dart
@@ -16,6 +16,7 @@ void main() {
         'name': 'Codex Sol',
         'agentType': 'codex',
         'command': 'codex --model gpt-5.6-sol',
+        'customPrompt': 'Prefer Small, Reviewable Changes',
         'description': 'Backend implementation',
         'quotaGroup': 'codex-personal',
         'createdAt': '2026-07-01T00:00:00.000Z',
@@ -25,10 +26,15 @@ void main() {
       expect(profile.name, 'Codex Sol');
       expect(profile.agentType, 'codex');
       expect(profile.command, 'codex --model gpt-5.6-sol');
+      expect(profile.customPrompt, 'Prefer Small, Reviewable Changes');
       expect(profile.launchMode, AgentProfileLaunchMode.command);
       expect(profile.quotaGroup, 'codex-personal');
       expect(profile.createdAt, DateTime.utc(2026, 7));
       expect(profile.toJson()['quotaGroup'], 'codex-personal');
+      expect(
+        profile.toJson()['customPrompt'],
+        'Prefer Small, Reviewable Changes',
+      );
     });
 
     test('parses managed configuration from a host payload', () {
@@ -171,6 +177,7 @@ void main() {
         agentType: 'codex',
         launchMode: AgentProfileLaunchMode.command,
         command: 'codex',
+        customPrompt: 'Prefer Small, Reviewable Changes',
       );
 
       final payload = client.payloads['agentProfile.upsert']!.single;
@@ -178,6 +185,7 @@ void main() {
       expect(payload['name'], 'Codex Sol');
       expect(payload['launchMode'], 'command');
       expect(payload['quotaGroup'], isNull);
+      expect(payload['customPrompt'], 'Prefer Small, Reviewable Changes');
     });
 
     test('upsert sends the id when updating a profile', () async {
@@ -194,12 +202,14 @@ void main() {
         agentType: 'codex',
         launchMode: AgentProfileLaunchMode.command,
         command: 'codex',
+        customPrompt: 'Use The Team Conventions',
         quotaGroup: 'codex-personal',
       );
 
       final payload = client.payloads['agentProfile.upsert']!.single;
       expect(payload['id'], 'prof_1');
       expect(payload['quotaGroup'], 'codex-personal');
+      expect(payload['customPrompt'], 'Use The Team Conventions');
     });
 
     test('controller clone reuses all profile fields without its id', () async {
@@ -230,6 +240,7 @@ void main() {
         agentType: 'codex',
         command: 'codex --model sol',
         description: 'Backend implementation',
+        customPrompt: 'Prefer Small, Reviewable Changes',
         quotaGroup: 'codex-personal',
         createdAt: DateTime.utc(2026, 7),
         updatedAt: DateTime.utc(2026, 7),
@@ -244,6 +255,7 @@ void main() {
       expect(payload['command'], 'codex --model sol');
       expect(payload['description'], 'Backend implementation');
       expect(payload['quotaGroup'], 'codex-personal');
+      expect(payload['customPrompt'], 'Prefer Small, Reviewable Changes');
     });
 
     test('managed upsert sends structured config and no raw command', () async {
@@ -398,6 +410,7 @@ Map<String, Object?> _profilePayload(String id, String name) {
     'name': name,
     'agentType': 'codex',
     'command': 'codex',
+    'customPrompt': '',
     'description': '',
     'quotaGroup': null,
     'createdAt': '2026-07-01T00:00:00.000Z',

--- a/test/widget/agent_profile_editor_test.dart
+++ b/test/widget/agent_profile_editor_test.dart
@@ -65,6 +65,7 @@ void main() {
     );
 
     expect(find.text('Prompt Delivery'), findsOneWidget);
+    expect(find.text('Custom Prompt'), findsOneWidget);
     expect(
       find.textContaining('appends the dispatched prompt'),
       findsOneWidget,
@@ -254,6 +255,7 @@ class _EditorHarness extends StatefulWidget {
 class _EditorHarnessState extends State<_EditorHarness> {
   late final TextEditingController _nameController;
   late final TextEditingController _commandController;
+  late final TextEditingController _customPromptController;
   late final TextEditingController _descriptionController;
   late final TextEditingController _quotaGroupController;
 
@@ -262,6 +264,7 @@ class _EditorHarnessState extends State<_EditorHarness> {
     super.initState();
     _nameController = TextEditingController(text: 'Codex');
     _commandController = TextEditingController(text: 'codex');
+    _customPromptController = TextEditingController();
     _descriptionController = TextEditingController();
     _quotaGroupController = TextEditingController();
   }
@@ -270,6 +273,7 @@ class _EditorHarnessState extends State<_EditorHarness> {
   void dispose() {
     _nameController.dispose();
     _commandController.dispose();
+    _customPromptController.dispose();
     _descriptionController.dispose();
     _quotaGroupController.dispose();
     super.dispose();
@@ -285,6 +289,7 @@ class _EditorHarnessState extends State<_EditorHarness> {
           child: AgentProfileEditor(
             nameController: _nameController,
             commandController: _commandController,
+            customPromptController: _customPromptController,
             descriptionController: _descriptionController,
             quotaGroupController: _quotaGroupController,
             adapter: widget.adapter,


### PR DESCRIPTION
## Summary

- Add a persisted Custom Prompt field to every Agent Profile and expose it in Settings.
- Compose delivered prompts in user, profile, project order for New Workspace and orchestration dispatches.
- Migrate existing runtime databases and document the precedence.

## Validation

- `flutter pub run build_runner build -d`
- `flutter analyze`
- `flutter test test/unit/runtime_agent_profile_repository_test.dart test/widget/agent_profile_editor_test.dart test/widget/agent_profiles_pane_test.dart`
- `make rust-test`
- `dart run tool/quality/check_max_lines.dart`

## Risk

Existing profiles default to an empty custom prompt and keep their current behavior.