### PR TITLE
feat: toggle pull request comment tasks

### DIFF
--- a/lib/src/features/pull_requests/application/forge_provider.dart
+++ b/lib/src/features/pull_requests/application/forge_provider.dart
@@ -38,6 +38,9 @@ abstract interface class ForgeProvider {
   /// Whether this provider can read and create pull-request comments.
   bool get supportsReviewComments;
 
+  /// Whether this provider can update existing pull-request comments.
+  bool get supportsReviewCommentEditing;
+
   /// Reports whether the provider's CLI is installed and authenticated for the
   /// host in [identity]. Never throws.
   Future<ForgeAuthStatus> checkAuth({required GitRemoteIdentity identity});
@@ -88,6 +91,16 @@ abstract interface class ForgeProvider {
     required GitRemoteIdentity identity,
     required String repoPath,
     required int number,
+    required String body,
+  });
+
+  /// Replaces the complete Markdown body of an existing review comment.
+  /// Provider permissions are enforced by the provider endpoint.
+  Future<void> updateReviewComment({
+    required GitRemoteIdentity identity,
+    required String repoPath,
+    required int number,
+    required ReviewCommentLocator locator,
     required String body,
   });
 

--- a/lib/src/features/pull_requests/application/workspace_pull_request_controller.dart
+++ b/lib/src/features/pull_requests/application/workspace_pull_request_controller.dart
@@ -16,7 +16,9 @@ import 'package:alera/src/features/pull_requests/domain/hosted_review.dart';
 import 'package:alera/src/features/pull_requests/domain/linked_review.dart';
 import 'package:alera/src/features/pull_requests/domain/review_check.dart';
 import 'package:alera/src/features/pull_requests/domain/review_check_details.dart';
+import 'package:alera/src/features/pull_requests/domain/review_comment.dart';
 import 'package:alera/src/features/pull_requests/domain/review_merge_method.dart';
+import 'package:alera/src/features/pull_requests/domain/review_comment_task_list.dart';
 import 'package:alera/src/features/pull_requests/domain/update_review_input.dart';
 import 'package:alera/src/features/pull_requests/domain/update_review_result.dart';
 import 'package:alera/src/features/pull_requests/domain/workspace_pull_request_scope.dart';
@@ -45,6 +47,9 @@ class WorkspacePullRequestController extends _$WorkspacePullRequestController
   Timer? _pollTimer;
   Duration _pollInterval = _minPollInterval;
   Future<void>? _refreshInFlight;
+  final Map<String, _PendingReviewCommentSave> _pendingCommentSaves =
+      <String, _PendingReviewCommentSave>{};
+  final Set<String> _savingCommentIds = <String>{};
   var _panelViewCount = 0;
   bool _visible = false;
   bool _disposed = false;
@@ -65,8 +70,10 @@ class WorkspacePullRequestController extends _$WorkspacePullRequestController
     ref.onDispose(() {
       _disposed = true;
       _pollTimer?.cancel();
+      _pendingCommentSaves.clear();
+      _savingCommentIds.clear();
     });
-    final initial = await _loader.load(scope);
+    final initial = _applyPendingCommentBodies(await _loader.load(scope));
     _schedulePoll(scope, snapshot: initial);
     return initial;
   }
