### PR TITLE
fix: unblock windows app shutdown

### DIFF
--- a/lib/src/features/runtime_host/application/runtime_host_lifecycle_service.dart
+++ b/lib/src/features/runtime_host/application/runtime_host_lifecycle_service.dart
@@ -185,8 +185,7 @@ final class RuntimeHostLifecycleService {
     }
 
     try {
-      await _client.shutdownRuntime(force: false);
-      await _waitUntilStopped();
+      await _shutdownForAppQuit(force: false);
       return true;
     } on StateError catch (error) {
       if (error.message.contains('No live Alera runtime host')) {
@@ -209,8 +208,7 @@ final class RuntimeHostLifecycleService {
         case RuntimeHostQuitDecision.leaveRuntimeOpen:
           return true;
         case RuntimeHostQuitDecision.forceStop:
-          await _client.shutdownRuntime(force: true);
-          await _waitUntilStopped();
+          await _shutdownForAppQuit(force: true);
           return true;
       }
     }
@@ -219,12 +217,43 @@ final class RuntimeHostLifecycleService {
   Future<void> _waitUntilStopped() async {
     final deadline = DateTime.now().add(_shutdownSettleTimeout);
     while (DateTime.now().isBefore(deadline)) {
-      final status = await _client.probeRuntimeStatus();
+      Map<String, Object?>? status;
+      try {
+        status = await _client.probeRuntimeStatus();
+      } on StateError catch (error) {
+        if (_isExpectedShutdownDisconnect(error)) {
+          return;
+        }
+        rethrow;
+      }
       if (status == null) {
         return;
       }
       await Future<void>.delayed(const Duration(milliseconds: 100));
     }
+  }
+
+  /// App quit only needs the shutdown request accepted. The sidecar is
+  /// detached, so waiting for its cleanup would keep the native window open
+  /// while it terminates terminal trees and flushes its stores.
+  Future<void> _shutdownForAppQuit({required bool force}) async {
+    try {
+      await _client.shutdownRuntime(force: force);
+    } on StateError catch (error) {
+      // Older sidecars can close the connection while processing shutdown
+      // before they write the response. Treat that expected disconnect as a
+      // best-effort shutdown so an app quit is never trapped behind EOF.
+      if (_isExpectedShutdownDisconnect(error)) {
+        return;
+      }
+      rethrow;
+    }
+  }
+
+  bool _isExpectedShutdownDisconnect(StateError error) {
+    final message = error.message;
+    return message.contains('Terminal host connection closed') ||
+        message.contains('No live Alera runtime host');
   }
 }
 

--- a/rust/alera-cli/src/terminal_host/client.rs
+++ b/rust/alera-cli/src/terminal_host/client.rs
@@ -35,6 +35,12 @@ pub enum ClientFrame {
     RestartRuntimeAfterWrite {
         inbox: UnboundedSender<ServerCommand>,
     },
+    /// Re-enters the actor only after this connection has written every frame
+    /// queued before the marker. Shutdown uses it so the caller receives the
+    /// successful response before disposal drops the connection.
+    ShutdownRuntimeAfterWrite {
+        inbox: UnboundedSender<ServerCommand>,
+    },
     /// Control frames carry the last terminal sequence accepted before them.
     /// The writer uses it as a causal barrier between snapshot replies and
     /// output produced after that snapshot.
@@ -71,7 +77,9 @@ impl ClientFrame {
                     }),
                 ))
             }
-            ClientFrame::UpgradeToBinary | ClientFrame::RestartRuntimeAfterWrite { .. } => None,
+            ClientFrame::UpgradeToBinary
+            | ClientFrame::RestartRuntimeAfterWrite { .. }
+            | ClientFrame::ShutdownRuntimeAfterWrite { .. } => None,
             ClientFrame::OrderedControl { .. } | ClientFrame::SequencedTerminal { .. } => {
                 unreachable!("payload strips internal ordering envelopes")
             }
