### PR TITLE
feat: add editor autosave

### DIFF
--- a/lib/src/features/settings/domain/alera_settings.dart
+++ b/lib/src/features/settings/domain/alera_settings.dart
@@ -224,13 +224,33 @@ class EditorSettings with EditorSettingsMappable {
   const EditorSettings({
     this.tabSize = 4,
     this.themeName = EditorSyntaxThemeNames.alera,
+    this.autosaveEnabled = false,
+    this.autosaveDelaySeconds = defaultAutosaveDelaySeconds,
   });
+
+  static const int minAutosaveDelaySeconds = 1;
+  static const int maxAutosaveDelaySeconds = 60;
+  static const int defaultAutosaveDelaySeconds = 1;
 
   /// Number of spaces inserted when the editor handles a Tab key press.
   final int tabSize;
 
   /// Syntax highlighting theme used by editor tabs.
   final String themeName;
+
+  /// Save dirty editor tabs after they have been idle for the configured delay.
+  final bool autosaveEnabled;
+
+  /// Number of idle seconds before an automatic editor save.
+  final int autosaveDelaySeconds;
+
+  /// Clamps persisted values before they are used to construct a timer.
+  int get effectiveAutosaveDelaySeconds => autosaveDelaySeconds
+      .clamp(minAutosaveDelaySeconds, maxAutosaveDelaySeconds)
+      .toInt();
+
+  Duration get autosaveDebounce =>
+      Duration(seconds: effectiveAutosaveDelaySeconds);
 
   static const EditorSettings defaults = EditorSettings();
 

--- a/lib/src/features/settings/domain/alera_settings.mapper.dart
+++ b/lib/src/features/settings/domain/alera_settings.mapper.dart
@@ -1101,17 +1101,35 @@ class EditorSettingsMapper extends ClassMapperBase<EditorSettings> {
     opt: true,
     def: EditorSyntaxThemeNames.alera,
   );
+  static bool _$autosaveEnabled(EditorSettings v) => v.autosaveEnabled;
+  static const Field<EditorSettings, bool> _f$autosaveEnabled = Field(
+    'autosaveEnabled',
+    _$autosaveEnabled,
+    opt: true,
+    def: false,
+  );
+  static int _$autosaveDelaySeconds(EditorSettings v) => v.autosaveDelaySeconds;
+  static const Field<EditorSettings, int> _f$autosaveDelaySeconds = Field(
+    'autosaveDelaySeconds',
+    _$autosaveDelaySeconds,
+    opt: true,
+    def: EditorSettings.defaultAutosaveDelaySeconds,
+  );
 
   @override
   final MappableFields<EditorSettings> fields = const {
     #tabSize: _f$tabSize,
     #themeName: _f$themeName,
+    #autosaveEnabled: _f$autosaveEnabled,
+    #autosaveDelaySeconds: _f$autosaveDelaySeconds,
   };
 
   static EditorSettings _instantiate(DecodingData data) {
     return EditorSettings(
       tabSize: data.dec(_f$tabSize),
       themeName: data.dec(_f$themeName),
+      autosaveEnabled: data.dec(_f$autosaveEnabled),
+      autosaveDelaySeconds: data.dec(_f$autosaveDelaySeconds),
     );
   }
 
@@ -1177,7 +1195,12 @@ extension EditorSettingsValueCopy<$R, $Out>
 
 abstract class EditorSettingsCopyWith<$R, $In extends EditorSettings, $Out>
     implements ClassCopyWith<$R, $In, $Out> {
-  $R call({int? tabSize, String? themeName});
+  $R call({
+    int? tabSize,
+    String? themeName,
+    bool? autosaveEnabled,
+    int? autosaveDelaySeconds,
+  });
   EditorSettingsCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(
     Then<$Out2, $R2> t,
   );
@@ -1192,16 +1215,29 @@ class _EditorSettingsCopyWithImpl<$R, $Out>
   late final ClassMapperBase<EditorSettings> $mapper =
       EditorSettingsMapper.ensureInitialized();
   @override
-  $R call({int? tabSize, String? themeName}) => $apply(
+  $R call({
+    int? tabSize,
+    String? themeName,
+    bool? autosaveEnabled,
+    int? autosaveDelaySeconds,
+  }) => $apply(
     FieldCopyWithData({
       if (tabSize != null) #tabSize: tabSize,
       if (themeName != null) #themeName: themeName,
+      if (autosaveEnabled != null) #autosaveEnabled: autosaveEnabled,
+      if (autosaveDelaySeconds != null)
+        #autosaveDelaySeconds: autosaveDelaySeconds,
     }),
   );
   @override
   EditorSettings $make(CopyWithData data) => EditorSettings(
     tabSize: data.get(#tabSize, or: $value.tabSize),
     themeName: data.get(#themeName, or: $value.themeName),
+    autosaveEnabled: data.get(#autosaveEnabled, or: $value.autosaveEnabled),
+    autosaveDelaySeconds: data.get(
+      #autosaveDelaySeconds,
+      or: $value.autosaveDelaySeconds,
+    ),
   );
 
   @override

--- a/lib/src/features/settings/presentation/panes/editor_pane.dart
+++ b/lib/src/features/settings/presentation/panes/editor_pane.dart
@@ -42,6 +42,7 @@ class EditorSettingsPane extends StatelessWidget {
           description: 'Defaults used by editor tabs.',
           children: <Widget>[
             SettingsIntegerRow(
+              key: const ValueKey<String>('editor-tab-size-row'),
               title: 'Tab Size',
               description: 'Spaces inserted when pressing tab.',
               value: settings.tabSize,
@@ -51,6 +52,32 @@ class EditorSettingsPane extends StatelessWidget {
               suffix: 'spaces',
               onChanged: (value) =>
                   onChanged(settings.copyWith(tabSize: value)),
+            ),
+          ],
+        ),
+        const SizedBox(height: AleraTokens.space16),
+        AleraSettingsGroup(
+          title: 'Autosave',
+          description: 'Save dirty editor tabs after they have been idle.',
+          children: <Widget>[
+            SettingsSwitchRow(
+              title: 'Autosave',
+              description: 'Automatically save editor changes after a pause.',
+              value: settings.autosaveEnabled,
+              onChanged: (value) =>
+                  onChanged(settings.copyWith(autosaveEnabled: value)),
+            ),
+            SettingsIntegerRow(
+              key: const ValueKey<String>('editor-autosave-delay-row'),
+              title: 'Autosave Delay',
+              description: 'Idle time before saving editor changes.',
+              value: settings.effectiveAutosaveDelaySeconds,
+              min: EditorSettings.minAutosaveDelaySeconds,
+              max: EditorSettings.maxAutosaveDelaySeconds,
+              step: 1,
+              suffix: 'seconds',
+              onChanged: (value) =>
+                  onChanged(settings.copyWith(autosaveDelaySeconds: value)),
             ),
           ],
         ),

--- a/lib/src/features/settings/presentation/settings_search_entries.dart
+++ b/lib/src/features/settings/presentation/settings_search_entries.dart
@@ -380,6 +380,16 @@ const List<SettingsSearchEntry> editorSearchEntries = <SettingsSearchEntry>[
     description: 'Spaces inserted when pressing tab in editor tabs.',
     keywords: <String>['indent', 'indentation', 'spaces', 'code'],
   ),
+  SettingsSearchEntry(
+    title: 'Autosave',
+    description: 'Automatically save dirty editor tabs after a pause.',
+    keywords: <String>['save', 'automatic', 'idle', 'file', 'changes'],
+  ),
+  SettingsSearchEntry(
+    title: 'Autosave Delay',
+    description: 'Idle time before saving editor changes.',
+    keywords: <String>['save', 'automatic', 'debounce', 'seconds'],
+  ),
 ];
 
 const List<SettingsSearchEntry> aiTextSearchEntries = <SettingsSearchEntry>[

--- a/lib/src/features/workbench/application/editor_autosave_controller.dart
+++ b/lib/src/features/workbench/application/editor_autosave_controller.dart
@@ -1,0 +1,169 @@
+import 'dart:async';
+
+// The public constructor keeps descriptive callback names while initializing
+// private state fields with the corresponding values.
+// ignore_for_file: prefer_initializing_formals
+
+typedef EditorAutosaveTimerFactory =
+    Timer Function(Duration delay, void Function() callback);
+
+/// Schedules one trailing autosave for a dirty editor and keeps failures
+/// paused until an explicit user action resumes it.
+class EditorAutosaveController {
+  EditorAutosaveController({
+    required bool enabled,
+    required Duration debounce,
+    required bool Function() isDirty,
+    required bool Function() isReady,
+    required Future<void> Function() save,
+    required void Function(Object error, StackTrace stackTrace) onError,
+    EditorAutosaveTimerFactory? scheduleTimer,
+  }) : _enabled = enabled,
+       _debounce = debounce,
+       _isDirty = isDirty,
+       _isReady = isReady,
+       _save = save,
+       _onError = onError,
+       _scheduleTimer =
+           scheduleTimer ?? ((delay, callback) => Timer(delay, callback));
+
+  bool _enabled;
+  Duration _debounce;
+  final bool Function() _isDirty;
+  final bool Function() _isReady;
+  final Future<void> Function() _save;
+  final void Function(Object error, StackTrace stackTrace) _onError;
+  final EditorAutosaveTimerFactory _scheduleTimer;
+  Timer? _timer;
+  var _saveInFlight = false;
+  var _paused = false;
+  var _disposed = false;
+  var _generation = 0;
+
+  bool get isPaused => _paused;
+
+  void updateSettings({required bool enabled, required Duration debounce}) {
+    if (_disposed) {
+      return;
+    }
+    final wasEnabled = _enabled;
+    final debounceChanged = _debounce != debounce;
+    _enabled = enabled;
+    _debounce = debounce;
+    if (!enabled) {
+      _cancelTimer();
+      _paused = false;
+      return;
+    }
+    if (!wasEnabled) {
+      _paused = false;
+    }
+    if (_paused) {
+      return;
+    }
+    if (debounceChanged && _timer != null) {
+      _scheduleIfEligible();
+      return;
+    }
+    notifyStateChanged();
+  }
+
+  /// Starts or resets the trailing debounce after editor text changes.
+  void notifyTextChanged() {
+    if (_disposed || !_enabled || _paused) {
+      return;
+    }
+    _cancelTimer();
+    _scheduleIfEligible();
+  }
+
+  /// Re-evaluates a pending save after loading or another save completes.
+  void notifyStateChanged() {
+    if (_disposed || _timer != null || _saveInFlight) {
+      return;
+    }
+    _scheduleIfEligible();
+  }
+
+  /// Cancels a pending timer without pausing future autosaves.
+  void cancelPending() {
+    if (_disposed) {
+      return;
+    }
+    _cancelTimer();
+  }
+
+  /// Pauses automatic attempts until [resume] or a settings toggle resumes it.
+  void pause() {
+    if (_disposed) {
+      return;
+    }
+    _paused = true;
+    _cancelTimer();
+  }
+
+  void resume() {
+    if (_disposed) {
+      return;
+    }
+    _paused = false;
+    notifyStateChanged();
+  }
+
+  void dispose() {
+    if (_disposed) {
+      return;
+    }
+    _disposed = true;
+    _generation += 1;
+    _timer?.cancel();
+    _timer = null;
+  }
+
+  void _scheduleIfEligible() {
+    if (_disposed ||
+        !_enabled ||
+        _paused ||
+        _saveInFlight ||
+        !_isDirty() ||
+        !_isReady()) {
+      return;
+    }
+    final generation = ++_generation;
+    _timer?.cancel();
+    _timer = _scheduleTimer(_debounce, () {
+      if (_disposed || generation != _generation) {
+        return;
+      }
+      _timer = null;
+      if (!_isDirty() || !_isReady()) {
+        return;
+      }
+      _saveInFlight = true;
+      unawaited(_runSave());
+    });
+  }
+
+  void _cancelTimer() {
+    _generation += 1;
+    _timer?.cancel();
+    _timer = null;
+  }
+
+  Future<void> _runSave() async {
+    try {
+      await _save();
+    } catch (error, stackTrace) {
+      if (!_disposed && _enabled) {
+        _paused = true;
+        _cancelTimer();
+        _onError(error, stackTrace);
+      }
+    } finally {
+      _saveInFlight = false;
+      if (!_disposed && !_paused) {
+        notifyStateChanged();
+      }
+    }
+  }
+}

--- a/lib/src/features/workbench/presentation/workspace_editor_loading.dart
+++ b/lib/src/features/workbench/presentation/workspace_editor_loading.dart
@@ -2,6 +2,7 @@ part of 'workspace_editor_surface.dart';
 
 extension _WorkspaceEditorLoading on _WorkspaceEditorSurfaceState {
   Future<void> _load() async {
+    _autosave.cancelPending();
     final requestId = ++_loadRequestId;
     final workspacePath = widget.workspace.path;
     final filePath = widget.tab.filePath;
@@ -40,6 +41,7 @@ extension _WorkspaceEditorLoading on _WorkspaceEditorSurfaceState {
       if (_isCurrentLoadRequest(requestId, workspacePath, filePath)) {
         _setEditorState(() => _loading = false);
         _applyPendingReveal();
+        _autosave.notifyStateChanged();
       }
     }
   }
@@ -48,6 +50,7 @@ extension _WorkspaceEditorLoading on _WorkspaceEditorSurfaceState {
     final filePath = widget.tab.filePath;
     if (filePath == null) {
       _invalidatePendingLoads();
+      _autosave.cancelPending();
       _loading = false;
       _loadError = null;
       return;
@@ -62,6 +65,7 @@ extension _WorkspaceEditorLoading on _WorkspaceEditorSurfaceState {
       _loadError = _document.loadError;
       _loading = false;
       _applyPendingReveal();
+      _autosave.notifyStateChanged();
       return;
     }
     _loading = true;

--- a/lib/src/features/workbench/presentation/workspace_editor_reveal.dart
+++ b/lib/src/features/workbench/presentation/workspace_editor_reveal.dart
@@ -5,6 +5,7 @@ extension _WorkspaceEditorReveal on _WorkspaceEditorSurfaceState {
     if (_isDirty()) {
       return;
     }
+    _autosave.cancelPending();
     _document.clearSnapshot();
     unawaited(_load());
   }

--- a/lib/src/features/workbench/presentation/workspace_editor_save.dart
+++ b/lib/src/features/workbench/presentation/workspace_editor_save.dart
@@ -1,0 +1,182 @@
+part of 'workspace_editor_surface.dart';
+
+extension _WorkspaceEditorSave on _WorkspaceEditorSurfaceState {
+  Future<void> _save() async {
+    final filePath = widget.tab.filePath;
+    if (filePath == null || _loading || _saving) {
+      return;
+    }
+    final loadError = _loadError;
+    if (loadError != null) {
+      _showToast(_messageFor(loadError), tone: AleraToastTone.error);
+      return;
+    }
+    if (!_document.canSave || !mounted) {
+      return;
+    }
+    final contentBeingSaved = _controller.text;
+    _setEditorState(() => _saving = true);
+    try {
+      final saved = await _write(overwriteIfChanged: false);
+      if (!mounted) {
+        return;
+      }
+      _acceptSavedIfUnchanged(saved, contentBeingSaved);
+      _autosave.resume();
+      _showToast('File saved');
+    } catch (error) {
+      if (!mounted) {
+        return;
+      }
+      if (error is native.WorkspaceFileError &&
+          error.kind == native.WorkspaceFileErrorKind.conflict) {
+        _autosave.pause();
+        await _resolveSaveConflict();
+      } else {
+        _showToast(_messageFor(error), tone: AleraToastTone.error);
+      }
+    } finally {
+      if (mounted) {
+        _setEditorState(() => _saving = false);
+      }
+      _autosave.notifyStateChanged();
+    }
+  }
+
+  Future<void> _saveAutomatically() async {
+    final filePath = widget.tab.filePath;
+    if (!mounted ||
+        filePath == null ||
+        _loading ||
+        _saving ||
+        _loadError != null ||
+        !_document.canSave) {
+      return;
+    }
+    final contentBeingSaved = _controller.text;
+    _setEditorState(() => _saving = true);
+    try {
+      final saved = await _write(overwriteIfChanged: false);
+      if (!mounted) {
+        return;
+      }
+      _acceptSavedIfUnchanged(saved, contentBeingSaved);
+    } finally {
+      if (mounted) {
+        _setEditorState(() => _saving = false);
+      }
+    }
+  }
+
+  Future<void> _discardChanges() async {
+    if (_loading || _saving || !_document.canSave) {
+      return;
+    }
+    final loadedText = _document.loadedText;
+    if (loadedText == null) {
+      return;
+    }
+    _document.updateCurrentText(loadedText);
+    _controller.text = loadedText;
+    _undoController.clear();
+    if (mounted) {
+      _setEditorState(() {});
+      _showToast('Changes discarded');
+    }
+    _autosave.notifyStateChanged();
+  }
+
+  Future<bool> _resolveSaveConflict() async {
+    final overwrite = await showDialog<bool>(
+      context: context,
+      builder: (context) => const AleraConfirmDialog(
+        title: 'File changed on disk',
+        message: 'Overwrite the file with the editor contents?',
+        confirmLabel: 'Overwrite',
+        destructive: true,
+      ),
+    );
+    if (overwrite != true || !mounted) {
+      return false;
+    }
+    final contentBeingSaved = _controller.text;
+    try {
+      final saved = await _write(overwriteIfChanged: true);
+      if (!mounted) {
+        return false;
+      }
+      _acceptSavedIfUnchanged(saved, contentBeingSaved);
+      _autosave.resume();
+      _showToast('File overwritten');
+      return true;
+    } catch (error) {
+      if (mounted) {
+        _showToast(_messageFor(error), tone: AleraToastTone.error);
+      }
+      return false;
+    }
+  }
+
+  Future<native.WorkspaceEditorTextFile> _write({
+    required bool overwriteIfChanged,
+  }) {
+    return _workspaceFiles.writeEditorTextFile(
+      workspacePath: widget.workspace.path,
+      relativePath: widget.tab.filePath!,
+      currentDisplayContent: _controller.text,
+      originalRawContent: _document.loadedRawText,
+      originalDisplayContent: _document.loadedText,
+      expectedContentToken: _document.contentToken,
+      overwriteIfChanged: overwriteIfChanged,
+      tabSize: _currentEditorTabSize(),
+    );
+  }
+
+  void _acceptSaved(native.WorkspaceEditorTextFile saved) {
+    _document.acceptSaved(saved, tabSize: _currentEditorTabSize());
+    _controller.text = _document.currentText ?? '';
+  }
+
+  void _acceptSavedIfUnchanged(
+    native.WorkspaceEditorTextFile saved,
+    String contentBeingSaved,
+  ) {
+    if (_controller.text == contentBeingSaved) {
+      _acceptSaved(saved);
+      return;
+    }
+    final currentText = _controller.text;
+    _document.acceptSaved(saved, tabSize: _currentEditorTabSize());
+    _document.updateCurrentText(currentText);
+  }
+
+  bool _isReadyForAutosave() {
+    return mounted &&
+        !_loading &&
+        !_saving &&
+        _loadError == null &&
+        _document.canSave;
+  }
+
+  void _handleControllerChanged() {
+    _document.updateCurrentText(_controller.text);
+    _autosave.notifyTextChanged();
+    _refreshStateSafely();
+  }
+
+  void _handleAutosaveError(Object error, StackTrace stackTrace) {
+    if (!mounted) {
+      return;
+    }
+    if (error is native.WorkspaceFileError &&
+        error.kind == native.WorkspaceFileErrorKind.conflict) {
+      _showToast('Autosave paused because the file changed on disk.');
+      unawaited(_resolveSaveConflict());
+      return;
+    }
+    _showToast(
+      'Autosave paused: ${_messageFor(error)}',
+      tone: AleraToastTone.error,
+    );
+  }
+}

--- a/lib/src/features/workbench/presentation/workspace_editor_surface.dart
+++ b/lib/src/features/workbench/presentation/workspace_editor_surface.dart
@@ -8,6 +8,7 @@ import 'package:alera/src/design_system/icons/alera_file_icon.dart';
 import 'package:alera/src/design_system/icons/alera_icons.dart';
 import 'package:alera/src/design_system/layout/alera_confirm_dialog.dart';
 import 'package:alera/src/features/settings/domain/editor_syntax_theme_catalog.dart';
+import 'package:alera/src/features/workbench/application/editor_autosave_controller.dart';
 import 'package:alera/src/features/workbench/application/workspace_file_preview_kind.dart';
 import 'package:alera/src/features/workbench/application/workspace_file_service.dart';
 import 'package:alera/src/features/workbench/domain/workspace.dart';
@@ -29,6 +30,7 @@ part 'workspace_editor_widgets.dart';
 part 'workspace_editor_focus.dart';
 part 'workspace_editor_reveal.dart';
 part 'workspace_editor_loading.dart';
+part 'workspace_editor_save.dart';
 
 class WorkspaceEditorSurface extends ConsumerStatefulWidget {
   const WorkspaceEditorSurface({
@@ -62,6 +64,7 @@ class _WorkspaceEditorSurfaceState
   late final WorkspaceFileService _workspaceFiles;
   late final EditorSessionRegistry _editorSessions;
   late final EditorSessionHandle _sessionHandle;
+  late final EditorAutosaveController _autosave;
   late EditorDocumentSession _document;
   Object? _loadError;
   bool _loading = true;
@@ -92,6 +95,22 @@ class _WorkspaceEditorSurfaceState
     );
     _controller.addListener(_handleControllerChanged);
     _document = _editorSessions.documentFor(widget.tab.id);
+    final editorSettings = ref.read(settingsControllerProvider).editor;
+    _autosave = EditorAutosaveController(
+      enabled: editorSettings.autosaveEnabled,
+      debounce: editorSettings.autosaveDebounce,
+      isDirty: _isDirty,
+      isReady: _isReadyForAutosave,
+      save: _saveAutomatically,
+      onError: _handleAutosaveError,
+    );
+    ref.listen(
+      settingsControllerProvider.select((settings) => settings.editor),
+      (previous, next) => _autosave.updateSettings(
+        enabled: next.autosaveEnabled,
+        debounce: next.autosaveDebounce,
+      ),
+    );
     _registerSession(widget.tab.id);
     _restoreDocumentOrLoad();
   }
@@ -102,6 +121,7 @@ class _WorkspaceEditorSurfaceState
     if (oldWidget.tab.id != widget.tab.id ||
         oldWidget.workspace.path != widget.workspace.path ||
         oldWidget.tab.filePath != widget.tab.filePath) {
+      _autosave.cancelPending();
       _replaceFocusNode();
       _editorSessions.unregister(oldWidget.tab.id, _sessionHandle);
       _document = _editorSessions.documentFor(widget.tab.id);
@@ -112,6 +132,7 @@ class _WorkspaceEditorSurfaceState
 
   @override
   void dispose() {
+    _autosave.dispose();
     _editorSessions.unregister(widget.tab.id, _sessionHandle);
     _focusNode.suppressThirdPartyListeners();
     _focusNode.unfocus();
@@ -229,61 +250,6 @@ class _WorkspaceEditorSurfaceState
     return null;
   }
 
-  Future<void> _save() async {
-    final filePath = widget.tab.filePath;
-    if (filePath == null || _loading || _saving) {
-      return;
-    }
-    final loadError = _loadError;
-    if (loadError != null) {
-      _showToast(_messageFor(loadError), tone: AleraToastTone.error);
-      return;
-    }
-    if (!_document.canSave) {
-      return;
-    }
-    setState(() => _saving = true);
-    try {
-      final saved = await _write(overwriteIfChanged: false);
-      if (!mounted) {
-        return;
-      }
-      _acceptSaved(saved);
-      _showToast('File saved');
-    } catch (error) {
-      if (!mounted) {
-        return;
-      }
-      if (error is native.WorkspaceFileError &&
-          error.kind == native.WorkspaceFileErrorKind.conflict) {
-        await _resolveSaveConflict();
-      } else {
-        _showToast(_messageFor(error), tone: AleraToastTone.error);
-      }
-    } finally {
-      if (mounted) {
-        setState(() => _saving = false);
-      }
-    }
-  }
-
-  Future<void> _discardChanges() async {
-    if (_loading || _saving || !_document.canSave) {
-      return;
-    }
-    final loadedText = _document.loadedText;
-    if (loadedText == null) {
-      return;
-    }
-    _document.updateCurrentText(loadedText);
-    _controller.text = loadedText;
-    _undoController.clear();
-    if (mounted) {
-      setState(() {});
-      _showToast('Changes discarded');
-    }
-  }
-
   Future<void> _openDiffForFile() async {
     final filePath = widget.tab.filePath;
     if (filePath == null) {
@@ -382,56 +348,7 @@ class _WorkspaceEditorSurfaceState
     );
   }
 
-  Future<void> _resolveSaveConflict() async {
-    final overwrite = await showDialog<bool>(
-      context: context,
-      builder: (context) => const AleraConfirmDialog(
-        title: 'File changed on disk',
-        message: 'Overwrite the file with the editor contents?',
-        confirmLabel: 'Overwrite',
-        destructive: true,
-      ),
-    );
-    if (overwrite != true) {
-      return;
-    }
-    if (!mounted) {
-      return;
-    }
-    final saved = await _write(overwriteIfChanged: true);
-    if (!mounted) {
-      return;
-    }
-    _acceptSaved(saved);
-    _showToast('File overwritten');
-  }
-
-  Future<native.WorkspaceEditorTextFile> _write({
-    required bool overwriteIfChanged,
-  }) {
-    return _workspaceFiles.writeEditorTextFile(
-      workspacePath: widget.workspace.path,
-      relativePath: widget.tab.filePath!,
-      currentDisplayContent: _controller.text,
-      originalRawContent: _document.loadedRawText,
-      originalDisplayContent: _document.loadedText,
-      expectedContentToken: _document.contentToken,
-      overwriteIfChanged: overwriteIfChanged,
-      tabSize: _currentEditorTabSize(),
-    );
-  }
-
-  void _acceptSaved(native.WorkspaceEditorTextFile saved) {
-    _document.acceptSaved(saved, tabSize: _currentEditorTabSize());
-    _controller.text = _document.currentText ?? '';
-  }
-
   bool _isDirty() => _document.isDirty;
-
-  void _handleControllerChanged() {
-    _document.updateCurrentText(_controller.text);
-    _refreshStateSafely();
-  }
 
   void _refreshStateSafely() {
     if (!mounted) {

--- a/roadmap.md
+++ b/roadmap.md
@@ -53,7 +53,7 @@ Comprehensive feature roadmap for Alera. Each feature is scored on two axes:
 | Markdown editor | 4 | 3 | Planned | WYSIWYG markdown editing with toolbar, slash menu, code blocks, tables, mermaid |
 | Markdown viewer | 2 | 3 | Shipped | View rendered markdown files in workspace tabs |
 | Open in with other softwares | 2 | 4 | Partial | Open workspace/folder in OS file manager (Linux selects via FileManager1.ShowItems with parent-folder fallback) and open repository in browser; no VS Code / Cursor / Zed / custom editor launcher yet |
-| Autosave | 2 | 4 | Planned | Automatic file saving with configurable behavior |
+| Autosave | 2 | 4 | Shipped | Optional idle editor saves with a bounded delay and conflict-safe writes |
 | Editor scroll restore | 1 | 3 | Planned | Persist and restore scroll position across sessions |
 | External file watch | 2 | 4 | Partial | Explorer and source-control file watches are live; editor reloads/conflicts on external disk changes; no full prompt-to-reload product surface yet |
 | PDF viewer | 3 | 2 | Shipped | Render PDFs with inline tabs and in-document search |
@@ -264,7 +264,7 @@ Comprehensive feature roadmap for Alera. Each feature is scored on two axes:
 | Terminal search | 2 | 5 | Planned |
 | Open in with other softwares | 2 | 4 | Partial |
 | Tab cycling & reopen closed tab | 2 | 4 | Partial |
-| Autosave | 2 | 4 | Planned |
+| Autosave | 2 | 4 | Shipped |
 | Worktree navigation history | 2 | 4 | Planned |
 | Status bar | 2 | 4 | Partial |
 

--- a/test/unit/alera_settings_json_test.dart
+++ b/test/unit/alera_settings_json_test.dart
@@ -1,0 +1,136 @@
+import 'package:alera/src/features/ai_text_generation/domain/ai_text_generation_settings.dart';
+import 'package:alera/src/features/keyboard/domain/keyboard_action.dart';
+import 'package:alera/src/features/keyboard/domain/keyboard_shortcut_settings.dart';
+import 'package:alera/src/features/settings/domain/alera_settings.dart';
+import 'package:alera/src/features/settings/domain/editor_syntax_theme_catalog.dart';
+import 'package:alera/src/features/settings/domain/terminal_theme_catalog.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('AleraSettings JSON', () {
+    test('round-trips through json', () {
+      const settings = AleraSettings(
+        general: GeneralSettings(
+          confirmProjectRemoval: false,
+          confirmWorkspaceRemoval: false,
+        ),
+        agents: AgentSettings(
+          agentStatusHooks: AgentStatusHookSettings(
+            codex: true,
+            claude: true,
+            cursor: true,
+            agy: true,
+            pi: true,
+            amp: true,
+            grok: true,
+          ),
+          agentStatusNotificationsEnabled: true,
+          keepComputerAwakeWhileAgentsWork: true,
+          defaultAgentProfileId: 'prof_1',
+        ),
+        editor: EditorSettings(
+          tabSize: 2,
+          themeName: EditorSyntaxThemeNames.nord,
+          autosaveEnabled: true,
+          autosaveDelaySeconds: 3,
+        ),
+        aiTextGeneration: AiTextGenerationSettings(
+          agent: AiTextGenerationAgent.agy,
+          selectedModelByAgent: <AiTextGenerationAgent, String>{
+            AiTextGenerationAgent.agy: 'Gemini 3.5 Flash (Medium)',
+          },
+          instructionsByOperation: <AiTextGenerationOperation, String>{
+            AiTextGenerationOperation.commitMessage:
+                'Use conventional commits.',
+          },
+        ),
+        terminal: TerminalSettings(
+          fontFamily: 'SF Mono',
+          fontSize: 15,
+          fontWeight: 500,
+          lineHeight: 1.4,
+          paddingX: 8,
+          paddingY: 10,
+          cursorShape: TerminalCursorShape.bar,
+          cursorBlink: true,
+          cursorOpacity: 0.75,
+          themeName: TerminalThemeNames.dracula,
+          backgroundOpacity: 0.9,
+          wordSeparators: ' /',
+          colorOverrides: TerminalColorOverrides(
+            foreground: '#eeeeee',
+            background: '#111111',
+            cursor: '#ff00ff',
+            selection: '#333333',
+          ),
+          scrollbackLines: 50000,
+          hostEmptyShutdownDelaySeconds: 5,
+          hostDetachedSessionShutdownDelaySeconds: 120,
+          hostScrollbackBytes: 24 * 1000 * 1000,
+        ),
+        keyboard: KeyboardShortcutSettings(
+          overrides: <KeyboardActionId, List<String>>{
+            KeyboardActionId.closeTab: <String>['Mod+Shift+W'],
+          },
+        ),
+      );
+
+      final restored = AleraSettings.fromJson(
+        Map<String, Object?>.from(settings.toMap()),
+      );
+
+      expect(restored.general.confirmProjectRemoval, isFalse);
+      expect(restored.general.confirmWorkspaceRemoval, isFalse);
+      expect(restored.agents.agentStatusHooks.codex, isTrue);
+      expect(restored.agents.agentStatusHooks.claude, isTrue);
+      expect(restored.agents.agentStatusHooks.copilot, isFalse);
+      expect(restored.agents.agentStatusHooks.cursor, isTrue);
+      expect(restored.agents.agentStatusHooks.agy, isTrue);
+      expect(restored.agents.agentStatusHooks.opencode, isFalse);
+      expect(restored.agents.agentStatusHooks.pi, isTrue);
+      expect(restored.agents.agentStatusHooks.amp, isTrue);
+      expect(restored.agents.agentStatusHooks.grok, isTrue);
+      expect(restored.agents.agentStatusNotificationsEnabled, isTrue);
+      expect(restored.agents.keepComputerAwakeWhileAgentsWork, isTrue);
+      expect(restored.agents.defaultAgentProfileId, 'prof_1');
+      expect(restored.editor.tabSize, 2);
+      expect(restored.editor.themeName, EditorSyntaxThemeNames.nord);
+      expect(restored.editor.autosaveEnabled, isTrue);
+      expect(restored.editor.autosaveDelaySeconds, 3);
+      expect(restored.aiTextGeneration.agent, AiTextGenerationAgent.agy);
+      expect(
+        restored.aiTextGeneration.modelFor(AiTextGenerationAgent.agy),
+        'Gemini 3.5 Flash (Medium)',
+      );
+      expect(
+        restored.aiTextGeneration.instructionsFor(
+          AiTextGenerationOperation.commitMessage,
+        ),
+        'Use conventional commits.',
+      );
+      expect(restored.terminal.fontFamily, 'SF Mono');
+      expect(restored.terminal.fontSize, 15);
+      expect(restored.terminal.fontWeight, 500);
+      expect(restored.terminal.lineHeight, 1.4);
+      expect(restored.terminal.paddingX, 8);
+      expect(restored.terminal.paddingY, 10);
+      expect(restored.terminal.cursorShape, TerminalCursorShape.bar);
+      expect(restored.terminal.cursorBlink, isTrue);
+      expect(restored.terminal.cursorOpacity, 0.75);
+      expect(restored.terminal.themeName, TerminalThemeNames.dracula);
+      expect(restored.terminal.backgroundOpacity, 0.9);
+      expect(restored.terminal.wordSeparators, ' /');
+      expect(restored.terminal.colorOverrides.foreground, '#eeeeee');
+      expect(restored.terminal.colorOverrides.background, '#111111');
+      expect(restored.terminal.colorOverrides.cursor, '#ff00ff');
+      expect(restored.terminal.colorOverrides.selection, '#333333');
+      expect(restored.terminal.scrollbackLines, 50000);
+      expect(restored.terminal.hostEmptyShutdownDelaySeconds, 5);
+      expect(restored.terminal.hostDetachedSessionShutdownDelaySeconds, 120);
+      expect(restored.terminal.hostScrollbackBytes, 24 * 1000 * 1000);
+      expect(restored.keyboard.overrides[KeyboardActionId.closeTab], <String>[
+        'Mod+Shift+W',
+      ]);
+    });
+  });
+}

--- a/test/unit/alera_settings_test.dart
+++ b/test/unit/alera_settings_test.dart
@@ -1,6 +1,4 @@
-import 'package:alera/src/features/keyboard/domain/keyboard_action.dart';
 import 'package:alera/src/features/ai_text_generation/domain/ai_text_generation_settings.dart';
-import 'package:alera/src/features/keyboard/domain/keyboard_shortcut_settings.dart';
 import 'package:alera/src/features/settings/domain/alera_settings.dart';
 import 'package:alera/src/features/settings/domain/editor_syntax_theme_catalog.dart';
 import 'package:alera/src/features/settings/domain/terminal_theme_catalog.dart';
@@ -65,6 +63,33 @@ void main() {
 
       expect(editor.tabSize, 4);
       expect(editor.themeName, EditorSyntaxThemeNames.alera);
+      expect(editor.autosaveEnabled, isFalse);
+      expect(editor.autosaveDelaySeconds, 1);
+      expect(editor.effectiveAutosaveDelaySeconds, 1);
+      expect(editor.autosaveDebounce, const Duration(seconds: 1));
+    });
+
+    test('backward-compatible editor settings use autosave defaults', () {
+      final editor = EditorSettings.fromJson(<String, Object?>{
+        'tabSize': 2,
+        'themeName': EditorSyntaxThemeNames.monokai,
+      });
+
+      expect(editor.tabSize, 2);
+      expect(editor.themeName, EditorSyntaxThemeNames.monokai);
+      expect(editor.autosaveEnabled, isFalse);
+      expect(editor.autosaveDelaySeconds, 1);
+    });
+
+    test('bounds persisted autosave delay before scheduling', () {
+      expect(
+        EditorSettings(autosaveDelaySeconds: 0).effectiveAutosaveDelaySeconds,
+        EditorSettings.minAutosaveDelaySeconds,
+      );
+      expect(
+        EditorSettings(autosaveDelaySeconds: 999).effectiveAutosaveDelaySeconds,
+        EditorSettings.maxAutosaveDelaySeconds,
+      );
     });
 
     test('ai text generation defaults cover Alera agents conservatively', () {
@@ -140,127 +165,6 @@ void main() {
       expect(hooks.pi, isTrue);
       expect(hooks.grok, isFalse);
       expect(hooks.anyEnabled, isTrue);
-    });
-
-    test('round-trips through json', () {
-      const settings = AleraSettings(
-        general: GeneralSettings(
-          confirmProjectRemoval: false,
-          confirmWorkspaceRemoval: false,
-        ),
-        agents: AgentSettings(
-          agentStatusHooks: AgentStatusHookSettings(
-            codex: true,
-            claude: true,
-            cursor: true,
-            agy: true,
-            pi: true,
-            amp: true,
-            grok: true,
-          ),
-          agentStatusNotificationsEnabled: true,
-          keepComputerAwakeWhileAgentsWork: true,
-          defaultAgentProfileId: 'prof_1',
-        ),
-        editor: EditorSettings(
-          tabSize: 2,
-          themeName: EditorSyntaxThemeNames.nord,
-        ),
-        aiTextGeneration: AiTextGenerationSettings(
-          agent: AiTextGenerationAgent.agy,
-          selectedModelByAgent: <AiTextGenerationAgent, String>{
-            AiTextGenerationAgent.agy: 'Gemini 3.5 Flash (Medium)',
-          },
-          instructionsByOperation: <AiTextGenerationOperation, String>{
-            AiTextGenerationOperation.commitMessage:
-                'Use conventional commits.',
-          },
-        ),
-        terminal: TerminalSettings(
-          fontFamily: 'SF Mono',
-          fontSize: 15,
-          fontWeight: 500,
-          lineHeight: 1.4,
-          paddingX: 8,
-          paddingY: 10,
-          cursorShape: TerminalCursorShape.bar,
-          cursorBlink: true,
-          cursorOpacity: 0.75,
-          themeName: TerminalThemeNames.dracula,
-          backgroundOpacity: 0.9,
-          wordSeparators: ' /',
-          colorOverrides: TerminalColorOverrides(
-            foreground: '#eeeeee',
-            background: '#111111',
-            cursor: '#ff00ff',
-            selection: '#333333',
-          ),
-          scrollbackLines: 50000,
-          hostEmptyShutdownDelaySeconds: 5,
-          hostDetachedSessionShutdownDelaySeconds: 120,
-          hostScrollbackBytes: 24 * 1000 * 1000,
-        ),
-        keyboard: KeyboardShortcutSettings(
-          overrides: <KeyboardActionId, List<String>>{
-            KeyboardActionId.closeTab: <String>['Mod+Shift+W'],
-          },
-        ),
-      );
-
-      final restored = AleraSettings.fromJson(
-        Map<String, Object?>.from(settings.toMap()),
-      );
-
-      expect(restored.general.confirmProjectRemoval, isFalse);
-      expect(restored.general.confirmWorkspaceRemoval, isFalse);
-      expect(restored.agents.agentStatusHooks.codex, isTrue);
-      expect(restored.agents.agentStatusHooks.claude, isTrue);
-      expect(restored.agents.agentStatusHooks.copilot, isFalse);
-      expect(restored.agents.agentStatusHooks.cursor, isTrue);
-      expect(restored.agents.agentStatusHooks.agy, isTrue);
-      expect(restored.agents.agentStatusHooks.opencode, isFalse);
-      expect(restored.agents.agentStatusHooks.pi, isTrue);
-      expect(restored.agents.agentStatusHooks.amp, isTrue);
-      expect(restored.agents.agentStatusHooks.grok, isTrue);
-      expect(restored.agents.agentStatusNotificationsEnabled, isTrue);
-      expect(restored.agents.keepComputerAwakeWhileAgentsWork, isTrue);
-      expect(restored.agents.defaultAgentProfileId, 'prof_1');
-      expect(restored.editor.tabSize, 2);
-      expect(restored.editor.themeName, EditorSyntaxThemeNames.nord);
-      expect(restored.aiTextGeneration.agent, AiTextGenerationAgent.agy);
-      expect(
-        restored.aiTextGeneration.modelFor(AiTextGenerationAgent.agy),
-        'Gemini 3.5 Flash (Medium)',
-      );
-      expect(
-        restored.aiTextGeneration.instructionsFor(
-          AiTextGenerationOperation.commitMessage,
-        ),
-        'Use conventional commits.',
-      );
-      expect(restored.terminal.fontFamily, 'SF Mono');
-      expect(restored.terminal.fontSize, 15);
-      expect(restored.terminal.fontWeight, 500);
-      expect(restored.terminal.lineHeight, 1.4);
-      expect(restored.terminal.paddingX, 8);
-      expect(restored.terminal.paddingY, 10);
-      expect(restored.terminal.cursorShape, TerminalCursorShape.bar);
-      expect(restored.terminal.cursorBlink, isTrue);
-      expect(restored.terminal.cursorOpacity, 0.75);
-      expect(restored.terminal.themeName, TerminalThemeNames.dracula);
-      expect(restored.terminal.backgroundOpacity, 0.9);
-      expect(restored.terminal.wordSeparators, ' /');
-      expect(restored.terminal.colorOverrides.foreground, '#eeeeee');
-      expect(restored.terminal.colorOverrides.background, '#111111');
-      expect(restored.terminal.colorOverrides.cursor, '#ff00ff');
-      expect(restored.terminal.colorOverrides.selection, '#333333');
-      expect(restored.terminal.scrollbackLines, 50000);
-      expect(restored.terminal.hostEmptyShutdownDelaySeconds, 5);
-      expect(restored.terminal.hostDetachedSessionShutdownDelaySeconds, 120);
-      expect(restored.terminal.hostScrollbackBytes, 24 * 1000 * 1000);
-      expect(restored.keyboard.overrides[KeyboardActionId.closeTab], <String>[
-        'Mod+Shift+W',
-      ]);
     });
 
     test('fromJson requires the current top-level schema', () {

--- a/test/unit/editor_autosave_controller_test.dart
+++ b/test/unit/editor_autosave_controller_test.dart
@@ -1,0 +1,276 @@
+import 'dart:async';
+
+import 'package:alera/src/features/workbench/application/editor_autosave_controller.dart';
+import 'package:alera/src/rust/api/workspace_files.dart' as native;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('EditorAutosaveController', () {
+    test('debounces text changes into one save', () async {
+      final timers = _FakeTimers();
+      var dirty = true;
+      var saves = 0;
+      final controller = _controller(
+        timers: timers,
+        dirty: () => dirty,
+        save: () async {
+          saves += 1;
+          dirty = false;
+        },
+      );
+      addTearDown(controller.dispose);
+
+      controller.notifyTextChanged();
+      controller.notifyTextChanged();
+      expect(timers.scheduled, 2);
+
+      await timers.fireLast();
+
+      expect(saves, 1);
+      expect(controller.isPaused, isFalse);
+    });
+
+    test('waits until loading or another save is complete', () async {
+      final timers = _FakeTimers();
+      var dirty = true;
+      var ready = false;
+      var saves = 0;
+      final controller = _controller(
+        timers: timers,
+        dirty: () => dirty,
+        ready: () => ready,
+        save: () async {
+          saves += 1;
+          dirty = false;
+        },
+      );
+      addTearDown(controller.dispose);
+
+      controller.notifyTextChanged();
+      expect(timers.scheduled, 0);
+
+      ready = true;
+      controller.notifyStateChanged();
+      await timers.fireLast();
+
+      expect(saves, 1);
+    });
+
+    test('cancels a pending save when autosave is disabled', () async {
+      final timers = _FakeTimers();
+      var saves = 0;
+      final controller = _controller(
+        timers: timers,
+        save: () async => saves += 1,
+      );
+      addTearDown(controller.dispose);
+
+      controller.notifyTextChanged();
+      controller.updateSettings(
+        enabled: false,
+        debounce: const Duration(seconds: 2),
+      );
+      await timers.fireAll();
+
+      expect(saves, 0);
+    });
+
+    test('does not save after disposal', () async {
+      final timers = _FakeTimers();
+      var saves = 0;
+      final controller = _controller(
+        timers: timers,
+        save: () async => saves += 1,
+      );
+
+      controller.notifyTextChanged();
+      controller.dispose();
+      await timers.fireAll();
+
+      expect(saves, 0);
+    });
+
+    test('does not start a duplicate save while one is in flight', () async {
+      final timers = _FakeTimers();
+      final saveGate = Completer<void>();
+      var dirty = true;
+      var saves = 0;
+      final controller = _controller(
+        timers: timers,
+        dirty: () => dirty,
+        save: () async {
+          saves += 1;
+          await saveGate.future;
+          dirty = false;
+        },
+      );
+      addTearDown(controller.dispose);
+
+      controller.notifyTextChanged();
+      await timers.fireLast();
+      controller.notifyTextChanged();
+      expect(timers.activeCount, 0);
+
+      saveGate.complete();
+      await Future<void>.delayed(Duration.zero);
+
+      expect(saves, 1);
+    });
+
+    test('pauses and reports a write error without retrying', () async {
+      final timers = _FakeTimers();
+      final error = StateError('file changed on disk');
+      Object? reportedError;
+      var saves = 0;
+      final controller = _controller(
+        timers: timers,
+        save: () async {
+          saves += 1;
+          throw error;
+        },
+        onError: (value, _) => reportedError = value,
+      );
+      addTearDown(controller.dispose);
+
+      controller.notifyTextChanged();
+      await timers.fireLast();
+      controller.notifyTextChanged();
+      await timers.fireAll();
+
+      expect(saves, 1);
+      expect(reportedError, same(error));
+      expect(controller.isPaused, isTrue);
+    });
+
+    test(
+      'does not report an in-flight error after autosave is disabled',
+      () async {
+        final timers = _FakeTimers();
+        final saveGate = Completer<void>();
+        Object? reportedError;
+        final controller = _controller(
+          timers: timers,
+          save: () async {
+            await saveGate.future;
+            throw StateError('save failed');
+          },
+          onError: (error, _) => reportedError = error,
+        );
+        addTearDown(controller.dispose);
+
+        controller.notifyTextChanged();
+        await timers.fireLast();
+        controller.updateSettings(
+          enabled: false,
+          debounce: const Duration(seconds: 1),
+        );
+        saveGate.complete();
+        await Future<void>.delayed(Duration.zero);
+
+        expect(reportedError, isNull);
+        expect(controller.isPaused, isFalse);
+      },
+    );
+
+    test('pauses after an external-file conflict', () async {
+      final timers = _FakeTimers();
+      const conflict = native.WorkspaceFileError(
+        kind: native.WorkspaceFileErrorKind.conflict,
+        context: 'note.txt',
+      );
+      Object? reportedError;
+      final controller = _controller(
+        timers: timers,
+        save: () async => throw conflict,
+        onError: (value, _) => reportedError = value,
+      );
+      addTearDown(controller.dispose);
+
+      controller.notifyTextChanged();
+      await timers.fireLast();
+
+      expect(reportedError, same(conflict));
+      expect(
+        (reportedError! as native.WorkspaceFileError).kind,
+        native.WorkspaceFileErrorKind.conflict,
+      );
+      expect(controller.isPaused, isTrue);
+    });
+  });
+}
+
+EditorAutosaveController _controller({
+  required _FakeTimers timers,
+  bool Function()? dirty,
+  bool Function()? ready,
+  Future<void> Function()? save,
+  void Function(Object error, StackTrace stackTrace)? onError,
+}) {
+  return EditorAutosaveController(
+    enabled: true,
+    debounce: const Duration(seconds: 1),
+    isDirty: dirty ?? () => true,
+    isReady: ready ?? () => true,
+    save: save ?? () async {},
+    onError: onError ?? (_, _) {},
+    scheduleTimer: timers.schedule,
+  );
+}
+
+class _FakeTimers {
+  final List<_FakeTimer> _timers = <_FakeTimer>[];
+
+  int get scheduled => _timers.length;
+
+  int get activeCount => _timers.where((timer) => timer.isActive).length;
+
+  Timer schedule(Duration duration, void Function() callback) {
+    final timer = _FakeTimer(callback);
+    _timers.add(timer);
+    return timer;
+  }
+
+  Future<void> fireLast() async {
+    for (var index = _timers.length - 1; index >= 0; index -= 1) {
+      final timer = _timers[index];
+      if (timer.isActive) {
+        timer.fire();
+        break;
+      }
+    }
+    await Future<void>.delayed(Duration.zero);
+  }
+
+  Future<void> fireAll() async {
+    for (final timer in List<_FakeTimer>.of(_timers)) {
+      if (timer.isActive) {
+        timer.fire();
+      }
+    }
+    await Future<void>.delayed(Duration.zero);
+  }
+}
+
+class _FakeTimer implements Timer {
+  _FakeTimer(this._callback);
+
+  final void Function() _callback;
+  var _active = true;
+
+  void fire() {
+    if (!_active) {
+      return;
+    }
+    _active = false;
+    _callback();
+  }
+
+  @override
+  void cancel() => _active = false;
+
+  @override
+  bool get isActive => _active;
+
+  @override
+  int get tick => 0;
+}

--- a/test/widget/settings_dialog_core_test_cases.dart
+++ b/test/widget/settings_dialog_core_test_cases.dart
@@ -62,11 +62,6 @@ void _registerSettingsDialogCoreTests() {
     await tester.pump();
   }
 
-  Future<void> selectEditorSectionLocal(WidgetTester tester) async {
-    await tester.tap(find.text('Editor').first);
-    await tester.pump();
-  }
-
   Future<void> selectAiTextSectionLocal(WidgetTester tester) async {
     await tester.tap(find.text('AI Text').first);
     await tester.pump();
@@ -241,54 +236,6 @@ void _registerSettingsDialogCoreTests() {
     expect(find.text('None'), findsWidgets);
     expect(find.text('No setup commands'), findsOneWidget);
     expect(find.text('pnpm install'), findsNothing);
-  });
-
-  testWidgets('edits and resets editor settings', (tester) async {
-    final container = await pumpSettingsDialogLocal(tester);
-    await selectEditorSectionLocal(tester);
-
-    expect(find.text('Editor'), findsWidgets);
-    expect(find.text('Tab Size'), findsOneWidget);
-    expect(find.text('Theme Preset'), findsOneWidget);
-    expect(container.read(settingsControllerProvider).editor.tabSize, 4);
-    expect(
-      container.read(settingsControllerProvider).editor.themeName,
-      EditorSyntaxThemeNames.alera,
-    );
-
-    await tester.enterText(
-      find.byKey(const ValueKey<String>('editor-theme-search-field')),
-      'monokai',
-    );
-    await tester.pump();
-    await tester.tap(find.text(EditorSyntaxThemeNames.monokai));
-    await tester.pump(const Duration(milliseconds: 50));
-
-    expect(
-      container.read(settingsControllerProvider).editor.themeName,
-      EditorSyntaxThemeNames.monokai,
-    );
-
-    await tester.ensureVisible(find.text('Tab Size'));
-    await tester.pump();
-
-    await tester.enterText(find.byType(TextField).last, '2');
-    await tester.testTextInput.receiveAction(TextInputAction.done);
-    await tester.pump(const Duration(milliseconds: 50));
-
-    expect(container.read(settingsControllerProvider).editor.tabSize, 2);
-
-    await tester.tap(find.text('Reset Editor'));
-    await tester.pump(const Duration(milliseconds: 50));
-
-    expect(
-      container.read(settingsControllerProvider).editor.tabSize,
-      EditorSettings.defaults.tabSize,
-    );
-    expect(
-      container.read(settingsControllerProvider).editor.themeName,
-      EditorSettings.defaults.themeName,
-    );
   });
 
   testWidgets('edits and resets AI text settings', (tester) async {

--- a/test/widget/settings_dialog_editor_test_cases.dart
+++ b/test/widget/settings_dialog_editor_test_cases.dart
@@ -1,0 +1,83 @@
+part of 'settings_dialog_test.dart';
+
+void _registerSettingsDialogEditorTests() {
+  testWidgets('edits and resets editor settings', (tester) async {
+    final container = await _pumpSettingsDialog(tester);
+    await tester.tap(find.text('Editor').first);
+    await tester.pump();
+
+    expect(find.text('Editor'), findsWidgets);
+    expect(find.text('Tab Size'), findsOneWidget);
+    expect(find.text('Theme Preset'), findsOneWidget);
+    expect(find.text('Autosave'), findsWidgets);
+    expect(find.text('Autosave Delay'), findsOneWidget);
+    expect(container.read(settingsControllerProvider).editor.tabSize, 4);
+    expect(
+      container.read(settingsControllerProvider).editor.themeName,
+      EditorSyntaxThemeNames.alera,
+    );
+    expect(
+      container.read(settingsControllerProvider).editor.autosaveEnabled,
+      isFalse,
+    );
+    expect(
+      container.read(settingsControllerProvider).editor.autosaveDelaySeconds,
+      EditorSettings.defaultAutosaveDelaySeconds,
+    );
+
+    await tester.tap(find.byType(Switch));
+    await tester.pump(const Duration(milliseconds: 50));
+    expect(
+      container.read(settingsControllerProvider).editor.autosaveEnabled,
+      isTrue,
+    );
+
+    await tester.enterText(
+      find.byKey(const ValueKey<String>('editor-theme-search-field')),
+      'monokai',
+    );
+    await tester.pump();
+    await tester.tap(find.text(EditorSyntaxThemeNames.monokai));
+    await tester.pump(const Duration(milliseconds: 50));
+
+    expect(
+      container.read(settingsControllerProvider).editor.themeName,
+      EditorSyntaxThemeNames.monokai,
+    );
+
+    await tester.ensureVisible(find.text('Tab Size'));
+    await tester.pump();
+
+    await tester.enterText(
+      find.descendant(
+        of: find.byKey(const ValueKey<String>('editor-tab-size-row')),
+        matching: find.byType(TextField),
+      ),
+      '2',
+    );
+    await tester.testTextInput.receiveAction(TextInputAction.done);
+    await tester.pump(const Duration(milliseconds: 50));
+
+    expect(container.read(settingsControllerProvider).editor.tabSize, 2);
+
+    await tester.tap(find.text('Reset Editor'));
+    await tester.pump(const Duration(milliseconds: 50));
+
+    expect(
+      container.read(settingsControllerProvider).editor.tabSize,
+      EditorSettings.defaults.tabSize,
+    );
+    expect(
+      container.read(settingsControllerProvider).editor.themeName,
+      EditorSettings.defaults.themeName,
+    );
+    expect(
+      container.read(settingsControllerProvider).editor.autosaveEnabled,
+      EditorSettings.defaults.autosaveEnabled,
+    );
+    expect(
+      container.read(settingsControllerProvider).editor.autosaveDelaySeconds,
+      EditorSettings.defaults.autosaveDelaySeconds,
+    );
+  });
+}

--- a/test/widget/settings_dialog_test.dart
+++ b/test/widget/settings_dialog_test.dart
@@ -46,6 +46,7 @@ import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 import '../unit/fake_project_config.dart';
 
 part 'settings_dialog_core_test_cases.dart';
+part 'settings_dialog_editor_test_cases.dart';
 part 'settings_dialog_project_test_cases.dart';
 part 'settings_dialog_ai_text_test_cases.dart';
 part 'settings_dialog_quota_test_cases.dart';
@@ -117,6 +118,7 @@ Future<void> _selectTerminalSection(WidgetTester tester) async {
 
 void main() {
   _registerSettingsDialogCoreTests();
+  _registerSettingsDialogEditorTests();
   _registerSettingsDialogProjectTests();
   _registerSettingsDialogAiTextTests();
   _registerSettingsDialogQuotaTests();


### PR DESCRIPTION
## Summary

- Add optional editor autosave with a bounded 1 to 60 second idle delay, disabled by default.
- Reuse conflict-safe editor writes and pause autosave after write failures or external-file conflicts.
- Add settings search entries, persistence coverage, editor integration tests, and mark Autosave shipped in the roadmap.

## Validation

- `flutter pub run build_runner build -d`
- `dart format --set-exit-if-changed lib test integration_test tool`
- `dart tool/quality/check_max_lines.dart`
- `flutter analyze`
- Focused settings, autosave, editor, file-service, and widget tests all passed.

The local `gh act` pull-request emulation was attempted but blocked by linked-worktree submodule resolution and Docker image authentication; hosted checks remain authoritative.