@@ -109,7 +116,7 @@ class WorkspacePullRequestController extends _$WorkspacePullRequestController
     try {
       final loaded = await _loader.load(scope);
       if (!_disposed) {
-        state = AsyncData(loaded);
+        state = AsyncData(_applyPendingCommentBodies(loaded));
       }
     } catch (error, stackTrace) {
       if (!_disposed) {
@@ -217,6 +224,49 @@ class WorkspacePullRequestController extends _$WorkspacePullRequestController
     _schedulePoll(scope);
   }
 
+  WorkspacePullRequestState _applyPendingCommentBodies(
+    WorkspacePullRequestState loaded,
+  ) {
+    if (_pendingCommentSaves.isEmpty) {
+      return loaded;
+    }
+    final currentComments = state.value?.comments ?? const <ReviewComment>[];
+    final loadedIds = loaded.comments.map((comment) => comment.id).toSet();
+    final settledIds = <String>{};
+    for (final comment in loaded.comments) {
+      final pending = _pendingCommentSaves[comment.id];
+      if (pending != null &&
+          !_savingCommentIds.contains(comment.id) &&
+          comment.body == pending.optimisticBody) {
+        settledIds.add(comment.id);
+      }
+    }
+    for (final commentId in settledIds) {
+      _pendingCommentSaves.remove(commentId);
+    }
+    final comments = <ReviewComment>[
+      for (final comment in loaded.comments)
+        _pendingCommentSaves[comment.id] == null
+            ? comment
+            : comment.copyWith(
+                body: _pendingCommentSaves[comment.id]!.optimisticBody,
+              ),
+      for (final comment in currentComments)
+        if (!loadedIds.contains(comment.id) &&
+            _pendingCommentSaves.containsKey(comment.id))
+          comment.copyWith(
+            body: _pendingCommentSaves[comment.id]!.optimisticBody,
+          ),
+    ];
+    return loaded.copyWith(
+      comments: comments,
+      savingCommentIds: <String>{
+        ...loaded.savingCommentIds,
+        ..._savingCommentIds,
+      },
+    );
+  }
+
   /// Runs an action that mutates persisted state, then reloads.
   Future<void> _run({
     required WorkspacePullRequestScope scope,
@@ -230,7 +280,7 @@ class WorkspacePullRequestController extends _$WorkspacePullRequestController
       await body();
       final reloaded = await _loader.load(scope);
       if (!_disposed) {
-        state = AsyncData(reloaded);
+        state = AsyncData(_applyPendingCommentBodies(reloaded));
         _resetPollInterval();
       }
     } on _ActionError catch (error) {
@@ -305,17 +355,19 @@ class WorkspacePullRequestController extends _$WorkspacePullRequestController
         return;
       }
       final failed = reloaded.errorMessage != null;
+      final visibleReload = _applyPendingCommentBodies(reloaded);
       state = AsyncData(
         failed
             ? current.copyWith(
                 clearAction: true,
                 errorMessage: reloaded.errorMessage,
               )
-            : reloaded,
+            : visibleReload,
       );
       if (origin == _RefreshOrigin.poll) {
         _advancePollInterval(
-          changed: !failed && reloaded.pollSignature != current.pollSignature,
+          changed:
+              !failed && visibleReload.pollSignature != current.pollSignature,
         );
       }
     } catch (error) {
@@ -374,4 +426,14 @@ class _ActionError implements Exception {
   const _ActionError(this.message);
 
   final String message;
+}
+
+class _PendingReviewCommentSave {
+  const _PendingReviewCommentSave({
+    required this.originalBody,
+    required this.optimisticBody,
+  });
+
+  final String originalBody;
+  final String optimisticBody;
 }

--- a/lib/src/features/pull_requests/application/workspace_pull_request_loader.dart
+++ b/lib/src/features/pull_requests/application/workspace_pull_request_loader.dart
@@ -123,6 +123,7 @@ class WorkspacePullRequestLoader {
         canCloseReview: forge.supportsReviewClosure,
         canChangeDraftStatus: forge.supportsReviewDraftConversion,
         canComment: forge.supportsReviewComments,
+        canEditComments: forge.supportsReviewCommentEditing,
       );
     } on ForgeNotAuthenticated {
       return WorkspacePullRequestState(

--- a/lib/src/features/pull_requests/application/workspace_pull_request_review_actions.dart
+++ b/lib/src/features/pull_requests/application/workspace_pull_request_review_actions.dart
@@ -114,12 +114,13 @@ mixin _WorkspacePullRequestReviewActions on _$WorkspacePullRequestController {
       );
       final reloaded = await controller._loader.load(controller.scope);
       if (!controller._disposed) {
+        final visibleReload = controller._applyPendingCommentBodies(reloaded);
         state = AsyncData(
-          reloaded.errorMessage == null
-              ? reloaded
+          visibleReload.errorMessage == null
+              ? visibleReload
               : current.copyWith(
                   clearAction: true,
-                  errorMessage: reloaded.errorMessage,
+                  errorMessage: visibleReload.errorMessage,
                 ),
         );
         controller._resetPollInterval();
@@ -134,6 +135,194 @@ mixin _WorkspacePullRequestReviewActions on _$WorkspacePullRequestController {
     } finally {
       controller._schedulePoll(controller.scope);
     }
+  }
+
+  /// Toggles one task-list item and updates only its containing comment.
+  Future<void> toggleReviewCommentTask(
+    String commentId,
+    int taskItemIndex,
+  ) async {
+    final controller = _controller;
+    final current = state.value;
+    if (current == null) {
+      _surfaceActionError('Comments are not available for this pull request.');
+      return;
+    }
+    if (current.savingCommentIds.contains(commentId)) {
+      return;
+    }
+    final review = current.review;
+    final commentIndex = current.comments.indexWhere(
+      (comment) => comment.id == commentId,
+    );
+    if (review == null ||
+        !review.isOpen ||
+        !current.canEditComments ||
+        commentIndex < 0) {
+      _surfaceActionError('This comment cannot be edited.');
+      return;
+    }
+    final comment = current.comments[commentIndex];
+    final locator = comment.locator;
+    if (locator == null) {
+      _surfaceActionError('This comment cannot be edited.');
+      return;
+    }
+    final changedBody = toggleReviewCommentTaskListItem(
+      comment.body,
+      taskItemIndex,
+    );
+    if (changedBody == null) {
+      return;
+    }
+    final identity = current.identity;
+    final forge = identity == null
+        ? null
+        : controller._registry.forProvider(identity.provider);
+    if (identity == null || forge == null) {
+      _surfaceActionError('No hosting provider is configured.');
+      return;
+    }
+
+    final pending = _PendingReviewCommentSave(
+      originalBody: comment.body,
+      optimisticBody: changedBody,
+    );
+    controller._pendingCommentSaves[commentId] = pending;
+    controller._savingCommentIds.add(commentId);
+    state = AsyncData(
+      current.copyWith(
+        comments: _replaceCommentBody(
+          current.comments,
+          commentId: commentId,
+          body: changedBody,
+        ),
+        savingCommentIds: <String>{...current.savingCommentIds, commentId},
+        clearError: true,
+      ),
+    );
+
+    try {
+      await forge.updateReviewComment(
+        identity: identity,
+        repoPath: controller.scope.repoPath,
+        number: review.number,
+        locator: locator,
+        body: changedBody,
+      );
+      List<ReviewComment>? refreshed;
+      String? refreshWarning;
+      try {
+        refreshed = await forge.getReviewComments(
+          identity: identity,
+          repoPath: controller.scope.repoPath,
+          number: review.number,
+        );
+      } catch (error) {
+        refreshWarning =
+            'Comment was updated, but the comments could not be refreshed: '
+            '${_commentErrorMessage(error)}';
+      }
+      final refreshedComment = refreshed
+          ?.where((comment) => comment.id == commentId)
+          .firstOrNull;
+      if (refreshedComment?.body == changedBody) {
+        controller._pendingCommentSaves.remove(commentId);
+      }
+      if (!controller._disposed) {
+        final latest = state.value ?? current;
+        final visible = refreshed == null
+            ? latest.comments
+            : controller
+                  ._applyPendingCommentBodies(
+                    latest.copyWith(comments: refreshed),
+                  )
+                  .comments;
+        final saving = <String>{...latest.savingCommentIds}..remove(commentId);
+        state = AsyncData(
+          latest.copyWith(
+            comments: _replaceCommentBody(
+              visible,
+              commentId: commentId,
+              body: changedBody,
+            ),
+            savingCommentIds: saving,
+            errorMessage: refreshWarning,
+            clearError: refreshWarning == null,
+          ),
+        );
+      }
+    } on ForgeException catch (error) {
+      _failCommentSave(commentId, pending, error);
+    } catch (error) {
+      _failCommentSave(commentId, pending, error);
+    } finally {
+      controller._savingCommentIds.remove(commentId);
+      controller._schedulePoll(controller.scope);
+    }
+  }
+
+  List<ReviewComment> _replaceCommentBody(
+    List<ReviewComment> comments, {
+    required String commentId,
+    required String body,
+  }) {
+    var found = false;
+    final result = <ReviewComment>[];
+    for (final comment in comments) {
+      if (comment.id == commentId) {
+        found = true;
+        result.add(comment.copyWith(body: body));
+      } else {
+        result.add(comment);
+      }
+    }
+    if (!found) {
+      final current = state.value?.comments;
+      if (current != null) {
+        for (final comment in current) {
+          if (comment.id == commentId) {
+            result.add(comment.copyWith(body: body));
+            break;
+          }
+        }
+      }
+    }
+    return result;
+  }
+
+  void _failCommentSave(
+    String commentId,
+    _PendingReviewCommentSave pending,
+    Object error,
+  ) {
+    final controller = _controller;
+    if (controller._disposed) {
+      return;
+    }
+    final current = state.value;
+    if (current == null) {
+      return;
+    }
+    final saving = <String>{...current.savingCommentIds}..remove(commentId);
+    controller._pendingCommentSaves.remove(commentId);
+    controller._savingCommentIds.remove(commentId);
+    state = AsyncData(
+      current.copyWith(
+        comments: _replaceCommentBody(
+          current.comments,
+          commentId: commentId,
+          body: pending.originalBody,
+        ),
+        savingCommentIds: saving,
+        errorMessage:
+            'Could not update comment: ${_commentErrorMessage(error)}',
+      ),
+    );
+  }
+
+  String _commentErrorMessage(Object error) {
+    return error is ForgeException ? error.message : error.toString();
   }
 
   Future<void> _runReviewMutation({

--- a/lib/src/features/pull_requests/application/workspace_pull_request_state.dart
+++ b/lib/src/features/pull_requests/application/workspace_pull_request_state.dart
@@ -40,6 +40,8 @@ class WorkspacePullRequestState {
     this.canCloseReview = false,
     this.canChangeDraftStatus = false,
     this.canComment = false,
+    this.canEditComments = false,
+    this.savingCommentIds = const <String>{},
     this.action,
     this.errorMessage,
   });
@@ -75,6 +77,8 @@ class WorkspacePullRequestState {
   final bool canCloseReview;
   final bool canChangeDraftStatus;
   final bool canComment;
+  final bool canEditComments;
+  final Set<String> savingCommentIds;
   final PullRequestAction? action;
   final String? errorMessage;
 
@@ -109,6 +113,8 @@ class WorkspacePullRequestState {
     bool? canCloseReview,
     bool? canChangeDraftStatus,
     bool? canComment,
+    bool? canEditComments,
+    Set<String>? savingCommentIds,
     PullRequestAction? action,
     bool clearAction = false,
     String? errorMessage,
@@ -131,6 +137,8 @@ class WorkspacePullRequestState {
       canCloseReview: canCloseReview ?? this.canCloseReview,
       canChangeDraftStatus: canChangeDraftStatus ?? this.canChangeDraftStatus,
       canComment: canComment ?? this.canComment,
+      canEditComments: canEditComments ?? this.canEditComments,
+      savingCommentIds: savingCommentIds ?? this.savingCommentIds,
       action: clearAction ? null : (action ?? this.action),
       errorMessage: clearError ? null : (errorMessage ?? this.errorMessage),
     );
@@ -143,7 +151,7 @@ class WorkspacePullRequestState {
         .map((c) => '${c.name}:${c.status.name}:${c.conclusion.name}')
         .join('|');
     final commentPart = comments
-        .map((comment) => '${comment.id}:${comment.createdAt}')
+        .map((comment) => '${comment.id}:${comment.createdAt}:${comment.body}')
         .join('|');
     return '${review?.number}:${review?.state.name}:${review?.title}:'
         '${suggestedReview?.number}:${suggestedReview?.state.name}:$dismissed:'

--- a/lib/src/features/pull_requests/domain/review_comment.dart
+++ b/lib/src/features/pull_requests/domain/review_comment.dart
@@ -1,6 +1,25 @@
 /// Where a pull-request comment was created.
 enum ReviewCommentKind { conversation, review }
 
+/// The provider-neutral source of an editable review comment.
+enum ReviewCommentSource { conversation, reviewSummary, reviewThread }
+
+/// Explicit identifiers needed to update an existing review comment.
+///
+/// [parentId] is the discussion/thread identifier for provider APIs that
+/// address a comment through its containing thread.
+class ReviewCommentLocator {
+  const ReviewCommentLocator({
+    required this.source,
+    required this.commentId,
+    this.parentId,
+  });
+
+  final ReviewCommentSource source;
+  final String commentId;
+  final String? parentId;
+}
+
 /// Provider-neutral comment displayed in the pull-request conversation.
 class ReviewComment {
   const ReviewComment({
@@ -13,6 +32,7 @@ class ReviewComment {
     this.path,
     this.line,
     this.resolved = false,
+    this.locator,
   });
 
   final String id;
@@ -24,4 +44,20 @@ class ReviewComment {
   final String? path;
   final int? line;
   final bool resolved;
+  final ReviewCommentLocator? locator;
+
+  ReviewComment copyWith({String? body, ReviewCommentLocator? locator}) {
+    return ReviewComment(
+      id: id,
+      author: author,
+      body: body ?? this.body,
+      createdAt: createdAt,
+      kind: kind,
+      url: url,
+      path: path,
+      line: line,
+      resolved: resolved,
+      locator: locator ?? this.locator,
+    );
+  }
 }

--- a/lib/src/features/pull_requests/domain/review_comment_task_list.dart
+++ b/lib/src/features/pull_requests/domain/review_comment_task_list.dart
@@ -1,0 +1,78 @@
+/// One task-list marker found in a review comment body.
+class ReviewCommentTaskListItem {
+  const ReviewCommentTaskListItem({
+    required this.markerOffset,
+    required this.checked,
+  });
+
+  /// The offset of the state character inside the square brackets.
+  final int markerOffset;
+  final bool checked;
+}
+
+final _reviewCommentTaskLine = RegExp(
+  r'^[ \t]*(?:>[ \t]*)*(?:(?:(?:-|\*|\+)[ \t]+)|(?:[0-9]+[.)][ \t]+))?\[([ xX])\][ \t]+\S.*$',
+);
+final _reviewCommentFence = RegExp(r'^[ \t]{0,3}(`{3,}|~{3,})');
+
+/// Finds task items in display order while skipping fenced code blocks.
+List<ReviewCommentTaskListItem> findReviewCommentTaskListItems(String body) {
+  final items = <ReviewCommentTaskListItem>[];
+  final lines = body.split('\n');
+  String? fenceCharacter;
+  var fenceLength = 0;
+  var offset = 0;
+
+  for (var index = 0; index < lines.length; index++) {
+    final rawLine = lines[index];
+    final line = rawLine.endsWith('\r')
+        ? rawLine.substring(0, rawLine.length - 1)
+        : rawLine;
+    final fence = _reviewCommentFence.firstMatch(line);
+    if (fence != null) {
+      final marker = fence.group(1)!;
+      final character = marker.substring(0, 1);
+      final rest = line.substring(fence.end).trim();
+      if (fenceCharacter == null) {
+        fenceCharacter = character;
+        fenceLength = marker.length;
+      } else if (character == fenceCharacter &&
+          marker.length >= fenceLength &&
+          rest.isEmpty) {
+        fenceCharacter = null;
+        fenceLength = 0;
+      }
+    } else if (fenceCharacter == null) {
+      final match = _reviewCommentTaskLine.firstMatch(line);
+      if (match != null) {
+        final stateOffset = line.indexOf('[', match.start) + 1;
+        items.add(
+          ReviewCommentTaskListItem(
+            markerOffset: offset + stateOffset,
+            checked: match.group(1)!.toLowerCase() == 'x',
+          ),
+        );
+      }
+    }
+    offset += rawLine.length;
+    if (index < lines.length - 1) {
+      offset++;
+    }
+  }
+  return items;
+}
+
+/// Toggles one task item and preserves every other byte of [body].
+String? toggleReviewCommentTaskListItem(String body, int itemIndex) {
+  final items = findReviewCommentTaskListItems(body);
+  if (itemIndex < 0 || itemIndex >= items.length) {
+    return null;
+  }
+  final item = items[itemIndex];
+  final replacement = item.checked ? ' ' : 'x';
+  return body.replaceRange(
+    item.markerOffset,
+    item.markerOffset + 1,
+    replacement,
+  );
+}

--- a/lib/src/features/pull_requests/infra/azure_devops_forge_provider.dart
+++ b/lib/src/features/pull_requests/infra/azure_devops_forge_provider.dart
@@ -42,6 +42,9 @@ class AzureDevOpsForgeProvider
   bool get supportsReviewCreation => true;
 
   @override
+  bool get supportsReviewCommentEditing => true;
+
+  @override
   bool get supportsReviewComments => true;
 
   @visibleForTesting
@@ -56,6 +59,11 @@ class AzureDevOpsForgeProvider
       ],
       'status': 1,
     });
+  }
+
+  @visibleForTesting
+  static String commentBodyJson(String body) {
+    return jsonEncode(<String, String>{'content': body});
   }
 
   /// PATCH body for retargeting a pull request via `az devops invoke`.

--- a/lib/src/features/pull_requests/infra/azure_devops_review_comments.dart
+++ b/lib/src/features/pull_requests/infra/azure_devops_review_comments.dart
@@ -87,6 +87,55 @@ mixin _AzureDevOpsReviewComments {
     }
   }
 
+  Future<void> updateReviewComment({
+    required GitRemoteIdentity identity,
+    required String repoPath,
+    required int number,
+    required ReviewCommentLocator locator,
+    required String body,
+  }) async {
+    final project = _project(identity);
+    final threadId = locator.parentId;
+    if (threadId == null || threadId.isEmpty) {
+      throw const ForgeRequestFailed(
+        'The Azure DevOps comment thread could not be determined.',
+      );
+    }
+    final tempDir = await Directory.systemTemp.createTemp('alera-pr-comment');
+    try {
+      final bodyFile = File(p.join(tempDir.path, 'body.json'));
+      await bodyFile.writeAsString(
+        AzureDevOpsForgeProvider.commentBodyJson(body),
+      );
+      await _azure._run(<String>[
+        'devops',
+        'invoke',
+        '--area',
+        'git',
+        '--resource',
+        'pullRequestThreadComments',
+        '--route-parameters',
+        'project=$project',
+        'repositoryId=${identity.repo}',
+        'pullRequestId=$number',
+        'threadId=$threadId',
+        'commentId=${locator.commentId}',
+        '--http-method',
+        'PATCH',
+        '--api-version',
+        '7.1',
+        '--in-file',
+        bodyFile.path,
+        '--organization',
+        azureOrgUrl(identity),
+        '--output',
+        'json',
+      ], repoPath);
+    } finally {
+      await tempDir.delete(recursive: true);
+    }
+  }
+
   Iterable<ReviewComment> _mapThread(Map<String, Object?> thread) sync* {
     final threadId = '${thread['id']}';
     final context = thread['threadContext'];
@@ -134,6 +183,15 @@ mixin _AzureDevOpsReviewComments {
         path: path,
         line: line,
         resolved: resolved,
+        locator: rawComment['id'] == null
+            ? null
+            : ReviewCommentLocator(
+                source: path == null
+                    ? ReviewCommentSource.conversation
+                    : ReviewCommentSource.reviewThread,
+                commentId: '${rawComment['id']}',
+                parentId: threadId,
+              ),
       );
     }
   }

--- a/lib/src/features/pull_requests/infra/github_forge_provider.dart
+++ b/lib/src/features/pull_requests/infra/github_forge_provider.dart
@@ -71,6 +71,9 @@ class GitHubForgeProvider
   @override
   bool get supportsReviewComments => true;
 
+  @override
+  bool get supportsReviewCommentEditing => true;
+
   /// `gh` accepts `[HOST/]OWNER/REPO`; the host prefix is only needed for
   /// GitHub Enterprise hosts.
   String _repoSlug(GitRemoteIdentity identity) {

--- a/lib/src/features/pull_requests/infra/github_review_comments.dart
+++ b/lib/src/features/pull_requests/infra/github_review_comments.dart
@@ -86,6 +86,7 @@ query($thread: ID!, $commentsAfter: String) {
           entry,
           kind: ReviewCommentKind.conversation,
           idPrefix: 'issue',
+          source: ReviewCommentSource.conversation,
         ),
       ...threads,
       for (final entry in reviews)
@@ -95,6 +96,7 @@ query($thread: ID!, $commentsAfter: String) {
             kind: ReviewCommentKind.conversation,
             idPrefix: 'review',
             createdAtField: 'submitted_at',
+            source: ReviewCommentSource.reviewSummary,
           ),
     ]..sort((a, b) => a.createdAt.compareTo(b.createdAt));
     return comments;
@@ -114,6 +116,34 @@ query($thread: ID!, $commentsAfter: String) {
       _github._repoSlug(identity),
       '--body',
       body,
+    ], repoPath);
+  }
+
+  Future<void> updateReviewComment({
+    required GitRemoteIdentity identity,
+    required String repoPath,
+    required int number,
+    required ReviewCommentLocator locator,
+    required String body,
+  }) async {
+    _github._ensureSupportedHost(identity);
+    final endpoint = switch (locator.source) {
+      ReviewCommentSource.conversation =>
+        'repos/${identity.owner}/${identity.repo}/issues/comments/${locator.commentId}',
+      ReviewCommentSource.reviewSummary =>
+        'repos/${identity.owner}/${identity.repo}/pulls/$number/reviews/${locator.commentId}',
+      ReviewCommentSource.reviewThread =>
+        'repos/${identity.owner}/${identity.repo}/pulls/comments/${locator.commentId}',
+    };
+    await _github._run(<String>[
+      'api',
+      '--hostname',
+      identity.host,
+      endpoint,
+      '--method',
+      'PATCH',
+      '--raw-field',
+      'body=$body',
     ], repoPath);
   }
 
@@ -313,8 +343,9 @@ query($thread: ID!, $commentsAfter: String) {
         continue;
       }
       final authorData = node['author'];
+      final databaseId = node['databaseId'];
       yield ReviewComment(
-        id: 'thread:$threadId:${node['databaseId']}',
+        id: 'thread:$threadId:$databaseId',
         author: authorData is Map<String, Object?>
             ? authorData['login'] as String? ?? 'Unknown author'
             : 'Unknown author',
@@ -327,6 +358,13 @@ query($thread: ID!, $commentsAfter: String) {
         path: node['path'] as String?,
         line: line,
         resolved: thread['isResolved'] == true,
+        locator: databaseId == null
+            ? null
+            : ReviewCommentLocator(
+                source: ReviewCommentSource.reviewThread,
+                commentId: '$databaseId',
+                parentId: threadId,
+              ),
       );
     }
   }
