### PR TITLE
fix: guard dictation model refresh after disposal

### DIFF
--- a/lib/src/features/settings/presentation/panes/ai_dictation_pane.dart
+++ b/lib/src/features/settings/presentation/panes/ai_dictation_pane.dart
@@ -34,6 +34,7 @@ class _AiDictationSettingsPaneState
   }
 
   Future<void> _refreshModelStatus() async {
+    if (!mounted) return;
     final installed = await ref
         .read(aiDictationModelStoreProvider)
         .isInstalled();

--- a/test/widget/ai_dictation_pane_test.dart
+++ b/test/widget/ai_dictation_pane_test.dart
@@ -1,0 +1,143 @@
+import 'dart:async';
+
+import 'package:alera/src/app/theme/alera_dark_theme.dart';
+import 'package:alera/src/features/ai_dictation/application/ai_dictation_providers.dart';
+import 'package:alera/src/features/ai_dictation/domain/ai_dictation_settings.dart';
+import 'package:alera/src/features/ai_dictation/infra/ai_dictation_model_store.dart';
+import 'package:alera/src/features/settings/presentation/panes/ai_dictation_pane.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('download finishing after the pane is closed does not throw', (
+    tester,
+  ) async {
+    final store = _FakeAiDictationModelStore();
+    await _pumpPane(tester, store);
+
+    await tester.tap(find.text('Download Model'));
+    await tester.pump();
+    expect(store.downloadCount, 1);
+
+    await _closePane(tester, store);
+    store.completeDownload();
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('removal finishing after the pane is closed does not throw', (
+    tester,
+  ) async {
+    final store = _FakeAiDictationModelStore(installed: true);
+    await _pumpPane(tester, store);
+
+    await tester.tap(find.text('Remove Model'));
+    await tester.pump();
+    expect(store.removeCount, 1);
+
+    await _closePane(tester, store);
+    store.completeRemove();
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('download finishing while mounted refreshes the model status', (
+    tester,
+  ) async {
+    final store = _FakeAiDictationModelStore();
+    await _pumpPane(tester, store);
+
+    await tester.tap(find.text('Download Model'));
+    await tester.pump();
+    store.completeDownload();
+    await tester.pumpAndSettle();
+
+    expect(find.text('Remove Model'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+}
+
+Future<void> _pumpPane(WidgetTester tester, AiDictationModelStore store) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [aiDictationModelStoreProvider.overrideWithValue(store)],
+      child: MaterialApp(
+        theme: buildAleraDarkTheme(),
+        home: Scaffold(
+          body: SizedBox(
+            width: 1200,
+            height: 1000,
+            child: AiDictationSettingsPane(
+              settings: AiDictationSettings.defaults,
+              onChanged: (_) {},
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+/// Replaces the pane the way closing the settings dialog does, so the pending
+/// model work completes against an unmounted element.
+Future<void> _closePane(
+  WidgetTester tester,
+  AiDictationModelStore store,
+) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [aiDictationModelStoreProvider.overrideWithValue(store)],
+      child: MaterialApp(
+        theme: buildAleraDarkTheme(),
+        home: const Scaffold(body: SizedBox.shrink()),
+      ),
+    ),
+  );
+  await tester.pump();
+}
+
+class _FakeAiDictationModelStore implements AiDictationModelStore {
+  _FakeAiDictationModelStore({this.installed = false});
+
+  final Completer<String> _download = Completer<String>();
+  final Completer<void> _remove = Completer<void>();
+
+  bool installed;
+  int downloadCount = 0;
+  int removeCount = 0;
+
+  void completeDownload() {
+    installed = true;
+    _download.complete('ggml-base.bin');
+  }
+
+  void completeRemove() {
+    installed = false;
+    _remove.complete();
+  }
+
+  @override
+  Future<bool> isInstalled() async => installed;
+
+  @override
+  Future<String> download({void Function(double progress)? onProgress}) {
+    downloadCount++;
+    return _download.future;
+  }
+
+  @override
+  Future<void> remove() {
+    removeCount++;
+    return _remove.future;
+  }
+
+  @override
+  Future<String> modelPath() async => 'ggml-base.bin';
+
+  @override
+  void dispose() {}
+}


### PR DESCRIPTION
## Summary

- Skip model-status refreshes after the AI Dictation settings pane unmounts.
- Add regression coverage for download and removal completion after the pane closes.

## Validation

- flutter test test/widget/ai_dictation_pane_test.dart
- flutter test --exclude-tags golden (3,008 passed)
- flutter analyze
- dart format --output=none --set-exit-if-changed lib test integration_test tool
- dart run tool/quality/check_max_lines.dart
- gh act pull_request -W .github/workflows/pr.yml -j static reached the shared setup action, then hit the linked-worktree emulation error: fatal: not a git repository: (null)

## Risk / Notes

- Lifecycle-only UI change; no generated, protocol, Rust, mobile, or documentation surfaces changed.
- PR #393 also edits the dictation pane, but this PR is limited to lifecycle safety and regression coverage.

Sentry: https://alera.sentry.io/issues/7667045256/

Fixes ALERA-DESKTOP-APP-D