### PR TITLE
fix: gate macos-only credential gap

### DIFF
--- a/rust/alera-cli/src/agent_quota/claude.rs
+++ b/rust/alera-cli/src/agent_quota/claude.rs
@@ -39,6 +39,7 @@ enum ClaudeCredentialGap {
     /// A credential store holds something that could not be read. On macOS the
     /// usual cause is a keychain item whose access control has not been granted
     /// to this binary yet.
+    #[cfg(target_os = "macos")]
     Unreadable,
     /// Credentials were read but carry no `claudeAiOauth` entry, so the account
     /// authenticates some other way.
@@ -49,6 +50,7 @@ impl ClaudeCredentialGap {
     fn message(self) -> &'static str {
         match self {
             ClaudeCredentialGap::Absent => "Not signed in to Claude",
+            #[cfg(target_os = "macos")]
             ClaudeCredentialGap::Unreadable => {
                 "Claude credentials could not be read; allow Alera access to the Claude Code keychain item"
             }

--- a/rust/alera-cli/src/agent_quota/tests.rs
+++ b/rust/alera-cli/src/agent_quota/tests.rs
@@ -171,12 +171,11 @@ fn default_claude_profile_falls_back_to_legacy_keychain() {
 }
 
 #[test]
-fn each_credential_gap_says_something_different() {
+fn each_available_credential_gap_says_something_different() {
     // These collapsed into "Not signed in to Claude", which sent users to
     // re-authenticate an account that was signed in the whole time.
     let messages = [
         ClaudeCredentialGap::Absent.message(),
-        ClaudeCredentialGap::Unreadable.message(),
         ClaudeCredentialGap::NotOauth.message(),
     ];
     assert_eq!(
@@ -184,12 +183,17 @@ fn each_credential_gap_says_something_different() {
             .iter()
             .collect::<std::collections::HashSet<_>>()
             .len(),
-        3
+        2
     );
     assert_eq!(
         ClaudeCredentialGap::Absent.message(),
         "Not signed in to Claude"
     );
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn unreadable_credential_gap_explains_keychain_access() {
     assert!(ClaudeCredentialGap::Unreadable
         .message()
         .contains("keychain"));


### PR DESCRIPTION
## Summary

Gate the macOS-only `ClaudeCredentialGap::Unreadable` variant and its Keychain-specific test. Linux Clippy previously reported the variant as dead code under `-D warnings`.

This is a follow-up to #361 and targets `fix/macos-ccs-profiles`.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `git diff --check`