@@ -335,6 +373,7 @@ query($thread: ID!, $commentsAfter: String) {
     Map<String, Object?> entry, {
     required ReviewCommentKind kind,
     required String idPrefix,
+    required ReviewCommentSource source,
     String createdAtField = 'created_at',
   }) {
     final user = entry['user'];
@@ -350,6 +389,9 @@ query($thread: ID!, $commentsAfter: String) {
           DateTime.fromMillisecondsSinceEpoch(0, isUtc: true),
       kind: kind,
       url: entry['html_url'] as String?,
+      locator: entry['id'] == null
+          ? null
+          : ReviewCommentLocator(source: source, commentId: '${entry['id']}'),
     );
   }
 }

--- a/lib/src/features/pull_requests/infra/gitlab_forge_provider.dart
+++ b/lib/src/features/pull_requests/infra/gitlab_forge_provider.dart
@@ -35,6 +35,9 @@ class GitLabForgeProvider
   @override
   bool get supportsReviewCreation => true;
 
+  @override
+  bool get supportsReviewCommentEditing => true;
+
   String _repoUrl(GitRemoteIdentity identity) =>
       'https://${identity.host}/${identity.owner}/${identity.repo}';
 

--- a/lib/src/features/pull_requests/infra/gitlab_review_comments.dart
+++ b/lib/src/features/pull_requests/infra/gitlab_review_comments.dart
@@ -33,9 +33,11 @@ mixin _GitLabReviewComments {
         final author = note['author'];
         final position = note['position'];
         final positioned = position is Map;
+        final noteId = note['id'];
+        final discussionId = discussion['id'];
         comments.add(
           ReviewComment(
-            id: 'discussion:${discussion['id']}:${note['id']}',
+            id: 'discussion:$discussionId:$noteId',
             author: author is Map
                 ? author['username'] as String? ??
                       author['name'] as String? ??
@@ -58,6 +60,15 @@ mixin _GitLabReviewComments {
                       ?.toInt()
                 : null,
             resolved: positioned && note['resolved'] == true,
+            locator: noteId == null
+                ? null
+                : ReviewCommentLocator(
+                    source: positioned
+                        ? ReviewCommentSource.reviewThread
+                        : ReviewCommentSource.conversation,
+                    commentId: '$noteId',
+                    parentId: positioned ? '$discussionId' : null,
+                  ),
           ),
         );
       }
@@ -77,6 +88,40 @@ mixin _GitLabReviewComments {
       repoPath,
       '${_gitlab._projectEndpoint(identity)}/merge_requests/$number/notes',
       method: 'POST',
+      fields: <String>['body=$body'],
+    );
+  }
+
+  Future<void> updateReviewComment({
+    required GitRemoteIdentity identity,
+    required String repoPath,
+    required int number,
+    required ReviewCommentLocator locator,
+    required String body,
+  }) async {
+    if (locator.source == ReviewCommentSource.reviewSummary) {
+      throw const ForgeRequestFailed(
+        'GitLab does not expose pull-request review summaries as comments.',
+      );
+    }
+    final discussionId = locator.parentId;
+    if (locator.source == ReviewCommentSource.reviewThread &&
+        (discussionId == null || discussionId.isEmpty)) {
+      throw const ForgeRequestFailed(
+        'The GitLab comment discussion could not be determined.',
+      );
+    }
+    final endpoint = locator.source == ReviewCommentSource.reviewThread
+        ? '${_gitlab._projectEndpoint(identity)}/merge_requests/$number'
+              '/discussions/${Uri.encodeComponent(discussionId!)}'
+              '/notes/${Uri.encodeComponent(locator.commentId)}'
+        : '${_gitlab._projectEndpoint(identity)}/merge_requests/$number'
+              '/notes/${Uri.encodeComponent(locator.commentId)}';
+    await _gitlab._api(
+      identity,
+      repoPath,
+      endpoint,
+      method: 'PUT',
       fields: <String>['body=$body'],
     );
   }

