### PR TITLE
fix: keep path taps and scroll while dragging files

### DIFF
--- a/lib/src/features/workbench/presentation/terminal_path_drop.dart
+++ b/lib/src/features/workbench/presentation/terminal_path_drop.dart
@@ -1,5 +1,6 @@
 import 'package:alera/src/features/workbench/domain/terminal_path_paste.dart';
 import 'package:alera/src/features/workbench/presentation/terminal_runtime.dart';
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:path/path.dart' as p;
 
@@ -28,11 +29,17 @@ class TerminalPathDragData implements TerminalPathDragPayload {
   final List<String> paths;
 }
 
-/// Immediate-path drag source for explorer and source control rows.
+/// Path drag source for explorer and source control rows.
 ///
-/// Uses [Draggable] rather than [LongPressDraggable] so desktop pointer drags
-/// start after touch slop instead of waiting for [kLongPressTimeout]. Long-press
-/// context menus on those rows stay on a separate gesture detector.
+/// Starts after horizontal touch slop rather than [kLongPressTimeout], matching
+/// desktop file-tree drag latency. Uses a horizontal multi-drag recognizer with
+/// [kTouchSlop] for every pointer kind so:
+/// - vertical pans still scroll the parent list
+/// - mouse clicks with a few pixels of drift still fire row [onTap] (plain
+///   [Draggable] uses [kPrecisePointerHitSlop] of 1px for mice and steals taps)
+///
+/// Explorer long-press / secondary-click context menus stay on a separate
+/// gesture detector outside this widget.
 class TerminalPathDraggable<T extends TerminalPathDragPayload>
     extends StatelessWidget {
   const TerminalPathDraggable({
@@ -48,12 +55,78 @@ class TerminalPathDraggable<T extends TerminalPathDragPayload>
 
   @override
   Widget build(BuildContext context) {
-    return Draggable<T>(
+    return _TerminalPathDragSource<T>(
       data: data,
       feedback: feedback,
       childWhenDragging: Opacity(opacity: 0.45, child: child),
       child: child,
     );
+  }
+}
+
+/// [Draggable] that recognizes path drags with horizontal [kTouchSlop].
+class _TerminalPathDragSource<T extends Object> extends Draggable<T> {
+  const _TerminalPathDragSource({
+    super.key,
+    required super.child,
+    required super.feedback,
+    super.data,
+    super.childWhenDragging,
+  }) : super(affinity: Axis.horizontal);
+
+  @override
+  MultiDragGestureRecognizer createRecognizer(
+    GestureMultiDragStartCallback onStart,
+  ) {
+    return _TerminalPathDragGestureRecognizer(
+      debugOwner: this,
+      allowedButtonsFilter: allowedButtonsFilter,
+    )..onStart = onStart;
+  }
+}
+
+/// Horizontal multi-drag that uses [kTouchSlop] for all pointer kinds.
+///
+/// [HorizontalMultiDragGestureRecognizer] still calls [computeHitSlop], which
+/// is 1px for mice. That is too tight next to row taps ([kTouchSlop] = 18).
+class _TerminalPathDragGestureRecognizer extends MultiDragGestureRecognizer {
+  _TerminalPathDragGestureRecognizer({
+    super.debugOwner,
+    super.allowedButtonsFilter,
+  });
+
+  @override
+  MultiDragPointerState createNewPointerState(PointerDownEvent event) {
+    return _TerminalPathDragPointerState(
+      event.position,
+      event.kind,
+      gestureSettings,
+    );
+  }
+
+  @override
+  String get debugDescription => 'terminal path drag';
+}
+
+class _TerminalPathDragPointerState extends MultiDragPointerState {
+  _TerminalPathDragPointerState(
+    super.initialPosition,
+    super.kind,
+    super.gestureSettings,
+  );
+
+  @override
+  void checkForResolutionAfterMove() {
+    assert(pendingDelta != null);
+    final slop = gestureSettings?.touchSlop ?? kTouchSlop;
+    if (pendingDelta!.dx.abs() > slop) {
+      resolve(GestureDisposition.accepted);
+    }
+  }
+
+  @override
+  void accepted(GestureMultiDragStartCallback starter) {
+    starter(initialPosition);
   }
 }
 

--- a/test/widget/terminal_path_drag_test.dart
+++ b/test/widget/terminal_path_drag_test.dart
@@ -21,6 +21,79 @@ void main() {
     expect(session.focusRequests, 1);
   });
 
+  testWidgets('vertical pans prefer scroll over path drag', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SizedBox(
+            height: 120,
+            child: ListView(
+              children: <Widget>[
+                SizedBox(
+                  height: 80,
+                  child: Center(
+                    child: TerminalPathDraggable<TerminalPathDragData>(
+                      data: const TerminalPathDragData(
+                        paths: <String>['/tmp/foo'],
+                      ),
+                      feedback: const Material(child: Text('Dragging Paths')),
+                      child: const Text('Drag Paths'),
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 400, child: Text('Below')),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    final gesture = await tester.startGesture(
+      tester.getCenter(find.text('Drag Paths')),
+    );
+    await gesture.moveBy(const Offset(0, -(kTouchSlop + 20)));
+    await tester.pump();
+    expect(find.text('Dragging Paths'), findsNothing);
+    await gesture.up();
+    await tester.pump();
+  });
+
+  testWidgets('sub-touch-slop mouse moves keep competing taps', (tester) async {
+    var taps = 0;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: GestureDetector(
+              onTap: () => taps += 1,
+              child: TerminalPathDraggable<TerminalPathDragData>(
+                data: const TerminalPathDragData(paths: <String>['/tmp/foo']),
+                feedback: const Material(child: Text('Dragging Paths')),
+                child: const Text('Drag Paths'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    // Use a mouse pointer so the test fails if we regress to ImmediateMultiDrag
+    // (kPrecisePointerHitSlop = 1px) instead of kTouchSlop.
+    final gesture = await tester.startGesture(
+      tester.getCenter(find.text('Drag Paths')),
+      kind: PointerDeviceKind.mouse,
+    );
+    await gesture.moveBy(const Offset(2, 0));
+    await tester.pump();
+    expect(find.text('Dragging Paths'), findsNothing);
+    await gesture.up();
+    await tester.pump();
+    expect(taps, 1);
+  });
+
   testWidgets('terminal error state rejects in-app path drags', (tester) async {
     final session = _CapturingTerminalSessionHandle(error: 'unavailable');
 
@@ -117,7 +190,7 @@ Future<void> _dragSourceToTerminal(
   final gesture = await tester.startGesture(
     tester.getCenter(find.text('Drag Paths')),
   );
-  // Immediate Draggable starts after touch slop, not after long-press.
+  // Path drag starts after horizontal touch slop, not after long-press.
   await gesture.moveBy(const Offset(kTouchSlop + 1, 0));
   await tester.pump();
   expect(find.text('Dragging Paths'), findsOneWidget);

--- a/test/widget/workbench_path_drag_sources_test.dart
+++ b/test/widget/workbench_path_drag_sources_test.dart
@@ -60,7 +60,7 @@ void main() {
     final source = tester.getCenter(find.text('readme.md'));
     final target = tester.getCenter(find.text('src'));
     final gesture = await tester.startGesture(source);
-    // Immediate Draggable starts after touch slop, not after long-press.
+    // Path drag starts after horizontal touch slop, not after long-press.
     await gesture.moveBy(const Offset(kTouchSlop + 1, 0));
     await tester.pump();
     await gesture.moveTo(target);


### PR DESCRIPTION
## Summary
- Follow-up to #364: plain `Draggable` used ImmediateMultiDrag with 1px mouse hit slop and no axis affinity.
- Path rows now use a horizontal multi-drag recognizer with `kTouchSlop` for every pointer kind.
- Mouse click drift of a few pixels still fires row taps; pure vertical pans still scroll explorer and Source Control lists.

## Validation
- `flutter analyze` on the changed files
- `flutter test test/widget/terminal_path_drag_test.dart test/widget/workbench_path_drag_sources_test.dart`

## Notes
- No docs update needed: gesture-arena detail only.