### PR TITLE
feat: refine terminal composer actions and image paste

### DIFF
--- a/lib/src/design_system/forms/alera_clipboard_paste_action.dart
+++ b/lib/src/design_system/forms/alera_clipboard_paste_action.dart
@@ -1,0 +1,30 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+/// Lets a field consume non-text clipboard content before Flutter pastes text.
+final class AleraClipboardPasteAction extends Action<PasteTextIntent> {
+  AleraClipboardPasteAction(this._onPaste);
+
+  final Future<bool> Function() _onPaste;
+
+  @override
+  bool get isActionEnabled => callingAction?.isActionEnabled ?? true;
+
+  @override
+  Object? invoke(PasteTextIntent intent) {
+    final defaultAction = callingAction;
+    unawaited(_invokePaste(intent, defaultAction));
+    return null;
+  }
+
+  Future<void> _invokePaste(
+    PasteTextIntent intent,
+    Action<PasteTextIntent>? defaultAction,
+  ) async {
+    if (await _onPaste()) {
+      return;
+    }
+    defaultAction?.invoke(intent);
+  }
+}

--- a/lib/src/design_system/forms/alera_composer.dart
+++ b/lib/src/design_system/forms/alera_composer.dart
@@ -1,5 +1,6 @@
 import 'package:alera/src/app/theme/alera_tokens.dart';
 import 'package:alera/src/design_system/buttons/alera_icon_button.dart';
+import 'package:alera/src/design_system/forms/alera_clipboard_paste_action.dart';
 import 'package:alera/src/design_system/forms/alera_text_actions_scope.dart';
 import 'package:alera/src/design_system/icons/alera_icons.dart';
 import 'package:alera/src/design_system/menus/alera_dropdown_entry.dart';
@@ -15,6 +16,7 @@ class AleraComposer extends StatefulWidget {
     required this.onClose,
     required this.textActions,
     required this.onTextActionSelected,
+    this.onPaste,
     this.enabled = true,
     this.hintText = 'Write a prompt for this terminal',
   });
@@ -25,6 +27,12 @@ class AleraComposer extends StatefulWidget {
   final VoidCallback onClose;
   final List<AleraTextActionMenuItem> textActions;
   final ValueChanged<String> onTextActionSelected;
+
+  /// Handles a paste before the default text action runs.
+  ///
+  /// Return `true` when the callback consumed the clipboard. Returning
+  /// `false` preserves Flutter's normal text-paste behavior.
+  final Future<bool> Function()? onPaste;
   final bool enabled;
   final String hintText;
 
@@ -89,6 +97,51 @@ class _AleraComposerState extends State<AleraComposer> {
     );
   }
 
