### PR TITLE
feat: add quick open and command palette

### DIFF
--- a/lib/src/features/keyboard/application/keyboard_command_dispatcher.dart
+++ b/lib/src/features/keyboard/application/keyboard_command_dispatcher.dart
@@ -4,6 +4,7 @@ import 'package:alera/src/app/providers.dart';
 import 'package:alera/src/design_system/layout/alera_confirm_dialog.dart';
 import 'package:alera/src/features/browser/application/browser_providers.dart';
 import 'package:alera/src/features/keyboard/domain/keyboard_action.dart';
+import 'package:alera/src/features/keyboard/presentation/keyboard_command_palette_dialog.dart';
 import 'package:alera/src/features/workbench/domain/workbench_layout.dart';
 import 'package:alera/src/features/workbench/domain/workbench_view_prefs.dart';
 import 'package:alera/src/features/workbench/domain/workspace_tab_record.dart';
@@ -30,6 +31,15 @@ class KeyboardCommandDispatcher {
     switch (id) {
       case KeyboardActionId.openSettings:
         unawaited(openSettingsDialog(context));
+      case KeyboardActionId.openQuickOpen:
+        unawaited(showQuickOpenFlow(context, ref));
+      case KeyboardActionId.openCommandPalette:
+        unawaited(
+          showKeyboardCommandPalette(
+            context,
+            onExecute: (command) => dispatch(command),
+          ),
+        );
       case KeyboardActionId.addProject:
         unawaited(showAddProjectFlow(context, ref));
       case KeyboardActionId.toggleSidebar:

--- a/lib/src/features/keyboard/domain/keyboard_action.dart
+++ b/lib/src/features/keyboard/domain/keyboard_action.dart
@@ -47,6 +47,8 @@ enum KeyboardActionGroup {
 @MappableEnum()
 enum KeyboardActionId {
   openSettings,
+  openQuickOpen,
+  openCommandPalette,
   addProject,
   toggleSidebar,
   createWorkspace,
@@ -151,6 +153,24 @@ const List<KeybindingDefinition> keybindingDefinitions = <KeybindingDefinition>[
     description: 'Open the settings dialog.',
     defaultBindings: PlatformBindings.uniform(<String>['Mod+Comma']),
     searchKeywords: <String>['preferences', 'config'],
+    allowInTerminal: true,
+  ),
+  KeybindingDefinition(
+    id: KeyboardActionId.openQuickOpen,
+    label: 'Quick Open',
+    group: KeyboardActionGroup.global,
+    description: 'Search and open a file in the active workspace.',
+    defaultBindings: PlatformBindings.uniform(<String>['Mod+P']),
+    searchKeywords: <String>['file', 'path', 'search', 'go to'],
+    allowInTerminal: true,
+  ),
+  KeybindingDefinition(
+    id: KeyboardActionId.openCommandPalette,
+    label: 'Command Palette',
+    group: KeyboardActionGroup.global,
+    description: 'Search and run an Alera command.',
+    defaultBindings: PlatformBindings.uniform(<String>['Mod+Shift+P']),
+    searchKeywords: <String>['commands', 'actions', 'search', 'run'],
     allowInTerminal: true,
   ),
   KeybindingDefinition(

--- a/lib/src/features/keyboard/domain/keyboard_action.mapper.dart
+++ b/lib/src/features/keyboard/domain/keyboard_action.mapper.dart
@@ -76,6 +76,10 @@ class KeyboardActionIdMapper extends EnumMapper<KeyboardActionId> {
     switch (value) {
       case r'openSettings':
         return KeyboardActionId.openSettings;
+      case r'openQuickOpen':
+        return KeyboardActionId.openQuickOpen;
+      case r'openCommandPalette':
+        return KeyboardActionId.openCommandPalette;
       case r'addProject':
         return KeyboardActionId.addProject;
       case r'toggleSidebar':
@@ -138,6 +142,10 @@ class KeyboardActionIdMapper extends EnumMapper<KeyboardActionId> {
     switch (self) {
       case KeyboardActionId.openSettings:
         return r'openSettings';
+      case KeyboardActionId.openQuickOpen:
+        return r'openQuickOpen';
+      case KeyboardActionId.openCommandPalette:
+        return r'openCommandPalette';
       case KeyboardActionId.addProject:
         return r'addProject';
       case KeyboardActionId.toggleSidebar:

--- a/lib/src/features/keyboard/domain/keyboard_command_palette.dart
+++ b/lib/src/features/keyboard/domain/keyboard_command_palette.dart
@@ -1,0 +1,104 @@
+import 'package:alera/src/features/keyboard/domain/keyboard_action.dart';
+
+class KeyboardCommandMatch {
+  const KeyboardCommandMatch({required this.definition, required this.score});
+
+  final KeybindingDefinition definition;
+  final int score;
+}
+
+const int defaultKeyboardCommandPaletteResultLimit = 50;
+
+/// Filters the central keyboard registry for Command Palette.
+List<KeyboardCommandMatch> filterKeyboardCommandPalette(
+  String query, {
+  List<KeybindingDefinition> definitions = keybindingDefinitions,
+  int limit = defaultKeyboardCommandPaletteResultLimit,
+}) {
+  if (limit <= 0) {
+    return const <KeyboardCommandMatch>[];
+  }
+  final normalizedQuery = query.trim().toLowerCase();
+  final matches = <KeyboardCommandMatch>[];
+  for (final definition in definitions) {
+    final score = _keyboardCommandScore(definition, normalizedQuery);
+    if (score != null) {
+      matches.add(KeyboardCommandMatch(definition: definition, score: score));
+    }
+  }
+  matches.sort((left, right) {
+    final scoreComparison = right.score.compareTo(left.score);
+    if (scoreComparison != 0) {
+      return scoreComparison;
+    }
+    final labelComparison = left.definition.label.toLowerCase().compareTo(
+      right.definition.label.toLowerCase(),
+    );
+    if (labelComparison != 0) {
+      return labelComparison;
+    }
+    return left.definition.id.name.compareTo(right.definition.id.name);
+  });
+  return matches.take(limit).toList(growable: false);
+}
+
+int? _keyboardCommandScore(KeybindingDefinition definition, String query) {
+  if (query.isEmpty) {
+    return 0;
+  }
+  final label = definition.label.toLowerCase();
+  if (label == query) {
+    return 100000;
+  }
+  if (label.startsWith(query)) {
+    return 90000;
+  }
+
+  var bestKeywordScore = 0;
+  for (final keyword in definition.searchKeywords) {
+    final normalizedKeyword = keyword.toLowerCase();
+    if (normalizedKeyword == query) {
+      bestKeywordScore = bestKeywordScore < 85000 ? 85000 : bestKeywordScore;
+    } else if (normalizedKeyword.startsWith(query)) {
+      bestKeywordScore = bestKeywordScore < 80000 ? 80000 : bestKeywordScore;
+    } else if (normalizedKeyword.contains(query)) {
+      bestKeywordScore = bestKeywordScore < 70000 ? 70000 : bestKeywordScore;
+    }
+  }
+  if (bestKeywordScore > 0) {
+    return bestKeywordScore;
+  }
+
+  final searchableText = <String>[
+    label,
+    definition.description.toLowerCase(),
+    definition.group.label.toLowerCase(),
+  ].join(' ');
+  if (searchableText.contains(query)) {
+    return 60000 - searchableText.indexOf(query).clamp(0, 999).toInt();
+  }
+  final fuzzyScore = _keyboardCommandFuzzyScore(searchableText, query);
+  return fuzzyScore == null ? null : 1000 + fuzzyScore;
+}
+
+int? _keyboardCommandFuzzyScore(String candidate, String query) {
+  var candidateIndex = 0;
+  var previousMatchIndex = -1;
+  var score = 0;
+  for (final queryCharacter in query.codeUnits) {
+    final matchIndex = candidate.indexOf(
+      String.fromCharCode(queryCharacter),
+      candidateIndex,
+    );
+    if (matchIndex < 0) {
+      return null;
+    }
+    score += matchIndex == candidateIndex ? 20 : 0;
+    if (previousMatchIndex >= 0) {
+      score -= (matchIndex - previousMatchIndex - 1) * 5;
+    }
+    previousMatchIndex = matchIndex;
+    candidateIndex = matchIndex + 1;
+  }
+  return score;
+}

--- a/lib/src/features/keyboard/presentation/keyboard_command_palette_dialog.dart
+++ b/lib/src/features/keyboard/presentation/keyboard_command_palette_dialog.dart
@@ -1,0 +1,238 @@
+import 'package:alera/src/app/providers.dart';
+import 'package:alera/src/app/theme/alera_tokens.dart';
+import 'package:alera/src/design_system/forms/alera_text_field.dart';
+import 'package:alera/src/design_system/icons/alera_icons.dart';
+import 'package:alera/src/design_system/layout/alera_dialog.dart';
+import 'package:alera/src/features/keyboard/application/keybinding_resolver.dart';
+import 'package:alera/src/features/keyboard/domain/keyboard_action.dart';
+import 'package:alera/src/features/keyboard/domain/keyboard_command_palette.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+Future<void> showKeyboardCommandPalette(
+  BuildContext context, {
+  required ValueChanged<KeyboardActionId> onExecute,
+}) async {
+  final previousFocus = FocusManager.instance.primaryFocus;
+  await showDialog<void>(
+    context: context,
+    builder: (_) => KeyboardCommandPaletteDialog(onExecute: onExecute),
+  );
+  if (previousFocus?.canRequestFocus ?? false) {
+    previousFocus!.requestFocus();
+  }
+}
+
+class KeyboardCommandPaletteDialog extends ConsumerStatefulWidget {
+  const KeyboardCommandPaletteDialog({super.key, required this.onExecute});
+
+  final ValueChanged<KeyboardActionId> onExecute;
+
+  @override
+  ConsumerState<KeyboardCommandPaletteDialog> createState() =>
+      _KeyboardCommandPaletteDialogState();
+}
+
+class _KeyboardCommandPaletteDialogState
+    extends ConsumerState<KeyboardCommandPaletteDialog> {
+  late final TextEditingController _queryController;
+  late final FocusNode _queryFocusNode;
+  List<KeyboardCommandMatch> _matches = const <KeyboardCommandMatch>[];
+  int _selectedIndex = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _queryController = TextEditingController();
+    _queryFocusNode = FocusNode();
+    _matches = filterKeyboardCommandPalette('');
+  }
+
+  @override
+  void dispose() {
+    _queryController.dispose();
+    _queryFocusNode.dispose();
+    super.dispose();
+  }
+
+  void _updateQuery(String query) {
+    setState(() {
+      _matches = filterKeyboardCommandPalette(query);
+      _selectedIndex = 0;
+    });
+  }
+
+  void _moveSelection(int delta) {
+    if (_matches.isEmpty) {
+      return;
+    }
+    setState(() {
+      _selectedIndex = (_selectedIndex + delta) % _matches.length;
+      if (_selectedIndex < 0) {
+        _selectedIndex += _matches.length;
+      }
+    });
+  }
+
+  void _executeSelected() {
+    if (_matches.isEmpty) {
+      return;
+    }
+    final id = _matches[_selectedIndex].definition.id;
+    Navigator.of(context).pop();
+    widget.onExecute(id);
+  }
+
+  KeyEventResult _handleKey(FocusNode node, KeyEvent event) {
+    if (event is! KeyDownEvent) {
+      return KeyEventResult.ignored;
+    }
+    switch (event.logicalKey) {
+      case LogicalKeyboardKey.escape:
+        Navigator.of(context).pop();
+        return KeyEventResult.handled;
+      case LogicalKeyboardKey.arrowDown:
+        _moveSelection(1);
+        return KeyEventResult.handled;
+      case LogicalKeyboardKey.arrowUp:
+        _moveSelection(-1);
+        return KeyEventResult.handled;
+      case LogicalKeyboardKey.enter:
+        _executeSelected();
+        return KeyEventResult.handled;
+      default:
+        return KeyEventResult.ignored;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final settings = ref.watch(
+      settingsControllerProvider.select((state) => state.keyboard),
+    );
+    final resolver = KeybindingResolver(settings: settings);
+    return Focus(
+      onKeyEvent: _handleKey,
+      child: AleraDialog(
+        maxWidth: AleraTokens.dialogWideWidth,
+        maxHeight: AleraTokens.dialogMaxHeight,
+        child: SizedBox(
+          width: AleraTokens.dialogWideWidth,
+          height: AleraTokens.dialogMaxHeight,
+          child: Padding(
+            padding: const EdgeInsets.all(AleraTokens.space20),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: <Widget>[
+                Text('Command Palette', style: theme.textTheme.titleMedium),
+                const SizedBox(height: AleraTokens.space16),
+                AleraTextField(
+                  controller: _queryController,
+                  focusNode: _queryFocusNode,
+                  autofocus: true,
+                  hintText: 'Search commands',
+                  prefixIcon: AleraIcons.search,
+                  onChanged: _updateQuery,
+                  onSubmitted: (_) => _executeSelected(),
+                ),
+                const SizedBox(height: AleraTokens.space12),
+                Expanded(child: _buildResults(theme, resolver)),
+                const Divider(height: AleraTokens.space20),
+                Text(
+                  'Use Up and Down to navigate, Enter to run, or Escape to close.',
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: AleraTokens.foregroundFaint,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildResults(ThemeData theme, KeybindingResolver resolver) {
+    if (_matches.isEmpty) {
+      final query = _queryController.text.trim();
+      return Center(
+        child: Text(
+          query.isEmpty
+              ? 'No commands are available.'
+              : 'No commands match "$query".',
+          style: theme.textTheme.bodyMedium?.copyWith(
+            color: AleraTokens.foregroundMuted,
+          ),
+          textAlign: TextAlign.center,
+        ),
+      );
+    }
+    return ListView.builder(
+      key: const ValueKey<String>('command-palette-results'),
+      padding: EdgeInsets.zero,
+      itemCount: _matches.length,
+      itemBuilder: (context, index) {
+        final definition = _matches[index].definition;
+        final selected = index == _selectedIndex;
+        final chords = resolver.effectiveChords(definition.id);
+        final shortcut = chords.isEmpty
+            ? 'No shortcut'
+            : chords
+                  .map(
+                    (chord) => chord.format(isMacOS: resolver.platform.isMacOS),
+                  )
+                  .join('  ');
+        return Material(
+          color: selected ? AleraTokens.accentSubtle : null,
+          child: InkWell(
+            key: ValueKey<KeyboardActionId>(definition.id),
+            onTap: () {
+              setState(() => _selectedIndex = index);
+              _executeSelected();
+            },
+            child: Padding(
+              padding: const EdgeInsets.symmetric(
+                horizontal: AleraTokens.space12,
+                vertical: AleraTokens.space8,
+              ),
+              child: Row(
+                children: <Widget>[
+                  const Icon(
+                    AleraIcons.keyboard,
+                    size: AleraTokens.space16,
+                    color: AleraTokens.foregroundMuted,
+                  ),
+                  const SizedBox(width: AleraTokens.space12),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: <Widget>[
+                        Text(
+                          definition.label,
+                          style: theme.textTheme.bodyMedium,
+                        ),
+                        const SizedBox(height: AleraTokens.space2),
+                        Text(
+                          definition.description,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: theme.textTheme.bodySmall?.copyWith(
+                            color: AleraTokens.foregroundMuted,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                  const SizedBox(width: AleraTokens.space12),
+                  Text(shortcut, style: AleraTokens.monoStyle),
+                ],
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/src/features/workbench/application/workspace_file_service.dart
+++ b/lib/src/features/workbench/application/workspace_file_service.dart
@@ -23,6 +23,16 @@ class WorkspaceFileService {
     );
   }
 
+  Future<List<native.WorkspaceFileEntry>> listFiles({
+    required String workspacePath,
+    int maxResults = 10000,
+  }) {
+    return native.listWorkspaceFiles(
+      workspacePath: workspacePath,
+      maxResults: maxResults,
+    );
+  }
+
   List<native.WorkspaceFileEntry> applyGitStatusSnapshot(
     List<native.WorkspaceFileEntry> entries,
     GitExplorerStatusSnapshot snapshot,

--- a/lib/src/features/workbench/domain/workspace_file_quick_open.dart
+++ b/lib/src/features/workbench/domain/workspace_file_quick_open.dart
@@ -1,0 +1,114 @@
+/// A ranked Quick Open candidate for a workspace file.
+class WorkspaceFileQuickOpenMatch {
+  const WorkspaceFileQuickOpenMatch({
+    required this.relativePath,
+    required this.score,
+  });
+
+  final String relativePath;
+  final int score;
+}
+
+const int defaultWorkspaceFileQuickOpenResultLimit = 50;
+const int defaultWorkspaceFileQuickOpenEnumerationLimit = 10000;
+
+/// Returns workspace-relative file paths ranked for a Quick Open query.
+///
+/// Exact paths, file-name prefixes, and path-segment matches are preferred
+/// before a looser fuzzy subsequence match. Ties are ordered by path so a
+/// changing filesystem traversal order cannot move the selected row.
+List<WorkspaceFileQuickOpenMatch> rankWorkspaceFileQuickOpenMatches(
+  Iterable<String> relativePaths,
+  String query, {
+  int limit = defaultWorkspaceFileQuickOpenResultLimit,
+}) {
+  if (limit <= 0) {
+    return const <WorkspaceFileQuickOpenMatch>[];
+  }
+  final normalizedQuery = query.trim().toLowerCase();
+  final matches = <WorkspaceFileQuickOpenMatch>[];
+  for (final relativePath in relativePaths) {
+    final score = _workspaceFileQuickOpenScore(relativePath, normalizedQuery);
+    if (score != null) {
+      matches.add(
+        WorkspaceFileQuickOpenMatch(relativePath: relativePath, score: score),
+      );
+    }
+  }
+  matches.sort((left, right) {
+    final scoreComparison = right.score.compareTo(left.score);
+    if (scoreComparison != 0) {
+      return scoreComparison;
+    }
+    final normalizedPathComparison = left.relativePath.toLowerCase().compareTo(
+      right.relativePath.toLowerCase(),
+    );
+    if (normalizedPathComparison != 0) {
+      return normalizedPathComparison;
+    }
+    return left.relativePath.compareTo(right.relativePath);
+  });
+  return matches.take(limit).toList(growable: false);
+}
+
+int? _workspaceFileQuickOpenScore(String relativePath, String query) {
+  if (query.isEmpty) {
+    return 0;
+  }
+  final candidate = relativePath.toLowerCase();
+  final segments = candidate.split(RegExp(r'[/\\]'));
+  final fileName = segments.last;
+  if (candidate == query) {
+    return 100000;
+  }
+  final exactSegmentIndex = segments.indexOf(query);
+  if (exactSegmentIndex >= 0) {
+    return 90000 - exactSegmentIndex;
+  }
+  if (candidate.startsWith(query)) {
+    return 80000;
+  }
+  final prefixSegmentIndex = segments.indexWhere(
+    (segment) => segment.startsWith(query),
+  );
+  if (prefixSegmentIndex >= 0) {
+    return 70000 - prefixSegmentIndex;
+  }
+  final containsIndex = candidate.indexOf(query);
+  if (containsIndex >= 0) {
+    return 60000 - containsIndex;
+  }
+  final fuzzyScore = _fuzzySubsequenceScore(candidate, query);
+  if (fuzzyScore == null) {
+    return null;
+  }
+  return 1000 + fuzzyScore + (fileName.startsWith(query) ? 100 : 0);
+}
+
+int? _fuzzySubsequenceScore(String candidate, String query) {
+  var candidateIndex = 0;
+  var previousMatchIndex = -1;
+  var score = 0;
+  for (final queryCharacter in query.codeUnits) {
+    final matchIndex = candidate.indexOf(
+      String.fromCharCode(queryCharacter),
+      candidateIndex,
+    );
+    if (matchIndex < 0) {
+      return null;
+    }
+    final isSegmentStart =
+        matchIndex == 0 ||
+        _isPathSeparator(candidate.codeUnitAt(matchIndex - 1));
+    score += isSegmentStart ? 100 : 0;
+    score += matchIndex == candidateIndex ? 20 : 0;
+    if (previousMatchIndex >= 0) {
+      score -= (matchIndex - previousMatchIndex - 1) * 5;
+    }
+    previousMatchIndex = matchIndex;
+    candidateIndex = matchIndex + 1;
+  }
+  return score;
+}
+
+bool _isPathSeparator(int codeUnit) => codeUnit == 0x2f || codeUnit == 0x5c;

--- a/lib/src/features/workbench/presentation/quick_open_dialog.dart
+++ b/lib/src/features/workbench/presentation/quick_open_dialog.dart
@@ -1,0 +1,364 @@
+import 'dart:async';
+
+import 'package:alera/src/app/theme/alera_tokens.dart';
+import 'package:alera/src/design_system/forms/alera_text_field.dart';
+import 'package:alera/src/design_system/icons/alera_file_icon.dart';
+import 'package:alera/src/design_system/icons/alera_icons.dart';
+import 'package:alera/src/design_system/layout/alera_dialog.dart';
+import 'package:alera/src/features/workbench/application/workbench_controller.dart';
+import 'package:alera/src/features/workbench/application/workbench_providers.dart';
+import 'package:alera/src/features/workbench/application/workspace_file_service.dart';
+import 'package:alera/src/features/workbench/domain/workspace_file_quick_open.dart';
+import 'package:alera/src/rust/api/workspace_files.dart' as native;
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class QuickOpenDialog extends ConsumerStatefulWidget {
+  const QuickOpenDialog({super.key});
+
+  @override
+  ConsumerState<QuickOpenDialog> createState() => _QuickOpenDialogState();
+}
+
+class _QuickOpenDialogState extends ConsumerState<QuickOpenDialog> {
+  late final TextEditingController _queryController;
+  late final FocusNode _queryFocusNode;
+  late final WorkspaceFileService _workspaceFiles;
+
+  String? _workspaceId;
+  List<String> _relativePaths = const <String>[];
+  List<WorkspaceFileQuickOpenMatch> _matches =
+      const <WorkspaceFileQuickOpenMatch>[];
+  bool _loading = true;
+  Object? _loadError;
+  int _selectedIndex = 0;
+  int _loadGeneration = 0;
+  final Map<String, GlobalKey> _rowKeys = <String, GlobalKey>{};
+
+  @override
+  void initState() {
+    super.initState();
+    _queryController = TextEditingController();
+    _queryFocusNode = FocusNode();
+    _workspaceFiles = ref.read(workspaceFileServiceProvider);
+    ref.listenManual<String?>(
+      workbenchControllerProvider.select((state) => state.activeWorkspaceId),
+      (previous, next) {
+        if (previous != next) {
+          unawaited(_reloadWorkspace());
+        }
+      },
+      fireImmediately: true,
+    );
+  }
+
+  @override
+  void dispose() {
+    _queryController.dispose();
+    _queryFocusNode.dispose();
+    super.dispose();
+  }
+
+  Future<void> _reloadWorkspace() async {
+    final workspace = ref.read(workbenchControllerProvider).activeWorkspace;
+    final workspaceId = workspace?.id;
+    final generation = ++_loadGeneration;
+    final workspaceChanged = _workspaceId != workspaceId;
+    _workspaceId = workspaceId;
+    if (workspaceChanged) {
+      _queryController.clear();
+    }
+    if (!mounted) {
+      return;
+    }
+    setState(() {
+      _relativePaths = const <String>[];
+      _matches = const <WorkspaceFileQuickOpenMatch>[];
+      _selectedIndex = 0;
+      _loadError = null;
+      _loading = workspace != null;
+      _rowKeys.clear();
+    });
+    if (workspace == null) {
+      if (mounted && generation == _loadGeneration) {
+        setState(() => _loading = false);
+      }
+      return;
+    }
+    try {
+      final entries = await _workspaceFiles.listFiles(
+        workspacePath: workspace.path,
+        maxResults: defaultWorkspaceFileQuickOpenEnumerationLimit,
+      );
+      if (!mounted || generation != _loadGeneration) {
+        return;
+      }
+      final paths = <String>[
+        for (final entry in entries)
+          if (entry.kind == native.WorkspaceFileKind.file ||
+              entry.kind == native.WorkspaceFileKind.symlink)
+            entry.relativePath,
+      ];
+      setState(() {
+        _relativePaths = paths;
+        _matches = _rankMatches();
+        _selectedIndex = 0;
+        _loading = false;
+      });
+    } catch (error) {
+      if (!mounted || generation != _loadGeneration) {
+        return;
+      }
+      setState(() {
+        _loadError = error;
+        _loading = false;
+      });
+    }
+  }
+
+  List<WorkspaceFileQuickOpenMatch> _rankMatches() {
+    return rankWorkspaceFileQuickOpenMatches(
+      _relativePaths,
+      _queryController.text,
+      limit: defaultWorkspaceFileQuickOpenResultLimit,
+    );
+  }
+
+  void _updateQuery(String query) {
+    setState(() {
+      _matches = _rankMatches();
+      _selectedIndex = 0;
+    });
+  }
+
+  void _moveSelection(int delta) {
+    if (_matches.isEmpty) {
+      return;
+    }
+    setState(() {
+      _selectedIndex = (_selectedIndex + delta) % _matches.length;
+      if (_selectedIndex < 0) {
+        _selectedIndex += _matches.length;
+      }
+    });
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted || _matches.isEmpty) {
+        return;
+      }
+      final rowContext =
+          _rowKeys[_matches[_selectedIndex].relativePath]?.currentContext;
+      if (rowContext != null) {
+        Scrollable.ensureVisible(
+          rowContext,
+          alignment: 0.5,
+          duration: AleraTokens.durationFast,
+        );
+      }
+    });
+  }
+
+  void _openSelected() {
+    final workspace = ref.read(workbenchControllerProvider).activeWorkspace;
+    if (workspace == null || _matches.isEmpty) {
+      return;
+    }
+    final relativePath = _matches[_selectedIndex].relativePath;
+    Navigator.of(context).pop();
+    unawaited(
+      ref
+          .read(workbenchControllerProvider.notifier)
+          .openFileTab(workspace: workspace, relativePath: relativePath),
+    );
+  }
+
+  KeyEventResult _handleKey(FocusNode node, KeyEvent event) {
+    if (event is! KeyDownEvent) {
+      return KeyEventResult.ignored;
+    }
+    switch (event.logicalKey) {
+      case LogicalKeyboardKey.escape:
+        Navigator.of(context).pop();
+        return KeyEventResult.handled;
+      case LogicalKeyboardKey.arrowDown:
+        _moveSelection(1);
+        return KeyEventResult.handled;
+      case LogicalKeyboardKey.arrowUp:
+        _moveSelection(-1);
+        return KeyEventResult.handled;
+      case LogicalKeyboardKey.enter:
+        _openSelected();
+        return KeyEventResult.handled;
+      default:
+        return KeyEventResult.ignored;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final workspace = ref.watch(
+      workbenchControllerProvider.select((state) => state.activeWorkspace),
+    );
+    return Focus(
+      onKeyEvent: _handleKey,
+      child: AleraDialog(
+        maxWidth: AleraTokens.dialogWideWidth,
+        maxHeight: AleraTokens.dialogMaxHeight,
+        child: SizedBox(
+          width: AleraTokens.dialogWideWidth,
+          height: AleraTokens.dialogMaxHeight,
+          child: Padding(
+            padding: const EdgeInsets.all(AleraTokens.space20),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: <Widget>[
+                Row(
+                  children: <Widget>[
+                    Text('Quick Open', style: theme.textTheme.titleMedium),
+                    const SizedBox(width: AleraTokens.space12),
+                    if (workspace != null)
+                      Expanded(
+                        child: Text(
+                          workspace.name,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: theme.textTheme.bodySmall?.copyWith(
+                            color: AleraTokens.foregroundMuted,
+                          ),
+                        ),
+                      ),
+                  ],
+                ),
+                const SizedBox(height: AleraTokens.space16),
+                AleraTextField(
+                  controller: _queryController,
+                  focusNode: _queryFocusNode,
+                  autofocus: true,
+                  hintText: 'Search workspace files',
+                  prefixIcon: AleraIcons.search,
+                  onChanged: _updateQuery,
+                  onSubmitted: (_) => _openSelected(),
+                ),
+                const SizedBox(height: AleraTokens.space12),
+                Expanded(child: _buildResults(theme)),
+                const Divider(height: AleraTokens.space20),
+                Text(
+                  'Use Up and Down to navigate, Enter to open, or Escape to close.',
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: AleraTokens.foregroundFaint,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildResults(ThemeData theme) {
+    if (_loading) {
+      return const Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            CircularProgressIndicator(),
+            SizedBox(height: AleraTokens.space12),
+            Text('Loading workspace files...'),
+          ],
+        ),
+      );
+    }
+    if (_loadError != null) {
+      return Center(
+        child: Padding(
+          padding: const EdgeInsets.all(AleraTokens.space16),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: <Widget>[
+              Icon(AleraIcons.error, color: AleraTokens.error),
+              const SizedBox(height: AleraTokens.space8),
+              Text(
+                'Could not load workspace files.',
+                style: theme.textTheme.bodyMedium,
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: AleraTokens.space4),
+              Text(
+                _loadError.toString(),
+                maxLines: 3,
+                overflow: TextOverflow.ellipsis,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: AleraTokens.foregroundMuted,
+                ),
+                textAlign: TextAlign.center,
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+    if (_matches.isEmpty) {
+      final query = _queryController.text.trim();
+      return Center(
+        child: Text(
+          query.isEmpty
+              ? 'No files are available in this workspace.'
+              : 'No files match "$query".',
+          style: theme.textTheme.bodyMedium?.copyWith(
+            color: AleraTokens.foregroundMuted,
+          ),
+          textAlign: TextAlign.center,
+        ),
+      );
+    }
+    return ListView.builder(
+      key: const ValueKey<String>('quick-open-results'),
+      padding: EdgeInsets.zero,
+      itemCount: _matches.length,
+      itemBuilder: (context, index) {
+        final match = _matches[index];
+        final selected = index == _selectedIndex;
+        final rowKey = _rowKeys.putIfAbsent(
+          match.relativePath,
+          () => GlobalKey(),
+        );
+        return Material(
+          key: rowKey,
+          color: selected ? AleraTokens.accentSubtle : null,
+          child: InkWell(
+            onTap: () {
+              setState(() => _selectedIndex = index);
+              _openSelected();
+            },
+            child: Padding(
+              padding: const EdgeInsets.symmetric(
+                horizontal: AleraTokens.space12,
+                vertical: AleraTokens.space8,
+              ),
+              child: Row(
+                children: <Widget>[
+                  AleraFileIcon(
+                    pathOrName: match.relativePath,
+                    kind: AleraFileIconKind.file,
+                    size: AleraTokens.space16,
+                  ),
+                  const SizedBox(width: AleraTokens.space12),
+                  Expanded(
+                    child: Text(
+                      match.relativePath,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: theme.textTheme.bodyMedium,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/src/features/workbench/presentation/workbench_dialog_launchers.dart
+++ b/lib/src/features/workbench/presentation/workbench_dialog_launchers.dart
@@ -15,6 +15,7 @@ import 'package:alera/src/features/workbench/domain/workspace_creation_result.da
 import 'package:alera/src/features/workbench/presentation/create_workspace_dialog.dart';
 import 'package:alera/src/features/workbench/infra/prompt_workspace_runtime_client.dart';
 import 'package:alera/src/features/workbench/presentation/prompt_workspace_dialog.dart';
+import 'package:alera/src/features/workbench/presentation/quick_open_dialog.dart';
 import 'package:alera/src/shared/infra/git/git_providers.dart';
 import 'package:alera/src/shared/infra/runtime/runtime_host_providers.dart';
 import 'package:alera/src/shared/infra/runtime/runtime_state_migration.dart';
@@ -38,6 +39,22 @@ Future<void> openSettingsDialog(
       initialProjectId: initialProjectId,
     ),
   );
+}
+
+/// Opens Quick Open for the active workspace and restores the prior focus when
+/// the modal route closes.
+Future<void> showQuickOpenFlow(BuildContext context, WidgetRef ref) async {
+  if (ref.read(workbenchControllerProvider).activeWorkspace == null) {
+    return;
+  }
+  final previousFocus = FocusManager.instance.primaryFocus;
+  await showDialog<void>(
+    context: context,
+    builder: (_) => const QuickOpenDialog(),
+  );
+  if (previousFocus?.canRequestFocus ?? false) {
+    previousFocus!.requestFocus();
+  }
 }
 
 Future<String?> showRenameDialog(

--- a/lib/src/rust/api/workspace_files.dart
+++ b/lib/src/rust/api/workspace_files.dart
@@ -19,6 +19,14 @@ Future<List<WorkspaceFileEntry>> listWorkspaceChildren({
   hideIgnored: hideIgnored,
 );
 
+Future<List<WorkspaceFileEntry>> listWorkspaceFiles({
+  required String workspacePath,
+  required int maxResults,
+}) => RustLib.instance.api.crateApiWorkspaceFilesListWorkspaceFiles(
+  workspacePath: workspacePath,
+  maxResults: maxResults,
+);
+
 Future<WorkspaceExplorerTreeProjection> projectWorkspaceExplorerTree({
   required String workspaceName,
   required String workspacePath,

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -74,7 +74,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.12.0';
 
   @override
-  int get rustContentHash => 353200493;
+  int get rustContentHash => 296909324;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -269,6 +269,11 @@ abstract class RustLibApi extends BaseApi {
     required String workspacePath,
     required String relativePath,
     required bool hideIgnored,
+  });
+
+  Future<List<WorkspaceFileEntry>> crateApiWorkspaceFilesListWorkspaceFiles({
+    required String workspacePath,
+    required int maxResults,
   });
 
   Future<List<GitWorktreeEntry>> crateApiGitListWorktrees({
@@ -1883,6 +1888,41 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
+  Future<List<WorkspaceFileEntry>> crateApiWorkspaceFilesListWorkspaceFiles({
+    required String workspacePath,
+    required int maxResults,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_String(workspacePath, serializer);
+          sse_encode_u_32(maxResults, serializer);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 43,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_list_workspace_file_entry,
+          decodeErrorData: sse_decode_workspace_file_error,
+        ),
+        constMeta: kCrateApiWorkspaceFilesListWorkspaceFilesConstMeta,
+        argValues: [workspacePath, maxResults],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiWorkspaceFilesListWorkspaceFilesConstMeta =>
+      const TaskConstMeta(
+        debugName: "list_workspace_files",
+        argNames: ["workspacePath", "maxResults"],
+      );
+
+  @override
   Future<List<GitWorktreeEntry>> crateApiGitListWorktrees({
     required String repoPath,
   }) {
@@ -1894,7 +1934,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 43,
+            funcId: 44,
             port: port_,
           );
         },
@@ -1928,7 +1968,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 44,
+            funcId: 45,
             port: port_,
           );
         },
@@ -1962,7 +2002,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 45,
+            funcId: 46,
             port: port_,
           );
         },
@@ -1998,7 +2038,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 46,
+            funcId: 47,
             port: port_,
           );
         },
@@ -2031,7 +2071,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 47,
+            funcId: 48,
             port: port_,
           );
         },
@@ -2059,7 +2099,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 48,
+            funcId: 49,
             port: port_,
           );
         },
@@ -2095,7 +2135,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 49,
+            funcId: 50,
             port: port_,
           );
         },
@@ -2136,7 +2176,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 50,
+              funcId: 51,
               port: port_,
             );
           },
@@ -2185,7 +2225,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 51,
+            funcId: 52,
             port: port_,
           );
         },
@@ -2231,7 +2271,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 52,
+            funcId: 53,
             port: port_,
           );
         },
@@ -2275,7 +2315,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 53,
+            funcId: 54,
             port: port_,
           );
         },
@@ -2311,7 +2351,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 54,
+            funcId: 55,
             port: port_,
           );
         },
@@ -2346,7 +2386,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 55,
+            funcId: 56,
             port: port_,
           );
         },
@@ -2383,7 +2423,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 56,
+            funcId: 57,
             port: port_,
           );
         },
@@ -2419,7 +2459,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 57,
+            funcId: 58,
             port: port_,
           );
         },
@@ -2454,7 +2494,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 58,
+            funcId: 59,
             port: port_,
           );
         },
@@ -2488,7 +2528,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 59,
+            funcId: 60,
             port: port_,
           );
         },
@@ -2518,7 +2558,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 60,
+            funcId: 61,
             port: port_,
           );
         },
@@ -2551,7 +2591,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 61,
+            funcId: 62,
             port: port_,
           );
         },
@@ -2584,7 +2624,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 62,
+            funcId: 63,
             port: port_,
           );
         },
@@ -2618,7 +2658,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 63,
+            funcId: 64,
             port: port_,
           );
         },
@@ -2653,7 +2693,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 64,
+            funcId: 65,
             port: port_,
           );
         },
@@ -2687,7 +2727,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 65,
+            funcId: 66,
             port: port_,
           );
         },
@@ -2721,7 +2761,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 66,
+            funcId: 67,
             port: port_,
           );
         },
