### PR TITLE
fix: handle invalid app logger output sinks

### DIFF
--- a/lib/src/shared/infra/logging/app_logger.dart
+++ b/lib/src/shared/infra/logging/app_logger.dart
@@ -23,6 +23,8 @@ abstract final class AppLogger {
   static bool _configured = false;
   static RotatingLogSink? _sink;
   static io.Directory? _directory;
+  static void Function(String) _consoleWriter = _writeToStdout;
+  static bool _consoleAvailable = true;
 
   static RotatingLogSink? get sink => _sink;
   static io.Directory? get logDirectory => _directory;
@@ -35,12 +37,15 @@ abstract final class AppLogger {
   static Future<void> configure({
     Level level = Level.INFO,
     io.Directory? directory,
+    void Function(String)? consoleWriter,
   }) async {
     if (_configured) {
       return;
     }
     _configured = true;
     Logger.root.level = level;
+    _consoleWriter = consoleWriter ?? _writeToStdout;
+    _consoleAvailable = true;
 
     try {
       _directory = directory ?? await _defaultDirectory();
@@ -57,27 +62,55 @@ abstract final class AppLogger {
   }
 
   static void _handleRecord(LogRecord record) {
-    // Plain text so a foreground `flutter run` stays readable, but redacted
-    // like the file: console output gets pasted into bug reports too.
-    io.stdout.writeln(
-      '[${record.level.name}] ${record.loggerName}: '
-      '${redactLogText(record.message)}',
-    );
-    unawaited(
-      _sink?.writeLine(
-            formatLogRecordLine(
-              timestamp: record.time,
-              level: record.level.name,
-              source: 'app',
-              logger: record.loggerName,
-              message: record.message,
-              error: record.error,
-              stackTrace: record.stackTrace,
-            ),
-          ) ??
-          Future<void>.value(),
-    );
+    _writeConsoleRecord(record);
+    _writeFileRecord(record);
   }
+
+  static void _writeConsoleRecord(LogRecord record) {
+    if (!_consoleAvailable) {
+      return;
+    }
+    try {
+      // Plain text so a foreground `flutter run` stays readable, but redacted
+      // like the file: console output gets pasted into bug reports too.
+      _consoleWriter(
+        '[${record.level.name}] ${record.loggerName}: '
+        '${redactLogText(record.message)}',
+      );
+    } on Object {
+      // A GUI process may have no valid stdout handle. Do not report this
+      // through Logger because that would re-enter this listener recursively.
+      _consoleAvailable = false;
+    }
+  }
+
+  static void _writeFileRecord(LogRecord record) {
+    final sink = _sink;
+    if (sink == null) {
+      return;
+    }
+    try {
+      unawaited(
+        sink.writeLine(
+          formatLogRecordLine(
+            timestamp: record.time,
+            level: record.level.name,
+            source: 'app',
+            logger: record.loggerName,
+            message: record.message,
+            error: record.error,
+            stackTrace: record.stackTrace,
+          ),
+        ),
+      );
+    } on Object {
+      // Formatting is part of the sink boundary and must not recurse through
+      // the global error handlers. Asynchronous file errors are caught by the
+      // sink's serialized write queue.
+    }
+  }
+
+  static void _writeToStdout(String line) => io.stdout.writeln(line);
 
   static void setLevel(Level level) => Logger.root.level = level;
 
@@ -97,6 +130,8 @@ abstract final class AppLogger {
     await _sink?.close();
     _sink = null;
     _directory = null;
+    _consoleWriter = _writeToStdout;
+    _consoleAvailable = true;
     _configured = false;
     Logger.root.clearListeners();
   }

--- a/lib/src/shared/infra/logging/app_logger.dart
+++ b/lib/src/shared/infra/logging/app_logger.dart
@@ -25,6 +25,7 @@ abstract final class AppLogger {
   static io.Directory? _directory;
   static void Function(String) _consoleWriter = _writeToStdout;
   static bool _consoleAvailable = true;
+  static int _consoleGeneration = 0;
 
   static RotatingLogSink? get sink => _sink;
   static io.Directory? get logDirectory => _directory;
@@ -38,6 +39,7 @@ abstract final class AppLogger {
     Level level = Level.INFO,
     io.Directory? directory,
     void Function(String)? consoleWriter,
+    Future<void>? consoleDone,
   }) async {
     if (_configured) {
       return;
@@ -46,6 +48,19 @@ abstract final class AppLogger {
     Logger.root.level = level;
     _consoleWriter = consoleWriter ?? _writeToStdout;
     _consoleAvailable = true;
+    final consoleGeneration = ++_consoleGeneration;
+    final consoleCompletion =
+        consoleDone ?? (consoleWriter == null ? io.stdout.done : null);
+    if (consoleCompletion != null) {
+      unawaited(
+        consoleCompletion.then<void>(
+          (_) => _disableConsole(consoleGeneration),
+          onError: (Object _, StackTrace _) {
+            _disableConsole(consoleGeneration);
+          },
+        ),
+      );
+    }
 
     try {
       _directory = directory ?? await _defaultDirectory();
@@ -112,6 +127,12 @@ abstract final class AppLogger {
 
   static void _writeToStdout(String line) => io.stdout.writeln(line);
 
+  static void _disableConsole(int generation) {
+    if (_consoleGeneration == generation) {
+      _consoleAvailable = false;
+    }
+  }
+
   static void setLevel(Level level) => Logger.root.level = level;
 
   /// Records an error that reached a global handler rather than a logger.
@@ -132,6 +153,7 @@ abstract final class AppLogger {
     _directory = null;
     _consoleWriter = _writeToStdout;
     _consoleAvailable = true;
+    _consoleGeneration++;
     _configured = false;
     Logger.root.clearListeners();
   }

--- a/test/unit/app_logger_test.dart
+++ b/test/unit/app_logger_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
@@ -148,6 +149,33 @@ void main() {
         expect(records.last['msg'], 'file sink remains available');
       },
     );
+
+    test('handles asynchronous console sink failures', () async {
+      var consoleWrites = 0;
+      final consoleDone = Completer<void>();
+      await AppLogger.configure(
+        directory: root,
+        consoleWriter: (_) => consoleWrites++,
+        consoleDone: consoleDone.future,
+      );
+
+      Logger('Workbench').info('before console failure');
+      consoleDone.completeError(
+        const FileSystemException(
+          'writeFrom failed',
+          '',
+          OSError('The handle is invalid', 6),
+        ),
+      );
+      await Future<void>.delayed(Duration.zero);
+      Logger('Workbench').info('after console failure');
+
+      final records = await readRecords();
+      expect(consoleWrites, 1);
+      expect(records, hasLength(2));
+      expect(records.first['msg'], 'before console failure');
+      expect(records.last['msg'], 'after console failure');
+    });
 
     test('honors the configured level', () async {
       await AppLogger.configure(level: Level.SEVERE, directory: root);

--- a/test/unit/app_logger_test.dart
+++ b/test/unit/app_logger_test.dart
@@ -115,6 +115,40 @@ void main() {
       expect(records.single['error'], contains('boom'));
     });
 
+    test(
+      'keeps file logging after the console handle becomes invalid',
+      () async {
+        var consoleWrites = 0;
+        await AppLogger.configure(
+          directory: root,
+          consoleWriter: (_) {
+            consoleWrites++;
+            throw const FileSystemException(
+              'writeFrom failed',
+              '',
+              OSError('The handle is invalid', 6),
+            );
+          },
+        );
+
+        expect(
+          () => AppLogger.recordError(
+            StateError('boom'),
+            StackTrace.fromString('#0 zoneFrame'),
+            context: 'Zone',
+          ),
+          returnsNormally,
+        );
+        Logger('Workbench').info('file sink remains available');
+
+        final records = await readRecords();
+        expect(consoleWrites, 1);
+        expect(records, hasLength(2));
+        expect(records.first['logger'], 'Zone');
+        expect(records.last['msg'], 'file sink remains available');
+      },
+    );
+
     test('honors the configured level', () async {
       await AppLogger.configure(level: Level.SEVERE, directory: root);
 


### PR DESCRIPTION
## Summary

- contain synchronous console and file-formatting failures at the AppLogger sink boundary
- consume asynchronous `stdout.done` failures and disable only the invalid console sink so structured file logging continues
- cover the Windows invalid-handle recursion path with synchronous and asynchronous regression tests

## Validation

- `flutter test test/unit/app_logger_test.dart`: 10 tests passed
- `flutter test test/unit/terminal_host_client_test.dart`: 40 tests passed
- hosted test shard 0 command with coverage before the review fix: 774 tests passed
- `dart format --output=none --set-exit-if-changed lib/src/shared/infra/logging/app_logger.dart test/unit/app_logger_test.dart`
- `flutter analyze`
- `dart run tool/quality/check_max_lines.dart`
- promptless `codex review --base main`: zero findings after one P1 fix iteration
- `gh act pull_request -W .github/workflows/pr.yml -j static` reached the workflow but stopped in shared setup with `fatal: not a git repository: (null)` before project checks

## Risk / Notes

- scoped to AppLogger sink delivery; window shutdown sequencing is unchanged
- no generated code or documentation changes are required

Sentry: https://alera.sentry.io/issues/7667045261/

Fixes ALERA-DESKTOP-APP-E
