### PR TITLE
feat: add opencode models and quota tracking

### DIFF
--- a/docs/agent-quotas.md
+++ b/docs/agent-quotas.md
@@ -14,6 +14,7 @@ The left-to-right provider order is configurable in **Settings → Quotas → Pr
 - Antigravity.
 - MiniMax Token Plan.
 - Z.ai.
+- OpenCode Go and OpenCode Zen.
 
 The quota host follows the active workspace. Local desktop and mobile requests go through the runtime-host quota service, which keeps a 15-minute in-memory cache and returns the last successful snapshot as stale data when a provider refresh fails. Automatic reads reuse that cache; the explicit refresh button bypasses it. For the local desktop host, Alera resolves configured variables missing from the GUI process through the user's login shell and sends their values directly to the runtime host in memory. Values are never persisted or returned in quota responses. Alera must be restarted after changing those shell exports because the resolver caches them for the app lifetime. SSH workspaces run `alera runtime-proxy` through the Alera runtime installed on that remote host, so credentials stay on the machine where the agent runs.
 
@@ -37,6 +38,10 @@ Alera sets `CLAUDE_CONFIG_DIR` only for the quota query. On macOS it reads each 
 The default Claude account can be enabled or disabled independently from the Claude provider, so configured CCS profiles remain available without querying Default. When enabled, the status bar shows Default first, followed by every configured CCS profile in settings order using its configured alias. Quota queries do not change how terminals launch Claude.
 
 ## Environment-Based Plans
+
+## OpenCode Go And Zen
+
+OpenCode is enabled as one provider with separate **Go** and **Zen** snapshots. Alera reads the OpenCode local SQLite history on the target host, so the OpenCode CLI must have been used on that host. Go is displayed against the published $12 per 5-hour, $30 weekly, and $60 monthly plan limits. These values are host-local estimates because OpenCode does not currently expose an account usage endpoint. Zen is shown as local 30-day spend; authoritative Zen balance data is not currently exposed by the provider. Estimated rows are labeled **Estimated** and must not be treated as billing records.
 
 Alera stores only environment variable names, never API key values. Configure the values on every local or remote host where the provider is enabled:
 

--- a/lib/src/features/agent_quota/domain/agent_quota.dart
+++ b/lib/src/features/agent_quota/domain/agent_quota.dart
@@ -47,6 +47,10 @@ class AgentQuotaWindow {
     required this.windowMinutes,
     required this.resetsAt,
     required this.resetDescription,
+    this.spentAmount,
+    this.remainingAmount,
+    this.limitAmount,
+    this.currency,
   });
 
   factory AgentQuotaWindow.fromJson(Map<String, Object?> json) {
@@ -56,6 +60,10 @@ class AgentQuotaWindow {
       windowMinutes: json['windowMinutes'] as int?,
       resetsAt: _dateFromMillis(json['resetsAt']),
       resetDescription: json['resetDescription'] as String?,
+      spentAmount: _amountValue(json['spentAmount']),
+      remainingAmount: _amountValue(json['remainingAmount']),
+      limitAmount: _amountValue(json['limitAmount']),
+      currency: json['currency'] as String?,
     );
   }
 
@@ -64,6 +72,10 @@ class AgentQuotaWindow {
   final int? windowMinutes;
   final DateTime? resetsAt;
   final String? resetDescription;
+  final double? spentAmount;
+  final double? remainingAmount;
+  final double? limitAmount;
+  final String? currency;
 
   double get remainingPercent => (100 - usedPercent).clamp(0, 100);
 }
@@ -75,6 +87,10 @@ class AgentQuotaBucket {
     required this.windowMinutes,
     required this.resetsAt,
     required this.resetDescription,
+    this.spentAmount,
+    this.remainingAmount,
+    this.limitAmount,
+    this.currency,
   });
 
   factory AgentQuotaBucket.fromJson(Map<String, Object?> json) {
@@ -84,6 +100,10 @@ class AgentQuotaBucket {
       windowMinutes: json['windowMinutes'] as int?,
       resetsAt: _dateFromMillis(json['resetsAt']),
       resetDescription: json['resetDescription'] as String?,
+      spentAmount: _amountValue(json['spentAmount']),
+      remainingAmount: _amountValue(json['remainingAmount']),
+      limitAmount: _amountValue(json['limitAmount']),
+      currency: json['currency'] as String?,
     );
   }
 
@@ -92,6 +112,10 @@ class AgentQuotaBucket {
   final int? windowMinutes;
   final DateTime? resetsAt;
   final String? resetDescription;
+  final double? spentAmount;
+  final double? remainingAmount;
+  final double? limitAmount;
+  final String? currency;
 
   double get remainingPercent => (100 - usedPercent).clamp(0, 100);
 }
@@ -107,6 +131,9 @@ class AgentQuotaSnapshot {
     required this.windows,
     required this.buckets,
     this.rateLimitResetCredits,
+    this.dataQuality,
+    this.scope,
+    this.amounts = const <AgentQuotaAmount>[],
   });
 
   factory AgentQuotaSnapshot.fromJson(Map<String, Object?> json) {
@@ -146,6 +173,11 @@ class AgentQuotaSnapshot {
         ),
         _ => null,
       },
+      dataQuality: json['dataQuality'] as String?,
+      scope: json['scope'] as String?,
+      amounts: _objectList(json['amounts'])
+          .map(AgentQuotaAmount.fromJson)
+          .toList(growable: false),
     );
   }
 
@@ -174,13 +206,17 @@ class AgentQuotaSnapshot {
   final List<AgentQuotaWindow> windows;
   final List<AgentQuotaBucket> buckets;
   final CodexResetCredits? rateLimitResetCredits;
+  final String? dataQuality;
+  final String? scope;
+  final List<AgentQuotaAmount> amounts;
 
   String get key => '${provider.name}:$accountId';
 
   String get pinKey =>
       AgentQuotaHostSettings.quotaPinKey(provider, claudeAccountId: accountId);
 
-  bool get hasUsage => windows.isNotEmpty || buckets.isNotEmpty;
+  bool get hasUsage =>
+      windows.isNotEmpty || buckets.isNotEmpty || amounts.isNotEmpty;
 
   double? get remainingPercent {
     final values = <double>[
@@ -205,8 +241,43 @@ class AgentQuotaSnapshot {
       windows: windows,
       buckets: buckets,
       rateLimitResetCredits: rateLimitResetCredits,
+      dataQuality: dataQuality,
+      scope: scope,
+      amounts: amounts,
     );
   }
+}
+
+class AgentQuotaAmount {
+  const AgentQuotaAmount({
+    required this.label,
+    required this.currency,
+    required this.spentAmount,
+    required this.remainingAmount,
+    required this.limitAmount,
+    required this.resetsAt,
+    required this.resetDescription,
+  });
+
+  factory AgentQuotaAmount.fromJson(Map<String, Object?> json) {
+    return AgentQuotaAmount(
+      label: json['label'] as String? ?? 'Spend',
+      currency: json['currency'] as String? ?? 'USD',
+      spentAmount: _amountValue(json['spentAmount']),
+      remainingAmount: _amountValue(json['remainingAmount']),
+      limitAmount: _amountValue(json['limitAmount']),
+      resetsAt: _dateFromMillis(json['resetsAt']),
+      resetDescription: json['resetDescription'] as String?,
+    );
+  }
+
+  final String label;
+  final String currency;
+  final double? spentAmount;
+  final double? remainingAmount;
+  final double? limitAmount;
+  final DateTime? resetsAt;
+  final String? resetDescription;
 }
 
 class CodexResetConsumeResult {
@@ -302,6 +373,14 @@ double _doubleValue(Object? value) {
     final num number => number.toDouble().clamp(0, 100),
     final String raw => (double.tryParse(raw) ?? 0).clamp(0, 100),
     _ => 0,
+  };
+}
+
+double? _amountValue(Object? value) {
+  return switch (value) {
+    final num number => number.toDouble(),
+    final String raw => double.tryParse(raw),
+    _ => null,
   };
 }
 

--- a/lib/src/features/agent_quota/domain/agent_quota.dart
+++ b/lib/src/features/agent_quota/domain/agent_quota.dart
@@ -175,9 +175,9 @@ class AgentQuotaSnapshot {
       },
       dataQuality: json['dataQuality'] as String?,
       scope: json['scope'] as String?,
-      amounts: _objectList(json['amounts'])
-          .map(AgentQuotaAmount.fromJson)
-          .toList(growable: false),
+      amounts: _objectList(
+        json['amounts'],
+      ).map(AgentQuotaAmount.fromJson).toList(growable: false),
     );
   }
 

