### PR TITLE
perf: reduce runtime host resource overhead

### DIFF
--- a/rust/alera-cli/src/cli_async_runtime.rs
+++ b/rust/alera-cli/src/cli_async_runtime.rs
@@ -1,0 +1,81 @@
+use std::io;
+
+use tokio::runtime::{Builder, Runtime};
+
+use crate::cli::Command;
+
+const MAX_HOST_WORKER_THREADS: usize = 4;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum RuntimeProfile {
+    Cli,
+    Host,
+}
+
+pub fn build(command: &Command) -> io::Result<Runtime> {
+    match profile(command) {
+        RuntimeProfile::Cli => Builder::new_current_thread().enable_all().build(),
+        RuntimeProfile::Host => Builder::new_multi_thread()
+            .worker_threads(host_worker_threads())
+            .enable_all()
+            .build(),
+    }
+}
+
+fn profile(command: &Command) -> RuntimeProfile {
+    match command {
+        Command::RuntimeHost(_) | Command::TerminalHost(_) => RuntimeProfile::Host,
+        _ => RuntimeProfile::Cli,
+    }
+}
+
+fn host_worker_threads() -> usize {
+    std::thread::available_parallelism()
+        .map(usize::from)
+        .unwrap_or(1)
+        .min(MAX_HOST_WORKER_THREADS)
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::Parser;
+
+    use super::*;
+    use crate::cli::Cli;
+
+    fn command(args: &[&str]) -> Command {
+        Cli::try_parse_from(args).unwrap().command
+    }
+
+    #[test]
+    fn ordinary_cli_commands_use_one_async_worker() {
+        let runtime = build(&command(&["alera", "version"])).unwrap();
+
+        assert_eq!(runtime.metrics().num_workers(), 1);
+    }
+
+    #[test]
+    fn runtime_host_workers_are_bounded_by_machine_parallelism() {
+        let runtime = build(&command(&[
+            "alera",
+            "runtime-host",
+            "--runtime-dir",
+            "/runtime",
+            "--control-file",
+            "/runtime/host.json",
+            "--token",
+            "test-token",
+        ]))
+        .unwrap();
+
+        assert_eq!(runtime.metrics().num_workers(), host_worker_threads());
+        assert!(runtime.metrics().num_workers() <= MAX_HOST_WORKER_THREADS);
+    }
+
+    #[test]
+    fn runtime_proxy_stays_on_the_lightweight_cli_runtime() {
+        let runtime = build(&command(&["alera", "runtime-proxy"])).unwrap();
+
+        assert_eq!(runtime.metrics().num_workers(), 1);
+    }
+}

--- a/rust/alera-cli/src/main.rs
+++ b/rust/alera-cli/src/main.rs
@@ -2,6 +2,7 @@ mod agent_quota;
 mod agent_status;
 mod browser_commands;
 mod cli;
+mod cli_async_runtime;
 mod cli_orchestration;
 mod cli_orchestration_runs;
 mod cli_orchestration_terminal;
@@ -76,24 +77,30 @@ use crate::tab_record_factory::tab_from_args;
 
 /// Usage-error exit code, matching the Dart CLI (`_usageExitCode`).
 const USAGE_EXIT_CODE: i32 = 64;
-#[tokio::main]
-async fn main() {
-    std::process::exit(run().await);
-}
 
