### PR TITLE
perf: start explorer and scm path drags immediately

### DIFF
--- a/lib/src/features/workbench/presentation/terminal_path_drop.dart
+++ b/lib/src/features/workbench/presentation/terminal_path_drop.dart
@@ -28,9 +28,14 @@ class TerminalPathDragData implements TerminalPathDragPayload {
   final List<String> paths;
 }
 
-class TerminalPathLongPressDraggable<T extends TerminalPathDragPayload>
+/// Immediate-path drag source for explorer and source control rows.
+///
+/// Uses [Draggable] rather than [LongPressDraggable] so desktop pointer drags
+/// start after touch slop instead of waiting for [kLongPressTimeout]. Long-press
+/// context menus on those rows stay on a separate gesture detector.
+class TerminalPathDraggable<T extends TerminalPathDragPayload>
     extends StatelessWidget {
-  const TerminalPathLongPressDraggable({
+  const TerminalPathDraggable({
     super.key,
     required this.data,
     required this.feedback,
@@ -43,7 +48,7 @@ class TerminalPathLongPressDraggable<T extends TerminalPathDragPayload>
 
   @override
   Widget build(BuildContext context) {
-    return LongPressDraggable<T>(
+    return Draggable<T>(
       data: data,
       feedback: feedback,
       childWhenDragging: Opacity(opacity: 0.45, child: child),

--- a/lib/src/features/workbench/presentation/workspace_explorer.dart
+++ b/lib/src/features/workbench/presentation/workspace_explorer.dart
@@ -227,21 +227,17 @@ class _WorkspaceExplorerState extends ConsumerState<WorkspaceExplorer> {
           _canDrop(details.data, entry.relativePath),
       onAcceptWithDetails: (details) =>
           unawaited(_moveEntry(details.data.relativePath, entry.relativePath)),
-      builder: (context, _, _) =>
-          TerminalPathLongPressDraggable<_ExplorerDragData>(
-            data: _ExplorerDragData(
-              relativePath: entry.relativePath,
-              absolutePath: _absolutePath(entry.relativePath),
-            ),
-            feedback: Material(
-              color: Colors.transparent,
-              child: SizedBox(
-                width: AleraTokens.sidebarDefaultWidth,
-                child: child,
-              ),
-            ),
-            child: child,
-          ),
+      builder: (context, _, _) => TerminalPathDraggable<_ExplorerDragData>(
+        data: _ExplorerDragData(
+          relativePath: entry.relativePath,
+          absolutePath: _absolutePath(entry.relativePath),
+        ),
+        feedback: Material(
+          color: Colors.transparent,
+          child: SizedBox(width: AleraTokens.sidebarDefaultWidth, child: child),
+        ),
+        child: child,
+      ),
     );
   }
 

--- a/lib/src/features/workbench/presentation/workspace_git_diff_panel_rows.dart
+++ b/lib/src/features/workbench/presentation/workspace_git_diff_panel_rows.dart
@@ -22,7 +22,7 @@ class _GitPathDragRegion extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return TerminalPathLongPressDraggable<TerminalPathDragData>(
+    return TerminalPathDraggable<TerminalPathDragData>(
       data: TerminalPathDragData(paths: <String>[absolutePath]),
       feedback: _GitPathDragFeedback(label: label, isDirectory: isDirectory),
       child: child,

--- a/test/widget/terminal_path_drag_test.dart
+++ b/test/widget/terminal_path_drag_test.dart
@@ -9,7 +9,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  testWidgets('long-press drag pastes paths and focuses the terminal', (
+  testWidgets('path drag pastes paths and focuses the terminal', (
     tester,
   ) async {
     final session = _CapturingTerminalSessionHandle();
@@ -94,7 +94,7 @@ Future<void> _pumpDragHarness(
             SizedBox(
               width: 200,
               child: Center(
-                child: TerminalPathLongPressDraggable<TerminalPathDragData>(
+                child: TerminalPathDraggable<TerminalPathDragData>(
                   data: TerminalPathDragData(paths: paths),
                   feedback: const Material(child: Text('Dragging Paths')),
                   child: const Text('Drag Paths'),
@@ -117,7 +117,9 @@ Future<void> _dragSourceToTerminal(
   final gesture = await tester.startGesture(
     tester.getCenter(find.text('Drag Paths')),
   );
-  await tester.pump(kLongPressTimeout + const Duration(milliseconds: 100));
+  // Immediate Draggable starts after touch slop, not after long-press.
+  await gesture.moveBy(const Offset(kTouchSlop + 1, 0));
+  await tester.pump();
   expect(find.text('Dragging Paths'), findsOneWidget);
 
   await gesture.moveTo(

--- a/test/widget/workbench_path_drag_sources_test.dart
+++ b/test/widget/workbench_path_drag_sources_test.dart
@@ -60,7 +60,9 @@ void main() {
     final source = tester.getCenter(find.text('readme.md'));
     final target = tester.getCenter(find.text('src'));
     final gesture = await tester.startGesture(source);
-    await tester.pump(kLongPressTimeout + const Duration(milliseconds: 100));
+    // Immediate Draggable starts after touch slop, not after long-press.
+    await gesture.moveBy(const Offset(kTouchSlop + 1, 0));
+    await tester.pump();
     await gesture.moveTo(target);
     await tester.pump();
     await gesture.up();
@@ -205,11 +207,11 @@ Future<void> _pumpSourceControl(
 
 Set<String> _terminalDragPaths(WidgetTester tester) {
   final finder = find.byWidgetPredicate(
-    (widget) => widget is TerminalPathLongPressDraggable,
+    (widget) => widget is TerminalPathDraggable,
   );
   return <String>{
     for (final element in finder.evaluate())
-      ...(element.widget as TerminalPathLongPressDraggable).data.paths,
+      ...(element.widget as TerminalPathDraggable).data.paths,
   };
 }
 


### PR DESCRIPTION
## Summary
- Explorer and Source Control path rows used `LongPressDraggable`, so drags waited for Flutter's ~500ms long-press timeout.
- Switch the shared path drag wrapper to immediate `Draggable` (same pattern as workbench tabs) so drags start after touch slop.
- Keep row context menus on their existing secondary-click / long-press detectors.

## Validation
- `flutter test test/widget/terminal_path_drag_test.dart test/widget/workbench_path_drag_sources_test.dart`
- `flutter analyze` on the changed files

## Notes
- Dense lists may compete a bit more with vertical scroll; that is the usual trade-off for immediate desktop drag.
- No docs update needed: UX detail only, no API/process change.