### PR TITLE
feat: refine terminal composer controls

### DIFF
--- a/lib/src/design_system/icons/alera_icons.dart
+++ b/lib/src/design_system/icons/alera_icons.dart
@@ -167,6 +167,8 @@ abstract final class AleraIcons {
   static const IconData terminal = LucideIcons.terminal;
   static const IconData code = LucideIcons.code;
   static const IconData keyboard = LucideIcons.keyboard;
+  // Prompt composer: write/send a message into the active terminal.
+  static const IconData composer = LucideIcons.messageSquarePlus;
   static const IconData ai = LucideIcons.sparkles;
   static const IconData package = LucideIcons.package;
   static const IconData public = LucideIcons.globe;

--- a/lib/src/features/settings/domain/alera_settings.dart
+++ b/lib/src/features/settings/domain/alera_settings.dart
@@ -71,6 +71,7 @@ class TerminalSettings with TerminalSettingsMappable {
     this.tuiScrollSensitivity = 1,
     this.clipboardOnSelect = false,
     this.allowOsc52Clipboard = false,
+    this.showComposerByDefault = false,
     this.hostEmptyShutdownDelaySeconds = 30,
     this.hostDetachedSessionShutdownDelaySeconds = 60 * 60,
     this.hostScrollbackBytes = 10 * 1000 * 1000,
@@ -96,6 +97,9 @@ class TerminalSettings with TerminalSettingsMappable {
   final int tuiScrollSensitivity;
   final bool clipboardOnSelect;
   final bool allowOsc52Clipboard;
+
+  /// Whether new terminal sessions open the prompt composer immediately.
+  final bool showComposerByDefault;
   final int hostEmptyShutdownDelaySeconds;
   final int hostDetachedSessionShutdownDelaySeconds;
   final int hostScrollbackBytes;
@@ -137,6 +141,7 @@ class TerminalSettings with TerminalSettingsMappable {
     tuiScrollSensitivity: 1,
     clipboardOnSelect: false,
     allowOsc52Clipboard: false,
+    showComposerByDefault: false,
     hostEmptyShutdownDelaySeconds: 30,
     hostDetachedSessionShutdownDelaySeconds: 60 * 60,
     hostScrollbackBytes: 10 * 1000 * 1000,

--- a/lib/src/features/settings/domain/alera_settings.mapper.dart
+++ b/lib/src/features/settings/domain/alera_settings.mapper.dart
@@ -484,6 +484,14 @@ class TerminalSettingsMapper extends ClassMapperBase<TerminalSettings> {
     opt: true,
     def: false,
   );
+  static bool _$showComposerByDefault(TerminalSettings v) =>
+      v.showComposerByDefault;
+  static const Field<TerminalSettings, bool> _f$showComposerByDefault = Field(
+    'showComposerByDefault',
+    _$showComposerByDefault,
+    opt: true,
+    def: false,
+  );
   static int _$hostEmptyShutdownDelaySeconds(TerminalSettings v) =>
       v.hostEmptyShutdownDelaySeconds;
   static const Field<TerminalSettings, int> _f$hostEmptyShutdownDelaySeconds =
@@ -552,6 +560,7 @@ class TerminalSettingsMapper extends ClassMapperBase<TerminalSettings> {
     #tuiScrollSensitivity: _f$tuiScrollSensitivity,
     #clipboardOnSelect: _f$clipboardOnSelect,
     #allowOsc52Clipboard: _f$allowOsc52Clipboard,
+    #showComposerByDefault: _f$showComposerByDefault,
     #hostEmptyShutdownDelaySeconds: _f$hostEmptyShutdownDelaySeconds,
     #hostDetachedSessionShutdownDelaySeconds:
         _f$hostDetachedSessionShutdownDelaySeconds,
@@ -582,6 +591,7 @@ class TerminalSettingsMapper extends ClassMapperBase<TerminalSettings> {
       tuiScrollSensitivity: data.dec(_f$tuiScrollSensitivity),
       clipboardOnSelect: data.dec(_f$clipboardOnSelect),
       allowOsc52Clipboard: data.dec(_f$allowOsc52Clipboard),
+      showComposerByDefault: data.dec(_f$showComposerByDefault),
       hostEmptyShutdownDelaySeconds: data.dec(_f$hostEmptyShutdownDelaySeconds),
       hostDetachedSessionShutdownDelaySeconds: data.dec(
         _f$hostDetachedSessionShutdownDelaySeconds,
@@ -679,6 +689,7 @@ abstract class TerminalSettingsCopyWith<$R, $In extends TerminalSettings, $Out>
     int? tuiScrollSensitivity,
     bool? clipboardOnSelect,
     bool? allowOsc52Clipboard,
+    bool? showComposerByDefault,
     int? hostEmptyShutdownDelaySeconds,
     int? hostDetachedSessionShutdownDelaySeconds,
     int? hostScrollbackBytes,
@@ -726,6 +737,7 @@ class _TerminalSettingsCopyWithImpl<$R, $Out>
     int? tuiScrollSensitivity,
     bool? clipboardOnSelect,
     bool? allowOsc52Clipboard,
+    bool? showComposerByDefault,
     int? hostEmptyShutdownDelaySeconds,
     int? hostDetachedSessionShutdownDelaySeconds,
     int? hostScrollbackBytes,
@@ -753,6 +765,8 @@ class _TerminalSettingsCopyWithImpl<$R, $Out>
       if (clipboardOnSelect != null) #clipboardOnSelect: clipboardOnSelect,
       if (allowOsc52Clipboard != null)
         #allowOsc52Clipboard: allowOsc52Clipboard,
+      if (showComposerByDefault != null)
+        #showComposerByDefault: showComposerByDefault,
       if (hostEmptyShutdownDelaySeconds != null)
         #hostEmptyShutdownDelaySeconds: hostEmptyShutdownDelaySeconds,
       if (hostDetachedSessionShutdownDelaySeconds != null)
@@ -797,6 +811,10 @@ class _TerminalSettingsCopyWithImpl<$R, $Out>
     allowOsc52Clipboard: data.get(
       #allowOsc52Clipboard,
       or: $value.allowOsc52Clipboard,
+    ),
+    showComposerByDefault: data.get(
+      #showComposerByDefault,
+      or: $value.showComposerByDefault,
     ),
     hostEmptyShutdownDelaySeconds: data.get(
       #hostEmptyShutdownDelaySeconds,

--- a/lib/src/features/settings/presentation/panes/terminal_pane.dart
+++ b/lib/src/features/settings/presentation/panes/terminal_pane.dart
@@ -237,6 +237,14 @@ class TerminalSettingsPane extends StatelessWidget {
                 onChanged: (value) =>
                     onChanged(settings.copyWith(allowOsc52Clipboard: value)),
               ),
+              SettingsSwitchRow(
+                title: 'Show Terminal Composer By Default',
+                description:
+                    'Open the prompt composer when a new terminal session starts.',
+                value: settings.showComposerByDefault,
+                onChanged: (value) =>
+                    onChanged(settings.copyWith(showComposerByDefault: value)),
+              ),
             ],
           ),
         ),

--- a/lib/src/features/settings/presentation/settings_search_entries_terminal.dart
+++ b/lib/src/features/settings/presentation/settings_search_entries_terminal.dart
@@ -96,6 +96,12 @@ const List<SettingsSearchEntry> terminalSearchEntries = <SettingsSearchEntry>[
     groupId: 'interaction',
   ),
   SettingsSearchEntry(
+    title: 'Show Terminal Composer By Default',
+    description: 'Open the prompt composer when a new terminal session starts.',
+    keywords: <String>['composer', 'prompt', 'input', 'default'],
+    groupId: 'interaction',
+  ),
+  SettingsSearchEntry(
     title: 'Scrollback Lines',
     description: 'Maximum terminal history retained per session.',
     keywords: <String>['history', 'buffer'],

--- a/lib/src/features/workbench/presentation/terminal_runtime_session_handle.dart
+++ b/lib/src/features/workbench/presentation/terminal_runtime_session_handle.dart
@@ -18,9 +18,6 @@ class _XtermTerminalSessionHandle extends TerminalSessionHandle
     this._onExit,
     this._onVisibilityChanged,
   ) {
-    if (_settings.showComposerByDefault) {
-      composerController.show();
-    }
     _terminal = _createTerminal();
     _osc8LinkTracker = Osc8TerminalLinkTracker(terminal: _terminal);
     _attachTerminal(_terminal);

--- a/lib/src/features/workbench/presentation/terminal_runtime_session_handle.dart
+++ b/lib/src/features/workbench/presentation/terminal_runtime_session_handle.dart
@@ -18,6 +18,9 @@ class _XtermTerminalSessionHandle extends TerminalSessionHandle
     this._onExit,
     this._onVisibilityChanged,
   ) {
+    if (_settings.showComposerByDefault) {
+      composerController.show();
+    }
     _terminal = _createTerminal();
     _osc8LinkTracker = Osc8TerminalLinkTracker(terminal: _terminal);
     _attachTerminal(_terminal);

--- a/lib/src/features/workbench/presentation/terminal_runtime_xterm_runtime.dart
+++ b/lib/src/features/workbench/presentation/terminal_runtime_xterm_runtime.dart
@@ -78,7 +78,7 @@ class XtermTerminalRuntime implements TerminalRuntime {
   }) {
     return _sessions
         .putIfAbsent(tab.id, () {
-          return _XtermTerminalSessionHandle(
+          final handle = _XtermTerminalSessionHandle(
             workspace,
             tab,
             _ptySessionFactory,
@@ -94,6 +94,12 @@ class XtermTerminalRuntime implements TerminalRuntime {
             _handleSessionExit,
             _handleVisibilityChanged,
           )..setAppForeground(_appForeground);
+          // Apply only at session creation so toggling the setting later does
+          // not reopen composers the user already closed.
+          if (_settings.showComposerByDefault) {
+            handle.composerController.show();
+          }
+          return handle;
         })
         .sync(workspace: workspace, tab: tab);
   }

--- a/lib/src/features/workbench/presentation/terminal_surface.dart
+++ b/lib/src/features/workbench/presentation/terminal_surface.dart
@@ -224,52 +224,53 @@ class _TerminalSurfaceState extends ConsumerState<TerminalSurface> {
                         ),
                       Positioned(
                         top: AleraTokens.space4,
-                        right: searchOpen
-                            ? AleraTokens.space48 + AleraTokens.space4
-                            : AleraTokens.space4,
-                        child: AleraIconButton(
-                          tooltip: _refreshing
-                              ? 'Refreshing Terminal'
-                              : 'Refresh Terminal',
-                          icon: _refreshing
-                              ? AleraIcons.loading
-                              : AleraIcons.refresh,
-                          backgroundColor: AleraTokens.surfaceElevated,
-                          borderColor: AleraTokens.borderSubtle,
-                          onPressed: _refreshing
-                              ? null
-                              : () => unawaited(_refreshTerminal()),
-                        ),
-                      ),
-                      Positioned(
-                        top:
-                            AleraTokens.space4 +
-                            AleraTokens.space32 +
-                            AleraTokens.space4,
-                        right: searchOpen
-                            ? AleraTokens.space48 + AleraTokens.space4
-                            : AleraTokens.space4,
-                        child: AleraIconButton(
-                          tooltip: widget.session.composerController.visible
-                              ? 'Hide Terminal Composer'
-                              : 'Show Terminal Composer',
-                          icon: AleraIcons.ai,
-                          iconColor: widget.session.composerController.visible
-                              ? AleraTokens.foreground
-                              : AleraTokens.foregroundMuted,
-                          backgroundColor:
-                              widget.session.composerController.visible
-                              ? AleraTokens.accentSubtle
-                              : AleraTokens.surfaceElevated,
-                          borderColor: AleraTokens.borderSubtle,
-                          onPressed: widget.session.composerController.toggle,
+                        right: AleraTokens.space4,
+                        child: Row(
+                          mainAxisSize: MainAxisSize.min,
+                          spacing: AleraTokens.space2,
+                          children: <Widget>[
+                            AleraIconButton(
+                              tooltip: widget.session.composerController.visible
+                                  ? 'Hide Terminal Composer'
+                                  : 'Show Terminal Composer',
+                              icon: AleraIcons.composer,
+                              iconColor:
+                                  widget.session.composerController.visible
+                                  ? AleraTokens.foreground
+                                  : AleraTokens.foregroundMuted,
+                              backgroundColor:
+                                  widget.session.composerController.visible
+                                  ? AleraTokens.accentSubtle
+                                  : AleraTokens.surfaceElevated,
+                              borderColor: AleraTokens.borderSubtle,
+                              onPressed:
+                                  widget.session.composerController.toggle,
+                            ),
+                            AleraIconButton(
+                              tooltip: _refreshing
+                                  ? 'Refreshing Terminal'
+                                  : 'Refresh Terminal',
+                              icon: _refreshing
+                                  ? AleraIcons.loading
+                                  : AleraIcons.refresh,
+                              backgroundColor: AleraTokens.surfaceElevated,
+                              borderColor: AleraTokens.borderSubtle,
+                              onPressed: _refreshing
+                                  ? null
+                                  : () => unawaited(_refreshTerminal()),
+                            ),
+                          ],
                         ),
                       ),
                       if (searchController != null && searchOpen)
                         Positioned(
                           top: AleraTokens.space4,
                           left: AleraTokens.space16,
-                          right: AleraTokens.space48 + AleraTokens.space4,
+                          // Leave room for the composer + refresh toolbar.
+                          right:
+                              AleraTokens.space48 +
+                              AleraTokens.space48 +
+                              AleraTokens.space4,
                           child: Align(
                             alignment: Alignment.topRight,
                             child: ConstrainedBox(

--- a/test/unit/alera_settings_test.dart
+++ b/test/unit/alera_settings_test.dart
@@ -28,6 +28,7 @@ void main() {
       expect(terminal.tuiScrollSensitivity, 1);
       expect(terminal.clipboardOnSelect, isFalse);
       expect(terminal.allowOsc52Clipboard, isFalse);
+      expect(terminal.showComposerByDefault, isFalse);
       expect(terminal.hostEmptyShutdownDelaySeconds, 30);
       expect(terminal.hostDetachedSessionShutdownDelaySeconds, 60 * 60);
       expect(terminal.hostScrollbackBytes, 10 * 1000 * 1000);
@@ -233,6 +234,7 @@ void main() {
         'tuiScrollSensitivity': 4,
         'clipboardOnSelect': true,
         'allowOsc52Clipboard': true,
+        'showComposerByDefault': true,
         'hostEmptyShutdownDelaySeconds': 45,
         'hostDetachedSessionShutdownDelaySeconds': 600,
         'hostScrollbackBytes': 16 * 1000 * 1000,
@@ -250,6 +252,7 @@ void main() {
       expect(restored.tuiScrollSensitivity, 4);
       expect(restored.clipboardOnSelect, isTrue);
       expect(restored.allowOsc52Clipboard, isTrue);
+      expect(restored.showComposerByDefault, isTrue);
       expect(restored.hostEmptyShutdownDelaySeconds, 45);
       expect(restored.hostDetachedSessionShutdownDelaySeconds, 600);
       expect(restored.hostScrollbackBytes, 16 * 1000 * 1000);

--- a/test/widget/terminal_surface_composer_test_cases.dart
+++ b/test/widget/terminal_surface_composer_test_cases.dart
@@ -1,7 +1,7 @@
 part of 'terminal_surface_test.dart';
 
 void _registerTerminalSurfaceComposerTests() {
-  testWidgets('composer control sits below refresh and submits a prompt', (
+  testWidgets('composer control sits left of refresh and submits a prompt', (
     tester,
   ) async {
     final session = _ImmediateNotifySessionHandle(tabId: 'tab-1');
@@ -12,8 +12,8 @@ void _registerTerminalSurfaceComposerTests() {
     final composerRect = tester.getRect(
       find.byTooltip('Show Terminal Composer'),
     );
-    expect(composerRect.top, greaterThan(refreshRect.bottom));
-    expect(composerRect.right, refreshRect.right);
+    expect(composerRect.right, lessThan(refreshRect.left));
+    expect(composerRect.top, refreshRect.top);
 
     await tester.tap(find.byTooltip('Show Terminal Composer'));
     await tester.pump();


### PR DESCRIPTION
## Summary
- switch the terminal composer toggle to a dedicated `messageSquarePlus` icon and place it left of refresh
- add `Show Terminal Composer By Default` under Terminal settings (off by default)
- open the composer automatically only for newly created terminal sessions when the setting is enabled

## Test plan
- [x] `flutter test test/unit/alera_settings_test.dart test/widget/terminal_surface_test.dart`
- [x] confirm the composer button sits left of refresh in a live terminal
- [x] toggle Settings → Terminal → Show Terminal Composer By Default and open a new terminal tab
- [x] verify existing terminal sessions keep their current composer visibility