@@ -388,6 +396,10 @@ async fn write_frame(
         }
         ClientFrame::RestartRuntimeAfterWrite { inbox } => {
             let _ = inbox.send(ServerCommand::RequestedRestart);
+            Ok(())
+        }
+        ClientFrame::ShutdownRuntimeAfterWrite { inbox } => {
+            let _ = inbox.send(ServerCommand::RequestedShutdown);
             Ok(())
         }
         ClientFrame::Json(value) if *binary => {

--- a/rust/alera-cli/src/terminal_host/mobile_gateway.rs
+++ b/rust/alera-cli/src/terminal_host/mobile_gateway.rs
@@ -214,6 +214,10 @@ async fn send_mobile_value(
         let _ = inbox.send(ServerCommand::RequestedRestart);
         return Ok(());
     }
+    if let ClientFrame::ShutdownRuntimeAfterWrite { inbox } = frame {
+        let _ = inbox.send(ServerCommand::RequestedShutdown);
+        return Ok(());
+    }
     if *binary {
         if let ClientFrame::Output { session_id, data } = frame {
             write

--- a/rust/alera-cli/src/terminal_host/server/client_delivery.rs
+++ b/rust/alera-cli/src/terminal_host/server/client_delivery.rs
@@ -128,6 +128,20 @@ impl ServerActor {
         }
     }
 
+    pub(super) fn shutdown_runtime_after_client_write(&self, client_id: u64) {
+        if let Some(client) = self.clients.get(&client_id) {
+            if client
+                .handle
+                .send_control(ClientFrame::ShutdownRuntimeAfterWrite {
+                    inbox: self.inbox.clone(),
+                })
+                .is_err()
+            {
+                self.disconnect_client_soon(client_id);
+            }
+        }
+    }
+
     pub(super) fn broadcast(&self, client_ids: &[u64], message: Value) {
         for id in client_ids {
             if let Some(client) = self.clients.get(id) {

--- a/rust/alera-cli/src/terminal_host/server/requests.rs
+++ b/rust/alera-cli/src/terminal_host/server/requests.rs
@@ -54,6 +54,7 @@ impl ServerActor {
     /// response target.
     pub(super) async fn handle_line(&mut self, client_id: u64, line: String) {
         let mut restart_after_response = false;
+        let mut shutdown_after_response = false;
         let decoded: Value = match serde_json::from_str(&line) {
             Ok(value) => value,
             // jsonDecode threw: no request id is available, so drop the client.
@@ -70,6 +71,7 @@ impl ServerActor {
         let outcome: HostResult<Value> = match extract_request(obj) {
             Ok((request_type, payload)) => {
                 restart_after_response = request_type == "host.restart";
+                shutdown_after_response = request_type == "host.shutdown";
                 if let Some(id) = request_id {
                     if self.emulator_requests.has_runtime_mutations()
                         && conflicts_with_runtime_mutation(&request_type)
@@ -146,6 +148,14 @@ impl ServerActor {
                     if restart_after_response {
                         self.restart_runtime_after_client_write(client_id);
                     }
+                    if shutdown_after_response {
+                        self.shutdown_runtime_after_client_write(client_id);
+                    }
+                } else if shutdown_after_response {
+                    // There is no response to order against for a malformed
+                    // request without an id, so preserve the legacy shutdown
+                    // behavior for that case.
+                    let _ = self.inbox.send(ServerCommand::RequestedShutdown);
                 }
             }
             Err(error) => {
@@ -297,7 +307,6 @@ impl ServerActor {
                         return Err(HostError::state(message));
                     }
                 }
-                let _ = self.inbox.send(ServerCommand::RequestedShutdown);
                 Ok(json!({
                     "stopped": true,
                     "forced": force,

--- a/rust/alera-cli/src/terminal_host/server/requests/tests.rs
+++ b/rust/alera-cli/src/terminal_host/server/requests/tests.rs
@@ -65,6 +65,49 @@ async fn soft_shutdown_counts_a_runtime_mutation_without_an_emulator_manager() {
 }
 
 #[tokio::test]
+async fn shutdown_response_precedes_disposal_marker() {
+    let dir = tempfile::tempdir().unwrap();
+    let (handle, mut receiver) = crate::terminal_host::client::ClientHandle::test_channels();
+    let mut actor = crate::terminal_host::server::actor_test_harness::test_actor(
+        &dir,
+        std::collections::HashMap::from([(
+            1,
+            crate::terminal_host::server::actor_test_harness::local_client(handle),
+        )]),
+        std::collections::HashMap::new(),
+    )
+    .await;
+    let (inbox, mut inbox_receiver) = tokio::sync::mpsc::unbounded_channel();
+    actor.inbox = inbox;
+
+    actor
+        .handle_line(
+            1,
+            serde_json::json!({
+                "id": 1,
+                "type": "host.shutdown",
+                "payload": {},
+            })
+            .to_string(),
+        )
+        .await;
+
+    let response = receiver.recv().await.unwrap().as_json().unwrap();
+    assert_eq!(response["id"], 1);
+    assert_eq!(response["ok"], true);
+    let marker = receiver.recv().await.unwrap();
+    assert!(matches!(
+        marker,
+        crate::terminal_host::client::ClientFrame::OrderedControl { frame, .. }
+            if matches!(
+                *frame,
+                crate::terminal_host::client::ClientFrame::ShutdownRuntimeAfterWrite { .. }
+            )
+    ));
+    assert!(inbox_receiver.try_recv().is_err());
+}
+
+#[tokio::test]
 async fn authenticated_mobile_client_can_request_a_safe_runtime_restart() {
     let dir = tempfile::tempdir().unwrap();
     let (handle, mut receiver) = crate::terminal_host::client::ClientHandle::test_channels();

--- a/test/unit/runtime_host_lifecycle_service_test.dart
+++ b/test/unit/runtime_host_lifecycle_service_test.dart
@@ -243,9 +243,9 @@ void main() {
 
       final allowed = await service.prepareAppQuit(
         keepRuntimeOpen: false,
-        confirmBusyQuit:
-            ({required String title, required String message}) async =>
-                RuntimeHostQuitDecision.cancel,
+        confirmBusyQuit: (
+                {required String title, required String message}) async =>
+            RuntimeHostQuitDecision.cancel,
       );
 
       expect(allowed, isFalse);
@@ -272,9 +272,9 @@ void main() {
 
         final allowed = await service.prepareAppQuit(
           keepRuntimeOpen: false,
-          confirmBusyQuit:
-              ({required String title, required String message}) async =>
-                  RuntimeHostQuitDecision.leaveRuntimeOpen,
+          confirmBusyQuit: (
+                  {required String title, required String message}) async =>
+              RuntimeHostQuitDecision.leaveRuntimeOpen,
         );
 
         expect(allowed, isTrue);
@@ -302,9 +302,9 @@ void main() {
 
       final allowed = await service.prepareAppQuit(
         keepRuntimeOpen: false,
-        confirmBusyQuit:
-            ({required String title, required String message}) async =>
-                RuntimeHostQuitDecision.forceStop,
+        confirmBusyQuit: (
+                {required String title, required String message}) async =>
+            RuntimeHostQuitDecision.forceStop,
       );
 
       expect(allowed, isTrue);
@@ -369,12 +369,12 @@ void main() {
       );
 
       await service.updateIfAvailable(
-        confirmForce:
-            ({
-              required String title,
-              required String message,
-              required String confirmLabel,
-            }) async => false,
+        confirmForce: ({
+          required String title,
+          required String message,
+          required String confirmLabel,
+        }) async =>
+            false,
       );
 
       expect(client.shutdownCalls, <bool>[false]);
@@ -400,12 +400,12 @@ void main() {
       );
 
       await service.updateIfAvailable(
-        confirmForce:
-            ({
-              required String title,
-              required String message,
-              required String confirmLabel,
-            }) async => true,
+        confirmForce: ({
+          required String title,
+          required String message,
+          required String confirmLabel,
+        }) async =>
+            true,
       );
 
       expect(client.shutdownCalls, <bool>[false, true]);

--- a/test/unit/runtime_host_lifecycle_service_test.dart
+++ b/test/unit/runtime_host_lifecycle_service_test.dart
@@ -422,7 +422,6 @@ final class _FakeRuntimeClient implements RuntimeHostLifecycleClient {
     this.busyOnSoftStop = false,
     this.probeThrows = false,
     this.shutdownLeavesHostRunning = false,
-    this.shutdownDisconnects = false,
     this.ensureStartedError,
   });
 
@@ -430,7 +429,6 @@ final class _FakeRuntimeClient implements RuntimeHostLifecycleClient {
   final bool busyOnSoftStop;
   final bool probeThrows;
   final bool shutdownLeavesHostRunning;
-  final bool shutdownDisconnects;
   final Object? ensureStartedError;
   final List<bool> shutdownCalls = <bool>[];
   int ensureStartedCalls = 0;
@@ -459,9 +457,6 @@ final class _FakeRuntimeClient implements RuntimeHostLifecycleClient {
         activeAgents: 1,
         activeSessions: 1,
       );
-    }
-    if (shutdownDisconnects) {
-      throw StateError('Terminal host connection closed.');
     }
     if (!shutdownLeavesHostRunning) {
       _stopped = true;

--- a/test/unit/runtime_host_lifecycle_service_test.dart
+++ b/test/unit/runtime_host_lifecycle_service_test.dart
@@ -202,31 +202,6 @@ void main() {
       expect(await client.probeRuntimeStatus(), isNotNull);
     });
 
-    test(
-      'prepareAppQuit allows an older host that closes during shutdown',
-      () async {
-        final client = _FakeRuntimeClient(
-          status: <String, Object?>{
-            'runtimeHostVersion': '1.2.0',
-            'persistent': false,
-          },
-          shutdownDisconnects: true,
-        );
-        final service = RuntimeHostLifecycleService(
-          client: client,
-          bundledVersionProbe: _FakeBundledProbe(
-            const BundledSidecarVersion(version: '1.2.0'),
-          ),
-          readConfig: () => TerminalHostConfig.defaults,
-        );
-
-        final allowed = await service.prepareAppQuit(keepRuntimeOpen: false);
-
-        expect(allowed, isTrue);
-        expect(client.shutdownCalls, <bool>[false]);
-      },
-    );
-
     test('prepareAppQuit cancels when busy quit is declined', () async {
       final client = _FakeRuntimeClient(
         status: <String, Object?>{

--- a/test/unit/runtime_host_lifecycle_service_test.dart
+++ b/test/unit/runtime_host_lifecycle_service_test.dart
@@ -178,6 +178,53 @@ void main() {
       expect(client.shutdownCalls, <bool>[false]);
     });
 
+    test('prepareAppQuit does not wait for detached host cleanup', () async {
+      final client = _FakeRuntimeClient(
+        status: <String, Object?>{
+          'runtimeHostVersion': '1.2.0',
+          'persistent': false,
+        },
+        shutdownLeavesHostRunning: true,
+      );
+      final service = RuntimeHostLifecycleService(
+        client: client,
+        bundledVersionProbe: _FakeBundledProbe(
+          const BundledSidecarVersion(version: '1.2.0'),
+        ),
+        readConfig: () => TerminalHostConfig.defaults,
+        shutdownSettleTimeout: const Duration(seconds: 5),
+      );
+
+      final allowed = await service.prepareAppQuit(keepRuntimeOpen: false);
+
+      expect(allowed, isTrue);
+      expect(client.shutdownCalls, <bool>[false]);
+      expect(await client.probeRuntimeStatus(), isNotNull);
+    });
+
+    test('prepareAppQuit allows an older host that closes during shutdown',
+        () async {
+      final client = _FakeRuntimeClient(
+        status: <String, Object?>{
+          'runtimeHostVersion': '1.2.0',
+          'persistent': false,
+        },
+        shutdownDisconnects: true,
+      );
+      final service = RuntimeHostLifecycleService(
+        client: client,
+        bundledVersionProbe: _FakeBundledProbe(
+          const BundledSidecarVersion(version: '1.2.0'),
+        ),
+        readConfig: () => TerminalHostConfig.defaults,
+      );
+
+      final allowed = await service.prepareAppQuit(keepRuntimeOpen: false);
+
+      expect(allowed, isTrue);
+      expect(client.shutdownCalls, <bool>[false]);
+    });
+
     test('prepareAppQuit cancels when busy quit is declined', () async {
       final client = _FakeRuntimeClient(
         status: <String, Object?>{
@@ -397,12 +444,16 @@ final class _FakeRuntimeClient implements RuntimeHostLifecycleClient {
     this.status,
     this.busyOnSoftStop = false,
     this.probeThrows = false,
+    this.shutdownLeavesHostRunning = false,
+    this.shutdownDisconnects = false,
     this.ensureStartedError,
   });
 
   Map<String, Object?>? status;
   final bool busyOnSoftStop;
   final bool probeThrows;
+  final bool shutdownLeavesHostRunning;
+  final bool shutdownDisconnects;
   final Object? ensureStartedError;
   final List<bool> shutdownCalls = <bool>[];
   int ensureStartedCalls = 0;
@@ -432,8 +483,13 @@ final class _FakeRuntimeClient implements RuntimeHostLifecycleClient {
         activeSessions: 1,
       );
     }
-    _stopped = true;
-    status = null;
+    if (shutdownDisconnects) {
+      throw StateError('Terminal host connection closed.');
+    }
+    if (!shutdownLeavesHostRunning) {
+      _stopped = true;
+      status = null;
+    }
     return RuntimeHostShutdownResult(stopped: true, forced: force);
   }
 

--- a/test/unit/runtime_host_lifecycle_service_test.dart
+++ b/test/unit/runtime_host_lifecycle_service_test.dart
@@ -202,28 +202,30 @@ void main() {
       expect(await client.probeRuntimeStatus(), isNotNull);
     });
 
-    test('prepareAppQuit allows an older host that closes during shutdown',
-        () async {
-      final client = _FakeRuntimeClient(
-        status: <String, Object?>{
-          'runtimeHostVersion': '1.2.0',
-          'persistent': false,
-        },
-        shutdownDisconnects: true,
-      );
-      final service = RuntimeHostLifecycleService(
-        client: client,
-        bundledVersionProbe: _FakeBundledProbe(
-          const BundledSidecarVersion(version: '1.2.0'),
-        ),
-        readConfig: () => TerminalHostConfig.defaults,
-      );
+    test(
+      'prepareAppQuit allows an older host that closes during shutdown',
+      () async {
+        final client = _FakeRuntimeClient(
+          status: <String, Object?>{
+            'runtimeHostVersion': '1.2.0',
+            'persistent': false,
+          },
+          shutdownDisconnects: true,
+        );
+        final service = RuntimeHostLifecycleService(
+          client: client,
+          bundledVersionProbe: _FakeBundledProbe(
+            const BundledSidecarVersion(version: '1.2.0'),
+          ),
+          readConfig: () => TerminalHostConfig.defaults,
+        );
 
-      final allowed = await service.prepareAppQuit(keepRuntimeOpen: false);
+        final allowed = await service.prepareAppQuit(keepRuntimeOpen: false);
 
-      expect(allowed, isTrue);
-      expect(client.shutdownCalls, <bool>[false]);
-    });
+        expect(allowed, isTrue);
+        expect(client.shutdownCalls, <bool>[false]);
+      },
+    );
 
     test('prepareAppQuit cancels when busy quit is declined', () async {
       final client = _FakeRuntimeClient(
@@ -243,9 +245,9 @@ void main() {
 
       final allowed = await service.prepareAppQuit(
         keepRuntimeOpen: false,
-        confirmBusyQuit: (
-                {required String title, required String message}) async =>
-            RuntimeHostQuitDecision.cancel,
+        confirmBusyQuit:
+            ({required String title, required String message}) async =>
+                RuntimeHostQuitDecision.cancel,
       );
 
       expect(allowed, isFalse);
@@ -272,9 +274,9 @@ void main() {
 
         final allowed = await service.prepareAppQuit(
           keepRuntimeOpen: false,
-          confirmBusyQuit: (
-                  {required String title, required String message}) async =>
-              RuntimeHostQuitDecision.leaveRuntimeOpen,
+          confirmBusyQuit:
+              ({required String title, required String message}) async =>
+                  RuntimeHostQuitDecision.leaveRuntimeOpen,
         );
 
         expect(allowed, isTrue);
@@ -302,9 +304,9 @@ void main() {
 
       final allowed = await service.prepareAppQuit(
         keepRuntimeOpen: false,
-        confirmBusyQuit: (
-                {required String title, required String message}) async =>
-            RuntimeHostQuitDecision.forceStop,
+        confirmBusyQuit:
+            ({required String title, required String message}) async =>
+                RuntimeHostQuitDecision.forceStop,
       );
 
       expect(allowed, isTrue);
@@ -369,12 +371,12 @@ void main() {
       );
 
       await service.updateIfAvailable(
-        confirmForce: ({
-          required String title,
-          required String message,
-          required String confirmLabel,
-        }) async =>
-            false,
+        confirmForce:
+            ({
+              required String title,
+              required String message,
+              required String confirmLabel,
+            }) async => false,
       );
 
       expect(client.shutdownCalls, <bool>[false]);
@@ -400,12 +402,12 @@ void main() {
       );
 
       await service.updateIfAvailable(
-        confirmForce: ({
-          required String title,
-          required String message,
-          required String confirmLabel,
-        }) async =>
-            true,
+        confirmForce:
+            ({
+              required String title,
+              required String message,
+              required String confirmLabel,
+            }) async => true,
       );
 
       expect(client.shutdownCalls, <bool>[false, true]);


### PR DESCRIPTION
## Summary

Fixes the Windows UI close delay caused by the runtime host closing its socket before the shutdown acknowledgment reached Flutter.

## Root cause

`host.shutdown` queued `RequestedShutdown` immediately from the Rust request handler. The actor then disposed the host and dropped client handles before the response was guaranteed to be written. Flutter observed `Terminal host connection closed`, waited on the generic request timeout, and the close gate refused to destroy the window. The app log recorded this as `AppWindowLifecycleCoordinator: app window close gate failed`.

## Changes

- Added a shutdown-after-write control marker, matching the existing restart ordering barrier.
- Moved shutdown disposal behind the successful response write.
- Made app quit wait only for shutdown acceptance; detached sidecar cleanup continues after the window closes.
- Treated expected shutdown EOF and connection closure as successful best-effort quit outcomes.
- Added regression coverage for response-before-disposal ordering and detached cleanup behavior.

## Validation

- `cargo fmt --manifest-path rust/Cargo.toml --all -- --check`
- All 14 `terminal_host::server::requests::tests` passed.
- Existing terminal client control-ordering test passed.
- Flutter tests could not run because the installed Flutter 3.22.3 SDK does not understand the repository's current `flutter.config` pubspec entry.

## Scope

Unrelated AI-dictation edits already present in the working tree were intentionally excluded.