--- a/lib/src/features/pull_requests/presentation/pull_request_comment_markdown.dart
+++ b/lib/src/features/pull_requests/presentation/pull_request_comment_markdown.dart
@@ -1,8 +1,10 @@
 import 'dart:async';
 
 import 'package:alera/src/app/theme/alera_tokens.dart';
+import 'package:alera/src/design_system/forms/alera_checkbox.dart';
 import 'package:alera/src/design_system/icons/alera_icons.dart';
 import 'package:flutter/material.dart';
+import 'package:gpt_markdown/custom_widgets/markdown_config.dart';
 import 'package:gpt_markdown/gpt_markdown.dart';
 
 class PullRequestCommentMarkdown extends StatelessWidget {
@@ -10,10 +12,16 @@ class PullRequestCommentMarkdown extends StatelessWidget {
     super.key,
     required this.body,
     required this.onOpenUrl,
+    this.taskListEditable = false,
+    this.taskListSaving = false,
+    this.onTaskListItemToggle,
   });
 
   final String body;
   final Future<void> Function(String url) onOpenUrl;
+  final bool taskListEditable;
+  final bool taskListSaving;
+  final Future<void> Function(int itemIndex)? onTaskListItemToggle;
 
   @override
   Widget build(BuildContext context) {
@@ -24,6 +32,15 @@ class PullRequestCommentMarkdown extends StatelessWidget {
           height: 1.4,
         ) ??
         const TextStyle(color: AleraTokens.foreground, height: 1.4);
+    final components = <MarkdownComponent>[
+      for (final component in MarkdownComponent.globalComponents)
+        if (component is! CheckBoxMd) component,
+      _PullRequestTaskCheckboxMd(
+        enabled:
+            taskListEditable && !taskListSaving && onTaskListItemToggle != null,
+        onToggle: onTaskListItemToggle,
+      ),
+    ];
     return SelectionArea(
       child: GptMarkdownTheme(
         gptThemeData: GptMarkdownThemeData(
@@ -51,6 +68,7 @@ class PullRequestCommentMarkdown extends StatelessWidget {
           child: GptMarkdown(
             body,
             style: bodyStyle,
+            components: components,
             codeBuilder: _buildCodeBlock,
             imageBuilder: buildPullRequestCommentImage,
             onLinkTap: (url, _) {
@@ -107,6 +125,47 @@ class PullRequestCommentMarkdown extends StatelessWidget {
           ),
         ],
       ),
+    );
+  }
+}
+
+class _PullRequestTaskCheckboxMd extends BlockMd {
+  _PullRequestTaskCheckboxMd({required this.enabled, required this.onToggle});
+
+  final bool enabled;
+  final Future<void> Function(int itemIndex)? onToggle;
+  var _nextItemIndex = 0;
+
+  @override
+  String get expString => r"\[((?:x|X| ))\][ \t]+(\S[^\n]*?)$";
+
+  @override
+  Widget build(BuildContext context, String text, GptMarkdownConfig config) {
+    final match = exp.firstMatch(text.trim());
+    if (match == null) {
+      return const SizedBox.shrink();
+    }
+    final itemIndex = _nextItemIndex++;
+    final checked = match.group(1)!.toLowerCase() == 'x';
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        AleraCheckbox(
+          value: checked,
+          enabled: enabled,
+          onChanged: (_) {
+            final callback = onToggle;
+            if (callback != null) {
+              unawaited(callback(itemIndex));
+            }
+          },
+        ),
+        const SizedBox(width: AleraTokens.space4),
+        Flexible(
+          child: MdWidget(context, match.group(2)!, false, config: config),
+        ),
+      ],
     );
   }
 }

