### PR TITLE
feat: add terminal composer attachments

### DIFF
--- a/lib/src/design_system/forms/alera_composer.dart
+++ b/lib/src/design_system/forms/alera_composer.dart
@@ -17,6 +17,8 @@ class AleraComposer extends StatefulWidget {
     required this.textActions,
     required this.onTextActionSelected,
     this.onPaste,
+    this.attachmentBar,
+    this.hasAttachments = false,
     this.enabled = true,
     this.hintText = 'Write a prompt for this terminal',
   });
@@ -33,6 +35,8 @@ class AleraComposer extends StatefulWidget {
   /// Return `true` when the callback consumed the clipboard. Returning
   /// `false` preserves Flutter's normal text-paste behavior.
   final Future<bool> Function()? onPaste;
+  final Widget? attachmentBar;
+  final bool hasAttachments;
   final bool enabled;
   final String hintText;
 
@@ -65,7 +69,8 @@ class _AleraComposerState extends State<AleraComposer> {
   void _handleControllerChanged() => setState(() {});
 
   bool get _canSend =>
-      widget.enabled && widget.controller.text.trim().isNotEmpty;
+      widget.enabled &&
+      (widget.controller.text.trim().isNotEmpty || widget.hasAttachments);
 
   bool get _hasSelection {
     final value = widget.controller.value;
@@ -156,6 +161,7 @@ class _AleraComposerState extends State<AleraComposer> {
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: <Widget>[
+            ?widget.attachmentBar,
             CallbackShortcuts(
               bindings: <ShortcutActivator, VoidCallback>{
                 const SingleActivator(LogicalKeyboardKey.enter): _send,

--- a/lib/src/design_system/forms/alera_composer.preview.dart
+++ b/lib/src/design_system/forms/alera_composer.preview.dart
@@ -1,9 +1,11 @@
 import 'package:alera/src/design_system/alera_preview.dart';
+import 'package:alera/src/app/theme/alera_tokens.dart';
 import 'package:alera/src/design_system/forms/alera_composer.dart';
 import 'package:alera/src/design_system/forms/alera_text_actions_scope.dart';
+import 'package:alera/src/design_system/icons/alera_icons.dart';
 import 'package:flutter/material.dart';
 
-@AleraPreview(name: 'Terminal', group: 'Composer', size: Size(560, 180))
+@AleraPreview(name: 'Terminal', group: 'Composer', size: Size(560, 220))
 Widget aleraComposerPreview() => const _ComposerPreview();
 
 class _ComposerPreview extends StatefulWidget {
@@ -31,11 +33,64 @@ class _ComposerPreviewState extends State<_ComposerPreview> {
       focusNode: _focusNode,
       onSend: _controller.clear,
       onClose: () {},
+      hasAttachments: true,
+      attachmentBar: const _PreviewAttachmentBar(),
       textActions: const <AleraTextActionMenuItem>[
         AleraTextActionMenuItem(id: 'improve', label: 'Improve Writing'),
         AleraTextActionMenuItem(id: 'shorten', label: 'Make Concise'),
       ],
       onTextActionSelected: (_) {},
+    );
+  }
+}
+
+class _PreviewAttachmentBar extends StatelessWidget {
+  const _PreviewAttachmentBar();
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(
+        AleraTokens.space8,
+        AleraTokens.space8,
+        AleraTokens.space8,
+        0,
+      ),
+      child: Align(
+        alignment: Alignment.centerLeft,
+        child: Container(
+          height: AleraTokens.space32,
+          decoration: BoxDecoration(
+            color: AleraTokens.surface,
+            borderRadius: BorderRadius.circular(AleraTokens.radiusMd),
+          ),
+          child: const Row(
+            mainAxisSize: MainAxisSize.min,
+            children: <Widget>[
+              SizedBox(
+                width: AleraTokens.space32,
+                child: Icon(
+                  AleraIcons.imageError,
+                  size: AleraTokens.space16,
+                  color: AleraTokens.foregroundFaint,
+                ),
+              ),
+              Padding(
+                padding: EdgeInsets.symmetric(horizontal: AleraTokens.space6),
+                child: Text('terminal-screenshot.png'),
+              ),
+              Padding(
+                padding: EdgeInsets.all(AleraTokens.space6),
+                child: Icon(
+                  AleraIcons.close,
+                  size: AleraTokens.space12,
+                  color: AleraTokens.foregroundFaint,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
     );
   }
 }

--- a/lib/src/features/workbench/application/terminal_composer_workspace_attachment.dart
+++ b/lib/src/features/workbench/application/terminal_composer_workspace_attachment.dart
@@ -1,0 +1,56 @@
+import 'package:alera/src/features/workbench/application/workspace_file_preview_kind.dart';
+import 'package:alera/src/features/workbench/application/workspace_file_service.dart';
+import 'package:alera/src/rust/api/workspace_files.dart' as native;
+import 'package:path/path.dart' as p;
+
+Future<bool> openTerminalComposerWorkspaceAttachment({
+  required String workspacePath,
+  required String filePath,
+  required WorkspaceFileService workspaceFiles,
+  required Future<void> Function(String relativePath) openFile,
+}) async {
+  final relativePath = terminalComposerWorkspaceRelativePath(
+    workspacePath: workspacePath,
+    filePath: filePath,
+  );
+  if (relativePath == null) {
+    return false;
+  }
+
+  try {
+    switch (workspaceFilePreviewKindForPath(relativePath)) {
+      case WorkspaceFilePreviewKind.image:
+      case WorkspaceFilePreviewKind.pdf:
+        await workspaceFiles.resolveWorkspaceFilePath(
+          workspacePath: workspacePath,
+          relativePath: relativePath,
+        );
+      case WorkspaceFilePreviewKind.text:
+      case WorkspaceFilePreviewKind.merman:
+        await workspaceFiles.readTextFile(
+          workspacePath: workspacePath,
+          relativePath: relativePath,
+        );
+    }
+  } on native.WorkspaceFileError {
+    return false;
+  }
+
+  await openFile(relativePath);
+  return true;
+}
+
+String? terminalComposerWorkspaceRelativePath({
+  required String workspacePath,
+  required String filePath,
+}) {
+  if (!p.isAbsolute(filePath)) {
+    return null;
+  }
+  final normalizedWorkspacePath = p.normalize(workspacePath);
+  final normalizedFilePath = p.normalize(filePath);
+  if (!p.isWithin(normalizedWorkspacePath, normalizedFilePath)) {
+    return null;
+  }
+  return p.relative(normalizedFilePath, from: normalizedWorkspacePath);
+}

--- a/lib/src/features/workbench/domain/terminal_composer_attachment.dart
+++ b/lib/src/features/workbench/domain/terminal_composer_attachment.dart
@@ -1,0 +1,32 @@
+import 'package:path/path.dart' as p;
+
+enum TerminalComposerAttachmentKind { image, file }
+
+final class TerminalComposerAttachment {
+  const TerminalComposerAttachment({
+    required this.id,
+    required this.kind,
+    required this.path,
+    required this.displayName,
+  });
+
+  final String id;
+  final TerminalComposerAttachmentKind kind;
+  final String path;
+  final String displayName;
+}
+
+TerminalComposerAttachmentKind terminalComposerAttachmentKindForPath(
+  String path,
+) {
+  final extension = p.extension(path).toLowerCase();
+  return const <String>{
+        '.gif',
+        '.jpeg',
+        '.jpg',
+        '.png',
+        '.webp',
+      }.contains(extension)
+      ? TerminalComposerAttachmentKind.image
+      : TerminalComposerAttachmentKind.file;
+}

--- a/lib/src/features/workbench/domain/terminal_composer_submission.dart
+++ b/lib/src/features/workbench/domain/terminal_composer_submission.dart
@@ -1,0 +1,34 @@
+import 'package:alera/src/features/workbench/domain/terminal_composer_attachment.dart';
+import 'package:alera/src/features/workbench/domain/terminal_image_paste.dart';
+
+String buildTerminalComposerSubmission({
+  required String prompt,
+  required Iterable<TerminalComposerAttachment> attachments,
+}) {
+  final images = <String>[];
+  final files = <String>[];
+  for (final attachment in attachments) {
+    final path = sanitizeTerminalImagePastePath(attachment.path);
+    if (path.isEmpty) {
+      continue;
+    }
+    switch (attachment.kind) {
+      case TerminalComposerAttachmentKind.image:
+        images.add(path);
+      case TerminalComposerAttachmentKind.file:
+        files.add(path);
+    }
+  }
+  final sections = <String>[
+    if (images.isNotEmpty) ...<String>['Attached images:', ...images],
+    if (files.isNotEmpty) ...<String>['Attached files:', ...files],
+  ];
+  if (sections.isEmpty) {
+    return prompt;
+  }
+  final attachmentText = sections.join('\n');
+  if (prompt.trim().isEmpty) {
+    return attachmentText;
+  }
+  return '$prompt\n\n$attachmentText';
+}

--- a/lib/src/features/workbench/infra/terminal_clipboard.dart
+++ b/lib/src/features/workbench/infra/terminal_clipboard.dart
@@ -2,11 +2,14 @@ import 'dart:io';
 
 import 'package:alera/src/rust/api/clipboard.dart' as native_clipboard;
 import 'package:flutter/services.dart';
+import 'package:pasteboard/pasteboard.dart';
 
 abstract interface class TerminalClipboard {
   Future<String?> readText();
 
   Future<void> writeText(String text);
+
+  Future<List<String>> readFilePaths();
 
   Future<String?> saveImageAsTempFile();
 }
@@ -28,6 +31,9 @@ final class NativeTerminalClipboard implements TerminalClipboard {
   Future<void> writeText(String text) {
     return Clipboard.setData(ClipboardData(text: text));
   }
+
+  @override
+  Future<List<String>> readFilePaths() => Pasteboard.files();
 
   @override
   Future<String?> saveImageAsTempFile() {

--- a/lib/src/features/workbench/presentation/terminal_composer.dart
+++ b/lib/src/features/workbench/presentation/terminal_composer.dart
@@ -19,11 +19,13 @@ class TerminalComposer extends StatelessWidget {
     required this.session,
     this.clipboard = const NativeTerminalClipboard(),
     this.externalUriLauncher,
+    this.onOpenWorkspaceFile,
   });
 
   final TerminalSessionHandle session;
   final TerminalClipboard clipboard;
   final ExternalUriLauncher? externalUriLauncher;
+  final Future<bool> Function(String path)? onOpenWorkspaceFile;
 
   @override
   Widget build(BuildContext context) {
@@ -116,6 +118,9 @@ class TerminalComposer extends StatelessWidget {
 
   Future<void> _openFile(String path) async {
     try {
+      if (await onOpenWorkspaceFile?.call(path) == true) {
+        return;
+      }
       await (externalUriLauncher ?? UrlLauncherExternalUriLauncher()).open(
         Uri.file(path),
       );

--- a/lib/src/features/workbench/presentation/terminal_composer.dart
+++ b/lib/src/features/workbench/presentation/terminal_composer.dart
@@ -3,47 +3,76 @@ import 'dart:async';
 import 'package:alera/src/design_system/feedback/alera_toast.dart';
 import 'package:alera/src/design_system/forms/alera_composer.dart';
 import 'package:alera/src/design_system/forms/alera_text_actions_scope.dart';
+import 'package:alera/src/features/workbench/domain/terminal_composer_attachment.dart';
+import 'package:alera/src/features/workbench/domain/terminal_composer_submission.dart';
 import 'package:alera/src/features/workbench/domain/terminal_image_paste.dart';
 import 'package:alera/src/features/workbench/infra/terminal_clipboard.dart';
+import 'package:alera/src/features/workbench/presentation/terminal_composer_attachment_bar.dart';
 import 'package:alera/src/features/workbench/presentation/terminal_runtime.dart';
+import 'package:alera/src/shared/infra/uri/external_uri_launcher.dart';
 import 'package:flutter/material.dart';
+import 'package:path/path.dart' as p;
 
 class TerminalComposer extends StatelessWidget {
   const TerminalComposer({
     super.key,
     required this.session,
     this.clipboard = const NativeTerminalClipboard(),
+    this.externalUriLauncher,
   });
 
   final TerminalSessionHandle session;
   final TerminalClipboard clipboard;
+  final ExternalUriLauncher? externalUriLauncher;
 
   @override
   Widget build(BuildContext context) {
     final composer = session.composerController;
     final textActionsScope = AleraTextActionsScope.maybeOf(context);
-    return AleraComposer(
-      controller: composer.textController,
-      focusNode: composer.focusNode,
-      enabled: !composer.submitting,
-      textActions: textActionsScope?.enabled == true
-          ? textActionsScope!.actions
-          : const [],
-      onTextActionSelected: (actionId) {
-        final focusContext = composer.focusNode.context;
-        final editableTextState = focusContext
-            ?.findAncestorStateOfType<EditableTextState>();
-        if (editableTextState != null) {
-          textActionsScope?.run(editableTextState, actionId);
-        }
-      },
-      onPaste: _pasteClipboard,
-      onSend: () => unawaited(_send(context)),
-      onClose: composer.hide,
+    return AnimatedBuilder(
+      animation: composer,
+      builder: (context, _) => AleraComposer(
+        controller: composer.textController,
+        focusNode: composer.focusNode,
+        enabled: !composer.submitting,
+        hasAttachments: composer.attachments.isNotEmpty,
+        attachmentBar: TerminalComposerAttachmentBar(
+          attachments: composer.attachments,
+          onRemove: composer.removeAttachment,
+          onOpenFile: (path) => unawaited(_openFile(path)),
+          enabled: !composer.submitting,
+        ),
+        textActions: textActionsScope?.enabled == true
+            ? textActionsScope!.actions
+            : const [],
+        onTextActionSelected: (actionId) {
+          final focusContext = composer.focusNode.context;
+          final editableTextState = focusContext
+              ?.findAncestorStateOfType<EditableTextState>();
+          if (editableTextState != null) {
+            textActionsScope?.run(editableTextState, actionId);
+          }
+        },
+        onPaste: _pasteClipboard,
+        onSend: () => unawaited(_send(context)),
+        onClose: composer.hide,
+      ),
     );
   }
 
   Future<bool> _pasteClipboard() async {
+    try {
+      final filePaths = await clipboard.readFilePaths();
+      if (filePaths.isNotEmpty) {
+        for (final path in filePaths.where((path) => path.isNotEmpty)) {
+          _addAttachment(path);
+        }
+        session.composerController.focusNode.requestFocus();
+        return true;
+      }
+    } catch (_) {
+      // Fall through to text and image clipboard formats.
+    }
     String? clipboardText;
     try {
       clipboardText = await clipboard.readText();
@@ -59,16 +88,7 @@ class TerminalComposer extends StatelessWidget {
         return false;
       }
       final composer = session.composerController;
-      final focusContext = composer.focusNode.context;
-      if (focusContext == null || !focusContext.mounted) {
-        return true;
-      }
-      final value = composer.textController.value;
-      final selection = _validSelection(value);
-      composer.textController.value = value.replaced(
-        selection,
-        sanitizeTerminalImagePastePath(imagePath),
-      );
+      _addAttachment(imagePath, kind: TerminalComposerAttachmentKind.image);
       composer.focusNode.requestFocus();
       return true;
     } catch (_) {
@@ -80,25 +100,47 @@ class TerminalComposer extends StatelessWidget {
     }
   }
 
-  TextSelection _validSelection(TextEditingValue value) {
-    final selection = value.selection;
-    if (selection.isValid &&
-        selection.start <= value.text.length &&
-        selection.end <= value.text.length) {
-      return selection;
+  void _addAttachment(String path, {TerminalComposerAttachmentKind? kind}) {
+    final resolvedKind = kind ?? terminalComposerAttachmentKindForPath(path);
+    final displayName = sanitizeTerminalImagePastePath(p.basename(path));
+    session.composerController.addAttachment(
+      kind: resolvedKind,
+      path: path,
+      displayName: displayName.isEmpty
+          ? resolvedKind == TerminalComposerAttachmentKind.image
+                ? 'Pasted Image'
+                : 'Pasted File'
+          : displayName,
+    );
+  }
+
+  Future<void> _openFile(String path) async {
+    try {
+      await (externalUriLauncher ?? UrlLauncherExternalUriLauncher()).open(
+        Uri.file(path),
+      );
+    } on Object catch (error) {
+      AleraToast.publish(
+        message: 'Could not open attached file: $error',
+        tone: AleraToastTone.error,
+      );
     }
-    return TextSelection.collapsed(offset: value.text.length);
   }
 
   Future<void> _send(BuildContext context) async {
     final composer = session.composerController;
     final prompt = composer.textController.text;
-    if (composer.submitting || prompt.trim().isEmpty) {
+    final attachments = composer.attachments;
+    if (composer.submitting || (prompt.trim().isEmpty && attachments.isEmpty)) {
       return;
     }
+    final submission = buildTerminalComposerSubmission(
+      prompt: prompt,
+      attachments: attachments,
+    );
     composer.setSubmitting(true);
     try {
-      final submitted = await session.submitText(prompt);
+      final submitted = await session.submitText(submission);
       if (!submitted) {
         AleraToast.publish(
           message: 'The terminal could not accept the prompt.',
@@ -106,8 +148,13 @@ class TerminalComposer extends StatelessWidget {
         );
         return;
       }
-      if (context.mounted && composer.textController.text == prompt) {
+      if (composer.textController.text == prompt) {
         composer.textController.clear();
+      }
+      composer.removeAttachments(
+        attachments.map((attachment) => attachment.id),
+      );
+      if (context.mounted) {
         composer.focusNode.requestFocus();
       }
     } on Object catch (error) {

--- a/lib/src/features/workbench/presentation/terminal_composer.dart
+++ b/lib/src/features/workbench/presentation/terminal_composer.dart
@@ -5,13 +5,11 @@ import 'package:alera/src/design_system/forms/alera_composer.dart';
 import 'package:alera/src/design_system/forms/alera_text_actions_scope.dart';
 import 'package:alera/src/features/workbench/domain/terminal_composer_attachment.dart';
 import 'package:alera/src/features/workbench/domain/terminal_composer_submission.dart';
-import 'package:alera/src/features/workbench/domain/terminal_image_paste.dart';
 import 'package:alera/src/features/workbench/infra/terminal_clipboard.dart';
 import 'package:alera/src/features/workbench/presentation/terminal_composer_attachment_bar.dart';
 import 'package:alera/src/features/workbench/presentation/terminal_runtime.dart';
 import 'package:alera/src/shared/infra/uri/external_uri_launcher.dart';
 import 'package:flutter/material.dart';
-import 'package:path/path.dart' as p;
 
 class TerminalComposer extends StatelessWidget {
   const TerminalComposer({
@@ -66,10 +64,9 @@ class TerminalComposer extends StatelessWidget {
     try {
       final filePaths = await clipboard.readFilePaths();
       if (filePaths.isNotEmpty) {
-        for (final path in filePaths.where((path) => path.isNotEmpty)) {
-          _addAttachment(path);
-        }
-        session.composerController.focusNode.requestFocus();
+        final composer = session.composerController;
+        composer.addPathAttachments(filePaths);
+        composer.focusNode.requestFocus();
         return true;
       }
     } catch (_) {
@@ -90,7 +87,10 @@ class TerminalComposer extends StatelessWidget {
         return false;
       }
       final composer = session.composerController;
-      _addAttachment(imagePath, kind: TerminalComposerAttachmentKind.image);
+      composer.addPathAttachment(
+        imagePath,
+        kind: TerminalComposerAttachmentKind.image,
+      );
       composer.focusNode.requestFocus();
       return true;
     } catch (_) {
@@ -100,20 +100,6 @@ class TerminalComposer extends StatelessWidget {
       );
       return true;
     }
-  }
-
-  void _addAttachment(String path, {TerminalComposerAttachmentKind? kind}) {
-    final resolvedKind = kind ?? terminalComposerAttachmentKindForPath(path);
-    final displayName = sanitizeTerminalImagePastePath(p.basename(path));
-    session.composerController.addAttachment(
-      kind: resolvedKind,
-      path: path,
-      displayName: displayName.isEmpty
-          ? resolvedKind == TerminalComposerAttachmentKind.image
-                ? 'Pasted Image'
-                : 'Pasted File'
-          : displayName,
-    );
   }
 
   Future<void> _openFile(String path) async {

--- a/lib/src/features/workbench/presentation/terminal_composer_attachment_bar.dart
+++ b/lib/src/features/workbench/presentation/terminal_composer_attachment_bar.dart
@@ -1,0 +1,175 @@
+import 'dart:io';
+
+import 'package:alera/src/app/theme/alera_tokens.dart';
+import 'package:alera/src/design_system/buttons/alera_icon_button.dart';
+import 'package:alera/src/design_system/icons/alera_icons.dart';
+import 'package:alera/src/features/workbench/domain/terminal_composer_attachment.dart';
+import 'package:alera/src/features/workbench/presentation/terminal_composer_image_preview.dart';
+import 'package:flutter/material.dart';
+
+class TerminalComposerAttachmentBar extends StatelessWidget {
+  const TerminalComposerAttachmentBar({
+    super.key,
+    required this.attachments,
+    required this.onRemove,
+    required this.onOpenFile,
+    this.enabled = true,
+  });
+
+  final List<TerminalComposerAttachment> attachments;
+  final ValueChanged<String> onRemove;
+  final ValueChanged<String> onOpenFile;
+  final bool enabled;
+
+  @override
+  Widget build(BuildContext context) {
+    if (attachments.isEmpty) {
+      return const SizedBox.shrink();
+    }
+    final sortedAttachments = List<TerminalComposerAttachment>.of(attachments)
+      ..sort((a, b) => _kindOrder(a.kind).compareTo(_kindOrder(b.kind)));
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(
+        AleraTokens.space8,
+        AleraTokens.space8,
+        AleraTokens.space8,
+        0,
+      ),
+      child: SizedBox(
+        height: AleraTokens.space32,
+        child: ListView.separated(
+          scrollDirection: Axis.horizontal,
+          itemCount: sortedAttachments.length,
+          separatorBuilder: (_, _) => const SizedBox(width: AleraTokens.space4),
+          itemBuilder: (context, index) {
+            final attachment = sortedAttachments[index];
+            return _TerminalComposerAttachmentChip(
+              attachment: attachment,
+              onRemove: () => onRemove(attachment.id),
+              onOpenFile: () => onOpenFile(attachment.path),
+              enabled: enabled,
+            );
+          },
+        ),
+      ),
+    );
+  }
+
+  int _kindOrder(TerminalComposerAttachmentKind kind) =>
+      kind == TerminalComposerAttachmentKind.image ? 0 : 1;
+}
+
+class _TerminalComposerAttachmentChip extends StatelessWidget {
+  const _TerminalComposerAttachmentChip({
+    required this.attachment,
+    required this.onRemove,
+    required this.onOpenFile,
+    required this.enabled,
+  });
+
+  final TerminalComposerAttachment attachment;
+  final VoidCallback onRemove;
+  final VoidCallback onOpenFile;
+  final bool enabled;
+
+  void _open(BuildContext context) {
+    if (attachment.kind == TerminalComposerAttachmentKind.image) {
+      showTerminalComposerImagePreview(context, attachment.path);
+      return;
+    }
+    onOpenFile();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      key: ValueKey<String>('terminal-composer-attachment-${attachment.id}'),
+      color: AleraTokens.surface,
+      borderRadius: BorderRadius.circular(AleraTokens.radiusMd),
+      clipBehavior: Clip.antiAlias,
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: <Widget>[
+          Tooltip(
+            message: attachment.kind == TerminalComposerAttachmentKind.image
+                ? 'View Image'
+                : 'Open File',
+            child: Semantics(
+              button: true,
+              label: attachment.kind == TerminalComposerAttachmentKind.image
+                  ? 'View Image ${attachment.displayName}'
+                  : 'Open File ${attachment.displayName}',
+              child: InkWell(
+                key: ValueKey<String>(
+                  'terminal-composer-attachment-open-${attachment.id}',
+                ),
+                mouseCursor: SystemMouseCursors.click,
+                onTap: () => _open(context),
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: <Widget>[
+                    if (attachment.kind == TerminalComposerAttachmentKind.image)
+                      SizedBox(
+                        width: AleraTokens.space32,
+                        height: AleraTokens.space32,
+                        child: Image.file(
+                          File(attachment.path),
+                          fit: BoxFit.cover,
+                          cacheWidth: (AleraTokens.space32 * 2).round(),
+                          errorBuilder: (_, _, _) => const Icon(
+                            AleraIcons.imageError,
+                            size: AleraTokens.space16,
+                            color: AleraTokens.foregroundFaint,
+                          ),
+                        ),
+                      )
+                    else
+                      const SizedBox(
+                        width: AleraTokens.space32,
+                        height: AleraTokens.space32,
+                        child: Icon(
+                          AleraIcons.fileGeneric,
+                          size: AleraTokens.space16,
+                          color: AleraTokens.foregroundMuted,
+                        ),
+                      ),
+                    ConstrainedBox(
+                      constraints: const BoxConstraints(
+                        maxWidth: AleraTokens.masterDetailMinWidth,
+                      ),
+                      child: Padding(
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: AleraTokens.space6,
+                        ),
+                        child: Text(
+                          attachment.displayName,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: Theme.of(context).textTheme.labelMedium
+                              ?.copyWith(color: AleraTokens.foregroundMuted),
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+          AleraIconButton(
+            key: ValueKey<String>(
+              'terminal-composer-attachment-remove-${attachment.id}',
+            ),
+            tooltip: attachment.kind == TerminalComposerAttachmentKind.image
+                ? 'Remove Image'
+                : 'Remove File',
+            icon: AleraIcons.close,
+            iconSize: AleraTokens.space12,
+            minSize: AleraTokens.space24,
+            onPressed: enabled ? onRemove : null,
+          ),
+          const SizedBox(width: AleraTokens.space4),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/src/features/workbench/presentation/terminal_composer_controller.dart
+++ b/lib/src/features/workbench/presentation/terminal_composer_controller.dart
@@ -1,15 +1,63 @@
+import 'dart:collection';
+
+import 'package:alera/src/features/workbench/domain/terminal_composer_attachment.dart';
 import 'package:flutter/material.dart';
 
 class TerminalComposerController extends ChangeNotifier {
   final textController = TextEditingController();
   final focusNode = FocusNode(debugLabel: 'TerminalComposer');
 
+  final List<TerminalComposerAttachment> _attachments =
+      <TerminalComposerAttachment>[];
+  late final List<TerminalComposerAttachment> attachments =
+      UnmodifiableListView<TerminalComposerAttachment>(_attachments);
   bool _visible = false;
   bool _submitting = false;
   bool _disposed = false;
+  int _nextAttachmentId = 0;
 
   bool get visible => _visible;
   bool get submitting => _submitting;
+
+  void addAttachment({
+    required TerminalComposerAttachmentKind kind,
+    required String path,
+    required String displayName,
+  }) {
+    if (_disposed) {
+      return;
+    }
+    _attachments.add(
+      TerminalComposerAttachment(
+        id: 'attachment-${_nextAttachmentId++}',
+        kind: kind,
+        path: path,
+        displayName: displayName,
+      ),
+    );
+    notifyListeners();
+  }
+
+  void removeAttachment(String id) {
+    removeAttachments(<String>[id]);
+  }
+
+  void removeAttachments(Iterable<String> ids) {
+    if (_disposed) {
+      return;
+    }
+    final removedIds = ids.toSet();
+    if (removedIds.isEmpty) {
+      return;
+    }
+    final previousLength = _attachments.length;
+    _attachments.removeWhere(
+      (attachment) => removedIds.contains(attachment.id),
+    );
+    if (_attachments.length != previousLength) {
+      notifyListeners();
+    }
+  }
 
   void toggle() => _setVisible(!_visible);
 
@@ -39,6 +87,7 @@ class TerminalComposerController extends ChangeNotifier {
       return;
     }
     _disposed = true;
+    _attachments.clear();
     textController.dispose();
     focusNode.dispose();
     super.dispose();

--- a/lib/src/features/workbench/presentation/terminal_composer_controller.dart
+++ b/lib/src/features/workbench/presentation/terminal_composer_controller.dart
@@ -1,11 +1,14 @@
 import 'dart:collection';
 
 import 'package:alera/src/features/workbench/domain/terminal_composer_attachment.dart';
+import 'package:alera/src/features/workbench/domain/terminal_image_paste.dart';
 import 'package:flutter/material.dart';
+import 'package:path/path.dart' as p;
 
 class TerminalComposerController extends ChangeNotifier {
   final textController = TextEditingController();
   final focusNode = FocusNode(debugLabel: 'TerminalComposer');
+  final dropTargetKey = GlobalKey(debugLabel: 'TerminalComposerDropTarget');
 
   final List<TerminalComposerAttachment> _attachments =
       <TerminalComposerAttachment>[];
@@ -36,6 +39,55 @@ class TerminalComposerController extends ChangeNotifier {
       ),
     );
     notifyListeners();
+  }
+
+  void addPathAttachment(String path, {TerminalComposerAttachmentKind? kind}) {
+    if (_disposed) {
+      return;
+    }
+    final attachment = _pathAttachment(path, kind: kind);
+    if (attachment != null) {
+      _attachments.add(attachment);
+      notifyListeners();
+    }
+  }
+
+  void addPathAttachments(Iterable<String> paths) {
+    if (_disposed) {
+      return;
+    }
+    var changed = false;
+    for (final path in paths) {
+      final attachment = _pathAttachment(path);
+      if (attachment != null) {
+        _attachments.add(attachment);
+        changed = true;
+      }
+    }
+    if (changed) {
+      notifyListeners();
+    }
+  }
+
+  TerminalComposerAttachment? _pathAttachment(
+    String path, {
+    TerminalComposerAttachmentKind? kind,
+  }) {
+    if (path.isEmpty) {
+      return null;
+    }
+    final resolvedKind = kind ?? terminalComposerAttachmentKindForPath(path);
+    final displayName = sanitizeTerminalImagePastePath(p.basename(path));
+    return TerminalComposerAttachment(
+      id: 'attachment-${_nextAttachmentId++}',
+      kind: resolvedKind,
+      path: path,
+      displayName: displayName.isEmpty
+          ? resolvedKind == TerminalComposerAttachmentKind.image
+                ? 'Pasted Image'
+                : 'Pasted File'
+          : displayName,
+    );
   }
 
   void removeAttachment(String id) {

--- a/lib/src/features/workbench/presentation/terminal_composer_drop_target.dart
+++ b/lib/src/features/workbench/presentation/terminal_composer_drop_target.dart
@@ -1,0 +1,46 @@
+import 'package:alera/src/features/workbench/presentation/terminal_path_drop.dart';
+import 'package:alera/src/features/workbench/presentation/terminal_runtime.dart';
+import 'package:flutter/material.dart';
+
+class TerminalComposerDropTarget extends StatelessWidget {
+  const TerminalComposerDropTarget({
+    super.key,
+    required this.session,
+    required this.child,
+  });
+
+  final TerminalSessionHandle session;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final composer = session.composerController;
+    return DragTarget<TerminalPathDragPayload>(
+      onWillAcceptWithDetails: (_) => !composer.submitting,
+      onAcceptWithDetails: (details) {
+        composer.addPathAttachments(details.data.paths);
+        composer.focusNode.requestFocus();
+      },
+      builder: (_, _, _) => child,
+    );
+  }
+}
+
+void handleTerminalFileDrop({
+  required TerminalSessionHandle session,
+  required Iterable<String> paths,
+  required Offset globalPosition,
+}) {
+  final composer = session.composerController;
+  final composerContext = composer.dropTargetKey.currentContext;
+  final renderBox = composerContext?.findRenderObject();
+  if (composer.visible &&
+      !composer.submitting &&
+      renderBox is RenderBox &&
+      renderBox.paintBounds.contains(renderBox.globalToLocal(globalPosition))) {
+    composer.addPathAttachments(paths);
+    composer.focusNode.requestFocus();
+    return;
+  }
+  handleTerminalPathDrop(session: session, paths: paths);
+}

--- a/lib/src/features/workbench/presentation/terminal_composer_image_preview.dart
+++ b/lib/src/features/workbench/presentation/terminal_composer_image_preview.dart
@@ -1,0 +1,71 @@
+import 'dart:io';
+
+import 'package:alera/src/app/theme/alera_tokens.dart';
+import 'package:alera/src/design_system/buttons/alera_icon_button.dart';
+import 'package:alera/src/design_system/icons/alera_icons.dart';
+import 'package:flutter/material.dart';
+
+void showTerminalComposerImagePreview(BuildContext context, String path) {
+  showDialog<void>(
+    context: context,
+    barrierColor: AleraTokens.barrierDark,
+    builder: (context) => _TerminalComposerImagePreview(path: path),
+  );
+}
+
+class _TerminalComposerImagePreview extends StatelessWidget {
+  const _TerminalComposerImagePreview({required this.path});
+
+  final String path;
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      key: const ValueKey<String>('terminal-composer-image-preview'),
+      children: <Widget>[
+        GestureDetector(
+          key: const ValueKey<String>(
+            'terminal-composer-image-preview-background',
+          ),
+          onTap: () => Navigator.of(context).pop(),
+          child: const SizedBox.expand(),
+        ),
+        Center(
+          child: InteractiveViewer(
+            maxScale: 5,
+            child: ClipRRect(
+              borderRadius: BorderRadius.circular(AleraTokens.radiusMd),
+              child: Image.file(
+                File(path),
+                fit: BoxFit.contain,
+                errorBuilder: (_, _, _) => const Icon(
+                  AleraIcons.imageError,
+                  size: AleraTokens.space48,
+                  color: AleraTokens.foregroundFaint,
+                ),
+              ),
+            ),
+          ),
+        ),
+        Positioned(
+          bottom: AleraTokens.space12,
+          left: 0,
+          right: 0,
+          child: Center(
+            child: AleraIconButton(
+              key: const ValueKey<String>(
+                'terminal-composer-image-preview-close',
+              ),
+              tooltip: 'Close Image Preview',
+              icon: AleraIcons.close,
+              iconColor: AleraTokens.foreground,
+              backgroundColor: AleraTokens.surface,
+              minSize: AleraTokens.space32,
+              onPressed: () => Navigator.of(context).pop(),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/src/features/workbench/presentation/terminal_composer_workspace_file_opener.dart
+++ b/lib/src/features/workbench/presentation/terminal_composer_workspace_file_opener.dart
@@ -1,17 +1,22 @@
 import 'package:alera/src/app/providers.dart';
 import 'package:alera/src/features/workbench/application/terminal_composer_workspace_attachment.dart';
 import 'package:alera/src/features/workbench/presentation/terminal_composer.dart';
+import 'package:alera/src/features/workbench/presentation/terminal_composer_drop_target.dart';
 import 'package:alera/src/features/workbench/presentation/terminal_runtime.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-TerminalComposer buildTerminalComposerForWorkspace(
+TerminalComposerDropTarget buildTerminalComposerForWorkspace(
   WidgetRef ref,
   TerminalSessionHandle session,
 ) {
-  return TerminalComposer(
+  return TerminalComposerDropTarget(
+    key: session.composerController.dropTargetKey,
     session: session,
-    onOpenWorkspaceFile: (filePath) =>
-        openTerminalComposerWorkspaceFile(ref, session.workspaceId, filePath),
+    child: TerminalComposer(
+      session: session,
+      onOpenWorkspaceFile: (filePath) =>
+          openTerminalComposerWorkspaceFile(ref, session.workspaceId, filePath),
+    ),
   );
 }
 

--- a/lib/src/features/workbench/presentation/terminal_composer_workspace_file_opener.dart
+++ b/lib/src/features/workbench/presentation/terminal_composer_workspace_file_opener.dart
@@ -1,0 +1,38 @@
+import 'package:alera/src/app/providers.dart';
+import 'package:alera/src/features/workbench/application/terminal_composer_workspace_attachment.dart';
+import 'package:alera/src/features/workbench/presentation/terminal_composer.dart';
+import 'package:alera/src/features/workbench/presentation/terminal_runtime.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+TerminalComposer buildTerminalComposerForWorkspace(
+  WidgetRef ref,
+  TerminalSessionHandle session,
+) {
+  return TerminalComposer(
+    session: session,
+    onOpenWorkspaceFile: (filePath) =>
+        openTerminalComposerWorkspaceFile(ref, session.workspaceId, filePath),
+  );
+}
+
+Future<bool> openTerminalComposerWorkspaceFile(
+  WidgetRef ref,
+  String workspaceId,
+  String filePath,
+) async {
+  final workspace = findWorkspaceById(
+    ref.read(workbenchControllerProvider),
+    workspaceId,
+  );
+  if (workspace == null) {
+    return false;
+  }
+  return openTerminalComposerWorkspaceAttachment(
+    workspacePath: workspace.path,
+    filePath: filePath,
+    workspaceFiles: ref.read(workspaceFileServiceProvider),
+    openFile: (relativePath) => ref
+        .read(workbenchControllerProvider.notifier)
+        .openFileTab(workspace: workspace, relativePath: relativePath),
+  );
+}

--- a/lib/src/features/workbench/presentation/terminal_surface.dart
+++ b/lib/src/features/workbench/presentation/terminal_surface.dart
@@ -8,7 +8,7 @@ import 'package:alera/src/features/keyboard/application/keybinding_resolver.dart
 import 'package:alera/src/features/keyboard/application/keyboard_command_dispatcher.dart';
 import 'package:alera/src/features/keyboard/domain/key_chord.dart';
 import 'package:alera/src/features/keyboard/domain/keyboard_action.dart';
-import 'package:alera/src/features/workbench/presentation/terminal_composer.dart';
+import 'package:alera/src/features/workbench/presentation/terminal_composer_workspace_file_opener.dart';
 import 'package:alera/src/features/workbench/presentation/terminal_path_drop.dart';
 import 'package:alera/src/features/workbench/presentation/terminal_runtime.dart';
 import 'package:alera/src/features/workbench/presentation/terminal_search_overlay.dart';
@@ -291,7 +291,7 @@ class _TerminalSurfaceState extends ConsumerState<TerminalSurface> {
                   ),
                 ),
                 if (widget.session.composerController.visible)
-                  TerminalComposer(session: widget.session),
+                  buildTerminalComposerForWorkspace(ref, widget.session),
               ],
             ),
           ),

--- a/lib/src/features/workbench/presentation/terminal_surface.dart
+++ b/lib/src/features/workbench/presentation/terminal_surface.dart
@@ -8,6 +8,7 @@ import 'package:alera/src/features/keyboard/application/keybinding_resolver.dart
 import 'package:alera/src/features/keyboard/application/keyboard_command_dispatcher.dart';
 import 'package:alera/src/features/keyboard/domain/key_chord.dart';
 import 'package:alera/src/features/keyboard/domain/keyboard_action.dart';
+import 'package:alera/src/features/workbench/presentation/terminal_composer_drop_target.dart';
 import 'package:alera/src/features/workbench/presentation/terminal_composer_workspace_file_opener.dart';
 import 'package:alera/src/features/workbench/presentation/terminal_path_drop.dart';
 import 'package:alera/src/features/workbench/presentation/terminal_runtime.dart';
@@ -163,9 +164,10 @@ class _TerminalSurfaceState extends ConsumerState<TerminalSurface> {
         return DropTarget(
           enable: error == null,
           onDragDone: (details) {
-            handleTerminalPathDrop(
+            handleTerminalFileDrop(
               session: widget.session,
               paths: details.files.map((file) => file.path),
+              globalPosition: details.globalPosition,
             );
           },
           child: DragTarget<TerminalPathDragPayload>(

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -12,6 +12,7 @@
 #include <file_selector_linux/file_selector_plugin.h>
 #include <media_kit_libs_linux/media_kit_libs_linux_plugin.h>
 #include <media_kit_video/media_kit_video_plugin.h>
+#include <pasteboard/pasteboard_plugin.h>
 #include <screen_retriever_linux/screen_retriever_linux_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
 #include <window_manager/window_manager_plugin.h>
@@ -35,6 +36,9 @@ void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) media_kit_video_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "MediaKitVideoPlugin");
   media_kit_video_plugin_register_with_registrar(media_kit_video_registrar);
+  g_autoptr(FlPluginRegistrar) pasteboard_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "PasteboardPlugin");
+  pasteboard_plugin_register_with_registrar(pasteboard_registrar);
   g_autoptr(FlPluginRegistrar) screen_retriever_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "ScreenRetrieverLinuxPlugin");
   screen_retriever_linux_plugin_register_with_registrar(screen_retriever_linux_registrar);

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -9,6 +9,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
   file_selector_linux
   media_kit_libs_linux
   media_kit_video
+  pasteboard
   screen_retriever_linux
   url_launcher_linux
   window_manager

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -13,6 +13,7 @@ import flutter_local_notifications
 import media_kit_libs_macos_video
 import media_kit_video
 import package_info_plus
+import pasteboard
 import path_provider_foundation
 import pdfium_flutter
 import screen_retriever_macos
@@ -29,6 +30,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   MediaKitLibsMacosVideoPlugin.register(with: registry.registrar(forPlugin: "MediaKitLibsMacosVideoPlugin"))
   MediaKitVideoPlugin.register(with: registry.registrar(forPlugin: "MediaKitVideoPlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
+  PasteboardPlugin.register(with: registry.registrar(forPlugin: "PasteboardPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   PDFiumFlutterPlugin.register(with: registry.registrar(forPlugin: "PDFiumFlutterPlugin"))
   ScreenRetrieverMacosPlugin.register(with: registry.registrar(forPlugin: "ScreenRetrieverMacosPlugin"))

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -987,6 +987,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.0"
+  pasteboard:
+    dependency: "direct main"
+    description:
+      name: pasteboard
+      sha256: fedbe8da188d2f713aa8b01260737342e6e1087534a3ab26e1a719f8d3e8f32f
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.0"
   path:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   flutter_riverpod: ^3.3.2
   logging: ^1.3.0
   path: ^1.9.1
+  pasteboard: ^0.5.0
   uuid: ^4.6.0
   path_provider: ^2.1.6
   ghostty_vte_flutter: ^0.1.5

--- a/test/unit/terminal_clipboard_test.dart
+++ b/test/unit/terminal_clipboard_test.dart
@@ -8,11 +8,13 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   const channel = MethodChannel('dev.leynier.alera/clipboard');
+  const fileChannel = MethodChannel('pasteboard');
   final messenger =
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
 
   tearDown(() {
     messenger.setMockMethodCallHandler(channel, null);
+    messenger.setMockMethodCallHandler(fileChannel, null);
   });
 
   test('uses the GTK image clipboard channel on Linux', () async {
@@ -28,4 +30,18 @@ void main() {
     expect(calls, hasLength(1));
     expect(calls.single.method, 'saveImageAsTempFile');
   }, skip: !Platform.isLinux);
+
+  test('reads copied file paths through the desktop pasteboard', () async {
+    final calls = <MethodCall>[];
+    messenger.setMockMethodCallHandler(fileChannel, (call) async {
+      calls.add(call);
+      return <String>['/tmp/first.txt', '/tmp/second.png'];
+    });
+
+    final paths = await const NativeTerminalClipboard().readFilePaths();
+
+    expect(paths, <String>['/tmp/first.txt', '/tmp/second.png']);
+    expect(calls, hasLength(1));
+    expect(calls.single.method, 'files');
+  });
 }

--- a/test/unit/terminal_composer_submission_test.dart
+++ b/test/unit/terminal_composer_submission_test.dart
@@ -1,0 +1,67 @@
+import 'package:alera/src/features/workbench/domain/terminal_composer_attachment.dart';
+import 'package:alera/src/features/workbench/domain/terminal_composer_submission.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('classifies ACP-compatible image extensions', () {
+    expect(
+      terminalComposerAttachmentKindForPath('/tmp/image.WEBP'),
+      TerminalComposerAttachmentKind.image,
+    );
+    expect(
+      terminalComposerAttachmentKindForPath('/tmp/report.pdf'),
+      TerminalComposerAttachmentKind.file,
+    );
+  });
+
+  test('builds grouped image and file sections after the prompt', () {
+    expect(
+      buildTerminalComposerSubmission(
+        prompt: 'Review these',
+        attachments: const <TerminalComposerAttachment>[
+          TerminalComposerAttachment(
+            id: 'image',
+            kind: TerminalComposerAttachmentKind.image,
+            path: '/tmp/before\x1b[201~after.png',
+            displayName: 'after.png',
+          ),
+          TerminalComposerAttachment(
+            id: 'file',
+            kind: TerminalComposerAttachmentKind.file,
+            path: '/tmp/report.pdf',
+            displayName: 'report.pdf',
+          ),
+        ],
+      ),
+      'Review these\n\n'
+      'Attached images:\n'
+      '/tmp/before\u241b[201~after.png\n'
+      'Attached files:\n'
+      '/tmp/report.pdf',
+    );
+  });
+
+  test('supports attachment-only and text-only submissions', () {
+    expect(
+      buildTerminalComposerSubmission(
+        prompt: '',
+        attachments: const <TerminalComposerAttachment>[
+          TerminalComposerAttachment(
+            id: 'file',
+            kind: TerminalComposerAttachmentKind.file,
+            path: '/tmp/report.pdf',
+            displayName: 'report.pdf',
+          ),
+        ],
+      ),
+      'Attached files:\n/tmp/report.pdf',
+    );
+    expect(
+      buildTerminalComposerSubmission(
+        prompt: 'Text only',
+        attachments: const <TerminalComposerAttachment>[],
+      ),
+      'Text only',
+    );
+  });
+}

--- a/test/unit/terminal_composer_workspace_attachment_test.dart
+++ b/test/unit/terminal_composer_workspace_attachment_test.dart
@@ -1,0 +1,107 @@
+import 'package:alera/src/features/workbench/application/terminal_composer_workspace_attachment.dart';
+import 'package:alera/src/features/workbench/application/workspace_file_service.dart';
+import 'package:alera/src/rust/api/workspace_files.dart' as native;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+
+void main() {
+  test('opens supported workspace text files inside Alera', () async {
+    final files = _FakeWorkspaceFileService();
+    final opened = <String>[];
+    final workspacePath = p.absolute('workspace');
+
+    final handled = await openTerminalComposerWorkspaceAttachment(
+      workspacePath: workspacePath,
+      filePath: p.join(workspacePath, 'lib', 'main.dart'),
+      workspaceFiles: files,
+      openFile: (relativePath) async => opened.add(relativePath),
+    );
+
+    expect(handled, isTrue);
+    expect(files.readTextPaths, <String>['lib/main.dart']);
+    expect(files.resolvedPaths, isEmpty);
+    expect(opened, <String>['lib/main.dart']);
+  });
+
+  test('resolves supported workspace previews before opening them', () async {
+    final files = _FakeWorkspaceFileService();
+    final opened = <String>[];
+    final workspacePath = p.absolute('workspace');
+
+    final handled = await openTerminalComposerWorkspaceAttachment(
+      workspacePath: workspacePath,
+      filePath: p.join(workspacePath, 'assets', 'image.png'),
+      workspaceFiles: files,
+      openFile: (relativePath) async => opened.add(relativePath),
+    );
+
+    expect(handled, isTrue);
+    expect(files.resolvedPaths, <String>['assets/image.png']);
+    expect(files.readTextPaths, isEmpty);
+    expect(opened, <String>['assets/image.png']);
+  });
+
+  test('leaves outside and unsupported files to the system launcher', () async {
+    final files = _FakeWorkspaceFileService(unsupportedText: true);
+    final opened = <String>[];
+    final workspacePath = p.absolute('workspace');
+
+    final outside = await openTerminalComposerWorkspaceAttachment(
+      workspacePath: workspacePath,
+      filePath: p.join(p.dirname(workspacePath), 'elsewhere', 'report.txt'),
+      workspaceFiles: files,
+      openFile: (relativePath) async => opened.add(relativePath),
+    );
+    final unsupported = await openTerminalComposerWorkspaceAttachment(
+      workspacePath: workspacePath,
+      filePath: p.join(workspacePath, 'archive.bin'),
+      workspaceFiles: files,
+      openFile: (relativePath) async => opened.add(relativePath),
+    );
+
+    expect(outside, isFalse);
+    expect(unsupported, isFalse);
+    expect(opened, isEmpty);
+  });
+}
+
+class _FakeWorkspaceFileService extends WorkspaceFileService {
+  _FakeWorkspaceFileService({this.unsupportedText = false});
+
+  final bool unsupportedText;
+  final List<String> readTextPaths = <String>[];
+  final List<String> resolvedPaths = <String>[];
+
+  @override
+  Future<native.WorkspaceTextFile> readTextFile({
+    required String workspacePath,
+    required String relativePath,
+  }) async {
+    readTextPaths.add(relativePath);
+    if (unsupportedText) {
+      throw const native.WorkspaceFileError(
+        kind: native.WorkspaceFileErrorKind.unsupported,
+        context: 'binary file',
+      );
+    }
+    return native.WorkspaceTextFile(
+      content: 'text',
+      contentToken: 'token',
+      modifiedMillis: 0,
+      size: BigInt.from(4),
+    );
+  }
+
+  @override
+  Future<ResolvedWorkspaceFile> resolveWorkspaceFilePath({
+    required String workspacePath,
+    required String relativePath,
+  }) async {
+    resolvedPaths.add(relativePath);
+    return ResolvedWorkspaceFile(
+      path: p.join(workspacePath, relativePath),
+      modifiedMicros: 0,
+      length: 1,
+    );
+  }
+}

--- a/test/unit/terminal_runtime_native_test_harness.dart
+++ b/test/unit/terminal_runtime_native_test_harness.dart
@@ -91,6 +91,7 @@ class _FakeTerminalClipboard implements TerminalClipboard {
 
   String? text;
   String? imagePath;
+  List<String> filePaths = <String>[];
   Object? readError;
   Object? imageError;
   final List<String> writes = <String>[];
@@ -103,6 +104,9 @@ class _FakeTerminalClipboard implements TerminalClipboard {
     }
     return text;
   }
+
+  @override
+  Future<List<String>> readFilePaths() async => filePaths;
 
   @override
   Future<String?> saveImageAsTempFile() async {

--- a/test/widget/terminal_path_drag_test.dart
+++ b/test/widget/terminal_path_drag_test.dart
@@ -1,3 +1,5 @@
+import 'package:alera/src/features/workbench/domain/terminal_composer_attachment.dart';
+import 'package:alera/src/features/workbench/presentation/terminal_composer_drop_target.dart';
 import 'package:alera/src/features/workbench/presentation/terminal_path_drop.dart';
 import 'package:alera/src/features/workbench/presentation/terminal_runtime.dart';
 import 'package:alera/src/features/workbench/presentation/terminal_surface.dart';
@@ -28,12 +30,62 @@ void main() {
     expect(session.pasted, isEmpty);
     expect(session.focusRequests, 0);
   });
+
+  testWidgets('composer turns in-app path drags into attachments', (
+    tester,
+  ) async {
+    final session = _CapturingTerminalSessionHandle();
+    session.composerController.show();
+
+    await _pumpDragHarness(
+      tester,
+      session,
+      paths: const <String>['/tmp/image.png', '/tmp/my file'],
+    );
+    await _dragSourceToTerminal(
+      tester,
+      target: find.byKey(session.composerController.dropTargetKey),
+    );
+
+    expect(session.pasted, isEmpty);
+    expect(session.composerController.attachments, hasLength(2));
+    expect(
+      session.composerController.attachments.map(
+        (attachment) => attachment.kind,
+      ),
+      <TerminalComposerAttachmentKind>[
+        TerminalComposerAttachmentKind.image,
+        TerminalComposerAttachmentKind.file,
+      ],
+    );
+  });
+
+  testWidgets('composer turns desktop file drops into attachments', (
+    tester,
+  ) async {
+    final session = _CapturingTerminalSessionHandle();
+    session.composerController.show();
+    await _pumpDragHarness(tester, session);
+
+    handleTerminalFileDrop(
+      session: session,
+      paths: const <String>['/tmp/image.webp', '/tmp/report.pdf'],
+      globalPosition: tester.getCenter(
+        find.byKey(session.composerController.dropTargetKey),
+      ),
+    );
+    await tester.pump();
+
+    expect(session.pasted, isEmpty);
+    expect(session.composerController.attachments, hasLength(2));
+  });
 }
 
 Future<void> _pumpDragHarness(
   WidgetTester tester,
-  _CapturingTerminalSessionHandle session,
-) async {
+  _CapturingTerminalSessionHandle session, {
+  List<String> paths = const <String>['/tmp/foo', '/tmp/my file'],
+}) async {
   await tester.pumpWidget(
     MaterialApp(
       home: Scaffold(
@@ -43,9 +95,7 @@ Future<void> _pumpDragHarness(
               width: 200,
               child: Center(
                 child: TerminalPathLongPressDraggable<TerminalPathDragData>(
-                  data: const TerminalPathDragData(
-                    paths: <String>['/tmp/foo', '/tmp/my file'],
-                  ),
+                  data: TerminalPathDragData(paths: paths),
                   feedback: const Material(child: Text('Dragging Paths')),
                   child: const Text('Drag Paths'),
                 ),
@@ -60,14 +110,19 @@ Future<void> _pumpDragHarness(
   await tester.pump();
 }
 
-Future<void> _dragSourceToTerminal(WidgetTester tester) async {
+Future<void> _dragSourceToTerminal(
+  WidgetTester tester, {
+  Finder? target,
+}) async {
   final gesture = await tester.startGesture(
     tester.getCenter(find.text('Drag Paths')),
   );
   await tester.pump(kLongPressTimeout + const Duration(milliseconds: 100));
   expect(find.text('Dragging Paths'), findsOneWidget);
 
-  await gesture.moveTo(tester.getCenter(find.byType(TerminalSurface)));
+  await gesture.moveTo(
+    tester.getCenter(target ?? find.byType(TerminalSurface)),
+  );
   await tester.pump();
   await gesture.up();
   await tester.pump();

--- a/test/widget/terminal_surface_composer_test_cases.dart
+++ b/test/widget/terminal_surface_composer_test_cases.dart
@@ -307,6 +307,46 @@ void _registerTerminalSurfaceComposerTests() {
     expect(launcher.openedUris, <Uri>[Uri.file('/tmp/report.pdf')]);
   });
 
+  testWidgets('composer opens supported workspace attachments inside Alera', (
+    tester,
+  ) async {
+    final session = _ImmediateNotifySessionHandle(tabId: 'tab-1');
+    session.composerController.addAttachment(
+      kind: TerminalComposerAttachmentKind.file,
+      path: '/workspace/lib/main.dart',
+      displayName: 'main.dart',
+    );
+    final launcher = _FakeExternalUriLauncher();
+    final openedWorkspacePaths = <String>[];
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: TerminalComposer(
+            session: session,
+            externalUriLauncher: launcher,
+            onOpenWorkspaceFile: (path) async {
+              openedWorkspacePaths.add(path);
+              return true;
+            },
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(
+      find.byKey(
+        const ValueKey<String>(
+          'terminal-composer-attachment-open-attachment-0',
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(openedWorkspacePaths, <String>['/workspace/lib/main.dart']);
+    expect(launcher.openedUris, isEmpty);
+  });
+
   testWidgets('composer preserves native text paste without probing images', (
     tester,
   ) async {

--- a/test/widget/terminal_surface_composer_test_cases.dart
+++ b/test/widget/terminal_surface_composer_test_cases.dart
@@ -94,7 +94,7 @@ void _registerTerminalSurfaceComposerTests() {
     }
   });
 
-  testWidgets('composer pastes an image path at the current selection', (
+  testWidgets('composer pastes an image as a clickable attachment', (
     tester,
   ) async {
     final session = _ImmediateNotifySessionHandle(tabId: 'tab-1');
@@ -110,10 +110,6 @@ void _registerTerminalSurfaceComposerTests() {
       ),
     );
     await tester.enterText(find.byType(TextField), 'Review this placeholder');
-    session.composerController.textController.selection = const TextSelection(
-      baseOffset: 12,
-      extentOffset: 23,
-    );
     final focusContext = tester.binding.focusManager.primaryFocus?.context;
     expect(focusContext, isNotNull);
 
@@ -126,9 +122,189 @@ void _registerTerminalSurfaceComposerTests() {
 
     expect(
       session.composerController.textController.text,
-      'Review this /tmp/alera-paste-\u241b.png',
+      'Review this placeholder',
     );
+    expect(session.composerController.attachments, hasLength(1));
+    expect(
+      session.composerController.attachments.single.path,
+      '/tmp/alera-paste-\x1b.png',
+    );
+    expect(find.text('alera-paste-\u241b.png'), findsOneWidget);
+    expect(clipboard.fileReads, 1);
     expect(clipboard.imageReads, 1);
+
+    await tester.tap(
+      find.byKey(
+        const ValueKey<String>(
+          'terminal-composer-attachment-open-attachment-0',
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      find.byKey(const ValueKey<String>('terminal-composer-image-preview')),
+      findsOneWidget,
+    );
+
+    await tester.tap(
+      find.byKey(
+        const ValueKey<String>('terminal-composer-image-preview-close'),
+      ),
+    );
+    await tester.pumpAndSettle();
+  });
+
+  testWidgets('composer removes an image attachment before submission', (
+    tester,
+  ) async {
+    final session = _ImmediateNotifySessionHandle(tabId: 'tab-1');
+    session.composerController.addAttachment(
+      kind: TerminalComposerAttachmentKind.image,
+      path: '/tmp/remove-me.png',
+      displayName: 'remove-me.png',
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(body: TerminalComposer(session: session)),
+      ),
+    );
+
+    expect(find.text('remove-me.png'), findsOneWidget);
+    await tester.tap(
+      find.byKey(
+        const ValueKey<String>(
+          'terminal-composer-attachment-remove-attachment-0',
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(session.composerController.attachments, isEmpty);
+    expect(find.text('remove-me.png'), findsNothing);
+  });
+
+  testWidgets('composer submits text and attachments then clears both', (
+    tester,
+  ) async {
+    final session = _ImmediateNotifySessionHandle(tabId: 'tab-1');
+    session.composerController.addAttachment(
+      kind: TerminalComposerAttachmentKind.image,
+      path: '/tmp/review.png',
+      displayName: 'review.png',
+    );
+    session.composerController.addAttachment(
+      kind: TerminalComposerAttachmentKind.file,
+      path: '/tmp/report.pdf',
+      displayName: 'report.pdf',
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(body: TerminalComposer(session: session)),
+      ),
+    );
+    await tester.enterText(find.byType(TextField), 'Review this change');
+    await tester.tap(
+      find.byKey(const ValueKey<String>('composer-send-button')),
+    );
+    await tester.pump();
+
+    expect(session.submittedTexts, <String>[
+      'Review this change\n\n'
+          'Attached images:\n/tmp/review.png\n'
+          'Attached files:\n/tmp/report.pdf',
+    ]);
+    expect(session.composerController.textController.text, isEmpty);
+    expect(session.composerController.attachments, isEmpty);
+  });
+
+  testWidgets('composer submits an attachment without prompt text', (
+    tester,
+  ) async {
+    final session = _ImmediateNotifySessionHandle(tabId: 'tab-1');
+    session.composerController.addAttachment(
+      kind: TerminalComposerAttachmentKind.image,
+      path: '/tmp/image-only.png',
+      displayName: 'image-only.png',
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(body: TerminalComposer(session: session)),
+      ),
+    );
+    await tester.tap(
+      find.byKey(const ValueKey<String>('composer-send-button')),
+    );
+    await tester.pump();
+
+    expect(session.submittedTexts, <String>[
+      'Attached images:\n/tmp/image-only.png',
+    ]);
+    expect(session.composerController.attachments, isEmpty);
+  });
+
+  testWidgets('composer pastes copied files and opens file attachments', (
+    tester,
+  ) async {
+    final session = _ImmediateNotifySessionHandle(tabId: 'tab-1');
+    final clipboard = _FakeComposerClipboard(
+      text: '/tmp/report.pdf',
+      filePaths: const <String>['/tmp/photo.webp', '/tmp/report.pdf'],
+    );
+    final launcher = _FakeExternalUriLauncher();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: TerminalComposer(
+            session: session,
+            clipboard: clipboard,
+            externalUriLauncher: launcher,
+          ),
+        ),
+      ),
+    );
+    await tester.enterText(find.byType(TextField), 'Review these files');
+    final focusContext = tester.binding.focusManager.primaryFocus?.context;
+    expect(focusContext, isNotNull);
+
+    Actions.invoke(
+      focusContext!,
+      const PasteTextIntent(SelectionChangedCause.keyboard),
+    );
+    await tester.pump();
+    await tester.pump();
+
+    expect(
+      session.composerController.textController.text,
+      'Review these files',
+    );
+    expect(session.composerController.attachments, hasLength(2));
+    expect(
+      session.composerController.attachments.map((item) => item.kind),
+      <TerminalComposerAttachmentKind>[
+        TerminalComposerAttachmentKind.image,
+        TerminalComposerAttachmentKind.file,
+      ],
+    );
+    expect(find.text('photo.webp'), findsOneWidget);
+    expect(find.text('report.pdf'), findsOneWidget);
+    expect(clipboard.fileReads, 1);
+    expect(clipboard.imageReads, 0);
+
+    await tester.tap(
+      find.byKey(
+        const ValueKey<String>(
+          'terminal-composer-attachment-open-attachment-1',
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(launcher.openedUris, <Uri>[Uri.file('/tmp/report.pdf')]);
   });
 
   testWidgets('composer preserves native text paste without probing images', (
@@ -174,16 +350,29 @@ void _registerTerminalSurfaceComposerTests() {
       session.composerController.textController.text,
       'Before clipboard text',
     );
+    expect(clipboard.fileReads, 1);
     expect(clipboard.imageReads, 0);
   });
 }
 
 final class _FakeComposerClipboard implements TerminalClipboard {
-  _FakeComposerClipboard({this.text, this.imagePath});
+  _FakeComposerClipboard({
+    this.text,
+    this.imagePath,
+    this.filePaths = const <String>[],
+  });
 
   final String? text;
   final String? imagePath;
+  final List<String> filePaths;
+  int fileReads = 0;
   int imageReads = 0;
+
+  @override
+  Future<List<String>> readFilePaths() async {
+    fileReads += 1;
+    return filePaths;
+  }
 
   @override
   Future<String?> readText() async => text;

--- a/test/widget/terminal_surface_test.dart
+++ b/test/widget/terminal_surface_test.dart
@@ -10,6 +10,7 @@ import 'package:alera/src/shared/infra/uri/external_uri_launcher.dart';
 import 'package:alera/src/features/settings/domain/alera_settings.dart';
 import 'package:alera/src/features/settings/domain/terminal_theme_catalog.dart';
 import 'package:alera/src/features/workbench/application/workbench_state.dart';
+import 'package:alera/src/features/workbench/domain/terminal_composer_attachment.dart';
 import 'package:alera/src/features/workbench/domain/workspace_tab_record.dart';
 import 'package:alera/src/features/workbench/domain/workspace.dart';
 import 'package:alera/src/features/workbench/infra/terminal_clipboard.dart';

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -12,6 +12,7 @@
 #include <file_selector_windows/file_selector_windows.h>
 #include <media_kit_libs_windows_video/media_kit_libs_windows_video_plugin_c_api.h>
 #include <media_kit_video/media_kit_video_plugin_c_api.h>
+#include <pasteboard/pasteboard_plugin.h>
 #include <screen_retriever_windows/screen_retriever_windows_plugin_c_api.h>
 #include <url_launcher_windows/url_launcher_windows.h>
 #include <window_manager/window_manager_plugin.h>
@@ -29,6 +30,8 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("MediaKitLibsWindowsVideoPluginCApi"));
   MediaKitVideoPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("MediaKitVideoPluginCApi"));
+  PasteboardPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("PasteboardPlugin"));
   ScreenRetrieverWindowsPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("ScreenRetrieverWindowsPluginCApi"));
   UrlLauncherWindowsRegisterWithRegistrar(

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -9,6 +9,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
   file_selector_windows
   media_kit_libs_windows_video
   media_kit_video
+  pasteboard
   screen_retriever_windows
   url_launcher_windows
   window_manager


### PR DESCRIPTION
## Summary
- render pasted and dropped images/files as removable Terminal Composer attachments
- keep Explorer and Source Control drops as attachments over the composer while preserving terminal path paste elsewhere
- open image previews in-app and supported workspace files in Alera, with the native launcher as fallback
- send grouped attachment paths to the terminal while preserving normal text paste

## Validation
- flutter analyze
- flutter test --reporter compact (2657 passed)
- flutter build linux --debug
- mobile: dart format, flutter analyze, flutter test (217 passed)
- cargo test --workspace
- dart tool/quality/check_max_lines.dart
- git diff --check

## Notes
- gh act was attempted before push. Flutter jobs hit the linked-worktree submodule checkout limitation, and its Rust container failure did not reproduce in the complete host cargo test run.