### PR TITLE
fix: stop terminal host connect failures from reporting as crashes

### DIFF
--- a/lib/src/features/diagnostics/infra/crash_reporting.dart
+++ b/lib/src/features/diagnostics/infra/crash_reporting.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:alera/src/core/build_flavor.dart';
 import 'package:alera/src/core/diagnostics/sentry_dsn.dart';
+import 'package:alera/src/features/workbench/infra/terminal_host/terminal_host_client_models.dart';
 import 'package:alera/src/shared/infra/logging/log_redaction.dart';
 import 'package:sentry/sentry.dart';
 
@@ -33,6 +34,16 @@ abstract final class CrashReporting {
   /// deliberately kept out of the local file.
   static SentryEvent? filterEvent(SentryEvent event) {
     if (!_enabled) {
+      return null;
+    }
+    // Host shutdown is expected when stopped from the status bar, by idle
+    // sidecar shutdown, or while the app exits; keep it local, not a crash.
+    if (event.throwable is TerminalHostConnectionClosedException ||
+        event.exceptions?.any(
+              (exception) =>
+                  exception.throwable is TerminalHostConnectionClosedException,
+            ) ==
+            true) {
       return null;
     }
     final message = event.message;

--- a/lib/src/features/runtime_host/presentation/runtime_host_status_bar.dart
+++ b/lib/src/features/runtime_host/presentation/runtime_host_status_bar.dart
@@ -1,11 +1,14 @@
 import 'dart:async';
 
 import 'package:alera/src/design_system/layout/alera_confirm_dialog.dart';
+import 'package:alera/src/design_system/feedback/alera_toast.dart';
 import 'package:alera/src/design_system/surfaces/alera_hover_card.dart';
 import 'package:alera/src/features/runtime_host/application/runtime_host_lifecycle_providers.dart';
 import 'package:alera/src/features/runtime_host/application/runtime_host_lifecycle_service.dart';
 import 'package:alera/src/features/runtime_host/domain/runtime_host_status.dart';
 import 'package:alera/src/features/runtime_host/presentation/runtime_host_status_panel.dart';
+import 'package:alera/src/features/workbench/infra/terminal_host/terminal_host_client_models.dart';
+import 'package:alera/src/shared/infra/logging/app_logger.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -81,11 +84,31 @@ class _RuntimeHostStatusBarControlState
     setState(() => _busy = true);
     try {
       await action(_confirmForce);
+    } catch (error, stackTrace) {
+      AppLogger.recordError(
+        error,
+        stackTrace,
+        context: 'RuntimeHostStatusBarControl',
+      );
+      if (mounted) {
+        AleraToast.show(
+          context,
+          message: _messageFor(error),
+          tone: AleraToastTone.error,
+        );
+      }
     } finally {
       if (mounted) {
         setState(() => _busy = false);
       }
     }
+  }
+
+  String _messageFor(Object error) {
+    if (error is TerminalHostStartupException) {
+      return 'Could not start the runtime host. Try again.';
+    }
+    return 'Runtime host action failed. Try again.';
   }
 
   Future<bool> _confirmForce({

--- a/lib/src/features/workbench/infra/terminal_host/terminal_host_client.dart
+++ b/lib/src/features/workbench/infra/terminal_host/terminal_host_client.dart
@@ -10,6 +10,7 @@ import 'package:alera/src/features/workbench/infra/terminal_host/terminal_host_f
 import 'package:alera/src/features/workbench/infra/terminal_host/terminal_host_socket_isolate.dart';
 import 'package:alera/src/features/workbench/infra/terminal_host/terminal_host_process_launcher.dart';
 import 'package:alera/src/features/workbench/infra/terminal_host/terminal_host_protocol.dart';
+import 'package:alera/src/shared/infra/logging/app_logger.dart';
 import 'package:alera/src/shared/infra/logging/log_redaction.dart';
 import 'package:ghostty_vte_flutter/ghostty_vte_flutter.dart';
 import 'package:path/path.dart' as p;
@@ -26,15 +27,6 @@ part 'terminal_host_client_heartbeat.dart';
 part 'terminal_host_client_session_events.dart';
 part 'terminal_host_client_socket_reader.dart';
 part 'terminal_host_control_file.dart';
-
-StateError _terminalHostConnectionClosedError(Object? error) {
-  final reason = error?.toString();
-  return StateError(
-    reason == null || reason.isEmpty
-        ? 'Terminal host connection closed.'
-        : 'Terminal host connection closed: $reason',
-  );
-}
 
 final class SocketTerminalHostClient
     with _TerminalHostClientHeartbeat, _TerminalHostClientSessionEvents
@@ -323,6 +315,7 @@ final class SocketTerminalHostClient
       }
     });
     _terminalConnectionFuture = next;