--- a/lib/src/features/pull_requests/presentation/pull_request_review_comments.dart
+++ b/lib/src/features/pull_requests/presentation/pull_request_review_comments.dart
@@ -4,15 +4,21 @@ class _PullRequestCommentsSection extends StatefulWidget {
   const _PullRequestCommentsSection({
     required this.comments,
     required this.canComment,
+    required this.canEditComments,
+    required this.savingCommentIds,
     required this.action,
     required this.onAddComment,
+    required this.onToggleTask,
     required this.onOpenUrl,
   });
 
   final List<ReviewComment> comments;
   final bool canComment;
+  final bool canEditComments;
+  final Set<String> savingCommentIds;
   final PullRequestAction? action;
   final Future<bool> Function(String body) onAddComment;
+  final Future<void> Function(String commentId, int itemIndex) onToggleTask;
   final Future<void> Function(String url) onOpenUrl;
 
   @override
@@ -140,6 +146,14 @@ class _PullRequestCommentsSectionState
             _ReviewCommentCard(
               comment: widget.comments[index],
               onOpenUrl: widget.onOpenUrl,
+              taskListEditable:
+                  widget.canEditComments &&
+                  widget.comments[index].locator != null,
+              taskListSaving: widget.savingCommentIds.contains(
+                widget.comments[index].id,
+              ),
+              onTaskListItemToggle: (itemIndex) =>
+                  widget.onToggleTask(widget.comments[index].id, itemIndex),
             ),
             if (index != widget.comments.length - 1)
               const SizedBox(height: AleraTokens.space8),
@@ -150,10 +164,19 @@ class _PullRequestCommentsSectionState
 }
 
 class _ReviewCommentCard extends StatelessWidget {
-  const _ReviewCommentCard({required this.comment, required this.onOpenUrl});
+  const _ReviewCommentCard({
+    required this.comment,
+    required this.onOpenUrl,
+    required this.taskListEditable,
+    required this.taskListSaving,
+    required this.onTaskListItemToggle,
+  });
 
   final ReviewComment comment;
   final Future<void> Function(String url) onOpenUrl;
+  final bool taskListEditable;
+  final bool taskListSaving;
+  final Future<void> Function(int itemIndex) onTaskListItemToggle;
 
   @override
   Widget build(BuildContext context) {
@@ -232,6 +255,9 @@ class _ReviewCommentCard extends StatelessWidget {
             PullRequestCommentMarkdown(
               body: comment.body,
               onOpenUrl: onOpenUrl,
+              taskListEditable: taskListEditable,
+              taskListSaving: taskListSaving,
+              onTaskListItemToggle: onTaskListItemToggle,
             ),
           ],
         ),

--- a/lib/src/features/pull_requests/presentation/pull_request_review_view.dart
+++ b/lib/src/features/pull_requests/presentation/pull_request_review_view.dart
@@ -37,6 +37,8 @@ class PullRequestReviewView extends StatefulWidget {
     required this.canCloseReview,
     required this.canChangeDraftStatus,
     required this.canComment,
+    this.canEditComments = false,
+    this.savingCommentIds = const <String>{},
     required this.action,
     required this.onOpenUrl,
     required this.onUnlink,
@@ -44,6 +46,7 @@ class PullRequestReviewView extends StatefulWidget {
     required this.onClose,
     required this.onDraftStatusChanged,
     required this.onAddComment,
+    this.onToggleTask = _ignorePullRequestTaskToggle,
     required this.onUpdate,
     required this.onLoadCheckDetails,
   });
@@ -56,6 +59,8 @@ class PullRequestReviewView extends StatefulWidget {
   final bool canCloseReview;
   final bool canChangeDraftStatus;
   final bool canComment;
+  final bool canEditComments;
+  final Set<String> savingCommentIds;
   final PullRequestAction? action;
   final Future<void> Function(String url) onOpenUrl;
   final Future<void> Function() onUnlink;
@@ -63,6 +68,7 @@ class PullRequestReviewView extends StatefulWidget {
   final Future<void> Function() onClose;
   final Future<void> Function(bool draft) onDraftStatusChanged;
   final Future<bool> Function(String body) onAddComment;
+  final Future<void> Function(String commentId, int itemIndex) onToggleTask;
   final Future<UpdateReviewResult> Function(UpdateReviewInput input) onUpdate;
   final Future<ReviewCheckDetails?> Function(ReviewCheck check)
   onLoadCheckDetails;
@@ -70,6 +76,11 @@ class PullRequestReviewView extends StatefulWidget {
   @override
   State<PullRequestReviewView> createState() => _PullRequestReviewViewState();
 }
+
+Future<void> _ignorePullRequestTaskToggle(
+  String commentId,
+  int itemIndex,
+) async {}
 
 class _PullRequestReviewViewState extends State<PullRequestReviewView> {
   final TextEditingController _titleController = TextEditingController();
@@ -165,8 +176,11 @@ class _PullRequestReviewViewState extends State<PullRequestReviewView> {
                 _PullRequestCommentsSection(
                   comments: widget.comments,
                   canComment: widget.canComment && review.isOpen,
+                  canEditComments: widget.canEditComments && review.isOpen,
+                  savingCommentIds: widget.savingCommentIds,
                   action: widget.action,
                   onAddComment: widget.onAddComment,
+                  onToggleTask: widget.onToggleTask,
                   onOpenUrl: widget.onOpenUrl,
                 ),
               ],

--- a/lib/src/features/pull_requests/presentation/workspace_pull_requests_panel.dart
+++ b/lib/src/features/pull_requests/presentation/workspace_pull_requests_panel.dart
@@ -193,6 +193,8 @@ class _PullRequestBody extends StatelessWidget {
         canCloseReview: state.canCloseReview,
         canChangeDraftStatus: state.canChangeDraftStatus,
         canComment: state.canComment,
+        canEditComments: state.canEditComments,
+        savingCommentIds: state.savingCommentIds,
         action: state.action,
         onOpenUrl: onOpenUrl,
         onUnlink: controller.unlink,
@@ -200,6 +202,7 @@ class _PullRequestBody extends StatelessWidget {
         onClose: controller.closeReview,
         onDraftStatusChanged: controller.setReviewDraft,
         onAddComment: controller.addReviewComment,
+        onToggleTask: controller.toggleReviewCommentTask,
         onUpdate: controller.updateReview,
         onLoadCheckDetails: controller.loadCheckDetails,
       );

--- a/test/unit/fake_forge_provider.dart
+++ b/test/unit/fake_forge_provider.dart
@@ -50,12 +50,19 @@ class FakeForgeProvider implements ForgeProvider {
   bool canCloseReview = true;
   bool canChangeDraftStatus = true;
   bool canComment = true;
+  bool canEditComments = true;
   List<ReviewComment> comments = <ReviewComment>[];
   Future<List<ReviewComment>> Function()? commentsLoader;
   int commentsCalls = 0;
   String? lastCommentBody;
   int addCommentCalls = 0;
   Object? addCommentError;
+  int updateCommentCalls = 0;
+  ReviewCommentLocator? lastCommentLocator;
+  String? lastUpdatedCommentBody;
+  Object? updateCommentError;
+  Future<void> Function(ReviewCommentLocator locator, String body)?
+  updateCommentAction;
   ReviewMergeMethod? lastMergeMethod;
   int mergeCalls = 0;
   Object? mergeError;
@@ -82,6 +89,9 @@ class FakeForgeProvider implements ForgeProvider {
 
   @override
   bool get supportsReviewComments => canComment;
+
+  @override
+  bool get supportsReviewCommentEditing => canEditComments;
 
   @override
   Future<ForgeAuthStatus> checkAuth({
@@ -163,6 +173,34 @@ class FakeForgeProvider implements ForgeProvider {
         createdAt: DateTime.utc(2026, 7, 16),
         kind: ReviewCommentKind.conversation,
       ),
+    ];
+  }
+
+  @override
+  Future<void> updateReviewComment({
+    required GitRemoteIdentity identity,
+    required String repoPath,
+    required int number,
+    required ReviewCommentLocator locator,
+    required String body,
+  }) async {
+    updateCommentCalls++;
+    lastCommentLocator = locator;
+    lastUpdatedCommentBody = body;
+    final error = updateCommentError;
+    if (error != null) {
+      throw error;
+    }
+    final action = updateCommentAction;
+    if (action != null) {
+      await action(locator, body);
+      return;
+    }
+    comments = <ReviewComment>[
+      for (final comment in comments)
+        comment.locator?.commentId == locator.commentId
+            ? comment.copyWith(body: body)
+            : comment,
     ];
   }
 

--- a/test/unit/forge_provider_comments_test.dart
+++ b/test/unit/forge_provider_comments_test.dart
@@ -221,6 +221,65 @@ void main() {
       expect(call.optionValue('repo'), 'leynier/alera');
       expect(call.optionValue('body'), 'Ready to merge');
     });
+
+    test('updates conversation, review summary, and inline comments', () async {
+      final runner = FakeRecordingProcessRunner(<Object>[
+        _ok('{}'),
+        _ok('{}'),
+        _ok('{}'),
+      ]);
+      final provider = GitHubForgeProvider(runner);
+
+      await provider.updateReviewComment(
+        identity: _githubIdentity,
+        repoPath: '/repo',
+        number: 123,
+        locator: const ReviewCommentLocator(
+          source: ReviewCommentSource.conversation,
+          commentId: '11',
+        ),
+        body: '- [x] exact\nline',
+      );
+      await provider.updateReviewComment(
+        identity: _githubIdentity,
+        repoPath: '/repo',
+        number: 123,
+        locator: const ReviewCommentLocator(
+          source: ReviewCommentSource.reviewSummary,
+          commentId: '12',
+        ),
+        body: 'Summary',
+      );
+      await provider.updateReviewComment(
+        identity: _githubIdentity,
+        repoPath: '/repo',
+        number: 123,
+        locator: const ReviewCommentLocator(
+          source: ReviewCommentSource.reviewThread,
+          commentId: '13',
+          parentId: 'thread-1',
+        ),
+        body: 'Inline',
+      );
+
+      expect(
+        runner.calls[0].arguments,
+        contains('repos/leynier/alera/issues/comments/11'),
+      );
+      expect(runner.calls[0].optionValue('method'), 'PATCH');
+      expect(
+        runner.calls[0].optionValue('raw-field'),
+        'body=- [x] exact\nline',
+      );
+      expect(
+        runner.calls[1].arguments,
+        contains('repos/leynier/alera/pulls/123/reviews/12'),
+      );
+      expect(
+        runner.calls[2].arguments,
+        contains('repos/leynier/alera/pulls/comments/13'),
+      );
+    });
   });
 
   group('AzureDevOpsForgeProvider comments', () {
@@ -282,5 +341,35 @@ void main() {
         '"commentType":1}],"status":1}',
       );
     });
+
+    test(
+      'updates a thread comment through the official comment endpoint',
+      () async {
+        final runner = FakeRecordingProcessRunner(<Object>[_ok('{}')]);
+        final provider = AzureDevOpsForgeProvider(runner);
+
+        await provider.updateReviewComment(
+          identity: _azureIdentity,
+          repoPath: '/repo',
+          number: 42,
+          locator: const ReviewCommentLocator(
+            source: ReviewCommentSource.reviewThread,
+            commentId: '2',
+            parentId: '11',
+          ),
+          body: '- [x] exact',
+        );
+
+        final call = runner.calls.single;
+        expect(call.optionValue('resource'), 'pullRequestThreadComments');
+        expect(call.optionValue('http-method'), 'PATCH');
+        expect(call.arguments, contains('threadId=11'));
+        expect(call.arguments, contains('commentId=2'));
+        expect(
+          AzureDevOpsForgeProvider.commentBodyJson('- [x] exact'),
+          '{"content":"- [x] exact"}',
+        );
+      },
+    );
   });
 }

--- a/test/unit/gitlab_forge_provider_test.dart
+++ b/test/unit/gitlab_forge_provider_test.dart
@@ -214,6 +214,52 @@ ${_reviewJson.trim()}
       expect(call.optionValue('raw-field'), 'body=Ready to merge');
       expect(call.arguments[1], endsWith('/merge_requests/42/notes'));
     });
