### PR TITLE
feat: add terminal search

### DIFF
--- a/lib/src/features/keyboard/application/keyboard_command_dispatcher.dart
+++ b/lib/src/features/keyboard/application/keyboard_command_dispatcher.dart
@@ -7,6 +7,7 @@ import 'package:alera/src/features/keyboard/domain/keyboard_action.dart';
 import 'package:alera/src/features/workbench/domain/workbench_layout.dart';
 import 'package:alera/src/features/workbench/domain/workbench_view_prefs.dart';
 import 'package:alera/src/features/workbench/domain/workspace_tab_record.dart';
+import 'package:alera/src/features/workbench/presentation/terminal_runtime.dart';
 import 'package:alera/src/features/workbench/presentation/workbench_dialog_launchers.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -15,10 +16,15 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 /// controller methods and dialog flows. Construct one per dispatch with the
 /// current [ref] and a [context] suitable for showing dialogs/toasts.
 class KeyboardCommandDispatcher {
-  const KeyboardCommandDispatcher({required this.ref, required this.context});
+  const KeyboardCommandDispatcher({
+    required this.ref,
+    required this.context,
+    this.terminalSession,
+  });
 
   final WidgetRef ref;
   final BuildContext context;
+  final TerminalSessionHandle? terminalSession;
 
   void dispatch(KeyboardActionId id) {
     switch (id) {
@@ -35,6 +41,8 @@ class KeyboardCommandDispatcher {
         );
       case KeyboardActionId.findInFiles:
         _showContextPanel(WorkbenchContextPanelTab.search);
+      case KeyboardActionId.findInTerminal:
+        _openTerminalSearch();
       case KeyboardActionId.replaceInFiles:
         _showContextPanel(WorkbenchContextPanelTab.search);
       case KeyboardActionId.saveFile:
@@ -112,6 +120,20 @@ class KeyboardCommandDispatcher {
     final controller = ref.read(workbenchControllerProvider.notifier);
     controller.setContextPanelTab(tab);
     controller.setRightSidebarVisible(true);
+  }
+
+  void _openTerminalSearch() {
+    final directSession = terminalSession;
+    if (directSession != null) {
+      directSession.openSearch();
+      return;
+    }
+    final state = ref.read(workbenchControllerProvider);
+    final tab = state.activeWorkspaceTab;
+    if (tab == null || tab.kind != WorkspaceTabKind.terminal) {
+      return;
+    }
+    ref.read(terminalRuntimeProvider).peekSession(tab.id)?.openSearch();
   }
 
   void _saveActiveEditor() {

--- a/lib/src/features/keyboard/domain/keyboard_action.dart
+++ b/lib/src/features/keyboard/domain/keyboard_action.dart
@@ -51,6 +51,7 @@ enum KeyboardActionId {
   toggleSidebar,
   createWorkspace,
   findInFiles,
+  findInTerminal,
   replaceInFiles,
   saveFile,
   newTerminalTab,
@@ -184,6 +185,15 @@ const List<KeybindingDefinition> keybindingDefinitions = <KeybindingDefinition>[
     description: 'Open workspace search.',
     defaultBindings: PlatformBindings.uniform(<String>['Mod+Shift+F']),
     searchKeywords: <String>['search', 'grep'],
+    allowInTerminal: true,
+  ),
+  KeybindingDefinition(
+    id: KeyboardActionId.findInTerminal,
+    label: 'Find in Terminal',
+    group: KeyboardActionGroup.global,
+    description: 'Search the active terminal scrollback.',
+    defaultBindings: PlatformBindings.uniform(<String>['Mod+F']),
+    searchKeywords: <String>['search', 'terminal', 'scrollback'],
     allowInTerminal: true,
   ),
   KeybindingDefinition(

--- a/lib/src/features/keyboard/domain/keyboard_action.mapper.dart
+++ b/lib/src/features/keyboard/domain/keyboard_action.mapper.dart
@@ -84,6 +84,8 @@ class KeyboardActionIdMapper extends EnumMapper<KeyboardActionId> {
         return KeyboardActionId.createWorkspace;
       case r'findInFiles':
         return KeyboardActionId.findInFiles;
+      case r'findInTerminal':
+        return KeyboardActionId.findInTerminal;
       case r'replaceInFiles':
         return KeyboardActionId.replaceInFiles;
       case r'saveFile':
@@ -140,6 +142,8 @@ class KeyboardActionIdMapper extends EnumMapper<KeyboardActionId> {
         return r'createWorkspace';
       case KeyboardActionId.findInFiles:
         return r'findInFiles';
+      case KeyboardActionId.findInTerminal:
+        return r'findInTerminal';
       case KeyboardActionId.replaceInFiles:
         return r'replaceInFiles';
       case KeyboardActionId.saveFile:

--- a/lib/src/features/workbench/domain/terminal_search.dart
+++ b/lib/src/features/workbench/domain/terminal_search.dart
@@ -1,0 +1,65 @@
+/// A line of terminal text that can be searched without retaining the whole
+/// terminal buffer as a second string.
+final class TerminalSearchLine {
+  const TerminalSearchLine({
+    required this.id,
+    required this.index,
+    required this.text,
+  });
+
+  final Object id;
+  final int index;
+  final String text;
+}
+
+/// A literal occurrence in one terminal buffer line.
+final class TerminalSearchMatch {
+  const TerminalSearchMatch({
+    required this.lineId,
+    required this.lineIndex,
+    required this.start,
+    required this.end,
+  });
+
+  final Object lineId;
+  final int lineIndex;
+  final int start;
+  final int end;
+}
+
+/// Finds non-overlapping literal matches in [lines].
+///
+/// Terminal search is case-insensitive by default. Regex syntax is never
+/// interpreted, so a query such as `[` is searched literally.
+List<TerminalSearchMatch> findTerminalSearchMatches(
+  Iterable<TerminalSearchLine> lines,
+  String query, {
+  bool caseSensitive = false,
+}) {
+  if (query.isEmpty) {
+    return const <TerminalSearchMatch>[];
+  }
+
+  final needle = caseSensitive ? query : query.toLowerCase();
+  final matches = <TerminalSearchMatch>[];
+  for (final line in lines) {
+    final haystack = caseSensitive ? line.text : line.text.toLowerCase();
+    var start = 0;
+    while (start < haystack.length) {
+      final matchStart = haystack.indexOf(needle, start);
+      if (matchStart < 0) {
+        break;
+      }
+      matches.add(
+        TerminalSearchMatch(
+          lineId: line.id,
+          lineIndex: line.index,
+          start: matchStart,
+          end: matchStart + needle.length,
+        ),
+      );
+      start = matchStart + needle.length;
+    }
+  }
+  return matches;
+}

--- a/lib/src/features/workbench/presentation/terminal_runtime.dart
+++ b/lib/src/features/workbench/presentation/terminal_runtime.dart
@@ -8,6 +8,7 @@ import 'dart:isolate';
 import 'package:alera/src/features/settings/domain/alera_settings.dart';
 import 'package:alera/src/features/workbench/presentation/terminal_buffer_budget.dart';
 import 'package:alera/src/features/workbench/presentation/terminal_link_resolver.dart';
+import 'package:alera/src/features/workbench/presentation/terminal_search_controller.dart';
 import 'package:alera/src/features/settings/domain/terminal_theme_catalog.dart';
 import 'package:alera/src/features/workbench/domain/terminal_agent_prompt_injection.dart';
 import 'package:alera/src/features/workbench/domain/terminal_image_paste.dart';
@@ -31,6 +32,7 @@ part 'terminal_runtime_posix_adapter.dart';
 part 'terminal_runtime_ghostty_adapter.dart';
 part 'terminal_runtime_xterm_runtime.dart';
 part 'terminal_runtime_session_handle.dart';
+part 'terminal_runtime_search.dart';
 part 'terminal_runtime_session_recovery.dart';
 part 'terminal_runtime_clipboard.dart';
 part 'terminal_runtime_output_batching.dart';
@@ -118,6 +120,15 @@ abstract class TerminalSessionHandle extends ChangeNotifier {
   ///
   /// Default is a no-op so test doubles stay source-compatible.
   void pasteText(String text) {}
+
+  /// The per-session terminal scrollback search model, when supported.
+  TerminalSearchController? get searchController => null;
+
+  /// Opens the search overlay for this terminal.
+  void openSearch() {}
+
+  /// Closes the search overlay for this terminal.
+  void closeSearch() {}
 }
 
 enum TerminalSessionOperation { starting, reconnecting, restarting }

--- a/lib/src/features/workbench/presentation/terminal_runtime_restore_progress.dart
+++ b/lib/src/features/workbench/presentation/terminal_runtime_restore_progress.dart
@@ -79,6 +79,7 @@ extension _TerminalRestoreProgressTracking on _XtermTerminalSessionHandle {
     _terminal = nextTerminal;
     _osc8LinkTracker = Osc8TerminalLinkTracker(terminal: nextTerminal);
     _attachTerminal(nextTerminal);
+    searchController.attachTerminal(nextTerminal);
     // Scrollback can reach the host's 10 MB cap, and parsing all of it in one
     // synchronous write blocked the frame that showed the terminal. Go through
     // the same per-frame batcher as live output instead.

--- a/lib/src/features/workbench/presentation/terminal_runtime_search.dart
+++ b/lib/src/features/workbench/presentation/terminal_runtime_search.dart
@@ -1,0 +1,125 @@
+part of 'terminal_runtime.dart';
+
+mixin _TerminalSearchSessionSupport on TerminalSessionHandle {
+  xterm.Terminal get _terminal;
+
+  ScrollController get _scrollController;
+
+  FocusNode get _focusNode;
+
+  GlobalKey<xterm.TerminalViewState> get _terminalViewKey;
+
+  xterm.TerminalController get _terminalController;
+
+  void _handleSelectionChanged();
+
+  void _detachTerminal(xterm.Terminal terminal);
+
+  void _clearPendingTerminalOutput();
+
+  Future<void> _stopPtySessionWithMode({
+    required bool suppressExit,
+    required bool terminate,
+  });
+
+  StreamSubscription<String> get _decodedOutputSub;
+
+  StreamController<List<int>> get _ptyOutputController;
+
+  ValueNotifier<String> get _titleNotifier;
+
+  ValueNotifier<TerminalRestoreProgress?> get _restoreProgress;
+
+  Osc8TerminalLinkTracker get _osc8LinkTracker;
+
+  Set<Object> get _visibilityLeases;
+
+  set _visible(bool value);
+
+  bool get _disposed;
+  set _disposed(bool value);
+
+  int get _startAttempt;
+  set _startAttempt(int value);
+
+  int get _outputVisibilityGeneration;
+  set _outputVisibilityGeneration(int value);
+
+  set _pointerInputResumePending(bool value);
+
+  set _pointerInputCatchUpChars(int value);
+
+  late final TerminalSearchController _searchController =
+      TerminalSearchController(
+        terminal: _terminal,
+        scrollToLine: _scrollToSearchLine,
+      );
+
+  @override
+  TerminalSearchController get searchController => _searchController;
+
+  @override
+  void openSearch() {
+    if (_disposed) {
+      return;
+    }
+    _searchController.open();
+    notifyListeners();
+  }
+
+  @override
+  void closeSearch() {
+    if (_disposed) {
+      return;
+    }
+    _searchController.close();
+    notifyListeners();
+  }
+
+  @override
+  void dispose({bool terminatePty = true}) {
+    _disposed = true;
+    _startAttempt += 1;
+    _outputVisibilityGeneration += 1;
+    _visibilityLeases.clear();
+    _visible = false;
+    _pointerInputResumePending = false;
+    _pointerInputCatchUpChars = 0;
+    _osc8LinkTracker.dispose();
+    _searchController.dispose();
+    _terminalController.removeListener(_handleSelectionChanged);
+    _terminalController.dispose();
+    _detachTerminal(_terminal);
+    _clearPendingTerminalOutput();
+    unawaited(
+      _stopPtySessionWithMode(suppressExit: true, terminate: terminatePty),
+    );
+    unawaited(_decodedOutputSub.cancel());
+    unawaited(_ptyOutputController.close());
+    _scrollController.dispose();
+    _focusNode.dispose();
+    _titleNotifier.dispose();
+    _restoreProgress.dispose();
+    super.dispose();
+  }
+
+  void _scrollToSearchLine(int lineIndex) {
+    if (_disposed || !_scrollController.hasClients) {
+      return;
+    }
+    final renderTerminal = _terminalViewKey.currentState?.renderTerminal;
+    if (renderTerminal == null || !renderTerminal.attached) {
+      return;
+    }
+    final lineHeight = renderTerminal.lineHeight;
+    if (!lineHeight.isFinite || lineHeight <= 0) {
+      return;
+    }
+    final position = _scrollController.position;
+    final target = (lineIndex * lineHeight).clamp(
+      position.minScrollExtent,
+      position.maxScrollExtent,
+    );
+    position.jumpTo(target.toDouble());
+  }
+}

--- a/lib/src/features/workbench/presentation/terminal_runtime_session_handle.dart
+++ b/lib/src/features/workbench/presentation/terminal_runtime_session_handle.dart
@@ -1,6 +1,7 @@
 part of 'terminal_runtime.dart';
 
-class _XtermTerminalSessionHandle extends TerminalSessionHandle {
+class _XtermTerminalSessionHandle extends TerminalSessionHandle
+    with _TerminalSearchSessionSupport {
   _XtermTerminalSessionHandle(
     this._workspace,
     this._tab,
@@ -43,20 +44,28 @@ class _XtermTerminalSessionHandle extends TerminalSessionHandle {
   /// visible, which is the only moment a new eviction candidate appears.
   final void Function(_XtermTerminalSessionHandle handle) _onVisibilityChanged;
   TerminalSettings _settings;
+  @override
   late xterm.Terminal _terminal;
+  @override
   late Osc8TerminalLinkTracker _osc8LinkTracker;
+  @override
   final GlobalKey<xterm.TerminalViewState> _terminalViewKey =
       GlobalKey<xterm.TerminalViewState>();
+  @override
   final xterm.TerminalController _terminalController = xterm.TerminalController(
     pointerInputs: const xterm.PointerInputs.all(),
   );
 
   /// Survives TerminalSurface dispose/rebuild so scroll position is preserved
   /// when switching tabs and coming back.
+  @override
   final ScrollController _scrollController = ScrollController();
+  @override
   final FocusNode _focusNode = FocusNode(debugLabel: 'TerminalSession');
+  @override
   final StreamController<List<int>> _ptyOutputController =
       StreamController<List<int>>();
+  @override
   late final StreamSubscription<String> _decodedOutputSub;
 
   final _TerminalOutputPipeline _output = _TerminalOutputPipeline();
@@ -66,10 +75,12 @@ class _XtermTerminalSessionHandle extends TerminalSessionHandle {
   Timer? _selectionCopyTimer;
   _TerminalPtySize? _pendingPtySize;
   int _ptyGeneration = 0;
+  @override
   int _startAttempt = 0;
   int? _activePtyGeneration;
   final Set<int> _exitedPtyGenerations = <int>{};
   final Set<int> _suppressedExitPtyGenerations = <int>{};
+  @override
   final Set<Object> _visibilityLeases = <Object>{};
 
   bool _starting = false;
@@ -77,19 +88,26 @@ class _XtermTerminalSessionHandle extends TerminalSessionHandle {
   bool _started = false;
   bool _running = false;
   String _title = '';
+  @override
   late final ValueNotifier<String> _titleNotifier = ValueNotifier<String>(
     displayTitle,
   );
   String? _errorMessage;
+  @override
   bool _visible = false;
   DateTime? _lastVisibleAt;
+  @override
   final ValueNotifier<TerminalRestoreProgress?> _restoreProgress =
       ValueNotifier<TerminalRestoreProgress?>(null);
   int _restoreGeneration = 0, _restoreTotalChars = 0, _restoreWrittenChars = 0;
   bool _pendingInteractionModeReset = false;
+  @override
   int _pointerInputCatchUpChars = 0;
+  @override
   bool _pointerInputResumePending = false;
+  @override
   int _outputVisibilityGeneration = 0;
+  @override
   bool _disposed = false;
 
   @override
@@ -527,6 +545,7 @@ class _XtermTerminalSessionHandle extends TerminalSessionHandle {
 
   Future<void> _pasteFromClipboard() => _pasteTerminalClipboard(this);
 
+  @override
   void _handleSelectionChanged() {
     _handleTerminalSelectionChanged(this);
   }
@@ -541,6 +560,7 @@ class _XtermTerminalSessionHandle extends TerminalSessionHandle {
     _attachSessionTerminal(this, terminal);
   }
 
+  @override
   void _detachTerminal(xterm.Terminal terminal) {
     _detachSessionTerminal(terminal);
   }
@@ -573,6 +593,7 @@ class _XtermTerminalSessionHandle extends TerminalSessionHandle {
     notifyListeners();
   }
 
+  @override
   void _clearPendingTerminalOutput() {
     _output.cancelDeferredFlush();
     _output.clear();
@@ -594,6 +615,7 @@ class _XtermTerminalSessionHandle extends TerminalSessionHandle {
     await _stopPtySessionWithMode(suppressExit: suppressExit, terminate: true);
   }
 
+  @override
   Future<void> _stopPtySessionWithMode({
     required bool suppressExit,
     required bool terminate,
@@ -640,32 +662,6 @@ class _XtermTerminalSessionHandle extends TerminalSessionHandle {
 
   @override
   void pasteText(String text) => _pasteTerminalText(this, text);
-
-  @override
-  void dispose({bool terminatePty = true}) {
-    _disposed = true;
-    _startAttempt += 1;
-    _outputVisibilityGeneration += 1;
-    _visibilityLeases.clear();
-    _visible = false;
-    _pointerInputResumePending = false;
-    _pointerInputCatchUpChars = 0;
-    _osc8LinkTracker.dispose();
-    _terminalController.removeListener(_handleSelectionChanged);
-    _terminalController.dispose();
-    _detachTerminal(_terminal);
-    _clearPendingTerminalOutput();
-    unawaited(
-      _stopPtySessionWithMode(suppressExit: true, terminate: terminatePty),
-    );
-    unawaited(_decodedOutputSub.cancel());
-    unawaited(_ptyOutputController.close());
-    _scrollController.dispose();
-    _focusNode.dispose();
-    _titleNotifier.dispose();
-    _restoreProgress.dispose();
-    super.dispose();
-  }
 
   void _requestFocusNow() {
     if (_disposed || !_focusNode.canRequestFocus) {

--- a/lib/src/features/workbench/presentation/terminal_runtime_testing.dart
+++ b/lib/src/features/workbench/presentation/terminal_runtime_testing.dart
@@ -180,6 +180,11 @@ bool terminalIsUsingAltBufferForTesting(TerminalSessionHandle session) {
 }
 
 @visibleForTesting
+bool terminalFocusHasFocusForTesting(TerminalSessionHandle session) {
+  return (session as _XtermTerminalSessionHandle)._focusNode.hasFocus;
+}
+
+@visibleForTesting
 TerminalVisibilityLease acquireTerminalVisibilityForTesting(
   TerminalSessionHandle session,
 ) {

--- a/lib/src/features/workbench/presentation/terminal_search_controller.dart
+++ b/lib/src/features/workbench/presentation/terminal_search_controller.dart
@@ -1,0 +1,307 @@
+import 'dart:math' show max;
+
+import 'package:alera/src/features/workbench/domain/terminal_search.dart';
+import 'package:flutter/foundation.dart';
+import 'package:xterm/xterm.dart' as xterm;
+
+typedef TerminalSearchLineScroller = void Function(int lineIndex);
+
+final class TerminalSearchController extends ChangeNotifier {
+  factory TerminalSearchController({
+    required xterm.Terminal terminal,
+    required TerminalSearchLineScroller scrollToLine,
+  }) {
+    return TerminalSearchController._(terminal, scrollToLine);
+  }
+
+  TerminalSearchController._(this._terminal, this._scrollToLine) {
+    _terminal.addListener(_handleTerminalChanged);
+  }
+
+  xterm.Terminal _terminal;
+  final TerminalSearchLineScroller _scrollToLine;
+  xterm.Buffer? _indexedBuffer;
+  int _indexedHeight = -1;
+  int _indexedWidth = -1;
+  bool _needsFullRefresh = true;
+  bool _isOpen = false;
+  String _query = '';
+  int _selectedIndex = -1;
+  final Map<xterm.BufferLine, List<_LineMatch>> _matchesByLine =
+      <xterm.BufferLine, List<_LineMatch>>{};
+  List<TerminalSearchMatch> _matches = const <TerminalSearchMatch>[];
+
+  bool get isOpen => _isOpen;
+
+  String get query => _query;
+
+  List<TerminalSearchMatch> get matches => _matches;
+
+  int get matchCount => _matches.length;
+
+  int? get selectedMatchNumber {
+    if (_selectedIndex < 0 || _selectedIndex >= _matches.length) {
+      return null;
+    }
+    return _selectedIndex + 1;
+  }
+
+  TerminalSearchMatch? get selectedMatch {
+    if (_selectedIndex < 0 || _selectedIndex >= _matches.length) {
+      return null;
+    }
+    return _matches[_selectedIndex];
+  }
+
+  void open() {
+    if (_isOpen) {
+      return;
+    }
+    _isOpen = true;
+    if (_query.isNotEmpty) {
+      _refresh(forceFull: _needsFullRefresh);
+    }
+    notifyListeners();
+  }
+
+  void close() {
+    if (!_isOpen) {
+      return;
+    }
+    _isOpen = false;
+    // Keep the query for the next invocation, but make reopening authoritative
+    // after output that arrived while the overlay was hidden.
+    _needsFullRefresh = true;
+    notifyListeners();
+  }
+
+  void setQuery(String query) {
+    if (_query == query) {
+      return;
+    }
+    _query = query;
+    _selectedIndex = -1;
+    _matchesByLine.clear();
+    _matches = const <TerminalSearchMatch>[];
+    _needsFullRefresh = true;
+    if (_query.isNotEmpty) {
+      _refresh(forceFull: true);
+      if (_matches.isNotEmpty) {
+        _selectedIndex = 0;
+        _scrollSelectedMatch();
+      }
+    }
+    notifyListeners();
+  }
+
+  void next() {
+    if (_matches.isEmpty) {
+      return;
+    }
+    _selectedIndex = (_selectedIndex + 1) % _matches.length;
+    _scrollSelectedMatch();
+    notifyListeners();
+  }
+
+  void previous() {
+    if (_matches.isEmpty) {
+      return;
+    }
+    _selectedIndex = (_selectedIndex - 1) % _matches.length;
+    if (_selectedIndex < 0) {
+      _selectedIndex = _matches.length - 1;
+    }
+    _scrollSelectedMatch();
+    notifyListeners();
+  }
+
+  /// Reattaches the search index when a snapshot replaces the emulator.
+  void attachTerminal(xterm.Terminal terminal) {
+    if (identical(_terminal, terminal)) {
+      return;
+    }
+    _terminal.removeListener(_handleTerminalChanged);
+    _terminal = terminal;
+    _terminal.addListener(_handleTerminalChanged);
+    _indexedBuffer = null;
+    _indexedHeight = -1;
+    _indexedWidth = -1;
+    _needsFullRefresh = true;
+    if (_isOpen && _query.isNotEmpty) {
+      _refresh(forceFull: true);
+      notifyListeners();
+    }
+  }
+
+  @visibleForTesting
+  bool get needsFullRefreshForTesting => _needsFullRefresh;
+
+  void _handleTerminalChanged() {
+    if (!_isOpen || _query.isEmpty) {
+      _needsFullRefresh = true;
+      return;
+    }
+    if (_refresh()) {
+      notifyListeners();
+    }
+  }
+
+  bool _refresh({bool forceFull = false}) {
+    if (_query.isEmpty) {
+      final hadMatches = _matches.isNotEmpty || _matchesByLine.isNotEmpty;
+      _matchesByLine.clear();
+      _matches = const <TerminalSearchMatch>[];
+      _selectedIndex = -1;
+      return hadMatches;
+    }
+
+    final buffer = _terminal.buffer;
+    final height = buffer.height;
+    final shouldScanAll =
+        forceFull ||
+        _needsFullRefresh ||
+        !identical(_indexedBuffer, buffer) ||
+        _indexedWidth != _terminal.viewWidth ||
+        _indexedHeight < 0 ||
+        height < _indexedHeight;
+    final selected = selectedMatch;
+
+    if (shouldScanAll) {
+      _matchesByLine.clear();
+      _scanLines(buffer, 0, height);
+    } else {
+      // A normal output batch appends from the previous tail. When the line
+      // count is stable, rescan only the visible tail because TUIs rewrite
+      // their viewport instead of the whole scrollback.
+      final start = height > _indexedHeight
+          ? max(0, _indexedHeight - 1)
+          : max(0, height - _terminal.viewHeight);
+      _removeMatchesInRange(buffer, start, height);
+      _scanLines(buffer, start, height);
+    }
+
+    _indexedBuffer = buffer;
+    _indexedHeight = height;
+    _indexedWidth = _terminal.viewWidth;
+    _needsFullRefresh = false;
+    _rebuildMatches(selected);
+    return true;
+  }
+
+  void _scanLines(xterm.Buffer buffer, int start, int end) {
+    final safeStart = start.clamp(0, buffer.height);
+    final safeEnd = end.clamp(safeStart, buffer.height);
+    for (var index = safeStart; index < safeEnd; index++) {
+      final line = buffer.lines[index];
+      final lineMatches = findTerminalSearchMatches(<TerminalSearchLine>[
+        TerminalSearchLine(id: line, index: index, text: line.getText()),
+      ], _query);
+      if (lineMatches.isEmpty) {
+        _matchesByLine.remove(line);
+      } else {
+        _matchesByLine[line] = <_LineMatch>[
+          for (final match in lineMatches)
+            _LineMatch(start: match.start, end: match.end),
+        ];
+      }
+    }
+  }
+
+  void _removeMatchesInRange(xterm.Buffer buffer, int start, int end) {
+    final staleLines = <xterm.BufferLine>[];
+    for (final line in _matchesByLine.keys) {
+      if (!_lineIndex(buffer, line).caseInRange(start, end)) {
+        continue;
+      }
+      staleLines.add(line);
+    }
+    for (final line in staleLines) {
+      _matchesByLine.remove(line);
+    }
+  }
+
+  void _rebuildMatches(TerminalSearchMatch? selected) {
+    final next = <TerminalSearchMatch>[];
+    final staleLines = <xterm.BufferLine>[];
+    for (final entry in _matchesByLine.entries) {
+      final lineIndex = _lineIndex(_terminal.buffer, entry.key);
+      if (lineIndex == null) {
+        staleLines.add(entry.key);
+        continue;
+      }
+      for (final match in entry.value) {
+        next.add(
+          TerminalSearchMatch(
+            lineId: entry.key,
+            lineIndex: lineIndex,
+            start: match.start,
+            end: match.end,
+          ),
+        );
+      }
+    }
+    for (final line in staleLines) {
+      _matchesByLine.remove(line);
+    }
+    next.sort((a, b) {
+      final lineOrder = a.lineIndex.compareTo(b.lineIndex);
+      return lineOrder == 0 ? a.start.compareTo(b.start) : lineOrder;
+    });
+    _matches = List<TerminalSearchMatch>.unmodifiable(next);
+
+    if (_matches.isEmpty) {
+      _selectedIndex = -1;
+      return;
+    }
+    if (selected != null) {
+      final retainedIndex = _matches.indexWhere(
+        (match) =>
+            identical(match.lineId, selected.lineId) &&
+            match.start == selected.start,
+      );
+      if (retainedIndex >= 0) {
+        _selectedIndex = retainedIndex;
+        return;
+      }
+    }
+    _selectedIndex = _selectedIndex.clamp(0, _matches.length - 1);
+  }
+
+  int? _lineIndex(xterm.Buffer buffer, xterm.BufferLine line) {
+    if (!line.attached) {
+      return null;
+    }
+    final index = line.index;
+    if (index < 0 || index >= buffer.height) {
+      return null;
+    }
+    return identical(buffer.lines[index], line) ? index : null;
+  }
+
+  void _scrollSelectedMatch() {
+    final match = selectedMatch;
+    if (match != null) {
+      _scrollToLine(match.lineIndex);
+    }
+  }
+
+  @override
+  void dispose() {
+    _terminal.removeListener(_handleTerminalChanged);
+    super.dispose();
+  }
+}
+
+final class _LineMatch {
+  const _LineMatch({required this.start, required this.end});
+
+  final int start;
+  final int end;
+}
+
+extension on int? {
+  bool caseInRange(int start, int end) {
+    final value = this;
+    return value != null && value >= start && value < end;
+  }
+}

--- a/lib/src/features/workbench/presentation/terminal_search_overlay.dart
+++ b/lib/src/features/workbench/presentation/terminal_search_overlay.dart
@@ -1,0 +1,152 @@
+import 'package:alera/src/app/theme/alera_tokens.dart';
+import 'package:alera/src/design_system/buttons/alera_icon_button.dart';
+import 'package:alera/src/design_system/forms/alera_text_field.dart';
+import 'package:alera/src/design_system/icons/alera_icons.dart';
+import 'package:alera/src/features/workbench/presentation/terminal_search_controller.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+class TerminalSearchOverlay extends StatefulWidget {
+  const TerminalSearchOverlay({
+    super.key,
+    required this.controller,
+    required this.onClose,
+  });
+
+  final TerminalSearchController controller;
+  final VoidCallback onClose;
+
+  @override
+  State<TerminalSearchOverlay> createState() => _TerminalSearchOverlayState();
+}
+
+class _TerminalSearchOverlayState extends State<TerminalSearchOverlay> {
+  late final TextEditingController _textController;
+  late final FocusNode _focusNode;
+
+  @override
+  void initState() {
+    super.initState();
+    _textController = TextEditingController(text: widget.controller.query);
+    _focusNode = FocusNode(debugLabel: 'TerminalSearch');
+    widget.controller.addListener(_handleControllerChanged);
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) {
+        _focusNode.requestFocus();
+        _textController.selection = TextSelection(
+          baseOffset: 0,
+          extentOffset: _textController.text.length,
+        );
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    widget.controller.removeListener(_handleControllerChanged);
+    _textController.dispose();
+    _focusNode.dispose();
+    super.dispose();
+  }
+
+  void _handleControllerChanged() {
+    if (!mounted) {
+      return;
+    }
+    if (_textController.text != widget.controller.query) {
+      _textController.value = TextEditingValue(
+        text: widget.controller.query,
+        selection: TextSelection.collapsed(
+          offset: widget.controller.query.length,
+        ),
+      );
+    }
+    setState(() {});
+  }
+
+  KeyEventResult _handleKey(FocusNode node, KeyEvent event) {
+    if (event is! KeyDownEvent) {
+      return KeyEventResult.ignored;
+    }
+    if (event.logicalKey == LogicalKeyboardKey.escape) {
+      widget.onClose();
+      return KeyEventResult.handled;
+    }
+    if (event.logicalKey == LogicalKeyboardKey.enter) {
+      widget.controller.next();
+      return KeyEventResult.handled;
+    }
+    return KeyEventResult.ignored;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final matchNumber = widget.controller.selectedMatchNumber;
+    final countLabel = widget.controller.query.isEmpty
+        ? null
+        : widget.controller.matchCount == 0
+        ? 'No results'
+        : '$matchNumber/${widget.controller.matchCount}';
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: AleraTokens.surfaceElevated,
+        border: Border.all(color: AleraTokens.borderSubtle),
+        borderRadius: BorderRadius.circular(AleraTokens.radiusMd),
+        boxShadow: const <BoxShadow>[
+          BoxShadow(
+            color: AleraTokens.shadowSoft,
+            blurRadius: AleraTokens.space8,
+            offset: Offset(0, AleraTokens.space4),
+          ),
+        ],
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(AleraTokens.space4),
+        child: Focus(
+          onKeyEvent: _handleKey,
+          child: Row(
+            children: <Widget>[
+              Expanded(
+                child: AleraTextField(
+                  controller: _textController,
+                  focusNode: _focusNode,
+                  hintText: 'Search Terminal',
+                  dense: true,
+                  fillColor: AleraTokens.surfaceVariant,
+                  onChanged: widget.controller.setQuery,
+                ),
+              ),
+              if (countLabel != null) ...<Widget>[
+                const SizedBox(width: AleraTokens.space8),
+                Text(countLabel, style: AleraTokens.monoStyle),
+              ],
+              const SizedBox(width: AleraTokens.space4),
+              AleraIconButton(
+                tooltip: 'Previous Match',
+                icon: AleraIcons.chevronUp,
+                onPressed: widget.controller.matchCount == 0
+                    ? null
+                    : widget.controller.previous,
+                minSize: AleraTokens.space32,
+              ),
+              AleraIconButton(
+                tooltip: 'Next Match',
+                icon: AleraIcons.chevronDown,
+                onPressed: widget.controller.matchCount == 0
+                    ? null
+                    : widget.controller.next,
+                minSize: AleraTokens.space32,
+              ),
+              AleraIconButton(
+                tooltip: 'Close Search',
+                icon: AleraIcons.close,
+                onPressed: widget.onClose,
+                minSize: AleraTokens.space32,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/features/workbench/presentation/terminal_surface.dart
+++ b/lib/src/features/workbench/presentation/terminal_surface.dart
@@ -10,6 +10,7 @@ import 'package:alera/src/features/keyboard/domain/key_chord.dart';
 import 'package:alera/src/features/keyboard/domain/keyboard_action.dart';
 import 'package:alera/src/features/workbench/presentation/terminal_path_drop.dart';
 import 'package:alera/src/features/workbench/presentation/terminal_runtime.dart';
+import 'package:alera/src/features/workbench/presentation/terminal_search_overlay.dart';
 import 'package:desktop_drop/desktop_drop.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -103,7 +104,11 @@ class _TerminalSurfaceState extends ConsumerState<TerminalSurface> {
         !resolved.allowInTerminal) {
       return KeyEventResult.ignored;
     }
-    KeyboardCommandDispatcher(ref: ref, context: context).dispatch(resolved.id);
+    KeyboardCommandDispatcher(
+      ref: ref,
+      context: context,
+      terminalSession: widget.session,
+    ).dispatch(resolved.id);
     return KeyEventResult.handled;
   }
 
@@ -117,6 +122,8 @@ class _TerminalSurfaceState extends ConsumerState<TerminalSurface> {
           _ => null,
         };
         final operation = error == null ? widget.session.operation : null;
+        final searchController = widget.session.searchController;
+        final searchOpen = searchController?.isOpen == true;
         return DropTarget(
           enable: error == null,
           onDragDone: (details) {
@@ -175,7 +182,9 @@ class _TerminalSurfaceState extends ConsumerState<TerminalSurface> {
                   ),
                 Positioned(
                   top: AleraTokens.space4,
-                  right: AleraTokens.space4,
+                  right: searchOpen
+                      ? AleraTokens.space48 + AleraTokens.space4
+                      : AleraTokens.space4,
                   child: AleraIconButton(
                     tooltip: _refreshing
                         ? 'Refreshing Terminal'
@@ -188,6 +197,27 @@ class _TerminalSurfaceState extends ConsumerState<TerminalSurface> {
                         : () => unawaited(_refreshTerminal()),
                   ),
                 ),
+                if (searchController != null && searchOpen)
+                  Positioned(
+                    top: AleraTokens.space4,
+                    left: AleraTokens.space16,
+                    right: AleraTokens.space48 + AleraTokens.space4,
+                    child: Align(
+                      alignment: Alignment.topRight,
+                      child: ConstrainedBox(
+                        constraints: const BoxConstraints(
+                          maxWidth: AleraTokens.dialogWideWidth,
+                        ),
+                        child: TerminalSearchOverlay(
+                          controller: searchController,
+                          onClose: () {
+                            widget.session.closeSearch();
+                            widget.session.requestFocus();
+                          },
+                        ),
+                      ),
+                    ),
+                  ),
               ],
             ),
           ),

--- a/roadmap.md
+++ b/roadmap.md
@@ -33,7 +33,7 @@ Comprehensive feature roadmap for Alera. Each feature is scored on two axes:
 
 | Feature | Difficulty | Utility | Status | Notes |
 |---|:---:|:---:|:---:|---|
-| Terminal search | 2 | 5 | Planned | In-terminal text search across scrollback |
+| Terminal search | 2 | 5 | Shipped | Literal, case-insensitive search across bounded scrollback with match navigation and `Mod+F` |
 | Terminal session persistence | 4 | 4 | Shipped | Runtime host checkpoints, bounded scrollback restore, PTY detach across app restart; live processes survive host lifecycle |
 | Terminal quick commands | 2 | 3 | Planned | Shortcut palette for frequently used terminal commands (mobile Terminal Quick Keys are local accessories, not this feature) |
 | Floating terminal panel | 3 | 3 | Planned | Floating, resizable terminal overlay with window controls |
@@ -246,7 +246,7 @@ Comprehensive feature roadmap for Alera. Each feature is scored on two axes:
 |---|:---:|:---:|
 | Agent auto-detection & registry | 3 | Partial |
 | Agent status tracking | 3 | Shipped |
-| Terminal search | 2 | Planned |
+| Terminal search | 2 | Shipped |
 | File Explorer panel | 4 | Shipped |
 | Code edition with LSP support | 5 | Partial |
 | Search panel | 3 | Shipped |
@@ -261,7 +261,7 @@ Comprehensive feature roadmap for Alera. Each feature is scored on two axes:
 
 | Feature | Difficulty | Utility | Status |
 |---|:---:|:---:|:---:|
-| Terminal search | 2 | 5 | Planned |
+| Terminal search | 2 | 5 | Shipped |
 | Open in with other softwares | 2 | 4 | Partial |
 | Tab cycling & reopen closed tab | 2 | 4 | Partial |
 | Autosave | 2 | 4 | Planned |

--- a/test/unit/terminal_search_controller_test.dart
+++ b/test/unit/terminal_search_controller_test.dart
@@ -1,0 +1,114 @@
+import 'package:alera/src/features/workbench/domain/terminal_search.dart';
+import 'package:alera/src/features/workbench/presentation/terminal_search_controller.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xterm/xterm.dart' as xterm;
+
+void main() {
+  test('finds literal matches case-insensitively by default', () {
+    final matches = findTerminalSearchMatches(const <TerminalSearchLine>[
+      TerminalSearchLine(id: 'first', index: 3, text: 'A [literal] match'),
+      TerminalSearchLine(id: 'second', index: 4, text: 'MATCH again'),
+    ], '[literal]');
+
+    expect(matches, hasLength(1));
+    expect(matches.single.lineId, 'first');
+    expect(matches.single.lineIndex, 3);
+    expect(matches.single.start, 2);
+    expect(matches.single.end, 11);
+  });
+
+  test('returns no results for an empty or missing query', () {
+    const lines = <TerminalSearchLine>[
+      TerminalSearchLine(id: 'line', index: 0, text: 'terminal output'),
+    ];
+
+    expect(findTerminalSearchMatches(lines, ''), isEmpty);
+    expect(findTerminalSearchMatches(lines, 'missing'), isEmpty);
+  });
+
+  test('supports explicit case-sensitive matching', () {
+    final matches = findTerminalSearchMatches(
+      const <TerminalSearchLine>[
+        TerminalSearchLine(id: 'line', index: 0, text: 'Match match'),
+      ],
+      'match',
+      caseSensitive: true,
+    );
+
+    expect(matches, hasLength(1));
+    expect(matches.single.start, 6);
+  });
+
+  test('navigates matches and wraps in both directions', () {
+    final terminal = _terminal()..write('needle\r\nother\r\nNEEDLE\r\nthird');
+    final visitedLines = <int>[];
+    final controller = TerminalSearchController(
+      terminal: terminal,
+      scrollToLine: visitedLines.add,
+    );
+    addTearDown(controller.dispose);
+
+    controller.open();
+    controller.setQuery('needle');
+
+    expect(controller.matchCount, 2);
+    expect(controller.selectedMatchNumber, 1);
+    expect(controller.selectedMatch?.lineIndex, 0);
+    expect(visitedLines, <int>[0]);
+
+    controller.next();
+    expect(controller.selectedMatchNumber, 2);
+    expect(controller.selectedMatch?.lineIndex, 2);
+
+    controller.next();
+    expect(controller.selectedMatchNumber, 1);
+    expect(controller.selectedMatch?.lineIndex, 0);
+
+    controller.previous();
+    expect(controller.selectedMatchNumber, 2);
+    expect(controller.selectedMatch?.lineIndex, 2);
+  });
+
+  test('updates matches after new output without rebuilding the query', () {
+    final terminal = _terminal()..write('ready\r\n');
+    final controller = TerminalSearchController(
+      terminal: terminal,
+      scrollToLine: (_) {},
+    );
+    addTearDown(controller.dispose);
+
+    controller.open();
+    controller.setQuery('result');
+    expect(controller.matchCount, 0);
+
+    terminal.write('new RESULT');
+
+    expect(controller.matchCount, 1);
+    expect(controller.selectedMatch?.lineIndex, 1);
+    expect(controller.needsFullRefreshForTesting, isFalse);
+  });
+
+  test('rechecks output that arrived while the overlay was closed', () {
+    final terminal = _terminal()..write('first');
+    final controller = TerminalSearchController(
+      terminal: terminal,
+      scrollToLine: (_) {},
+    );
+    addTearDown(controller.dispose);
+
+    controller.open();
+    controller.setQuery('later');
+    expect(controller.matchCount, 0);
+
+    controller.close();
+    terminal.write('\r\nlater');
+    controller.open();
+
+    expect(controller.matchCount, 1);
+    expect(controller.selectedMatch?.lineIndex, 1);
+  });
+}
+
+xterm.Terminal _terminal() {
+  return xterm.Terminal(maxLines: 64)..resize(80, 8);
+}

--- a/test/widget/terminal_surface_interaction_test_cases.dart
+++ b/test/widget/terminal_surface_interaction_test_cases.dart
@@ -352,6 +352,20 @@ void _registerTerminalSurfaceInteractionTests() {
         expect(allowedResult, KeyEventResult.handled);
         expect(allowedController.collapsedValues, <bool>[true]);
 
+        await tester.sendKeyDownEvent(LogicalKeyboardKey.metaLeft);
+        final allowedSearchResult = allowedSession.onKeyEvent!.call(
+          focusNode,
+          const KeyDownEvent(
+            timeStamp: Duration.zero,
+            physicalKey: PhysicalKeyboardKey.keyF,
+            logicalKey: LogicalKeyboardKey.keyF,
+          ),
+        );
+        await tester.sendKeyUpEvent(LogicalKeyboardKey.metaLeft);
+
+        expect(allowedSearchResult, KeyEventResult.handled);
+        expect(allowedSession.openSearchCallCount, 1);
+
         final blockedSession = _ShortcutCaptureSessionHandle(tabId: 'tab-2');
         final blockedController = _FakeWorkbenchController();
         await pumpShortcutSurface(
@@ -377,9 +391,55 @@ void _registerTerminalSurfaceInteractionTests() {
 
         expect(blockedResult, KeyEventResult.ignored);
         expect(blockedController.collapsedValues, isEmpty);
+
+        await tester.sendKeyDownEvent(LogicalKeyboardKey.metaLeft);
+        final terminalFirstSearchResult = blockedSession.onKeyEvent!.call(
+          focusNode,
+          const KeyDownEvent(
+            timeStamp: Duration.zero,
+            physicalKey: PhysicalKeyboardKey.keyF,
+            logicalKey: LogicalKeyboardKey.keyF,
+          ),
+        );
+        await tester.sendKeyUpEvent(LogicalKeyboardKey.metaLeft);
+
+        expect(terminalFirstSearchResult, KeyEventResult.handled);
+        expect(blockedSession.openSearchCallCount, 1);
       } finally {
         debugDefaultTargetPlatformOverride = null;
       }
     },
   );
+
+  testWidgets('terminal search closes on Escape and restores terminal focus', (
+    tester,
+  ) async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.linux;
+    try {
+      final factory = _FakeTerminalPtySessionFactory();
+      final runtime = XtermTerminalRuntime(
+        ptySessionFactory: factory,
+        shellLaunchesBuilder: _testShellLaunches,
+      );
+      addTearDown(runtime.dispose);
+      final session = runtime.sessionFor(workspace: _workspace(), tab: _tab());
+
+      await _pumpTerminalSurface(tester, session);
+      session.openSearch();
+      await tester.pump();
+      await tester.pump();
+
+      expect(find.byType(TextField), findsOneWidget);
+      expect(tester.binding.focusManager.primaryFocus, isNotNull);
+
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.escape);
+      await tester.pump();
+      await tester.pump();
+
+      expect(find.byType(TextField), findsNothing);
+      expect(terminalFocusHasFocusForTesting(session), isTrue);
+    } finally {
+      debugDefaultTargetPlatformOverride = null;
+    }
+  });
 }

--- a/test/widget/terminal_surface_test_harness.dart
+++ b/test/widget/terminal_surface_test_harness.dart
@@ -267,6 +267,7 @@ class _ShortcutCaptureSessionHandle extends TerminalSessionHandle {
   final String tabId;
 
   FocusOnKeyEventCallback? onKeyEvent;
+  int openSearchCallCount = 0;
 
   @override
   String get workspaceId => 'workspace-1';
@@ -310,6 +311,11 @@ class _ShortcutCaptureSessionHandle extends TerminalSessionHandle {
 
   @override
   void requestFocus() {}
+
+  @override
+  void openSearch() {
+    openSearchCallCount += 1;
+  }
 }
 
 class _FakeWorkbenchController extends WorkbenchController {


### PR DESCRIPTION
## Summary
- add per-session literal search across bounded terminal scrollback
- add overlay navigation, Escape/focus restoration, and Mod+F keyboard routing
- mark Terminal search as Shipped in the roadmap

## Validation
- flutter test focused terminal search, surface, keyboard, and runtime suites
- dart format --set-exit-if-changed lib test integration_test tool
- dart run tool/quality/check_max_lines.dart
- flutter analyze

## Notes
- no terminal host protocol or persistence payload changes
- gh act was attempted but blocked by linked-worktree git discovery and Docker image authentication limits; hosted checks remain authoritative