### PR TITLE
docs: record why the linux dependencies stay declared

### DIFF
--- a/tool/release/package_linux.sh
+++ b/tool/release/package_linux.sh
@@ -57,6 +57,25 @@ installed_size="$(du -sk "$deb_root/opt/alera" | awk '{print $1}')"
 # every entry is one `ldd` over the bundle resolves. An extra name makes users
 # install a library Alera never loads: `libayatana-appindicator3` was listed
 # here for a tray that no binary in the bundle links or dlopens.
+#
+# These stay declared rather than copied into the payload, which is not the
+# same tradeoff for each of them:
+#
+#   libsecret-1-0, libsqlite3-0  Already dependencies of libwebkit2gtk-4.1-0,
+#     so declaring them costs the user no extra install. Shipping our own would
+#     put a second copy under the same SONAME into the process that hosts the
+#     system WebKit, and whichever loads first wins for both.
+#   libmpv2, libjson-glib-1.0-0  Not reachable by dropping a .so into lib/ as
+#     things stand: only `alera` carries RUNPATH `$ORIGIN/lib`, while the
+#     plugins that actually need these keep the build tree's RUNPATH, so the
+#     loader never searches lib/ for them. Bundling either means fixing that
+#     first.
+#   libgtk-3-0, libwebkit2gtk-4.1-0  Never bundle. GTK loads theme, GIO,
+#     pixbuf and input method modules from the system that are built against
+#     the system GTK, so a second one breaks IME. WebKitGTK links that same
+#     GTK, needs its own libexec helper processes, and takes browser-engine
+#     CVE fixes from the distribution within days rather than at our release
+#     cadence.
 cat >"$deb_root/DEBIAN/control" <<DEB
 Package: alera
 Version: ${deb_version}


### PR DESCRIPTION
Apilado sobre #381.

## Summary

Cierra la pregunta de por qué el `.deb` declara dependencias en vez de traerlas dentro. Cada una es un caso distinto y ninguno se deduce de la lista, así que la razón queda escrita donde alguien intentaría cambiarla.

- **`libsecret-1-0`, `libsqlite3-0`**: `libwebkit2gtk-4.1-0` ya depende de ambas, así que declararlas no le cuesta al usuario ninguna instalación extra. Traer las nuestras metería una segunda copia bajo el mismo SONAME en el proceso que hospeda al WebKit del sistema, y la que cargue primero manda para las dos.
- **`libmpv2`, `libjson-glib-1.0-0`**: soltar una `.so` en `lib/` no basta hoy. Solo `alera` lleva `RUNPATH $ORIGIN/lib`; los plugins que declaran esos `NEEDED` conservan el RUNPATH del árbol de build, así que el loader nunca busca en `lib/` para ellos. Empaquetar cualquiera de las dos empieza por arreglar eso.
- **`libgtk-3-0`, `libwebkit2gtk-4.1-0`**: nunca. GTK carga del sistema módulos de tema, GIO, pixbuf y de método de entrada compilados contra el GTK del sistema, así que un segundo GTK rompe el IME. WebKitGTK enlaza ese mismo GTK, necesita sus procesos auxiliares de `libexec`, y recibe parches de CVE de motor de navegador de la distribución en días en vez de a nuestra cadencia de release.

## Validation

Solo comentarios. `bash -n` sobre el script y suite unitaria verde.