### PR TITLE
fix: link landing author mentions

### DIFF
--- a/landing/src/layouts/Layout.astro
+++ b/landing/src/layouts/Layout.astro
@@ -49,7 +49,7 @@ const softwareJsonLd = {
   author: {
     '@type': 'Person',
     name: 'Leynier Gutiérrez González',
-    url: 'https://github.com/leynier',
+    url: 'https://leynier.dev',
   },
   codeRepository: 'https://github.com/leynier/alera',
   programmingLanguage: ['Dart', 'Rust'],
@@ -69,7 +69,7 @@ const articleJsonLd =
         author: {
           '@type': 'Person',
           name: 'Leynier Gutiérrez González',
-          url: 'https://github.com/leynier',
+          url: 'https://leynier.dev',
         },
         publisher: {
           '@type': 'Organization',

--- a/landing/src/pages/download.astro
+++ b/landing/src/pages/download.astro
@@ -422,9 +422,13 @@ const platforms = [
         > issues the certificate to open source projects at no cost.
       </p>
       <p class="text-body-md text-foreground-muted mb-4 leading-relaxed">
-        Alera is maintained by one person, who fills every role: Leynier
-        Gutiérrez González is the sole committer, reviewer, and approver of
-        signing requests.
+        Alera is maintained by one person, who fills every role: <a
+          href="https://leynier.dev"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="text-foreground underline underline-offset-4 hover:opacity-80 transition-opacity duration-fast"
+          >Leynier Gutiérrez González</a
+        > is the sole committer, reviewer, and approver of signing requests.
       </p>
       <p class="text-body-md text-foreground-muted mb-4 leading-relaxed">
         Data handling is described in the <a

--- a/landing/src/pages/privacy.astro
+++ b/landing/src/pages/privacy.astro
@@ -15,7 +15,7 @@ import TrustDocument from '../components/TrustDocument.astro';
     updated="July 27, 2026"
   >
     <h2>Who Operates Alera</h2>
-    <p>Alera is an open-source project maintained by Leynier Gutiérrez González. Questions and privacy requests can be sent to <a href="mailto:privacy@alera.build">privacy@alera.build</a>.</p>
+    <p>Alera is an open-source project maintained by <a href="https://leynier.dev">Leynier Gutiérrez González</a>. Questions and privacy requests can be sent to <a href="mailto:privacy@alera.build">privacy@alera.build</a>.</p>
 
     <h2>Information We Process</h2>
     <ul>


### PR DESCRIPTION
## Summary

- Link every visible mention of Leynier Gutiérrez González on the landing pages to https://leynier.dev.
- Point the landing JSON-LD author metadata at the same personal site.

## Validation

- `git diff --check`
- `bun install --frozen-lockfile`
- `bun run build` from `landing/`
- Confirmed the generated `/privacy` and `/download` HTML contains the visible links.

Documentation does not need changes because this is a focused landing content/link update.