### PR TITLE
fix: restore automation list loading

### DIFF
--- a/rust/alera-core/src/runtime/automation_store.rs
+++ b/rust/alera-core/src/runtime/automation_store.rs
@@ -109,12 +109,17 @@ impl RuntimeStore {
         include_trashed: bool,
     ) -> Result<Vec<AutomationDefinition>> {
         let query = if include_trashed {
-            "SELECT state, revision, dataJson FROM automations ORDER BY name COLLATE NOCASE ASC"
+            "SELECT state, revision, dataJson FROM automations"
         } else {
-            "SELECT state, revision, dataJson FROM automations WHERE state <> 'trashed' ORDER BY name COLLATE NOCASE ASC"
+            "SELECT state, revision, dataJson FROM automations WHERE state <> 'trashed'"
         };
         let rows = sqlx::query(query).fetch_all(self.pool()).await?;
-        rows.into_iter().map(decode_definition).collect()
+        let mut definitions = rows
+            .into_iter()
+            .map(decode_definition)
+            .collect::<Result<Vec<_>>>()?;
+        definitions.sort_by_cached_key(|definition| definition.name.to_lowercase());
+        Ok(definitions)
     }
 
     pub async fn find_automation(&self, id: &str) -> Result<Option<AutomationDefinition>> {

--- a/rust/alera-core/src/runtime/automation_store_tests.rs
+++ b/rust/alera-core/src/runtime/automation_store_tests.rs
@@ -61,6 +61,33 @@ fn definition() -> AutomationDefinition {
 }
 
 #[tokio::test]
+async fn list_automations_sorts_names_stored_in_definition_json() {
+    let directory = TempDir::new().unwrap();
+    let store = RuntimeStore::open(directory.path()).await.unwrap();
+    let actor = definition().created_by.clone();
+    let mut later = definition();
+    later.id = "automation-zebra".into();
+    later.slug = "zebra".into();
+    later.name = "zebra".into();
+    store.upsert_automation(later, actor.clone()).await.unwrap();
+    let mut earlier = definition();
+    earlier.id = "automation-alpha".into();
+    earlier.slug = "alpha".into();
+    earlier.name = "Alpha".into();
+    store.upsert_automation(earlier, actor).await.unwrap();
+
+    let listed = store.list_automations(false).await.unwrap();
+
+    assert_eq!(
+        listed
+            .into_iter()
+            .map(|automation| automation.name)
+            .collect::<Vec<_>>(),
+        vec!["Alpha", "zebra"]
+    );
+}
+
+#[tokio::test]
 async fn revisioned_upsert_invalidates_material_approval() {
     let directory = TempDir::new().unwrap();
     let store = RuntimeStore::open(directory.path()).await.unwrap();


### PR DESCRIPTION
## Summary

- load Automations without querying a nonexistent `automations.name` column
- preserve case-insensitive name ordering after decoding each definition from `dataJson`
- cover the real SQLite schema with a regression test

## Root Cause

Automation names are stored inside `dataJson`, but the list query attempted to sort by a normalized SQL column that was never part of the table schema. This made the Automations dialog fail even with an empty database.

## Validation

- `cargo test -p alera-core --features runtime list_automations_sorts_names_stored_in_definition_json`
- `make rust-test`
- `git diff --check`

## Notes

`gh act pull_request -W .github/workflows/pr.yml -j rust` could not start because Docker authentication rejected the runner image pull. No project code ran in that local emulation attempt.