+
+    test(
+      'updates top-level and discussion notes through their endpoints',
+      () async {
+        final topLevelRunner = FakeRecordingProcessRunner(<Object>[_ok('{}')]);
+        await GitLabForgeProvider(topLevelRunner).updateReviewComment(
+          identity: _identity,
+          repoPath: '/repo',
+          number: 42,
+          locator: const ReviewCommentLocator(
+            source: ReviewCommentSource.conversation,
+            commentId: '7',
+          ),
+          body: '- [x] exact',
+        );
+        expect(
+          topLevelRunner.calls.single.arguments[1],
+          endsWith('/merge_requests/42/notes/7'),
+        );
+        expect(topLevelRunner.calls.single.optionValue('method'), 'PUT');
+        expect(
+          topLevelRunner.calls.single.optionValue('raw-field'),
+          'body=- [x] exact',
+        );
+
+        final discussionRunner = FakeRecordingProcessRunner(<Object>[
+          _ok('{}'),
+        ]);
+        await GitLabForgeProvider(discussionRunner).updateReviewComment(
+          identity: _identity,
+          repoPath: '/repo',
+          number: 42,
+          locator: const ReviewCommentLocator(
+            source: ReviewCommentSource.reviewThread,
+            commentId: '8',
+            parentId: 'discussion-1',
+          ),
+          body: 'Inline',
+        );
+        expect(
+          discussionRunner.calls.single.arguments[1],
+          endsWith('/merge_requests/42/discussions/discussion-1/notes/8'),
+        );
+        expect(discussionRunner.calls.single.optionValue('method'), 'PUT');
+      },
+    );
   });
 
   group('GitLabForgeProvider mutations', () {

--- a/test/unit/review_comment_task_list_test.dart
+++ b/test/unit/review_comment_task_list_test.dart
@@ -1,0 +1,75 @@
+import 'package:alera/src/features/pull_requests/domain/review_comment_task_list.dart';
+import 'package:alera/src/features/pull_requests/domain/review_comment.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test(
+    'finds supported unordered, ordered, and quoted task items in order',
+    () {
+      const body = '''
+- [ ] Same
+  * [x] Nested
++ [X] Same
+1) [ ] Ordered
+> - [ ] Quoted
+```text
+- [ ] Code
+```
+''';
+
+      final items = findReviewCommentTaskListItems(body);
+
+      expect(items, hasLength(5));
+      expect(items.map((item) => item.checked), <bool>[
+        false,
+        true,
+        true,
+        false,
+        false,
+      ]);
+      expect(items.map((item) => body[item.markerOffset]), <String>[
+        ' ',
+        'x',
+        'X',
+        ' ',
+        ' ',
+      ]);
+    },
+  );
+
+  test('toggles one duplicate without changing any other byte', () {
+    const body = '- [ ] Same\r\n- [ ] Same\r\n';
+
+    expect(
+      toggleReviewCommentTaskListItem(body, 1),
+      '- [ ] Same\r\n- [x] Same\r\n',
+    );
+    expect(toggleReviewCommentTaskListItem(body, 2), isNull);
+  });
+
+  test('unchecks uppercase markers with a one-character replacement', () {
+    const body = '- [X] Keep formatting';
+
+    expect(toggleReviewCommentTaskListItem(body, 0), '- [ ] Keep formatting');
+  });
+
+  test('copies a review comment without changing its body or locator', () {
+    final original = ReviewComment(
+      id: 'comment',
+      author: 'alice',
+      body: 'Body',
+      createdAt: DateTime.utc(2026, 7, 16),
+      kind: ReviewCommentKind.review,
+      locator: const ReviewCommentLocator(
+        source: ReviewCommentSource.reviewThread,
+        commentId: '10',
+        parentId: 'thread-1',
+      ),
+    );
+
+    final copy = original.copyWith();
+
+    expect(copy.body, 'Body');
+    expect(copy.locator, same(original.locator));
+  });
+}