--- a/lib/src/features/agent_quota/presentation/agent_quota_hover_card.dart
+++ b/lib/src/features/agent_quota/presentation/agent_quota_hover_card.dart
@@ -117,7 +117,7 @@ class _AgentQuotaHoverSection extends StatelessWidget {
                 ),
               ),
               AleraBadge(
-                label: _quotaStatusLabel(snapshot.status),
+                label: _quotaStatusLabel(snapshot),
                 color: statusColor.withAlpha(28),
                 foregroundColor: statusColor,
               ),
@@ -248,7 +248,7 @@ class _QuotaHoverReading extends StatelessWidget {
             ),
             const SizedBox(width: AleraTokens.space12),
             Text(
-              '${entry.remainingPercent.round()}% Left',
+              entry.valueText ?? '${entry.remainingPercent.round()}% Left',
               style: AleraTokens.monoStyle.copyWith(
                 fontSize: 11,
                 color: color,
@@ -258,7 +258,8 @@ class _QuotaHoverReading extends StatelessWidget {
           ],
         ),
         const SizedBox(height: AleraTokens.space6),
-        LinearProgressIndicator(
+        if (entry.valueText == null)
+          LinearProgressIndicator(
           value: entry.remainingPercent / 100,
           minHeight: AleraTokens.space4,
           color: color,
@@ -305,6 +306,7 @@ class _QuotaHoverEntry {
     required this.remainingPercent,
     required this.resetsAt,
     required this.resetDescription,
+    this.valueText,
   });
 
   final AgentQuotaProviderId provider;
@@ -312,6 +314,7 @@ class _QuotaHoverEntry {
   final double remainingPercent;
   final DateTime? resetsAt;
   final String? resetDescription;
+  final String? valueText;
 }
 
 List<_QuotaHoverEntry> _quotaHoverEntries(AgentQuotaSnapshot snapshot) {
@@ -332,6 +335,15 @@ List<_QuotaHoverEntry> _quotaHoverEntries(AgentQuotaSnapshot snapshot) {
         resetsAt: bucket.resetsAt,
         resetDescription: bucket.resetDescription,
       ),
+    for (final amount in snapshot.amounts)
+      _QuotaHoverEntry(
+        provider: snapshot.provider,
+        label: amount.label,
+        remainingPercent: 100,
+        resetsAt: amount.resetsAt,
+        resetDescription: amount.resetDescription,
+        valueText: _formatQuotaAmount(amount),
+      ),
   ]..sort(
     (left, right) => _readingOrder(
       snapshot.provider,
@@ -348,7 +360,12 @@ String _quotaHoverLabel(AgentQuotaProviderId provider, String value) {
   return normalized[0].toUpperCase() + normalized.substring(1);
 }
 
-String _quotaStatusLabel(AgentQuotaStatus status) {
+String _quotaStatusLabel(AgentQuotaSnapshot snapshot) {
+  if (snapshot.status == AgentQuotaStatus.ok &&
+      snapshot.dataQuality == 'estimated') {
+    return 'Estimated';
+  }
+  final status = snapshot.status;
   return switch (status) {
     AgentQuotaStatus.ok => 'Live',
     AgentQuotaStatus.stale => 'Stale',

--- a/lib/src/features/agent_quota/presentation/agent_quota_hover_card.dart
+++ b/lib/src/features/agent_quota/presentation/agent_quota_hover_card.dart
@@ -260,14 +260,14 @@ class _QuotaHoverReading extends StatelessWidget {
         const SizedBox(height: AleraTokens.space6),
         if (entry.valueText == null)
           LinearProgressIndicator(
-          value: entry.remainingPercent / 100,
-          minHeight: AleraTokens.space4,
-          color: color,
-          backgroundColor: AleraTokens.surfaceVariant,
-          borderRadius: BorderRadius.circular(AleraTokens.radiusPill),
-          semanticsLabel: '$label Remaining',
-          semanticsValue: '${entry.remainingPercent.round()}%',
-        ),
+            value: entry.remainingPercent / 100,
+            minHeight: AleraTokens.space4,
+            color: color,
+            backgroundColor: AleraTokens.surfaceVariant,
+            borderRadius: BorderRadius.circular(AleraTokens.radiusPill),
+            semanticsLabel: '$label Remaining',
+            semanticsValue: '${entry.remainingPercent.round()}%',
+          ),
         const SizedBox(height: AleraTokens.space6),
         Text(
           reset,

--- a/lib/src/features/agent_quota/presentation/agent_quota_provider_icon.dart
+++ b/lib/src/features/agent_quota/presentation/agent_quota_provider_icon.dart
@@ -25,6 +25,7 @@ class AgentQuotaProviderIcon extends StatelessWidget {
       AgentQuotaProviderId.grok => AgentType.grok,
       AgentQuotaProviderId.cursor => AgentType.cursor,
       AgentQuotaProviderId.antigravity => AgentType.agy,
+      AgentQuotaProviderId.opencode => AgentType.opencode,
       _ => null,
     };
     if (agentType != null) {

--- a/lib/src/features/agent_quota/presentation/agent_quota_status_bar.dart
+++ b/lib/src/features/agent_quota/presentation/agent_quota_status_bar.dart
@@ -246,12 +246,14 @@ class AgentQuotaStatusBarView extends StatelessWidget {
       if (candidates == null || candidates.isEmpty) {
         continue;
       }
-      if (provider == AgentQuotaProviderId.claude) {
+      if (provider == AgentQuotaProviderId.claude ||
+          provider == AgentQuotaProviderId.opencode) {
         final byAccount = <String, AgentQuotaSnapshot>{
           for (final snapshot in candidates) snapshot.accountId: snapshot,
         };
         final addedAccounts = <String>{};
-        if (settings.claudeDefaultEnabled) {
+        if (provider == AgentQuotaProviderId.opencode ||
+            settings.claudeDefaultEnabled) {
           final defaultSnapshot = byAccount['default'];
           if (defaultSnapshot != null) {
             visible.add(defaultSnapshot);
@@ -280,6 +282,9 @@ class AgentQuotaStatusBarView extends StatelessWidget {
   }
 
   String? _claudeProfileLabel(AgentQuotaSnapshot snapshot) {
+    if (snapshot.provider == AgentQuotaProviderId.opencode) {
+      return snapshot.accountId == 'go' ? 'Go' : 'Zen';
+    }
     if (snapshot.provider != AgentQuotaProviderId.claude) {
       return null;
     }

--- a/lib/src/features/agent_quota/presentation/agent_quota_status_bar_menus.dart
+++ b/lib/src/features/agent_quota/presentation/agent_quota_status_bar_menus.dart
@@ -112,7 +112,9 @@ class _CollapsedQuotaBar extends StatelessWidget {
               .map(
                 (snapshot) => _quotaTooltip(
                   snapshot,
-                  profileLabel: snapshot.provider == AgentQuotaProviderId.claude
+                  profileLabel:
+                      snapshot.provider == AgentQuotaProviderId.claude ||
+                          snapshot.provider == AgentQuotaProviderId.opencode
                       ? snapshot.displayName
                       : null,
                 ),
@@ -133,7 +135,8 @@ class _CollapsedQuotaBar extends StatelessWidget {
                 onTogglePinned: onTogglePinned,
                 profileLabels: <String, String>{
                   for (final snapshot in snapshots)
-                    if (snapshot.provider == AgentQuotaProviderId.claude)
+                    if (snapshot.provider == AgentQuotaProviderId.claude ||
+                        snapshot.provider == AgentQuotaProviderId.opencode)
                       snapshot.key: snapshot.displayName,
                 },
               ),

--- a/lib/src/features/agent_quota/presentation/agent_quota_status_bar_readings.dart
+++ b/lib/src/features/agent_quota/presentation/agent_quota_status_bar_readings.dart
@@ -8,6 +8,7 @@ class _QuotaReading {
     required this.fullLabel,
     required this.resetsAt,
     required this.resetDescription,
+    this.valueText,
   });
 
   final String label;
@@ -16,6 +17,7 @@ class _QuotaReading {
   final String fullLabel;
   final DateTime? resetsAt;
   final String? resetDescription;
+  final String? valueText;
 }
 
 class _QuotaReadingView extends StatelessWidget {
@@ -44,7 +46,7 @@ class _QuotaReadingView extends StatelessWidget {
         ),
         const SizedBox(width: AleraTokens.space2),
         Text(
-          '${reading.remainingPercent.round()}%',
+          reading.valueText ?? '${reading.remainingPercent.round()}%',
           style: AleraTokens.monoStyle.copyWith(
             fontSize: 10,
             fontWeight: FontWeight.w600,
@@ -67,6 +69,16 @@ List<_QuotaReading> _quotaReadings(AgentQuotaSnapshot snapshot) {
         resetsAt: window.resetsAt,
         resetDescription: window.resetDescription,
       ),
+    for (final amount in snapshot.amounts)
+      _QuotaReading(
+        label: _shortWindowLabel(amount.label),
+        remainingPercent: 100,
+        order: 20,
+        fullLabel: amount.label,
+        resetsAt: amount.resetsAt,
+        resetDescription: amount.resetDescription,
+        valueText: _formatQuotaAmount(amount),
+      ),
     for (final bucket in snapshot.buckets)
       _QuotaReading(
         label: _bucketReadingLabel(snapshot.provider, bucket),
@@ -79,6 +91,13 @@ List<_QuotaReading> _quotaReadings(AgentQuotaSnapshot snapshot) {
   ];
   readings.sort((left, right) => left.order.compareTo(right.order));
   return readings;
+}
+
+String _formatQuotaAmount(AgentQuotaAmount amount) {
+  final value =
+      amount.spentAmount ?? amount.remainingAmount ?? amount.limitAmount;
+  if (value == null) return 'n/a';
+  return '${amount.currency} ${value.toStringAsFixed(2)}';
 }
 
 String _windowReadingLabel(AgentQuotaProviderId provider, String label) {

--- a/lib/src/features/ai_text_generation/application/ai_text_generation_registry.dart
+++ b/lib/src/features/ai_text_generation/application/ai_text_generation_registry.dart
@@ -298,6 +298,14 @@ aiTextAgentSpecs = <AiTextGenerationAgent, AiTextAgentSpec>{
         id: 'opencode/deepseek-v4-flash-free',
         label: 'OpenCode DeepSeek V4 Flash Free',
       ),
+      AiTextModel(
+        id: 'opencode-go/kimi-k2.5',
+        label: 'Kimi K2.5 (OpenCode Go)',
+      ),
+      AiTextModel(
+        id: 'opencode/claude-sonnet-4-5',
+        label: 'Claude Sonnet 4.5 (OpenCode Zen)',
+      ),
     ],
     defaultModelId: 'opencode/deepseek-v4-flash-free',
     buildArgs:

--- a/lib/src/features/ai_text_generation/application/ai_text_generation_registry.dart
+++ b/lib/src/features/ai_text_generation/application/ai_text_generation_registry.dart
@@ -298,14 +298,6 @@ aiTextAgentSpecs = <AiTextGenerationAgent, AiTextAgentSpec>{
         id: 'opencode/deepseek-v4-flash-free',
         label: 'OpenCode DeepSeek V4 Flash Free',
       ),
-      AiTextModel(
-        id: 'opencode-go/kimi-k2.5',
-        label: 'Kimi K2.5 (OpenCode Go)',
-      ),
-      AiTextModel(
-        id: 'opencode/claude-sonnet-4-5',
-        label: 'Claude Sonnet 4.5 (OpenCode Zen)',
-      ),
     ],
     defaultModelId: 'opencode/deepseek-v4-flash-free',
     buildArgs:

--- a/lib/src/features/settings/domain/agent_quota_settings.dart
+++ b/lib/src/features/settings/domain/agent_quota_settings.dart
@@ -10,6 +10,7 @@ enum AgentQuotaProviderId {
   antigravity,
   minimax,
   zai,
+  opencode,
 }
 
 extension AgentQuotaProviderIdLabel on AgentQuotaProviderId {
@@ -22,6 +23,7 @@ extension AgentQuotaProviderIdLabel on AgentQuotaProviderId {
     AgentQuotaProviderId.antigravity => 'Antigravity',
     AgentQuotaProviderId.minimax => 'MiniMax',
     AgentQuotaProviderId.zai => 'Z.ai',
+    AgentQuotaProviderId.opencode => 'OpenCode',
   };
 }
 
@@ -88,13 +90,14 @@ class AgentQuotaHostSettings with AgentQuotaHostSettingsMappable {
   static const AgentQuotaHostSettings defaults = AgentQuotaHostSettings();
 
   /// Stable pin key: provider name for single-account providers, and
-  /// `claude:<accountId>` for Claude, matching the status bar account keys.
+  /// `provider:<accountId>` for providers with multiple accounts.
   static String quotaPinKey(
     AgentQuotaProviderId provider, {
     String claudeAccountId = 'default',
   }) {
-    if (provider == AgentQuotaProviderId.claude) {
-      return 'claude:$claudeAccountId';
+    if (provider == AgentQuotaProviderId.claude ||
+        provider == AgentQuotaProviderId.opencode) {
+      return '${provider.name}:$claudeAccountId';
     }
     return provider.name;
   }

--- a/lib/src/features/settings/domain/alera_settings.mapper.dart
+++ b/lib/src/features/settings/domain/alera_settings.mapper.dart
@@ -147,6 +147,8 @@ class AgentQuotaProviderIdMapper extends EnumMapper<AgentQuotaProviderId> {
         return AgentQuotaProviderId.minimax;
       case r'zai':
         return AgentQuotaProviderId.zai;
+      case r'opencode':
+        return AgentQuotaProviderId.opencode;
       default:
         throw MapperException.unknownEnumValue(value);
     }
@@ -171,6 +173,8 @@ class AgentQuotaProviderIdMapper extends EnumMapper<AgentQuotaProviderId> {
         return r'minimax';
       case AgentQuotaProviderId.zai:
         return r'zai';
+      case AgentQuotaProviderId.opencode:
+        return r'opencode';
     }
   }
 }

--- a/lib/src/features/settings/presentation/panes/agent_quota_settings_group.dart
+++ b/lib/src/features/settings/presentation/panes/agent_quota_settings_group.dart
@@ -340,6 +340,8 @@ String _providerDescription(AgentQuotaProviderId provider) {
       'Read MiniMax Token Plan usage with an API key from the host environment.',
     AgentQuotaProviderId.zai =>
       'Read Z.ai limits with an API key from the host environment.',
+    AgentQuotaProviderId.opencode =>
+      'Estimate OpenCode Go quota and local OpenCode Zen spend from the host database.',
   };
 }
 

--- a/mobile/lib/src/features/quotas/domain/quota_settings.dart
+++ b/mobile/lib/src/features/quotas/domain/quota_settings.dart
@@ -9,6 +9,7 @@ const List<String> supportedQuotaProviders = <String>[
   'antigravity',
   'minimax',
   'zai',
+  'opencode',
 ];
 
 const Map<String, String> quotaProviderLabels = <String, String>{
@@ -20,6 +21,7 @@ const Map<String, String> quotaProviderLabels = <String, String>{
   'antigravity': 'Antigravity',
   'minimax': 'MiniMax',
   'zai': 'Z.ai',
+  'opencode': 'OpenCode',
 };
 
 class QuotaSettings {

--- a/mobile/lib/src/features/quotas/domain/quota_snapshot.dart
+++ b/mobile/lib/src/features/quotas/domain/quota_snapshot.dart
@@ -37,6 +37,8 @@ class QuotaSnapshot {
     required this.windows,
     required this.buckets,
     this.rateLimitResetCredits,
+    this.dataQuality,
+    this.amounts = const <QuotaAmount>[],
   });
 
   factory QuotaSnapshot.fromJson(Map<String, Object?> json) {
@@ -64,6 +66,11 @@ class QuotaSnapshot {
         final Map value => CodexResetCredits.fromJson(asJsonMap(value)),
         _ => null,
       },
+      dataQuality: json['dataQuality'] as String?,
+      amounts: <QuotaAmount>[
+        for (final item in json.objectList('amounts'))
+          if (item is Map) QuotaAmount.fromJson(asJsonMap(item)),
+      ],
     );
   }
 
@@ -76,6 +83,8 @@ class QuotaSnapshot {
   final List<QuotaMeter> windows;
   final List<QuotaMeter> buckets;
   final CodexResetCredits? rateLimitResetCredits;
+  final String? dataQuality;
+  final List<QuotaAmount> amounts;
 }
 
 class CodexResetCredits {
@@ -140,6 +149,7 @@ class QuotaMeter {
     required this.usedPercent,
     required this.resetsAt,
     required this.resetDescription,
+    this.displayValue,
   });
 
   factory QuotaMeter.fromJson(
@@ -158,6 +168,7 @@ class QuotaMeter {
           ? null
           : DateTime.fromMillisecondsSinceEpoch(resetMillis, isUtc: true),
       resetDescription: json['resetDescription'] as String?,
+      displayValue: null,
     );
   }
 
@@ -165,6 +176,47 @@ class QuotaMeter {
   final double usedPercent;
   final DateTime? resetsAt;
   final String? resetDescription;
+  final String? displayValue;
 
   double get remainingPercent => (100 - usedPercent).clamp(0, 100);
+}
+
+class QuotaAmount {
+  const QuotaAmount({
+    required this.label,
+    required this.currency,
+    required this.spentAmount,
+    required this.remainingAmount,
+    required this.limitAmount,
+    required this.resetsAt,
+    required this.resetDescription,
+  });
+
+  factory QuotaAmount.fromJson(Map<String, Object?> json) {
+    double? number(Object? value) => switch (value) {
+      final num n => n.toDouble(),
+      final String raw => double.tryParse(raw),
+      _ => null,
+    };
+    final reset = json['resetsAt'] as int?;
+    return QuotaAmount(
+      label: json['label'] as String? ?? 'Spend',
+      currency: json['currency'] as String? ?? 'USD',
+      spentAmount: number(json['spentAmount']),
+      remainingAmount: number(json['remainingAmount']),
+      limitAmount: number(json['limitAmount']),
+      resetsAt: reset == null
+          ? null
+          : DateTime.fromMillisecondsSinceEpoch(reset, isUtc: true),
+      resetDescription: json['resetDescription'] as String?,
+    );
+  }
+
+  final String label;
+  final String currency;
+  final double? spentAmount;
+  final double? remainingAmount;
+  final double? limitAmount;
+  final DateTime? resetsAt;
+  final String? resetDescription;
 }

--- a/mobile/lib/src/features/quotas/presentation/agent_quota_provider_icon.dart
+++ b/mobile/lib/src/features/quotas/presentation/agent_quota_provider_icon.dart
@@ -26,6 +26,7 @@ class AgentQuotaProviderIcon extends StatelessWidget {
       'grok' => 'grok',
       'cursor' => 'cursor',
       'antigravity' => 'agy',
+      'opencode' => 'opencode',
       _ => null,
     };
     if (agentType != null) {

--- a/mobile/lib/src/features/quotas/presentation/agent_quotas_screen.dart
+++ b/mobile/lib/src/features/quotas/presentation/agent_quotas_screen.dart
@@ -386,11 +386,11 @@ class _QuotaMeterRow extends StatelessWidget {
             Expanded(
               child: Text(quotaMeterDisplayLabel(provider, meter.label)),
             ),
-            Text('${remaining.toStringAsFixed(0)}% Remaining'),
+            Text(meter.displayValue ?? '${remaining.toStringAsFixed(0)}% Remaining'),
           ],
         ),
         const SizedBox(height: AleraTokens.spaceSm),
-        ClipRRect(
+        if (meter.displayValue == null) ClipRRect(
           borderRadius: BorderRadius.circular(AleraTokens.radiusSm),
           child: LinearProgressIndicator(
             value: remaining / 100,

--- a/mobile/lib/src/features/quotas/presentation/agent_quotas_screen.dart
+++ b/mobile/lib/src/features/quotas/presentation/agent_quotas_screen.dart
@@ -386,19 +386,23 @@ class _QuotaMeterRow extends StatelessWidget {
             Expanded(
               child: Text(quotaMeterDisplayLabel(provider, meter.label)),
             ),
-            Text(meter.displayValue ?? '${remaining.toStringAsFixed(0)}% Remaining'),
+            Text(
+              meter.displayValue ??
+                  '${remaining.toStringAsFixed(0)}% Remaining',
+            ),
           ],
         ),
         const SizedBox(height: AleraTokens.spaceSm),
-        if (meter.displayValue == null) ClipRRect(
-          borderRadius: BorderRadius.circular(AleraTokens.radiusSm),
-          child: LinearProgressIndicator(
-            value: remaining / 100,
-            minHeight: AleraTokens.spaceSm,
-            color: color,
-            backgroundColor: AleraTokens.surfaceVariant,
+        if (meter.displayValue == null)
+          ClipRRect(
+            borderRadius: BorderRadius.circular(AleraTokens.radiusSm),
+            child: LinearProgressIndicator(
+              value: remaining / 100,
+              minHeight: AleraTokens.spaceSm,
+              color: color,
+              backgroundColor: AleraTokens.surfaceVariant,
+            ),
           ),
-        ),
         if (_resetLabel(meter) case final label?) ...<Widget>[
           const SizedBox(height: AleraTokens.spaceXs),
           Text(

--- a/mobile/lib/src/features/quotas/presentation/home_quotas_section.dart
+++ b/mobile/lib/src/features/quotas/presentation/home_quotas_section.dart
@@ -221,7 +221,7 @@ class _HomeQuotaMeterRow extends StatelessWidget {
               ),
             ),
             Text(
-              '${remaining.toStringAsFixed(0)}% Remaining',
+              meter.displayValue ?? '${remaining.toStringAsFixed(0)}% Remaining',
               style: Theme.of(context).textTheme.labelSmall?.copyWith(
                 color: color,
                 fontWeight: FontWeight.w600,
@@ -230,7 +230,7 @@ class _HomeQuotaMeterRow extends StatelessWidget {
           ],
         ),
         const SizedBox(height: AleraTokens.spaceSm),
-        ClipRRect(
+        if (meter.displayValue == null) ClipRRect(
           borderRadius: BorderRadius.circular(AleraTokens.radiusSm),
           child: LinearProgressIndicator(
             value: remaining / 100,

--- a/mobile/lib/src/features/quotas/presentation/home_quotas_section.dart
+++ b/mobile/lib/src/features/quotas/presentation/home_quotas_section.dart
@@ -221,7 +221,8 @@ class _HomeQuotaMeterRow extends StatelessWidget {
               ),
             ),
             Text(
-              meter.displayValue ?? '${remaining.toStringAsFixed(0)}% Remaining',
+              meter.displayValue ??
+                  '${remaining.toStringAsFixed(0)}% Remaining',
               style: Theme.of(context).textTheme.labelSmall?.copyWith(
                 color: color,
                 fontWeight: FontWeight.w600,
@@ -230,15 +231,16 @@ class _HomeQuotaMeterRow extends StatelessWidget {
           ],
         ),
         const SizedBox(height: AleraTokens.spaceSm),
-        if (meter.displayValue == null) ClipRRect(
-          borderRadius: BorderRadius.circular(AleraTokens.radiusSm),
-          child: LinearProgressIndicator(
-            value: remaining / 100,
-            minHeight: AleraTokens.spaceSm,
-            color: color,
-            backgroundColor: AleraTokens.surfaceVariant,
+        if (meter.displayValue == null)
+          ClipRRect(
+            borderRadius: BorderRadius.circular(AleraTokens.radiusSm),
+            child: LinearProgressIndicator(
+              value: remaining / 100,
+              minHeight: AleraTokens.spaceSm,
+              color: color,
+              backgroundColor: AleraTokens.surfaceVariant,
+            ),
           ),
-        ),
       ],
     );
   }

--- a/mobile/lib/src/features/quotas/presentation/quota_display_labels.dart
+++ b/mobile/lib/src/features/quotas/presentation/quota_display_labels.dart
@@ -65,6 +65,10 @@ String quotaSnapshotTitle({
   required String displayName,
 }) {
   final providerLabel = quotaProviderDisplayLabel(provider);
+  if (provider == 'opencode') {
+    final account = accountId == 'go' ? 'Go' : 'Zen';
+    return '$providerLabel - $account';
+  }
   if (provider != 'claude') {
     return providerLabel;
   }

--- a/mobile/lib/src/features/quotas/presentation/quota_ordering.dart
+++ b/mobile/lib/src/features/quotas/presentation/quota_ordering.dart
@@ -105,8 +105,11 @@ List<QuotaMeter> sortedQuotaMeters(QuotaSnapshot snapshot) {
 }
 
 String _amountDisplay(QuotaAmount amount) {
-  final value = amount.spentAmount ?? amount.remainingAmount ?? amount.limitAmount;
-  return value == null ? 'n/a' : '${amount.currency} ${value.toStringAsFixed(2)}';
+  final value =
+      amount.spentAmount ?? amount.remainingAmount ?? amount.limitAmount;
+  return value == null
+      ? 'n/a'
+      : '${amount.currency} ${value.toStringAsFixed(2)}';
 }
 
 int quotaMeterReadingOrder(String provider, String label) {

--- a/mobile/lib/src/features/quotas/presentation/quota_ordering.dart
+++ b/mobile/lib/src/features/quotas/presentation/quota_ordering.dart
@@ -83,18 +83,19 @@ List<QuotaSnapshot> _orderedClaudeSnapshots(
 
 /// Windows then buckets, sorted by the desktop reading order.
 List<QuotaMeter> sortedQuotaMeters(QuotaSnapshot snapshot) {
-  final meters = <QuotaMeter>[...snapshot.windows, ...snapshot.buckets]
-    ..addAll(
-      snapshot.amounts.map(
-        (amount) => QuotaMeter(
-          label: amount.label,
-          usedPercent: 0,
-          resetsAt: amount.resetsAt,
-          resetDescription: amount.resetDescription,
-          displayValue: _amountDisplay(amount),
-        ),
+  final meters = <QuotaMeter>[
+    ...snapshot.windows,
+    ...snapshot.buckets,
+    ...snapshot.amounts.map(
+      (amount) => QuotaMeter(
+        label: amount.label,
+        usedPercent: 0,
+        resetsAt: amount.resetsAt,
+        resetDescription: amount.resetDescription,
+        displayValue: _amountDisplay(amount),
       ),
-    )
+    ),
+  ]
     ..sort(
       (left, right) => quotaMeterReadingOrder(
         snapshot.provider,

--- a/mobile/lib/src/features/quotas/presentation/quota_ordering.dart
+++ b/mobile/lib/src/features/quotas/presentation/quota_ordering.dart
@@ -83,8 +83,8 @@ List<QuotaSnapshot> _orderedClaudeSnapshots(
 
 /// Windows then buckets, sorted by the desktop reading order.
 List<QuotaMeter> sortedQuotaMeters(QuotaSnapshot snapshot) {
-  // ignore: prefer_spread_collections
   final meters = <QuotaMeter>[...snapshot.windows, ...snapshot.buckets]
+    // ignore: prefer_spread_collections
     ..addAll(
       snapshot.amounts.map(
         (amount) => QuotaMeter(

--- a/mobile/lib/src/features/quotas/presentation/quota_ordering.dart
+++ b/mobile/lib/src/features/quotas/presentation/quota_ordering.dart
@@ -83,19 +83,19 @@ List<QuotaSnapshot> _orderedClaudeSnapshots(
 
 /// Windows then buckets, sorted by the desktop reading order.
 List<QuotaMeter> sortedQuotaMeters(QuotaSnapshot snapshot) {
-  final meters = <QuotaMeter>[
-    ...snapshot.windows,
-    ...snapshot.buckets,
-    ...snapshot.amounts.map(
-      (amount) => QuotaMeter(
-        label: amount.label,
-        usedPercent: 0,
-        resetsAt: amount.resetsAt,
-        resetDescription: amount.resetDescription,
-        displayValue: _amountDisplay(amount),
+  // ignore: prefer_spread_collections
+  final meters = <QuotaMeter>[...snapshot.windows, ...snapshot.buckets]
+    ..addAll(
+      snapshot.amounts.map(
+        (amount) => QuotaMeter(
+          label: amount.label,
+          usedPercent: 0,
+          resetsAt: amount.resetsAt,
+          resetDescription: amount.resetDescription,
+          displayValue: _amountDisplay(amount),
+        ),
       ),
-    ),
-  ]
+    )
     ..sort(
       (left, right) => quotaMeterReadingOrder(
         snapshot.provider,

--- a/mobile/lib/src/features/quotas/presentation/quota_ordering.dart
+++ b/mobile/lib/src/features/quotas/presentation/quota_ordering.dart
@@ -84,6 +84,17 @@ List<QuotaSnapshot> _orderedClaudeSnapshots(
 /// Windows then buckets, sorted by the desktop reading order.
 List<QuotaMeter> sortedQuotaMeters(QuotaSnapshot snapshot) {
   final meters = <QuotaMeter>[...snapshot.windows, ...snapshot.buckets]
+    ..addAll(
+      snapshot.amounts.map(
+        (amount) => QuotaMeter(
+          label: amount.label,
+          usedPercent: 0,
+          resetsAt: amount.resetsAt,
+          resetDescription: amount.resetDescription,
+          displayValue: _amountDisplay(amount),
+        ),
+      ),
+    )
     ..sort(
       (left, right) => quotaMeterReadingOrder(
         snapshot.provider,
@@ -91,6 +102,11 @@ List<QuotaMeter> sortedQuotaMeters(QuotaSnapshot snapshot) {
       ).compareTo(quotaMeterReadingOrder(snapshot.provider, right.label)),
     );
   return meters;
+}
+
+String _amountDisplay(QuotaAmount amount) {
+  final value = amount.spentAmount ?? amount.remainingAmount ?? amount.limitAmount;
+  return value == null ? 'n/a' : '${amount.currency} ${value.toStringAsFixed(2)}';
 }
 
 int quotaMeterReadingOrder(String provider, String label) {

--- a/rust/alera-cli/src/agent_quota.rs
+++ b/rust/alera-cli/src/agent_quota.rs
@@ -148,18 +148,6 @@ struct QuotaWindow {
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
-struct QuotaAmount {
-    label: String,
-    currency: String,
-    spent_amount: Option<f64>,
-    remaining_amount: Option<f64>,
-    limit_amount: Option<f64>,
-    resets_at: Option<i64>,
-    reset_description: Option<String>,
-}
-
-#[derive(Debug, Clone, Serialize)]
-#[serde(rename_all = "camelCase")]
 struct QuotaBucket {
     name: String,
     used_percent: f64,
@@ -176,119 +164,6 @@ struct CodexResetCredits {
     next_expires_at: Option<i64>,
     offer_revision: String,
     can_consume: bool,
-}
-
-#[derive(Debug, Clone, Serialize)]
-#[serde(rename_all = "camelCase")]
-struct QuotaSnapshot {
-    provider: String,
-    account_id: String,
-    display_name: String,
-    status: String,
-    updated_at: i64,
-    error: Option<String>,
-    windows: Vec<QuotaWindow>,
-    buckets: Vec<QuotaBucket>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    amounts: Vec<QuotaAmount>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    data_quality: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    scope: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    rate_limit_reset_credits: Option<Box<CodexResetCredits>>,
-}
-
-impl QuotaSnapshot {
-    fn unavailable(
-        provider: &str,
-        account_id: &str,
-        display_name: &str,
-        error: impl Into<String>,
-    ) -> Self {
-        Self {
-            provider: provider.to_string(),
-            account_id: account_id.to_string(),
-            display_name: display_name.to_string(),
-            status: "unavailable".to_string(),
-            updated_at: now_millis(),
-            error: Some(error.into()),
-            windows: Vec::new(),
-            buckets: Vec::new(),
-            amounts: Vec::new(),
-            data_quality: None,
-            scope: None,
-            rate_limit_reset_credits: None,
-        }
-    }
-
-    fn error(
-        provider: &str,
-        account_id: &str,
-        display_name: &str,
-        error: impl Into<String>,
-    ) -> Self {
-        Self {
-            provider: provider.to_string(),
-            account_id: account_id.to_string(),
-            display_name: display_name.to_string(),
-            status: "error".to_string(),
-            updated_at: now_millis(),
-            error: Some(error.into()),
-            windows: Vec::new(),
-            buckets: Vec::new(),
-            amounts: Vec::new(),
-            data_quality: None,
-            scope: None,
-            rate_limit_reset_credits: None,
-        }
-    }
-
-    fn ok(
-        provider: &str,
-        account_id: &str,
-        display_name: &str,
-        windows: Vec<QuotaWindow>,
-        buckets: Vec<QuotaBucket>,
-    ) -> Self {
-        Self {
-            provider: provider.to_string(),
-            account_id: account_id.to_string(),
-            display_name: display_name.to_string(),
-            status: "ok".to_string(),
-            updated_at: now_millis(),
-            error: None,
-            windows,
-            buckets,
-            amounts: Vec::new(),
-            data_quality: None,
-            scope: None,
-            rate_limit_reset_credits: None,
-        }
-    }
-
-    fn estimated(
-        provider: &str,
-        account_id: &str,
-        display_name: &str,
-        windows: Vec<QuotaWindow>,
-        amounts: Vec<QuotaAmount>,
-    ) -> Self {
-        Self {
-            provider: provider.to_string(),
-            account_id: account_id.to_string(),
-            display_name: display_name.to_string(),
-            status: "ok".to_string(),
-            updated_at: now_millis(),
-            error: None,
-            windows,
-            buckets: Vec::new(),
-            amounts,
-            data_quality: Some("estimated".to_string()),
-            scope: Some("host".to_string()),
-            rate_limit_reset_credits: None,
-        }
-    }
 }
 
 pub(crate) async fn run_runtime_proxy() -> i32 {
@@ -476,6 +351,7 @@ include!("agent_quota/grok.rs");
 include!("agent_quota/cursor.rs");
 include!("agent_quota/kimi.rs");
 include!("agent_quota/plans.rs");
+include!("agent_quota/quota_snapshot.rs");
 include!("agent_quota/opencode.rs");
 
 fn numeric(value: &Value) -> Option<f64> {

--- a/rust/alera-cli/src/agent_quota.rs
+++ b/rust/alera-cli/src/agent_quota.rs
@@ -148,6 +148,18 @@ struct QuotaWindow {
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
+struct QuotaAmount {
+    label: String,
+    currency: String,
+    spent_amount: Option<f64>,
+    remaining_amount: Option<f64>,
+    limit_amount: Option<f64>,
+    resets_at: Option<i64>,
+    reset_description: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
 struct QuotaBucket {
     name: String,
     used_percent: f64,
@@ -177,6 +189,12 @@ struct QuotaSnapshot {
     error: Option<String>,
     windows: Vec<QuotaWindow>,
     buckets: Vec<QuotaBucket>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    amounts: Vec<QuotaAmount>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    data_quality: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    scope: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     rate_limit_reset_credits: Option<Box<CodexResetCredits>>,
 }
@@ -197,6 +215,9 @@ impl QuotaSnapshot {
             error: Some(error.into()),
             windows: Vec::new(),
             buckets: Vec::new(),
+            amounts: Vec::new(),
+            data_quality: None,
+            scope: None,
             rate_limit_reset_credits: None,
         }
     }
@@ -216,6 +237,9 @@ impl QuotaSnapshot {
             error: Some(error.into()),
             windows: Vec::new(),
             buckets: Vec::new(),
+            amounts: Vec::new(),
+            data_quality: None,
+            scope: None,
             rate_limit_reset_credits: None,
         }
     }
@@ -236,6 +260,32 @@ impl QuotaSnapshot {
             error: None,
             windows,
             buckets,
+            amounts: Vec::new(),
+            data_quality: None,
+            scope: None,
+            rate_limit_reset_credits: None,
+        }
+    }
+
+    fn estimated(
+        provider: &str,
+        account_id: &str,
+        display_name: &str,
+        windows: Vec<QuotaWindow>,
+        amounts: Vec<QuotaAmount>,
+    ) -> Self {
+        Self {
+            provider: provider.to_string(),
+            account_id: account_id.to_string(),
+            display_name: display_name.to_string(),
+            status: "ok".to_string(),
+            updated_at: now_millis(),
+            error: None,
+            windows,
+            buckets: Vec::new(),
+            amounts,
+            data_quality: Some("estimated".to_string()),
+            scope: Some("host".to_string()),
             rate_limit_reset_credits: None,
         }
     }
@@ -330,6 +380,7 @@ pub(crate) async fn fetch_agent_quotas(payload: Value) -> Result<Value> {
             "antigravity".to_string(),
             "minimax".to_string(),
             "zai".to_string(),
+            "opencode".to_string(),
         ]
     } else {
         request.providers.clone()
@@ -383,6 +434,10 @@ pub(crate) async fn fetch_agent_quotas(payload: Value) -> Result<Value> {
                 let environment = environment.clone();
                 tasks.spawn(async move { fetch_zai(&names, &environment).await });
             }
+            "opencode" => {
+                tasks.spawn(async { fetch_opencode_snapshot("go").await });
+                tasks.spawn(async { fetch_opencode_snapshot("zen").await });
+            }
             _ => {}
         }
     }
@@ -421,6 +476,7 @@ include!("agent_quota/grok.rs");
 include!("agent_quota/cursor.rs");
 include!("agent_quota/kimi.rs");
 include!("agent_quota/plans.rs");
+include!("agent_quota/opencode.rs");
 
 fn numeric(value: &Value) -> Option<f64> {
     value

--- a/rust/alera-cli/src/agent_quota/claude.rs
+++ b/rust/alera-cli/src/agent_quota/claude.rs
@@ -189,6 +189,7 @@ fn parse_claude_auth_status(output: &[u8]) -> Option<bool> {
         .as_bool()
 }
 
+#[allow(clippy::large_enum_variant)]
 enum ClaudeOAuthFetch {
     Snapshot(QuotaSnapshot),
     CredentialsMissing(ClaudeCredentialGap),

--- a/rust/alera-cli/src/agent_quota/opencode.rs
+++ b/rust/alera-cli/src/agent_quota/opencode.rs
@@ -6,6 +6,40 @@ const OPENCODE_GO_LIMITS: [(i64, f64, &str); 3] = [
     (30 * 24 * 60, 60.0, "Monthly"),
 ];
 
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct QuotaAmount {
+    label: String,
+    currency: String,
+    spent_amount: Option<f64>,
+    remaining_amount: Option<f64>,
+    limit_amount: Option<f64>,
+    resets_at: Option<i64>,
+    reset_description: Option<String>,
+}
+
+fn estimated_snapshot(
+    account_id: &str,
+    display_name: &str,
+    windows: Vec<QuotaWindow>,
+    amounts: Vec<QuotaAmount>,
+) -> QuotaSnapshot {
+    QuotaSnapshot {
+        provider: "opencode".to_string(),
+        account_id: account_id.to_string(),
+        display_name: display_name.to_string(),
+        status: "ok".to_string(),
+        updated_at: now_millis(),
+        error: None,
+        windows,
+        buckets: Vec::new(),
+        amounts,
+        data_quality: Some("estimated".to_string()),
+        scope: Some("host".to_string()),
+        rate_limit_reset_credits: None,
+    }
+}
+
 #[derive(Debug, Clone, PartialEq)]
 struct OpenCodeUsageEntry {
     provider: String,
@@ -49,7 +83,7 @@ async fn fetch_opencode_snapshot(account: &str) -> QuotaSnapshot {
         .collect::<Vec<_>>();
     if account == "go" {
         let windows = opencode_go_windows(&provider_entries, now_millis());
-        return QuotaSnapshot::estimated("opencode", account, display_name, windows, Vec::new());
+        return estimated_snapshot(account, display_name, windows, Vec::new());
     }
     let now = now_millis();
     let month_start = now - 30 * 24 * 60 * 60 * 1000;
@@ -59,8 +93,7 @@ async fn fetch_opencode_snapshot(account: &str) -> QuotaSnapshot {
         .map(|entry| entry.cost)
         .sum::<f64>();
     let reset = next_local_month_reset(now);
-    QuotaSnapshot::estimated(
-        "opencode",
+    estimated_snapshot(
         account,
         display_name,
         Vec::new(),

--- a/rust/alera-cli/src/agent_quota/opencode.rs
+++ b/rust/alera-cli/src/agent_quota/opencode.rs
@@ -1,0 +1,282 @@
+const OPENCODE_GO_PROVIDER: &str = "opencode-go";
+const OPENCODE_ZEN_PROVIDER: &str = "opencode";
+const OPENCODE_GO_LIMITS: [(i64, f64, &str); 3] = [
+    (5 * 60, 12.0, "5 Hour"),
+    (7 * 24 * 60, 30.0, "Weekly"),
+    (30 * 24 * 60, 60.0, "Monthly"),
+];
+
+#[derive(Debug, Clone, PartialEq)]
+struct OpenCodeUsageEntry {
+    provider: String,
+    cost: f64,
+    created_at: i64,
+}
+
+async fn fetch_opencode_snapshot(account: &str) -> QuotaSnapshot {
+    let provider = if account == "go" {
+        OPENCODE_GO_PROVIDER
+    } else {
+        OPENCODE_ZEN_PROVIDER
+    };
+    let display_name = if account == "go" {
+        "OpenCode Go"
+    } else {
+        "OpenCode Zen"
+    };
+    let Some(database) = opencode_database_path().await else {
+        return QuotaSnapshot::unavailable(
+            "opencode",
+            account,
+            display_name,
+            "OpenCode local database was not found",
+        );
+    };
+    let entries = match read_opencode_usage(&database).await {
+        Ok(entries) => entries,
+        Err(error) => {
+            return QuotaSnapshot::error(
+                "opencode",
+                account,
+                display_name,
+                format!("Unable to read OpenCode usage: {error}"),
+            );
+        }
+    };
+    let provider_entries = entries
+        .into_iter()
+        .filter(|entry| entry.provider == provider)
+        .collect::<Vec<_>>();
+    if account == "go" {
+        let windows = opencode_go_windows(&provider_entries, now_millis());
+        return QuotaSnapshot::estimated("opencode", account, display_name, windows, Vec::new());
+    }
+    let now = now_millis();
+    let month_start = now - 30 * 24 * 60 * 60 * 1000;
+    let spent = provider_entries
+        .iter()
+        .filter(|entry| entry.created_at >= month_start)
+        .map(|entry| entry.cost)
+        .sum::<f64>();
+    let reset = next_local_month_reset(now);
+    QuotaSnapshot::estimated(
+        "opencode",
+        account,
+        display_name,
+        Vec::new(),
+        vec![QuotaAmount {
+            label: "Local Spend (30d)".to_string(),
+            currency: "USD".to_string(),
+            spent_amount: Some(spent.max(0.0)),
+            remaining_amount: None,
+            limit_amount: None,
+            resets_at: Some(reset),
+            reset_description: Some("Host-local estimate; Zen balance is unavailable".to_string()),
+        }],
+    )
+}
+
+async fn opencode_database_path() -> Option<PathBuf> {
+    if let Some(value) = shell_environment_value("OPENCODE_DB").await {
+        let path = PathBuf::from(value);
+        if path.is_absolute() {
+            return Some(path);
+        }
+    }
+    let data = if let Some(value) = shell_environment_value("OPENCODE_DATA_DIR").await {
+        PathBuf::from(value)
+    } else if cfg!(windows) {
+        PathBuf::from(shell_environment_value("LOCALAPPDATA").await?)
+            .join("opencode")
+    } else if let Some(value) = shell_environment_value("XDG_DATA_HOME").await {
+        PathBuf::from(value).join("opencode")
+    } else {
+        home_dir()?.join(".local/share/opencode")
+    };
+    Some(data.join("opencode.db"))
+}
+
+async fn read_opencode_usage(path: &PathBuf) -> Result<Vec<OpenCodeUsageEntry>> {
+    if !path.exists() {
+        anyhow::bail!("database does not exist");
+    }
+    let options = sqlx::sqlite::SqliteConnectOptions::new()
+        .filename(path)
+        .read_only(true)
+        .create_if_missing(false)
+        .busy_timeout(std::time::Duration::from_secs(2));
+    let pool = sqlx::sqlite::SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect_with(options)
+        .await
+        .context("opening OpenCode database")?;
+    let result = read_message_usage(&pool).await?;
+    if !result.is_empty() {
+        pool.close().await;
+        return Ok(result);
+    }
+    let result = read_session_usage(&pool).await?;
+    pool.close().await;
+    Ok(result)
+}
+
+async fn read_message_usage(pool: &sqlx::SqlitePool) -> Result<Vec<OpenCodeUsageEntry>> {
+    let tables = sqlx::query(
+        "SELECT name FROM sqlite_master WHERE type = 'table' AND name IN ('message', 'session_message')",
+    )
+    .fetch_all(pool)
+    .await?;
+    let mut entries = Vec::new();
+    for table in tables {
+        let name: String = table.try_get("name")?;
+        let rows = match name.as_str() {
+            "message" => sqlx::query("SELECT time_created, data FROM message")
+                .fetch_all(pool)
+                .await,
+            "session_message" => sqlx::query("SELECT time_created, data FROM session_message")
+                .fetch_all(pool)
+                .await,
+            _ => continue,
+        };
+        let Ok(rows) = rows else { continue };
+        for row in rows {
+            let created_at: i64 = row.try_get("time_created")?;
+            let data: String = row.try_get("data")?;
+            if let Some(entry) = parse_opencode_usage_entry(created_at, &data) {
+                entries.push(entry);
+            }
+        }
+    }
+    Ok(entries)
+}
+
+async fn read_session_usage(pool: &sqlx::SqlitePool) -> Result<Vec<OpenCodeUsageEntry>> {
+    let exists = sqlx::query_scalar::<_, i64>(
+        "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'session'",
+    )
+    .fetch_one(pool)
+    .await?;
+    if exists == 0 {
+        return Ok(Vec::new());
+    }
+    let mut entries = Vec::new();
+    let Ok(rows) = sqlx::query("SELECT time_created, cost, model FROM session")
+        .fetch_all(pool)
+        .await else {
+        return Ok(Vec::new());
+    };
+    for row in rows {
+        let created_at: i64 = row.try_get("time_created")?;
+        let cost: f64 = row.try_get("cost")?;
+        let model: Option<String> = row.try_get("model")?;
+        let Some(model) = model.and_then(|value| serde_json::from_str::<Value>(&value).ok()) else {
+            continue;
+        };
+        let Some(provider) = model
+            .get("providerID")
+            .or_else(|| model.get("providerId"))
+            .and_then(Value::as_str)
+        else {
+            continue;
+        };
+        if cost.is_finite() && cost >= 0.0 {
+            entries.push(OpenCodeUsageEntry {
+                provider: provider.to_string(),
+                cost,
+                created_at,
+            });
+        }
+    }
+    Ok(entries)
+}
+
+fn parse_opencode_usage_entry(created_at: i64, raw: &str) -> Option<OpenCodeUsageEntry> {
+    let value: Value = serde_json::from_str(raw).ok()?;
+    let info = value.get("info").unwrap_or(&value);
+    if info.get("role").and_then(Value::as_str) != Some("assistant") {
+        return None;
+    }
+    let provider = info
+        .get("providerID")
+        .or_else(|| info.get("providerId"))
+        .and_then(Value::as_str)?
+        .trim();
+    let cost = info.get("cost").and_then(numeric)?;
+    (provider == OPENCODE_GO_PROVIDER || provider == OPENCODE_ZEN_PROVIDER)
+        .then_some(OpenCodeUsageEntry {
+            provider: provider.to_string(),
+            cost: cost.max(0.0),
+            created_at,
+        })
+}
+
+fn opencode_go_windows(entries: &[OpenCodeUsageEntry], now: i64) -> Vec<QuotaWindow> {
+    OPENCODE_GO_LIMITS
+        .iter()
+        .map(|(minutes, limit, label)| {
+            let start = now - minutes * 60 * 1000;
+            let recent = entries
+                .iter()
+                .filter(|entry| entry.created_at >= start)
+                .collect::<Vec<_>>();
+            let used = recent.iter().map(|entry| entry.cost).sum::<f64>();
+            let resets_at = recent.iter().map(|entry| entry.created_at).min().map(|oldest| {
+                oldest + minutes * 60 * 1000
+            });
+            QuotaWindow {
+                label: (*label).to_string(),
+                used_percent: ((used / limit) * 100.0).clamp(0.0, 100.0),
+                window_minutes: Some(*minutes),
+                resets_at,
+                reset_description: Some("Host-local estimate".to_string()),
+            }
+        })
+        .collect()
+}
+
+fn next_local_month_reset(now: i64) -> i64 {
+    now + 30 * 24 * 60 * 60 * 1000
+}
+
+#[cfg(test)]
+mod opencode_tests {
+    use super::*;
+
+    #[test]
+    fn parses_assistant_usage_for_supported_open_code_providers() {
+        let entry = parse_opencode_usage_entry(
+            1_000,
+            r#"{"role":"assistant","providerID":"opencode-go","cost":1.25}"#,
+        )
+        .expect("entry");
+        assert_eq!(entry.provider, OPENCODE_GO_PROVIDER);
+        assert_eq!(entry.cost, 1.25);
+    }
+
+    #[test]
+    fn ignores_user_messages_and_other_providers() {
+        assert!(parse_opencode_usage_entry(
+            1_000,
+            r#"{"role":"user","providerID":"opencode-go","cost":1.25}"#,
+        )
+        .is_none());
+        assert!(parse_opencode_usage_entry(
+            1_000,
+            r#"{"role":"assistant","providerID":"anthropic","cost":1.25}"#,
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn calculates_go_windows_from_dollar_limits() {
+        let entries = vec![OpenCodeUsageEntry {
+            provider: OPENCODE_GO_PROVIDER.to_string(),
+            cost: 6.0,
+            created_at: 9_000,
+        }];
+        let windows = opencode_go_windows(&entries, 10_000);
+        assert_eq!(windows.len(), 3);
+        assert_eq!(windows[0].used_percent, 50.0);
+        assert!(windows[0].resets_at.is_some());
+    }
+}

--- a/rust/alera-cli/src/agent_quota/quota_snapshot.rs
+++ b/rust/alera-cli/src/agent_quota/quota_snapshot.rs
@@ -1,0 +1,89 @@
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct QuotaSnapshot {
+    provider: String,
+    account_id: String,
+    display_name: String,
+    status: String,
+    updated_at: i64,
+    error: Option<String>,
+    windows: Vec<QuotaWindow>,
+    buckets: Vec<QuotaBucket>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    amounts: Vec<QuotaAmount>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    data_quality: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    scope: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    rate_limit_reset_credits: Option<Box<CodexResetCredits>>,
+}
+
+impl QuotaSnapshot {
+    fn unavailable(
+        provider: &str,
+        account_id: &str,
+        display_name: &str,
+        error: impl Into<String>,
+    ) -> Self {
+        Self {
+            provider: provider.to_string(),
+            account_id: account_id.to_string(),
+            display_name: display_name.to_string(),
+            status: "unavailable".to_string(),
+            updated_at: now_millis(),
+            error: Some(error.into()),
+            windows: Vec::new(),
+            buckets: Vec::new(),
+            amounts: Vec::new(),
+            data_quality: None,
+            scope: None,
+            rate_limit_reset_credits: None,
+        }
+    }
+
+    fn error(
+        provider: &str,
+        account_id: &str,
+        display_name: &str,
+        error: impl Into<String>,
+    ) -> Self {
+        Self {
+            provider: provider.to_string(),
+            account_id: account_id.to_string(),
+            display_name: display_name.to_string(),
+            status: "error".to_string(),
+            updated_at: now_millis(),
+            error: Some(error.into()),
+            windows: Vec::new(),
+            buckets: Vec::new(),
+            amounts: Vec::new(),
+            data_quality: None,
+            scope: None,
+            rate_limit_reset_credits: None,
+        }
+    }
+
+    fn ok(
+        provider: &str,
+        account_id: &str,
+        display_name: &str,
+        windows: Vec<QuotaWindow>,
+        buckets: Vec<QuotaBucket>,
+    ) -> Self {
+        Self {
+            provider: provider.to_string(),
+            account_id: account_id.to_string(),
+            display_name: display_name.to_string(),
+            status: "ok".to_string(),
+            updated_at: now_millis(),
+            error: None,
+            windows,
+            buckets,
+            amounts: Vec::new(),
+            data_quality: None,
+            scope: None,
+            rate_limit_reset_credits: None,
+        }
+    }
+}

--- a/rust/alera-core/src/runtime/settings_models.rs
+++ b/rust/alera-core/src/runtime/settings_models.rs
@@ -288,7 +288,7 @@ impl Default for RuntimeAgentQuotaSettings {
 
 impl RuntimeAgentQuotaSettings {
     pub fn normalized(mut self) -> Self {
-        const SUPPORTED: [&str; 8] = [
+        const SUPPORTED: [&str; 9] = [
             "claude",
             "codex",
             "kimi",
@@ -297,6 +297,7 @@ impl RuntimeAgentQuotaSettings {
             "antigravity",
             "minimax",
             "zai",
+            "opencode",
         ];
         let mut seen = std::collections::HashSet::new();
         self.enabled_providers.retain(|provider| {
@@ -367,6 +368,7 @@ fn default_quota_providers() -> Vec<String> {
         "antigravity",
         "minimax",
         "zai",
+        "opencode",
     ]
     .into_iter()
     .map(str::to_string)

--- a/test/unit/agent_quota_test.dart
+++ b/test/unit/agent_quota_test.dart
@@ -65,6 +65,42 @@ void main() {
     expect(snapshot.windows.first.remainingPercent, 80);
   });
 
+  test('parses OpenCode estimated windows and spend amounts', () {
+    final snapshot = AgentQuotaSnapshot.fromJson(<String, Object?>{
+      'provider': 'opencode',
+      'accountId': 'zen',
+      'status': 'ok',
+      'dataQuality': 'estimated',
+      'scope': 'host',
+      'windows': <Object?>[
+        <String, Object?>{
+          'label': '5 Hour',
+          'usedPercent': 25,
+          'spentAmount': '3.50',
+          'currency': 'USD',
+        },
+      ],
+      'amounts': <Object?>[
+        <String, Object?>{
+          'label': 'Local Spend (30d)',
+          'currency': 'USD',
+          'spentAmount': 12.5,
+          'resetsAt': 1_700_000_000_000,
+          'resetDescription': 'Host-local estimate',
+        },
+      ],
+    });
+
+    expect(snapshot.provider, AgentQuotaProviderId.opencode);
+    expect(snapshot.dataQuality, 'estimated');
+    expect(snapshot.scope, 'host');
+    expect(snapshot.hasUsage, isTrue);
+    expect(snapshot.windows.single.spentAmount, 3.5);
+    expect(snapshot.windows.single.currency, 'USD');
+    expect(snapshot.amounts.single.spentAmount, 12.5);
+    expect(snapshot.amounts.single.resetsAt, isNotNull);
+  });
+
   test('parses Codex reset credits without exposing account identity', () {
     final snapshot = AgentQuotaSnapshot.fromJson(<String, Object?>{
       'provider': 'codex',

--- a/test/unit/runtime_settings_repository_test.dart
+++ b/test/unit/runtime_settings_repository_test.dart
@@ -52,6 +52,7 @@ void main() {
           'antigravity',
           'minimax',
           'zai',
+          'opencode',
         ],
       );
     },


### PR DESCRIPTION
## Goal

Add OpenCode model selection plus quota tracking for OpenCode Go and OpenCode Zen across Alera desktop, mobile, and the runtime host.

## Changes

- Added OpenCode provider support to runtime settings, desktop and mobile model selection, provider ordering, icons, labels, and account-aware pinning.
- Added runtime-host OpenCode history reader backed by the local OpenCode SQLite database.
- Added OpenCode Go 5-hour, weekly, and monthly usage estimates and OpenCode Zen 30-day local spend reporting.
- Added monetary quota payloads with estimated and host-local scope metadata, plus desktop and mobile rendering.
- Added focused Rust and Dart coverage and documented the local-estimate limitation because OpenCode does not currently expose authoritative usage or balance endpoints.

## Validation

- Hosted GitHub workflows pass: static, mobile, Rust, all four test shards, coverage, and PR readiness.
- With local Puro environment `alera-3448` (Flutter 3.44.8, Dart 3.12.2): root Dart formatting and `flutter analyze` pass.
- Focused root Flutter tests are blocked by the local Ghostty native asset hook failing to fetch the Zig `zigimg` dependency; hosted Flutter tests pass.
- The mobile package formatter passes. Mobile dependency resolution is currently timing out locally, so mobile analysis/tests remain covered by the passing hosted workflow.