### PR TITLE
feat: add terminal prompt composer

### DIFF
--- a/lib/src/design_system/forms/alera_composer.dart
+++ b/lib/src/design_system/forms/alera_composer.dart
@@ -1,0 +1,257 @@
+import 'package:alera/src/app/theme/alera_tokens.dart';
+import 'package:alera/src/design_system/buttons/alera_icon_button.dart';
+import 'package:alera/src/design_system/forms/alera_text_actions_scope.dart';
+import 'package:alera/src/design_system/icons/alera_icons.dart';
+import 'package:alera/src/design_system/menus/alera_dropdown_entry.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+class AleraComposer extends StatefulWidget {
+  const AleraComposer({
+    super.key,
+    required this.controller,
+    required this.focusNode,
+    required this.onSend,
+    required this.onClose,
+    required this.textActions,
+    required this.onTextActionSelected,
+    this.enabled = true,
+    this.hintText = 'Write a prompt for this terminal',
+  });
+
+  final TextEditingController controller;
+  final FocusNode focusNode;
+  final VoidCallback onSend;
+  final VoidCallback onClose;
+  final List<AleraTextActionMenuItem> textActions;
+  final ValueChanged<String> onTextActionSelected;
+  final bool enabled;
+  final String hintText;
+
+  @override
+  State<AleraComposer> createState() => _AleraComposerState();
+}
+
+class _AleraComposerState extends State<AleraComposer> {
+  @override
+  void initState() {
+    super.initState();
+    widget.controller.addListener(_handleControllerChanged);
+  }
+
+  @override
+  void didUpdateWidget(AleraComposer oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.controller != widget.controller) {
+      oldWidget.controller.removeListener(_handleControllerChanged);
+      widget.controller.addListener(_handleControllerChanged);
+    }
+  }
+
+  @override
+  void dispose() {
+    widget.controller.removeListener(_handleControllerChanged);
+    super.dispose();
+  }
+
+  void _handleControllerChanged() => setState(() {});
+
+  bool get _canSend =>
+      widget.enabled && widget.controller.text.trim().isNotEmpty;
+
+  bool get _hasSelection {
+    final value = widget.controller.value;
+    final selection = value.selection;
+    return selection.isValid &&
+        !selection.isCollapsed &&
+        selection.start >= 0 &&
+        selection.end <= value.text.length;
+  }
+
+  void _send() {
+    if (_canSend) {
+      widget.onSend();
+    }
+  }
+
+  void _insertLineBreak() {
+    if (!widget.enabled) {
+      return;
+    }
+    final value = widget.controller.value;
+    final selection = value.selection;
+    final start = selection.start < 0 ? value.text.length : selection.start;
+    final end = selection.end < 0 ? value.text.length : selection.end;
+    widget.controller.value = value.copyWith(
+      text: value.text.replaceRange(start, end, '\n'),
+      selection: TextSelection.collapsed(offset: start + 1),
+      composing: TextRange.empty,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final textActionsEnabled = widget.textActions.isNotEmpty && _hasSelection;
+    return Padding(
+      padding: const EdgeInsets.all(AleraTokens.space12),
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          color: AleraTokens.surfaceVariant,
+          borderRadius: BorderRadius.circular(AleraTokens.radiusXl),
+          border: Border.all(color: AleraTokens.border),
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            CallbackShortcuts(
+              bindings: <ShortcutActivator, VoidCallback>{
+                const SingleActivator(LogicalKeyboardKey.enter): _send,
+                const SingleActivator(LogicalKeyboardKey.enter, shift: true):
+                    _insertLineBreak,
+                const SingleActivator(LogicalKeyboardKey.escape):
+                    widget.onClose,
+              },
+              child: TextField(
+                controller: widget.controller,
+                focusNode: widget.focusNode,
+                enabled: widget.enabled,
+                minLines: 2,
+                maxLines: 6,
+                textInputAction: TextInputAction.newline,
+                style: Theme.of(context).textTheme.bodyMedium,
+                contextMenuBuilder: AleraTextActionsScope.buildContextMenu,
+                decoration: InputDecoration(
+                  hintText: widget.hintText,
+                  filled: true,
+                  fillColor: Colors.transparent,
+                  hoverColor: Colors.transparent,
+                  contentPadding: const EdgeInsets.fromLTRB(
+                    AleraTokens.space12,
+                    AleraTokens.space16,
+                    AleraTokens.space12,
+                    AleraTokens.space8,
+                  ),
+                  border: InputBorder.none,
+                  enabledBorder: InputBorder.none,
+                  focusedBorder: InputBorder.none,
+                  disabledBorder: InputBorder.none,
+                ),
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(
+                AleraTokens.space8,
+                0,
+                AleraTokens.space8,
+                AleraTokens.space8,
+              ),
+              child: Row(
+                children: <Widget>[
+                  Expanded(
+                    child: Align(
+                      alignment: Alignment.centerLeft,
+                      child: _TextActionsMenu(
+                        actions: widget.textActions,
+                        enabled: textActionsEnabled,
+                        onSelected: widget.onTextActionSelected,
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: AleraTokens.space8),
+                  AleraIconButton(
+                    key: const ValueKey<String>('composer-send-button'),
+                    tooltip: 'Send Prompt',
+                    icon: AleraIcons.arrowUp,
+                    iconColor: _canSend
+                        ? AleraTokens.onAccent
+                        : AleraTokens.foregroundFaint,
+                    backgroundColor: _canSend
+                        ? AleraTokens.accent
+                        : AleraTokens.surface,
+                    borderRadius: AleraTokens.radiusPill,
+                    minSize: AleraTokens.space32,
+                    onPressed: _canSend ? _send : null,
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _TextActionsMenu extends StatelessWidget {
+  const _TextActionsMenu({
+    required this.actions,
+    required this.enabled,
+    required this.onSelected,
+  });
+
+  final List<AleraTextActionMenuItem> actions;
+  final bool enabled;
+  final ValueChanged<String> onSelected;
+
+  @override
+  Widget build(BuildContext context) {
+    final tooltip = actions.isEmpty
+        ? 'No Text Actions Available'
+        : enabled
+        ? 'Text Actions'
+        : 'Select Prompt Text to Use Text Actions';
+    return Tooltip(
+      message: tooltip,
+      child: PopupMenuButton<String>(
+        enabled: enabled,
+        tooltip: '',
+        onSelected: onSelected,
+        color: AleraTokens.surface,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(AleraTokens.radiusMd),
+          side: const BorderSide(color: AleraTokens.border),
+        ),
+        itemBuilder: (context) => <PopupMenuEntry<String>>[
+          for (final action in actions)
+            AleraDropdownEntry<String>(value: action.id, label: action.label),
+        ],
+        child: MouseRegion(
+          cursor: enabled ? SystemMouseCursors.click : SystemMouseCursors.basic,
+          child: Padding(
+            padding: const EdgeInsets.symmetric(
+              horizontal: AleraTokens.space8,
+              vertical: AleraTokens.space4,
+            ),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: <Widget>[
+                Icon(
+                  AleraIcons.ai,
+                  size: AleraTokens.space16,
+                  color: enabled
+                      ? AleraTokens.foregroundMuted
+                      : AleraTokens.foregroundFaint,
+                ),
+                const SizedBox(width: AleraTokens.space6),
+                Text(
+                  'Text Actions',
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: enabled
+                        ? AleraTokens.foregroundMuted
+                        : AleraTokens.foregroundFaint,
+                  ),
+                ),
+                const SizedBox(width: AleraTokens.space4),
+                const Icon(
+                  AleraIcons.chevronDown,
+                  size: AleraTokens.space16,
+                  color: AleraTokens.foregroundFaint,
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/design_system/forms/alera_composer.preview.dart
+++ b/lib/src/design_system/forms/alera_composer.preview.dart
@@ -1,0 +1,41 @@
+import 'package:alera/src/design_system/alera_preview.dart';
+import 'package:alera/src/design_system/forms/alera_composer.dart';
+import 'package:alera/src/design_system/forms/alera_text_actions_scope.dart';
+import 'package:flutter/material.dart';
+
+@AleraPreview(name: 'Terminal', group: 'Composer', size: Size(560, 180))
+Widget aleraComposerPreview() => const _ComposerPreview();
+
+class _ComposerPreview extends StatefulWidget {
+  const _ComposerPreview();
+
+  @override
+  State<_ComposerPreview> createState() => _ComposerPreviewState();
+}
+
+class _ComposerPreviewState extends State<_ComposerPreview> {
+  final _controller = TextEditingController(text: 'Summarize these changes');
+  final _focusNode = FocusNode();
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    _focusNode.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AleraComposer(
+      controller: _controller,
+      focusNode: _focusNode,
+      onSend: _controller.clear,
+      onClose: () {},
+      textActions: const <AleraTextActionMenuItem>[
+        AleraTextActionMenuItem(id: 'improve', label: 'Improve Writing'),
+        AleraTextActionMenuItem(id: 'shorten', label: 'Make Concise'),
+      ],
+      onTextActionSelected: (_) {},
+    );
+  }
+}

--- a/lib/src/design_system/forms/alera_text_actions_scope.dart
+++ b/lib/src/design_system/forms/alera_text_actions_scope.dart
@@ -5,17 +5,37 @@ import 'package:flutter/material.dart';
 typedef AleraTextActionsContextMenuHandler =
     void Function(BuildContext context, EditableTextState editableTextState);
 
+typedef AleraTextActionHandler =
+    void Function(EditableTextState editableTextState, String actionId);
+
+class AleraTextActionMenuItem {
+  const AleraTextActionMenuItem({required this.id, required this.label});
+
+  final String id;
+  final String label;
+}
+
 /// Adds the optional Text Actions entry without taking ownership of editing.
 class AleraTextActionsScope extends InheritedWidget {
   const AleraTextActionsScope({
     super.key,
     required this.enabled,
     required this.onOpen,
+    this.actions = const <AleraTextActionMenuItem>[],
+    this.onRun,
     required super.child,
   });
 
   final bool enabled;
   final AleraTextActionsContextMenuHandler onOpen;
+  final List<AleraTextActionMenuItem> actions;
+  final AleraTextActionHandler? onRun;
+
+  void run(EditableTextState editableTextState, String actionId) {
+    if (enabled) {
+      onRun?.call(editableTextState, actionId);
+    }
+  }
 
   static AleraTextActionsScope? maybeOf(BuildContext context) {
     return context.dependOnInheritedWidgetOfExactType<AleraTextActionsScope>();
@@ -100,6 +120,9 @@ class AleraTextActionsScope extends InheritedWidget {
 
   @override
   bool updateShouldNotify(AleraTextActionsScope oldWidget) {
-    return enabled != oldWidget.enabled || onOpen != oldWidget.onOpen;
+    return enabled != oldWidget.enabled ||
+        onOpen != oldWidget.onOpen ||
+        actions != oldWidget.actions ||
+        onRun != oldWidget.onRun;
   }
 }

--- a/lib/src/design_system/gallery/design_system_gallery.dart
+++ b/lib/src/design_system/gallery/design_system_gallery.dart
@@ -9,7 +9,9 @@ import 'package:alera/src/design_system/feedback/alera_empty_state.dart';
 import 'package:alera/src/design_system/feedback/alera_status_dot.dart';
 import 'package:alera/src/design_system/feedback/alera_status_indicator.dart';
 import 'package:alera/src/design_system/forms/alera_number_field.dart';
+import 'package:alera/src/design_system/forms/alera_composer.dart';
 import 'package:alera/src/design_system/forms/alera_search_field.dart';
+import 'package:alera/src/design_system/forms/alera_text_actions_scope.dart';
 import 'package:alera/src/design_system/forms/alera_text_field.dart';
 import 'package:alera/src/design_system/forms/alera_color_picker.dart';
 import 'package:alera/src/design_system/icons/alera_icons.dart';
@@ -68,6 +70,42 @@ Widget galleryInputs() => Column(
     ),
   ],
 );
+
+@AleraPreview(name: 'Composer', group: 'Gallery', size: Size(560, 180))
+Widget galleryComposer() => const _GalleryComposer();
+
+class _GalleryComposer extends StatefulWidget {
+  const _GalleryComposer();
+
+  @override
+  State<_GalleryComposer> createState() => _GalleryComposerState();
+}
+
+class _GalleryComposerState extends State<_GalleryComposer> {
+  final _controller = TextEditingController(text: 'Explain the failing test');
+  final _focusNode = FocusNode();
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    _focusNode.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AleraComposer(
+      controller: _controller,
+      focusNode: _focusNode,
+      onSend: _controller.clear,
+      onClose: () {},
+      textActions: const <AleraTextActionMenuItem>[
+        AleraTextActionMenuItem(id: 'concise', label: 'Make Concise'),
+      ],
+      onTextActionSelected: (_) {},
+    );
+  }
+}
 
 @AleraPreview(name: 'Feedback', group: 'Gallery', size: Size(420, 240))
 Widget galleryFeedback() => Column(

--- a/lib/src/features/keyboard/application/keyboard_command_dispatcher.dart
+++ b/lib/src/features/keyboard/application/keyboard_command_dispatcher.dart
@@ -57,6 +57,8 @@ class KeyboardCommandDispatcher {
         _showContextPanel(WorkbenchContextPanelTab.search);
       case KeyboardActionId.findInTerminal:
         _openTerminalSearch();
+      case KeyboardActionId.toggleTerminalComposer:
+        _toggleTerminalComposer();
       case KeyboardActionId.replaceInFiles:
         _showContextPanel(WorkbenchContextPanelTab.search);
       case KeyboardActionId.saveFile:
@@ -148,6 +150,23 @@ class KeyboardCommandDispatcher {
       return;
     }
     ref.read(terminalRuntimeProvider).peekSession(tab.id)?.openSearch();
+  }
+
+  void _toggleTerminalComposer() {
+    final directSession = terminalSession;
+    if (directSession != null) {
+      directSession.composerController.toggle();
+      return;
+    }
+    final tab = ref.read(workbenchControllerProvider).activeWorkspaceTab;
+    if (tab == null || tab.kind != WorkspaceTabKind.terminal) {
+      return;
+    }
+    ref
+        .read(terminalRuntimeProvider)
+        .peekSession(tab.id)
+        ?.composerController
+        .toggle();
   }
 
   void _saveActiveEditor() {

--- a/lib/src/features/keyboard/domain/keyboard_action.dart
+++ b/lib/src/features/keyboard/domain/keyboard_action.dart
@@ -56,6 +56,7 @@ enum KeyboardActionId {
   navigateForward,
   findInFiles,
   findInTerminal,
+  toggleTerminalComposer,
   replaceInFiles,
   saveFile,
   newTerminalTab,
@@ -240,6 +241,15 @@ const List<KeybindingDefinition> keybindingDefinitions = <KeybindingDefinition>[
     description: 'Search the active terminal scrollback.',
     defaultBindings: PlatformBindings.uniform(<String>['Mod+F']),
     searchKeywords: <String>['search', 'terminal', 'scrollback'],
+    allowInTerminal: true,
+  ),
+  KeybindingDefinition(
+    id: KeyboardActionId.toggleTerminalComposer,
+    label: 'Toggle Terminal Composer',
+    group: KeyboardActionGroup.tabs,
+    description: 'Show or hide the prompt composer for the active terminal.',
+    defaultBindings: PlatformBindings.uniform(<String>['Mod+Shift+Enter']),
+    searchKeywords: <String>['prompt', 'compose', 'agent', 'terminal'],
     allowInTerminal: true,
   ),
   KeybindingDefinition(

--- a/lib/src/features/keyboard/domain/keyboard_action.mapper.dart
+++ b/lib/src/features/keyboard/domain/keyboard_action.mapper.dart
@@ -94,6 +94,8 @@ class KeyboardActionIdMapper extends EnumMapper<KeyboardActionId> {
         return KeyboardActionId.findInFiles;
       case r'findInTerminal':
         return KeyboardActionId.findInTerminal;
+      case r'toggleTerminalComposer':
+        return KeyboardActionId.toggleTerminalComposer;
       case r'replaceInFiles':
         return KeyboardActionId.replaceInFiles;
       case r'saveFile':
@@ -160,6 +162,8 @@ class KeyboardActionIdMapper extends EnumMapper<KeyboardActionId> {
         return r'findInFiles';
       case KeyboardActionId.findInTerminal:
         return r'findInTerminal';
+      case KeyboardActionId.toggleTerminalComposer:
+        return r'toggleTerminalComposer';
       case KeyboardActionId.replaceInFiles:
         return r'replaceInFiles';
       case KeyboardActionId.saveFile:

--- a/lib/src/features/text_actions/presentation/text_actions_scope.dart
+++ b/lib/src/features/text_actions/presentation/text_actions_scope.dart
@@ -43,8 +43,15 @@ class _TextActionsScopeState extends ConsumerState<TextActionsScope> {
         settings.textActions.enabledActions.isNotEmpty;
     return AleraTextActionsScope(
       enabled: enabled,
+      actions: <AleraTextActionMenuItem>[
+        for (final action in settings.textActions.enabledActions)
+          AleraTextActionMenuItem(id: action.id, label: action.name),
+      ],
       onOpen: (context, editableTextState) =>
           _openMenu(context, editableTextState, activeWorkspacePath),
+      onRun: (editableTextState, actionId) => unawaited(
+        _runAction(editableTextState, actionId, activeWorkspacePath),
+      ),
       child: widget.child,
     );
   }
@@ -96,13 +103,13 @@ class _TextActionsScopeState extends ConsumerState<TextActionsScope> {
       return;
     }
     unawaited(
-      _runAction(editableTextState, selectedAction, activeWorkspacePath),
+      _runAction(editableTextState, selectedAction.id, activeWorkspacePath),
     );
   }
 
   Future<void> _runAction(
     EditableTextState editableTextState,
-    TextAction action,
+    String actionId,
     String? activeWorkspacePath,
   ) async {
     if (!editableTextState.mounted ||
@@ -124,28 +131,39 @@ class _TextActionsScopeState extends ConsumerState<TextActionsScope> {
     if (selectedText.isEmpty) {
       return;
     }
+    final settings = ref.read(settingsControllerProvider);
+    final action = settings.textActions.actions
+        .where((candidate) => candidate.id == actionId && candidate.enabled)
+        .firstOrNull;
+    if (action == null) {
+      return;
+    }
     _runningFields.add(editableTextState);
     final runId = 'text-action-${++_runSequence}';
     AleraToast.publish(message: 'Running ${action.name}.');
     try {
-      final settings = ref.read(settingsControllerProvider);
-      final currentAction = settings.textActions.actions
+      final currentSettings = ref.read(settingsControllerProvider);
+      final currentAction = currentSettings.textActions.actions
           .where((candidate) => candidate.id == action.id)
           .firstOrNull;
       if (currentAction == null || !currentAction.enabled) {
         return;
       }
-      final agent = currentAction.effectiveAgent(settings.aiTextGeneration);
-      final model = currentAction.effectiveModel(settings.aiTextGeneration);
+      final agent = currentAction.effectiveAgent(
+        currentSettings.aiTextGeneration,
+      );
+      final model = currentAction.effectiveModel(
+        currentSettings.aiTextGeneration,
+      );
       final reasoning = currentAction.reasoningFor(
-        settings.aiTextGeneration,
+        currentSettings.aiTextGeneration,
         model: model,
       );
       final result = await ref
           .read(aiTextAgentRunnerProvider)
           .run(
             AiTextAgentRunRequest(
-              settings: settings.aiTextGeneration,
+              settings: currentSettings.aiTextGeneration,
               prompt: buildTextActionPrompt(
                 instruction: currentAction.prompt,
                 selectedText: selectedText,

--- a/lib/src/features/workbench/presentation/terminal_composer.dart
+++ b/lib/src/features/workbench/presentation/terminal_composer.dart
@@ -1,0 +1,67 @@
+import 'dart:async';
+
+import 'package:alera/src/design_system/feedback/alera_toast.dart';
+import 'package:alera/src/design_system/forms/alera_composer.dart';
+import 'package:alera/src/design_system/forms/alera_text_actions_scope.dart';
+import 'package:alera/src/features/workbench/presentation/terminal_runtime.dart';
+import 'package:flutter/material.dart';
+
+class TerminalComposer extends StatelessWidget {
+  const TerminalComposer({super.key, required this.session});
+
+  final TerminalSessionHandle session;
+
+  @override
+  Widget build(BuildContext context) {
+    final composer = session.composerController;
+    final textActionsScope = AleraTextActionsScope.maybeOf(context);
+    return AleraComposer(
+      controller: composer.textController,
+      focusNode: composer.focusNode,
+      enabled: !composer.submitting,
+      textActions: textActionsScope?.enabled == true
+          ? textActionsScope!.actions
+          : const [],
+      onTextActionSelected: (actionId) {
+        final focusContext = composer.focusNode.context;
+        final editableTextState = focusContext
+            ?.findAncestorStateOfType<EditableTextState>();
+        if (editableTextState != null) {
+          textActionsScope?.run(editableTextState, actionId);
+        }
+      },
+      onSend: () => unawaited(_send(context)),
+      onClose: composer.hide,
+    );
+  }
+
+  Future<void> _send(BuildContext context) async {
+    final composer = session.composerController;
+    final prompt = composer.textController.text;
+    if (composer.submitting || prompt.trim().isEmpty) {
+      return;
+    }
+    composer.setSubmitting(true);
+    try {
+      final submitted = await session.submitText(prompt);
+      if (!submitted) {
+        AleraToast.publish(
+          message: 'The terminal could not accept the prompt.',
+          tone: AleraToastTone.error,
+        );
+        return;
+      }
+      if (context.mounted && composer.textController.text == prompt) {
+        composer.textController.clear();
+        composer.focusNode.requestFocus();
+      }
+    } on Object catch (error) {
+      AleraToast.publish(
+        message: 'The terminal could not accept the prompt: $error',
+        tone: AleraToastTone.error,
+      );
+    } finally {
+      composer.setSubmitting(false);
+    }
+  }
+}

--- a/lib/src/features/workbench/presentation/terminal_composer_controller.dart
+++ b/lib/src/features/workbench/presentation/terminal_composer_controller.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+
+class TerminalComposerController extends ChangeNotifier {
+  final textController = TextEditingController();
+  final focusNode = FocusNode(debugLabel: 'TerminalComposer');
+
+  bool _visible = false;
+  bool _submitting = false;
+  bool _disposed = false;
+
+  bool get visible => _visible;
+  bool get submitting => _submitting;
+
+  void toggle() => _setVisible(!_visible);
+
+  void show() => _setVisible(true);
+
+  void hide() => _setVisible(false);
+
+  void setSubmitting(bool value) {
+    if (_disposed || _submitting == value) {
+      return;
+    }
+    _submitting = value;
+    notifyListeners();
+  }
+
+  void _setVisible(bool value) {
+    if (_disposed || _visible == value) {
+      return;
+    }
+    _visible = value;
+    notifyListeners();
+  }
+
+  @override
+  void dispose() {
+    if (_disposed) {
+      return;
+    }
+    _disposed = true;
+    textController.dispose();
+    focusNode.dispose();
+    super.dispose();
+  }
+}

--- a/lib/src/features/workbench/presentation/terminal_runtime.dart
+++ b/lib/src/features/workbench/presentation/terminal_runtime.dart
@@ -7,6 +7,7 @@ import 'dart:isolate';
 
 import 'package:alera/src/features/settings/domain/alera_settings.dart';
 import 'package:alera/src/features/workbench/presentation/terminal_buffer_budget.dart';
+import 'package:alera/src/features/workbench/presentation/terminal_composer_controller.dart';
 import 'package:alera/src/features/workbench/presentation/terminal_link_resolver.dart';
 import 'package:alera/src/features/workbench/presentation/terminal_search_controller.dart';
 import 'package:alera/src/features/settings/domain/terminal_theme_catalog.dart';
@@ -49,6 +50,9 @@ part 'terminal_runtime_restore_progress.dart';
 part 'terminal_runtime_testing.dart';
 
 abstract class TerminalSessionHandle extends ChangeNotifier {
+  final TerminalComposerController composerController =
+      TerminalComposerController();
+
   String get tabId;
 
   String get workspaceId;
@@ -120,6 +124,11 @@ abstract class TerminalSessionHandle extends ChangeNotifier {
   ///
   /// Default is a no-op so test doubles stay source-compatible.
   void pasteText(String text) {}
+
+  /// Pastes [text] into the foreground terminal process and presses Enter.
+  ///
+  /// Returns false when the PTY could not accept the prompt.
+  Future<bool> submitText(String text) async => false;
 
   /// The per-session terminal scrollback search model, when supported.
   TerminalSearchController? get searchController => null;

--- a/lib/src/features/workbench/presentation/terminal_runtime_search.dart
+++ b/lib/src/features/workbench/presentation/terminal_runtime_search.dart
@@ -103,6 +103,7 @@ mixin _TerminalSearchSessionSupport on TerminalSessionHandle {
     _focusNode.dispose();
     _titleNotifier.dispose();
     _restoreProgress.dispose();
+    composerController.dispose();
     super.dispose();
   }
 

--- a/lib/src/features/workbench/presentation/terminal_runtime_session_handle.dart
+++ b/lib/src/features/workbench/presentation/terminal_runtime_session_handle.dart
@@ -653,6 +653,20 @@ class _XtermTerminalSessionHandle extends TerminalSessionHandle
   @override
   void pasteText(String text) => _pasteTerminalText(this, text);
 
+  @override
+  Future<bool> submitText(String text) async {
+    if (_disposed || text.trim().isEmpty) {
+      return false;
+    }
+    await ensureStarted();
+    if (_disposed || !_running || _ptySession == null) {
+      return false;
+    }
+    _pasteTerminalText(this, text);
+    _handleTerminalInput('\r');
+    return true;
+  }
+
   void _requestFocusNow() {
     if (_disposed || !_focusNode.canRequestFocus) {
       return;

--- a/lib/src/features/workbench/presentation/terminal_surface.dart
+++ b/lib/src/features/workbench/presentation/terminal_surface.dart
@@ -8,6 +8,7 @@ import 'package:alera/src/features/keyboard/application/keybinding_resolver.dart
 import 'package:alera/src/features/keyboard/application/keyboard_command_dispatcher.dart';
 import 'package:alera/src/features/keyboard/domain/key_chord.dart';
 import 'package:alera/src/features/keyboard/domain/keyboard_action.dart';
+import 'package:alera/src/features/workbench/presentation/terminal_composer.dart';
 import 'package:alera/src/features/workbench/presentation/terminal_path_drop.dart';
 import 'package:alera/src/features/workbench/presentation/terminal_runtime.dart';
 import 'package:alera/src/features/workbench/presentation/terminal_search_overlay.dart';
@@ -34,11 +35,13 @@ class _TerminalSurfaceState extends ConsumerState<TerminalSurface> {
   TerminalVisibilityLease? _visibilityLease;
   bool _refreshing = false;
   int _refreshGeneration = 0;
+  late bool _composerVisible;
 
   @override
   void initState() {
     super.initState();
     _visibilityLease = widget.session.acquireVisibility();
+    _attachComposer(widget.session);
     _scheduleStart(widget.session);
   }
 
@@ -50,6 +53,8 @@ class _TerminalSurfaceState extends ConsumerState<TerminalSurface> {
       _refreshing = false;
       _visibilityLease?.dispose();
       _visibilityLease = widget.session.acquireVisibility();
+      _detachComposer(oldWidget.session);
+      _attachComposer(widget.session);
       _scheduleStart(widget.session);
     }
   }
@@ -58,7 +63,35 @@ class _TerminalSurfaceState extends ConsumerState<TerminalSurface> {
   void dispose() {
     _visibilityLease?.dispose();
     _visibilityLease = null;
+    _detachComposer(widget.session);
     super.dispose();
+  }
+
+  void _attachComposer(TerminalSessionHandle session) {
+    _composerVisible = session.composerController.visible;
+    session.composerController.addListener(_handleComposerChanged);
+  }
+
+  void _detachComposer(TerminalSessionHandle session) {
+    session.composerController.removeListener(_handleComposerChanged);
+  }
+
+  void _handleComposerChanged() {
+    final visible = widget.session.composerController.visible;
+    if (visible == _composerVisible) {
+      return;
+    }
+    _composerVisible = visible;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted || widget.session.composerController.visible != visible) {
+        return;
+      }
+      if (visible) {
+        widget.session.composerController.focusNode.requestFocus();
+      } else {
+        widget.session.requestFocus();
+      }
+    });
   }
 
   void _scheduleStart(TerminalSessionHandle session) {
@@ -115,7 +148,10 @@ class _TerminalSurfaceState extends ConsumerState<TerminalSurface> {
   @override
   Widget build(BuildContext context) {
     return AnimatedBuilder(
-      animation: widget.session,
+      animation: Listenable.merge(<Listenable>[
+        widget.session,
+        widget.session.composerController,
+      ]),
       builder: (context, _) {
         final error = switch (widget.session.errorMessage) {
           final String message when message.trim().isNotEmpty => message,
@@ -140,84 +176,121 @@ class _TerminalSurfaceState extends ConsumerState<TerminalSurface> {
                 paths: details.data.paths,
               );
             },
-            builder: (context, _, _) => Stack(
+            builder: (context, _, _) => Column(
               children: <Widget>[
-                Positioned.fill(
-                  child: error == null
-                      ? DecoratedBox(
-                          decoration: const BoxDecoration(
-                            color: AleraTokens.bg,
-                          ),
-                          child: widget.session.buildView(
-                            autofocus: widget.autofocus,
-                            onKeyEvent: _handleTerminalKey,
-                          ),
-                        )
-                      : _TerminalErrorState(
-                          message: error,
-                          onReconnect: widget.session.reconnect,
-                          onRestart: widget.session.canRestart
-                              ? () => _confirmRestart(context)
-                              : null,
+                Expanded(
+                  child: Stack(
+                    children: <Widget>[
+                      Positioned.fill(
+                        child: error == null
+                            ? DecoratedBox(
+                                decoration: const BoxDecoration(
+                                  color: AleraTokens.bg,
+                                ),
+                                child: widget.session.buildView(
+                                  autofocus: widget.autofocus,
+                                  onKeyEvent: _handleTerminalKey,
+                                ),
+                              )
+                            : _TerminalErrorState(
+                                message: error,
+                                onReconnect: widget.session.reconnect,
+                                onRestart: widget.session.canRestart
+                                    ? () => _confirmRestart(context)
+                                    : null,
+                              ),
+                      ),
+                      if (operation != null)
+                        Positioned.fill(
+                          child: _TerminalOperationState(operation: operation),
                         ),
-                ),
-                if (operation != null)
-                  Positioned.fill(
-                    child: _TerminalOperationState(operation: operation),
-                  ),
-                // Restoring an evicted terminal replays its whole scrollback over
-                // several frames. The corner spinner does not read as a wait that
-                // long, so cover the area until the history is back.
-                if (error == null)
-                  Positioned.fill(
-                    child: ValueListenableBuilder<TerminalRestoreProgress?>(
-                      valueListenable: widget.session.restoreProgress,
-                      builder: (context, progress, _) {
-                        if (progress == null) {
-                          return const SizedBox.shrink();
-                        }
-                        return _TerminalRestoreState(progress: progress);
-                      },
-                    ),
-                  ),
-                Positioned(
-                  top: AleraTokens.space4,
-                  right: searchOpen
-                      ? AleraTokens.space48 + AleraTokens.space4
-                      : AleraTokens.space4,
-                  child: AleraIconButton(
-                    tooltip: _refreshing
-                        ? 'Refreshing Terminal'
-                        : 'Refresh Terminal',
-                    icon: _refreshing ? AleraIcons.loading : AleraIcons.refresh,
-                    backgroundColor: AleraTokens.surfaceElevated,
-                    borderColor: AleraTokens.borderSubtle,
-                    onPressed: _refreshing
-                        ? null
-                        : () => unawaited(_refreshTerminal()),
-                  ),
-                ),
-                if (searchController != null && searchOpen)
-                  Positioned(
-                    top: AleraTokens.space4,
-                    left: AleraTokens.space16,
-                    right: AleraTokens.space48 + AleraTokens.space4,
-                    child: Align(
-                      alignment: Alignment.topRight,
-                      child: ConstrainedBox(
-                        constraints: const BoxConstraints(
-                          maxWidth: AleraTokens.dialogWideWidth,
+                      // Restoring an evicted terminal replays its whole scrollback over
+                      // several frames. The corner spinner does not read as a wait that
+                      // long, so cover the area until the history is back.
+                      if (error == null)
+                        Positioned.fill(
+                          child:
+                              ValueListenableBuilder<TerminalRestoreProgress?>(
+                                valueListenable: widget.session.restoreProgress,
+                                builder: (context, progress, _) {
+                                  if (progress == null) {
+                                    return const SizedBox.shrink();
+                                  }
+                                  return _TerminalRestoreState(
+                                    progress: progress,
+                                  );
+                                },
+                              ),
                         ),
-                        child: TerminalSearchOverlay(
-                          controller: searchController,
-                          onClose: () {
-                            widget.session.closeSearch();
-                            widget.session.requestFocus();
-                          },
+                      Positioned(
+                        top: AleraTokens.space4,
+                        right: searchOpen
+                            ? AleraTokens.space48 + AleraTokens.space4
+                            : AleraTokens.space4,
+                        child: AleraIconButton(
+                          tooltip: _refreshing
+                              ? 'Refreshing Terminal'
+                              : 'Refresh Terminal',
+                          icon: _refreshing
+                              ? AleraIcons.loading
+                              : AleraIcons.refresh,
+                          backgroundColor: AleraTokens.surfaceElevated,
+                          borderColor: AleraTokens.borderSubtle,
+                          onPressed: _refreshing
+                              ? null
+                              : () => unawaited(_refreshTerminal()),
                         ),
                       ),
-                    ),
+                      Positioned(
+                        top:
+                            AleraTokens.space4 +
+                            AleraTokens.space32 +
+                            AleraTokens.space4,
+                        right: searchOpen
+                            ? AleraTokens.space48 + AleraTokens.space4
+                            : AleraTokens.space4,
+                        child: AleraIconButton(
+                          tooltip: widget.session.composerController.visible
+                              ? 'Hide Terminal Composer'
+                              : 'Show Terminal Composer',
+                          icon: AleraIcons.ai,
+                          iconColor: widget.session.composerController.visible
+                              ? AleraTokens.foreground
+                              : AleraTokens.foregroundMuted,
+                          backgroundColor:
+                              widget.session.composerController.visible
+                              ? AleraTokens.accentSubtle
+                              : AleraTokens.surfaceElevated,
+                          borderColor: AleraTokens.borderSubtle,
+                          onPressed: widget.session.composerController.toggle,
+                        ),
+                      ),
+                      if (searchController != null && searchOpen)
+                        Positioned(
+                          top: AleraTokens.space4,
+                          left: AleraTokens.space16,
+                          right: AleraTokens.space48 + AleraTokens.space4,
+                          child: Align(
+                            alignment: Alignment.topRight,
+                            child: ConstrainedBox(
+                              constraints: const BoxConstraints(
+                                maxWidth: AleraTokens.dialogWideWidth,
+                              ),
+                              child: TerminalSearchOverlay(
+                                controller: searchController,
+                                onClose: () {
+                                  widget.session.closeSearch();
+                                  widget.session.requestFocus();
+                                },
+                              ),
+                            ),
+                          ),
+                        ),
+                    ],
                   ),
+                ),
+                if (widget.session.composerController.visible)
+                  TerminalComposer(session: widget.session),
               ],
             ),
           ),

--- a/test/widget/alera_composer_test.dart
+++ b/test/widget/alera_composer_test.dart
@@ -1,0 +1,88 @@
+import 'package:alera/src/design_system/forms/alera_composer.dart';
+import 'package:alera/src/design_system/forms/alera_text_actions_scope.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('Enter sends while Shift+Enter inserts a line break', (
+    tester,
+  ) async {
+    final controller = TextEditingController();
+    final focusNode = FocusNode();
+    var sends = 0;
+    addTearDown(controller.dispose);
+    addTearDown(focusNode.dispose);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: AleraComposer(
+            controller: controller,
+            focusNode: focusNode,
+            onSend: () => sends += 1,
+            onClose: () {},
+            textActions: const <AleraTextActionMenuItem>[],
+            onTextActionSelected: (_) {},
+          ),
+        ),
+      ),
+    );
+
+    await tester.enterText(find.byType(TextField), 'Prompt');
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.shiftLeft);
+    await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+    await tester.sendKeyUpEvent(LogicalKeyboardKey.shiftLeft);
+    await tester.pump();
+
+    expect(controller.text, 'Prompt\n');
+    expect(sends, 0);
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+    await tester.pump();
+
+    expect(sends, 1);
+  });
+
+  testWidgets(
+    'configured Text Actions are available for selected prompt text',
+    (tester) async {
+      final controller = TextEditingController(text: 'Improve this');
+      final focusNode = FocusNode();
+      String? selectedAction;
+      addTearDown(controller.dispose);
+      addTearDown(focusNode.dispose);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AleraComposer(
+              controller: controller,
+              focusNode: focusNode,
+              onSend: () {},
+              onClose: () {},
+              textActions: const <AleraTextActionMenuItem>[
+                AleraTextActionMenuItem(id: 'concise', label: 'Make Concise'),
+              ],
+              onTextActionSelected: (id) => selectedAction = id,
+            ),
+          ),
+        ),
+      );
+
+      controller.selection = const TextSelection(
+        baseOffset: 0,
+        extentOffset: 7,
+      );
+      await tester.pump();
+      await tester.tap(find.text('Text Actions'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Make Concise'), findsOneWidget);
+      await tester.tap(find.text('Make Concise'));
+      await tester.pumpAndSettle();
+
+      expect(selectedAction, 'concise');
+    },
+  );
+}

--- a/test/widget/keyboard_command_dispatcher_test.dart
+++ b/test/widget/keyboard_command_dispatcher_test.dart
@@ -139,6 +139,13 @@ void main() {
       ref: harness.ref,
       context: harness.context,
     );
+    final activeSession = runtime.sessionFor(
+      workspace: workspace,
+      tab: firstTab,
+    );
+
+    dispatcher.dispatch(KeyboardActionId.toggleTerminalComposer);
+    expect(activeSession.composerController.visible, isTrue);
 
     dispatcher.dispatch(KeyboardActionId.newTerminalTab);
     await tester.pump();

--- a/test/widget/terminal_surface_composer_test_cases.dart
+++ b/test/widget/terminal_surface_composer_test_cases.dart
@@ -1,0 +1,96 @@
+part of 'terminal_surface_test.dart';
+
+void _registerTerminalSurfaceComposerTests() {
+  testWidgets('composer control sits below refresh and submits a prompt', (
+    tester,
+  ) async {
+    final session = _ImmediateNotifySessionHandle(tabId: 'tab-1');
+
+    await _pumpTerminalSurface(tester, session);
+
+    final refreshRect = tester.getRect(find.byTooltip('Refresh Terminal'));
+    final composerRect = tester.getRect(
+      find.byTooltip('Show Terminal Composer'),
+    );
+    expect(composerRect.top, greaterThan(refreshRect.bottom));
+    expect(composerRect.right, refreshRect.right);
+
+    await tester.tap(find.byTooltip('Show Terminal Composer'));
+    await tester.pump();
+
+    expect(find.byTooltip('Hide Terminal Composer'), findsOneWidget);
+    expect(find.text('Text Actions'), findsOneWidget);
+
+    await tester.enterText(find.byType(TextField), 'Review this change');
+    await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+    await tester.pump();
+
+    expect(session.submittedTexts, <String>['Review this change']);
+    expect(find.text('Review this change'), findsNothing);
+  });
+
+  testWidgets('composer exposes configured Text Actions for prompt selection', (
+    tester,
+  ) async {
+    final session = _ImmediateNotifySessionHandle(tabId: 'tab-1');
+    String? selectedActionId;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: AleraTextActionsScope(
+            enabled: true,
+            actions: const <AleraTextActionMenuItem>[
+              AleraTextActionMenuItem(id: 'concise', label: 'Make Concise'),
+            ],
+            onOpen: (_, _) {},
+            onRun: (_, actionId) => selectedActionId = actionId,
+            child: SizedBox.expand(child: TerminalSurface(session: session)),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.tap(find.byTooltip('Show Terminal Composer'));
+    await tester.pump();
+
+    await tester.enterText(find.byType(TextField), 'Improve this prompt');
+    session.composerController.textController.selection = const TextSelection(
+      baseOffset: 0,
+      extentOffset: 7,
+    );
+    await tester.pump();
+    await tester.tap(find.text('Text Actions'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Make Concise'));
+    await tester.pumpAndSettle();
+
+    expect(selectedActionId, 'concise');
+  });
+
+  testWidgets('runtime prompt submission pastes text before Enter', (
+    tester,
+  ) async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.linux;
+    try {
+      final factory = _FakeTerminalPtySessionFactory();
+      final runtime = XtermTerminalRuntime(
+        ptySessionFactory: factory,
+        shellLaunchesBuilder: _testShellLaunches,
+      );
+      addTearDown(runtime.dispose);
+      final session = runtime.sessionFor(workspace: _workspace(), tab: _tab());
+
+      await session.ensureStarted();
+      final submitted = await session.submitText('Review this change');
+
+      expect(submitted, isTrue);
+      expect(factory.sessions.single.writes.map(utf8.decode).toList(), <String>[
+        'Review this change',
+        '\r',
+      ]);
+    } finally {
+      debugDefaultTargetPlatformOverride = null;
+    }
+  });
+}

--- a/test/widget/terminal_surface_core_test_cases.dart
+++ b/test/widget/terminal_surface_core_test_cases.dart
@@ -57,7 +57,11 @@ void _registerTerminalSurfaceRuntimeTests() {
 
     expect(find.byTooltip('Refreshing Terminal'), findsOneWidget);
     expect(
-      tester.widget<IconButton>(find.byType(IconButton)).onPressed,
+      tester
+          .widget<IconButton>(
+            find.widgetWithIcon(IconButton, AleraIcons.loading),
+          )
+          .onPressed,
       isNull,
     );
     expect(session.refreshRenderingCallCount, 1);

--- a/test/widget/terminal_surface_interaction_test_cases.dart
+++ b/test/widget/terminal_surface_interaction_test_cases.dart
@@ -366,6 +366,22 @@ void _registerTerminalSurfaceInteractionTests() {
         expect(allowedSearchResult, KeyEventResult.handled);
         expect(allowedSession.openSearchCallCount, 1);
 
+        await tester.sendKeyDownEvent(LogicalKeyboardKey.metaLeft);
+        await tester.sendKeyDownEvent(LogicalKeyboardKey.shiftLeft);
+        final composerResult = allowedSession.onKeyEvent!.call(
+          focusNode,
+          const KeyDownEvent(
+            timeStamp: Duration.zero,
+            physicalKey: PhysicalKeyboardKey.enter,
+            logicalKey: LogicalKeyboardKey.enter,
+          ),
+        );
+        await tester.sendKeyUpEvent(LogicalKeyboardKey.shiftLeft);
+        await tester.sendKeyUpEvent(LogicalKeyboardKey.metaLeft);
+
+        expect(composerResult, KeyEventResult.handled);
+        expect(allowedSession.composerController.visible, isTrue);
+
         final blockedSession = _ShortcutCaptureSessionHandle(tabId: 'tab-2');
         final blockedController = _FakeWorkbenchController();
         await pumpShortcutSurface(

--- a/test/widget/terminal_surface_test.dart
+++ b/test/widget/terminal_surface_test.dart
@@ -3,6 +3,8 @@ import 'dart:convert';
 
 import 'package:alera/src/app/providers.dart';
 import 'package:alera/src/app/theme/alera_tokens.dart';
+import 'package:alera/src/design_system/forms/alera_text_actions_scope.dart';
+import 'package:alera/src/design_system/icons/alera_icons.dart';
 import 'package:alera/src/features/keyboard/domain/keyboard_action.dart';
 import 'package:alera/src/shared/infra/uri/external_uri_launcher.dart';
 import 'package:alera/src/features/settings/domain/alera_settings.dart';
@@ -22,12 +24,14 @@ import 'package:ghostty_vte_flutter/ghostty_vte_flutter.dart';
 import 'package:xterm/xterm.dart' as xterm;
 
 part 'terminal_surface_core_test_cases.dart';
+part 'terminal_surface_composer_test_cases.dart';
 part 'terminal_surface_interaction_test_cases.dart';
 part 'terminal_surface_tab_switch_test_cases.dart';
 part 'terminal_surface_test_harness.dart';
 
 void main() {
   _registerTerminalSurfaceRuntimeTests();
+  _registerTerminalSurfaceComposerTests();
   _registerTerminalSurfaceInteractionTests();
   _registerTerminalSurfaceTabSwitchTests();
 }

--- a/test/widget/terminal_surface_test_harness.dart
+++ b/test/widget/terminal_surface_test_harness.dart
@@ -205,6 +205,7 @@ class _ImmediateNotifySessionHandle extends TerminalSessionHandle {
 
   int ensureStartedCallCount = 0;
   int refreshRenderingCallCount = 0;
+  final List<String> submittedTexts = <String>[];
   bool _started = false;
 
   @override
@@ -254,6 +255,12 @@ class _ImmediateNotifySessionHandle extends TerminalSessionHandle {
   Future<void> refreshRendering() async {
     refreshRenderingCallCount += 1;
     await refreshCompleter?.future;
+  }
+
+  @override
+  Future<bool> submitText(String text) async {
+    submittedTexts.add(text);
+    return true;
   }
 
   @override


### PR DESCRIPTION
## Summary

- add a per-terminal prompt composer matching the ACP chat Compose styling
- toggle Compose from the terminal toolbar or the configurable Mod+Shift+Enter shortcut
- submit prompts through the terminal PTY and expose configured Text Actions for selected prompt text
- add design-system previews and widget coverage for interaction, geometry, shortcuts, and submission

## Validation

- `flutter pub run build_runner build -d`
- `dart format --set-exit-if-changed lib test integration_test tool`
- `flutter analyze`
- `flutter test` (2641 tests)
- `dart tool/quality/check_max_lines.dart`
- mobile `dart format --set-exit-if-changed lib test integration_test tool`
- mobile `flutter analyze`
- mobile `flutter test` (217 tests)
- `git diff --check`

## Notes

- Local `gh act` prerequisites passed, but the static job could not initialize required submodules in this linked worktree because `act` reported `fatal: not a git repository: (null)`. Hosted GitHub Actions are the authoritative CI run.