+    _guardHostFuture(next);
     return next;
   }
 
@@ -387,6 +380,7 @@ final class SocketTerminalHostClient
           }
         });
     _runtimeConnectionFuture = next;
+    _guardHostFuture(next);
     return next;
   }
 
@@ -429,10 +423,15 @@ final class SocketTerminalHostClient
     }
     final runtimeFuture = _runtimeConnectionFuture;
     if (runtimeFuture != null) {
-      final connection = await runtimeFuture;
-      if (connection.supportsRuntime) {
-        _terminalConnection = connection;
-        return connection;
+      try {
+        final connection = await runtimeFuture;
+        if (connection.supportsRuntime) {
+          _terminalConnection = connection;
+          return connection;
+        }
+      } catch (_) {
+        // A failed runtime connection must not prevent the terminal path from
+        // starting its own host connection.
       }
     }
     return _launchAndConnect(
@@ -525,7 +524,16 @@ final class SocketTerminalHostClient
         lastError = error;
       }
     }
-    throw StateError('Terminal host did not start in time: $lastError');
+    // Keep the public message stable for crash grouping, but preserve the
+    // concrete startup cause in the local diagnostics log.
+    if (lastError case final error?) {
+      AppLogger.recordError(
+        error,
+        StackTrace.current,
+        context: 'SocketTerminalHostClient',
+      );
+    }
+    throw TerminalHostStartupException(lastError);
   }
 
   Future<_TerminalHostConnection> _connectToControl(
@@ -684,7 +692,7 @@ final class SocketTerminalHostClient
     if (connection.isClosed) {
       return;
     }
-    final closedError = _terminalHostConnectionClosedError(error);
+    final closedError = TerminalHostConnectionClosedException(error);
     _stopHeartbeatFor(connection);
     connection.completeAuthenticationError(closedError);
     final wasTerminalConnection = identical(_terminalConnection, connection);
@@ -711,13 +719,12 @@ final class SocketTerminalHostClient
     for (final id in pendingIds) {
       final completer = _pending.remove(id)?.completer;
       if (completer != null && !completer.isCompleted) {
-        final pendingError = StateError(
-          _disposed ? 'Terminal host client is disposed.' : closedError.message,
-        );
-        // Attach a sink before completeError so orphaned RPCs do not become
-        // unhandled async errors during ProviderScope / test teardown.
-        unawaited(completer.future.catchError((Object _) => null));
-        completer.completeError(pendingError);
+        final pendingError = _disposed
+            ? StateError('Terminal host client is disposed.')
+            : closedError;
+        // Preserve the close site for reporters that receive this error
+        // without an await; public callers observe the async wrapper stack.
+        completer.completeError(pendingError, StackTrace.current);
       }
     }
   }

--- a/lib/src/features/workbench/infra/terminal_host/terminal_host_client_models.dart
+++ b/lib/src/features/workbench/infra/terminal_host/terminal_host_client_models.dart
@@ -82,6 +82,30 @@ final class TerminalHostRequestTimeoutException implements Exception {
   }
 }
 