--- a/test/unit/workspace_pull_request_comments_controller_test.dart
+++ b/test/unit/workspace_pull_request_comments_controller_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:alera/src/features/pull_requests/application/forge_provider.dart';
 import 'package:alera/src/features/pull_requests/application/forge_provider_registry.dart';
 import 'package:alera/src/features/pull_requests/application/pull_request_providers.dart';
@@ -126,5 +128,159 @@ void main() {
         .value!;
     expect(state.comments, <ReviewComment>[existing]);
     expect(state.errorMessage, contains('permission denied'));
+  });
+
+  test(
+    'optimistically updates one comment and blocks only that comment',
+    () async {
+      final first = ReviewComment(
+        id: 'c1',
+        author: 'reviewer',
+        body: '- [ ] first',
+        createdAt: DateTime.utc(2026, 7, 16),
+        kind: ReviewCommentKind.conversation,
+        locator: const ReviewCommentLocator(
+          source: ReviewCommentSource.conversation,
+          commentId: '1',
+        ),
+      );
+      final second = ReviewComment(
+        id: 'c2',
+        author: 'reviewer',
+        body: '- [ ] second',
+        createdAt: DateTime.utc(2026, 7, 16, 1),
+        kind: ReviewCommentKind.review,
+        locator: const ReviewCommentLocator(
+          source: ReviewCommentSource.reviewThread,
+          commentId: '2',
+          parentId: 'thread-2',
+        ),
+      );
+      final release = Completer<void>();
+      final forge = FakeForgeProvider()
+        ..branchReview = _review
+        ..comments = <ReviewComment>[first, second]
+        ..updateCommentAction = (_, _) => release.future;
+      final container = _container(forge);
+      addTearDown(container.dispose);
+
+      await container.read(
+        workspacePullRequestControllerProvider(_scope).future,
+      );
+      final controller = container.read(
+        workspacePullRequestControllerProvider(_scope).notifier,
+      );
+      final firstSave = controller.toggleReviewCommentTask('c1', 0);
+      await Future<void>.delayed(Duration.zero);
+
+      var state = container
+          .read(workspacePullRequestControllerProvider(_scope))
+          .value!;
+      expect(state.canEditComments, isTrue);
+      expect(state.savingCommentIds, <String>{'c1'});
+      expect(state.comments.first.body, '- [x] first');
+      expect(state.savingCommentIds, <String>{'c1'});
+
+      await controller.toggleReviewCommentTask('c1', 0);
+      expect(forge.updateCommentCalls, 1);
+
+      final secondSave = controller.toggleReviewCommentTask('c2', 0);
+      await Future<void>.delayed(Duration.zero);
+      expect(forge.updateCommentCalls, 2);
+      expect(
+        container
+            .read(workspacePullRequestControllerProvider(_scope))
+            .value!
+            .savingCommentIds,
+        <String>{'c1', 'c2'},
+      );
+
+      release.complete();
+      await Future.wait(<Future<void>>[firstSave, secondSave]);
+      state = container
+          .read(workspacePullRequestControllerProvider(_scope))
+          .value!;
+      expect(state.comments[0].body, '- [x] first');
+      expect(state.comments[1].body, '- [x] second');
+      expect(state.savingCommentIds, isEmpty);
+      expect(state.errorMessage, isNull);
+      expect(forge.commentsCalls, greaterThan(2));
+    },
+  );
+
+  test(
+    'rolls back a rejected task update and surfaces the provider error',
+    () async {
+      final comment = ReviewComment(
+        id: 'c1',
+        author: 'reviewer',
+        body: '- [ ] first',
+        createdAt: DateTime.utc(2026, 7, 16),
+        kind: ReviewCommentKind.conversation,
+        locator: const ReviewCommentLocator(
+          source: ReviewCommentSource.conversation,
+          commentId: '1',
+        ),
+      );
+      final forge = FakeForgeProvider()
+        ..branchReview = _review
+        ..comments = <ReviewComment>[comment]
+        ..updateCommentError = StateError('permission denied');
+      final container = _container(forge);
+      addTearDown(container.dispose);
+
+      await container.read(
+        workspacePullRequestControllerProvider(_scope).future,
+      );
+      await container
+          .read(workspacePullRequestControllerProvider(_scope).notifier)
+          .toggleReviewCommentTask('c1', 0);
+
+      final state = container
+          .read(workspacePullRequestControllerProvider(_scope))
+          .value!;
+      expect(state.comments.single.body, '- [ ] first');
+      expect(state.savingCommentIds, isEmpty);
+      expect(state.errorMessage, contains('permission denied'));
+    },
+  );
+
+  test('keeps a successful change visible when refresh fails', () async {
+    final comment = ReviewComment(
+      id: 'c1',
+      author: 'reviewer',
+      body: '- [ ] first',
+      createdAt: DateTime.utc(2026, 7, 16),
+      kind: ReviewCommentKind.conversation,
+      locator: const ReviewCommentLocator(
+        source: ReviewCommentSource.conversation,
+        commentId: '1',
+      ),
+    );
+    var commentsLoads = 0;
+    final forge = FakeForgeProvider()
+      ..branchReview = _review
+      ..comments = <ReviewComment>[comment]
+      ..commentsLoader = () async {
+        commentsLoads++;
+        if (commentsLoads > 1) {
+          throw StateError('network unavailable');
+        }
+        return <ReviewComment>[comment];
+      };
+    final container = _container(forge);
+    addTearDown(container.dispose);
+
+    await container.read(workspacePullRequestControllerProvider(_scope).future);
+    await container
+        .read(workspacePullRequestControllerProvider(_scope).notifier)
+        .toggleReviewCommentTask('c1', 0);
+
+    final state = container
+        .read(workspacePullRequestControllerProvider(_scope))
+        .value!;
+    expect(state.comments.single.body, '- [x] first');
+    expect(state.savingCommentIds, isEmpty);
+    expect(state.errorMessage, contains('comments could not be refreshed'));
   });
 }

