### PR TITLE
fix: align terminal link utf-16 spans

### DIFF
--- a/lib/src/features/workbench/presentation/terminal_link_resolver.dart
+++ b/lib/src/features/workbench/presentation/terminal_link_resolver.dart
@@ -291,14 +291,18 @@ final class _LogicalTerminalLine {
         if (width < 1 || column + width > segmentEnd) {
           continue;
         }
-        text.writeCharCode(codePoint);
-        spans.add(
-          _CharacterCellSpan(
-            row: currentRow,
-            startX: column,
-            endXExclusive: column + width,
-          ),
+        final span = _CharacterCellSpan(
+          row: currentRow,
+          startX: column,
+          endXExclusive: column + width,
         );
+        text.writeCharCode(codePoint);
+        spans.add(span);
+        // RegExp match offsets use UTF-16 code units, so both halves of an
+        // astral code point must map back to the same terminal cell.
+        if (codePoint > 0xffff) {
+          spans.add(span);
+        }
       }
     }
     return _LogicalTerminalLine(text: text.toString(), spans: spans);

--- a/test/unit/terminal_link_resolver_test.dart
+++ b/test/unit/terminal_link_resolver_test.dart
@@ -77,6 +77,23 @@ void main() {
     expect(link!.uri, Uri.parse(url));
   });
 
+  test('resolves a line-ending url after an astral glyph', () {
+    final terminal = xterm.Terminal();
+    terminal.resize(200, 24);
+    const url = 'https://example.com';
+    terminal.write('${'😀'.padRight(135)}$url');
+
+    final link = resolveVisibleHttpLinkAt(
+      terminal: terminal,
+      offset: const xterm.CellOffset(136, 0),
+    );
+
+    expect(link, isNotNull);
+    expect(link!.uri, Uri.parse(url));
+    expect(link.start, const xterm.CellOffset(135, 0));
+    expect(link.end, const xterm.CellOffset(154, 0));
+  });
+
   test('ignores offsets outside visible urls and trims ] and } suffixes', () {
     final terminal = xterm.Terminal();
     terminal.resize(80, 24);


### PR DESCRIPTION
## Summary

- Align visible terminal URL cell spans with Dart UTF-16 match offsets for astral glyphs.
- Add a regression for a URL whose match ends at the logical line length and previously read span index 153 from 0..152.

## Validation

- dart format --output=none --set-exit-if-changed lib/src/features/workbench/presentation/terminal_link_resolver.dart test/unit/terminal_link_resolver_test.dart
- flutter test test/unit/terminal_link_resolver_test.dart test/unit/xterm_regression_test.dart test/widget/terminal_surface_test.dart
- flutter analyze
- dart run tool/quality/check_max_lines.dart
- git diff --check
- gh act pull_request -W .github/workflows/pr.yml -j static --pull=false reached workflow setup, then hit the linked-worktree emulation error fatal: not a git repository: (null); hosted checks remain authoritative.

## Codex Review Loop

- Promptless branch review: uv run /home/leynier/.agents/skills/codex-review-loop/scripts/run_review.py --base main
- Archived session: 019ff489-d831-7dc2-b753-e212570c35d9
- Result: zero actionable findings. The reviewer confirmed the UTF-16 span mapping preserves terminal cell geometry and all focused validation passed.

## Risk / Notes

- Parser-only change with no generated, native, mobile, or documentation updates required.
- Sentry: https://alera.sentry.io/issues/7660010002/

Fixes ALERA-DESKTOP-APP-A
