### PR TITLE
fix: tolerate stale terminal reclaim requests

### DIFF
--- a/rust/alera-cli/src/terminal_host/server/client_delivery.rs
+++ b/rust/alera-cli/src/terminal_host/server/client_delivery.rs
@@ -26,11 +26,16 @@ impl ServerActor {
         self.require_request_allowed(client_id, request_type)
     }
 
-    pub(super) fn require_session(&self, payload: &Value) -> HostResult<String> {
+    pub(super) fn require_session_id(&self, payload: &Value) -> HostResult<String> {
         let session_id = match payload.get("sessionId") {
             Some(Value::String(value)) => value.clone(),
             _ => return Err(HostError::format("Terminal session id is required.")),
         };
+        Ok(session_id)
+    }
+
+    pub(super) fn require_session(&self, payload: &Value) -> HostResult<String> {
+        let session_id = self.require_session_id(payload)?;
         if !self.sessions.contains_key(&session_id) {
             return Err(HostError::state(format!(
                 "Terminal session is not attached: {session_id}"

--- a/rust/alera-cli/src/terminal_host/server/requests.rs
+++ b/rust/alera-cli/src/terminal_host/server/requests.rs
@@ -426,7 +426,7 @@ impl ServerActor {
                         "terminal.reclaim is only available to desktop clients.",
                     ));
                 }
-                let session_id = self.require_session(payload)?;
+                let session_id = self.require_session_id(payload)?;
                 let restored = self.reclaim_terminal_for_desktop(&session_id);
                 Ok(json!({ "restored": restored }))
             }

--- a/rust/alera-cli/src/terminal_host/server/requests/tests.rs
+++ b/rust/alera-cli/src/terminal_host/server/requests/tests.rs
@@ -16,6 +16,38 @@ use crate::terminal_host::protocol::{
 };
 
 #[tokio::test]
+async fn terminal_reclaim_treats_a_missing_session_as_already_released() {
+    let dir = tempfile::tempdir().unwrap();
+    let (handle, mut receiver) = crate::terminal_host::client::ClientHandle::test_channels();
+    let mut actor = crate::terminal_host::server::actor_test_harness::test_actor(
+        &dir,
+        std::collections::HashMap::from([(
+            1,
+            crate::terminal_host::server::actor_test_harness::local_client(handle),
+        )]),
+        std::collections::HashMap::new(),
+    )
+    .await;
+
+    actor
+        .handle_line(
+            1,
+            serde_json::json!({
+                "id": 1,
+                "type": "terminal.reclaim",
+                "payload": {"sessionId": "stale-session"},
+            })
+            .to_string(),
+        )
+        .await;
+
+    let response = receiver.recv().await.unwrap().as_json().unwrap();
+    assert_eq!(response["id"], 1);
+    assert_eq!(response["ok"], true);
+    assert_eq!(response["payload"]["restored"], false);
+}
+
+#[tokio::test]
 async fn soft_shutdown_counts_a_runtime_mutation_without_an_emulator_manager() {
     let dir = tempfile::tempdir().unwrap();
     let (handle, mut receiver) = crate::terminal_host::client::ClientHandle::test_channels();


### PR DESCRIPTION
## Summary

- treat a missing desktop terminal session as an idempotent reclaim no-op
- preserve authentication, desktop-only access, and malformed session ID errors
- add request-level regression coverage for stale session IDs

## Validation

- `cargo test --manifest-path rust/Cargo.toml -p alera-cli terminal_reclaim_treats_a_missing_session_as_already_released`
- `make rust-test`
- `dart format --output=none --set-exit-if-changed lib test integration_test tool`
- `dart tool/quality/check_max_lines.dart`
- `flutter analyze && flutter test`
- `cd mobile && dart format --output=none --set-exit-if-changed lib test && flutter analyze && flutter test`
- `gh act pull_request -W .github/workflows/pr.yml -j rust` could not start because Docker registry authentication rejected the runner image pull

## Notes

- fixes the desktop Take Back path reported by [ALERA-DESKTOP-APP-8](https://alera.sentry.io/issues/7647306369/)
- mobile terminal lifecycle behavior remains outside this scoped fix