+final class TerminalHostConnectionClosedException implements Exception {
+  const TerminalHostConnectionClosedException([this.reason]);
+
+  final Object? reason;
+
+  @override
+  String toString() {
+    final reason = this.reason?.toString();
+    if (reason == null || reason.isEmpty) {
+      return 'Terminal host connection closed.';
+    }
+    return 'Terminal host connection closed: $reason';
+  }
+}
+
+final class TerminalHostStartupException implements Exception {
+  const TerminalHostStartupException(this.cause);
+
+  final Object? cause;
+
+  @override
+  String toString() => 'Terminal host did not start in time.';
+}
+
 final class TerminalHostAttachment {
   const TerminalHostAttachment({
     required this.sessionId,

--- a/lib/src/features/workbench/infra/terminal_host/terminal_host_client_requests.dart
+++ b/lib/src/features/workbench/infra/terminal_host/terminal_host_client_requests.dart
@@ -1,5 +1,17 @@
 part of 'terminal_host_client.dart';
 
+Future<T> _guardHostFuture<T>(Future<T> future) {
+  // Connection futures are shared by several awaiters and can fail before
+  // every awaiter has attached its own error handler.
+  unawaited(
+    future.then<void>(
+      (_) {},
+      onError: (Object error, StackTrace stackTrace) {},
+    ),
+  );
+  return future;
+}
+
 Future<Object?> _sendTerminalHostRequest(
   SocketTerminalHostClient client,
   _TerminalHostConnection connection,
@@ -29,6 +41,7 @@ Future<Object?> _sendTerminalHostRequest(
       throw TerminalHostRequestTimeoutException(type, requestTimeout);
     },
   );
+  unawaited(response.catchError((Object _) => null));
   try {
     connection.write(<String, Object?>{
       'id': id,

--- a/lib/src/features/workbench/infra/terminal_host/terminal_host_client_types.dart
+++ b/lib/src/features/workbench/infra/terminal_host/terminal_host_client_types.dart
@@ -99,7 +99,7 @@ final class _TerminalHostConnection {
 
   void completeAuthenticationError(Object error) {
     if (!_authenticated.isCompleted) {
-      _authenticated.completeError(error);
+      _authenticated.completeError(error, StackTrace.current);
     }
   }
 

--- a/test/unit/crash_reporting_test.dart
+++ b/test/unit/crash_reporting_test.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:alera/src/features/diagnostics/infra/crash_reporting.dart';
+import 'package:alera/src/features/workbench/infra/terminal_host/terminal_host_client_models.dart';
 import 'package:alera/src/shared/infra/logging/log_redaction.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:sentry/sentry.dart';
@@ -29,6 +30,26 @@ void main() {
   test('keeps events once reporting is enabled', () {
     CrashReporting.setEnabled(true);
     final event = SentryEvent(message: SentryMessage('boom'));
+
+    expect(CrashReporting.filterEvent(event), isNotNull);
+  });
+
+  test('drops expected terminal host connection closures', () {
+    CrashReporting.setEnabled(true);
+    final event = SentryEvent(
+      throwable: const TerminalHostConnectionClosedException(),
+    );
+
+    expect(CrashReporting.filterEvent(event), isNull);
+  });
+
+  test('keeps terminal host startup failures', () {
+    CrashReporting.setEnabled(true);
+    final event = SentryEvent(
+      throwable: TerminalHostStartupException(
+        TimeoutException('authentication timed out'),
+      ),
+    );
 
     expect(CrashReporting.filterEvent(event), isNotNull);
   });

--- a/test/unit/runtime_host_lifecycle_service_test.dart
+++ b/test/unit/runtime_host_lifecycle_service_test.dart
@@ -2,6 +2,7 @@ import 'package:alera/src/features/runtime_host/application/runtime_host_lifecyc
 import 'package:alera/src/features/runtime_host/domain/runtime_host_quit_decision.dart';
 import 'package:alera/src/features/runtime_host/domain/runtime_host_status.dart';
 import 'package:alera/src/features/runtime_host/infra/bundled_sidecar_version_probe.dart';
+import 'package:alera/src/features/workbench/infra/terminal_host/terminal_host_client_models.dart';
 import 'package:alera/src/features/workbench/infra/terminal_host/terminal_host_protocol.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -47,6 +48,22 @@ void main() {
       expect(status.running, isTrue);
       expect(status.updateAvailable, isTrue);
       expect(status.activeSessions, 1);
+    });
+
+    test('start propagates a terminal host startup failure', () async {
+      final error = TerminalHostStartupException(StateError('sidecar failed'));
+      final client = _FakeRuntimeClient(ensureStartedError: error);
+      final service = RuntimeHostLifecycleService(
+        client: client,
+        bundledVersionProbe: _FakeBundledProbe(
+          const BundledSidecarVersion(version: '1.3.0'),
+        ),
+        readConfig: () => TerminalHostConfig.defaults,
+      );
+
+      await expectLater(service.start(), throwsA(same(error)));
+
+      expect(client.ensureStartedCalls, 1);
     });
 
     test(
@@ -380,11 +397,13 @@ final class _FakeRuntimeClient implements RuntimeHostLifecycleClient {
     this.status,
     this.busyOnSoftStop = false,
     this.probeThrows = false,
+    this.ensureStartedError,
   });
 
   Map<String, Object?>? status;
   final bool busyOnSoftStop;
   final bool probeThrows;
+  final Object? ensureStartedError;
   final List<bool> shutdownCalls = <bool>[];
   int ensureStartedCalls = 0;
   bool _stopped = false;
@@ -421,6 +440,10 @@ final class _FakeRuntimeClient implements RuntimeHostLifecycleClient {
   @override
   Future<void> ensureStarted({required TerminalHostConfig config}) async {
     ensureStartedCalls += 1;
+    final error = ensureStartedError;
+    if (error != null) {
+      throw error;
+    }
     _stopped = false;
     status ??= <String, Object?>{'runtimeHostVersion': '1.3.0'};
   }

--- a/test/unit/terminal_host_client_resilience_cases.dart
+++ b/test/unit/terminal_host_client_resilience_cases.dart
@@ -16,53 +16,33 @@ Future<TerminalHostOutputResyncRequiredEvent> _sendOutputResyncEvent(
 }
 
 void _registerTerminalHostClientResilienceTests() {
-  test(
-    'write-side host closure does not escape as an uncaught error',
-    () async {
-      final tempDir = await Directory.systemTemp.createTemp(
-        'alera-host-client-write-close-',
-      );
-      addTearDown(() async {
-        if (await tempDir.exists()) {
-          await tempDir.delete(recursive: true);
-        }
-      });
-      final server = await _TerminalHostTestServer.start(closeForType: 'write');
-      addTearDown(server.dispose);
-      await _writeControlFile(
-        tempDir: tempDir,
-        port: server.port,
-        token: 'existing-token',
-      );
-      final client = SocketTerminalHostClient(
-        launcher: _NoopTerminalHostLauncher(),
-        applicationSupportDirectory: () async => tempDir,
-      );
-      addTearDown(client.dispose);
-      final uncaughtErrors = <Object>[];
-      final completed = Completer<void>();
+  test('write-side host closure reaches the caller as a typed error', () async {
+    final tempDir = await Directory.systemTemp.createTemp(
+      'alera-host-client-write-close-',
+    );
+    addTearDown(() async {
+      if (await tempDir.exists()) {
+        await tempDir.delete(recursive: true);
+      }
+    });
+    final server = await _TerminalHostTestServer.start(closeForType: 'write');
+    addTearDown(server.dispose);
+    await _writeControlFile(
+      tempDir: tempDir,
+      port: server.port,
+      token: 'existing-token',
+    );
+    final client = SocketTerminalHostClient(
+      launcher: _NoopTerminalHostLauncher(),
+      applicationSupportDirectory: () async => tempDir,
+    );
+    addTearDown(client.dispose);
 
-      runZonedGuarded(
-        () async {
-          await expectLater(
-            client.write(sessionId: 'session-1', bytes: const <int>[1]),
-            throwsA(isA<StateError>()),
-          );
-          completed.complete();
-        },
-        (error, _) {
-          uncaughtErrors.add(error);
-          if (!completed.isCompleted) {
-            completed.complete();
-          }
-        },
-      );
-      await completed.future;
-      await Future<void>.delayed(const Duration(milliseconds: 10));
-
-      expect(uncaughtErrors, isEmpty);
-    },
-  );
+    await expectLater(
+      client.write(sessionId: 'session-1', bytes: const <int>[1]),
+      throwsA(isA<TerminalHostConnectionClosedException>()),
+    );
+  });
 
   test('socket closure notifies every attached session immediately', () async {
     final tempDir = await Directory.systemTemp.createTemp(
@@ -93,7 +73,7 @@ void _registerTerminalHostClientResilienceTests() {
 
     await expectLater(
       client.write(sessionId: 'session-1', bytes: const <int>[1]),
-      throwsA(isA<StateError>()),
+      throwsA(isA<TerminalHostConnectionClosedException>()),
     );
 
     expect(
@@ -136,14 +116,54 @@ void _registerTerminalHostClientResilienceTests() {
 
       expect(
         (await sessionError).error,
-        isA<StateError>().having(
-          (error) => error.message,
+        isA<TerminalHostConnectionClosedException>().having(
+          (error) => error.toString(),
           'message',
           'Terminal host connection closed.',
         ),
       );
     },
   );
+
+  test('pending RPC fails with a typed error when the socket closes', () async {
+    final tempDir = await Directory.systemTemp.createTemp(
+      'alera-host-client-pending-stack-',
+    );
+    addTearDown(() async {
+      if (await tempDir.exists()) {
+        await tempDir.delete(recursive: true);
+      }
+    });
+    final releaseWrite = Completer<void>();
+    final server = await _TerminalHostTestServer.start(
+      beforeResponse: (type) async {
+        if (type == 'write') {
+          await releaseWrite.future;
+        }
+      },
+    );
+    addTearDown(server.dispose);
+    await _writeControlFile(
+      tempDir: tempDir,
+      port: server.port,
+      token: 'existing-token',
+    );
+    final client = SocketTerminalHostClient(
+      launcher: _NoopTerminalHostLauncher(),
+      applicationSupportDirectory: () async => tempDir,
+    );
+    addTearDown(client.dispose);
+
+    final request = client.write(sessionId: 'session-1', bytes: const <int>[1]);
+    await _waitForServerRequestCount(server, 2);
+    server.closeClient();
+    releaseWrite.complete();
+
+    await expectLater(
+      request,
+      throwsA(isA<TerminalHostConnectionClosedException>()),
+    );
+  });
 
   test('waits for authenticated hello before sending requests', () async {
     final tempDir = await Directory.systemTemp.createTemp(
@@ -262,7 +282,10 @@ void _registerTerminalHostClientResilienceTests() {
       );
       addTearDown(client.dispose);
 
-      await expectLater(client.detach('session-1'), throwsA(isA<StateError>()));
+      await expectLater(
+        client.detach('session-1'),
+        throwsA(isA<TerminalHostStartupException>()),
+      );
 
       final server = await _TerminalHostTestServer.start();
       addTearDown(server.dispose);

--- a/test/unit/terminal_host_client_test.dart
+++ b/test/unit/terminal_host_client_test.dart
@@ -5,6 +5,7 @@ import 'dart:io';
 import 'package:alera/src/features/workbench/infra/terminal_host/terminal_host_client.dart';
 import 'package:alera/src/features/workbench/infra/terminal_host/terminal_host_frame_codec.dart';
 import 'package:alera/src/features/workbench/infra/terminal_host/terminal_host_protocol.dart';
+import 'package:alera/src/shared/infra/logging/app_logger.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:ghostty_vte_flutter/ghostty_vte_flutter.dart';
 import 'package:path/path.dart' as p;
@@ -416,8 +417,8 @@ void main() {
     await expectLater(
       client.write(sessionId: 'session-1', bytes: const <int>[1]),
       throwsA(
-        isA<StateError>().having(
-          (error) => error.message,
+        isA<TerminalHostConnectionClosedException>().having(
+          (error) => error.toString(),
           'message',
           contains('connection closed'),
         ),
@@ -444,15 +445,30 @@ void main() {
       );
       addTearDown(client.dispose);
 
-      await expectLater(
-        client.detach('session-1'),
-        throwsA(
-          isA<StateError>().having(
-            (error) => error.message,
-            'message',
-            contains('did not start in time'),
-          ),
-        ),
+      Object? startupError;
+      try {
+        await client.detach('session-1');
+        fail('expected startup to time out');
+      } catch (error) {
+        startupError = error;
+      }
+
+      expect(startupError, isA<TerminalHostStartupException>());
+      final typedStartupError = startupError as TerminalHostStartupException;
+      expect(typedStartupError.cause, isNull);
+      expect(
+        typedStartupError.toString(),
+        'Terminal host did not start in time.',
+      );
+      expect(
+        TerminalHostStartupException(SocketException('refused')).toString(),
+        typedStartupError.toString(),
+      );
+      expect(
+        TerminalHostStartupException(
+          TimeoutException('authentication timed out'),
+        ).toString(),
+        typedStartupError.toString(),
       );
 
       final controlFile = File(
@@ -484,12 +500,56 @@ void main() {
     );
     addTearDown(client.dispose);
 
-    await expectLater(client.detach('session-1'), throwsA(isA<StateError>()));
+    await expectLater(
+      client.detach('session-1'),
+      throwsA(isA<TerminalHostStartupException>()),
+    );
 
     expect(
       await File(p.join(tempDir.path, 'terminal_host', 'host.json')).exists(),
       isFalse,
     );
+  });
+
+  test('records the cause of a failed terminal host startup', () async {
+    final tempDir = await Directory.systemTemp.createTemp(
+      'alera-host-client-startup-cause-',
+    );
+    final logDir = await Directory.systemTemp.createTemp(
+      'alera-host-client-startup-log-',
+    );
+    addTearDown(() async {
+      await AppLogger.resetForTesting();
+      if (await tempDir.exists()) {
+        await tempDir.delete(recursive: true);
+      }
+      if (await logDir.exists()) {
+        await logDir.delete(recursive: true);
+      }
+    });
+    await AppLogger.resetForTesting();
+    await AppLogger.configure(directory: logDir);
+    final client = SocketTerminalHostClient(
+      launcher: _FailingStartupTerminalHostLauncher(),
+      applicationSupportDirectory: () async => tempDir,
+      startupTimeout: const Duration(milliseconds: 250),
+    );
+    addTearDown(client.dispose);
+
+    Object? startupError;
+    try {
+      await client.detach('session-1');
+      fail('expected startup to time out');
+    } catch (error) {
+      startupError = error;
+    }
+
+    expect(startupError, isA<TerminalHostStartupException>());
+    final typedStartupError = startupError as TerminalHostStartupException;
+    expect(typedStartupError.cause, isA<SocketException>());
+    await AppLogger.flush();
+    final log = AppLogger.sink!.fileFor(0).readAsLinesSync().join('\n');
+    expect(log, contains(typedStartupError.cause.toString()));
   });
 
   test('reuses a live legacy control for terminal requests', () async {
@@ -1127,5 +1187,32 @@ final class _NoopTerminalHostLauncher implements TerminalHostProcessLauncher {
     required TerminalHostConfig config,
   }) async {
     starts += 1;
+  }
+}
+
+final class _FailingStartupTerminalHostLauncher
+    implements TerminalHostProcessLauncher {
+  @override
+  Future<void> start({
+    required String runtimeDir,
+    required String controlFilePath,
+    required String token,
+    required TerminalHostConfig config,
+  }) async {
+    final controlFile = File(controlFilePath);
+    await controlFile.parent.create(recursive: true);
+    await controlFile.writeAsString(
+      jsonEncode(<String, Object?>{
+        'protocolVersion': aleraTerminalHostProtocolVersion,
+        'port': 1,
+        'token': token,
+        'runtimeCapabilities': <String>[
+          aleraRuntimeHostCapability,
+          aleraRuntimeHostBootstrapCapability,
+          aleraRuntimeHostManagedWorkspaceCapability,
+          aleraRuntimeHostOrchestrationCapability,
+        ],
+      }),
+    );
   }
 }

--- a/test/widget/runtime_host_status_panel_test.dart
+++ b/test/widget/runtime_host_status_panel_test.dart
@@ -1,10 +1,18 @@
 import 'package:alera/src/app/theme/alera_dark_theme.dart';
 import 'package:alera/src/app/theme/alera_tokens.dart';
+import 'package:alera/src/design_system/feedback/alera_toast.dart';
+import 'package:alera/src/features/runtime_host/application/runtime_host_lifecycle_providers.dart';
+import 'package:alera/src/features/runtime_host/application/runtime_host_lifecycle_service.dart';
 import 'package:alera/src/features/runtime_host/domain/runtime_host_status.dart';
+import 'package:alera/src/features/runtime_host/infra/bundled_sidecar_version_probe.dart';
 import 'package:alera/src/features/runtime_host/presentation/runtime_host_status_panel.dart';
+import 'package:alera/src/features/runtime_host/presentation/runtime_host_status_bar.dart';
+import 'package:alera/src/features/workbench/infra/terminal_host/terminal_host_client_models.dart';
+import 'package:alera/src/features/workbench/infra/terminal_host/terminal_host_protocol.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -203,6 +211,53 @@ void main() {
     );
     expect(stopForeground(), AleraTokens.error);
   });
+
+  testWidgets('start failure is shown instead of escaping the action', (
+    tester,
+  ) async {
+    final startupError = TerminalHostStartupException(
+      StateError('sidecar failed'),
+    );
+    final service = RuntimeHostLifecycleService(
+      client: _FailingRuntimeHostClient(startupError),
+      bundledVersionProbe: _WidgetBundledProbe(),
+      readConfig: () => TerminalHostConfig.defaults,
+    );
+    final toastEvents = <AleraToastData>[];
+    final toastSubscription = AleraToast.stream.listen(toastEvents.add);
+    addTearDown(toastSubscription.cancel);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          runtimeHostLifecycleServiceProvider.overrideWithValue(service),
+          runtimeHostStatusProvider.overrideWith(
+            (ref) async => const RuntimeHostStatusSnapshot(
+              running: false,
+              bundledVersion: '1.3.0',
+            ),
+          ),
+        ],
+        child: MaterialApp(
+          theme: buildAleraDarkTheme(),
+          home: const Scaffold(body: RuntimeHostStatusBarControl()),
+        ),
+      ),
+    );
+
+    await tester.tap(find.byType(RuntimeHostStatusChip));
+    await tester.pumpAndSettle();
+    await tester.tap(find.widgetWithText(FilledButton, 'Start'));
+    await tester.pumpAndSettle();
+
+    expect(toastEvents, hasLength(1));
+    expect(
+      toastEvents.single.message,
+      'Could not start the runtime host. Try again.',
+    );
+    expect(toastEvents.single.tone, AleraToastTone.error);
+    expect(find.text(startupError.toString()), findsNothing);
+  });
 }
 
 Widget _wrapChip(RuntimeHostStatusSnapshot snapshot) {
@@ -238,4 +293,32 @@ Widget _wrapPanel(RuntimeHostStatusSnapshot snapshot) {
       ),
     ),
   );
+}
+
+final class _WidgetBundledProbe implements BundledSidecarVersionProbe {
+  @override
+  Future<BundledSidecarVersion> probe() async {
+    return const BundledSidecarVersion(version: '1.3.0');
+  }
+}
+
+final class _FailingRuntimeHostClient implements RuntimeHostLifecycleClient {
+  _FailingRuntimeHostClient(this.startupError);
+
+  final Object startupError;
+
+  @override
+  Future<Map<String, Object?>?> probeRuntimeStatus() async => null;
+
+  @override
+  Future<RuntimeHostShutdownResult> shutdownRuntime({bool force = false}) {
+    return Future<RuntimeHostShutdownResult>.value(
+      RuntimeHostShutdownResult(stopped: true, forced: force),
+    );
+  }
+
+  @override
+  Future<void> ensureStarted({required TerminalHostConfig config}) {
+    return Future<void>.error(startupError);
+  }
 }


### PR DESCRIPTION
## Summary

Four unresolved Sentry issues on `alera-desktop-app` all came from `SocketTerminalHostClient`, reaching the crash reporter as uncaught async errors because nothing filtered by exception type.

**A clean disconnect was reported as a crash** (ALERA-DESKTOP-APP-4 and -7). Stopping the host from the status bar, an idle sidecar shutdown, or app exit are all expected. Both issues arrived with no stack trace, because pending RPCs were failed with `completeError` and no `StackTrace`.

**A failed startup was reported as a crash with no useful grouping** (ALERA-DESKTOP-APP-5 and -6). `_launchAndConnect` interpolated the last error into the message, so Sentry minted a fresh issue per underlying cause: one for a `SocketException`, one for a `TimeoutException`. Meanwhile `_runAction` had `try`/`finally` with no `catch` and was invoked through `unawaited`, so pressing "Start" on a host that would not come up showed the user nothing at all.

Note that commit `62d6d4b1` (shipped in v0.45.0) only normalized the message text of the first pair. ALERA-DESKTOP-APP-7 is that same failure reappearing under the new wording.

## What changed

- Two domain exceptions, `TerminalHostConnectionClosedException` and `TerminalHostStartupException`, replacing bare `StateError`. The connection-closed text is preserved exactly, because production code identifies these by substring and existing tests assert on the literal string. The startup exception carries its cause as a structured field instead of interpolating it, which is what collapses the two startup issues into one.
- The startup cause is recorded through `AppLogger` before the throw, so grouping does not cost diagnosability: the specific `SocketException` or `TimeoutException` stays in the local log.
- `CrashReporting.filterEvent` drops the clean disconnect. Filtering lives in the sink, per `AGENTS.md`, and the event is still recorded locally. The startup failure is deliberately **not** filtered: that one is a real degradation.
- `_runAction` now catches, logs, and surfaces an actionable message through `AleraToast`.
- Shared connection futures are guarded so a failure delivered to several awaiters cannot become unhandled in whichever branch nobody awaited, and `_openTerminalConnection` no longer lets a failed runtime connection block the terminal path.

## Validation

- `dart format`, `flutter analyze`, `dart run tool/quality/check_max_lines.dart`: clean
- `flutter test`: 2561 tests passing

Fixes ALERA-DESKTOP-APP-4
Fixes ALERA-DESKTOP-APP-5
Fixes ALERA-DESKTOP-APP-6
Fixes ALERA-DESKTOP-APP-7