+  Widget _buildTextField(BuildContext context) {
+    final field = TextField(
+      controller: widget.controller,
+      focusNode: widget.focusNode,
+      enabled: widget.enabled,
+      minLines: 2,
+      maxLines: 6,
+      textInputAction: TextInputAction.newline,
+      style: Theme.of(context).textTheme.bodyMedium,
+      contextMenuBuilder: (context, editableTextState) {
+        return AleraTextActionsScope.buildContextMenu(
+          context,
+          editableTextState,
+          onPaste: widget.onPaste,
+        );
+      },
+      decoration: InputDecoration(
+        hintText: widget.hintText,
+        filled: true,
+        fillColor: Colors.transparent,
+        hoverColor: Colors.transparent,
+        contentPadding: const EdgeInsets.fromLTRB(
+          AleraTokens.space12,
+          AleraTokens.space16,
+          AleraTokens.space12,
+          AleraTokens.space8,
+        ),
+        border: InputBorder.none,
+        enabledBorder: InputBorder.none,
+        focusedBorder: InputBorder.none,
+        disabledBorder: InputBorder.none,
+      ),
+    );
+    final onPaste = widget.onPaste;
+    if (onPaste == null) {
+      return field;
+    }
+    return Actions(
+      actions: <Type, Action<Intent>>{
+        PasteTextIntent: AleraClipboardPasteAction(onPaste),
+      },
+      child: field,
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final textActionsEnabled = widget.textActions.isNotEmpty && _hasSelection;
@@ -111,32 +164,7 @@ class _AleraComposerState extends State<AleraComposer> {
                 const SingleActivator(LogicalKeyboardKey.escape):
                     widget.onClose,
               },
-              child: TextField(
-                controller: widget.controller,
-                focusNode: widget.focusNode,
-                enabled: widget.enabled,
-                minLines: 2,
-                maxLines: 6,
-                textInputAction: TextInputAction.newline,
-                style: Theme.of(context).textTheme.bodyMedium,
-                contextMenuBuilder: AleraTextActionsScope.buildContextMenu,
-                decoration: InputDecoration(
-                  hintText: widget.hintText,
-                  filled: true,
-                  fillColor: Colors.transparent,
-                  hoverColor: Colors.transparent,
-                  contentPadding: const EdgeInsets.fromLTRB(
-                    AleraTokens.space12,
-                    AleraTokens.space16,
-                    AleraTokens.space12,
-                    AleraTokens.space8,
-                  ),
-                  border: InputBorder.none,
-                  enabledBorder: InputBorder.none,
-                  focusedBorder: InputBorder.none,
-                  disabledBorder: InputBorder.none,
-                ),
-              ),
+              child: _buildTextField(context),
             ),
             Padding(
               padding: const EdgeInsets.fromLTRB(
@@ -206,12 +234,24 @@ class _TextActionsMenu extends StatelessWidget {
         enabled: enabled,
         tooltip: '',
         onSelected: onSelected,
+        constraints: const BoxConstraints(minWidth: 220),
         color: AleraTokens.surface,
         shape: RoundedRectangleBorder(
           borderRadius: BorderRadius.circular(AleraTokens.radiusMd),
           side: const BorderSide(color: AleraTokens.border),
         ),
         itemBuilder: (context) => <PopupMenuEntry<String>>[
+          PopupMenuItem<String>(
+            enabled: false,
+            height: AleraTokens.space32,
+            padding: const EdgeInsets.symmetric(horizontal: AleraTokens.space8),
+            child: Text(
+              'Select Text Action',
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                color: AleraTokens.foregroundFaint,
+              ),
+            ),
+          ),
           for (final action in actions)
             AleraDropdownEntry<String>(value: action.id, label: action.label),
         ],

--- a/lib/src/design_system/forms/alera_text_field.dart
+++ b/lib/src/design_system/forms/alera_text_field.dart
@@ -1,6 +1,5 @@
-import 'dart:async';
-
 import 'package:alera/src/app/theme/alera_tokens.dart';
+import 'package:alera/src/design_system/forms/alera_clipboard_paste_action.dart';
 import 'package:alera/src/design_system/forms/alera_text_actions_scope.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -192,7 +191,7 @@ class AleraTextField extends StatelessWidget {
     }
     return Actions(
       actions: <Type, Action<Intent>>{
-        PasteTextIntent: _ClipboardAwarePasteAction(paste),
+        PasteTextIntent: AleraClipboardPasteAction(paste),
       },
       child: field,
     );
@@ -214,30 +213,4 @@ class AleraTextField extends StatelessWidget {
     borderRadius: BorderRadius.circular(AleraTokens.radiusLg),
     borderSide: BorderSide(color: color),
   );
-}
-
-final class _ClipboardAwarePasteAction extends Action<PasteTextIntent> {
-  _ClipboardAwarePasteAction(this._onPaste);
-
-  final Future<bool> Function() _onPaste;
-
-  @override
-  bool get isActionEnabled => callingAction?.isActionEnabled ?? true;
-
-  @override
-  Object? invoke(PasteTextIntent intent) {
-    final defaultAction = callingAction;
-    unawaited(_invokePaste(intent, defaultAction));
-    return null;
-  }
-
-  Future<void> _invokePaste(
-    PasteTextIntent intent,
-    Action<PasteTextIntent>? defaultAction,
-  ) async {
-    if (await _onPaste()) {
-      return;
-    }
-    defaultAction?.invoke(intent);
-  }
 }

--- a/lib/src/features/workbench/presentation/terminal_composer.dart
+++ b/lib/src/features/workbench/presentation/terminal_composer.dart
@@ -3,13 +3,20 @@ import 'dart:async';
 import 'package:alera/src/design_system/feedback/alera_toast.dart';
 import 'package:alera/src/design_system/forms/alera_composer.dart';
 import 'package:alera/src/design_system/forms/alera_text_actions_scope.dart';
+import 'package:alera/src/features/workbench/domain/terminal_image_paste.dart';
+import 'package:alera/src/features/workbench/infra/terminal_clipboard.dart';
 import 'package:alera/src/features/workbench/presentation/terminal_runtime.dart';
 import 'package:flutter/material.dart';
 
 class TerminalComposer extends StatelessWidget {
-  const TerminalComposer({super.key, required this.session});
+  const TerminalComposer({
+    super.key,
+    required this.session,
+    this.clipboard = const NativeTerminalClipboard(),
+  });
 
   final TerminalSessionHandle session;
+  final TerminalClipboard clipboard;
 
   @override
   Widget build(BuildContext context) {
@@ -30,9 +37,57 @@ class TerminalComposer extends StatelessWidget {
           textActionsScope?.run(editableTextState, actionId);
         }
       },
+      onPaste: _pasteClipboard,
       onSend: () => unawaited(_send(context)),
       onClose: composer.hide,
     );
+  }
+
+  Future<bool> _pasteClipboard() async {
+    String? clipboardText;
+    try {
+      clipboardText = await clipboard.readText();
+    } catch (_) {
+      // Image-only clipboards can reject text reads on some platforms.
+    }
+    if (clipboardText != null && clipboardText.isNotEmpty) {
+      return false;
+    }
+    try {
+      final imagePath = await clipboard.saveImageAsTempFile();
+      if (imagePath == null || imagePath.isEmpty) {
+        return false;
+      }
+      final composer = session.composerController;
+      final focusContext = composer.focusNode.context;
+      if (focusContext == null || !focusContext.mounted) {
+        return true;
+      }
+      final value = composer.textController.value;
+      final selection = _validSelection(value);
+      composer.textController.value = value.replaced(
+        selection,
+        sanitizeTerminalImagePastePath(imagePath),
+      );
+      composer.focusNode.requestFocus();
+      return true;
+    } catch (_) {
+      AleraToast.publish(
+        message: 'Could not paste clipboard image.',
+        tone: AleraToastTone.error,
+      );
+      return true;
+    }
+  }
+
+  TextSelection _validSelection(TextEditingValue value) {
+    final selection = value.selection;
+    if (selection.isValid &&
+        selection.start <= value.text.length &&
+        selection.end <= value.text.length) {
+      return selection;
+    }
+    return TextSelection.collapsed(offset: value.text.length);
   }
 
   Future<void> _send(BuildContext context) async {

--- a/test/widget/alera_composer_test.dart
+++ b/test/widget/alera_composer_test.dart
@@ -78,6 +78,7 @@ void main() {
       await tester.tap(find.text('Text Actions'));
       await tester.pumpAndSettle();
 
+      expect(find.text('Select Text Action'), findsOneWidget);
       expect(find.text('Make Concise'), findsOneWidget);
       await tester.tap(find.text('Make Concise'));
       await tester.pumpAndSettle();

--- a/test/widget/terminal_surface_composer_test_cases.dart
+++ b/test/widget/terminal_surface_composer_test_cases.dart
@@ -93,4 +93,107 @@ void _registerTerminalSurfaceComposerTests() {
       debugDefaultTargetPlatformOverride = null;
     }
   });
