### PR TITLE
fix: preserve context panel tabs across workspaces

### DIFF
--- a/lib/src/features/shell/presentation/alera_shell_page_body.dart
+++ b/lib/src/features/shell/presentation/alera_shell_page_body.dart
@@ -110,7 +110,6 @@ class _AleraShellPageBodyState extends ConsumerState<_AleraShellPageBody> {
                             workspace: workspace,
                             prefs: shell.viewPrefs,
                             sourceControlScope: sourceControlScope,
-                            sourceControlAvailable: sourceControlScope != null,
                             focusedSourceControlRoot: canSelectSourceControlRoot
                                 ? shell
                                       .viewPrefs

--- a/lib/src/features/workbench/application/workbench_controller_internals.dart
+++ b/lib/src/features/workbench/application/workbench_controller_internals.dart
@@ -87,43 +87,6 @@ mixin _WorkbenchControllerInternals on _$WorkbenchController {
     }
   }
 
-  WorkbenchContextPanelTab _supportedContextPanelTabForProjectWorkspace({
-    required Project? project,
-    required Workspace? workspace,
-    required WorkbenchViewPrefs prefs,
-    required WorkbenchContextPanelTab tab,
-  }) {
-    if (workspace == null) {
-      return tab;
-    }
-    final sourceControlScope = WorkspaceSourceControlScope.resolve(
-      project: project,
-      workspace: workspace,
-      prefs: prefs,
-    );
-    if (sourceControlScope == null && tab == WorkbenchContextPanelTab.gitDiff) {
-      return WorkbenchContextPanelTab.explorer;
-    }
-    return tab;
-  }
-
-  WorkbenchViewPrefs _viewPrefsForProjectContext({
-    required Project? project,
-    required Workspace? workspace,
-    required WorkbenchViewPrefs prefs,
-  }) {
-    final activeContextPanelTab = _supportedContextPanelTabForProjectWorkspace(
-      project: project,
-      workspace: workspace,
-      prefs: prefs,
-      tab: prefs.activeContextPanelTab,
-    );
-    if (activeContextPanelTab == prefs.activeContextPanelTab) {
-      return prefs;
-    }
-    return prefs.copyWith(activeContextPanelTab: activeContextPanelTab);
-  }
-
   Project? _projectById(Iterable<Project> projects, String? projectId) {
     if (projectId == null) {
       return null;
@@ -131,23 +94,6 @@ mixin _WorkbenchControllerInternals on _$WorkbenchController {
     for (final project in projects) {
       if (project.id == projectId) {
         return project;
-      }
-    }
-    return null;
-  }
-
-  Workspace? _workspaceById(
-    Map<String, List<Workspace>> workspacesByProject,
-    String? workspaceId,
-  ) {
-    if (workspaceId == null) {
-      return null;
-    }
-    for (final workspaces in workspacesByProject.values) {
-      for (final workspace in workspaces) {
-        if (workspace.id == workspaceId) {
-          return workspace;
-        }
       }
     }
     return null;
@@ -166,11 +112,7 @@ mixin _WorkbenchControllerInternals on _$WorkbenchController {
     final expandedPrefs = changedPrefs
         ? prefs.copyWith(collapsedProjectIds: nextCollapsed)
         : prefs;
-    final nextViewPrefs = _viewPrefsForProjectContext(
-      project: project,
-      workspace: null,
-      prefs: expandedPrefs,
-    );
+    final nextViewPrefs = expandedPrefs;
     final prefsChanged = !identical(nextViewPrefs, prefs);
     state = state.copyWith(
       viewPrefs: nextViewPrefs,

--- a/lib/src/features/workbench/application/workbench_controller_projects.dart
+++ b/lib/src/features/workbench/application/workbench_controller_projects.dart
@@ -84,13 +84,7 @@ mixin _WorkbenchControllerProjects
       )..remove(workspace.id);
       final wasActive = state.activeWorkspaceId == workspace.id;
       final prefs = state.viewPrefs;
-      final nextPrefs = wasActive
-          ? _viewPrefsForProjectContext(
-              project: state.activeProject,
-              workspace: null,
-              prefs: prefs,
-            )
-          : prefs;
+      final nextPrefs = prefs;
 
       state = state.copyWith(
         tabsByWorkspace: tabsByWorkspace,
@@ -394,11 +388,7 @@ mixin _WorkbenchControllerProjects
     bool recordHistory = true,
   }) async {
     final prefs = state.viewPrefs;
-    final nextPrefs = _viewPrefsForProjectContext(
-      project: project,
-      workspace: workspace,
-      prefs: prefs,
-    );
+    final nextPrefs = prefs;
     state = state.copyWith(
       activeProjectId: project.id,
       activeWorkspaceId: workspace.id,
@@ -428,11 +418,7 @@ mixin _WorkbenchControllerProjects
 
   Future<void> activateProject(Project project) async {
     final prefs = state.viewPrefs;
-    final nextPrefs = _viewPrefsForProjectContext(
-      project: project,
-      workspace: null,
-      prefs: prefs,
-    );
+    final nextPrefs = prefs;
     state = state.copyWith(
       activeProjectId: project.id,
       activeWorkspaceId: null,

--- a/lib/src/features/workbench/application/workbench_controller_sync.dart
+++ b/lib/src/features/workbench/application/workbench_controller_sync.dart
@@ -71,17 +71,8 @@ mixin _WorkbenchControllerSync
       workspacesByProject: updatedWorkspaces,
       preferredWorkspaceId: state.activeWorkspaceId,
     );
-    final activeWorkspace = _workspaceById(
-      updatedWorkspaces,
-      activeWorkspaceId,
-    );
-    final nextViewPrefs = _viewPrefsForProjectContext(
-      project: _projectById(projects, activeProjectId),
-      workspace: activeWorkspace,
-      prefs: prunedViewPrefs,
-    );
-    final viewPrefsChanged =
-        prefsChanged || !identical(nextViewPrefs, prunedViewPrefs);
+    final nextViewPrefs = prunedViewPrefs;
+    final viewPrefsChanged = prefsChanged;
 
     state = state.copyWith(
       projects: projects,
@@ -217,16 +208,8 @@ mixin _WorkbenchControllerSync
             sourceControlRootByWorkspaceId: prunedSourceControlRoots,
           )
         : expandedViewPrefs;
-    final activeWorkspace = _workspaceById(nextWorkspaces, activeWorkspaceId);
-    final nextViewPrefs = _viewPrefsForProjectContext(
-      project: _projectById(state.projects, candidateProjectId),
-      workspace: activeWorkspace,
-      prefs: workspacePrunedViewPrefs,
-    );
-    final viewPrefsChanged =
-        expansionChanged ||
-        sourceControlRootsChanged ||
-        !identical(nextViewPrefs, workspacePrunedViewPrefs);
+    final nextViewPrefs = workspacePrunedViewPrefs;
+    final viewPrefsChanged = expansionChanged || sourceControlRootsChanged;
     state = state.copyWith(
       workspacesByProject: nextWorkspaces,
       viewPrefs: nextViewPrefs,

--- a/lib/src/features/workbench/application/workbench_controller_view_prefs.dart
+++ b/lib/src/features/workbench/application/workbench_controller_view_prefs.dart
@@ -239,16 +239,10 @@ mixin _WorkbenchControllerViewPrefs
   }
 
   void setContextPanelTab(WorkbenchContextPanelTab tab) {
-    final nextTab = _supportedContextPanelTabForProjectWorkspace(
-      project: state.activeProject,
-      workspace: state.activeWorkspace,
-      prefs: state.viewPrefs,
-      tab: tab,
-    );
-    if (state.viewPrefs.activeContextPanelTab == nextTab) {
+    if (state.viewPrefs.activeContextPanelTab == tab) {
       return;
     }
-    _updateViewPrefs(state.viewPrefs.copyWith(activeContextPanelTab: nextTab));
+    _updateViewPrefs(state.viewPrefs.copyWith(activeContextPanelTab: tab));
   }
 
   void setExplorerMode(WorkspaceExplorerMode mode) {
@@ -339,16 +333,8 @@ mixin _WorkbenchControllerViewPrefs
     final nextRoots = Map<String, String>.from(
       state.viewPrefs.sourceControlRootByWorkspaceId,
     )..remove(workspace.id);
-    final nextTab =
-        state.viewPrefs.activeContextPanelTab ==
-            WorkbenchContextPanelTab.gitDiff
-        ? WorkbenchContextPanelTab.explorer
-        : state.viewPrefs.activeContextPanelTab;
     _updateViewPrefs(
-      state.viewPrefs.copyWith(
-        sourceControlRootByWorkspaceId: nextRoots,
-        activeContextPanelTab: nextTab,
-      ),
+      state.viewPrefs.copyWith(sourceControlRootByWorkspaceId: nextRoots),
     );
   }
 

--- a/lib/src/features/workbench/presentation/workspace_context_sidebar.dart
+++ b/lib/src/features/workbench/presentation/workspace_context_sidebar.dart
@@ -1,5 +1,6 @@
 import 'package:alera/src/app/theme/alera_tokens.dart';
 import 'package:alera/src/design_system/buttons/alera_icon_button.dart';
+import 'package:alera/src/design_system/feedback/alera_empty_state.dart';
 import 'package:alera/src/design_system/icons/alera_icons.dart';
 import 'package:alera/src/features/agent_canvas/presentation/agent_canvas_panel.dart';
 import 'package:alera/src/features/pull_requests/presentation/workspace_pull_requests_panel.dart';
@@ -18,7 +19,6 @@ class WorkspaceContextSidebar extends StatelessWidget {
     required this.workspace,
     required this.prefs,
     this.sourceControlScope,
-    this.sourceControlAvailable = true,
     this.focusedSourceControlRoot,
     required this.onToggleVisible,
     required this.onResize,
@@ -41,7 +41,6 @@ class WorkspaceContextSidebar extends StatelessWidget {
   final Workspace workspace;
   final WorkbenchViewPrefs prefs;
   final WorkspaceSourceControlScope? sourceControlScope;
-  final bool sourceControlAvailable;
   final String? focusedSourceControlRoot;
   final VoidCallback onToggleVisible;
   final ValueChanged<double> onResize;
@@ -63,8 +62,8 @@ class WorkspaceContextSidebar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final sourceControlScope = _effectiveSourceControlScope;
-    final activeTab = _effectiveActiveTab;
+    final sourceControlScope = this.sourceControlScope;
+    final activeTab = prefs.activeContextPanelTab;
     return DecoratedBox(
       decoration: const BoxDecoration(
         color: AleraTokens.surfaceVariant,
@@ -78,7 +77,6 @@ class WorkspaceContextSidebar extends StatelessWidget {
                 children: <Widget>[
                   _ContextTabHeader(
                     activeTab: activeTab,
-                    sourceControlAvailable: sourceControlScope != null,
                     onSetActiveTab: onSetContextPanelTab,
                     onToggleVisible: onToggleVisible,
                   ),
@@ -101,26 +99,41 @@ class WorkspaceContextSidebar extends StatelessWidget {
                         workspace: workspace,
                         onOpenMatch: onOpenSearchMatch,
                       ),
-                      WorkbenchContextPanelTab.gitDiff => WorkspaceGitDiffPanel(
-                        workspace: workspace,
-                        sourceControlScope: sourceControlScope!,
-                        viewMode: prefs.gitDiffViewMode,
-                        onViewModeChanged: onSetGitDiffViewMode,
-                        onOpenGitDiff: onOpenGitDiff,
-                        onOpenGitCommitDiff: onOpenGitCommitDiff,
-                        onClearSourceControlRoot:
-                            sourceControlScope.isWorkspaceRoot
-                            ? null
-                            : onClearSourceControlRoot,
-                      ),
+                      WorkbenchContextPanelTab.gitDiff =>
+                        sourceControlScope == null
+                            ? const AleraEmptyState(
+                                icon: AleraIcons.gitBranch,
+                                title: 'Source Control Unavailable',
+                                message:
+                                    'This workspace is not connected to a Git repository, so there are no changes to show.',
+                              )
+                            : WorkspaceGitDiffPanel(
+                                workspace: workspace,
+                                sourceControlScope: sourceControlScope,
+                                viewMode: prefs.gitDiffViewMode,
+                                onViewModeChanged: onSetGitDiffViewMode,
+                                onOpenGitDiff: onOpenGitDiff,
+                                onOpenGitCommitDiff: onOpenGitCommitDiff,
+                                onClearSourceControlRoot:
+                                    sourceControlScope.isWorkspaceRoot
+                                    ? null
+                                    : onClearSourceControlRoot,
+                              ),
                       WorkbenchContextPanelTab.pullRequests =>
-                        WorkspacePullRequestsPanel(
-                          key: ValueKey<String>(
-                            'workspace-pull-requests:${workspace.id}:${sourceControlScope!.path}',
-                          ),
-                          workspace: workspace,
-                          repoPath: sourceControlScope.path,
-                        ),
+                        sourceControlScope == null
+                            ? const AleraEmptyState(
+                                icon: AleraIcons.gitPullRequest,
+                                title: 'Pull Request Unavailable',
+                                message:
+                                    'This workspace is not connected to a Git repository, so there are no Pull Requests to show.',
+                              )
+                            : WorkspacePullRequestsPanel(
+                                key: ValueKey<String>(
+                                  'workspace-pull-requests:${workspace.id}:${sourceControlScope.path}',
+                                ),
+                                workspace: workspace,
+                                repoPath: sourceControlScope.path,
+                              ),
                       WorkbenchContextPanelTab.agentCanvas => AgentCanvasPanel(
                         workspace: workspace,
                         onOpenFile: (relativePath) async {
@@ -152,37 +165,12 @@ class WorkspaceContextSidebar extends StatelessWidget {
             )
           : _CollapsedContextRail(
               activeTab: activeTab,
-              sourceControlAvailable: sourceControlScope != null,
               onOpenTab: (tab) {
                 onSetContextPanelTab(tab);
                 onToggleVisible();
               },
               onToggleVisible: onToggleVisible,
             ),
-    );
-  }
-
-  WorkbenchContextPanelTab get _effectiveActiveTab {
-    if (_effectiveSourceControlScope == null &&
-        (prefs.activeContextPanelTab == WorkbenchContextPanelTab.gitDiff ||
-            prefs.activeContextPanelTab ==
-                WorkbenchContextPanelTab.pullRequests)) {
-      return WorkbenchContextPanelTab.explorer;
-    }
-    return prefs.activeContextPanelTab;
-  }
-
-  WorkspaceSourceControlScope? get _effectiveSourceControlScope {
-    if (sourceControlScope != null) {
-      return sourceControlScope;
-    }
-    if (!sourceControlAvailable) {
-      return null;
-    }
-    return WorkspaceSourceControlScope(
-      workspaceId: workspace.id,
-      workspacePath: workspace.path,
-      path: workspace.path,
     );
   }
 }
@@ -236,13 +224,11 @@ class _ResizableRightSidebarState extends State<_ResizableRightSidebar> {
 class _CollapsedContextRail extends StatelessWidget {
   const _CollapsedContextRail({
     required this.activeTab,
-    required this.sourceControlAvailable,
     required this.onOpenTab,
     required this.onToggleVisible,
   });
 
   final WorkbenchContextPanelTab activeTab;
-  final bool sourceControlAvailable;
   final ValueChanged<WorkbenchContextPanelTab> onOpenTab;
   final VoidCallback onToggleVisible;
 
@@ -268,24 +254,22 @@ class _CollapsedContextRail extends StatelessWidget {
             icon: AleraIcons.search,
             onPressed: () => onOpenTab(WorkbenchContextPanelTab.search),
           ),
-          if (sourceControlAvailable) ...<Widget>[
-            const SizedBox(height: AleraTokens.space6),
-            _ContextTabButton(
-              tab: WorkbenchContextPanelTab.gitDiff,
-              activeTab: activeTab,
-              tooltip: 'Source Control',
-              icon: AleraIcons.gitBranch,
-              onPressed: () => onOpenTab(WorkbenchContextPanelTab.gitDiff),
-            ),
-            const SizedBox(height: AleraTokens.space6),
-            _ContextTabButton(
-              tab: WorkbenchContextPanelTab.pullRequests,
-              activeTab: activeTab,
-              tooltip: 'Pull Request',
-              icon: AleraIcons.gitPullRequest,
-              onPressed: () => onOpenTab(WorkbenchContextPanelTab.pullRequests),
-            ),
-          ],
+          const SizedBox(height: AleraTokens.space6),
+          _ContextTabButton(
+            tab: WorkbenchContextPanelTab.gitDiff,
+            activeTab: activeTab,
+            tooltip: 'Source Control',
+            icon: AleraIcons.gitBranch,
+            onPressed: () => onOpenTab(WorkbenchContextPanelTab.gitDiff),
+          ),
+          const SizedBox(height: AleraTokens.space6),
+          _ContextTabButton(
+            tab: WorkbenchContextPanelTab.pullRequests,
+            activeTab: activeTab,
+            tooltip: 'Pull Request',
+            icon: AleraIcons.gitPullRequest,
+            onPressed: () => onOpenTab(WorkbenchContextPanelTab.pullRequests),
+          ),
           const SizedBox(height: AleraTokens.space6),
           _ContextTabButton(
             tab: WorkbenchContextPanelTab.agentCanvas,
@@ -312,13 +296,11 @@ class _CollapsedContextRail extends StatelessWidget {
 class _ContextTabHeader extends StatelessWidget {
   const _ContextTabHeader({
     required this.activeTab,
-    required this.sourceControlAvailable,
     required this.onSetActiveTab,
     required this.onToggleVisible,
   });
 
   final WorkbenchContextPanelTab activeTab;
-  final bool sourceControlAvailable;
   final ValueChanged<WorkbenchContextPanelTab> onSetActiveTab;
   final VoidCallback onToggleVisible;
 
@@ -352,26 +334,24 @@ class _ContextTabHeader extends StatelessWidget {
                 onPressed: () =>
                     onSetActiveTab(WorkbenchContextPanelTab.search),
               ),
-              if (sourceControlAvailable) ...<Widget>[
-                const SizedBox(width: AleraTokens.space6),
-                _ContextTabButton(
-                  tab: WorkbenchContextPanelTab.gitDiff,
-                  activeTab: activeTab,
-                  tooltip: 'Source Control',
-                  icon: AleraIcons.gitBranch,
-                  onPressed: () =>
-                      onSetActiveTab(WorkbenchContextPanelTab.gitDiff),
-                ),
-                const SizedBox(width: AleraTokens.space6),
-                _ContextTabButton(
-                  tab: WorkbenchContextPanelTab.pullRequests,
-                  activeTab: activeTab,
-                  tooltip: 'Pull Request',
-                  icon: AleraIcons.gitPullRequest,
-                  onPressed: () =>
-                      onSetActiveTab(WorkbenchContextPanelTab.pullRequests),
-                ),
-              ],
+              const SizedBox(width: AleraTokens.space6),
+              _ContextTabButton(
+                tab: WorkbenchContextPanelTab.gitDiff,
+                activeTab: activeTab,
+                tooltip: 'Source Control',
+                icon: AleraIcons.gitBranch,
+                onPressed: () =>
+                    onSetActiveTab(WorkbenchContextPanelTab.gitDiff),
+              ),
+              const SizedBox(width: AleraTokens.space6),
+              _ContextTabButton(
+                tab: WorkbenchContextPanelTab.pullRequests,
+                activeTab: activeTab,
+                tooltip: 'Pull Request',
+                icon: AleraIcons.gitPullRequest,
+                onPressed: () =>
+                    onSetActiveTab(WorkbenchContextPanelTab.pullRequests),
+              ),
               const SizedBox(width: AleraTokens.space6),
               _ContextTabButton(
                 tab: WorkbenchContextPanelTab.agentCanvas,

--- a/test/unit/workbench_controller_view_prefs_test_cases.dart
+++ b/test/unit/workbench_controller_view_prefs_test_cases.dart
@@ -209,13 +209,10 @@ void _registerWorkbenchControllerViewPrefsTests() {
   });
 
   test(
-    'selecting a folder workspace replaces source control with explorer',
+    'selecting a folder workspace preserves source control and pull request tabs',
     () async {
       await _controller.bootstrap();
-      _controller.setContextPanelTab(WorkbenchContextPanelTab.gitDiff);
-      await _flush();
-      final saveCountBeforeFolderSelection =
-          _harness.viewPrefsRepository.saveCount;
+      final gitWorkspace = await _selectMainWorkspace(_controller, _harness);
       final folderPath = p.join(_harness.tempDir.path, 'notes');
       Directory(folderPath).createSync(recursive: true);
       final now = DateTime.utc(2026, 5, 22);
@@ -235,24 +232,31 @@ void _registerWorkbenchControllerViewPrefsTests() {
       final folderWorkspace = _controller.state
           .workspacesFor(folderProject.id)
           .single;
-      await _controller.selectWorkspace(
-        project: folderProject,
-        workspace: folderWorkspace,
-      );
-      await _flush();
 
-      expect(
-        _controller.state.viewPrefs.activeContextPanelTab,
-        WorkbenchContextPanelTab.explorer,
-      );
-      expect(
-        _harness.viewPrefsRepository.prefs.activeContextPanelTab,
-        WorkbenchContextPanelTab.explorer,
-      );
-      expect(
-        _harness.viewPrefsRepository.saveCount,
-        greaterThan(saveCountBeforeFolderSelection),
-      );
+      for (final tab in <WorkbenchContextPanelTab>[
+        WorkbenchContextPanelTab.gitDiff,
+        WorkbenchContextPanelTab.pullRequests,
+      ]) {
+        _controller.setContextPanelTab(tab);
+        await _flush();
+
+        await _controller.selectWorkspace(
+          project: folderProject,
+          workspace: folderWorkspace,
+        );
+        await _flush();
+
+        expect(_controller.state.viewPrefs.activeContextPanelTab, tab);
+        expect(_harness.viewPrefsRepository.prefs.activeContextPanelTab, tab);
+
+        await _controller.selectWorkspace(
+          project: _harness.project,
+          workspace: gitWorkspace,
+        );
+        await _flush();
+
+        expect(_controller.state.viewPrefs.activeContextPanelTab, tab);
+      }
     },
   );
 
@@ -338,7 +342,7 @@ void _registerWorkbenchControllerViewPrefsTests() {
       );
       expect(
         _controller.state.viewPrefs.activeContextPanelTab,
-        WorkbenchContextPanelTab.explorer,
+        WorkbenchContextPanelTab.gitDiff,
       );
     },
   );

--- a/test/unit/workbench_controller_view_prefs_test_cases.dart
+++ b/test/unit/workbench_controller_view_prefs_test_cases.dart
@@ -232,7 +232,6 @@ void _registerWorkbenchControllerViewPrefsTests() {
       final folderWorkspace = _controller.state
           .workspacesFor(folderProject.id)
           .single;
-
       for (final tab in <WorkbenchContextPanelTab>[
         WorkbenchContextPanelTab.gitDiff,
         WorkbenchContextPanelTab.pullRequests,

--- a/test/widget/workspace_explorer_context_sidebar_cases.dart
+++ b/test/widget/workspace_explorer_context_sidebar_cases.dart
@@ -1,0 +1,170 @@
+part of 'workspace_explorer_test.dart';
+
+void _registerWorkspaceExplorerContextSidebarTests() {
+  testWidgets(
+    'context sidebar keeps source control tabs and explains missing git scope',
+    (tester) async {
+      final service = _FakeWorkspaceFileService();
+
+      await tester.pumpWidget(
+        _withWorkspaceFiles(
+          service,
+          child: MaterialApp(
+            home: Scaffold(
+              body: WorkspaceContextSidebar(
+                workspace: _workspace(),
+                prefs: WorkbenchViewPrefs.defaults.copyWith(
+                  activeContextPanelTab: WorkbenchContextPanelTab.gitDiff,
+                ),
+                onToggleVisible: () {},
+                onResize: (_) {},
+                onSetContextPanelTab: (_) {},
+                onSetExplorerMode: (_) {},
+                onSetGitDiffViewMode: (_) {},
+                onOpenFile: (_) {},
+                onOpenGitDiff:
+                    ({
+                      relativePath,
+                      area,
+                      gitDiffRoot,
+                      required scope,
+                    }) async {},
+                onOpenGitCommitDiff:
+                    ({
+                      relativePath,
+                      oldPath,
+                      required scope,
+                      gitDiffRoot,
+                      required commitOid,
+                      parentOid,
+                      required compareRef,
+                      subject,
+                      message,
+                    }) async {},
+                onOpenSearchMatch: (_) {},
+                onPathMoved: (_, _) async {},
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byTooltip('Explorer'), findsOneWidget);
+      expect(find.byTooltip('Search'), findsOneWidget);
+      expect(find.byTooltip('Source Control'), findsOneWidget);
+      expect(find.byTooltip('Pull Request'), findsOneWidget);
+      expect(find.text('Source Control Unavailable'), findsOneWidget);
+      expect(
+        find.text(
+          'This workspace is not connected to a Git repository, so there are no changes to show.',
+        ),
+        findsOneWidget,
+      );
+      expect(find.byType(WorkspaceExplorer), findsNothing);
+
+      await tester.pumpWidget(
+        _withWorkspaceFiles(
+          service,
+          child: MaterialApp(
+            home: Scaffold(
+              body: WorkspaceContextSidebar(
+                workspace: _workspace(),
+                prefs: WorkbenchViewPrefs.defaults.copyWith(
+                  activeContextPanelTab: WorkbenchContextPanelTab.pullRequests,
+                  rightSidebarVisible: false,
+                ),
+                onToggleVisible: () {},
+                onResize: (_) {},
+                onSetContextPanelTab: (_) {},
+                onSetExplorerMode: (_) {},
+                onSetGitDiffViewMode: (_) {},
+                onOpenFile: (_) {},
+                onOpenGitDiff:
+                    ({
+                      relativePath,
+                      area,
+                      gitDiffRoot,
+                      required scope,
+                    }) async {},
+                onOpenGitCommitDiff:
+                    ({
+                      relativePath,
+                      oldPath,
+                      required scope,
+                      gitDiffRoot,
+                      required commitOid,
+                      parentOid,
+                      required compareRef,
+                      subject,
+                      message,
+                    }) async {},
+                onOpenSearchMatch: (_) {},
+                onPathMoved: (_, _) async {},
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byTooltip('Expand panel'), findsOneWidget);
+      expect(find.byTooltip('Source Control'), findsOneWidget);
+      expect(find.byTooltip('Pull Request'), findsOneWidget);
+
+      await tester.pumpWidget(
+        _withWorkspaceFiles(
+          service,
+          child: MaterialApp(
+            home: Scaffold(
+              body: WorkspaceContextSidebar(
+                workspace: _workspace(),
+                prefs: WorkbenchViewPrefs.defaults.copyWith(
+                  activeContextPanelTab: WorkbenchContextPanelTab.pullRequests,
+                ),
+                onToggleVisible: () {},
+                onResize: (_) {},
+                onSetContextPanelTab: (_) {},
+                onSetExplorerMode: (_) {},
+                onSetGitDiffViewMode: (_) {},
+                onOpenFile: (_) {},
+                onOpenGitDiff:
+                    ({
+                      relativePath,
+                      area,
+                      gitDiffRoot,
+                      required scope,
+                    }) async {},
+                onOpenGitCommitDiff:
+                    ({
+                      relativePath,
+                      oldPath,
+                      required scope,
+                      gitDiffRoot,
+                      required commitOid,
+                      parentOid,
+                      required compareRef,
+                      subject,
+                      message,
+                    }) async {},
+                onOpenSearchMatch: (_) {},
+                onPathMoved: (_, _) async {},
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byTooltip('Source Control'), findsOneWidget);
+      expect(find.byTooltip('Pull Request'), findsOneWidget);
+      expect(find.text('Pull Request Unavailable'), findsOneWidget);
+      expect(
+        find.text(
+          'This workspace is not connected to a Git repository, so there are no Pull Requests to show.',
+        ),
+        findsOneWidget,
+      );
+    },
+  );
+}

--- a/test/widget/workspace_explorer_test.dart
+++ b/test/widget/workspace_explorer_test.dart
@@ -24,9 +24,11 @@ import 'package:flutter_test/flutter_test.dart';
 import '../unit/fake_git_backend.dart';
 
 part 'workspace_explorer_cursor_cases.dart';
+part 'workspace_explorer_context_sidebar_cases.dart';
 part 'workspace_explorer_git_snapshot_cases.dart';
 
 void main() {
+  _registerWorkspaceExplorerContextSidebarTests();
   _registerWorkspaceExplorerGitSnapshotTests();
   _registerWorkspaceExplorerCursorTests();
 
@@ -672,172 +674,6 @@ void main() {
     expect(find.byType(WorkspaceExplorer), findsOneWidget);
   });
 
-  testWidgets(
-    'context sidebar keeps source control tabs and explains missing git scope',
-    (tester) async {
-      final service = _FakeWorkspaceFileService();
-
-      await tester.pumpWidget(
-        _withWorkspaceFiles(
-          service,
-          child: MaterialApp(
-            home: Scaffold(
-              body: WorkspaceContextSidebar(
-                workspace: _workspace(),
-                prefs: WorkbenchViewPrefs.defaults.copyWith(
-                  activeContextPanelTab: WorkbenchContextPanelTab.gitDiff,
-                ),
-                onToggleVisible: () {},
-                onResize: (_) {},
-                onSetContextPanelTab: (_) {},
-                onSetExplorerMode: (_) {},
-                onSetGitDiffViewMode: (_) {},
-                onOpenFile: (_) {},
-                onOpenGitDiff:
-                    ({
-                      relativePath,
-                      area,
-                      gitDiffRoot,
-                      required scope,
-                    }) async {},
-                onOpenGitCommitDiff:
-                    ({
-                      relativePath,
-                      oldPath,
-                      required scope,
-                      gitDiffRoot,
-                      required commitOid,
-                      parentOid,
-                      required compareRef,
-                      subject,
-                      message,
-                    }) async {},
-                onOpenSearchMatch: (_) {},
-                onPathMoved: (_, _) async {},
-              ),
-            ),
-          ),
-        ),
-      );
-      await tester.pumpAndSettle();
-
-      expect(find.byTooltip('Explorer'), findsOneWidget);
-      expect(find.byTooltip('Search'), findsOneWidget);
-      expect(find.byTooltip('Source Control'), findsOneWidget);
-      expect(find.byTooltip('Pull Request'), findsOneWidget);
-      expect(find.text('Source Control Unavailable'), findsOneWidget);
-      expect(
-        find.text(
-          'This workspace is not connected to a Git repository, so there are no changes to show.',
-        ),
-        findsOneWidget,
-      );
-      expect(find.byType(WorkspaceExplorer), findsNothing);
-
-      await tester.pumpWidget(
-        _withWorkspaceFiles(
-          service,
-          child: MaterialApp(
-            home: Scaffold(
-              body: WorkspaceContextSidebar(
-                workspace: _workspace(),
-                prefs: WorkbenchViewPrefs.defaults.copyWith(
-                  activeContextPanelTab: WorkbenchContextPanelTab.pullRequests,
-                  rightSidebarVisible: false,
-                ),
-                onToggleVisible: () {},
-                onResize: (_) {},
-                onSetContextPanelTab: (_) {},
-                onSetExplorerMode: (_) {},
-                onSetGitDiffViewMode: (_) {},
-                onOpenFile: (_) {},
-                onOpenGitDiff:
-                    ({
-                      relativePath,
-                      area,
-                      gitDiffRoot,
-                      required scope,
-                    }) async {},
-                onOpenGitCommitDiff:
-                    ({
-                      relativePath,
-                      oldPath,
-                      required scope,
-                      gitDiffRoot,
-                      required commitOid,
-                      parentOid,
-                      required compareRef,
-                      subject,
-                      message,
-                    }) async {},
-                onOpenSearchMatch: (_) {},
-                onPathMoved: (_, _) async {},
-              ),
-            ),
-          ),
-        ),
-      );
-      await tester.pumpAndSettle();
-
-      expect(find.byTooltip('Expand panel'), findsOneWidget);
-      expect(find.byTooltip('Source Control'), findsOneWidget);
-      expect(find.byTooltip('Pull Request'), findsOneWidget);
-
-      await tester.pumpWidget(
-        _withWorkspaceFiles(
-          service,
-          child: MaterialApp(
-            home: Scaffold(
-              body: WorkspaceContextSidebar(
-                workspace: _workspace(),
-                prefs: WorkbenchViewPrefs.defaults.copyWith(
-                  activeContextPanelTab: WorkbenchContextPanelTab.pullRequests,
-                ),
-                onToggleVisible: () {},
-                onResize: (_) {},
-                onSetContextPanelTab: (_) {},
-                onSetExplorerMode: (_) {},
-                onSetGitDiffViewMode: (_) {},
-                onOpenFile: (_) {},
-                onOpenGitDiff:
-                    ({
-                      relativePath,
-                      area,
-                      gitDiffRoot,
-                      required scope,
-                    }) async {},
-                onOpenGitCommitDiff:
-                    ({
-                      relativePath,
-                      oldPath,
-                      required scope,
-                      gitDiffRoot,
-                      required commitOid,
-                      parentOid,
-                      required compareRef,
-                      subject,
-                      message,
-                    }) async {},
-                onOpenSearchMatch: (_) {},
-                onPathMoved: (_, _) async {},
-              ),
-            ),
-          ),
-        ),
-      );
-      await tester.pumpAndSettle();
-
-      expect(find.byTooltip('Source Control'), findsOneWidget);
-      expect(find.byTooltip('Pull Request'), findsOneWidget);
-      expect(find.text('Pull Request Unavailable'), findsOneWidget);
-      expect(
-        find.text(
-          'This workspace is not connected to a Git repository, so there are no Pull Requests to show.',
-        ),
-        findsOneWidget,
-      );
-    },
-  );
 }
 
 Future<void> _pumpExplorer(

--- a/test/widget/workspace_explorer_test.dart
+++ b/test/widget/workspace_explorer_test.dart
@@ -672,101 +672,172 @@ void main() {
     expect(find.byType(WorkspaceExplorer), findsOneWidget);
   });
 
-  testWidgets('context sidebar hides source control when unavailable', (
-    tester,
-  ) async {
-    final service = _FakeWorkspaceFileService();
+  testWidgets(
+    'context sidebar keeps source control tabs and explains missing git scope',
+    (tester) async {
+      final service = _FakeWorkspaceFileService();
 
-    await tester.pumpWidget(
-      _withWorkspaceFiles(
-        service,
-        child: MaterialApp(
-          home: Scaffold(
-            body: WorkspaceContextSidebar(
-              workspace: _workspace(),
-              prefs: WorkbenchViewPrefs.defaults.copyWith(
-                activeContextPanelTab: WorkbenchContextPanelTab.gitDiff,
+      await tester.pumpWidget(
+        _withWorkspaceFiles(
+          service,
+          child: MaterialApp(
+            home: Scaffold(
+              body: WorkspaceContextSidebar(
+                workspace: _workspace(),
+                prefs: WorkbenchViewPrefs.defaults.copyWith(
+                  activeContextPanelTab: WorkbenchContextPanelTab.gitDiff,
+                ),
+                onToggleVisible: () {},
+                onResize: (_) {},
+                onSetContextPanelTab: (_) {},
+                onSetExplorerMode: (_) {},
+                onSetGitDiffViewMode: (_) {},
+                onOpenFile: (_) {},
+                onOpenGitDiff:
+                    ({
+                      relativePath,
+                      area,
+                      gitDiffRoot,
+                      required scope,
+                    }) async {},
+                onOpenGitCommitDiff:
+                    ({
+                      relativePath,
+                      oldPath,
+                      required scope,
+                      gitDiffRoot,
+                      required commitOid,
+                      parentOid,
+                      required compareRef,
+                      subject,
+                      message,
+                    }) async {},
+                onOpenSearchMatch: (_) {},
+                onPathMoved: (_, _) async {},
               ),
-              sourceControlAvailable: false,
-              onToggleVisible: () {},
-              onResize: (_) {},
-              onSetContextPanelTab: (_) {},
-              onSetExplorerMode: (_) {},
-              onSetGitDiffViewMode: (_) {},
-              onOpenFile: (_) {},
-              onOpenGitDiff:
-                  ({relativePath, area, gitDiffRoot, required scope}) async {},
-              onOpenGitCommitDiff:
-                  ({
-                    relativePath,
-                    oldPath,
-                    required scope,
-                    gitDiffRoot,
-                    required commitOid,
-                    parentOid,
-                    required compareRef,
-                    subject,
-                    message,
-                  }) async {},
-              onOpenSearchMatch: (_) {},
-              onPathMoved: (_, _) async {},
             ),
           ),
         ),
-      ),
-    );
-    await tester.pumpAndSettle();
+      );
+      await tester.pumpAndSettle();
 
-    expect(find.byTooltip('Explorer'), findsOneWidget);
-    expect(find.byTooltip('Search'), findsOneWidget);
-    expect(find.byTooltip('Source Control'), findsNothing);
-    expect(find.byIcon(AleraIcons.gitBranch), findsNothing);
-    expect(find.byType(WorkspaceExplorer), findsOneWidget);
+      expect(find.byTooltip('Explorer'), findsOneWidget);
+      expect(find.byTooltip('Search'), findsOneWidget);
+      expect(find.byTooltip('Source Control'), findsOneWidget);
+      expect(find.byTooltip('Pull Request'), findsOneWidget);
+      expect(find.text('Source Control Unavailable'), findsOneWidget);
+      expect(
+        find.text(
+          'This workspace is not connected to a Git repository, so there are no changes to show.',
+        ),
+        findsOneWidget,
+      );
+      expect(find.byType(WorkspaceExplorer), findsNothing);
 
-    await tester.pumpWidget(
-      _withWorkspaceFiles(
-        service,
-        child: MaterialApp(
-          home: Scaffold(
-            body: WorkspaceContextSidebar(
-              workspace: _workspace(),
-              prefs: WorkbenchViewPrefs.defaults.copyWith(
-                activeContextPanelTab: WorkbenchContextPanelTab.gitDiff,
-                rightSidebarVisible: false,
+      await tester.pumpWidget(
+        _withWorkspaceFiles(
+          service,
+          child: MaterialApp(
+            home: Scaffold(
+              body: WorkspaceContextSidebar(
+                workspace: _workspace(),
+                prefs: WorkbenchViewPrefs.defaults.copyWith(
+                  activeContextPanelTab: WorkbenchContextPanelTab.pullRequests,
+                  rightSidebarVisible: false,
+                ),
+                onToggleVisible: () {},
+                onResize: (_) {},
+                onSetContextPanelTab: (_) {},
+                onSetExplorerMode: (_) {},
+                onSetGitDiffViewMode: (_) {},
+                onOpenFile: (_) {},
+                onOpenGitDiff:
+                    ({
+                      relativePath,
+                      area,
+                      gitDiffRoot,
+                      required scope,
+                    }) async {},
+                onOpenGitCommitDiff:
+                    ({
+                      relativePath,
+                      oldPath,
+                      required scope,
+                      gitDiffRoot,
+                      required commitOid,
+                      parentOid,
+                      required compareRef,
+                      subject,
+                      message,
+                    }) async {},
+                onOpenSearchMatch: (_) {},
+                onPathMoved: (_, _) async {},
               ),
-              sourceControlAvailable: false,
-              onToggleVisible: () {},
-              onResize: (_) {},
-              onSetContextPanelTab: (_) {},
-              onSetExplorerMode: (_) {},
-              onSetGitDiffViewMode: (_) {},
-              onOpenFile: (_) {},
-              onOpenGitDiff:
-                  ({relativePath, area, gitDiffRoot, required scope}) async {},
-              onOpenGitCommitDiff:
-                  ({
-                    relativePath,
-                    oldPath,
-                    required scope,
-                    gitDiffRoot,
-                    required commitOid,
-                    parentOid,
-                    required compareRef,
-                    subject,
-                    message,
-                  }) async {},
-              onOpenSearchMatch: (_) {},
-              onPathMoved: (_, _) async {},
             ),
           ),
         ),
-      ),
-    );
+      );
+      await tester.pumpAndSettle();
 
-    expect(find.byTooltip('Expand panel'), findsOneWidget);
-    expect(find.byTooltip('Source Control'), findsNothing);
-    expect(find.byIcon(AleraIcons.gitBranch), findsNothing);
-  });
+      expect(find.byTooltip('Expand panel'), findsOneWidget);
+      expect(find.byTooltip('Source Control'), findsOneWidget);
+      expect(find.byTooltip('Pull Request'), findsOneWidget);
+
+      await tester.pumpWidget(
+        _withWorkspaceFiles(
+          service,
+          child: MaterialApp(
+            home: Scaffold(
+              body: WorkspaceContextSidebar(
+                workspace: _workspace(),
+                prefs: WorkbenchViewPrefs.defaults.copyWith(
+                  activeContextPanelTab: WorkbenchContextPanelTab.pullRequests,
+                ),
+                onToggleVisible: () {},
+                onResize: (_) {},
+                onSetContextPanelTab: (_) {},
+                onSetExplorerMode: (_) {},
+                onSetGitDiffViewMode: (_) {},
+                onOpenFile: (_) {},
+                onOpenGitDiff:
+                    ({
+                      relativePath,
+                      area,
+                      gitDiffRoot,
+                      required scope,
+                    }) async {},
+                onOpenGitCommitDiff:
+                    ({
+                      relativePath,
+                      oldPath,
+                      required scope,
+                      gitDiffRoot,
+                      required commitOid,
+                      parentOid,
+                      required compareRef,
+                      subject,
+                      message,
+                    }) async {},
+                onOpenSearchMatch: (_) {},
+                onPathMoved: (_, _) async {},
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byTooltip('Source Control'), findsOneWidget);
+      expect(find.byTooltip('Pull Request'), findsOneWidget);
+      expect(find.text('Pull Request Unavailable'), findsOneWidget);
+      expect(
+        find.text(
+          'This workspace is not connected to a Git repository, so there are no Pull Requests to show.',
+        ),
+        findsOneWidget,
+      );
+    },
+  );
 }
 
 Future<void> _pumpExplorer(

--- a/test/widget/workspace_explorer_test.dart
+++ b/test/widget/workspace_explorer_test.dart
@@ -673,7 +673,6 @@ void main() {
     expect(find.byIcon(AleraIcons.gitBranch), findsOneWidget);
     expect(find.byType(WorkspaceExplorer), findsOneWidget);
   });
-
 }
 
 Future<void> _pumpExplorer(


### PR DESCRIPTION
## Summary

- Keep Source Control and Pull Request tabs visible in folder non-git workspaces.
- Show centered unavailable states explaining why those tabs have no content without a Git scope.
- Preserve the selected context panel tab when switching workspaces.

## Root cause

Workspace activation normalized Git-only tabs back to Explorer whenever the active workspace had no Git scope, so returning to the original workspace lost the previous panel selection.

## Validation

- `dart format --output=none --set-exit-if-changed lib test integration_test tool`
- `flutter analyze`
- `flutter test test/widget/workspace_explorer_test.dart test/unit/workbench_controller_test.dart test/widget/workspace_pull_requests_panel_test.dart`
- `git diff --check`

The local `gh act` PR emulation was attempted; Flutter setup/submodule cloning and container-permission failures were emulator limitations. Hosted PR checks remain authoritative.