### PR TITLE
fix: restore source control action layout

### DIFF
--- a/lib/src/features/workbench/presentation/workspace_git_diff_panel_toolbar.dart
+++ b/lib/src/features/workbench/presentation/workspace_git_diff_panel_toolbar.dart
@@ -84,7 +84,7 @@ class _SourceControlToolbar extends StatelessWidget {
                   style: Theme.of(context).textTheme.titleSmall,
                 ),
               ),
-              Flexible(
+              Expanded(
                 child: SingleChildScrollView(
                   scrollDirection: Axis.horizontal,
                   reverse: true,
@@ -188,16 +188,17 @@ class _SourceControlToolbar extends StatelessWidget {
           ),
           const SizedBox(height: AleraTokens.space8),
           Row(
-            mainAxisAlignment: MainAxisAlignment.end,
             children: <Widget>[
-              _PrimaryActionButton(
-                action: primaryAction,
-                state: data,
-                busy: busy,
-                onPressed: primaryAction == null
-                    ? null
-                    : () => onPrimaryAction(primaryAction),
-                onSelected: onSelectMenuAction,
+              Expanded(
+                child: _PrimaryActionButton(
+                  action: primaryAction,
+                  state: data,
+                  busy: busy,
+                  onPressed: primaryAction == null
+                      ? null
+                      : () => onPrimaryAction(primaryAction),
+                  onSelected: onSelectMenuAction,
+                ),
               ),
             ],
           ),
@@ -444,19 +445,14 @@ class _PrimaryActionButton extends StatelessWidget {
             child: SizedBox(
               height: _height,
               child: Row(
-                mainAxisSize: MainAxisSize.min,
                 children: <Widget>[
-                  ConstrainedBox(
-                    constraints: const BoxConstraints(minHeight: _height),
+                  Expanded(
                     child: InkWell(
                       mouseCursor: enabled
                           ? SystemMouseCursors.click
                           : SystemMouseCursors.basic,
                       onTap: enabled ? onPressed : null,
-                      child: Padding(
-                        padding: const EdgeInsets.symmetric(
-                          horizontal: AleraTokens.space12,
-                        ),
+                      child: Center(
                         child: Row(
                           mainAxisSize: MainAxisSize.min,
                           children: <Widget>[

--- a/test/widget/workspace_git_diff_panel_test.dart
+++ b/test/widget/workspace_git_diff_panel_test.dart
@@ -746,7 +746,7 @@ void main() {
     },
   );
 
-  testWidgets('primary source control action is compact and clickable', (
+  testWidgets('source control actions align with the content edges', (
     tester,
   ) async {
     final backend = FakeGitBackend()
@@ -775,9 +775,12 @@ void main() {
     );
     expect(splitButton, findsOneWidget);
     final splitButtonRect = tester.getRect(splitButton);
+    final messageFieldRect = tester.getRect(_messageField());
+    final refreshRect = tester.getRect(find.byTooltip('Refresh'));
     expect(splitButtonRect.height, 28);
-    expect(splitButtonRect.right, closeTo(412, 0.1));
-    expect(splitButtonRect.width, lessThan(240));
+    expect(splitButtonRect.left, closeTo(messageFieldRect.left, 0.1));
+    expect(splitButtonRect.right, closeTo(messageFieldRect.right, 0.1));
+    expect(refreshRect.right, closeTo(messageFieldRect.right, 0.1));
 
     final primaryAction = find.ancestor(
       of: find.text('Stage All'),


### PR DESCRIPTION
## Summary

- restore the full-width Source Control primary action button
- align the top action group flush with the right content edge
- cover both layout contracts with widget geometry assertions

## Validation

- `dart format --output=none --set-exit-if-changed lib test integration_test tool`
- `dart tool/quality/check_max_lines.dart`
- `flutter analyze`
- `flutter test test/widget/workspace_git_diff_panel_test.dart` (31 tests)

## Notes

- `gh act` could not pass the linked-worktree submodule setup step (`fatal: not a git repository: (null)`), so hosted checks remain authoritative.