### PR TITLE
feat: expand dictation controls

### DIFF
--- a/lib/src/design_system/forms/alera_composer.dart
+++ b/lib/src/design_system/forms/alera_composer.dart
@@ -19,7 +19,7 @@ class AleraComposer extends StatefulWidget {
     this.onPaste,
     this.attachmentBar,
     this.footer,
-    this.leadingAction,
+    this.trailingAction,
     this.hasAttachments = false,
     this.enabled = true,
     this.hintText = 'Write a prompt for this terminal',
@@ -39,7 +39,7 @@ class AleraComposer extends StatefulWidget {
   final Future<bool> Function()? onPaste;
   final Widget? attachmentBar;
   final Widget? footer;
-  final Widget? leadingAction;
+  final Widget? trailingAction;
   final bool hasAttachments;
   final bool enabled;
   final String hintText;
@@ -194,9 +194,6 @@ class _AleraComposerState extends State<AleraComposer> {
                         child: Row(
                           mainAxisSize: MainAxisSize.min,
                           children: <Widget>[
-                            ?widget.leadingAction,
-                            if (widget.leadingAction != null)
-                              const SizedBox(width: AleraTokens.space4),
                             _TextActionsMenu(
                               actions: widget.textActions,
                               enabled: textActionsEnabled,
@@ -207,6 +204,9 @@ class _AleraComposerState extends State<AleraComposer> {
                       ),
                     ),
                     const SizedBox(width: AleraTokens.space8),
+                    ?widget.trailingAction,
+                    if (widget.trailingAction != null)
+                      const SizedBox(width: AleraTokens.space4),
                     AleraIconButton(
                       key: const ValueKey<String>('composer-send-button'),
                       tooltip: 'Send Prompt',

--- a/lib/src/features/ai_dictation/presentation/ai_dictation_control.dart
+++ b/lib/src/features/ai_dictation/presentation/ai_dictation_control.dart
@@ -10,9 +10,14 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 class AiDictationControl extends StatelessWidget {
-  const AiDictationControl({super.key, required this.targetId});
+  const AiDictationControl({
+    super.key,
+    required this.targetId,
+    this.enabled = true,
+  });
 
   final String targetId;
+  final bool enabled;
 
   @override
   Widget build(BuildContext context) {
@@ -40,8 +45,10 @@ class AiDictationControl extends StatelessWidget {
               ? AleraTokens.onAccent
               : AleraTokens.foregroundMuted,
           backgroundColor: active ? AleraTokens.accent : null,
-          borderColor: active ? AleraTokens.accent : AleraTokens.border,
-          onPressed: busy ? null : () => unawaited(_toggle(service, active)),
+          borderRadius: AleraTokens.radiusPill,
+          onPressed: busy || !enabled
+              ? null
+              : () => unawaited(_toggle(service, active)),
         );
       },
     );

--- a/lib/src/features/ai_dictation/presentation/ai_dictation_field_overlay.dart
+++ b/lib/src/features/ai_dictation/presentation/ai_dictation_field_overlay.dart
@@ -1,0 +1,46 @@
+import 'package:alera/src/app/theme/alera_tokens.dart';
+import 'package:alera/src/features/ai_dictation/presentation/ai_dictation_control.dart';
+import 'package:alera/src/features/ai_dictation/presentation/ai_dictation_target.dart';
+import 'package:flutter/material.dart';
+
+class AiDictationFieldOverlay extends StatelessWidget {
+  const AiDictationFieldOverlay({
+    super.key,
+    required this.controller,
+    required this.focusNode,
+    required this.child,
+    this.initialPrompt,
+    this.controlKey,
+    this.enabled = true,
+  });
+
+  final TextEditingController controller;
+  final FocusNode focusNode;
+  final Widget child;
+  final String? initialPrompt;
+  final Key? controlKey;
+  final bool enabled;
+
+  @override
+  Widget build(BuildContext context) {
+    return AiDictationTarget(
+      controller: controller,
+      focusNode: focusNode,
+      initialPrompt: initialPrompt,
+      builder: (context, targetId) => Stack(
+        children: <Widget>[
+          child,
+          Positioned(
+            top: AleraTokens.space8,
+            right: AleraTokens.space8,
+            child: AiDictationControl(
+              key: controlKey,
+              targetId: targetId,
+              enabled: enabled,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/src/features/codex_chat/presentation/codex_chat_surface_composer.dart
+++ b/lib/src/features/codex_chat/presentation/codex_chat_surface_composer.dart
@@ -285,8 +285,6 @@ class _CodexComposerState extends State<_CodexComposer> {
                                     'codex-composer-controls-row',
                                   ),
                                   children: <Widget>[
-                                    AiDictationControl(targetId: targetId),
-                                    const SizedBox(width: AleraTokens.space6),
                                     Expanded(
                                       child: SingleChildScrollView(
                                         scrollDirection: Axis.horizontal,
@@ -346,6 +344,13 @@ class _CodexComposerState extends State<_CodexComposer> {
                                           ],
                                         ),
                                       ),
+                                    ),
+                                    const SizedBox(width: AleraTokens.space2),
+                                    AiDictationControl(
+                                      key: const ValueKey<String>(
+                                        'codex-dictation-control',
+                                      ),
+                                      targetId: targetId,
                                     ),
                                     const SizedBox(width: AleraTokens.space2),
                                     _buildActionButton(canSubmit: canSubmit),

--- a/lib/src/features/pull_requests/presentation/pull_request_composer.dart
+++ b/lib/src/features/pull_requests/presentation/pull_request_composer.dart
@@ -10,6 +10,7 @@ import 'package:alera/src/features/ai_text_generation/application/ai_text_genera
 import 'package:alera/src/features/ai_text_generation/application/ai_text_generation_providers.dart';
 import 'package:alera/src/features/ai_text_generation/application/ai_text_generation_service.dart';
 import 'package:alera/src/features/ai_text_generation/domain/ai_text_generation_settings.dart';
+import 'package:alera/src/features/ai_dictation/presentation/ai_dictation_field_overlay.dart';
 import 'package:alera/src/features/pull_requests/domain/hosted_review.dart';
 import 'package:alera/src/features/pull_requests/presentation/pull_request_field_decoration.dart';
 import 'package:alera/src/features/pull_requests/presentation/pull_request_link_form.dart';
@@ -19,6 +20,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 part 'pull_request_composer_actions.dart';
+part 'pull_request_composer_form.dart';
 
 /// User-entered result of the inline create-pull-request form.
 class CreateReviewDraft {
@@ -76,6 +78,8 @@ class _PullRequestComposerState extends ConsumerState<PullRequestComposer> {
   late final TextEditingController _titleController;
   late final TextEditingController _bodyController;
   late final TextEditingController _linkController;
+  late final FocusNode _titleFocusNode;
+  late final FocusNode _bodyFocusNode;
   late String _baseBranch;
   String? _errorText;
   bool _generating = false;
@@ -90,6 +94,8 @@ class _PullRequestComposerState extends ConsumerState<PullRequestComposer> {
     _titleController = TextEditingController(text: widget.headBranch ?? '');
     _bodyController = TextEditingController();
     _linkController = TextEditingController();
+    _titleFocusNode = FocusNode();
+    _bodyFocusNode = FocusNode();
     _baseBranch = _resolveBaseBranch(widget.suggestedBaseBranch);
   }
 
@@ -126,6 +132,8 @@ class _PullRequestComposerState extends ConsumerState<PullRequestComposer> {
     _titleController.dispose();
     _bodyController.dispose();
     _linkController.dispose();
+    _titleFocusNode.dispose();
+    _bodyFocusNode.dispose();
     super.dispose();
   }
 
@@ -288,6 +296,8 @@ class _PullRequestComposerState extends ConsumerState<PullRequestComposer> {
     );
   }
 
+  void _update(VoidCallback callback) => setState(callback);
+
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
@@ -380,102 +390,6 @@ class _PullRequestComposerState extends ConsumerState<PullRequestComposer> {
           ],
         ],
       ),
-    );
-  }
-
-  Widget _buildCreateForm(ThemeData theme, {required bool aiEnabled}) {
-    final enabled = !widget.busy && widget.canCreate && !_generating;
-    final canGenerate =
-        aiEnabled && widget.canCreate && !widget.busy && !_generating;
-    final titleField = TextField(
-      controller: _titleController,
-      contextMenuBuilder: AleraTextActionsScope.buildContextMenu,
-      enabled: enabled,
-      style: theme.textTheme.bodySmall?.copyWith(color: AleraTokens.foreground),
-      cursorColor: AleraTokens.foreground,
-      decoration: pullRequestFieldDecoration(theme, hint: 'Title'),
-      onChanged: (_) {
-        if (_errorText != null) {
-          setState(() => _errorText = null);
-        }
-      },
-    );
-    final descriptionField = TextField(
-      controller: _bodyController,
-      contextMenuBuilder: AleraTextActionsScope.buildContextMenu,
-      enabled: enabled,
-      minLines: 3,
-      maxLines: 20,
-      style: theme.textTheme.bodySmall?.copyWith(color: AleraTokens.foreground),
-      cursorColor: AleraTokens.foreground,
-      decoration: pullRequestFieldDecoration(theme, hint: 'Description'),
-    );
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: <Widget>[
-        AleraDropdownField<String>(
-          labelText: 'Base Branch',
-          value: _baseBranch,
-          enabled: enabled,
-          entries: _baseEntries,
-          onChanged: (value) {
-            setState(() {
-              _baseBranch = value;
-              _errorText = null;
-            });
-          },
-        ),
-        const SizedBox(height: AleraTokens.space12),
-        Row(
-          children: <Widget>[
-            Expanded(
-              child: Text(
-                'Title',
-                style: theme.textTheme.labelSmall?.copyWith(
-                  color: AleraTokens.foregroundMuted,
-                ),
-              ),
-            ),
-            if (aiEnabled || _generating)
-              _AiPullRequestButton(
-                generating: _generating,
-                canGenerate: canGenerate,
-                onGenerate: () => unawaited(_generateDetails()),
-                onCancel: _cancelGenerate,
-              ),
-          ],
-        ),
-        const SizedBox(height: AleraTokens.space4),
-        if (_generating) _AiDimmedBlock(child: titleField) else titleField,
-        const SizedBox(height: AleraTokens.space12),
-        _labeledField(
-          theme,
-          label: 'Description',
-          child: _generating
-              ? _AiGeneratingOverlay(child: descriptionField)
-              : descriptionField,
-        ),
-      ],
-    );
-  }
-
-  Widget _labeledField(
-    ThemeData theme, {
-    required String label,
-    required Widget child,
-  }) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: <Widget>[
-        Text(
-          label,
-          style: theme.textTheme.labelSmall?.copyWith(
-            color: AleraTokens.foregroundMuted,
-          ),
-        ),
-        const SizedBox(height: AleraTokens.space4),
-        child,
-      ],
     );
   }
 }

--- a/lib/src/features/pull_requests/presentation/pull_request_composer_form.dart
+++ b/lib/src/features/pull_requests/presentation/pull_request_composer_form.dart
@@ -1,0 +1,134 @@
+part of 'pull_request_composer.dart';
+
+extension _PullRequestComposerForm on _PullRequestComposerState {
+  Widget _buildCreateForm(ThemeData theme, {required bool aiEnabled}) {
+    final enabled = !widget.busy && widget.canCreate && !_generating;
+    final canGenerate =
+        aiEnabled && widget.canCreate && !widget.busy && !_generating;
+    final titleField = TextField(
+      key: const ValueKey<String>('pull-request-title-field'),
+      controller: _titleController,
+      focusNode: _titleFocusNode,
+      contextMenuBuilder: AleraTextActionsScope.buildContextMenu,
+      enabled: enabled,
+      style: theme.textTheme.bodySmall?.copyWith(color: AleraTokens.foreground),
+      cursorColor: AleraTokens.foreground,
+      decoration: pullRequestFieldDecoration(
+        theme,
+        hint: 'Title',
+        hasTrailingControl: true,
+      ),
+      onChanged: (_) {
+        if (_errorText != null) {
+          _update(() => _errorText = null);
+        }
+      },
+    );
+    final descriptionField = TextField(
+      key: const ValueKey<String>('pull-request-description-field'),
+      controller: _bodyController,
+      focusNode: _bodyFocusNode,
+      contextMenuBuilder: AleraTextActionsScope.buildContextMenu,
+      enabled: enabled,
+      minLines: 3,
+      maxLines: 20,
+      style: theme.textTheme.bodySmall?.copyWith(color: AleraTokens.foreground),
+      cursorColor: AleraTokens.foreground,
+      decoration: pullRequestFieldDecoration(
+        theme,
+        hint: 'Description',
+        hasTrailingControl: true,
+      ),
+    );
+    final titleWithDictation = AiDictationFieldOverlay(
+      controller: _titleController,
+      focusNode: _titleFocusNode,
+      initialPrompt: 'The user is writing a pull request title.',
+      controlKey: const ValueKey<String>(
+        'pull-request-title-dictation-control',
+      ),
+      enabled: enabled,
+      child: titleField,
+    );
+    final descriptionWithDictation = AiDictationFieldOverlay(
+      controller: _bodyController,
+      focusNode: _bodyFocusNode,
+      initialPrompt: 'The user is writing a pull request description.',
+      controlKey: const ValueKey<String>(
+        'pull-request-description-dictation-control',
+      ),
+      enabled: enabled,
+      child: descriptionField,
+    );
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: <Widget>[
+        AleraDropdownField<String>(
+          labelText: 'Base Branch',
+          value: _baseBranch,
+          enabled: enabled,
+          entries: _baseEntries,
+          onChanged: (value) {
+            _update(() {
+              _baseBranch = value;
+              _errorText = null;
+            });
+          },
+        ),
+        const SizedBox(height: AleraTokens.space12),
+        Row(
+          children: <Widget>[
+            Expanded(
+              child: Text(
+                'Title',
+                style: theme.textTheme.labelSmall?.copyWith(
+                  color: AleraTokens.foregroundMuted,
+                ),
+              ),
+            ),
+            if (aiEnabled || _generating)
+              _AiPullRequestButton(
+                generating: _generating,
+                canGenerate: canGenerate,
+                onGenerate: () => unawaited(_generateDetails()),
+                onCancel: _cancelGenerate,
+              ),
+          ],
+        ),
+        const SizedBox(height: AleraTokens.space4),
+        if (_generating)
+          _AiDimmedBlock(child: titleWithDictation)
+        else
+          titleWithDictation,
+        const SizedBox(height: AleraTokens.space12),
+        _labeledField(
+          theme,
+          label: 'Description',
+          child: _generating
+              ? _AiGeneratingOverlay(child: descriptionWithDictation)
+              : descriptionWithDictation,
+        ),
+      ],
+    );
+  }
+
+  Widget _labeledField(
+    ThemeData theme, {
+    required String label,
+    required Widget child,
+  }) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        Text(
+          label,
+          style: theme.textTheme.labelSmall?.copyWith(
+            color: AleraTokens.foregroundMuted,
+          ),
+        ),
+        const SizedBox(height: AleraTokens.space4),
+        child,
+      ],
+    );
+  }
+}

--- a/lib/src/features/pull_requests/presentation/pull_request_field_decoration.dart
+++ b/lib/src/features/pull_requests/presentation/pull_request_field_decoration.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 InputDecoration pullRequestFieldDecoration(
   ThemeData theme, {
   required String hint,
+  bool hasTrailingControl = false,
 }) {
   return InputDecoration(
     isDense: true,
@@ -15,6 +16,13 @@ InputDecoration pullRequestFieldDecoration(
     hintStyle: theme.textTheme.bodySmall?.copyWith(
       color: AleraTokens.foregroundFaint,
     ),
-    contentPadding: const EdgeInsets.all(AleraTokens.space12),
+    contentPadding: hasTrailingControl
+        ? const EdgeInsets.fromLTRB(
+            AleraTokens.space12,
+            AleraTokens.space12,
+            AleraTokens.space48,
+            AleraTokens.space12,
+          )
+        : const EdgeInsets.all(AleraTokens.space12),
   );
 }

--- a/lib/src/features/workbench/presentation/prompt_workspace_dialog.dart
+++ b/lib/src/features/workbench/presentation/prompt_workspace_dialog.dart
@@ -16,8 +16,7 @@ import 'package:alera/src/features/workbench/domain/workspace_parent_selection_o
 import 'package:alera/src/features/workbench/domain/terminal_image_paste.dart';
 import 'package:alera/src/features/workbench/infra/prompt_workspace_clipboard.dart';
 import 'package:alera/src/features/workbench/infra/prompt_workspace_runtime_client.dart';
-import 'package:alera/src/features/ai_dictation/presentation/ai_dictation_control.dart';
-import 'package:alera/src/features/ai_dictation/presentation/ai_dictation_target.dart';
+import 'package:alera/src/features/ai_dictation/presentation/ai_dictation_field_overlay.dart';
 import 'package:flutter/material.dart';
 import 'package:uuid/uuid.dart';
 

--- a/lib/src/features/workbench/presentation/prompt_workspace_dialog_form.dart
+++ b/lib/src/features/workbench/presentation/prompt_workspace_dialog_form.dart
@@ -9,12 +9,16 @@ extension _PromptWorkspaceDialogForm on _PromptWorkspaceDialogState {
           mainAxisSize: MainAxisSize.min,
           crossAxisAlignment: CrossAxisAlignment.start,
           children: <Widget>[
-            AiDictationTarget(
+            AiDictationFieldOverlay(
               controller: _promptController,
               focusNode: _promptFocusNode,
               initialPrompt:
                   'The user is describing a software task for Alera.',
-              builder: (context, targetId) => AleraTextField(
+              controlKey: const ValueKey<String>(
+                'prompt-workspace-dictation-control',
+              ),
+              enabled: !_working && created == null,
+              child: AleraTextField(
                 controller: _promptController,
                 focusNode: _promptFocusNode,
                 labelText: 'Initial Prompt',
@@ -25,7 +29,7 @@ extension _PromptWorkspaceDialogForm on _PromptWorkspaceDialogState {
                 autofocus: true,
                 enabled: !_working && created == null,
                 onPaste: _pastePromptClipboard,
-                suffix: AiDictationControl(targetId: targetId),
+                suffix: const SizedBox(width: AleraTokens.space32),
               ),
             ),
             const SizedBox(height: AleraTokens.space16),

--- a/lib/src/features/workbench/presentation/terminal_composer.dart
+++ b/lib/src/features/workbench/presentation/terminal_composer.dart
@@ -59,7 +59,10 @@ class TerminalComposer extends StatelessWidget {
             }
           },
           onPaste: _pasteClipboard,
-          leadingAction: AiDictationControl(targetId: targetId),
+          trailingAction: AiDictationControl(
+            key: const ValueKey<String>('terminal-composer-dictation-control'),
+            targetId: targetId,
+          ),
           onSend: () => unawaited(_send(context)),
           onClose: composer.hide,
         ),

--- a/lib/src/features/workbench/presentation/workspace_git_diff_panel.dart
+++ b/lib/src/features/workbench/presentation/workspace_git_diff_panel.dart
@@ -11,6 +11,7 @@ import 'package:alera/src/design_system/layout/alera_confirm_dialog.dart';
 import 'package:alera/src/design_system/layout/alera_dialog.dart';
 import 'package:alera/src/design_system/menus/alera_dropdown_entry.dart';
 import 'package:alera/src/design_system/surfaces/hover_container.dart';
+import 'package:alera/src/features/ai_dictation/presentation/ai_dictation_field_overlay.dart';
 import 'package:alera/src/features/ai_text_generation/application/ai_text_generation_providers.dart';
 import 'package:alera/src/features/ai_text_generation/application/ai_text_generation_service.dart';
 import 'package:alera/src/features/ai_text_generation/domain/ai_text_generation_settings.dart';
@@ -75,6 +76,7 @@ class WorkspaceGitDiffPanel extends ConsumerStatefulWidget {
 
 class _WorkspaceGitDiffPanelState extends ConsumerState<WorkspaceGitDiffPanel> {
   final TextEditingController _messageController = TextEditingController();
+  final FocusNode _messageFocusNode = FocusNode();
   final TextEditingController _filterController = TextEditingController();
   final Set<String> _collapsedSections = <String>{};
   final Set<String> _collapsedTreeNodes = <String>{};
@@ -132,6 +134,7 @@ class _WorkspaceGitDiffPanelState extends ConsumerState<WorkspaceGitDiffPanel> {
     );
     _commitMessageGenerationId += 1;
     _messageController.dispose();
+    _messageFocusNode.dispose();
     _filterController.dispose();
     super.dispose();
   }
@@ -163,6 +166,7 @@ class _WorkspaceGitDiffPanelState extends ConsumerState<WorkspaceGitDiffPanel> {
       children: <Widget>[
         _SourceControlToolbar(
           messageController: _messageController,
+          messageFocusNode: _messageFocusNode,
           filterController: _filterController,
           viewMode: widget.viewMode,
           groupMode: widget.groupMode,

--- a/lib/src/features/workbench/presentation/workspace_git_diff_panel_commit_message_field.dart
+++ b/lib/src/features/workbench/presentation/workspace_git_diff_panel_commit_message_field.dart
@@ -3,6 +3,7 @@ part of 'workspace_git_diff_panel.dart';
 class _CommitMessageField extends StatelessWidget {
   const _CommitMessageField({
     required this.controller,
+    required this.focusNode,
     required this.enabled,
     required this.generating,
     required this.onChanged,
@@ -10,6 +11,7 @@ class _CommitMessageField extends StatelessWidget {
   });
 
   final TextEditingController controller;
+  final FocusNode focusNode;
   final bool enabled;
   final bool generating;
   final ValueChanged<String> onChanged;
@@ -19,7 +21,9 @@ class _CommitMessageField extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final field = TextField(
+      key: const ValueKey<String>('source-control-message-field'),
       controller: controller,
+      focusNode: focusNode,
       contextMenuBuilder: AleraTextActionsScope.buildContextMenu,
       enabled: enabled && !generating,
       minLines: 3,
@@ -39,7 +43,7 @@ class _CommitMessageField extends StatelessWidget {
         contentPadding: const EdgeInsets.fromLTRB(
           AleraTokens.space8,
           AleraTokens.space16,
-          AleraTokens.space8,
+          AleraTokens.space48,
           AleraTokens.space8,
         ),
         border: _messageBorder(AleraTokens.borderSubtle),
@@ -48,7 +52,15 @@ class _CommitMessageField extends StatelessWidget {
       ),
     );
     if (!generating) {
-      return field;
+      return AiDictationFieldOverlay(
+        controller: controller,
+        focusNode: focusNode,
+        initialPrompt:
+            'The user is writing a Git commit message for staged changes.',
+        controlKey: const ValueKey<String>('source-control-dictation-control'),
+        enabled: enabled,
+        child: field,
+      );
     }
     return Stack(
       children: <Widget>[

--- a/lib/src/features/workbench/presentation/workspace_git_diff_panel_toolbar.dart
+++ b/lib/src/features/workbench/presentation/workspace_git_diff_panel_toolbar.dart
@@ -3,6 +3,7 @@ part of 'workspace_git_diff_panel.dart';
 class _SourceControlToolbar extends StatelessWidget {
   const _SourceControlToolbar({
     required this.messageController,
+    required this.messageFocusNode,
     required this.filterController,
     required this.viewMode,
     required this.groupMode,
@@ -28,6 +29,7 @@ class _SourceControlToolbar extends StatelessWidget {
   });
 
   final TextEditingController messageController;
+  final FocusNode messageFocusNode;
   final TextEditingController filterController;
   final GitDiffViewMode viewMode;
   final GitDiffGroupMode groupMode;
@@ -177,6 +179,7 @@ class _SourceControlToolbar extends StatelessWidget {
           const SizedBox(height: AleraTokens.space8),
           _CommitMessageField(
             controller: messageController,
+            focusNode: messageFocusNode,
             enabled: !busy,
             generating: generatingCommitMessage,
             onChanged: (_) => onMessageChanged(),

--- a/test/widget/codex_chat_surface_test.dart
+++ b/test/widget/codex_chat_surface_test.dart
@@ -308,6 +308,9 @@ void main() {
     final sendButton = tester.getRect(
       find.byKey(const ValueKey<String>('composer-action-button')),
     );
+    final dictationControl = tester.getRect(
+      find.byKey(const ValueKey<String>('codex-dictation-control')),
+    );
     final contextIndicator = tester.getRect(
       find.byWidgetPredicate(
         (widget) => widget is CircularProgressIndicator && widget.value == 0.1,
@@ -319,6 +322,15 @@ void main() {
     expect(
       composerShell.right - sendButton.right,
       lessThanOrEqualTo(AleraTokens.space12),
+    );
+    expect(dictationControl.right, lessThanOrEqualTo(sendButton.left));
+    expect(
+      sendButton.left - dictationControl.right,
+      lessThanOrEqualTo(AleraTokens.space4),
+    );
+    expect(
+      (dictationControl.center.dy - sendButton.center.dy).abs(),
+      lessThanOrEqualTo(AleraTokens.space2),
     );
     expect(
       modelConfiguration.left - contextIndicator.right,

--- a/test/widget/prompt_workspace_dialog_test.dart
+++ b/test/widget/prompt_workspace_dialog_test.dart
@@ -7,11 +7,16 @@ import 'package:alera/src/features/workbench/infra/prompt_workspace_runtime_clie
 import 'package:alera/src/features/workbench/presentation/prompt_workspace_dialog.dart';
 import 'package:alera/src/design_system/forms/alera_dropdown_field.dart';
 import 'package:alera/src/design_system/forms/alera_text_field.dart';
+import 'package:alera/src/app/theme/alera_tokens.dart';
+import 'package:alera/src/features/settings/application/settings_controller.dart';
+import 'package:alera/src/features/settings/domain/alera_settings.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 part 'prompt_workspace_dialog_clipboard_test_cases.dart';
+part 'prompt_workspace_dialog_test_support.dart';
 
 void main() {
   _registerPromptWorkspaceClipboardTests();
@@ -38,79 +43,86 @@ void main() {
     String? launchedProfileId;
 
     await tester.pumpWidget(
-      MaterialApp(
-        home: Builder(
-          builder: (context) => Scaffold(
-            body: FilledButton(
-              onPressed: () async {
-                dialogResult = await showDialog<PromptWorkspaceDialogResult>(
-                  context: context,
-                  builder: (_) => PromptWorkspaceDialog(
-                    projects: <Project>[project],
-                    agentProfiles: <AgentProfile>[profile, preferredProfile],
-                    defaultAgentProfileId: preferredProfile.id,
-                    loadBranches: (_) async => <String>['main'],
-                    checkBranchExists: (_, _) async => false,
-                    workspaceBranches: (_) => const <String>{},
-                    parentWorkspaces: const <Workspace>[],
-                    generateIdentity:
-                        ({
-                          required operationId,
-                          required projectId,
-                          required prompt,
-                        }) async {
-                          generatedPrompt = prompt;
-                          return const GeneratedWorkspaceIdentity(
-                            workspaceName: 'Prompt Workspace',
-                            branchName: 'feat/prompt-workspace',
-                          );
-                        },
-                    cancelGeneration: (_) async {},
-                    createWorkspace:
-                        ({
-                          required project,
-                          required sourceBranch,
-                          required newBranchName,
-                          required name,
-                          parentWorkspaceId,
-                        }) async {
-                          createdBranch = newBranchName;
-                          createdName = name;
-                          createdParentWorkspaceId = parentWorkspaceId;
-                          return WorkspaceCreationResult(
-                            workspace: Workspace(
-                              id: 'workspace-1',
-                              projectId: project.id,
-                              name: name,
-                              branch: newBranchName,
-                              sourceBranch: sourceBranch,
-                              path: '/repo/alera-workspace',
-                              kind: WorkspaceKind.linked,
-                              status: WorkspaceStatus.active,
-                              createdAt: now,
-                              updatedAt: now,
-                            ),
-                            setupReport: WorktreeSetupReport.empty,
-                          );
-                        },
-                    launchAgent:
-                        ({
-                          required workspaceId,
-                          required profileId,
-                          required prompt,
-                        }) async {
-                          launchedPrompt = prompt;
-                          launchedProfileId = profileId;
-                          return AgentProfileLaunchResult(
-                            tabId: 'tab-1',
-                            agentType: preferredProfile.agentType,
-                            profileId: profileId,
-                          );
-                        },
-                  ),
-                );
-              },
-              child: const Text('Open'),
+      ProviderScope(
+        overrides: [
+          settingsControllerProvider.overrideWith(
+            _PromptSettingsController.new,
+          ),
+        ],
+        child: MaterialApp(
+          home: Builder(
+            builder: (context) => Scaffold(
+              body: FilledButton(
+                onPressed: () async {
+                  dialogResult = await showDialog<PromptWorkspaceDialogResult>(
+                    context: context,
+                    builder: (_) => PromptWorkspaceDialog(
+                      projects: <Project>[project],
+                      agentProfiles: <AgentProfile>[profile, preferredProfile],
+                      defaultAgentProfileId: preferredProfile.id,
+                      loadBranches: (_) async => <String>['main'],
+                      checkBranchExists: (_, _) async => false,
+                      workspaceBranches: (_) => const <String>{},
+                      parentWorkspaces: const <Workspace>[],
+                      generateIdentity:
+                          ({
+                            required operationId,
+                            required projectId,
+                            required prompt,
+                          }) async {
+                            generatedPrompt = prompt;
+                            return const GeneratedWorkspaceIdentity(
+                              workspaceName: 'Prompt Workspace',
+                              branchName: 'feat/prompt-workspace',
+                            );
+                          },
+                      cancelGeneration: (_) async {},
+                      createWorkspace:
+                          ({
+                            required project,
+                            required sourceBranch,
+                            required newBranchName,
+                            required name,
+                            parentWorkspaceId,
+                          }) async {
+                            createdBranch = newBranchName;
+                            createdName = name;
+                            createdParentWorkspaceId = parentWorkspaceId;
+                            return WorkspaceCreationResult(
+                              workspace: Workspace(
+                                id: 'workspace-1',
+                                projectId: project.id,
+                                name: name,
+                                branch: newBranchName,
+                                sourceBranch: sourceBranch,
+                                path: '/repo/alera-workspace',
+                                kind: WorkspaceKind.linked,
+                                status: WorkspaceStatus.active,
+                                createdAt: now,
+                                updatedAt: now,
+                              ),
+                              setupReport: WorktreeSetupReport.empty,
+                            );
+                          },
+                      launchAgent:
+                          ({
+                            required workspaceId,
+                            required profileId,
+                            required prompt,
+                          }) async {
+                            launchedPrompt = prompt;
+                            launchedProfileId = profileId;
+                            return AgentProfileLaunchResult(
+                              tabId: 'tab-1',
+                              agentType: preferredProfile.agentType,
+                              profileId: profileId,
+                            );
+                          },
+                    ),
+                  );
+                },
+                child: const Text('Open'),
+              ),
             ),
           ),
         ),
@@ -119,6 +131,20 @@ void main() {
 
     await tester.tap(find.text('Open'));
     await tester.pumpAndSettle();
+    final promptField = tester.getRect(
+      find.widgetWithText(TextField, 'Initial Prompt'),
+    );
+    final dictationControl = tester.getRect(
+      find.byKey(const ValueKey<String>('prompt-workspace-dictation-control')),
+    );
+    expect(
+      dictationControl.top - promptField.top,
+      lessThanOrEqualTo(AleraTokens.space12),
+    );
+    expect(
+      promptField.right - dictationControl.right,
+      lessThanOrEqualTo(AleraTokens.space12),
+    );
     await tester.enterText(
       find.widgetWithText(TextField, 'Initial Prompt'),
       'Build workspace creation',
@@ -442,57 +468,5 @@ void main() {
 
       expect(createdParentWorkspaceId, orcaFeature.id);
     },
-  );
-}
-
-Project _project({
-  required String id,
-  required String name,
-  required DateTime now,
-}) {
-  return Project(
-    id: id,
-    name: name,
-    repoPath: '/repo/${name.toLowerCase()}',
-    createdAt: now,
-    updatedAt: now,
-  );
-}
-
-AgentProfile _profile({
-  required String id,
-  required String name,
-  String agentType = 'codex',
-  String command = 'codex',
-  required DateTime now,
-}) {
-  return AgentProfile(
-    id: id,
-    name: name,
-    agentType: agentType,
-    command: command,
-    createdAt: now,
-    updatedAt: now,
-  );
-}
-
-Workspace _workspace({
-  required String id,
-  required String projectId,
-  required String name,
-  required String branch,
-  required WorkspaceKind kind,
-  required DateTime now,
-}) {
-  return Workspace(
-    id: id,
-    projectId: projectId,
-    name: name,
-    branch: branch,
-    path: '/repo/$projectId/$id',
-    kind: kind,
-    status: WorkspaceStatus.active,
-    createdAt: now,
-    updatedAt: now,
   );
 }

--- a/test/widget/prompt_workspace_dialog_test_support.dart
+++ b/test/widget/prompt_workspace_dialog_test_support.dart
@@ -1,0 +1,58 @@
+part of 'prompt_workspace_dialog_test.dart';
+
+class _PromptSettingsController extends SettingsController {
+  @override
+  AleraSettings build() => AleraSettings.defaults;
+}
+
+Project _project({
+  required String id,
+  required String name,
+  required DateTime now,
+}) {
+  return Project(
+    id: id,
+    name: name,
+    repoPath: '/repo/${name.toLowerCase()}',
+    createdAt: now,
+    updatedAt: now,
+  );
+}
+
+AgentProfile _profile({
+  required String id,
+  required String name,
+  String agentType = 'codex',
+  String command = 'codex',
+  required DateTime now,
+}) {
+  return AgentProfile(
+    id: id,
+    name: name,
+    agentType: agentType,
+    command: command,
+    createdAt: now,
+    updatedAt: now,
+  );
+}
+
+Workspace _workspace({
+  required String id,
+  required String projectId,
+  required String name,
+  required String branch,
+  required WorkspaceKind kind,
+  required DateTime now,
+}) {
+  return Workspace(
+    id: id,
+    projectId: projectId,
+    name: name,
+    branch: branch,
+    path: '/repo/$projectId/$id',
+    kind: kind,
+    status: WorkspaceStatus.active,
+    createdAt: now,
+    updatedAt: now,
+  );
+}

--- a/test/widget/terminal_surface_composer_test_cases.dart
+++ b/test/widget/terminal_surface_composer_test_cases.dart
@@ -21,6 +21,22 @@ void _registerTerminalSurfaceComposerTests() {
     expect(find.byTooltip('Hide Terminal Composer'), findsOneWidget);
     expect(find.text('Text Actions'), findsOneWidget);
 
+    final dictationRect = tester.getRect(
+      find.byKey(const ValueKey<String>('terminal-composer-dictation-control')),
+    );
+    final sendRect = tester.getRect(
+      find.byKey(const ValueKey<String>('composer-send-button')),
+    );
+    expect(dictationRect.right, lessThanOrEqualTo(sendRect.left));
+    expect(
+      sendRect.left - dictationRect.right,
+      lessThanOrEqualTo(AleraTokens.space8),
+    );
+    expect(
+      (dictationRect.center.dy - sendRect.center.dy).abs(),
+      lessThanOrEqualTo(AleraTokens.space2),
+    );
+
     await tester.enterText(find.byType(TextField), 'Review this change');
     await tester.sendKeyEvent(LogicalKeyboardKey.enter);
     await tester.pump();

--- a/test/widget/terminal_surface_test_harness.dart
+++ b/test/widget/terminal_surface_test_harness.dart
@@ -40,9 +40,16 @@ Future<void> _pumpTerminalSurface(
   TerminalSessionHandle session,
 ) async {
   await tester.pumpWidget(
-    MaterialApp(
-      home: Scaffold(
-        body: SizedBox.expand(child: TerminalSurface(session: session)),
+    ProviderScope(
+      overrides: [
+        settingsControllerProvider.overrideWith(
+          () => _FakeSettingsController(AleraSettings.defaults),
+        ),
+      ],
+      child: MaterialApp(
+        home: Scaffold(
+          body: SizedBox.expand(child: TerminalSurface(session: session)),
+        ),
       ),
     ),
   );

--- a/test/widget/workspace_git_diff_panel_test.dart
+++ b/test/widget/workspace_git_diff_panel_test.dart
@@ -1463,9 +1463,21 @@ void main() {
       const EdgeInsets.fromLTRB(
         AleraTokens.space8,
         AleraTokens.space16,
-        AleraTokens.space8,
+        AleraTokens.space48,
         AleraTokens.space8,
       ),
+    );
+    final fieldRect = tester.getRect(_messageField());
+    final dictationRect = tester.getRect(
+      find.byKey(const ValueKey<String>('source-control-dictation-control')),
+    );
+    expect(
+      dictationRect.top - fieldRect.top,
+      lessThanOrEqualTo(AleraTokens.space12),
+    );
+    expect(
+      fieldRect.right - dictationRect.right,
+      lessThanOrEqualTo(AleraTokens.space12),
     );
   });
 

--- a/test/widget/workspace_pull_requests_panel_test.dart
+++ b/test/widget/workspace_pull_requests_panel_test.dart
@@ -8,11 +8,15 @@ import 'package:alera/src/shared/git_hosting/domain/git_hosting_provider.dart';
 import 'package:alera/src/features/pull_requests/domain/hosted_review.dart';
 import 'package:alera/src/features/pull_requests/domain/linked_review.dart';
 import 'package:alera/src/features/pull_requests/presentation/workspace_pull_requests_panel.dart';
+import 'package:alera/src/features/pull_requests/presentation/pull_request_composer.dart';
+import 'package:alera/src/design_system/buttons/alera_icon_button.dart';
+import 'package:alera/src/app/theme/alera_tokens.dart';
 import 'package:alera/src/features/settings/application/settings_controller.dart';
 import 'package:alera/src/features/settings/domain/alera_settings.dart';
 import 'package:alera/src/features/workbench/application/workbench_controller.dart';
 import 'package:alera/src/features/workbench/application/workbench_state.dart';
 import 'package:alera/src/features/workbench/domain/workspace.dart';
+import 'package:alera/src/features/workbench/domain/workbench_view_prefs.dart';
 import 'package:alera/src/shared/infra/git/git_providers.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -38,6 +42,86 @@ class _PanelWorkbenchController extends WorkbenchController {
 }
 
 void main() {
+  testWidgets('places borderless dictation controls in pull request fields', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          gitBackendProvider.overrideWithValue(FakeGitBackend()),
+          settingsControllerProvider.overrideWithValue(AleraSettings.defaults),
+        ],
+        child: MaterialApp(
+          home: Scaffold(
+            body: SizedBox(
+              width: 360,
+              height: 640,
+              child: PullRequestComposer(
+                repoPath: '/repo',
+                headBranch: 'feat/dictation',
+                baseBranches: const <String>['main'],
+                suggestedBaseBranch: 'main',
+                canCreate: true,
+                busy: false,
+                suggestedReview: null,
+                createAction: PullRequestCreateAction.publish,
+                onCreate: (_) {},
+                onLink: (_) {},
+                onCreateActionChanged: (_) {},
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    final titleField = tester.getRect(
+      find.byKey(const ValueKey<String>('pull-request-title-field')),
+    );
+    final titleControl = tester.getRect(
+      find.byKey(
+        const ValueKey<String>('pull-request-title-dictation-control'),
+      ),
+    );
+    final descriptionField = tester.getRect(
+      find.byKey(const ValueKey<String>('pull-request-description-field')),
+    );
+    final descriptionControl = tester.getRect(
+      find.byKey(
+        const ValueKey<String>('pull-request-description-dictation-control'),
+      ),
+    );
+
+    expect(
+      titleField.right - titleControl.right,
+      lessThanOrEqualTo(AleraTokens.space12),
+    );
+    expect(
+      (titleControl.center.dy - titleField.center.dy).abs(),
+      lessThanOrEqualTo(AleraTokens.space4),
+    );
+    expect(
+      descriptionControl.top - descriptionField.top,
+      lessThanOrEqualTo(AleraTokens.space12),
+    );
+    expect(
+      descriptionField.right - descriptionControl.right,
+      lessThanOrEqualTo(AleraTokens.space12),
+    );
+
+    final iconButton = tester.widget<AleraIconButton>(
+      find.descendant(
+        of: find.byKey(
+          const ValueKey<String>('pull-request-description-dictation-control'),
+        ),
+        matching: find.byType(AleraIconButton),
+      ),
+    );
+    expect(iconButton.borderColor, isNull);
+    expect(iconButton.borderRadius, AleraTokens.radiusPill);
+  });
+
   testWidgets('keeps the review visible while Refresh shows loading', (
     tester,
   ) async {


### PR DESCRIPTION
## Summary

- move the Codex Chat and Terminal microphones beside Send/Stop
- use a borderless circular dictation control and place it at the top right of multiline fields
- add dictation to Source Control and pull request title and description fields
- cover the requested positions with geometry-level widget tests

## Validation

- flutter analyze
- flutter test
- dart format --output=none --set-exit-if-changed lib test integration_test tool
- dart tool/quality/check_max_lines.dart
- focused widget suites: 198 tests

## Notes

- local gh act static could not start because the Docker image pull rejected the configured Docker credentials; hosted checks remain authoritative