### PR TITLE
feat: paste workspace-relative paths on terminal drops

### DIFF
--- a/lib/src/features/workbench/application/terminal_composer_workspace_attachment.dart
+++ b/lib/src/features/workbench/application/terminal_composer_workspace_attachment.dart
@@ -1,7 +1,7 @@
 import 'package:alera/src/features/workbench/application/workspace_file_preview_kind.dart';
 import 'package:alera/src/features/workbench/application/workspace_file_service.dart';
+import 'package:alera/src/features/workbench/domain/workspace_relative_path.dart';
 import 'package:alera/src/rust/api/workspace_files.dart' as native;
-import 'package:path/path.dart' as p;
 
 Future<bool> openTerminalComposerWorkspaceAttachment({
   required String workspacePath,
@@ -44,13 +44,8 @@ String? terminalComposerWorkspaceRelativePath({
   required String workspacePath,
   required String filePath,
 }) {
-  if (!p.isAbsolute(filePath)) {
-    return null;
-  }
-  final normalizedWorkspacePath = p.normalize(workspacePath);
-  final normalizedFilePath = p.normalize(filePath);
-  if (!p.isWithin(normalizedWorkspacePath, normalizedFilePath)) {
-    return null;
-  }
-  return p.relative(normalizedFilePath, from: normalizedWorkspacePath);
+  return workspaceRelativePath(
+    workspacePath: workspacePath,
+    filePath: filePath,
+  );
 }

--- a/lib/src/features/workbench/domain/terminal_composer_submission.dart
+++ b/lib/src/features/workbench/domain/terminal_composer_submission.dart
@@ -1,9 +1,11 @@
 import 'package:alera/src/features/workbench/domain/terminal_composer_attachment.dart';
 import 'package:alera/src/features/workbench/domain/terminal_image_paste.dart';
+import 'package:alera/src/features/workbench/domain/workspace_relative_path.dart';
 
 String buildTerminalComposerSubmission({
   required String prompt,
   required Iterable<TerminalComposerAttachment> attachments,
+  String? workspacePath,
 }) {
   final images = <String>[];
   final files = <String>[];
@@ -12,11 +14,15 @@ String buildTerminalComposerSubmission({
     if (path.isEmpty) {
       continue;
     }
+    final submissionPath = workspacePath == null
+        ? path
+        : workspaceRelativePath(workspacePath: workspacePath, filePath: path) ??
+              path;
     switch (attachment.kind) {
       case TerminalComposerAttachmentKind.image:
-        images.add(path);
+        images.add(submissionPath);
       case TerminalComposerAttachmentKind.file:
-        files.add(path);
+        files.add(submissionPath);
     }
   }
   final sections = <String>[

--- a/lib/src/features/workbench/domain/workspace_relative_path.dart
+++ b/lib/src/features/workbench/domain/workspace_relative_path.dart
@@ -1,0 +1,22 @@
+import 'package:path/path.dart' as p;
+
+/// Returns [filePath] relative to [workspacePath] when the file lives inside
+/// the workspace, or null when it does not. A file equal to the workspace
+/// root resolves to '.'.
+String? workspaceRelativePath({
+  required String workspacePath,
+  required String filePath,
+  p.Context? pathContext,
+}) {
+  final context = pathContext ?? p.context;
+  if (!context.isAbsolute(filePath)) {
+    return null;
+  }
+  final normalizedWorkspacePath = context.normalize(workspacePath);
+  final normalizedFilePath = context.normalize(filePath);
+  if (!context.isWithin(normalizedWorkspacePath, normalizedFilePath) &&
+      !context.equals(normalizedWorkspacePath, normalizedFilePath)) {
+    return null;
+  }
+  return context.relative(normalizedFilePath, from: normalizedWorkspacePath);
+}

--- a/lib/src/features/workbench/presentation/terminal_composer.dart
+++ b/lib/src/features/workbench/presentation/terminal_composer.dart
@@ -128,6 +128,7 @@ class TerminalComposer extends StatelessWidget {
     final submission = buildTerminalComposerSubmission(
       prompt: prompt,
       attachments: attachments,
+      workspacePath: session.workspacePath,
     );
     composer.setSubmitting(true);
     try {

--- a/lib/src/features/workbench/presentation/terminal_path_drop.dart
+++ b/lib/src/features/workbench/presentation/terminal_path_drop.dart
@@ -1,4 +1,5 @@
 import 'package:alera/src/features/workbench/domain/terminal_path_paste.dart';
+import 'package:alera/src/features/workbench/domain/workspace_relative_path.dart';
 import 'package:alera/src/features/workbench/presentation/terminal_runtime.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
@@ -130,12 +131,27 @@ class _TerminalPathDragPointerState extends MultiDragPointerState {
   }
 }
 
-/// Pastes absolute paths into [session] after an OS or in-app drop.
+/// Pastes paths into [session] after an OS or in-app drop.
+///
+/// Paths inside the session's workspace are pasted relative to the workspace
+/// root; anything else keeps its absolute form.
 void handleTerminalPathDrop({
   required TerminalSessionHandle session,
   required Iterable<String> paths,
 }) {
-  final text = formatPathsForTerminalPaste(paths);
+  final workspacePath = session.workspacePath;
+  final text = formatPathsForTerminalPaste(
+    workspacePath == null
+        ? paths
+        : paths.map(
+            (path) =>
+                workspaceRelativePath(
+                  workspacePath: workspacePath,
+                  filePath: path,
+                ) ??
+                path,
+          ),
+  );
   if (text.isEmpty) {
     return;
   }

--- a/lib/src/features/workbench/presentation/terminal_runtime.dart
+++ b/lib/src/features/workbench/presentation/terminal_runtime.dart
@@ -59,6 +59,13 @@ abstract class TerminalSessionHandle extends ChangeNotifier {
 
   String get workspaceId;
 
+  /// Absolute path of the workspace root, used to relativize dropped paths.
+  ///
+  /// Defaulted so the many test doubles of this class do not each have to
+  /// restate a workspace they do not own; a null value keeps dropped paths
+  /// absolute.
+  String? get workspacePath => null;
+
   /// The runtime-host identity used to select the matching Agent Canvas.
   /// Test and synthetic handles may omit it when they do not own a PTY.
   String? get terminalSessionId => null;

--- a/lib/src/features/workbench/presentation/terminal_runtime_session_handle.dart
+++ b/lib/src/features/workbench/presentation/terminal_runtime_session_handle.dart
@@ -118,6 +118,8 @@ class _XtermTerminalSessionHandle extends TerminalSessionHandle
   @override
   String get workspaceId => _workspace.id;
   @override
+  String get workspacePath => _workspace.path;
+  @override
   String get terminalSessionId => _tab.terminalSessionId;
 
   @override

--- a/test/unit/terminal_composer_submission_test.dart
+++ b/test/unit/terminal_composer_submission_test.dart
@@ -64,4 +64,39 @@ void main() {
       'Text only',
     );
   });
+
+  test('relativizes attachment paths inside the workspace', () {
+    expect(
+      buildTerminalComposerSubmission(
+        prompt: 'Review these',
+        workspacePath: '/tmp/project',
+        attachments: const <TerminalComposerAttachment>[
+          TerminalComposerAttachment(
+            id: 'image',
+            kind: TerminalComposerAttachmentKind.image,
+            path: '/tmp/project/assets/before.png',
+            displayName: 'before.png',
+          ),
+          TerminalComposerAttachment(
+            id: 'file',
+            kind: TerminalComposerAttachmentKind.file,
+            path: '/tmp/project/docs/report.pdf',
+            displayName: 'report.pdf',
+          ),
+          TerminalComposerAttachment(
+            id: 'outside',
+            kind: TerminalComposerAttachmentKind.file,
+            path: '/tmp/other/notes.txt',
+            displayName: 'notes.txt',
+          ),
+        ],
+      ),
+      'Review these\n\n'
+      'Attached images:\n'
+      'assets/before.png\n'
+      'Attached files:\n'
+      'docs/report.pdf\n'
+      '/tmp/other/notes.txt',
+    );
+  });
 }

--- a/test/unit/terminal_path_drop_test.dart
+++ b/test/unit/terminal_path_drop_test.dart
@@ -47,6 +47,25 @@ void main() {
     expect(session.focusRequests, 1);
   });
 
+  test('pastes workspace files relative to the workspace root', () {
+    final session = _CapturingTerminalSessionHandle()
+      ..workspacePath = '/tmp/project';
+
+    handleTerminalPathDrop(
+      session: session,
+      paths: <String>[
+        '/tmp/project/packages/app/main.dart',
+        '/tmp/project/my file.txt',
+        '/tmp/other/absolute.txt',
+      ],
+    );
+
+    expect(session.pasted, <String>[
+      "packages/app/main.dart 'my file.txt' /tmp/other/absolute.txt ",
+    ]);
+    expect(session.focusRequests, 1);
+  });
+
   test('ignores empty path lists', () {
     final session = _CapturingTerminalSessionHandle();
 
@@ -61,6 +80,9 @@ class _CapturingTerminalSessionHandle extends TerminalSessionHandle {
   final List<String> pasted = <String>[];
   int focusRequests = 0;
   final ValueNotifier<String> _title = ValueNotifier<String>('Terminal');
+
+  @override
+  String? workspacePath;
 
   @override
   String get tabId => 'tab';

--- a/test/unit/workspace_relative_path_test.dart
+++ b/test/unit/workspace_relative_path_test.dart
@@ -1,0 +1,90 @@
+import 'package:alera/src/features/workbench/domain/workspace_relative_path.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+
+void main() {
+  final posix = p.Context(style: p.Style.posix);
+  final windows = p.Context(style: p.Style.windows);
+
+  test('returns null for a non-absolute file path', () {
+    expect(
+      workspaceRelativePath(
+        workspacePath: '/tmp/project',
+        filePath: 'packages/app/main.dart',
+        pathContext: posix,
+      ),
+      isNull,
+    );
+  });
+
+  test('relativizes a file inside the workspace', () {
+    expect(
+      workspaceRelativePath(
+        workspacePath: '/tmp/project',
+        filePath: '/tmp/project/packages/app/main.dart',
+        pathContext: posix,
+      ),
+      'packages/app/main.dart',
+    );
+  });
+
+  test('resolves the workspace root itself to a dot', () {
+    expect(
+      workspaceRelativePath(
+        workspacePath: '/tmp/project',
+        filePath: '/tmp/project',
+        pathContext: posix,
+      ),
+      '.',
+    );
+  });
+
+  test('normalizes redundant segments before comparing', () {
+    expect(
+      workspaceRelativePath(
+        workspacePath: '/tmp/project/',
+        filePath: '/tmp/project/packages/../README.md',
+        pathContext: posix,
+      ),
+      'README.md',
+    );
+  });
+
+  test('keeps files outside the workspace absolute', () {
+    expect(
+      workspaceRelativePath(
+        workspacePath: '/tmp/project',
+        filePath: '/tmp/other/main.dart',
+        pathContext: posix,
+      ),
+      isNull,
+    );
+    expect(
+      workspaceRelativePath(
+        workspacePath: '/tmp/project',
+        filePath: '/tmp/project-other/main.dart',
+        pathContext: posix,
+      ),
+      isNull,
+    );
+  });
+
+  test('relativizes with Windows separators and case-insensitive roots', () {
+    expect(
+      workspaceRelativePath(
+        workspacePath: r'C:\project',
+        filePath: r'c:\project\packages\app\main.dart',
+        pathContext: windows,
+      ),
+      r'packages\app\main.dart',
+    );
+    expect(
+      workspaceRelativePath(
+        workspacePath: r'C:\project',
+        filePath: r'D:\other\main.dart',
+        pathContext: windows,
+      ),
+      isNull,
+    );
+  });
+}

--- a/test/widget/terminal_path_drag_test.dart
+++ b/test/widget/terminal_path_drag_test.dart
@@ -21,6 +21,29 @@ void main() {
     expect(session.focusRequests, 1);
   });
 
+  testWidgets('path drag pastes workspace files as relative paths', (
+    tester,
+  ) async {
+    final session = _CapturingTerminalSessionHandle(
+      workspacePath: '/tmp/project',
+    );
+
+    await _pumpDragHarness(
+      tester,
+      session,
+      paths: const <String>[
+        '/tmp/project/packages/app/main.dart',
+        '/tmp/other/absolute.txt',
+      ],
+    );
+    await _dragSourceToTerminal(tester);
+
+    expect(session.pasted, <String>[
+      'packages/app/main.dart /tmp/other/absolute.txt ',
+    ]);
+    expect(session.focusRequests, 1);
+  });
+
   testWidgets('vertical pans prefer scroll over path drag', (tester) async {
     await tester.pumpWidget(
       MaterialApp(
@@ -204,12 +227,15 @@ Future<void> _dragSourceToTerminal(
 }
 
 class _CapturingTerminalSessionHandle extends TerminalSessionHandle {
-  _CapturingTerminalSessionHandle({this.error});
+  _CapturingTerminalSessionHandle({this.error, this.workspacePath});
 
   final String? error;
   final List<String> pasted = <String>[];
   int focusRequests = 0;
   final ValueNotifier<String> _title = ValueNotifier<String>('Terminal');
+
+  @override
+  final String? workspacePath;
 
   @override
   String get tabId => 'tab';

--- a/tool/quality/max_lines_baseline.txt
+++ b/tool/quality/max_lines_baseline.txt
@@ -58,7 +58,7 @@
 661	test/unit/agent_hook_event_normalizer_test.dart
 669	test/unit/app_providers_test_harness.dart
 675	rust/alera-core/src/git.rs
-676	lib/src/features/workbench/presentation/terminal_runtime_session_handle.dart
+678	lib/src/features/workbench/presentation/terminal_runtime_session_handle.dart
 678	test/unit/workbench_controller_test_harness.dart
 684	test/unit/workbench_listing_test.dart
 686	test/widget/alera_shell_page_sidebar_actions_test_cases.dart


### PR DESCRIPTION
## Summary

When dropping files into a terminal (direct paste) or the composer (attachments submitted in the prompt), paths that live inside the terminal's workspace are now pasted relative to the workspace root instead of as absolute paths. Applies to Explorer, Source Control, and OS file drops. Paths outside the workspace (or when the workspace is unknown) stay absolute.

## Changes

- New domain helper `workspaceRelativePath` (single source of truth; `terminalComposerWorkspaceRelativePath` now delegates to it).
- `TerminalSessionHandle.workspacePath` getter (defaulted to null so test doubles keep compiling); production handle returns the workspace root.
- `handleTerminalPathDrop` relativizes paths before formatting for paste.
- `buildTerminalComposerSubmission` takes optional `workspacePath` and relativizes attachment paths in the submitted text; attachments keep storing absolute paths (opening in editor unchanged).

## Validation

- `dart format` clean, `flutter analyze` no issues.
- 26 tests pass: unit tests for the helper (posix + windows case-insensitive branches), drop handler, composer submission, and an end-to-end widget drag test.

## Notes

- Relative to the workspace root, not the shell cwd; a `cd` inside the terminal can make the path unresolvable.
- Symlinked workspace paths fall back to absolute (same limitation as the existing relativizer).