+
+  testWidgets('composer pastes an image path at the current selection', (
+    tester,
+  ) async {
+    final session = _ImmediateNotifySessionHandle(tabId: 'tab-1');
+    final clipboard = _FakeComposerClipboard(
+      imagePath: '/tmp/alera-paste-\x1b.png',
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: TerminalComposer(session: session, clipboard: clipboard),
+        ),
+      ),
+    );
+    await tester.enterText(find.byType(TextField), 'Review this placeholder');
+    session.composerController.textController.selection = const TextSelection(
+      baseOffset: 12,
+      extentOffset: 23,
+    );
+    final focusContext = tester.binding.focusManager.primaryFocus?.context;
+    expect(focusContext, isNotNull);
+
+    Actions.invoke(
+      focusContext!,
+      const PasteTextIntent(SelectionChangedCause.keyboard),
+    );
+    await tester.pump();
+    await tester.pump();
+
+    expect(
+      session.composerController.textController.text,
+      'Review this /tmp/alera-paste-\u241b.png',
+    );
+    expect(clipboard.imageReads, 1);
+  });
+
+  testWidgets('composer preserves native text paste without probing images', (
+    tester,
+  ) async {
+    tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+      SystemChannels.platform,
+      (call) async {
+        if (call.method == 'Clipboard.getData') {
+          return <String, Object?>{'text': 'clipboard text'};
+        }
+        return null;
+      },
+    );
+    addTearDown(
+      () => tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        SystemChannels.platform,
+        null,
+      ),
+    );
+    final session = _ImmediateNotifySessionHandle(tabId: 'tab-1');
+    final clipboard = _FakeComposerClipboard(text: 'clipboard text');
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: TerminalComposer(session: session, clipboard: clipboard),
+        ),
+      ),
+    );
+    await tester.enterText(find.byType(TextField), 'Before ');
+    final focusContext = tester.binding.focusManager.primaryFocus?.context;
+    expect(focusContext, isNotNull);
+
+    Actions.invoke(
+      focusContext!,
+      const PasteTextIntent(SelectionChangedCause.keyboard),
+    );
+    await tester.pump();
+    await tester.pumpAndSettle();
+
+    expect(
+      session.composerController.textController.text,
+      'Before clipboard text',
+    );
+    expect(clipboard.imageReads, 0);
+  });
+}
+
+final class _FakeComposerClipboard implements TerminalClipboard {
+  _FakeComposerClipboard({this.text, this.imagePath});
+
+  final String? text;
+  final String? imagePath;
+  int imageReads = 0;
+
+  @override
+  Future<String?> readText() async => text;
+
+  @override
+  Future<String?> saveImageAsTempFile() async {
+    imageReads += 1;
+    return imagePath;
+  }
+
+  @override
+  Future<void> writeText(String text) async {}
 }

