### PR TITLE
fix: guard mobile skill installs after disposal

### DIFF
--- a/mobile/lib/src/features/settings/application/host_tools_controllers.dart
+++ b/mobile/lib/src/features/settings/application/host_tools_controllers.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:alera_mobile/src/features/runtime/application/host_connection_controller.dart';
 import 'package:alera_mobile/src/features/settings/domain/portable_host_settings.dart';
+import 'package:logging/logging.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'host_tools_controllers.g.dart';
@@ -48,58 +49,100 @@ class SkillInstallState {
 
 @riverpod
 class SkillInstallController extends _$SkillInstallController {
+  final Logger _logger = Logger('SkillInstallController');
   StreamSubscription<Object?>? _subscription;
   String? _operationId;
+  bool _disposed = false;
 
   @override
   SkillInstallState build(String hostId, String skill) {
-    ref.onDispose(() => unawaited(_subscription?.cancel()));
+    ref.onDispose(() {
+      _disposed = true;
+      _operationId = null;
+      unawaited(_cancelSubscription());
+    });
     return const SkillInstallState();
   }
 
   Future<void> install(String runner) async {
-    if (state.phase == 'installing') {
+    if (_disposed || state.phase == 'installing') {
       return;
     }
-    final client = await ref.read(
-      hostConnectionControllerProvider(hostId).future,
-    );
-    if (!client.supportsHostTools) {
-      state = const SkillInstallState(
-        phase: 'failed',
-        message: 'Update the runtime to install skills.',
+    try {
+      final client = await ref.read(
+        hostConnectionControllerProvider(hostId).future,
       );
-      return;
-    }
-    _operationId = '${DateTime.now().microsecondsSinceEpoch}-$skill';
-    await _subscription?.cancel();
-    _subscription = client.events.listen((event) {
-      if (event.name != 'agentSkillInstallProgress' ||
-          event.payload['operationId'] != _operationId) {
+      if (_disposed) {
         return;
       }
-      state = SkillInstallState(
-        phase: event.payload['phase'] as String? ?? 'installing',
-        message: event.payload['message'] as String?,
+      if (!client.supportsHostTools) {
+        state = const SkillInstallState(
+          phase: 'failed',
+          message: 'Update the runtime to install skills.',
+        );
+        return;
+      }
+      final operationId = '${DateTime.now().microsecondsSinceEpoch}-$skill';
+      _operationId = operationId;
+      await _cancelSubscription();
+      if (_disposed || _operationId != operationId) {
+        return;
+      }
+      _subscription = client.events.listen((event) {
+        if (_disposed ||
+            _operationId != operationId ||
+            event.name != 'agentSkillInstallProgress' ||
+            event.payload['operationId'] != operationId) {
+          return;
+        }
+        state = SkillInstallState(
+          phase: event.payload['phase'] as String? ?? 'installing',
+          message: event.payload['message'] as String?,
+        );
+      });
+      state = const SkillInstallState(
+        phase: 'installing',
+        message: 'Installing skill',
       );
-    });
-    state = const SkillInstallState(
-      phase: 'installing',
-      message: 'Installing skill',
-    );
-    try {
       final result = await client.installSkill(
         skill: skill,
         runner: runner,
-        operationId: _operationId,
+        operationId: operationId,
       );
+      if (!result.succeeded) {
+        _logger.warning('skill install failed: ${result.summary}');
+      }
+      if (_disposed || _operationId != operationId) {
+        return;
+      }
       state = SkillInstallState(
         phase: result.succeeded ? 'completed' : 'failed',
         message: result.summary,
         result: result,
       );
-    } on Object catch (error) {
+    } on Object catch (error, stackTrace) {
+      _logger.warning('skill install failed', error, stackTrace);
+      if (_disposed) {
+        return;
+      }
       state = SkillInstallState(phase: 'failed', message: error.toString());
+    }
+  }
+
+  Future<void> _cancelSubscription() async {
+    final subscription = _subscription;
+    _subscription = null;
+    if (subscription == null) {
+      return;
+    }
+    try {
+      await subscription.cancel();
+    } on Object catch (error, stackTrace) {
+      _logger.warning(
+        'skill install progress subscription failed to cancel',
+        error,
+        stackTrace,
+      );
     }
   }
 }

--- a/mobile/lib/src/features/settings/application/host_tools_controllers.g.dart
+++ b/mobile/lib/src/features/settings/application/host_tools_controllers.g.dart
@@ -260,7 +260,7 @@ final class SkillInstallControllerProvider
 }
 
 String _$skillInstallControllerHash() =>
-    r'75493db8dba46381e06b2f7fb9d540b269640b34';
+    r'b135f90d2ddbc8ed8b0eb0235374523acb9e0480';
 
 final class SkillInstallControllerFamily extends $Family
     with

--- a/mobile/test/host_tools_controllers_test.dart
+++ b/mobile/test/host_tools_controllers_test.dart
@@ -1,0 +1,285 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:alera_mobile/src/features/runtime/application/host_connection_controller.dart';
+import 'package:alera_mobile/src/features/runtime/infra/mobile_runtime_client.dart';
+import 'package:alera_mobile/src/features/settings/application/host_tools_controllers.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+void main() {
+  test('Mounted skill install publishes progress and completion', () async {
+    final channel = _SkillInstallChannel();
+    addTearDown(channel.dispose);
+    final client = await _authenticatedClient(channel);
+    final container = _containerFor(client);
+    addTearDown(container.dispose);
+    addTearDown(client.dispose);
+    final provider = skillInstallControllerProvider('host-1', 'cli');
+    final subscription = container.listen(provider, (_, _) {});
+    addTearDown(subscription.close);
+
+    final install = container.read(provider.notifier).install('npx');
+    final request = await channel.installRequest;
+    final operationId = _operationId(request);
+    channel.emitProgress(operationId, 'Preparing install');
+    await pumpEventQueue();
+
+    expect(
+      container.read(provider),
+      isA<SkillInstallState>()
+          .having((value) => value.phase, 'phase', 'installing')
+          .having((value) => value.message, 'message', 'Preparing install'),
+    );
+
+    channel.completeInstall(succeeded: true, summary: 'Skill installed');
+    await install;
+
+    expect(
+      container.read(provider),
+      isA<SkillInstallState>()
+          .having((value) => value.phase, 'phase', 'completed')
+          .having((value) => value.message, 'message', 'Skill installed')
+          .having((value) => value.result?.succeeded, 'succeeded', isTrue),
+    );
+  });
+
+  test('Mounted skill install publishes request errors', () async {
+    final channel = _SkillInstallChannel();
+    addTearDown(channel.dispose);
+    final client = await _authenticatedClient(channel);
+    final container = _containerFor(client);
+    addTearDown(container.dispose);
+    addTearDown(client.dispose);
+    final provider = skillInstallControllerProvider('host-1', 'cli');
+    final subscription = container.listen(provider, (_, _) {});
+    addTearDown(subscription.close);
+
+    final install = container.read(provider.notifier).install('npx');
+    await channel.installRequest;
+    channel.failInstall('Runner failed');
+    await install;
+
+    expect(
+      container.read(provider),
+      isA<SkillInstallState>()
+          .having((value) => value.phase, 'phase', 'failed')
+          .having(
+            (value) => value.message,
+            'message',
+            contains('Runner failed'),
+          ),
+    );
+  });
+
+  test('Completion after disposal does not write provider state', () async {
+    final channel = _SkillInstallChannel();
+    addTearDown(channel.dispose);
+    final client = await _authenticatedClient(channel);
+    final container = _containerFor(client);
+    addTearDown(container.dispose);
+    addTearDown(client.dispose);
+    final provider = skillInstallControllerProvider('host-1', 'cli');
+    final subscription = container.listen(provider, (_, _) {});
+
+    final install = container.read(provider.notifier).install('npx');
+    await channel.installRequest;
+    subscription.close();
+    await pumpEventQueue();
+    expect(container.exists(provider), isFalse);
+
+    channel.completeInstall(succeeded: true, summary: 'Skill installed');
+
+    await expectLater(install, completes);
+  });
+
+  test('Request error after disposal does not write provider state', () async {
+    final channel = _SkillInstallChannel();
+    addTearDown(channel.dispose);
+    final client = await _authenticatedClient(channel);
+    final container = _containerFor(client);
+    addTearDown(container.dispose);
+    addTearDown(client.dispose);
+    final provider = skillInstallControllerProvider('host-1', 'cli');
+    final subscription = container.listen(provider, (_, _) {});
+
+    final install = container.read(provider.notifier).install('npx');
+    final request = await channel.installRequest;
+    subscription.close();
+    await pumpEventQueue();
+    expect(container.exists(provider), isFalse);
+
+    channel.emitProgress(_operationId(request), 'Install still running');
+    channel.failInstall('Runner failed');
+
+    await expectLater(install, completes);
+  });
+}
+
+ProviderContainer _containerFor(MobileRuntimeClient client) {
+  return ProviderContainer(
+    overrides: [
+      hostConnectionControllerProvider.overrideWith2(
+        (_) => _TestHostConnection(client),
+      ),
+    ],
+  );
+}
+
+Future<MobileRuntimeClient> _authenticatedClient(
+  _SkillInstallChannel channel,
+) async {
+  final client = MobileRuntimeClient.forTesting(channel);
+  await client.authenticate(deviceId: 'device-1', deviceToken: 'token-1');
+  return client;
+}
+
+String _operationId(Map<String, Object?> request) {
+  final payload = request['payload']! as Map<String, Object?>;
+  return payload['operationId']! as String;
+}
+
+final class _TestHostConnection extends HostConnectionController {
+  _TestHostConnection(this.client);
+
+  final MobileRuntimeClient client;
+
+  @override
+  Future<MobileRuntimeClient> build(String hostId) async => client;
+}
+
+final class _SkillInstallChannel implements WebSocketChannel {
+  _SkillInstallChannel() {
+    _outgoing.stream.listen(_handleRequest);
+  }
+
+  final StreamController<Object?> _incoming =
+      StreamController<Object?>.broadcast(sync: true);
+  final StreamController<Object?> _outgoing =
+      StreamController<Object?>.broadcast(sync: true);
+  final Completer<Map<String, Object?>> _installRequest =
+      Completer<Map<String, Object?>>();
+  Map<String, Object?>? _pendingInstall;
+
+  Future<Map<String, Object?>> get installRequest => _installRequest.future;
+
+  void _handleRequest(Object? raw) {
+    final request = jsonDecode(raw! as String) as Map<String, Object?>;
+    if (request['type'] == 'mobile.hello') {
+      _respond(request, <String, Object?>{
+        'runtimeCapabilities': <String>[mobileHostToolsCapability],
+      });
+      return;
+    }
+    if (request['type'] == 'agentSkill.install') {
+      _pendingInstall = request;
+      _installRequest.complete(request);
+      return;
+    }
+    _respond(request, const <String, Object?>{});
+  }
+
+  void emitProgress(String operationId, String message) {
+    _incoming.add(
+      jsonEncode(<String, Object?>{
+        'event': 'agentSkillInstallProgress',
+        'payload': <String, Object?>{
+          'operationId': operationId,
+          'phase': 'installing',
+          'message': message,
+        },
+      }),
+    );
+  }
+
+  void completeInstall({required bool succeeded, required String summary}) {
+    _respond(_takePendingInstall(), <String, Object?>{
+      'succeeded': succeeded,
+      'summary': summary,
+    });
+  }
+
+  void failInstall(String message) {
+    final request = _takePendingInstall();
+    _incoming.add(
+      jsonEncode(<String, Object?>{
+        'id': request['id'],
+        'ok': false,
+        'error': message,
+      }),
+    );
+  }
+
+  Map<String, Object?> _takePendingInstall() {
+    final request = _pendingInstall;
+    _pendingInstall = null;
+    if (request == null) {
+      throw StateError('No skill install request is pending.');
+    }
+    return request;
+  }
+
+  void _respond(Map<String, Object?> request, Map<String, Object?> payload) {
+    _incoming.add(
+      jsonEncode(<String, Object?>{
+        'id': request['id'],
+        'ok': true,
+        'payload': payload,
+      }),
+    );
+  }
+
+  Future<void> dispose() async {
+    if (!_incoming.isClosed) {
+      await _incoming.close();
+    }
+    if (!_outgoing.isClosed) {
+      await _outgoing.close();
+    }
+  }
+
+  @override
+  int? get closeCode => null;
+
+  @override
+  String? get closeReason => null;
+
+  @override
+  String? get protocol => null;
+
+  @override
+  Future<void> get ready => Future<void>.value();
+
+  @override
+  Stream<Object?> get stream => _incoming.stream;
+
+  @override
+  late final WebSocketSink sink = _TestWebSocketSink(_outgoing.sink);
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+final class _TestWebSocketSink implements WebSocketSink {
+  _TestWebSocketSink(this._sink);
+
+  final StreamSink<Object?> _sink;
+
+  @override
+  Future<void> get done => _sink.done;
+
+  @override
+  void add(Object? data) => _sink.add(data);
+
+  @override
+  void addError(Object error, [StackTrace? stackTrace]) {
+    _sink.addError(error, stackTrace);
+  }
+
+  @override
+  Future<void> addStream(Stream<Object?> stream) => _sink.addStream(stream);
+
+  @override
+  Future<void> close([int? closeCode, String? closeReason]) => _sink.close();
+}


### PR DESCRIPTION
## Summary

- stop skill install progress and completion callbacks from writing Riverpod state after auto-disposal
- keep mounted progress, completion, and error state behavior while logging install and cancellation failures
- add provider lifecycle regressions for mounted and post-disposal success and error paths

## Validation

- `cd mobile && dart run build_runner build`
- `cd mobile && dart format --set-exit-if-changed lib test`
- `cd mobile && flutter analyze`
- `cd mobile && flutter test test/host_tools_controllers_test.dart`
- `cd mobile && flutter test` (444 tests)
- `dart run tool/quality/check_max_lines.dart`
- `git diff --check`
- `gh act pull_request -W .github/workflows/pr.yml -j mobile` could not start because Docker registry authentication rejected the runner image pull; hosted checks remain authoritative

## Risk / Notes

- mobile-only lifecycle change; the host install continues after UI disposal because the protocol has no cancellation request
- https://alera.sentry.io/issues/7654426492/

Fixes ALERA-MOBILE-APP-4