-async fn run() -> i32 {
+fn main() {
     let cli = match Cli::try_parse() {
         Ok(cli) => cli,
         Err(error) => {
             let _ = error.print();
-            // Help/version requests exit cleanly; real usage errors use code 64.
-            return if error.use_stderr() {
+            std::process::exit(if error.use_stderr() {
                 USAGE_EXIT_CODE
             } else {
                 0
-            };
+            });
         }
     };
+    let runtime = match cli_async_runtime::build(&cli.command) {
+        Ok(runtime) => runtime,
+        Err(error) => {
+            eprintln!("Failed to initialize the Alera async runtime: {error}");
+            std::process::exit(1);
+        }
+    };
+    std::process::exit(runtime.block_on(run(cli)));
+}
+
+async fn run(cli: Cli) -> i32 {
     match cli.command {
         Command::RuntimeHost(args) => runtime_host_command::run(args).await,
         Command::RuntimeProxy => agent_quota::run_runtime_proxy().await,

--- a/rust/alera-cli/src/terminal_host/history_store.rs
+++ b/rust/alera-cli/src/terminal_host/history_store.rs
@@ -9,6 +9,7 @@ use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions, S
 use sqlx::{Row, SqlitePool};
 
 pub const HISTORY_DATABASE_FILE_NAME: &str = "terminal_history.sqlite";
+const HISTORY_STORE_MAX_CONNECTIONS: u32 = 2;
 
 const CREATE_CHECKPOINTS_TABLE_SQL: &str = "\
 CREATE TABLE IF NOT EXISTS checkpoints (\n\
@@ -65,7 +66,13 @@ impl TerminalHostHistoryStore {
             .create_if_missing(true)
             .journal_mode(SqliteJournalMode::Wal)
             .synchronous(SqliteSynchronous::Normal);
-        let pool = SqlitePoolOptions::new().connect_with(options).await?;
+        // SQLite runs one worker thread per pooled connection. Output writes
+        // are serialized by SQLite itself; a second connection lets a read or
+        // trim proceed without retaining the default pool of ten threads.
+        let pool = SqlitePoolOptions::new()
+            .max_connections(HISTORY_STORE_MAX_CONNECTIONS)
+            .connect_with(options)
+            .await?;
         destroy_legacy_checkpoint_schema(&pool).await?;
         destroy_unsequenced_output_chunks_schema(&pool).await?;
         sqlx::query(CREATE_CHECKPOINTS_TABLE_SQL)

--- a/rust/alera-cli/src/terminal_host/history_store/tests.rs
+++ b/rust/alera-cli/src/terminal_host/history_store/tests.rs
@@ -16,6 +16,17 @@ fn sample(session_id: &str) -> TerminalHostCheckpoint {
 }
 
 #[tokio::test]
+async fn connection_pool_is_bounded_for_sqlite_worker_threads() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = TerminalHostHistoryStore::open(dir.path()).await.unwrap();
+
+    assert_eq!(
+        store.pool.options().get_max_connections(),
+        HISTORY_STORE_MAX_CONNECTIONS
+    );
+}
+
+#[tokio::test]
 async fn upsert_append_then_read_round_trips_incremental_chunks() {
     let dir = tempfile::tempdir().unwrap();
     let store = TerminalHostHistoryStore::open(dir.path()).await.unwrap();

--- a/rust/alera-cli/src/terminal_host/resources.rs
+++ b/rust/alera-cli/src/terminal_host/resources.rs
@@ -5,6 +5,8 @@ use chrono::Utc;
 use serde_json::{json, Value};
 use sysinfo::{Pid, ProcessRefreshKind, ProcessesToUpdate, System};
 
+#[cfg(test)]
+mod cache_release_tests;
 mod history;
 mod process_tree;
 mod snapshot_payload;
@@ -120,6 +122,15 @@ impl ResourceSampler {
     /// gap, because a delta measured across that gap would describe minutes of
     /// history as if it were the last two seconds.
     pub fn reset_cpu_baseline(&mut self) {
+        self.refreshes = 0;
+    }
+
+    /// Drop process rows once nobody is reading resource snapshots.
+    ///
+    /// History stays available for the next viewing window, but the process
+    /// table and its CPU baseline are useful only while sampling is active.
+    pub fn release_process_cache(&mut self) {
+        self.system = System::new();
         self.refreshes = 0;
     }
 

--- a/rust/alera-cli/src/terminal_host/resources/cache_release_tests.rs
+++ b/rust/alera-cli/src/terminal_host/resources/cache_release_tests.rs
@@ -1,0 +1,18 @@
+use super::*;
+
+#[test]
+fn releasing_the_process_cache_forgets_rows_and_cpu_baseline() {
+    let mut sampler = ResourceSampler::default();
+    let self_pid = std::process::id();
+    for _ in 0..REFRESHES_BEFORE_CPU_IS_VALID {
+        sampler.sample(&[], self_pid, None);
+    }
+    assert!(!sampler.system.processes().is_empty());
+    assert!(sampler.refreshes >= REFRESHES_BEFORE_CPU_IS_VALID);
+
+    sampler.release_process_cache();
+
+    assert!(sampler.system.processes().is_empty());
+    assert_eq!(sampler.refreshes, 0);
+    assert_eq!(sampler.sample(&[], self_pid, None)["warming"], json!(true));
+}

--- a/rust/alera-cli/src/terminal_host/server/resource_requests.rs
+++ b/rust/alera-cli/src/terminal_host/server/resource_requests.rs
@@ -16,6 +16,7 @@ pub(super) struct ResourceMonitorState {
     ticker: DemandDrivenTicker,
     last_snapshot: Option<Value>,
     sample_in_flight: bool,
+    release_sampler_when_ready: bool,
     /// Pid of the app process to attribute, as reported by the last caller.
     app_pid: Option<u32>,
 }
@@ -27,6 +28,7 @@ impl Default for ResourceMonitorState {
             ticker: DemandDrivenTicker::new(RESOURCE_IDLE_STOP),
             last_snapshot: None,
             sample_in_flight: false,
+            release_sampler_when_ready: false,
             app_pid: None,
         }
     }
@@ -35,7 +37,27 @@ impl Default for ResourceMonitorState {
 impl ResourceMonitorState {
     fn stop_ticker(&mut self) {
         self.ticker.stop();
+        self.last_snapshot = None;
+        self.app_pid = None;
+        if self.sample_in_flight {
+            self.release_sampler_when_ready = true;
+        } else if let Ok(mut sampler) = self.sampler.lock() {
+            sampler.release_process_cache();
+        }
+    }
+
+    fn finish_sample(&mut self, snapshot: Value) {
         self.sample_in_flight = false;
+        if self.release_sampler_when_ready {
+            self.release_sampler_when_ready = false;
+            if let Ok(mut sampler) = self.sampler.lock() {
+                sampler.release_process_cache();
+            }
+            if self.ticker.is_idle() {
+                return;
+            }
+        }
+        self.last_snapshot = Some(snapshot);
     }
 }
 
@@ -104,8 +126,7 @@ impl ServerActor {
     }
 
     pub(super) fn handle_resource_sample_ready(&mut self, snapshot: Value) {
-        self.resources.sample_in_flight = false;
-        self.resources.last_snapshot = Some(snapshot);
+        self.resources.finish_sample(snapshot);
     }
 
     fn resource_session_roots(&self) -> Vec<SessionPidRoot> {
@@ -161,5 +182,58 @@ mod tests {
         assert!(parse_app_pid(&json!({ "appPid": 0 })).is_err());
         assert!(parse_app_pid(&json!({ "appPid": -1 })).is_err());
         assert!(parse_app_pid(&json!({ "appPid": "one" })).is_err());
+    }
+
+    #[test]
+    fn stopping_an_idle_monitor_releases_cached_resources() {
+        let mut resources = ResourceMonitorState::default();
+        resources
+            .sampler
+            .lock()
+            .unwrap()
+            .sample(&[], std::process::id(), None);
+        resources.last_snapshot = Some(json!({"sample": true}));
+        resources.app_pid = Some(42);
+
+        resources.stop_ticker();
+
+        assert!(resources.last_snapshot.is_none());
+        assert!(resources.app_pid.is_none());
+        assert_eq!(
+            resources
+                .sampler
+                .lock()
+                .unwrap()
+                .sample(&[], std::process::id(), None)["warming"],
+            json!(true)
+        );
+    }
+
+    #[test]
+    fn an_in_flight_idle_sample_is_discarded_before_releasing_its_cache() {
+        let mut resources = ResourceMonitorState::default();
+        resources
+            .sampler
+            .lock()
+            .unwrap()
+            .sample(&[], std::process::id(), None);
+        resources.sample_in_flight = true;
+
+        resources.stop_ticker();
+        assert!(resources.release_sampler_when_ready);
+
+        resources.finish_sample(json!({"stale": true}));
+
+        assert!(!resources.sample_in_flight);
+        assert!(!resources.release_sampler_when_ready);
+        assert!(resources.last_snapshot.is_none());
+        assert_eq!(
+            resources
+                .sampler
+                .lock()
+                .unwrap()
+                .sample(&[], std::process::id(), None)["warming"],
+            json!(true)
+        );
     }
 }

--- a/rust/alera-core/src/runtime/store.rs
+++ b/rust/alera-core/src/runtime/store.rs
@@ -23,6 +23,7 @@ use super::{
 
 pub const RUNTIME_DATABASE_FILE_NAME: &str = "runtime.sqlite";
 pub const LOCAL_HOST_ID: &str = "local";
+const RUNTIME_STORE_MAX_CONNECTIONS: u32 = 4;
 
 #[derive(Debug, Error)]
 pub enum RuntimeStoreError {
@@ -54,7 +55,14 @@ impl RuntimeStore {
             .create_if_missing(true)
             .journal_mode(SqliteJournalMode::Wal)
             .synchronous(SqliteSynchronous::Normal);
-        let pool = SqlitePoolOptions::new().connect_with(options).await?;
+        // SQLite gives every pooled connection its own worker thread. The
+        // runtime actor serializes ordinary mutations, while a few background
+        // jobs can read concurrently, so the default of ten only leaves idle
+        // threads and connection-local caches behind after a burst.
+        let pool = SqlitePoolOptions::new()
+            .max_connections(RUNTIME_STORE_MAX_CONNECTIONS)
+            .connect_with(options)
+            .await?;
         let store = RuntimeStore { pool };
         store.migrate().await?;
         harden_sqlite_files(&path)?;
@@ -1754,6 +1762,16 @@ fn empty_to_none(value: Option<String>) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn connection_pool_is_bounded_for_sqlite_worker_threads() {
+        let (_dir, store) = store().await;
+
+        assert_eq!(
+            store.pool.options().get_max_connections(),
+            RUNTIME_STORE_MAX_CONNECTIONS
+        );
+    }
 
     async fn store() -> (tempfile::TempDir, RuntimeStore) {
         let dir = tempfile::tempdir().unwrap();


### PR DESCRIPTION
## Summary

- use a single-thread async runtime for ordinary CLI commands and cap the persistent host at four workers
- bound SQLite worker pools and release process sampling state after resource monitoring goes idle
- add coverage for runtime selection, pool limits, and idle sampler cleanup

## Validation

- `dart tool/quality/check_max_lines.dart`
- `make rust-test`
- documented PTY flake `cancelling_active_worker_interrupts_before_idle_banner_delivery` passed when rerun in isolation
- Release host measurement: 25 to 13 threads and 1.66 GiB to 0.85 GiB VSZ, with idle CPU unchanged at 0% and fixed RSS unchanged at about 21 MiB
- `gh act pull_request -W .github/workflows/pr.yml -j rust` could not pull its runner image because Docker authentication was rejected before repository steps ran