--- a/test/widget/terminal_surface_test.dart
+++ b/test/widget/terminal_surface_test.dart
@@ -12,6 +12,8 @@ import 'package:alera/src/features/settings/domain/terminal_theme_catalog.dart';
 import 'package:alera/src/features/workbench/application/workbench_state.dart';
 import 'package:alera/src/features/workbench/domain/workspace_tab_record.dart';
 import 'package:alera/src/features/workbench/domain/workspace.dart';
+import 'package:alera/src/features/workbench/infra/terminal_clipboard.dart';
+import 'package:alera/src/features/workbench/presentation/terminal_composer.dart';
 import 'package:alera/src/features/workbench/presentation/terminal_runtime.dart';
 import 'package:alera/src/features/workbench/presentation/terminal_surface.dart';
 import 'package:flutter/gestures.dart';


### PR DESCRIPTION
## Summary

- align the Terminal Composer Text Actions popup with the ACP model selector structure
- paste image-only clipboard content as a sanitized temporary path at the current composer selection
- preserve native text paste behavior through a shared clipboard-aware paste action

## Validation

- dart format --set-exit-if-changed lib test integration_test tool
- flutter analyze
- flutter test (2643 tests)
- dart tool/quality/check_max_lines.dart
- mobile dart format --set-exit-if-changed lib test
- mobile flutter analyze
- mobile flutter test (217 tests)
- git diff --check

## Notes

- gh act pull_request -W .github/workflows/pr.yml was attempted. Docker image authentication and linked-worktree submodule initialization failed before project validation ran, so hosted GitHub Actions remain authoritative.