### PR TITLE
fix: align source control actions right

### DIFF
--- a/lib/src/features/workbench/presentation/workspace_git_diff_panel_toolbar.dart
+++ b/lib/src/features/workbench/presentation/workspace_git_diff_panel_toolbar.dart
@@ -188,17 +188,16 @@ class _SourceControlToolbar extends StatelessWidget {
           ),
           const SizedBox(height: AleraTokens.space8),
           Row(
+            mainAxisAlignment: MainAxisAlignment.end,
             children: <Widget>[
-              Expanded(
-                child: _PrimaryActionButton(
-                  action: primaryAction,
-                  state: data,
-                  busy: busy,
-                  onPressed: primaryAction == null
-                      ? null
-                      : () => onPrimaryAction(primaryAction),
-                  onSelected: onSelectMenuAction,
-                ),
+              _PrimaryActionButton(
+                action: primaryAction,
+                state: data,
+                busy: busy,
+                onPressed: primaryAction == null
+                    ? null
+                    : () => onPrimaryAction(primaryAction),
+                onSelected: onSelectMenuAction,
               ),
             ],
           ),
@@ -445,14 +444,19 @@ class _PrimaryActionButton extends StatelessWidget {
             child: SizedBox(
               height: _height,
               child: Row(
+                mainAxisSize: MainAxisSize.min,
                 children: <Widget>[
-                  Expanded(
+                  ConstrainedBox(
+                    constraints: const BoxConstraints(minHeight: _height),
                     child: InkWell(
                       mouseCursor: enabled
                           ? SystemMouseCursors.click
                           : SystemMouseCursors.basic,
                       onTap: enabled ? onPressed : null,
-                      child: Center(
+                      child: Padding(
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: AleraTokens.space12,
+                        ),
                         child: Row(
                           mainAxisSize: MainAxisSize.min,
                           children: <Widget>[

--- a/test/widget/workspace_git_diff_panel_test.dart
+++ b/test/widget/workspace_git_diff_panel_test.dart
@@ -774,7 +774,10 @@ void main() {
       ),
     );
     expect(splitButton, findsOneWidget);
-    expect(tester.getSize(splitButton).height, 28);
+    final splitButtonRect = tester.getRect(splitButton);
+    expect(splitButtonRect.height, 28);
+    expect(splitButtonRect.right, closeTo(412, 0.1));
+    expect(splitButtonRect.width, lessThan(240));
 
     final primaryAction = find.ancestor(
       of: find.text('Stage All'),


### PR DESCRIPTION
## Summary

- align the Source Control primary split action to the right edge of the toolbar
- keep the action compact while preserving its click and menu targets
- cover the right-edge and compact-width geometry in the widget test

## Validation

- `flutter analyze`
- `flutter test test/widget/workspace_git_diff_panel_test.dart test/widget/workspace_source_control_icons_test.dart`
- `flutter test`

## Notes

- local `gh act` could not complete because the linked worktree and container environment failed before the equivalent hosted setup; hosted checks remain authoritative