@@ -2753,7 +2793,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 67,
+            funcId: 68,
             port: port_,
           );
         },
@@ -2786,7 +2826,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 68,
+            funcId: 69,
             port: port_,
           );
         },
@@ -2822,7 +2862,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 69,
+            funcId: 70,
             port: port_,
           );
         },
@@ -2861,7 +2901,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 70,
+            funcId: 71,
             port: port_,
           );
         },
@@ -2900,7 +2940,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 71,
+              funcId: 72,
               port: port_,
             );
           },
@@ -2945,7 +2985,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 72,
+              funcId: 73,
               port: port_,
             );
           },
@@ -2990,7 +3030,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 73,
+              funcId: 74,
               port: port_,
             );
           },
@@ -3042,7 +3082,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 74,
+            funcId: 75,
             port: port_,
           );
         },
@@ -3102,7 +3142,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 75,
+            funcId: 76,
             port: port_,
           );
         },

--- a/rust/src/api/workspace_files.rs
+++ b/rust/src/api/workspace_files.rs
@@ -7,6 +7,7 @@ use ignore::WalkBuilder;
 
 mod editor_text;
 mod explorer_tree;
+mod quick_open;
 mod source_control_watcher;
 mod watcher;
 
@@ -200,6 +201,13 @@ pub fn list_workspace_children(
             .then_with(|| left.name.cmp(&right.name))
     });
     Ok(entries)
