### PR TITLE
fix: acknowledge tab removal before codex cleanup

### DIFF
--- a/lib/src/features/diagnostics/infra/crash_reporting.dart
+++ b/lib/src/features/diagnostics/infra/crash_reporting.dart
@@ -38,6 +38,8 @@ abstract final class CrashReporting {
     }
     // Host shutdown is expected when stopped from the status bar, by idle
     // sidecar shutdown, or while the app exits; keep it local, not a crash.
+    // A request timeout is deliberately excluded: its stable legacy message
+    // mentions closure, but a slow request is not evidence of a dead socket.
     if (event.throwable is TerminalHostConnectionClosedException ||
         event.exceptions?.any(
               (exception) =>

--- a/rust/alera-cli/src/terminal_host/server/codex_runtime_cleanup.rs
+++ b/rust/alera-cli/src/terminal_host/server/codex_runtime_cleanup.rs
@@ -1,4 +1,6 @@
 use std::collections::HashSet;
+use std::future::Future;
+use std::pin::Pin;
 
 use alera_core::runtime::{RuntimeStore, Workspace, WorkspaceTabRecord};
 use serde_json::json;
@@ -29,8 +31,7 @@ pub(super) struct CodexCleanupEntry {
 }
 
 pub(super) struct PreparedCodexCleanup {
-    server: Option<CodexAppServer>,
-    _cleanup_receiver: Option<UnboundedReceiver<ServerCommand>>,
+    post_commit_cleanup: Option<Pin<Box<dyn Future<Output = ()> + Send>>>,
     entries: Vec<CodexCleanupEntry>,
 }
 
@@ -81,44 +82,64 @@ impl CodexCleanupPlan {
                 return Err(error);
             }
         }
+        let post_commit_cleanup =
+            prepare_post_commit_cleanup(server, cleanup_receiver, &self.entries);
         Ok(PreparedCodexCleanup {
-            server,
-            _cleanup_receiver: cleanup_receiver,
+            post_commit_cleanup,
             entries: self.entries,
         })
     }
 }
 
 impl PreparedCodexCleanup {
-    pub(super) async fn delete_threads_after_commit(&self) {
-        let mut deleted_threads = HashSet::new();
-        for entry in self.entries.iter().filter(|entry| entry.delete_thread) {
-            let Some(thread_id) = entry
-                .thread_id
-                .as_ref()
-                .filter(|thread_id| deleted_threads.insert((*thread_id).clone()))
-            else {
-                continue;
-            };
-            let Some(server) = self.server.as_ref() else {
-                continue;
-            };
-            if let Err(error) = server
-                .request("thread/delete", json!({"threadId": thread_id}))
-                .await
-            {
-                tracing::warn!(
-                    tab_id = %entry.tab_id,
-                    error = %error.wire_message(),
-                    "could not delete Codex thread after stopping active work"
-                );
-            }
+    pub(super) fn delete_threads_after_commit(&mut self) {
+        if let Some(cleanup) = self.post_commit_cleanup.take() {
+            drop(tokio::spawn(cleanup));
         }
     }
 
     pub(super) fn into_entries(self) -> Vec<CodexCleanupEntry> {
         self.entries
     }
+}
+
+fn prepare_post_commit_cleanup(
+    server: Option<CodexAppServer>,
+    cleanup_receiver: Option<UnboundedReceiver<ServerCommand>>,
+    entries: &[CodexCleanupEntry],
+) -> Option<Pin<Box<dyn Future<Output = ()> + Send>>> {
+    let server = server?;
+    let mut deleted_threads = HashSet::new();
+    let deletions = entries
+        .iter()
+        .filter(|entry| entry.delete_thread)
+        .filter_map(|entry| {
+            let thread_id = entry.thread_id.as_ref()?.clone();
+            deleted_threads
+                .insert(thread_id.clone())
+                .then(|| (entry.tab_id.clone(), thread_id))
+        })
+        .collect::<Vec<_>>();
+    if deletions.is_empty() {
+        return None;
+    }
+    Some(Box::pin(async move {
+        for (tab_id, thread_id) in deletions {
+            if let Err(error) = server
+                .request("thread/delete", json!({"threadId": thread_id}))
+                .await
+            {
+                tracing::warn!(
+                    tab_id = %tab_id,
+                    error = %error.wire_message(),
+                    "could not delete Codex thread after stopping active work"
+                );
+            }
+        }
+        // A temporary app-server sends notifications through this receiver.
+        // Keep it alive until every deletion has completed.
+        drop(cleanup_receiver);
+    }))
 }
 
 pub(in crate::terminal_host::server) async fn apply_cleanup_activity(
@@ -341,4 +362,40 @@ pub(super) fn stale_codex_interrupt(error: &HostError) -> bool {
 pub(super) fn codex_tab_uses_workspace(tab: &WorkspaceTabRecord, workspace: &Workspace) -> bool {
     tab.workspace_id == workspace.id
         || active_cwd(tab).is_some_and(|cwd| path_matches(&cwd, &workspace.path))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn post_commit_cleanup_does_not_delay_mutation_completion() {
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+        let (finished_tx, mut finished_rx) = tokio::sync::oneshot::channel();
+        let mut cleanup = PreparedCodexCleanup {
+            post_commit_cleanup: Some(Box::pin(async move {
+                started_tx.send(()).unwrap();
+                release_rx.await.unwrap();
+                finished_tx.send(()).unwrap();
+            })),
+            entries: Vec::new(),
+        };
+
+        cleanup.delete_threads_after_commit();
+        assert!(cleanup.post_commit_cleanup.is_none());
+        started_rx.await.unwrap();
+        assert_eq!(
+            finished_rx.try_recv(),
+            Err(tokio::sync::oneshot::error::TryRecvError::Empty)
+        );
+
+        release_tx.send(()).unwrap();
+        tokio::time::timeout(Duration::from_secs(1), finished_rx)
+            .await
+            .expect("post-commit cleanup should finish")
+            .expect("post-commit cleanup task should not stop early");
+    }
 }

--- a/rust/alera-cli/src/terminal_host/server/runtime_mutations.rs
+++ b/rust/alera-cli/src/terminal_host/server/runtime_mutations.rs
@@ -95,7 +95,7 @@ pub(super) async fn run_runtime_mutation(
     request: RuntimeMutationRequest,
     codex_cleanup: Option<CodexCleanupPlan>,
 ) -> RuntimeMutationOutcome {
-    let prepared_codex_cleanup = if let Some(cleanup) = codex_cleanup {
+    let mut prepared_codex_cleanup = if let Some(cleanup) = codex_cleanup {
         match cleanup.prepare().await {
             Ok(prepared) => Some(prepared),
             Err(error) => {
@@ -317,8 +317,11 @@ pub(super) async fn run_runtime_mutation(
     closed_session_tab_ids.sort_unstable();
     closed_session_tab_ids.dedup();
     if result.is_ok() {
-        if let Some(cleanup) = prepared_codex_cleanup.as_ref() {
-            cleanup.delete_threads_after_commit().await;
+        if let Some(cleanup) = prepared_codex_cleanup.as_mut() {
+            // The store mutation is the acknowledgement boundary. Codex can
+            // take up to its request timeout to delete a thread, and that
+            // best-effort cleanup must not hold tab removal responses open.
+            cleanup.delete_threads_after_commit();
         }
     }
     let pending_codex_cleanup = prepared_codex_cleanup

--- a/test/unit/crash_reporting_test.dart
+++ b/test/unit/crash_reporting_test.dart
@@ -43,6 +43,22 @@ void main() {
     expect(CrashReporting.filterEvent(event), isNull);
   });
 
+  test('keeps terminal host request timeouts as actionable failures', () {
+    CrashReporting.setEnabled(true);
+    const timeout = TerminalHostRequestTimeoutException(
+      'tab.remove',
+      Duration(seconds: 10),
+    );
+    final event = SentryEvent(throwable: timeout);
+
+    expect(CrashReporting.filterEvent(event), same(event));
+    expect(
+      timeout.toString(),
+      'Terminal host request "tab.remove" timed out after 10000 ms. '
+      'The connection was closed.',
+    );
+  });
+
   test('keeps terminal host startup failures', () {
     CrashReporting.setEnabled(true);
     final event = SentryEvent(


### PR DESCRIPTION
## Summary

Acknowledge `tab.remove` after the durable runtime mutation instead of waiting up to 90 seconds for best-effort Codex thread deletion. The cleanup continues asynchronously, so the desktop request no longer reaches its 10-second timeout while persistence correctness and pre-commit interruption remain intact.

Preserve the stable timeout exception text and explicitly verify that request timeouts remain actionable in Sentry while typed connection-closed exceptions stay filtered.

Sentry: https://alera.sentry.io/issues/7664983528/

## Screenshots

No visual change.

## Testing

- [x] `dart format --output=none --set-exit-if-changed lib test integration_test tool`
- [x] `flutter analyze`
- [x] `dart run tool/quality/check_max_lines.dart`
- [x] `flutter test test/unit/crash_reporting_test.dart`
- [x] `make rust-test`
- [x] Added Rust coverage proving post-commit cleanup returns promptly and completes asynchronously
- [ ] `flutter test --coverage --exclude-tags golden` - deferred to hosted sharded PR checks
- [ ] Golden tests - no UI change
- [ ] Desktop E2E/build - no app-shell, UI, protocol, or platform build change

Local `gh act pull_request -W .github/workflows/pr.yml -j rust -j static -j test` was attempted with `act` 0.2.89 and a running Docker daemon. All test shards stopped during submodule initialization with the linked-worktree emulation error `fatal: not a git repository: (null)` before project code ran; native validation above is green and hosted checks are authoritative.

## AI Review Report

Reviewed the mutation acknowledgement boundary, temporary Codex app-server receiver lifetime, duplicate thread deletion behavior, shutdown semantics, stable exception text, and crash classification. The final implementation keeps active-turn interruption before the durable mutation, detaches only warning-level post-commit thread deletion, and retains timeout reporting as actionable.

Cross-platform behavior is unchanged: the fix is host-runtime scheduling with no path, shell, label, shortcut, or protocol differences across macOS, Linux, and Windows.

## Security Audit

No new inputs, commands, paths, credentials, dependencies, or permissions. Existing Codex app-server requests and logging remain unchanged.

## Notes

Best-effort thread deletion can stop if the host shuts down immediately after acknowledging the mutation, matching its existing warning-only semantics. No documentation update is needed because there is no API, protocol, schema, setup, or user-visible workflow change.