### PR TITLE
feat: attribute linux deb and rpm installs to their package manager

### DIFF
--- a/lib/src/features/updater/domain/alera_update.dart
+++ b/lib/src/features/updater/domain/alera_update.dart
@@ -207,10 +207,14 @@ String? packageManagerUpgradeCommand({
     PackageInstallMethod.homebrewCask => 'brew upgrade --cask alera',
     PackageInstallMethod.scoop => 'scoop update alera',
     PackageInstallMethod.chocolatey => 'choco upgrade alera -y',
-    PackageInstallMethod.unmanaged => linuxPackageUpgradeCommand(
+    PackageInstallMethod.linuxSystemPackage => linuxPackageUpgradeCommand(
       update: update,
       channel: channel,
     ),
+    // An unmanaged Linux install is a directory the user extracted themselves,
+    // which `apt` and `dnf` know nothing about: offering their upgrade there
+    // either reports no change or upgrades a different copy.
+    PackageInstallMethod.unmanaged => null,
   };
 }
 

--- a/lib/src/features/updater/domain/package_install_method.dart
+++ b/lib/src/features/updater/domain/package_install_method.dart
@@ -11,6 +11,12 @@ enum PackageInstallMethod {
   scoop,
   chocolatey,
 
+  /// A deb or rpm install: `dpkg` or `rpm` owns `/opt/alera`.
+  ///
+  /// Which of the two it is comes from `/etc/os-release`, not from the path, so
+  /// the distinction lives with the update rather than with the installation.
+  linuxSystemPackage,
+
   /// A plain download, or anything Alera cannot attribute to a manager.
   unmanaged,
 }
@@ -68,8 +74,35 @@ PackageManagerInstall packageManagerInstallFromExecutablePath({
   return switch (platform) {
     'macos' => _macosInstall(context, segments),
     'windows' => _windowsInstall(context, segments),
+    'linux' => _linuxInstall(segments),
     _ => PackageManagerInstall.unmanaged,
   };
+}
+
+/// The prefix `tool/release/package_linux.sh` installs the deb and rpm payload
+/// under. `/usr/bin/alera` is a symlink into it, and `Platform.resolvedExecutable`
+/// resolves symlinks, so the running executable always reports this path.
+const List<String> _linuxPackagePrefix = <String>['opt', 'alera'];
+
+PackageManagerInstall _linuxInstall(List<String> segments) {
+  // Anchored at the filesystem root: a tarball extracted into
+  // `~/projects/opt/alera` is not a packaged installation, and treating it as
+  // one would send the user to an `apt` upgrade that cannot see it.
+  final root = segments.isNotEmpty && segments.first == '/' ? 1 : 0;
+  final matches =
+      segments.length > root + _linuxPackagePrefix.length &&
+      segments[root] == _linuxPackagePrefix[0] &&
+      segments[root + 1] == _linuxPackagePrefix[1];
+  if (!matches) {
+    return PackageManagerInstall.unmanaged;
+  }
+  // Deliberately without a manager or relaunch executable: the deb and rpm
+  // upgrades need `sudo`, so they run in Alera's command terminal where a
+  // password prompt has a PTY to appear on, not in the detached shell that
+  // Homebrew and Scoop use after the app has already closed.
+  return const PackageManagerInstall(
+    method: PackageInstallMethod.linuxSystemPackage,
+  );
 }
 
 PackageManagerInstall _macosInstall(p.Context context, List<String> segments) {
@@ -152,6 +185,10 @@ String? packageManagerLabel(PackageInstallMethod method) {
     PackageInstallMethod.homebrewCask => 'Homebrew',
     PackageInstallMethod.scoop => 'Scoop',
     PackageInstallMethod.chocolatey => 'Chocolatey',
+    // Null on purpose: the path says the install is packaged but not by which
+    // manager, and naming the wrong one is worse than naming none. The Linux
+    // copy comes from the update's installer kind instead.
+    PackageInstallMethod.linuxSystemPackage => null,
     PackageInstallMethod.unmanaged => null,
   };
 }

--- a/lib/src/features/updater/domain/package_manager_upgrade_script.dart
+++ b/lib/src/features/updater/domain/package_manager_upgrade_script.dart
@@ -56,7 +56,12 @@ PackageManagerUpgradeScript? packageManagerUpgradeScript(
         '-File',
       ],
     ),
-    PackageInstallMethod.chocolatey || PackageInstallMethod.unmanaged => null,
+    // Chocolatey and the Linux packages both need elevation, so neither can be
+    // handed to a detached shell: the prompt would appear with no window left
+    // to explain it. Linux answers it in Alera's command terminal instead.
+    PackageInstallMethod.chocolatey ||
+    PackageInstallMethod.linuxSystemPackage ||
+    PackageInstallMethod.unmanaged => null,
   };
 }
 

