### PR TITLE
fix: package only alera.app in the macos release asset

### DIFF
--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -323,7 +323,20 @@ jobs:
           dart tool/native_helpers/verify_desktop_runtime_bundle.dart \
             --platform macos \
             --bundle "$BUNDLE_DIR"
-          tar -czf "release-assets/alera-${RELEASE_VERSION}-macos.tar.gz" -C "$BUNDLE_DIR" .
+          # Only the app, never the directory that contains it. BUNDLE_DIR is
+          # the Xcode products root on macOS (it is the runnable bundle itself
+          # on Windows and Linux), so archiving `.` shipped every dSYM, every
+          # per-pod build product and a loose copy of each framework alongside
+          # Alera.app: 450 MB published where the app is 271 MB.
+          # COPYFILE_DISABLE keeps macOS tar from adding its `._*` AppleDouble
+          # files for the xattrs Xcode leaves behind.
+          asset="release-assets/alera-${RELEASE_VERSION}-macos.tar.gz"
+          COPYFILE_DISABLE=1 tar -czf "$asset" -C "$BUNDLE_DIR" Alera.app
+          roots="$(tar -tzf "$asset" | awk -F/ '{print $1}' | sort -u)"
+          if [[ "$roots" != "Alera.app" ]]; then
+            echo "::error::macOS asset must contain only Alera.app, got: $roots"
+            exit 1
+          fi
 
       - name: Package Windows release assets
         if: matrix.platform == 'windows'


### PR DESCRIPTION
## Summary

The macOS `BUNDLE_DIR` is the Xcode products root, while on Windows and Linux the same variable is the runnable bundle itself. Archiving `.` therefore published the whole directory next to `Alera.app`: every dSYM, every per-pod build product and a loose copy of each framework.

Measured on the published `v0.54.0` assets:

| Artefacto | Comprimido | Sin comprimir | Contenido |
| --- | --- | --- | --- |
| `alera-0.54.0-macos.tar.gz` | 449.8 MB | 1384.6 MB | products root; `Alera.app` es 271.5 MB, el 19 % |
| `alera-0.54.0-windows.tar.gz` | 68.4 MB | 172.3 MB | solo el directorio ejecutable |
| `alera-0.54.0-linux.deb` | 40.7 MB | 140.3 MB instalados | solo `/opt/alera` |

Lo que sobraba, por peso: `FlutterMacOS.framework.dSYM` 496 MB, `alera_native/` 253 MB, `code_forge/` 63 MB, `XCFrameworkIntermediates/` 58 MB, `App.framework` 55 MB suelto, y un directorio por cada plugin. En total unos 1113 MB ajenos a la app, de los que unos 530 MB son símbolos de depuración publicados sin querer.

El zip que sirve el auto-updater pesa 107 MB y contiene solo la app, así que esa ruta ya estaba bien: la rota era solo la del release de GitHub. El cask de Homebrew descarga precisamente este asset e instala únicamente `Alera.app`.

## Changes

- `tar` empaqueta `Alera.app` en vez de `.`, con `COPYFILE_DISABLE=1` para que el `tar` de macOS no añada los `._*` de AppleDouble.
- Falla el job si el tarball llega a tener una segunda entrada de primer nivel.
- `BUNDLE_DIR` no cambia: lo consumen otros dos pasos que ya resuelven bien la ruta de la app.

## Validation

- Lógica de `tar` y del guard probada en local contra un bundle sintético, incluido el caso negativo (el guard detecta el empaquetado anterior).
- Sobre un build real de macOS: el tarball resultante tiene `[Alera.app]` como única raíz y pesa 59 MB.
- `flutter analyze` limpio y suite unitaria verde.

## Risks

El cask no cambia: sigue extrayendo `Alera.app` en la raíz del staging, que es lo que `app "Alera.app"` espera, y el `sha256` se recalcula en el paso de publicación.