### PR TITLE
fix: refresh quota state after action disposal

### DIFF
--- a/lib/src/features/agent_quota/presentation/agent_quota_hover_card.dart
+++ b/lib/src/features/agent_quota/presentation/agent_quota_hover_card.dart
@@ -169,6 +169,9 @@ class _ClaudeTryWithTuiButtonState
       return;
     }
     setState(() => _loading = true);
+    // The hover card can be disposed while the TUI request is in flight. Keep
+    // its longer-lived scope so the cached result still triggers a refresh.
+    final container = ProviderScope.containerOf(context, listen: false);
     try {
       final hostId = widget.hostId;
       final targets = ref.read(sshTargetsProvider).value ?? const <SshTarget>[];
@@ -183,11 +186,10 @@ class _ClaudeTryWithTuiButtonState
             accountId: widget.snapshot.accountId,
             displayName: widget.snapshot.displayName,
           );
-      ref.invalidate(agentQuotaStateProvider);
     } on Object {
       // Status bar refresh / next poll shows the updated error snapshot.
-      ref.invalidate(agentQuotaStateProvider);
     } finally {
+      container.invalidate(agentQuotaStateProvider);
       if (mounted) {
         setState(() => _loading = false);
       }

--- a/test/widget/agent_quota_tui_dispose_test.dart
+++ b/test/widget/agent_quota_tui_dispose_test.dart
@@ -1,0 +1,108 @@
+import 'dart:async';
+
+import 'package:alera/src/app/theme/alera_dark_theme.dart';
+import 'package:alera/src/features/agent_quota/application/agent_quota_providers.dart';
+import 'package:alera/src/features/agent_quota/domain/agent_quota.dart';
+import 'package:alera/src/features/agent_quota/presentation/agent_quota_status_bar.dart';
+import 'package:alera/src/features/remote_hosts/application/ssh_target_providers.dart';
+import 'package:alera/src/features/remote_hosts/domain/ssh_target.dart';
+import 'package:alera/src/features/settings/domain/alera_settings.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('refreshes quotas after the TUI action button is disposed', (
+    tester,
+  ) async {
+    final service = _PendingClaudeTuiService();
+    var quotaBuilds = 0;
+    final container = ProviderContainer(
+      overrides: [
+        agentQuotaServiceProvider.overrideWithValue(service),
+        sshTargetsProvider.overrideWith(
+          (ref) => Stream.value(const <SshTarget>[]),
+        ),
+        agentQuotaStateProvider.overrideWith((ref) async {
+          quotaBuilds += 1;
+          return AgentQuotaState.empty('local');
+        }),
+      ],
+    );
+    addTearDown(container.dispose);
+    final subscription = container.listen(agentQuotaStateProvider, (_, _) {});
+    addTearDown(subscription.close);
+    await container.read(agentQuotaStateProvider.future);
+
+    final snapshot = AgentQuotaSnapshot(
+      provider: AgentQuotaProviderId.claude,
+      accountId: 'dev',
+      displayName: 'Development',
+      status: AgentQuotaStatus.unavailable,
+      updatedAt: DateTime.utc(2026),
+      error: 'OAuth unavailable',
+      windows: const <AgentQuotaWindow>[],
+      buckets: const <AgentQuotaBucket>[],
+    );
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp(
+          theme: buildAleraDarkTheme(),
+          home: Scaffold(
+            body: AgentQuotaStatusBarView(
+              hostId: 'local',
+              snapshots: <AgentQuotaSnapshot>[snapshot],
+              settings: const AgentQuotaHostSettings(
+                enabledProviders: <AgentQuotaProviderId>[
+                  AgentQuotaProviderId.claude,
+                ],
+                claudeProfiles: <ClaudeQuotaProfileSettings>[
+                  ClaudeQuotaProfileSettings(alias: 'ccdev', profile: 'dev'),
+                ],
+              ),
+              onRefresh: () {},
+              onTogglePinned: (_, _) {},
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final mouse = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    addTearDown(mouse.removePointer);
+    await mouse.addPointer(location: Offset.zero);
+    await mouse.moveTo(tester.getCenter(find.text('ccdev')));
+    await tester.pump(const Duration(milliseconds: 400));
+    await tester.tap(find.text('Try With TUI'));
+    await tester.pump();
+    expect(service.callCount, 1);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(container: container, child: const SizedBox()),
+    );
+    service.completion.complete(snapshot);
+    await tester.pump();
+    await container.read(agentQuotaStateProvider.future);
+
+    expect(tester.takeException(), isNull);
+    expect(quotaBuilds, 2);
+  });
+}
+
+class _PendingClaudeTuiService extends Fake implements AgentQuotaService {
+  final completion = Completer<AgentQuotaSnapshot>();
+  var callCount = 0;
+
+  @override
+  Future<AgentQuotaSnapshot> fetchClaudeTui({
+    required String hostId,
+    required SshTarget? target,
+    required String accountId,
+    String? displayName,
+  }) {
+    callCount += 1;
+    return completion.future;
+  }
+}


### PR DESCRIPTION
## Summary
- refresh agent quota state through the enclosing provider container after the Claude TUI action completes
- cover completion after the transient action widget is disposed

## Validation
- `flutter test test/widget/agent_quota_tui_dispose_test.dart test/widget/agent_quota_status_bar_test.dart test/unit/agent_quota_test.dart test/unit/agent_quota_settings_test.dart`
- `dart format --output=none --set-exit-if-changed lib/src/features/agent_quota/presentation/agent_quota_hover_card.dart test/widget/agent_quota_tui_dispose_test.dart`
- `flutter analyze`
- `dart run tool/quality/check_max_lines.dart`
- `gh act pull_request -W .github/workflows/pr.yml -j static` reached the linked-worktree gitdir emulation limitation before project steps

## Risk / Notes
- Low risk: scoped to the Claude quota TUI action lifecycle; no API, generated-code, Rust, mobile, or documentation changes.
- Sentry: https://alera.sentry.io/issues/7665850889/

Fixes ALERA-DESKTOP-APP-C