+}
+
+pub fn list_workspace_files(
+    workspace_path: String,
+    max_results: u32,
+) -> Result<Vec<WorkspaceFileEntry>, WorkspaceFileError> {
+    quick_open::list_workspace_files(workspace_path, max_results)
 }
 
 pub fn project_workspace_explorer_tree(

--- a/rust/src/api/workspace_files/quick_open.rs
+++ b/rust/src/api/workspace_files/quick_open.rs
@@ -1,0 +1,229 @@
+use std::fs;
+use std::path::Path;
+
+use ignore::WalkBuilder;
+
+use super::{
+    content_token, is_protected_child_path, is_protected_relative_path, modified_millis,
+    relative_string, workspace_root, WorkspaceFileEntry, WorkspaceFileError,
+    WorkspaceFileErrorKind, WorkspaceFileKind,
+};
+
+const MAX_QUICK_OPEN_FILES: usize = 20_000;
+
+pub(super) fn list_workspace_files(
+    workspace_path: String,
+    max_results: u32,
+) -> Result<Vec<WorkspaceFileEntry>, WorkspaceFileError> {
+    let root = workspace_root(&workspace_path)?;
+    let result_limit = (max_results as usize).min(MAX_QUICK_OPEN_FILES);
+    if result_limit == 0 {
+        return Ok(Vec::new());
+    }
+
+    let filter_root = root.clone();
+    let walker = WalkBuilder::new(&root)
+        .hidden(false)
+        .parents(true)
+        .require_git(false)
+        .follow_links(false)
+        .filter_entry(move |entry| {
+            entry.path() == filter_root || !is_protected_child_path(entry.path())
+        })
+        .build();
+    let mut entries = Vec::with_capacity(result_limit.min(1024));
+    for result in walker {
+        if entries.len() >= result_limit {
+            break;
+        }
+        let entry = result.map_err(|error| {
+            WorkspaceFileError::new(WorkspaceFileErrorKind::Io, error.to_string())
+        })?;
+        if let Some(file) = quick_open_entry(&root, entry.path())? {
+            entries.push(file);
+        }
+    }
+
+    entries.sort_by(|left, right| {
+        left.relative_path
+            .to_lowercase()
+            .cmp(&right.relative_path.to_lowercase())
+            .then_with(|| left.relative_path.cmp(&right.relative_path))
+    });
+    Ok(entries)
+}
+
+fn quick_open_entry(
+    root: &Path,
+    path: &Path,
+) -> Result<Option<WorkspaceFileEntry>, WorkspaceFileError> {
+    let relative_path = relative_string(root, path)?;
+    if relative_path.is_empty() || is_protected_relative_path(&relative_path) {
+        return Ok(None);
+    }
+
+    let link_metadata = fs::symlink_metadata(path)
+        .map_err(|error| WorkspaceFileError::from_io(error, path.to_string_lossy()))?;
+    let is_symlink = link_metadata.file_type().is_symlink();
+    if is_symlink {
+        let canonical = match fs::canonicalize(path) {
+            Ok(canonical) => canonical,
+            Err(_) => return Ok(None),
+        };
+        if !canonical.starts_with(root) {
+            return Ok(None);
+        }
+        let canonical_relative = relative_string(root, &canonical)?;
+        if is_protected_relative_path(&canonical_relative) {
+            return Ok(None);
+        }
+    }
+
+    let metadata = if is_symlink {
+        match fs::metadata(path) {
+            Ok(metadata) => metadata,
+            Err(_) => return Ok(None),
+        }
+    } else {
+        link_metadata
+    };
+    if !metadata.is_file() {
+        return Ok(None);
+    }
+    let name = path
+        .file_name()
+        .map(|name| name.to_string_lossy().to_string())
+        .unwrap_or_else(|| relative_path.clone());
+    Ok(Some(WorkspaceFileEntry {
+        relative_path,
+        name: name.clone(),
+        kind: if is_symlink {
+            WorkspaceFileKind::Symlink
+        } else {
+            WorkspaceFileKind::File
+        },
+        size: metadata.len(),
+        modified_millis: modified_millis(&metadata),
+        content_token: content_token(&metadata),
+        is_ignored: false,
+        is_hidden: name.starts_with('.'),
+        is_symlink,
+        is_protected: false,
+        has_children_hint: false,
+        git_status: None,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io;
+    use std::path::Path;
+
+    use super::*;
+
+    fn workspace_path(dir: &tempfile::TempDir) -> String {
+        dir.path().to_string_lossy().into_owned()
+    }
+
+    fn create_file_symlink(source: &Path, link: &Path) -> io::Result<()> {
+        #[cfg(unix)]
+        {
+            std::os::unix::fs::symlink(source, link)
+        }
+        #[cfg(windows)]
+        {
+            std::os::windows::fs::symlink_file(source, link)
+        }
+        #[cfg(not(any(unix, windows)))]
+        {
+            let _ = (source, link);
+            Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                "file symlinks are unsupported on this platform",
+            ))
+        }
+    }
+
+    #[test]
+    fn list_workspace_files_recurses_and_uses_workspace_ignore_rules() {
+        let workspace = tempfile::tempdir().expect("tempdir");
+        fs::write(
+            workspace.path().join(".gitignore"),
+            "ignored.txt\nignored-dir/\n",
+        )
+        .expect("write gitignore");
+        fs::create_dir_all(workspace.path().join("src/nested")).expect("create nested dirs");
+        fs::write(workspace.path().join("src/main.dart"), "void main() {}").expect("write main");
+        fs::write(workspace.path().join("src/nested/helper.dart"), "helper").expect("write helper");
+        fs::write(workspace.path().join("ignored.txt"), "ignored").expect("write ignored");
+        fs::create_dir(workspace.path().join("ignored-dir")).expect("create ignored dir");
+        fs::write(workspace.path().join("ignored-dir/secret.txt"), "ignored")
+            .expect("write ignored secret");
+        for protected in [".git", ".hg", ".svn"] {
+            fs::create_dir(workspace.path().join(protected)).expect("create protected dir");
+            fs::write(workspace.path().join(protected).join("secret"), "protected")
+                .expect("write protected file");
+        }
+
+        let entries = list_workspace_files(workspace_path(&workspace), 100).unwrap();
+        let paths = entries
+            .iter()
+            .map(|entry| entry.relative_path.as_str())
+            .collect::<Vec<_>>();
+
+        assert!(paths.contains(&".gitignore"));
+        assert!(paths.contains(&"src/main.dart"));
+        assert!(paths.contains(&"src/nested/helper.dart"));
+        assert!(!paths.contains(&"ignored.txt"));
+        assert!(!paths.contains(&"ignored-dir/secret.txt"));
+        assert!(!paths.iter().any(|path| {
+            path.starts_with(".git/") || path.starts_with(".hg/") || path.starts_with(".svn/")
+        }));
+    }
+
+    #[test]
+    fn list_workspace_files_respects_result_bound() {
+        let workspace = tempfile::tempdir().expect("tempdir");
+        for name in ["one.txt", "two.txt", "three.txt", "four.txt"] {
+            fs::write(workspace.path().join(name), name).expect("write file");
+        }
+
+        let entries = list_workspace_files(workspace_path(&workspace), 2).unwrap();
+
+        assert_eq!(entries.len(), 2);
+        assert!(entries
+            .iter()
+            .all(|entry| matches!(entry.kind, WorkspaceFileKind::File)));
+    }
+
+    #[test]
+    fn list_workspace_files_skips_symlink_escapes_and_keeps_local_files() {
+        let workspace = tempfile::tempdir().expect("tempdir");
+        let outside = tempfile::tempdir().expect("outside tempdir");
+        let outside_file = outside.path().join("outside.txt");
+        fs::write(&outside_file, "outside").expect("write outside file");
+        let outside_link = workspace.path().join("outside-link.txt");
+        if let Err(error) = create_file_symlink(&outside_file, &outside_link) {
+            eprintln!("skipping symlink test because symlink creation failed: {error}");
+            return;
+        }
+
+        let local_file = workspace.path().join("local.txt");
+        fs::write(&local_file, "local").expect("write local file");
+        let local_link = workspace.path().join("local-link.txt");
+        if let Err(error) = create_file_symlink(&local_file, &local_link) {
+            eprintln!("skipping local symlink assertion because symlink creation failed: {error}");
+            return;
+        }
+
+        let entries = list_workspace_files(workspace_path(&workspace), 100).unwrap();
+        let paths = entries
+            .iter()
+            .map(|entry| entry.relative_path.as_str())
+            .collect::<Vec<_>>();
+
+        assert!(paths.contains(&"local.txt"));
+        assert!(paths.contains(&"local-link.txt"));
+        assert!(!paths.contains(&"outside-link.txt"));
+    }
+}

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -38,7 +38,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.12.0";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 353200493;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 296909324;
 
 // Section: executor
 
@@ -1543,6 +1543,45 @@ fn wire__crate__api__workspace_files__list_workspace_children_impl(
                             api_workspace_path,
                             api_relative_path,
                             api_hide_ignored,
+                        )?;
+                        Ok(output_ok)
+                    })(),
+                )
+            }
+        },
+    )
+}
+fn wire__crate__api__workspace_files__list_workspace_files_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "list_workspace_files",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_workspace_path = <String>::sse_decode(&mut deserializer);
+            let api_max_results = <u32>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, crate::api::workspace_files::WorkspaceFileError>(
+                    (move || {
+                        let output_ok = crate::api::workspace_files::list_workspace_files(
+                            api_workspace_path,
+                            api_max_results,
                         )?;
                         Ok(output_ok)
                     })(),
@@ -4702,163 +4741,169 @@ fn pde_ffi_dispatcher_primary_impl(
             rust_vec_len,
             data_len,
         ),
-        43 => wire__crate__api__git__list_worktrees_impl(port, ptr, rust_vec_len, data_len),
-        44 => wire__crate__api__workspace_files__move_workspace_entry_impl(
+        43 => wire__crate__api__workspace_files__list_workspace_files_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        45 => wire__crate__api__workspace_search__preview_workspace_replace_impl(
+        44 => wire__crate__api__git__list_worktrees_impl(port, ptr, rust_vec_len, data_len),
+        45 => wire__crate__api__workspace_files__move_workspace_entry_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        46 => wire__crate__api__workspace_search__preview_workspace_replace_cancelable_impl(
+        46 => wire__crate__api__workspace_search__preview_workspace_replace_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        47 => {
+        47 => wire__crate__api__workspace_search__preview_workspace_replace_cancelable_impl(
+            port,
+            ptr,
+            rust_vec_len,
+            data_len,
+        ),
+        48 => {
             wire__crate__api__process__process_close_stdin_impl(port, ptr, rust_vec_len, data_len)
         }
-        48 => wire__crate__api__process__process_kill_impl(port, ptr, rust_vec_len, data_len),
-        49 => wire__crate__api__process__process_run_impl(port, ptr, rust_vec_len, data_len),
-        50 => wire__crate__api__process__process_start_impl(port, ptr, rust_vec_len, data_len),
-        51 => {
+        49 => wire__crate__api__process__process_kill_impl(port, ptr, rust_vec_len, data_len),
+        50 => wire__crate__api__process__process_run_impl(port, ptr, rust_vec_len, data_len),
+        51 => wire__crate__api__process__process_start_impl(port, ptr, rust_vec_len, data_len),
+        52 => {
             wire__crate__api__process__process_write_stdin_impl(port, ptr, rust_vec_len, data_len)
         }
-        52 => wire__crate__api__workspace_files__project_workspace_explorer_tree_impl(
+        53 => wire__crate__api__workspace_files__project_workspace_explorer_tree_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        53 => wire__crate__api__workspace_files__read_workspace_editor_text_file_impl(
+        54 => wire__crate__api__workspace_files__read_workspace_editor_text_file_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        54 => wire__crate__api__workspace_files__read_workspace_text_file_impl(
+        55 => wire__crate__api__workspace_files__read_workspace_text_file_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        55 => wire__crate__api__git__refresh_source_branch_impl(port, ptr, rust_vec_len, data_len),
-        56 => wire__crate__api__git__remove_worktree_impl(port, ptr, rust_vec_len, data_len),
-        57 => wire__crate__api__workspace_files__rename_workspace_entry_impl(
+        56 => wire__crate__api__git__refresh_source_branch_impl(port, ptr, rust_vec_len, data_len),
+        57 => wire__crate__api__git__remove_worktree_impl(port, ptr, rust_vec_len, data_len),
+        58 => wire__crate__api__workspace_files__rename_workspace_entry_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        58 => wire__crate__api__merman_viewer__render_merman_workspace_file_impl(
+        59 => wire__crate__api__merman_viewer__render_merman_workspace_file_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        59 => wire__crate__api__workspace_search__replace_workspace_matches_impl(
+        60 => wire__crate__api__workspace_search__replace_workspace_matches_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        60 => wire__crate__api__clipboard__save_clipboard_image_as_temp_file_impl(
+        61 => wire__crate__api__clipboard__save_clipboard_image_as_temp_file_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        61 => wire__crate__api__workspace_search__search_workspace_impl(
+        62 => wire__crate__api__workspace_search__search_workspace_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        62 => wire__crate__api__workspace_search__search_workspace_cancelable_impl(
+        63 => wire__crate__api__workspace_search__search_workspace_cancelable_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        63 => wire__crate__api__agent_hooks__set_agent_hook_enabled_agents_impl(
+        64 => wire__crate__api__agent_hooks__set_agent_hook_enabled_agents_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        64 => wire__crate__api__agent_hooks__start_agent_hook_receiver_impl(
+        65 => wire__crate__api__agent_hooks__start_agent_hook_receiver_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        65 => wire__crate__api__workspace_files__start_source_control_watcher_impl(
+        66 => wire__crate__api__workspace_files__start_source_control_watcher_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        66 => wire__crate__api__workspace_files__start_workspace_explorer_watcher_impl(
+        67 => wire__crate__api__workspace_files__start_workspace_explorer_watcher_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        67 => wire__crate__api__agent_hooks__stop_agent_hook_receiver_impl(
+        68 => wire__crate__api__agent_hooks__stop_agent_hook_receiver_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        68 => wire__crate__api__workspace_files__stop_source_control_watcher_impl(
+        69 => wire__crate__api__workspace_files__stop_source_control_watcher_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        69 => wire__crate__api__workspace_files__stop_workspace_explorer_watcher_impl(
+        70 => wire__crate__api__workspace_files__stop_workspace_explorer_watcher_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        70 => wire__crate__api__workspace_files__update_workspace_explorer_watcher_impl(
+        71 => wire__crate__api__workspace_files__update_workspace_explorer_watcher_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        71 => wire__crate__api__agent_hooks__watch_agent_hook_event_batches_impl(
+        72 => wire__crate__api__agent_hooks__watch_agent_hook_event_batches_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        72 => wire__crate__api__workspace_files__watch_source_control_events_impl(
+        73 => wire__crate__api__workspace_files__watch_source_control_events_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        73 => wire__crate__api__workspace_files__watch_workspace_explorer_events_impl(
+        74 => wire__crate__api__workspace_files__watch_workspace_explorer_events_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        74 => wire__crate__api__workspace_files__write_workspace_editor_text_file_impl(
+        75 => wire__crate__api__workspace_files__write_workspace_editor_text_file_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        75 => wire__crate__api__workspace_files__write_workspace_text_file_impl(
+        76 => wire__crate__api__workspace_files__write_workspace_text_file_impl(
             port,
             ptr,
             rust_vec_len,

--- a/test/unit/keybinding_resolver_test.dart
+++ b/test/unit/keybinding_resolver_test.dart
@@ -142,6 +142,41 @@ void main() {
     );
   });
 
+  test(
+    'quick open and command palette have distinct terminal-safe defaults',
+    () {
+      final resolver = KeybindingResolver(
+        settings: KeyboardShortcutSettings.defaults,
+        platform: KeyboardPlatform.macos,
+      );
+
+      expect(
+        resolver
+            .effectiveChords(KeyboardActionId.openQuickOpen)
+            .single
+            .toCanonicalString(),
+        'Mod+P',
+      );
+      expect(
+        resolver
+            .effectiveChords(KeyboardActionId.openCommandPalette)
+            .single
+            .toCanonicalString(),
+        'Mod+Shift+P',
+      );
+      expect(
+        keybindingDefinitionsById[KeyboardActionId.openQuickOpen]!
+            .allowInTerminal,
+        isTrue,
+      );
+      expect(
+        keybindingDefinitionsById[KeyboardActionId.openCommandPalette]!
+            .allowInTerminal,
+        isTrue,
+      );
+    },
+  );
+
   group('resolveAction', () {
     test('matches the right action on macOS', () {
       final resolver = KeybindingResolver(

--- a/test/unit/keyboard_command_palette_test.dart
+++ b/test/unit/keyboard_command_palette_test.dart
@@ -24,6 +24,57 @@ void main() {
     expect(matches.first.definition.id, KeyboardActionId.openCommandPalette);
   });
 
+  test(
+    'keyword prefixes, contains matches, and fuzzy labels are searchable',
+    () {
+      expect(
+        filterKeyboardCommandPalette('act').first.definition.id,
+        KeyboardActionId.openCommandPalette,
+      );
+      expect(
+        filterKeyboardCommandPalette('tions').first.definition.id,
+        KeyboardActionId.openCommandPalette,
+      );
+      expect(
+        filterKeyboardCommandPalette('dialog').first.definition.id,
+        KeyboardActionId.openSettings,
+      );
+      expect(
+        filterKeyboardCommandPalette('cmdp').first.definition.id,
+        KeyboardActionId.openCommandPalette,
+      );
+    },
+  );
+
+  test('identical labels use the stable action id as a tie breaker', () {
+    final definitions = <KeybindingDefinition>[
+      const KeybindingDefinition(
+        id: KeyboardActionId.openSettings,
+        label: 'Same Action',
+        group: KeyboardActionGroup.global,
+        description: 'First.',
+        defaultBindings: PlatformBindings.uniform(<String>['Mod+1']),
+      ),
+      const KeybindingDefinition(
+        id: KeyboardActionId.addProject,
+        label: 'Same Action',
+        group: KeyboardActionGroup.global,
+        description: 'Second.',
+        defaultBindings: PlatformBindings.uniform(<String>['Mod+2']),
+      ),
+    ];
+
+    final matches = filterKeyboardCommandPalette(
+      'same action',
+      definitions: definitions,
+    );
+
+    expect(matches.map((match) => match.definition.id), <KeyboardActionId>[
+      KeyboardActionId.addProject,
+      KeyboardActionId.openSettings,
+    ]);
+  });
+
   test('command results are bounded with stable label ordering', () {
     final definitions = <KeybindingDefinition>[
       const KeybindingDefinition(

--- a/test/unit/keyboard_command_palette_test.dart
+++ b/test/unit/keyboard_command_palette_test.dart
@@ -1,0 +1,67 @@
+import 'package:alera/src/features/keyboard/domain/keyboard_action.dart';
+import 'package:alera/src/features/keyboard/domain/keyboard_command_palette.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('empty query returns the complete central command registry', () {
+    final matches = filterKeyboardCommandPalette('');
+
+    expect(matches.length, keybindingDefinitions.length);
+    expect(matches.first.definition.id, KeyboardActionId.addProject);
+  });
+
+  test('filters labels and keywords case insensitively', () {
+    final matches = filterKeyboardCommandPalette('QUICK');
+
+    expect(matches.map((match) => match.definition.id), <KeyboardActionId>[
+      KeyboardActionId.openQuickOpen,
+    ]);
+  });
+
+  test('label matches outrank keyword matches', () {
+    final matches = filterKeyboardCommandPalette('command');
+
+    expect(matches.first.definition.id, KeyboardActionId.openCommandPalette);
+  });
+
+  test('command results are bounded with stable label ordering', () {
+    final definitions = <KeybindingDefinition>[
+      const KeybindingDefinition(
+        id: KeyboardActionId.openSettings,
+        label: 'Alpha Action',
+        group: KeyboardActionGroup.global,
+        description: 'Run the same command.',
+        defaultBindings: PlatformBindings.uniform(<String>['Mod+1']),
+        searchKeywords: <String>['shared'],
+      ),
+      const KeybindingDefinition(
+        id: KeyboardActionId.addProject,
+        label: 'Beta Action',
+        group: KeyboardActionGroup.global,
+        description: 'Run the same command.',
+        defaultBindings: PlatformBindings.uniform(<String>['Mod+2']),
+        searchKeywords: <String>['shared'],
+      ),
+      const KeybindingDefinition(
+        id: KeyboardActionId.toggleSidebar,
+        label: 'Gamma Action',
+        group: KeyboardActionGroup.global,
+        description: 'Run the same command.',
+        defaultBindings: PlatformBindings.uniform(<String>['Mod+3']),
+        searchKeywords: <String>['shared'],
+      ),
+    ];
+
+    final matches = filterKeyboardCommandPalette(
+      'shared',
+      definitions: definitions,
+      limit: 2,
+    );
+
+    expect(matches.length, 2);
+    expect(matches.map((match) => match.definition.label), <String>[
+      'Alpha Action',
+      'Beta Action',
+    ]);
+  });
+}

--- a/test/unit/workspace_file_quick_open_test.dart
+++ b/test/unit/workspace_file_quick_open_test.dart
@@ -56,6 +56,16 @@ void main() {
     );
   });
 
+  test('contains matches are ranked before fuzzy matches', () {
+    final matches = rankWorkspaceFileQuickOpenMatches(<String>[
+      'lib/terminal.dart',
+      'lib/microtasks.dart',
+    ], 'minal');
+
+    expect(matches.first.relativePath, 'lib/terminal.dart');
+    expect(matches.first.score, greaterThan(1000));
+  });
+
   test('result count is bounded and ties have stable ordering', () {
     final matches = rankWorkspaceFileQuickOpenMatches(
       <String>['src/b.dart', 'src/a.dart', 'src/c.dart'],

--- a/test/unit/workspace_file_quick_open_test.dart
+++ b/test/unit/workspace_file_quick_open_test.dart
@@ -1,0 +1,72 @@
+import 'package:alera/src/features/workbench/domain/workspace_file_quick_open.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('empty query returns deterministic paths', () {
+    final matches = rankWorkspaceFileQuickOpenMatches(<String>[
+      'lib/zeta.dart',
+      'A.dart',
+      'a.dart',
+    ], '');
+
+    expect(matches.map((match) => match.relativePath), <String>[
+      'A.dart',
+      'a.dart',
+      'lib/zeta.dart',
+    ]);
+  });
+
+  test('matching is case insensitive', () {
+    final matches = rankWorkspaceFileQuickOpenMatches(<String>[
+      'lib/README.md',
+      'lib/reader.dart',
+    ], 'readme');
+
+    expect(matches.map((match) => match.relativePath), <String>[
+      'lib/README.md',
+    ]);
+  });
+
+  test('exact paths outrank prefixes and path-segment matches', () {
+    final matches = rankWorkspaceFileQuickOpenMatches(<String>[
+      'lib/main.dart',
+      'main.dart',
+      'lib/maintenance.dart',
+      'src/main_test.dart',
+    ], 'main.dart');
+
+    expect(matches.map((match) => match.relativePath), <String>[
+      'main.dart',
+      'lib/main.dart',
+      'src/main_test.dart',
+      'lib/maintenance.dart',
+    ]);
+  });
+
+  test('fuzzy subsequence matching finds useful path segments', () {
+    final matches = rankWorkspaceFileQuickOpenMatches(<String>[
+      'lib/workspace_state.dart',
+      'lib/workbench.dart',
+      'README.md',
+    ], 'wst');
+
+    expect(
+      matches.map((match) => match.relativePath),
+      contains('lib/workspace_state.dart'),
+    );
+  });
+
+  test('result count is bounded and ties have stable ordering', () {
+    final matches = rankWorkspaceFileQuickOpenMatches(
+      <String>['src/b.dart', 'src/a.dart', 'src/c.dart'],
+      'src',
+      limit: 2,
+    );
+
+    expect(matches.length, 2);
+    expect(matches.map((match) => match.relativePath), <String>[
+      'src/a.dart',
+      'src/b.dart',
+    ]);
+  });
+}

--- a/test/widget/keyboard_command_dispatcher_test.dart
+++ b/test/widget/keyboard_command_dispatcher_test.dart
@@ -7,6 +7,7 @@ import 'package:alera/src/features/browser/application/browser_providers.dart';
 import 'package:alera/src/features/browser/domain/browser_engine_models.dart';
 import 'package:alera/src/features/keyboard/application/keyboard_command_dispatcher.dart';
 import 'package:alera/src/features/keyboard/domain/keyboard_action.dart';
+import 'package:alera/src/features/keyboard/presentation/keyboard_command_palette_dialog.dart';
 import 'package:alera/src/features/projects/domain/project.dart';
 import 'package:alera/src/features/settings/domain/alera_settings.dart';
 import 'package:alera/src/features/workbench/application/workbench_state.dart';
@@ -352,6 +353,12 @@ void main() {
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 300));
     expect(find.text('Application'), findsWidgets);
+    Navigator.of(harness.context).pop();
+    await tester.pumpAndSettle();
+
+    dispatcher.dispatch(KeyboardActionId.openCommandPalette);
+    await tester.pumpAndSettle();
+    expect(find.byType(KeyboardCommandPaletteDialog), findsOneWidget);
     Navigator.of(harness.context).pop();
     await tester.pumpAndSettle();
 

--- a/test/widget/keyboard_command_palette_dialog_test.dart
+++ b/test/widget/keyboard_command_palette_dialog_test.dart
@@ -1,0 +1,96 @@
+import 'package:alera/src/features/keyboard/domain/keyboard_action.dart';
+import 'package:alera/src/features/keyboard/presentation/keyboard_command_palette_dialog.dart';
+import 'package:alera/src/features/settings/application/settings_controller.dart';
+import 'package:alera/src/features/settings/domain/alera_settings.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+void main() {
+  testWidgets('filters commands and executes the selected action', (
+    tester,
+  ) async {
+    KeyboardActionId? executed;
+    await _pumpCommandPalette(tester, onExecute: (id) => executed = id);
+
+    await tester.tap(find.text('Open Command Palette'));
+    await tester.pumpAndSettle();
+    await tester.enterText(find.byType(TextField), 'quick');
+    await tester.pump();
+
+    expect(find.text('Quick Open'), findsOneWidget);
+    expect(
+      find.byKey(
+        const ValueKey<KeyboardActionId>(KeyboardActionId.openCommandPalette),
+      ),
+      findsNothing,
+    );
+    await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+    await tester.pumpAndSettle();
+
+    expect(executed, KeyboardActionId.openQuickOpen);
+    expect(find.text('Command Palette'), findsNothing);
+  });
+
+  testWidgets('Escape closes and restores focus', (tester) async {
+    final anchorFocus = FocusNode();
+    addTearDown(anchorFocus.dispose);
+    await _pumpCommandPalette(tester, anchorFocus: anchorFocus);
+    anchorFocus.requestFocus();
+    await tester.pump();
+
+    await tester.tap(find.text('Open Command Palette'));
+    await tester.pumpAndSettle();
+    await tester.enterText(find.byType(TextField), 'not a command');
+    await tester.pump();
+    expect(find.text('No commands match "not a command".'), findsOneWidget);
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+    await tester.pumpAndSettle();
+    expect(find.text('Command Palette'), findsNothing);
+    expect(anchorFocus.hasFocus, isTrue);
+  });
+}
+
+Future<void> _pumpCommandPalette(
+  WidgetTester tester, {
+  ValueChanged<KeyboardActionId>? onExecute,
+  FocusNode? anchorFocus,
+}) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        settingsControllerProvider.overrideWith(
+          () => _CommandPaletteSettingsController(AleraSettings.defaults),
+        ),
+      ],
+      child: MaterialApp(
+        home: Scaffold(
+          body: Focus(
+            focusNode: anchorFocus,
+            child: Builder(
+              builder: (context) => FilledButton(
+                onPressed: () => showKeyboardCommandPalette(
+                  context,
+                  onExecute: onExecute ?? (_) {},
+                ),
+                child: const Text('Open Command Palette'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pump();
+}
+
+class _CommandPaletteSettingsController extends SettingsController {
+  _CommandPaletteSettingsController(this._seed);
+
+  final AleraSettings _seed;
+
+  @override
+  AleraSettings build() => _seed;
+}

--- a/test/widget/quick_open_dialog_test.dart
+++ b/test/widget/quick_open_dialog_test.dart
@@ -1,0 +1,274 @@
+import 'dart:async';
+
+import 'package:alera/src/features/workbench/application/workbench_controller.dart';
+import 'package:alera/src/features/workbench/application/workbench_providers.dart';
+import 'package:alera/src/features/workbench/application/workbench_state.dart';
+import 'package:alera/src/features/workbench/application/workspace_file_service.dart';
+import 'package:alera/src/features/workbench/domain/workspace.dart';
+import 'package:alera/src/features/workbench/domain/workspace_tab_record.dart';
+import 'package:alera/src/features/workbench/presentation/workbench_dialog_launchers.dart';
+import 'package:alera/src/rust/api/workspace_files.dart' as native;
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+void main() {
+  testWidgets('shows loading, filters files, and opens the selected file', (
+    tester,
+  ) async {
+    final workspace = _workspace('workspace-1', 'Main', '/repo/main');
+    final controller = _QuickOpenTestController(_state(workspace));
+    final files = Completer<List<native.WorkspaceFileEntry>>();
+    final service = _QuickOpenFileService(files: files);
+    await _pumpQuickOpen(tester, controller: controller, service: service);
+
+    await tester.tap(find.text('Open Quick Open'));
+    await tester.pump();
+    expect(find.text('Loading workspace files...'), findsOneWidget);
+
+    files.complete(<native.WorkspaceFileEntry>[
+      _file('lib/main.dart'),
+      _file('lib/main_test.dart'),
+      _file('notes.txt'),
+    ]);
+    await tester.pumpAndSettle();
+    expect(find.text('lib/main.dart'), findsOneWidget);
+    expect(find.text('lib/main_test.dart'), findsOneWidget);
+
+    await tester.enterText(find.byType(TextField), 'main_test.dart');
+    await tester.pump();
+    expect(find.text('lib/main.dart'), findsNothing);
+    expect(find.text('lib/main_test.dart'), findsOneWidget);
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+    await tester.pumpAndSettle();
+    expect(controller.openedFiles, <String>['lib/main_test.dart']);
+  });
+
+  testWidgets('arrow navigation, Escape, and focus restoration work', (
+    tester,
+  ) async {
+    final workspace = _workspace('workspace-1', 'Main', '/repo/main');
+    final controller = _QuickOpenTestController(_state(workspace));
+    final anchorFocus = FocusNode();
+    addTearDown(anchorFocus.dispose);
+    await _pumpQuickOpen(
+      tester,
+      controller: controller,
+      service: _QuickOpenFileService(
+        entries: <native.WorkspaceFileEntry>[_file('a.dart'), _file('b.dart')],
+      ),
+      anchorFocus: anchorFocus,
+    );
+    anchorFocus.requestFocus();
+    await tester.pump();
+
+    await tester.tap(find.text('Open Quick Open'));
+    await tester.pumpAndSettle();
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+    await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+    await tester.pumpAndSettle();
+    expect(controller.openedFiles, <String>['b.dart']);
+    expect(anchorFocus.hasFocus, isTrue);
+
+    await tester.tap(find.text('Open Quick Open'));
+    await tester.pumpAndSettle();
+    await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+    await tester.pumpAndSettle();
+    expect(find.text('Quick Open'), findsNothing);
+    expect(anchorFocus.hasFocus, isTrue);
+  });
+
+  testWidgets('shows empty and error states', (tester) async {
+    final workspace = _workspace('workspace-1', 'Main', '/repo/main');
+    final controller = _QuickOpenTestController(_state(workspace));
+    await _pumpQuickOpen(
+      tester,
+      controller: controller,
+      service: _QuickOpenFileService(
+        entries: const <native.WorkspaceFileEntry>[],
+      ),
+    );
+
+    await tester.tap(find.text('Open Quick Open'));
+    await tester.pumpAndSettle();
+    expect(
+      find.text('No files are available in this workspace.'),
+      findsOneWidget,
+    );
+    await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+    await tester.pumpAndSettle();
+
+    await _pumpQuickOpen(
+      tester,
+      controller: controller,
+      service: _QuickOpenFileService(error: StateError('enumeration failed')),
+    );
+    await tester.tap(find.text('Open Quick Open'));
+    await tester.pumpAndSettle();
+    expect(find.text('Could not load workspace files.'), findsOneWidget);
+  });
+
+  testWidgets('restarts the search when the active workspace changes', (
+    tester,
+  ) async {
+    final first = _workspace('workspace-1', 'Main', '/repo/main');
+    final second = _workspace('workspace-2', 'Feature', '/repo/feature');
+    final controller = _QuickOpenTestController(
+      _state(first, extraWorkspaces: <Workspace>[second]),
+    );
+    final service = _QuickOpenFileService(
+      entriesByWorkspacePath: <String, List<native.WorkspaceFileEntry>>{
+        first.path: <native.WorkspaceFileEntry>[_file('old.dart')],
+        second.path: <native.WorkspaceFileEntry>[_file('new.dart')],
+      },
+    );
+    await _pumpQuickOpen(tester, controller: controller, service: service);
+
+    await tester.tap(find.text('Open Quick Open'));
+    await tester.pumpAndSettle();
+    expect(find.text('old.dart'), findsOneWidget);
+
+    controller.switchWorkspace(second.id);
+    await tester.pumpAndSettle();
+    expect(find.text('old.dart'), findsNothing);
+    expect(find.text('new.dart'), findsOneWidget);
+  });
+}
+
+Future<void> _pumpQuickOpen(
+  WidgetTester tester, {
+  required _QuickOpenTestController controller,
+  required _QuickOpenFileService service,
+  FocusNode? anchorFocus,
+}) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        workbenchControllerProvider.overrideWith(() => controller),
+        workspaceFileServiceProvider.overrideWithValue(service),
+      ],
+      child: MaterialApp(
+        home: Scaffold(
+          body: Focus(
+            focusNode: anchorFocus,
+            child: Consumer(
+              builder: (context, ref, _) => FilledButton(
+                onPressed: () => showQuickOpenFlow(context, ref),
+                child: const Text('Open Quick Open'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pump();
+}
+
+WorkbenchState _state(
+  Workspace active, {
+  List<Workspace> extraWorkspaces = const <Workspace>[],
+}) {
+  return WorkbenchState(
+    workspacesByProject: <String, List<Workspace>>{
+      active.projectId: <Workspace>[active, ...extraWorkspaces],
+    },
+    activeWorkspaceId: active.id,
+  );
+}
+
+Workspace _workspace(String id, String name, String path) {
+  final now = DateTime.utc(2026);
+  return Workspace(
+    id: id,
+    projectId: 'project-1',
+    name: name,
+    path: path,
+    createdAt: now,
+    updatedAt: now,
+    kind: WorkspaceKind.main,
+    status: WorkspaceStatus.active,
+  );
+}
+
+native.WorkspaceFileEntry _file(String relativePath) {
+  return native.WorkspaceFileEntry(
+    relativePath: relativePath,
+    name: relativePath.split('/').last,
+    kind: native.WorkspaceFileKind.file,
+    size: BigInt.zero,
+    modifiedMillis: 0,
+    contentToken: '$relativePath-token',
+    isIgnored: false,
+    isHidden: false,
+    isSymlink: false,
+    isProtected: false,
+    hasChildrenHint: false,
+  );
+}
+
+class _QuickOpenFileService extends WorkspaceFileService {
+  _QuickOpenFileService({
+    this.entries = const <native.WorkspaceFileEntry>[],
+    this.error,
+    this.files,
+    this.entriesByWorkspacePath =
+        const <String, List<native.WorkspaceFileEntry>>{},
+  });
+
+  final List<native.WorkspaceFileEntry> entries;
+  final Object? error;
+  final Completer<List<native.WorkspaceFileEntry>>? files;
+  final Map<String, List<native.WorkspaceFileEntry>> entriesByWorkspacePath;
+
+  @override
+  Future<List<native.WorkspaceFileEntry>> listFiles({
+    required String workspacePath,
+    int maxResults = 10000,
+  }) {
+    if (error != null) {
+      return Future<List<native.WorkspaceFileEntry>>.error(error!);
+    }
+    if (files != null) {
+      return files!.future;
+    }
+    return Future.value(entriesByWorkspacePath[workspacePath] ?? entries);
+  }
+}
+
+class _QuickOpenTestController extends WorkbenchController {
+  _QuickOpenTestController(this._seed);
+
+  final WorkbenchState _seed;
+  final List<String> openedFiles = <String>[];
+
+  @override
+  WorkbenchState build() => _seed;
+
+  @override
+  Future<void> bootstrap() async {}
+
+  @override
+  Future<WorkspaceTabRecord> openFileTab({
+    required Workspace workspace,
+    required String relativePath,
+    String? targetGroupId,
+  }) async {
+    openedFiles.add(relativePath);
+    final now = DateTime.utc(2026);
+    return WorkspaceTabRecord(
+      id: 'tab-${openedFiles.length}',
+      workspaceId: workspace.id,
+      kind: WorkspaceTabKind.editor,
+      title: relativePath,
+      createdAt: now,
+      updatedAt: now,
+    );
+  }
+
+  void switchWorkspace(String workspaceId) {
+    state = state.copyWith(activeWorkspaceId: workspaceId);
+  }
+}


### PR DESCRIPTION
## Summary
- add native bounded Quick Open file discovery and fuzzy navigation
- add Command Palette actions through the central keyboard registry and dispatcher
- cover ranking, workspace changes, focus, error and empty states, and native ignore and symlink boundaries

## Validation
- flutter analyze
- flutter test (2,614 passed)
- make rust-test
- dart tool/quality/check_max_lines.dart
- git diff --check

Local gh act was attempted but could not complete because linked-worktree submodule checkout is unsupported; hosted checks remain authoritative.