--- a/test/widget/pull_request_review_comment_task_widget_test.dart
+++ b/test/widget/pull_request_review_comment_task_widget_test.dart
@@ -1,0 +1,148 @@
+import 'package:alera/src/design_system/forms/alera_checkbox.dart';
+import 'package:alera/src/shared/git_hosting/domain/git_hosting_provider.dart';
+import 'package:alera/src/features/pull_requests/domain/hosted_review.dart';
+import 'package:alera/src/features/pull_requests/domain/review_check.dart';
+import 'package:alera/src/features/pull_requests/domain/review_check_details.dart';
+import 'package:alera/src/features/pull_requests/domain/review_comment.dart';
+import 'package:alera/src/features/pull_requests/domain/review_merge_method.dart';
+import 'package:alera/src/features/pull_requests/domain/update_review_result.dart';
+import 'package:alera/src/features/pull_requests/presentation/pull_request_review_view.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+const _review = HostedReview(
+  provider: GitHostingProvider.github,
+  number: 42,
+  title: 'feat: tasks',
+  state: HostedReviewState.open,
+  url: 'https://github.com/leynier/alera/pull/42',
+);
+
+Widget _wrap({
+  required List<ReviewComment> comments,
+  required bool canEditComments,
+  Set<String> savingCommentIds = const <String>{},
+  required Future<void> Function(String commentId, int itemIndex) onToggle,
+}) {
+  return MaterialApp(
+    home: Scaffold(
+      body: PullRequestReviewView(
+        review: _review,
+        checks: const <ReviewCheck>[],
+        comments: comments,
+        baseBranches: const <String>['main'],
+        mergeMethods: const <ReviewMergeMethod>[ReviewMergeMethod.mergeCommit],
+        canCloseReview: false,
+        canChangeDraftStatus: false,
+        canComment: false,
+        canEditComments: canEditComments,
+        savingCommentIds: savingCommentIds,
+        action: null,
+        onOpenUrl: (_) async {},
+        onUnlink: () async {},
+        onMerge: (_) async {},
+        onClose: () async {},
+        onDraftStatusChanged: (_) async {},
+        onAddComment: (_) async => true,
+        onToggleTask: onToggle,
+        onUpdate: (_) async => const UpdateReviewSuccess(_review),
+        onLoadCheckDetails: (_) async => const ReviewCheckDetails(),
+      ),
+    ),
+  );
+}
+
+void main() {
+  testWidgets(
+    'task-list controls invoke the callback when editing is allowed',
+    (tester) async {
+      final toggles = <String>[];
+      await tester.pumpWidget(
+        _wrap(
+          canEditComments: true,
+          comments: <ReviewComment>[
+            ReviewComment(
+              id: 'task-comment',
+              author: 'alice',
+              body: '- [ ] First\n- [x] Second',
+              createdAt: DateTime.utc(2026, 7, 16),
+              kind: ReviewCommentKind.conversation,
+              locator: const ReviewCommentLocator(
+                source: ReviewCommentSource.conversation,
+                commentId: '10',
+              ),
+            ),
+          ],
+          onToggle: (commentId, itemIndex) async {
+            toggles.add('$commentId:$itemIndex');
+          },
+        ),
+      );
+
+      expect(find.byType(AleraCheckbox), findsNWidgets(2));
+      expect(
+        tester.widget<AleraCheckbox>(find.byType(AleraCheckbox).first).enabled,
+        isTrue,
+      );
+      await tester.tap(find.byType(AleraCheckbox).first);
+      await tester.pump();
+      expect(toggles, <String>['task-comment:0']);
+    },
+  );
+
+  testWidgets('task-list controls disable unsupported and saving comments', (
+    tester,
+  ) async {
+    final comments = <ReviewComment>[
+      ReviewComment(
+        id: 'saving',
+        author: 'alice',
+        body: '- [ ] Saving',
+        createdAt: DateTime.utc(2026, 7, 16),
+        kind: ReviewCommentKind.conversation,
+        locator: const ReviewCommentLocator(
+          source: ReviewCommentSource.conversation,
+          commentId: '11',
+        ),
+      ),
+      ReviewComment(
+        id: 'available',
+        author: 'bob',
+        body: '- [ ] Available',
+        createdAt: DateTime.utc(2026, 7, 16, 1),
+        kind: ReviewCommentKind.review,
+        locator: const ReviewCommentLocator(
+          source: ReviewCommentSource.reviewThread,
+          commentId: '12',
+          parentId: 'thread-12',
+        ),
+      ),
+    ];
+    await tester.pumpWidget(
+      _wrap(
+        canEditComments: true,
+        savingCommentIds: const <String>{'saving'},
+        comments: comments,
+        onToggle: (_, _) async {},
+      ),
+    );
+
+    final controls = tester.widgetList<AleraCheckbox>(
+      find.byType(AleraCheckbox),
+    );
+    expect(controls.elementAt(0).enabled, isFalse);
+    expect(controls.elementAt(1).enabled, isTrue);
+
+    await tester.pumpWidget(
+      _wrap(
+        canEditComments: false,
+        comments: <ReviewComment>[comments.first],
+        onToggle: (_, _) async {},
+      ),
+    );
+    expect(
+      tester.widget<AleraCheckbox>(find.byType(AleraCheckbox)).enabled,
+      isFalse,
+    );
+  });
+}


### PR DESCRIPTION
## Summary

- make Markdown task-list checkboxes interactive in Pull Request comments
- persist full comment bodies through GitHub, GitLab, and Azure DevOps official APIs
- apply optimistic per-comment updates with save isolation, refresh reconciliation, rollback, and visible provider errors
- cover conversation comments, review summaries where exposed, and inline review threads

## Validation

- dart format --output=none --set-exit-if-changed lib test integration_test tool
- dart tool/quality/check_max_lines.dart
- flutter analyze
- focused Pull Request domain, provider, controller, and widget tests: 59 passed
- CI=true flutter test --coverage --exclude-tags golden: 2,650 passed, 2 expected PTY skips
- coverage report: 100% domain lines (3,109/3,109)
- git diff --check
- gh act pull_request -W .github/workflows/pr.yml -j static reached setup, then hit the known linked-worktree container limitation: fatal: not a git repository: (null)

## Notes

- provider permissions remain authoritative; a rejected update rolls back locally
- no generated surfaces or documentation changes were required