### PR TITLE
feat: unify text context menus

### DIFF
--- a/lib/src/app/theme/alera_tokens.dart
+++ b/lib/src/app/theme/alera_tokens.dart
@@ -39,6 +39,7 @@ abstract final class AleraTokens {
   // by its text: 720px fits roughly 95 columns at the mono size.
   static const double dialogTerminalWidth = 720.0;
   static const double dialogTerminalHeight = 460.0;
+  static const double contextMenuWidth = 220.0;
   static const double wideContentBreakpoint = 760.0;
   static const double desktopPreviewWidth = 980.0;
   static const double dividerExtent = 1.0;

--- a/lib/src/design_system/forms/alera_number_field.dart
+++ b/lib/src/design_system/forms/alera_number_field.dart
@@ -1,4 +1,5 @@
 import 'package:alera/src/app/theme/alera_tokens.dart';
+import 'package:alera/src/design_system/forms/alera_text_actions_scope.dart';
 import 'package:alera/src/design_system/icons/alera_icons.dart';
 import 'package:flutter/material.dart';
 
@@ -90,6 +91,13 @@ class _AleraNumberFieldState extends State<AleraNumberField> {
           child: TextField(
             controller: _controller,
             keyboardType: TextInputType.number,
+            contextMenuBuilder: (context, editableTextState) {
+              return AleraTextActionsScope.buildContextMenu(
+                context,
+                editableTextState,
+                textActionsEnabled: false,
+              );
+            },
             onSubmitted: (_) => _commit(),
             onEditingComplete: _commit,
             decoration: InputDecoration(suffixText: widget.suffix),

--- a/lib/src/design_system/forms/alera_text_actions_scope.dart
+++ b/lib/src/design_system/forms/alera_text_actions_scope.dart
@@ -1,12 +1,35 @@
 import 'dart:async';
 
+import 'package:alera/src/design_system/menus/alera_text_selection_toolbar.dart';
 import 'package:flutter/material.dart';
 
 typedef AleraTextActionsContextMenuHandler =
-    void Function(BuildContext context, EditableTextState editableTextState);
+    void Function(
+      BuildContext context,
+      AleraTextActionTarget target,
+      Offset globalAnchor,
+    );
 
 typedef AleraTextActionHandler =
-    void Function(EditableTextState editableTextState, String actionId);
+    void Function(AleraTextActionTarget target, String actionId);
+
+typedef AleraTextActionReplacementHandler =
+    bool Function(TextEditingValue captured, String replacement);
+
+class AleraTextActionTarget {
+  /// Adapts any editable surface to the shared Text Actions runner.
+  const AleraTextActionTarget({
+    required this.identity,
+    required this.readValue,
+    required this.isAvailable,
+    required this.applyReplacement,
+  });
+
+  final Object identity;
+  final TextEditingValue Function() readValue;
+  final bool Function() isAvailable;
+  final AleraTextActionReplacementHandler applyReplacement;
+}
 
 class AleraTextActionMenuItem {
   const AleraTextActionMenuItem({required this.id, required this.label});
@@ -31,9 +54,23 @@ class AleraTextActionsScope extends InheritedWidget {
   final List<AleraTextActionMenuItem> actions;
   final AleraTextActionHandler? onRun;
 
-  void run(EditableTextState editableTextState, String actionId) {
+  void open(
+    BuildContext context,
+    AleraTextActionTarget target,
+    Offset globalAnchor,
+  ) {
     if (enabled) {
-      onRun?.call(editableTextState, actionId);
+      onOpen(context, target, globalAnchor);
+    }
+  }
+
+  void run(EditableTextState editableTextState, String actionId) {
+    runTarget(_editableTextTarget(editableTextState), actionId);
+  }
+
+  void runTarget(AleraTextActionTarget target, String actionId) {
+    if (enabled) {
+      onRun?.call(target, actionId);
     }
   }
 
@@ -96,15 +133,46 @@ class AleraTextActionsScope extends InheritedWidget {
           label: 'Text Actions',
           onPressed: () {
             ContextMenuController.removeAny();
-            scope!.onOpen(context, editableTextState);
+            final anchors = editableTextState.contextMenuAnchors;
+            scope!.open(
+              context,
+              _editableTextTarget(editableTextState),
+              anchors.secondaryAnchor ?? anchors.primaryAnchor,
+            );
           },
           type: ContextMenuButtonType.custom,
         ),
       );
     }
-    return AdaptiveTextSelectionToolbar.buttonItems(
+    return AleraTextSelectionToolbar(
       anchors: editableTextState.contextMenuAnchors,
       buttonItems: items,
+    );
+  }
+
+  static AleraTextActionTarget _editableTextTarget(
+    EditableTextState editableTextState,
+  ) {
+    return AleraTextActionTarget(
+      identity: editableTextState,
+      readValue: () => editableTextState.textEditingValue,
+      isAvailable: () => editableTextState.mounted,
+      applyReplacement: (captured, replacement) {
+        final editingContext = editableTextState.widget.focusNode.context;
+        if (editingContext == null || !editingContext.mounted) {
+          return false;
+        }
+        Actions.invoke(
+          editingContext,
+          ReplaceTextIntent(
+            captured,
+            replacement,
+            captured.selection,
+            SelectionChangedCause.toolbar,
+          ),
+        );
+        return true;
+      },
     );
   }
 

--- a/lib/src/design_system/menus/alera_dropdown_menu_item.dart
+++ b/lib/src/design_system/menus/alera_dropdown_menu_item.dart
@@ -1,0 +1,74 @@
+import 'package:alera/src/app/theme/alera_tokens.dart';
+import 'package:alera/src/design_system/icons/alera_icons.dart';
+import 'package:flutter/material.dart';
+
+/// Dropdown-style interactive row for compact action menus.
+class AleraDropdownMenuItem extends StatelessWidget {
+  const AleraDropdownMenuItem({
+    super.key,
+    required this.label,
+    required this.onTap,
+    this.leading,
+    this.selected = false,
+    this.enabled = true,
+    this.autofocus = false,
+  });
+
+  final String label;
+  final VoidCallback? onTap;
+  final Widget? leading;
+  final bool selected;
+  final bool enabled;
+  final bool autofocus;
+
+  @override
+  Widget build(BuildContext context) {
+    final itemEnabled = enabled && onTap != null;
+    final color = itemEnabled
+        ? AleraTokens.foreground
+        : AleraTokens.foregroundFaint;
+    return SizedBox(
+      height: AleraTokens.space32 + AleraTokens.space4,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: AleraTokens.space2 / 2),
+        child: InkWell(
+          autofocus: autofocus,
+          onTap: itemEnabled ? onTap : null,
+          mouseCursor: itemEnabled
+              ? SystemMouseCursors.click
+              : SystemMouseCursors.basic,
+          borderRadius: BorderRadius.circular(AleraTokens.radiusLg),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(
+              horizontal: AleraTokens.space8,
+              vertical: AleraTokens.space4,
+            ),
+            child: Row(
+              children: <Widget>[
+                if (leading != null) ...<Widget>[
+                  leading!,
+                  const SizedBox(width: AleraTokens.space8),
+                ],
+                Expanded(
+                  child: Text(
+                    label,
+                    overflow: TextOverflow.ellipsis,
+                    style: Theme.of(
+                      context,
+                    ).textTheme.bodyMedium?.copyWith(color: color),
+                  ),
+                ),
+                if (selected)
+                  const Icon(
+                    AleraIcons.check,
+                    size: AleraTokens.space16,
+                    color: AleraTokens.foreground,
+                  ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/design_system/menus/alera_dropdown_menu_item.preview.dart
+++ b/lib/src/design_system/menus/alera_dropdown_menu_item.preview.dart
@@ -1,0 +1,29 @@
+import 'package:alera/src/app/theme/alera_tokens.dart';
+import 'package:alera/src/design_system/alera_preview.dart';
+import 'package:alera/src/design_system/menus/alera_dropdown_menu_item.dart';
+import 'package:flutter/material.dart';
+
+@AleraPreview(
+  name: 'Actions',
+  group: 'Dropdown Menu Item',
+  size: Size(220, 150),
+)
+Widget aleraDropdownMenuItemPreview() => Material(
+  color: AleraTokens.surface,
+  shape: RoundedRectangleBorder(
+    borderRadius: BorderRadius.circular(AleraTokens.radiusMd),
+    side: const BorderSide(color: AleraTokens.border),
+  ),
+  child: const Padding(
+    padding: EdgeInsets.all(AleraTokens.space12),
+    child: Column(
+      mainAxisSize: MainAxisSize.min,
+      children: <Widget>[
+        AleraDropdownMenuItem(label: 'Copy', onTap: _noop),
+        AleraDropdownMenuItem(label: 'Select All', onTap: _noop),
+      ],
+    ),
+  ),
+);
+
+void _noop() {}

--- a/lib/src/design_system/menus/alera_text_selection_toolbar.dart
+++ b/lib/src/design_system/menus/alera_text_selection_toolbar.dart
@@ -1,0 +1,110 @@
+import 'package:alera/src/app/theme/alera_tokens.dart';
+import 'package:alera/src/design_system/menus/alera_dropdown_menu_item.dart';
+import 'package:flutter/material.dart';
+
+/// Alera-styled text selection menu on pointer platforms.
+///
+/// Touch platforms keep Flutter's adaptive toolbar so their native selection
+/// behavior and geometry remain unchanged.
+class AleraTextSelectionToolbar extends StatelessWidget {
+  const AleraTextSelectionToolbar({
+    super.key,
+    required this.anchors,
+    required this.buttonItems,
+  });
+
+  final TextSelectionToolbarAnchors anchors;
+  final List<ContextMenuButtonItem> buttonItems;
+
+  static Widget editableText(
+    BuildContext context,
+    EditableTextState editableTextState,
+  ) {
+    return AleraTextSelectionToolbar(
+      anchors: editableTextState.contextMenuAnchors,
+      buttonItems: editableTextState.contextMenuButtonItems,
+    );
+  }
+
+  static Widget selectableRegion(
+    BuildContext context,
+    SelectableRegionState selectableRegionState,
+  ) {
+    return AleraTextSelectionToolbar(
+      anchors: selectableRegionState.contextMenuAnchors,
+      buttonItems: selectableRegionState.contextMenuButtonItems,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (buttonItems.isEmpty) {
+      return const SizedBox.shrink();
+    }
+    if (!_usesPointerMenu(Theme.of(context).platform)) {
+      return AdaptiveTextSelectionToolbar.buttonItems(
+        anchors: anchors,
+        buttonItems: buttonItems,
+      );
+    }
+
+    final screenPadding =
+        MediaQuery.paddingOf(context).top + AleraTokens.space8;
+    final localAdjustment = Offset(AleraTokens.space8, screenPadding);
+    final popupTheme = Theme.of(context).popupMenuTheme;
+    return Padding(
+      padding: EdgeInsets.fromLTRB(
+        AleraTokens.space8,
+        screenPadding,
+        AleraTokens.space8,
+        AleraTokens.space8,
+      ),
+      child: CustomSingleChildLayout(
+        delegate: DesktopTextSelectionToolbarLayoutDelegate(
+          anchor: anchors.primaryAnchor - localAdjustment,
+        ),
+        child: SizedBox(
+          width: AleraTokens.contextMenuWidth,
+          child: Material(
+            color: AleraTokens.surface,
+            elevation: popupTheme.elevation ?? 0,
+            clipBehavior: Clip.antiAlias,
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(AleraTokens.radiusMd),
+              side: const BorderSide(color: AleraTokens.border),
+            ),
+            child: Padding(
+              padding:
+                  popupTheme.menuPadding ??
+                  const EdgeInsets.all(AleraTokens.space12),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: <Widget>[
+                  for (final item in buttonItems)
+                    AleraDropdownMenuItem(
+                      label: AdaptiveTextSelectionToolbar.getButtonLabel(
+                        context,
+                        item,
+                      ),
+                      onTap: item.onPressed,
+                    ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  static bool _usesPointerMenu(TargetPlatform platform) {
+    return switch (platform) {
+      TargetPlatform.linux ||
+      TargetPlatform.macOS ||
+      TargetPlatform.windows => true,
+      TargetPlatform.android ||
+      TargetPlatform.fuchsia ||
+      TargetPlatform.iOS => false,
+    };
+  }
+}

--- a/lib/src/design_system/menus/alera_text_selection_toolbar.preview.dart
+++ b/lib/src/design_system/menus/alera_text_selection_toolbar.preview.dart
@@ -1,0 +1,22 @@
+import 'package:alera/src/design_system/alera_preview.dart';
+import 'package:alera/src/design_system/menus/alera_text_selection_toolbar.dart';
+import 'package:flutter/material.dart';
+
+@AleraPreview(
+  name: 'Text Selection',
+  group: 'Text Selection Toolbar',
+  size: Size(280, 220),
+)
+Widget aleraTextSelectionToolbarPreview() => AleraTextSelectionToolbar(
+  anchors: const TextSelectionToolbarAnchors(primaryAnchor: Offset(140, 180)),
+  buttonItems: <ContextMenuButtonItem>[
+    ContextMenuButtonItem(type: ContextMenuButtonType.cut, onPressed: _noop),
+    ContextMenuButtonItem(type: ContextMenuButtonType.copy, onPressed: _noop),
+    ContextMenuButtonItem(
+      type: ContextMenuButtonType.selectAll,
+      onPressed: _noop,
+    ),
+  ],
+);
+
+void _noop() {}

--- a/lib/src/design_system/surfaces/alera_command_line.dart
+++ b/lib/src/design_system/surfaces/alera_command_line.dart
@@ -1,4 +1,5 @@
 import 'package:alera/src/app/theme/alera_tokens.dart';
+import 'package:alera/src/design_system/menus/alera_text_selection_toolbar.dart';
 import 'package:flutter/material.dart';
 
 /// A shell command shown verbatim, selectable, with room for the action that
@@ -37,6 +38,7 @@ class AleraCommandLine extends StatelessWidget {
           Expanded(
             child: SelectableText(
               command,
+              contextMenuBuilder: AleraTextSelectionToolbar.editableText,
               style: AleraTokens.monoStyle.copyWith(
                 color: AleraTokens.foreground,
               ),

--- a/lib/src/features/browser/presentation/browser_certificate_trust_dialog.dart
+++ b/lib/src/features/browser/presentation/browser_certificate_trust_dialog.dart
@@ -1,6 +1,7 @@
 import 'package:alera/src/app/theme/alera_tokens.dart';
 import 'package:alera/src/design_system/icons/alera_icons.dart';
 import 'package:alera/src/design_system/layout/alera_dialog.dart';
+import 'package:alera/src/design_system/menus/alera_text_selection_toolbar.dart';
 import 'package:alera/src/features/browser/domain/browser_security.dart';
 import 'package:alera/src/features/browser/domain/browser_trusted_certificate.dart';
 import 'package:flutter/material.dart';
@@ -63,6 +64,7 @@ class BrowserCertificateTrustDialog extends StatelessWidget {
               ),
               child: SelectableText(
                 displayBrowserCertificateFingerprint(request.fingerprintSha256),
+                contextMenuBuilder: AleraTextSelectionToolbar.editableText,
                 style: AleraTokens.monoStyle.copyWith(
                   color: AleraTokens.foreground,
                 ),
@@ -155,6 +157,7 @@ class _CertificateDetail extends StatelessWidget {
           Expanded(
             child: SelectableText(
               value,
+              contextMenuBuilder: AleraTextSelectionToolbar.editableText,
               style: theme.textTheme.bodySmall?.copyWith(
                 color: AleraTokens.foreground,
               ),

--- a/lib/src/features/browser/presentation/browser_security_dialog.dart
+++ b/lib/src/features/browser/presentation/browser_security_dialog.dart
@@ -1,6 +1,7 @@
 import 'package:alera/src/app/theme/alera_tokens.dart';
 import 'package:alera/src/design_system/icons/alera_icons.dart';
 import 'package:alera/src/design_system/layout/alera_dialog.dart';
+import 'package:alera/src/design_system/menus/alera_text_selection_toolbar.dart';
 import 'package:alera/src/features/browser/domain/browser_security.dart';
 import 'package:flutter/material.dart';
 
@@ -118,6 +119,7 @@ class _SecurityDetail extends StatelessWidget {
           Expanded(
             child: SelectableText(
               value,
+              contextMenuBuilder: AleraTextSelectionToolbar.editableText,
               style: theme.textTheme.bodySmall?.copyWith(
                 color: AleraTokens.foreground,
                 fontFamily: 'JetBrains Mono',

--- a/lib/src/features/pull_requests/presentation/pull_request_comment_markdown.dart
+++ b/lib/src/features/pull_requests/presentation/pull_request_comment_markdown.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:alera/src/app/theme/alera_tokens.dart';
 import 'package:alera/src/design_system/forms/alera_checkbox.dart';
 import 'package:alera/src/design_system/icons/alera_icons.dart';
+import 'package:alera/src/design_system/menus/alera_text_selection_toolbar.dart';
 import 'package:flutter/material.dart';
 import 'package:gpt_markdown/custom_widgets/markdown_config.dart';
 import 'package:gpt_markdown/gpt_markdown.dart';
@@ -42,6 +43,7 @@ class PullRequestCommentMarkdown extends StatelessWidget {
       ),
     ];
     return SelectionArea(
+      contextMenuBuilder: AleraTextSelectionToolbar.selectableRegion,
       child: GptMarkdownTheme(
         gptThemeData: GptMarkdownThemeData(
           brightness: Brightness.dark,

--- a/lib/src/features/settings/presentation/panes/agent_profile_editor.dart
+++ b/lib/src/features/settings/presentation/panes/agent_profile_editor.dart
@@ -4,6 +4,7 @@ import 'package:alera/src/design_system/forms/alera_setting_row.dart';
 import 'package:alera/src/design_system/forms/alera_text_field.dart';
 import 'package:alera/src/design_system/icons/alera_icons.dart';
 import 'package:alera/src/design_system/layout/alera_settings_group.dart';
+import 'package:alera/src/design_system/menus/alera_text_selection_toolbar.dart';
 import 'package:alera/src/design_system/surfaces/alera_command_line.dart';
 import 'package:alera/src/features/agent_profiles/domain/agent_profile.dart';
 import 'package:alera/src/features/agent_profiles/domain/agent_profile_adapters.dart';
@@ -166,6 +167,8 @@ class AgentProfileEditor extends StatelessWidget {
                       controlWidth: 320,
                       child: SelectableText(
                         managedCommandPreview,
+                        contextMenuBuilder:
+                            AleraTextSelectionToolbar.editableText,
                         style: theme.textTheme.bodySmall?.copyWith(
                           color: AleraTokens.foregroundMuted,
                         ),

--- a/lib/src/features/settings/presentation/panes/skill_install_output_dialog.dart
+++ b/lib/src/features/settings/presentation/panes/skill_install_output_dialog.dart
@@ -2,6 +2,7 @@ import 'package:alera/src/app/theme/alera_tokens.dart';
 import 'package:alera/src/design_system/icons/alera_icons.dart';
 import 'package:alera/src/design_system/layout/alera_dialog.dart';
 import 'package:alera/src/design_system/layout/alera_dialog_header.dart';
+import 'package:alera/src/design_system/menus/alera_text_selection_toolbar.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
@@ -57,6 +58,7 @@ class SkillInstallOutputDialog extends StatelessWidget {
                 child: SingleChildScrollView(
                   child: SelectableText(
                     output,
+                    contextMenuBuilder: AleraTextSelectionToolbar.editableText,
                     style: AleraTokens.monoStyle.copyWith(
                       color: AleraTokens.foreground,
                     ),

--- a/lib/src/features/text_actions/presentation/text_actions_scope.dart
+++ b/lib/src/features/text_actions/presentation/text_actions_scope.dart
@@ -26,7 +26,7 @@ class TextActionsScope extends ConsumerStatefulWidget {
 }
 
 class _TextActionsScopeState extends ConsumerState<TextActionsScope> {
-  final Set<EditableTextState> _runningFields = <EditableTextState>{};
+  final Set<Object> _runningTargets = <Object>{};
   var _runSequence = 0;
 
   @override
@@ -47,21 +47,21 @@ class _TextActionsScopeState extends ConsumerState<TextActionsScope> {
         for (final action in settings.textActions.enabledActions)
           AleraTextActionMenuItem(id: action.id, label: action.name),
       ],
-      onOpen: (context, editableTextState) =>
-          _openMenu(context, editableTextState, activeWorkspacePath),
-      onRun: (editableTextState, actionId) => unawaited(
-        _runAction(editableTextState, actionId, activeWorkspacePath),
-      ),
+      onOpen: (context, target, globalAnchor) =>
+          _openMenu(context, target, globalAnchor, activeWorkspacePath),
+      onRun: (target, actionId) =>
+          unawaited(_runAction(target, actionId, activeWorkspacePath)),
       child: widget.child,
     );
   }
 
   Future<void> _openMenu(
     BuildContext context,
-    EditableTextState editableTextState,
+    AleraTextActionTarget target,
+    Offset globalAnchor,
     String? activeWorkspacePath,
   ) async {
-    if (_runningFields.contains(editableTextState)) {
+    if (_runningTargets.contains(target.identity)) {
       return;
     }
     final settings = ref.read(settingsControllerProvider);
@@ -77,8 +77,6 @@ class _TextActionsScopeState extends ConsumerState<TextActionsScope> {
     if (overlayBox is! RenderBox) {
       return;
     }
-    final anchors = editableTextState.contextMenuAnchors;
-    final globalAnchor = anchors.secondaryAnchor ?? anchors.primaryAnchor;
     final anchor = overlayBox.globalToLocal(globalAnchor);
     final position = RelativeRect.fromLTRB(
       anchor.dx,
@@ -102,21 +100,18 @@ class _TextActionsScopeState extends ConsumerState<TextActionsScope> {
     if (selectedAction == null || !mounted) {
       return;
     }
-    unawaited(
-      _runAction(editableTextState, selectedAction.id, activeWorkspacePath),
-    );
+    unawaited(_runAction(target, selectedAction.id, activeWorkspacePath));
   }
 
   Future<void> _runAction(
-    EditableTextState editableTextState,
+    AleraTextActionTarget target,
     String actionId,
     String? activeWorkspacePath,
   ) async {
-    if (!editableTextState.mounted ||
-        _runningFields.contains(editableTextState)) {
+    if (!target.isAvailable() || _runningTargets.contains(target.identity)) {
       return;
     }
-    final captured = editableTextState.textEditingValue;
+    final captured = target.readValue();
     final selection = captured.selection;
     if (!selection.isValid ||
         selection.isCollapsed ||
@@ -138,7 +133,7 @@ class _TextActionsScopeState extends ConsumerState<TextActionsScope> {
     if (action == null) {
       return;
     }
-    _runningFields.add(editableTextState);
+    _runningTargets.add(target.identity);
     final runId = 'text-action-${++_runSequence}';
     AleraToast.publish(message: 'Running ${action.name}.');
     try {
@@ -175,10 +170,10 @@ class _TextActionsScopeState extends ConsumerState<TextActionsScope> {
               reasoning: reasoning,
             ),
           );
-      if (!mounted || !editableTextState.mounted) {
+      if (!mounted || !target.isAvailable()) {
         return;
       }
-      final currentValue = editableTextState.textEditingValue;
+      final currentValue = target.readValue();
       if (currentValue != captured) {
         AleraToast.publish(
           message: 'Text changed while the action was running.',
@@ -196,21 +191,13 @@ class _TextActionsScopeState extends ConsumerState<TextActionsScope> {
         );
         return;
       }
-      final editingContext = editableTextState.widget.focusNode.context;
-      if (editingContext == null || !editingContext.mounted) {
+      if (!target.applyReplacement(captured, result.text)) {
         AleraToast.publish(
           message: 'Text action could not update this field.',
           tone: AleraToastTone.error,
         );
         return;
       }
-      Actions.invoke(
-        editingContext,
-        buildTextActionReplacementIntent(
-          captured: captured,
-          replacement: result.text,
-        ),
-      );
       AleraToast.publish(
         message: 'Text action applied.',
         tone: AleraToastTone.success,
@@ -228,7 +215,7 @@ class _TextActionsScopeState extends ConsumerState<TextActionsScope> {
         tone: AleraToastTone.error,
       );
     } finally {
-      _runningFields.remove(editableTextState);
+      _runningTargets.remove(target.identity);
     }
   }
 }

--- a/lib/src/features/workbench/presentation/workspace_editor_surface.dart
+++ b/lib/src/features/workbench/presentation/workspace_editor_surface.dart
@@ -4,6 +4,7 @@ import 'package:alera/src/app/providers.dart';
 import 'package:alera/src/app/theme/alera_tokens.dart';
 import 'package:alera/src/design_system/buttons/alera_icon_button.dart';
 import 'package:alera/src/design_system/feedback/alera_toast.dart';
+import 'package:alera/src/design_system/forms/alera_text_actions_scope.dart';
 import 'package:alera/src/design_system/icons/alera_file_icon.dart';
 import 'package:alera/src/design_system/icons/alera_icons.dart';
 import 'package:alera/src/design_system/layout/alera_confirm_dialog.dart';
@@ -18,6 +19,7 @@ import 'package:alera/src/rust/api/workspace_files.dart' as native;
 import 'package:alera/src/shared/infra/git/git_diff_models.dart';
 import 'package:alera/src/shared/infra/git/git_providers.dart';
 import 'package:code_forge/code_forge.dart' as code_forge;
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter/scheduler.dart';
@@ -31,6 +33,7 @@ part 'workspace_editor_focus.dart';
 part 'workspace_editor_reveal.dart';
 part 'workspace_editor_loading.dart';
 part 'workspace_editor_save.dart';
+part 'workspace_editor_text_actions.dart';
 
 class WorkspaceEditorSurface extends ConsumerStatefulWidget {
   const WorkspaceEditorSurface({
@@ -70,6 +73,7 @@ class _WorkspaceEditorSurfaceState
   bool _loading = true;
   bool _saving = false;
   bool _stateRefreshQueued = false;
+  Offset? _lastSecondaryTapGlobalPosition;
   int _loadRequestId = 0;
 
   @override
@@ -104,7 +108,7 @@ class _WorkspaceEditorSurfaceState
       save: _saveAutomatically,
       onError: _handleAutosaveError,
     );
-    ref.listen(
+    ref.listenManual(
       settingsControllerProvider.select((settings) => settings.editor),
       (previous, next) => _autosave.updateSettings(
         enabled: next.autosaveEnabled,
@@ -170,33 +174,38 @@ class _WorkspaceEditorSurfaceState
     } else {
       content = Stack(
         children: <Widget>[
-          code_forge.CodeForge(
-            key: ValueKey<String>(
-              workspaceEditorCodeForgeKey(
-                tabId: widget.tab.id,
-                filePath: filePath,
-                themeName: effectiveThemeName,
+          Listener(
+            onPointerDown: _captureEditorPointerDown,
+            child: code_forge.CodeForge(
+              key: ValueKey<String>(
+                workspaceEditorCodeForgeKey(
+                  tabId: widget.tab.id,
+                  filePath: filePath,
+                  themeName: effectiveThemeName,
+                ),
               ),
-            ),
-            controller: _controller,
-            undoController: _undoController,
-            findController: _findController,
-            focusNode: _focusNode,
-            autoFocus: widget.autofocus,
-            lineWrap: true,
-            enableLocalSuggestions: false,
-            enableGuideLines: true,
-            enableGutter: true,
-            enableGutterDivider: false,
-            editorTheme: editorTheme,
-            language: _languageForPath(filePath),
-            tabSize: effectiveTabSize,
-            useSpaceAsTab: true,
-            scrollbarDecoration: _scrollbarDecoration(),
-            textStyle: Theme.of(context).textTheme.bodyMedium?.copyWith(
-              fontFamily: 'JetBrains Mono',
-              color: rootStyle.color ?? AleraTokens.foreground,
-              height: 1.35,
+              controller: _controller,
+              undoController: _undoController,
+              findController: _findController,
+              focusNode: _focusNode,
+              autoFocus: widget.autofocus,
+              lineWrap: true,
+              enableLocalSuggestions: false,
+              enableGuideLines: true,
+              enableGutter: true,
+              enableGutterDivider: false,
+              editorTheme: editorTheme,
+              language: _languageForPath(filePath),
+              tabSize: effectiveTabSize,
+              useSpaceAsTab: true,
+              scrollbarDecoration: _scrollbarDecoration(),
+              suggestionStyle: _editorOverlayStyle(context),
+              customContextMenuItems: _editorTextActionMenuItems(context),
+              textStyle: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                fontFamily: 'JetBrains Mono',
+                color: rootStyle.color ?? AleraTokens.foreground,
+                height: 1.35,
+              ),
             ),
           ),
           if (_saving)
@@ -483,13 +492,4 @@ String workspaceEditorDisplayPath({
     return p.relative(normalizedFilePath, from: workspacePath);
   }
   return filePath;
-}
-
-@visibleForTesting
-String workspaceEditorCodeForgeKey({
-  required String tabId,
-  required String filePath,
-  required String themeName,
-}) {
-  return 'workspace-editor-$tabId-$filePath-$themeName';
 }

--- a/lib/src/features/workbench/presentation/workspace_editor_text_actions.dart
+++ b/lib/src/features/workbench/presentation/workspace_editor_text_actions.dart
@@ -1,0 +1,98 @@
+part of 'workspace_editor_surface.dart';
+
+extension _WorkspaceEditorTextActions on _WorkspaceEditorSurfaceState {
+  void _captureEditorPointerDown(PointerDownEvent event) {
+    if (event.buttons == kSecondaryMouseButton) {
+      _lastSecondaryTapGlobalPosition = event.position;
+    }
+  }
+
+  List<code_forge.CustomContextMenu>? _editorTextActionMenuItems(
+    BuildContext context,
+  ) {
+    final scope = AleraTextActionsScope.maybeOf(context);
+    if (scope?.enabled != true ||
+        !workspaceEditorHasTextActionSelection(
+          text: _controller.text,
+          selection: _controller.selection,
+        )) {
+      return null;
+    }
+    return <code_forge.CustomContextMenu>[
+      code_forge.CustomContextMenu(
+        label: 'Text Actions',
+        description: '',
+        onPress: () => _openEditorTextActions(context, scope!),
+      ),
+    ];
+  }
+
+  void _openEditorTextActions(
+    BuildContext context,
+    AleraTextActionsScope scope,
+  ) {
+    final anchor =
+        _lastSecondaryTapGlobalPosition ?? _editorCenterGlobalPosition(context);
+    scope.open(context, _editorTextActionTarget(), anchor);
+  }
+
+  Offset _editorCenterGlobalPosition(BuildContext context) {
+    final renderObject = context.findRenderObject();
+    if (renderObject is RenderBox) {
+      return renderObject.localToGlobal(renderObject.size.center(Offset.zero));
+    }
+    return Offset.zero;
+  }
+
+  AleraTextActionTarget _editorTextActionTarget() {
+    return AleraTextActionTarget(
+      identity: _controller,
+      readValue: _editorTextEditingValue,
+      isAvailable: () => mounted && !_loading && _loadError == null,
+      applyReplacement: (captured, replacement) {
+        if (!mounted || _editorTextEditingValue() != captured) {
+          return false;
+        }
+        final selection = captured.selection;
+        _controller.replaceRange(selection.start, selection.end, replacement);
+        return true;
+      },
+    );
+  }
+
+  TextEditingValue _editorTextEditingValue() {
+    return TextEditingValue(
+      text: _controller.text,
+      selection: _controller.selection,
+    );
+  }
+
+  code_forge.SuggestionStyle _editorOverlayStyle(BuildContext context) {
+    return code_forge.SuggestionStyle(
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(AleraTokens.radiusMd),
+        side: const BorderSide(color: AleraTokens.border),
+      ),
+      backgroundColor: AleraTokens.surface,
+      focusColor: AleraTokens.surfaceElevated,
+      hoverColor: AleraTokens.surfaceElevated,
+      splashColor: Colors.transparent,
+      textStyle: Theme.of(
+        context,
+      ).textTheme.bodyMedium!.copyWith(color: AleraTokens.foreground),
+      itemHeight: AleraTokens.space32 + AleraTokens.space4,
+    );
+  }
+}
+
+@visibleForTesting
+bool workspaceEditorHasTextActionSelection({
+  required String text,
+  required TextSelection selection,
+}) {
+  return selection.isValid &&
+      !selection.isCollapsed &&
+      selection.start >= 0 &&
+      selection.end <= text.length &&
+      text.substring(selection.start, selection.end).isNotEmpty;
+}

--- a/lib/src/features/workbench/presentation/workspace_editor_widgets.dart
+++ b/lib/src/features/workbench/presentation/workspace_editor_widgets.dart
@@ -1,5 +1,14 @@
 part of 'workspace_editor_surface.dart';
 
+@visibleForTesting
+String workspaceEditorCodeForgeKey({
+  required String tabId,
+  required String filePath,
+  required String themeName,
+}) {
+  return 'workspace-editor-$tabId-$filePath-$themeName';
+}
+
 class _EditorFileBar extends StatelessWidget {
   const _EditorFileBar({
     required this.path,

--- a/lib/src/features/workbench/presentation/workspace_markdown_viewer_surface.dart
+++ b/lib/src/features/workbench/presentation/workspace_markdown_viewer_surface.dart
@@ -6,6 +6,7 @@ import 'package:alera/src/design_system/buttons/alera_icon_button.dart';
 import 'package:alera/src/design_system/feedback/alera_toast.dart';
 import 'package:alera/src/design_system/icons/alera_file_icon.dart';
 import 'package:alera/src/design_system/icons/alera_icons.dart';
+import 'package:alera/src/design_system/menus/alera_text_selection_toolbar.dart';
 import 'package:alera/src/features/workbench/application/workspace_file_service.dart';
 import 'package:alera/src/features/workbench/domain/workspace.dart';
 import 'package:alera/src/features/workbench/domain/workspace_tab_record.dart';
@@ -87,6 +88,7 @@ class _WorkspaceMarkdownViewerSurfaceState
       content = _MarkdownViewerMessage(message: _messageFor(loadError));
     } else {
       content = SelectionArea(
+        contextMenuBuilder: AleraTextSelectionToolbar.selectableRegion,
         child: SingleChildScrollView(
           padding: const EdgeInsets.all(AleraTokens.space24),
           child: GptMarkdownTheme(

--- a/test/widget/alera_text_selection_toolbar_test.dart
+++ b/test/widget/alera_text_selection_toolbar_test.dart
@@ -1,0 +1,97 @@
+import 'package:alera/src/app/theme/alera_dark_theme.dart';
+import 'package:alera/src/app/theme/alera_tokens.dart';
+import 'package:alera/src/design_system/menus/alera_dropdown_menu_item.dart';
+import 'package:alera/src/design_system/menus/alera_text_selection_toolbar.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('desktop selection menu matches Alera dropdown interactions', (
+    tester,
+  ) async {
+    var copied = false;
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: buildAleraDarkTheme().copyWith(platform: TargetPlatform.linux),
+        home: Scaffold(
+          body: AleraTextSelectionToolbar(
+            anchors: const TextSelectionToolbarAnchors(
+              primaryAnchor: Offset(240, 180),
+            ),
+            buttonItems: <ContextMenuButtonItem>[
+              ContextMenuButtonItem(
+                type: ContextMenuButtonType.copy,
+                onPressed: () => copied = true,
+              ),
+              ContextMenuButtonItem(
+                type: ContextMenuButtonType.selectAll,
+                onPressed: () {},
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byType(AleraDropdownMenuItem), findsNWidgets(2));
+    expect(find.text('Copy'), findsOneWidget);
+    expect(find.text('Select all'), findsOneWidget);
+    expect(
+      tester.getSize(find.byType(AleraDropdownMenuItem).first).height,
+      AleraTokens.space32 + AleraTokens.space4,
+    );
+    expect(
+      tester
+          .widgetList<InkWell>(find.byType(InkWell))
+          .map((inkWell) => inkWell.mouseCursor),
+      everyElement(SystemMouseCursors.click),
+    );
+
+    final menu = tester.widget<SizedBox>(
+      find.byWidgetPredicate(
+        (widget) =>
+            widget is SizedBox && widget.width == AleraTokens.contextMenuWidth,
+      ),
+    );
+    expect(menu.width, AleraTokens.contextMenuWidth);
+    final surface = tester
+        .widgetList<Material>(find.byType(Material))
+        .firstWhere(
+          (material) =>
+              material.color == AleraTokens.surface &&
+              material.shape is RoundedRectangleBorder,
+        );
+    final shape = surface.shape! as RoundedRectangleBorder;
+    expect(shape.borderRadius, BorderRadius.circular(AleraTokens.radiusMd));
+    expect(shape.side.color, AleraTokens.border);
+
+    await tester.tap(find.text('Copy'));
+    expect(copied, isTrue);
+  });
+
+  testWidgets('touch platforms retain Flutter adaptive selection toolbar', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: buildAleraDarkTheme().copyWith(platform: TargetPlatform.android),
+        home: Scaffold(
+          body: AleraTextSelectionToolbar(
+            anchors: const TextSelectionToolbarAnchors(
+              primaryAnchor: Offset(240, 180),
+            ),
+            buttonItems: <ContextMenuButtonItem>[
+              ContextMenuButtonItem(
+                type: ContextMenuButtonType.copy,
+                onPressed: () {},
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byType(AdaptiveTextSelectionToolbar), findsOneWidget);
+    expect(find.byType(AleraDropdownMenuItem), findsNothing);
+  });
+}

--- a/test/widget/terminal_surface_composer_test_cases.dart
+++ b/test/widget/terminal_surface_composer_test_cases.dart
@@ -43,7 +43,7 @@ void _registerTerminalSurfaceComposerTests() {
             actions: const <AleraTextActionMenuItem>[
               AleraTextActionMenuItem(id: 'concise', label: 'Make Concise'),
             ],
-            onOpen: (_, _) {},
+            onOpen: (_, _, _) {},
             onRun: (_, actionId) => selectedActionId = actionId,
             child: SizedBox.expand(child: TerminalSurface(session: session)),
           ),

--- a/test/widget/text_actions_context_menu_test.dart
+++ b/test/widget/text_actions_context_menu_test.dart
@@ -1,5 +1,6 @@
 import 'package:alera/src/design_system/forms/alera_text_actions_scope.dart';
 import 'package:alera/src/design_system/forms/alera_text_field.dart';
+import 'package:alera/src/design_system/menus/alera_text_selection_toolbar.dart';
 import 'package:alera/src/features/pull_requests/presentation/pull_request_link_form.dart';
 import 'package:alera/src/features/text_actions/application/text_action_replacement.dart';
 import 'package:flutter/material.dart';
@@ -17,7 +18,7 @@ void main() {
         home: Scaffold(
           body: AleraTextActionsScope(
             enabled: true,
-            onOpen: (_, _) => opened = true,
+            onOpen: (_, _, _) => opened = true,
             child: TextField(
               controller: controller,
               contextMenuBuilder: AleraTextActionsScope.buildContextMenu,
@@ -35,8 +36,8 @@ void main() {
               tester.element(editableFinder),
               editable,
             )
-            as AdaptiveTextSelectionToolbar;
-    final items = toolbar.buttonItems!;
+            as AleraTextSelectionToolbar;
+    final items = toolbar.buttonItems;
 
     expect(
       items.take(nativeItems.length).map((item) => item.type),
@@ -68,7 +69,7 @@ void main() {
           home: Scaffold(
             body: AleraTextActionsScope(
               enabled: scopeEnabled,
-              onOpen: (_, _) {},
+              onOpen: (_, _, _) {},
               child: TextField(
                 controller: controller,
                 readOnly: readOnly,
@@ -94,8 +95,8 @@ void main() {
                 editable,
                 textActionsEnabled: textActionsEnabled,
               )
-              as AdaptiveTextSelectionToolbar;
-      return toolbar.buttonItems!;
+              as AleraTextSelectionToolbar;
+      return toolbar.buttonItems;
     }
 
     bool hasTextActions(List<ContextMenuButtonItem> items) =>
@@ -126,7 +127,7 @@ void main() {
         home: Scaffold(
           body: AleraTextActionsScope(
             enabled: true,
-            onOpen: (_, _) {},
+            onOpen: (_, _, _) {},
             child: AleraTextField(
               controller: controller,
               onPaste: () async {
@@ -144,8 +145,8 @@ void main() {
     final field = tester.widget<TextField>(find.byType(TextField));
     final toolbar =
         field.contextMenuBuilder!(tester.element(editableFinder), editable)
-            as AdaptiveTextSelectionToolbar;
-    final paste = toolbar.buttonItems!.firstWhere(
+            as AleraTextSelectionToolbar;
+    final paste = toolbar.buttonItems.firstWhere(
       (item) => item.type == ContextMenuButtonType.paste,
     );
 
@@ -165,7 +166,7 @@ void main() {
         home: Scaffold(
           body: AleraTextActionsScope(
             enabled: true,
-            onOpen: (_, _) {},
+            onOpen: (_, _, _) {},
             child: PullRequestLinkForm(
               controller: controller,
               busy: false,
@@ -183,10 +184,10 @@ void main() {
     final field = tester.widget<TextField>(find.byType(TextField));
     final toolbar =
         field.contextMenuBuilder!(tester.element(editableFinder), editable)
-            as AdaptiveTextSelectionToolbar;
+            as AleraTextSelectionToolbar;
 
     expect(
-      toolbar.buttonItems!.any((item) => item.label == 'Text Actions'),
+      toolbar.buttonItems.any((item) => item.label == 'Text Actions'),
       isTrue,
     );
   });

--- a/test/widget/workspace_editor_surface_test.dart
+++ b/test/widget/workspace_editor_surface_test.dart
@@ -92,6 +92,30 @@ void main() {
 
     expect(aleraKey, isNot(monokaiKey));
   });
+
+  test('offers Text Actions only for a valid editor selection', () {
+    expect(
+      workspaceEditorHasTextActionSelection(
+        text: 'Selected text',
+        selection: const TextSelection(baseOffset: 0, extentOffset: 8),
+      ),
+      isTrue,
+    );
+    expect(
+      workspaceEditorHasTextActionSelection(
+        text: 'Selected text',
+        selection: const TextSelection.collapsed(offset: 4),
+      ),
+      isFalse,
+    );
+    expect(
+      workspaceEditorHasTextActionSelection(
+        text: 'Selected text',
+        selection: const TextSelection(baseOffset: 0, extentOffset: 20),
+      ),
+      isFalse,
+    );
+  });
 }
 
 Workspace _workspace() {


### PR DESCRIPTION
## Summary

- add an Alera-styled desktop text selection menu with click cursors
- expose Text Actions in the CodeForge editor with undo and concurrent-change safety
- fix the editor surface Riverpod listener lifecycle

## Validation

- `dart format --set-exit-if-changed lib test integration_test tool`
- `dart tool/quality/check_max_lines.dart`
- `flutter analyze`
- `CI=true flutter test --coverage --exclude-tags golden -r compact` - 2671 passed, 2 expected skips
- `dart tool/quality/coverage_report.dart --input coverage/lcov.info --min-lines 100 --worst 25` - 100.00%, 3131/3131 maintained domain lines
- `gh act pull_request -W .github/workflows/pr.yml -j static -j test` - test bodies passed locally; `act` reported a parallel shared-checkout/cache teardown limitation, so hosted checks are authoritative

## Notes

- CodeForge's native Cut, Copy, and Paste rows remain package-owned; the Alera Text Actions submenu uses the shared dropdown styling and click cursor.