### PR TITLE
fix: recover stale mobile terminal attachments

### DIFF
--- a/mobile/lib/src/features/terminal/application/terminal_session_controller.dart
+++ b/mobile/lib/src/features/terminal/application/terminal_session_controller.dart
@@ -13,9 +13,7 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'terminal_session_controller.g.dart';
 
-/// Raised into the session state when the desktop takes the viewport back
-/// (`terminalDriverChanged` with a desktop driver); the tabs screen reacts by
-/// leaving the terminal.
+/// Raised when a desktop driver takes the terminal viewport back.
 class DesktopReclaimedTerminal implements Exception {
   const DesktopReclaimedTerminal();
 
@@ -23,8 +21,7 @@ class DesktopReclaimedTerminal implements Exception {
   String toString() => 'Desktop took back the terminal';
 }
 
-/// A live attachment to one terminal tab: the session handle, the scrollback
-/// snapshot to replay, and the filtered output stream.
+/// A live terminal attachment with its replay snapshot and filtered output.
 class TerminalTabSession {
   TerminalTabSession({
     required this.sessionId,
@@ -37,12 +34,10 @@ class TerminalTabSession {
   final bool running;
   final _TerminalSnapshotPayload _snapshot;
 
-  /// Carries the full event, not just the bytes, so a resync answer that
-  /// replaces the scrollback stays ordered against the live output around it.
+  /// Carries full events so resync replacement stays ordered with live output.
   final Stream<MobileTerminalOutputEvent> output;
 
-  /// Transfers the one-shot restore payload to the emulator and releases the
-  /// controller's reference so rendered scrollback is not retained twice.
+  /// Transfers restore bytes without retaining rendered scrollback twice.
   List<int> takeSnapshot() => _snapshot.take();
 
   int get retainedSnapshotBytes => _snapshot.retainedBytes;
@@ -72,6 +67,7 @@ class TerminalSessionController extends _$TerminalSessionController {
   bool _disposed = false;
   bool _recovering = false;
   bool _desktopReclaimed = false;
+  Completer<void>? _recoveryCompletion;
   MobileTerminalClient? _pendingRecoveryClient;
   int _cols = defaultTerminalCols;
   int _rows = defaultTerminalRows;
@@ -231,9 +227,11 @@ class TerminalSessionController extends _$TerminalSessionController {
     }
     if (_recovering) {
       _pendingRecoveryClient = client;
-      return;
+      return _recoveryCompletion?.future ?? Future<void>.value();
     }
     _recovering = true;
+    final completion = Completer<void>();
+    _recoveryCompletion = completion;
     var nextClient = client;
     try {
       while (!_desktopReclaimed && !_disposed) {
@@ -276,6 +274,8 @@ class TerminalSessionController extends _$TerminalSessionController {
     } finally {
       _pendingRecoveryClient = null;
       _recovering = false;
+      _recoveryCompletion = null;
+      completion.complete();
     }
   }
 
@@ -284,8 +284,8 @@ class TerminalSessionController extends _$TerminalSessionController {
       _logger.warning('ignoring terminal reconnect after controller disposal');
       return;
     }
-    _recovering = true;
     state = const AsyncLoading<TerminalTabSession>(progress: 0.25);
+    final previousClient = _client;
     try {
       ref.invalidate(hostConnectionControllerProvider(hostId));
       ref.invalidate(terminalClientProvider(hostId));
@@ -296,19 +296,13 @@ class TerminalSessionController extends _$TerminalSessionController {
         );
         return;
       }
-      final session = await client.attachTerminal(
-        tabId,
-        cols: _cols,
-        rows: _rows,
-      );
-      if (_disposed) {
-        _logger.warning(
-          'discarding terminal reconnect session after controller disposal',
-        );
-        unawaited(_detachQuietly(client, session.attachment.sessionId));
-        return;
+      final activeRecovery = _recoveryCompletion;
+      if (activeRecovery != null) {
+        await activeRecovery.future;
+      } else if (identical(previousClient, client) ||
+          !identical(_client, client)) {
+        await _recoverWithClient(client);
       }
-      state = AsyncData(_bindSession(client, session));
     } catch (error, stackTrace) {
       if (_disposed) {
         _logger.warning(
@@ -319,8 +313,6 @@ class TerminalSessionController extends _$TerminalSessionController {
         return;
       }
       state = AsyncError(error, stackTrace);
-    } finally {
-      _recovering = false;
     }
   }
 
@@ -377,50 +369,40 @@ class TerminalSessionController extends _$TerminalSessionController {
     }
   }
 
-  /// Raw keystrokes: the accessory bar and direct mode. These must never be
-  /// pasted or deferred, since each one is already a single key.
-  Future<void> write(List<int> bytes) async {
-    final session = await future;
-    final client = await ref.read(terminalClientProvider(hostId).future);
-    await client.writeTerminal(session.sessionId, bytes);
-  }
+  /// Raw accessory/direct keys are never pasted or deferred.
+  Future<void> write(List<int> bytes) => _runAttachedOperation(
+    (client, sessionId) => client.writeTerminal(sessionId, bytes),
+  );
 
-  /// Text from an explicit Paste action. It never submits the prompt, but it
-  /// uses bracketed paste when control characters or a large payload require
-  /// protection from the foreground line editor.
-  Future<void> pasteText(String text) async {
-    final session = await future;
-    final client = await ref.read(terminalClientProvider(hostId).future);
+  /// Explicit paste never submits and brackets only when the text needs it.
+  Future<void> pasteText(String text) => _runAttachedOperation((client, id) {
     final delivery = TerminalComposeDelivery.forText(
       text,
       withEnter: false,
       hostSupportsDeferredInput: client.supportsDeferredTerminalInput,
     );
-    await client.writeTerminal(
-      session.sessionId,
+    return client.writeTerminal(
+      id,
       delivery.bytes,
       bracketedPaste: delivery.bracketedPaste,
     );
-  }
+  });
 
-  /// Compose-mode send. The prompt and its Enter become separate PTY writes
-  /// when the host supports it, because an agent TUI reads a CR arriving inside
-  /// an input burst as a literal newline instead of a submit.
-  Future<void> sendComposedText(String text, {required bool withEnter}) async {
-    final session = await future;
-    final client = await ref.read(terminalClientProvider(hostId).future);
-    final delivery = TerminalComposeDelivery.forText(
-      text,
-      withEnter: withEnter,
-      hostSupportsDeferredInput: client.supportsDeferredTerminalInput,
-    );
-    await client.writeTerminal(
-      session.sessionId,
-      delivery.bytes,
-      bracketedPaste: delivery.bracketedPaste,
-      deferredEnter: delivery.deferredEnter,
-    );
-  }
+  /// Compose send separates prompt bytes from Enter when the host supports it.
+  Future<void> sendComposedText(String text, {required bool withEnter}) =>
+      _runAttachedOperation((client, id) {
+        final delivery = TerminalComposeDelivery.forText(
+          text,
+          withEnter: withEnter,
+          hostSupportsDeferredInput: client.supportsDeferredTerminalInput,
+        );
+        return client.writeTerminal(
+          id,
+          delivery.bytes,
+          bracketedPaste: delivery.bracketedPaste,
+          deferredEnter: delivery.deferredEnter,
+        );
+      });
 
   Future<void> resize(int cols, int rows) async {
     if (cols <= 0 || rows <= 0) {
@@ -428,10 +410,74 @@ class TerminalSessionController extends _$TerminalSessionController {
     }
     _cols = cols;
     _rows = rows;
-    final session = await future;
-    final client = await ref.read(terminalClientProvider(hostId).future);
-    await client.resizeTerminal(session.sessionId, cols, rows);
+    await _runAttachedOperation(
+      (client, sessionId) => client.resizeTerminal(sessionId, cols, rows),
+    );
   }
+
+  Future<void> _runAttachedOperation(
+    Future<void> Function(MobileTerminalClient client, String sessionId)
+    operation,
+  ) async {
+    final session = await future;
+    if (_disposed) {
+      return;
+    }
+    final client = _client;
+    if (client == null) {
+      throw StateError('Terminal session has no bound client.');
+    }
+    try {
+      await operation(client, session.sessionId);
+      return;
+    } on Object catch (error) {
+      if (!_isSessionNotAttached(error)) {
+        rethrow;
+      }
+      await (_recoveryCompletion?.future ?? _recoverWithClient(client));
+      if (_disposed) {
+        return;
+      }
+      if (state case AsyncError(:final error, :final stackTrace)) {
+        _logger.warning(
+          'terminal late attach recovery failed',
+          error,
+          stackTrace,
+        );
+        return;
+      }
+      final recovered = switch (state) {
+        AsyncData(value: final value) => value,
+        _ => null,
+      };
+      final recoveredClient = _client;
+      if (recovered == null || recoveredClient == null) {
+        return;
+      }
+      try {
+        await operation(recoveredClient, recovered.sessionId);
+      } on Object catch (retryError, retryStackTrace) {
+        if (!_isSessionNotAttached(retryError)) {
+          rethrow;
+        }
+        if (_disposed) {
+          _logger.warning('terminal retry failed after controller disposal');
+          return;
+        }
+        _logger.warning(
+          'terminal session remained unavailable after reattach',
+          retryError,
+          retryStackTrace,
+        );
+        state = AsyncError(retryError, retryStackTrace);
+      }
+    }
+  }
+
+  bool _isSessionNotAttached(Object error) =>
+      (error is StateError ? error.message : error.toString()).contains(
+        'Terminal session is not attached',
+      );
 
   Future<void> _detachQuietly(
     MobileTerminalClient client,
@@ -449,5 +495,4 @@ class TerminalSessionController extends _$TerminalSessionController {
   }
 }
 
-/// Convenience for pre-resolving the session id of a tab without attaching.
 String terminalSessionIdOf(WorkspaceTabSummary tab) => tab.terminalSessionId;

--- a/mobile/lib/src/features/terminal/application/terminal_session_controller.g.dart
+++ b/mobile/lib/src/features/terminal/application/terminal_session_controller.g.dart
@@ -53,7 +53,7 @@ final class TerminalSessionControllerProvider
 }
 
 String _$terminalSessionControllerHash() =>
-    r'd92a4ca485a6d2246cfb429538ec07bfd34c0fa1';
+    r'f948fe702c5f00aecd0390ae40f9f547bb36e7d0';
 
 final class TerminalSessionControllerFamily extends $Family
     with

--- a/mobile/test/support/fake_terminal_client.dart
+++ b/mobile/test/support/fake_terminal_client.dart
@@ -49,6 +49,8 @@ class FakeTerminalClient
   final List<List<int>> writes = <List<int>>[];
   final List<({String tabId, int cols, int rows})> attachments =
       <({String tabId, int cols, int rows})>[];
+  final List<Object> writeErrors = <Object>[];
+  final List<Object> resizeErrors = <Object>[];
   Future<void>? attachCompletion;
   Future<void>? removeTabCompletion;
   Future<void>? terminateCompletion;
@@ -263,12 +265,18 @@ class FakeTerminalClient
       'write $sessionId ${bytes.length} '
       'paste=$bracketedPaste enter=$deferredEnter',
     );
+    if (writeErrors.isNotEmpty) {
+      throw writeErrors.removeAt(0);
+    }
     writes.add(bytes);
   }
 
   @override
   Future<void> resizeTerminal(String sessionId, int cols, int rows) async {
     calls.add('resize $sessionId $cols $rows');
+    if (resizeErrors.isNotEmpty) {
+      throw resizeErrors.removeAt(0);
+    }
   }
 
   @override

--- a/mobile/test/terminal_session_lifecycle_test.dart
+++ b/mobile/test/terminal_session_lifecycle_test.dart
@@ -147,6 +147,174 @@ void main() {
       );
     },
   );
+
+  test('Stale terminal write reattaches and retries once', () async {
+    final client = FakeTerminalClient()
+      ..tabs = <WorkspaceTabSummary>[fakeTab(id: 'tab-1', title: 'Terminal 1')];
+    final container = ProviderContainer(
+      overrides: [
+        terminalClientProvider('host-1').overrideWith((ref) async => client),
+      ],
+    );
+    addTearDown(container.dispose);
+    addTearDown(client.dispose);
+    final subscription = container.listen(
+      terminalSessionControllerProvider('host-1', 'tab-1'),
+      (_, _) {},
+    );
+    addTearDown(subscription.close);
+    await container.read(
+      terminalSessionControllerProvider('host-1', 'tab-1').future,
+    );
+    final notifier = container.read(
+      terminalSessionControllerProvider('host-1', 'tab-1').notifier,
+    );
+    await notifier.resize(48, 22);
+    client.writeErrors.add(
+      StateError('Terminal session is not attached: session-tab-1'),
+    );
+
+    await notifier.write(<int>[1, 2]);
+
+    expect(client.attachments, hasLength(2));
+    expect(client.attachments.last, (tabId: 'tab-1', cols: 48, rows: 22));
+    expect(
+      client.calls.where((call) => call.startsWith('write session-tab-1')),
+      hasLength(2),
+    );
+    expect(client.writes, <List<int>>[
+      <int>[1, 2],
+    ]);
+    expect(
+      container.read(terminalSessionControllerProvider('host-1', 'tab-1')),
+      isA<AsyncData<TerminalTabSession>>(),
+    );
+  });
+
+  test(
+    'Stale terminal resize reattaches with the requested dimensions',
+    () async {
+      final client = FakeTerminalClient()
+        ..tabs = <WorkspaceTabSummary>[
+          fakeTab(id: 'tab-1', title: 'Terminal 1'),
+        ]
+        ..resizeErrors.add(
+          StateError('Terminal session is not attached: session-tab-1'),
+        );
+      final container = ProviderContainer(
+        overrides: [
+          terminalClientProvider('host-1').overrideWith((ref) async => client),
+        ],
+      );
+      addTearDown(container.dispose);
+      addTearDown(client.dispose);
+      final subscription = container.listen(
+        terminalSessionControllerProvider('host-1', 'tab-1'),
+        (_, _) {},
+      );
+      addTearDown(subscription.close);
+      await container.read(
+        terminalSessionControllerProvider('host-1', 'tab-1').future,
+      );
+      final notifier = container.read(
+        terminalSessionControllerProvider('host-1', 'tab-1').notifier,
+      );
+
+      await notifier.resize(48, 22);
+
+      expect(client.attachments, hasLength(2));
+      expect(client.attachments.last, (tabId: 'tab-1', cols: 48, rows: 22));
+      expect(
+        client.calls.where((call) => call == 'resize session-tab-1 48 22'),
+        hasLength(2),
+      );
+    },
+  );
+
+  test('Unrelated terminal write failures still propagate', () async {
+    final client = FakeTerminalClient()
+      ..tabs = <WorkspaceTabSummary>[fakeTab(id: 'tab-1', title: 'Terminal 1')]
+      ..writeErrors.add(StateError('write failed'));
+    final container = ProviderContainer(
+      overrides: [
+        terminalClientProvider('host-1').overrideWith((ref) async => client),
+      ],
+    );
+    addTearDown(container.dispose);
+    addTearDown(client.dispose);
+    final subscription = container.listen(
+      terminalSessionControllerProvider('host-1', 'tab-1'),
+      (_, _) {},
+    );
+    addTearDown(subscription.close);
+    await container.read(
+      terminalSessionControllerProvider('host-1', 'tab-1').future,
+    );
+    final notifier = container.read(
+      terminalSessionControllerProvider('host-1', 'tab-1').notifier,
+    );
+
+    await expectLater(
+      notifier.write(<int>[1]),
+      throwsA(
+        isA<StateError>().having(
+          (error) => error.message,
+          'message',
+          'write failed',
+        ),
+      ),
+    );
+
+    expect(client.attachments, hasLength(1));
+  });
+
+  test(
+    'Disposal during stale-session reattach discards the late result',
+    () async {
+      final attachCompletion = Completer<void>();
+      final client = FakeTerminalClient()
+        ..tabs = <WorkspaceTabSummary>[
+          fakeTab(id: 'tab-1', title: 'Terminal 1'),
+        ]
+        ..writeErrors.add(
+          StateError('Terminal session is not attached: session-tab-1'),
+        );
+      final container = ProviderContainer(
+        overrides: [
+          terminalClientProvider('host-1').overrideWith((ref) async => client),
+        ],
+      );
+      addTearDown(container.dispose);
+      addTearDown(client.dispose);
+      final subscription = container.listen(
+        terminalSessionControllerProvider('host-1', 'tab-1'),
+        (_, _) {},
+      );
+      await container.read(
+        terminalSessionControllerProvider('host-1', 'tab-1').future,
+      );
+      final notifier = container.read(
+        terminalSessionControllerProvider('host-1', 'tab-1').notifier,
+      );
+      client.attachCompletion = attachCompletion.future;
+
+      final write = notifier.write(<int>[1]);
+      await _waitUntil(() => client.attachments.length == 2);
+      subscription.close();
+      await pumpEventQueue();
+      attachCompletion.complete();
+
+      await write;
+      await _waitUntil(
+        () =>
+            client.calls
+                .where((call) => call == 'detach session-tab-1')
+                .length ==
+            2,
+      );
+      expect(client.writes, isEmpty);
+    },
+  );
 }
 
 class _TestAppLifecycleController extends AppLifecycleController {


### PR DESCRIPTION
## Summary

- Recover a mobile terminal when the host definitively rejects a write or resize because its session is no longer attached.
- Reattach the same tab and dimensions, coalesce concurrent recovery, and retry the rejected operation once.
- Preserve unrelated errors and discard late attachments after Riverpod auto-disposal.

## Root Cause

The mobile controller recovered proactively on lifecycle and client changes, but a host-side terminal disappearance could still race a later write or resize. That definitive rejection escaped the asynchronous UI callback and repeated in Sentry.

## Validation

- `dart run build_runner build` in `mobile/`
- `flutter analyze` in `mobile/`
- `flutter test` in `mobile/` - 444 passed
- focused terminal controller/input tests - 32 passed
- root `flutter analyze`
- root Dart formatting check
- `dart run tool/quality/check_max_lines.dart`
- `gh act pull_request -W .github/workflows/pr.yml -j mobile` reached checkout, then hit the linked-worktree emulation limitation `fatal: not a git repository: (null)` before project validation

Sentry: https://alera.sentry.io/issues/7665824576/

Fixes ALERA-MOBILE-APP-5
