### PR TITLE
fix: keep windows shutdown confirmation on navigator route

### DIFF
--- a/lib/src/app/app.dart
+++ b/lib/src/app/app.dart
@@ -6,6 +6,7 @@ import 'package:alera/src/features/diagnostics/presentation/diagnostics_settings
 import 'package:alera/src/features/shell/presentation/alera_shell_page.dart';
 import 'package:alera/src/features/text_actions/presentation/text_actions_scope.dart';
 import 'package:alera/src/features/updater/presentation/update_availability_watch.dart';
+import 'package:alera/src/features/runtime_host/presentation/runtime_host_quit_gate_scope.dart';
 import 'package:flutter/material.dart';
 
 class AleraApp extends StatelessWidget {
@@ -15,7 +16,7 @@ class AleraApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       title: kAleraAppName,
-      home: const AleraShellPage(),
+      home: const RuntimeHostQuitGateScope(child: AleraShellPage()),
       debugShowCheckedModeBanner: false,
       builder: (context, child) {
         return AppWindowLifecycleScope(

--- a/lib/src/features/app_window/presentation/app_window_lifecycle_scope.dart
+++ b/lib/src/features/app_window/presentation/app_window_lifecycle_scope.dart
@@ -3,7 +3,6 @@ import 'dart:async';
 import 'package:alera/src/features/app_window/application/app_window_controller.dart';
 import 'package:alera/src/features/app_window/application/app_window_platform.dart';
 import 'package:alera/src/features/app_window/application/app_window_providers.dart';
-import 'package:alera/src/features/runtime_host/presentation/runtime_host_quit_gate_scope.dart';
 import 'package:alera/src/shared/infra/storage/storage_providers.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -55,7 +54,7 @@ class _AppWindowLifecycleScopeState
         });
       }
     }
-    return RuntimeHostQuitGateScope(child: widget.child);
+    return widget.child;
   }
 
   @override

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,5 +1,7 @@
 import 'package:alera/src/app/app.dart';
 import 'package:alera/src/features/shell/presentation/alera_shell_page.dart';
+import 'package:alera/src/features/runtime_host/presentation/runtime_host_quit_gate_scope.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -8,5 +10,20 @@ void main() {
     await tester.pumpWidget(const ProviderScope(child: AleraApp()));
     await tester.pump(const Duration(seconds: 1));
     expect(find.byType(AleraShellPage), findsOneWidget);
+  });
+
+  testWidgets('places the runtime quit gate below the navigator', (
+    tester,
+  ) async {
+    await tester.pumpWidget(const ProviderScope(child: AleraApp()));
+    await tester.pump(const Duration(seconds: 1));
+
+    expect(
+      find.ancestor(
+        of: find.byType(RuntimeHostQuitGateScope),
+        matching: find.byType(Navigator),
+      ),
+      findsOneWidget,
+    );
   });
 }


### PR DESCRIPTION
## summary

Fixes the Windows app-close path when the runtime host still has active work.

## root cause

The runtime quit gate was mounted from `MaterialApp.builder`, which gives it a context above the Navigator. When shutdown detected active work, `_confirmBusyQuit` called `showDialog(context: context)`; `Navigator.of(context)` then threw `Null check operator used on a null value`. The app-window close coordinator caught that exception and cancelled destruction, leaving the UI and runtime host running.

## changes

- Mount `RuntimeHostQuitGateScope` as the routed home content so its context is below the Navigator.
- Leave `AppWindowLifecycleScope` responsible only for app-window lifecycle startup and shutdown.
- Add a widget regression test asserting the quit gate has a Navigator ancestor.

## validation

- `puro --env alera-3448 dart format --output=none --set-exit-if-changed ...`
- `puro --env alera-3448 flutter analyze`
- `puro --env alera-3448 flutter test test/widget_test.dart test/unit/runtime_host_lifecycle_service_test.dart`
- Full `puro --env alera-3448 flutter test` was run; the repository's existing Windows/golden baseline failures remain unrelated to this change.