### PR TITLE
docs: update landing beta messaging

### DIFF
--- a/landing/src/components/Faq.astro
+++ b/landing/src/components/Faq.astro
@@ -18,7 +18,7 @@ const faqs = [
   },
   {
     question: 'Is Alera ready to use today?',
-    answer: 'It\'s in early preview. The core workflow (projects, worktree workspaces, multi-agent terminals, persistent sessions, live activity tracking, visual source control, pull requests and checks, agent quota tracking) is shipping. Linux installs from a signed package repository with the one-liner above, macOS installs with Homebrew, Windows with Scoop or Chocolatey, every platform can download from GitHub Releases, and you can always run it from source.',
+    answer: 'Alera is in public beta. The core workflow (projects, worktree workspaces, multi-agent terminals, persistent sessions, live activity tracking, visual source control, pull requests and checks, agent quota tracking) is shipping. Linux installs from a signed package repository with the one-liner above, macOS installs with Homebrew, Windows with Scoop or Chocolatey, every platform can download from GitHub Releases, and you can always run it from source.',
   },
   {
     question: 'When will SSH worktrees, LSP editing, or feature X land?',

--- a/landing/src/components/Hero.astro
+++ b/landing/src/components/Hero.astro
@@ -30,7 +30,7 @@ const staticTagline = ['in parallel', 'at native performance', 'without Electron
         <span class="animate-ping absolute inline-flex h-full w-full rounded-full bg-success opacity-50"></span>
         <span class="relative inline-flex rounded-full h-2 w-2 bg-success"></span>
       </span>
-      Open source · early preview
+      Open Source · Public Beta
       <svg class="w-3 h-3 transition-transform duration-fast group-hover:translate-x-0.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
         <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7" />
       </svg>

--- a/landing/src/content/blog/welcome-to-alera.md
+++ b/landing/src/content/blog/welcome-to-alera.md
@@ -31,4 +31,4 @@ curl -fsSL https://alera.build/install.sh | sh
 
 Then open Alera and start an agent the same way you would in any terminal. If something feels off, we want to hear about it: issues and feedback live on [GitHub](https://github.com/leynier/alera), and we read them.
 
-This is an early preview and it is moving fast. We will use this blog to write honestly about what we are building, what broke along the way, and what we changed our minds about. Thanks for being here at the start.
+This is a public beta and it is moving fast. We will use this blog to write honestly about what we are building, what broke along the way, and what we changed our minds about. Thanks for being here at the start.

--- a/landing/src/layouts/Layout.astro
+++ b/landing/src/layouts/Layout.astro
@@ -40,7 +40,7 @@ const softwareJsonLd = {
   operatingSystem: 'macOS, Windows, Linux',
   url: siteUrl,
   downloadUrl: 'https://github.com/leynier/alera/releases',
-  softwareVersion: 'early-preview',
+  softwareVersion: 'beta',
   offers: {
     '@type': 'Offer',
     price: '0',

--- a/landing/src/pages/terms.astro
+++ b/landing/src/pages/terms.astro
@@ -12,7 +12,7 @@ import TrustDocument from '../components/TrustDocument.astro';
     eyebrow="Service Agreement"
     title="Terms Of Service"
     summary="These terms cover the optional Alera account and cloud notification service. The local open-source application remains governed by its repository license."
-    updated="July 27, 2026"
+    updated="August 1, 2026"
   >
     <h2>Using The Service</h2>
     <p>You may use Alera's account and notification service if you can legally agree to these terms. You are responsible for activity from your signed-in runtimes and mobile devices and for removing access from devices you no longer control.</p>
@@ -30,13 +30,13 @@ import TrustDocument from '../components/TrustDocument.astro';
     <p>You retain rights to your projects and workspace names. If you enable detailed push notifications, you instruct Alera to send the selected status, project name, and workspace name through Firebase Cloud Messaging to your registered device. Prompts and terminal contents are not included in push payloads.</p>
 
     <h2>Availability</h2>
-    <p>The service is an early preview provided on a best-effort basis without a service-level agreement. Features may change, pause, or be discontinued. We will try to avoid unnecessary disruption, but notification delivery is not guaranteed and must not be used for emergency, safety-critical, or time-critical workflows.</p>
+    <p>The service is a public beta provided on a best-effort basis without a service-level agreement. Features may change, pause, or be discontinued. We will try to avoid unnecessary disruption, but notification delivery is not guaranteed and must not be used for emergency, safety-critical, or time-critical workflows.</p>
 
     <h2>Suspension And Termination</h2>
     <p>You may stop using the service or delete your account at any time. We may restrict or suspend access to protect users, providers, or the service; respond to unlawful activity; or enforce these terms. Where practical, we will provide a reason and a path to contact us.</p>
 
     <h2>Disclaimers And Liability</h2>
-    <p>To the maximum extent permitted by law, the cloud service is provided as available and without warranties of uninterrupted operation, fitness for a particular purpose, or error-free delivery. Alera is not liable for lost work, missed notifications, provider outages, or indirect or consequential losses arising from use of the preview service. Rights that cannot legally be waived remain unaffected.</p>
+    <p>To the maximum extent permitted by law, the cloud service is provided as available and without warranties of uninterrupted operation, fitness for a particular purpose, or error-free delivery. Alera is not liable for lost work, missed notifications, provider outages, or indirect or consequential losses arising from use of the beta service. Rights that cannot legally be waived remain unaffected.</p>
 
     <h2>Changes</h2>
     <p>We may update these terms as the service evolves. Material changes will be posted here with a new effective date. Continued use after the effective date means you accept the updated terms where permitted by law.</p>


### PR DESCRIPTION
## Summary

- update the landing hero and FAQ from early preview to public beta
- align structured metadata, terms, and the welcome post with the beta status
- refresh the terms effective date

## Validation

- `bun run build` from `landing/`
- `git diff --check`
- `gh act pull_request -W .github/workflows/landing.yml`

No runtime behavior changes.