--- a/lib/src/features/updater/infra/desktop_update_service.dart
+++ b/lib/src/features/updater/infra/desktop_update_service.dart
@@ -291,7 +291,11 @@ String _manualUpdateMessage({
   if (manager != null) {
     return 'Update ${update.version} is available through $manager.';
   }
+  // Only an installation dpkg or rpm actually owns can be pointed at the
+  // repository. A directory the user extracted themselves is invisible to apt
+  // and dnf, so sending them there would upgrade nothing, or a different copy.
   if (update.platform == 'linux' &&
+      packageInstall.method == PackageInstallMethod.linuxSystemPackage &&
       config.channel == AleraUpdateChannel.stable &&
       (update.installerKind == 'deb' || update.installerKind == 'rpm')) {
     return 'Update ${update.version} is available through the Linux package repository.';

--- a/test/unit/desktop_update_service_test.dart
+++ b/test/unit/desktop_update_service_test.dart
@@ -124,6 +124,9 @@ void main() {
             loadLinuxInstallerKind: () async => installerKind,
             platform: 'linux',
             backend: backend,
+            // The payload prefix the deb and rpm install under, so the
+            // detection that routes the update runs for real here.
+            resolvedExecutable: '/opt/alera/alera',
           );
 
           final result = await service.checkForUpdates();
@@ -169,6 +172,29 @@ void main() {
       expect(result.autoInstallAllowed, isFalse);
       expect(result.message, contains('requires a supported Linux package'));
     });
+
+    // A directory the user extracted themselves is invisible to apt and dnf,
+    // so pointing it at the repository would upgrade nothing, or another copy.
+    test(
+      'does not send an unmanaged Linux install to the repository',
+      () async {
+        final service = DesktopAleraUpdateService(
+          config: _config(autoInstallEnabled: true),
+          loadPackageInfo: () async => _packageInfo('1'),
+          loadLinuxInstallerKind: () async => 'deb',
+          platform: 'linux',
+          backend: _FakeDesktopUpdaterBackend(
+            candidate: _candidate(platform: 'linux'),
+          ),
+          resolvedExecutable: '/home/leynier/.local/share/alera/alera',
+        );
+
+        final result = await service.checkForUpdates();
+
+        expect(result.message, isNot(contains('package repository')));
+        expect(result.message, contains('requires a supported Linux package'));
+      },
+    );
 
     test('keeps package-managed installations on their manager path', () async {
       final launched = <Uri>[];

--- a/test/unit/package_install_method_test.dart
+++ b/test/unit/package_install_method_test.dart
@@ -119,13 +119,36 @@ void main() {
 
     // Linux distribution is owned by apt and dnf, which are detected from the
     // artifact rather than from the path.
-    test('never attributes a Linux install to a desktop package manager', () {
-      final install = packageManagerInstallFromExecutablePath(
-        platform: 'linux',
-        executablePath: '/opt/alera/alera',
-      );
+    test(
+      'attributes the deb and rpm payload prefix to the system packages',
+      () {
+        final install = packageManagerInstallFromExecutablePath(
+          platform: 'linux',
+          executablePath: '/opt/alera/alera',
+        );
 
-      expect(install.method, PackageInstallMethod.unmanaged);
+        expect(install.method, PackageInstallMethod.linuxSystemPackage);
+        expect(install.isPackageManaged, isTrue);
+        // The deb and rpm upgrades need sudo, so they run in the command
+        // terminal rather than in a detached shell after the app has closed.
+        expect(install.canRunUpgrade, isFalse);
+      },
+    );
+
+    test('leaves a Linux tarball install unmanaged', () {
+      for (final path in const <String>[
+        '/home/leynier/.local/share/alera/alera',
+        '/home/leynier/projects/opt/alera/alera',
+      ]) {
+        expect(
+          packageManagerInstallFromExecutablePath(
+            platform: 'linux',
+            executablePath: path,
+          ).method,
+          PackageInstallMethod.unmanaged,
+          reason: path,
+        );
+      }
     });
 
     test('labels each manager for the update copy', () {
@@ -139,6 +162,12 @@ void main() {
         'Chocolatey',
       );
       expect(packageManagerLabel(PackageInstallMethod.unmanaged), isNull);
+      // The path proves the install is packaged but not by which manager, and
+      // the update's installer kind is what resolves apt against dnf.
+      expect(
+        packageManagerLabel(PackageInstallMethod.linuxSystemPackage),
+        isNull,
+      );
     });
   });
 
@@ -170,12 +199,12 @@ void main() {
       );
     });
 
-    test('keeps the Linux behavior for an unmanaged installation', () {
+    test('sends a packaged Linux install to its own manager', () {
       expect(
         packageManagerUpgradeCommand(
           update: _update(platform: 'linux', kind: 'deb'),
           channel: AleraUpdateChannel.stable,
-          installMethod: PackageInstallMethod.unmanaged,
+          installMethod: PackageInstallMethod.linuxSystemPackage,
         ),
         'sudo apt-get update && sudo apt-get install --only-upgrade alera',
       );
@@ -183,18 +212,26 @@ void main() {
         packageManagerUpgradeCommand(
           update: _update(platform: 'linux', kind: 'rpm'),
           channel: AleraUpdateChannel.stable,
-          installMethod: PackageInstallMethod.unmanaged,
+          installMethod: PackageInstallMethod.linuxSystemPackage,
         ),
         'sudo dnf upgrade alera',
       );
-      expect(
-        packageManagerUpgradeCommand(
-          update: _update(),
-          channel: AleraUpdateChannel.stable,
-          installMethod: PackageInstallMethod.unmanaged,
-        ),
-        isNull,
-      );
+    });
+
+    // apt and dnf know nothing about a directory the user extracted, so their
+    // upgrade would report no change or upgrade a different copy.
+    test('offers no manager command for an unmanaged installation', () {
+      for (final kind in const <String>['deb', 'rpm', 'tar.gz']) {
+        expect(
+          packageManagerUpgradeCommand(
+            update: _update(platform: 'linux', kind: kind),
+            channel: AleraUpdateChannel.stable,
+            installMethod: PackageInstallMethod.unmanaged,
+          ),
+          isNull,
+          reason: kind,
+        );
+      }
     });
 
     // Release candidates are GitHub assets only; no package manager carries

--- a/test/widget/update_settings_section_test.dart
+++ b/test/widget/update_settings_section_test.dart
@@ -1,6 +1,7 @@
 import 'package:alera/src/app/providers.dart';
 import 'package:alera/src/app/theme/alera_dark_theme.dart';
 import 'package:alera/src/features/updater/domain/alera_update.dart';
+import 'package:alera/src/features/updater/domain/package_install_method.dart';
 import 'package:alera/src/features/updater/presentation/update_settings_section.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -43,7 +44,13 @@ void main() {
           message: 'Update 1.2.3 is available through the package repository.',
         ),
       );
-      await _pumpSection(tester, controller);
+      await _pumpSection(
+        tester,
+        controller,
+        packageInstall: const PackageManagerInstall(
+          method: PackageInstallMethod.linuxSystemPackage,
+        ),
+      );
 
       expect(find.text(_debUpgradeCommand), findsOneWidget);
       expect(find.text('Installation Guide'), findsOneWidget);
@@ -69,7 +76,14 @@ void main() {
           latest: _latest().copyWith(platform: 'linux', installerKind: 'deb'),
         ),
       );
-      await _pumpSection(tester, controller, runtime: runtime);
+      await _pumpSection(
+        tester,
+        controller,
+        runtime: runtime,
+        packageInstall: const PackageManagerInstall(
+          method: PackageInstallMethod.linuxSystemPackage,
+        ),
+      );
 
       await tester.tap(find.text('Run Update'));
       await tester.pumpAndSettle();
@@ -250,11 +264,16 @@ Future<void> _pumpSection(
   WidgetTester tester,
   _FakeUpdateController controller, {
   FakeCommandTerminalRuntime? runtime,
+  // Stated rather than inherited from wherever the test runner happens to
+  // live: which manager owns the installation is what decides whether an
+  // upgrade command is offered at all.
+  PackageManagerInstall packageInstall = PackageManagerInstall.unmanaged,
 }) async {
   await tester.pumpWidget(
     ProviderScope(
       overrides: [
         aleraUpdateControllerProvider.overrideWith(() => controller),
+        packageManagerInstallProvider.overrideWithValue(packageInstall),
         if (runtime != null) terminalRuntimeProvider.overrideWithValue(runtime),
       ],
       child: MaterialApp(


### PR DESCRIPTION
Apilado sobre #379.

## Summary

`packageManagerInstallFromExecutablePath` devolvía `unmanaged` para cualquier instalación de Linux, así que nada distinguía un directorio que el usuario extrajo de uno que `dpkg` o `rpm` poseen bajo `/opt/alera`. Dos consecuencias:

- A un usuario de tarball se le ofrecía `sudo apt-get update && sudo apt-get install --only-upgrade alera`, que no actualiza nada o actualiza otra copia.
- No existía ninguna guarda que impidiera a una futura actualización en sitio reemplazar un directorio gestionado a espaldas de su gestor.

## Changes

- `PackageInstallMethod.linuxSystemPackage`, detectado por el prefijo que instala `tool/release/package_linux.sh`, anclado a la raíz del sistema de ficheros para que `~/projects/opt/alera` no se confunda con él.
- Solo esa instalación recibe el comando de apt o dnf; la no gestionada ya no recibe ninguno.
- El método no lleva ejecutable de gestor a propósito: esos upgrades necesitan `sudo`, así que corren en la terminal embebida de Alera, donde el prompt de contraseña tiene un PTY, y no en el shell desacoplado que usan Homebrew y Scoop después de cerrar la app. Ese camino ya existía en `_UpgradeCommand`; lo que faltaba era la detección.
- `_manualUpdateMessage` también se estrecha: solo una instalación que dpkg o rpm posee se manda al repositorio.

## Validation

- Tests nuevos de detección: `/opt/alera/alera` da `linuxSystemPackage` con `isPackageManaged` y sin `canRunUpgrade`; `~/.local/share/alera/alera` y `~/projects/opt/alera/alera` siguen siendo `unmanaged`.
- Los tests del servicio ejercitan la detección de verdad pasando `resolvedExecutable` en vez de fijar el enum.
- `flutter analyze` limpio, 2122 tests unitarios y los de widget del diálogo de ajustes verdes.