### PR TITLE
fix: harden app window shutdown ordering

### DIFF
--- a/lib/src/features/app_window/application/app_window_controller.dart
+++ b/lib/src/features/app_window/application/app_window_controller.dart
@@ -160,6 +160,7 @@ class AppWindowLifecycleCoordinator extends AppWindowEventListener {
   Future<void> _saveQueue = Future<void>.value();
   bool _started = false;
   bool _closing = false;
+  bool _closeCommitted = false;
   bool _closed = false;
 
   /// Optional gate invoked before the window is destroyed. Return `false` to
@@ -271,6 +272,7 @@ class AppWindowLifecycleCoordinator extends AppWindowEventListener {
       _logWarningIfActive('app window close gate failed', error, stackTrace);
       return;
     }
+    _closeCommitted = true;
     try {
       await flush();
     } catch (error, stackTrace) {
@@ -304,7 +306,7 @@ class AppWindowLifecycleCoordinator extends AppWindowEventListener {
     StackTrace stackTrace,
   ) {
     // Desktop stdio may already be invalid once a committed close starts.
-    if (_closing || _closed) {
+    if (_closeCommitted || _closed) {
       return;
     }
     _logger.warning(message, error, stackTrace);

--- a/lib/src/features/app_window/application/app_window_controller.dart
+++ b/lib/src/features/app_window/application/app_window_controller.dart
@@ -160,6 +160,7 @@ class AppWindowLifecycleCoordinator extends AppWindowEventListener {
   Future<void> _saveQueue = Future<void>.value();
   bool _started = false;
   bool _closing = false;
+  bool _closed = false;
 
   /// Optional gate invoked before the window is destroyed. Return `false` to
   /// cancel the close (for example when the user declines force-stopping the
@@ -169,7 +170,7 @@ class AppWindowLifecycleCoordinator extends AppWindowEventListener {
   }
 
   Future<void> start() async {
-    if (_started) {
+    if (_started || _closed) {
       return;
     }
     _started = true;
@@ -186,12 +187,15 @@ class AppWindowLifecycleCoordinator extends AppWindowEventListener {
     _debounceTimer = null;
     _window.removeListener(this);
     _started = false;
-    if (!_closing) {
+    if (!_closing && !_closed) {
       await _window.setPreventClose(false);
     }
   }
 
   Future<void> flush() async {
+    if (_closed) {
+      return;
+    }
     _debounceTimer?.cancel();
     _debounceTimer = null;
     await _saveCurrentState();
@@ -199,7 +203,7 @@ class AppWindowLifecycleCoordinator extends AppWindowEventListener {
 
   @override
   void onWindowClose() {
-    if (_closing) {
+    if (_closing || _closed) {
       return;
     }
     _closing = true;
@@ -237,7 +241,7 @@ class AppWindowLifecycleCoordinator extends AppWindowEventListener {
   void onWindowLeaveFullScreen() => _saveSoon(immediate: true);
 
   void _saveSoon({bool immediate = false}) {
-    if (!_started || _closing) {
+    if (!_started || _closing || _closed) {
       return;
     }
     _debounceTimer?.cancel();
@@ -262,27 +266,56 @@ class AppWindowLifecycleCoordinator extends AppWindowEventListener {
         }
       }
     } catch (error, stackTrace) {
-      _logger.warning('app window close gate failed', error, stackTrace);
+      // Logging listeners are synchronous and may request another close.
       _closing = false;
+      _logWarningIfActive('app window close gate failed', error, stackTrace);
       return;
     }
     try {
       await flush();
     } catch (error, stackTrace) {
-      _logger.warning(
+      _logWarningIfActive(
         'failed to flush app window state on close',
         error,
         stackTrace,
       );
     } finally {
-      _window.removeListener(this);
-      await _closeStrategy.close(_window);
+      await _finishClose();
     }
+  }
+
+  /// Marks teardown complete and destroys the window at most once.
+  Future<void> _finishClose() async {
+    if (_closed) {
+      return;
+    }
+    _closed = true;
+    _closing = true;
+    _started = false;
+    _debounceTimer?.cancel();
+    _debounceTimer = null;
+    _window.removeListener(this);
+    await _closeStrategy.close(_window);
+  }
+
+  void _logWarningIfActive(
+    String message,
+    Object error,
+    StackTrace stackTrace,
+  ) {
+    // Desktop stdio may already be invalid once a committed close starts.
+    if (_closing || _closed) {
+      return;
+    }
+    _logger.warning(message, error, stackTrace);
   }
 
   Future<void> _saveCurrentState() {
     _saveQueue = _saveQueue
         .then((_) async {
+          if (_closed) {
+            return;
+          }
           final state = await _captureCurrentState();
           if (state == null || state == _lastState) {
             return;
@@ -291,7 +324,11 @@ class AppWindowLifecycleCoordinator extends AppWindowEventListener {
           await _repository.save(state);
         })
         .catchError((Object error, StackTrace stackTrace) {
-          _logger.warning('failed to save app window state', error, stackTrace);
+          _logWarningIfActive(
+            'failed to save app window state',
+            error,
+            stackTrace,
+          );
         });
     return _saveQueue;
   }

--- a/test/unit/app_window_lifecycle_coordinator_test.dart
+++ b/test/unit/app_window_lifecycle_coordinator_test.dart
@@ -1,0 +1,199 @@
+import 'dart:async';
+import 'dart:ui';
+
+import 'package:alera/src/features/app_window/application/app_window_controller.dart';
+import 'package:alera/src/features/app_window/application/app_window_state_repository.dart';
+import 'package:alera/src/features/app_window/domain/app_window_state.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:logging/logging.dart';
+
+void main() {
+  group('AppWindowLifecycleCoordinator shutdown', () {
+    test('resets close state before a gate failure is logged', () async {
+      final repository = _RecordingStateRepository();
+      final window = _RecordingWindowController();
+      final logger = Logger.detached('close-gate-ordering');
+      var gateCalls = 0;
+      final coordinator = AppWindowLifecycleCoordinator(
+        repository: repository,
+        window: window,
+        saveDebounce: Duration.zero,
+        logger: logger,
+        closeGate: () async {
+          gateCalls += 1;
+          if (gateCalls == 1) {
+            throw StateError('quit gate failed');
+          }
+          return true;
+        },
+      );
+      final subscription = logger.onRecord.listen((_) {
+        window.emit((listener) => listener.onWindowClose());
+      });
+      addTearDown(subscription.cancel);
+      await coordinator.start();
+
+      window.emit((listener) => listener.onWindowClose());
+      await _waitFor(() => window.destroyCalls == 1);
+
+      expect(gateCalls, 2);
+      expect(window.destroyCalls, 1);
+      expect(window.preventCloseValues, <bool>[true, false]);
+    });
+
+    test('does not publish warnings during committed close', () async {
+      final repository = _RecordingStateRepository()
+        ..saveError = StateError('disk full');
+      final window = _RecordingWindowController();
+      final logger = Logger.detached('committed-close');
+      final records = <LogRecord>[];
+      final subscription = logger.onRecord.listen(records.add);
+      addTearDown(subscription.cancel);
+      final coordinator = AppWindowLifecycleCoordinator(
+        repository: repository,
+        window: window,
+        saveDebounce: Duration.zero,
+        logger: logger,
+      );
+      await coordinator.start();
+
+      window.emit((listener) => listener.onWindowClose());
+      await _waitFor(() => window.destroyCalls == 1);
+
+      expect(records, isEmpty);
+      expect(window.destroyCalls, 1);
+      expect(window.preventCloseValues, <bool>[true, false]);
+    });
+
+    test('closes once and ignores post-close state work', () async {
+      final repository = _RecordingStateRepository();
+      final window = _RecordingWindowController();
+      final gate = Completer<bool>();
+      var gateCalls = 0;
+      final coordinator = AppWindowLifecycleCoordinator(
+        repository: repository,
+        window: window,
+        saveDebounce: Duration.zero,
+        closeGate: () {
+          gateCalls += 1;
+          return gate.future;
+        },
+      );
+      await coordinator.start();
+
+      window.emit((listener) => listener.onWindowClose());
+      window.emit((listener) => listener.onWindowClose());
+      gate.complete(true);
+      await _waitFor(() => window.destroyCalls == 1);
+      final savesAtClose = repository.saved.length;
+
+      window.bounds = const Rect.fromLTWH(100, 120, 900, 600);
+      window.emit((listener) => listener.onWindowResized());
+      window.emit((listener) => listener.onWindowClose());
+      await coordinator.flush();
+
+      expect(gateCalls, 1);
+      expect(window.destroyCalls, 1);
+      expect(repository.saved, hasLength(savesAtClose));
+      expect(window.preventCloseValues, <bool>[true, false]);
+    });
+  });
+}
+
+class _RecordingStateRepository implements AppWindowStateRepository {
+  AppWindowState? state;
+  Object? saveError;
+  final List<AppWindowState> saved = <AppWindowState>[];
+
+  @override
+  Future<void> clear() async {
+    state = null;
+  }
+
+  @override
+  Future<AppWindowState?> load() async => state;
+
+  @override
+  Future<void> save(AppWindowState state) async {
+    final error = saveError;
+    if (error != null) {
+      throw error;
+    }
+    this.state = state;
+    saved.add(state);
+  }
+}
+
+class _RecordingWindowController implements AppWindowController {
+  final List<AppWindowEventListener> listeners = <AppWindowEventListener>[];
+  final List<bool> preventCloseValues = <bool>[];
+  Rect bounds = const Rect.fromLTWH(20, 30, 800, 500);
+  int destroyCalls = 0;
+
+  void emit(void Function(AppWindowEventListener listener) notify) {
+    for (final listener in List<AppWindowEventListener>.from(listeners)) {
+      notify(listener);
+    }
+  }
+
+  @override
+  void addListener(AppWindowEventListener listener) {
+    listeners.add(listener);
+  }
+
+  @override
+  Future<void> close() async {
+    emit((listener) => listener.onWindowClose());
+  }
+
+  @override
+  Future<void> destroy() async {
+    destroyCalls += 1;
+  }
+
+  @override
+  Future<Rect> getBounds() async => bounds;
+
+  @override
+  Future<bool> isFullScreen() async => false;
+
+  @override
+  Future<bool> isMaximized() async => false;
+
+  @override
+  Future<bool> isMinimized() async => false;
+
+  @override
+  Future<void> maximize() async {}
+
+  @override
+  void removeListener(AppWindowEventListener listener) {
+    listeners.remove(listener);
+  }
+
+  @override
+  Future<void> setBounds(Rect bounds) async {
+    this.bounds = bounds;
+  }
+
+  @override
+  Future<void> setFullScreen(bool value) async {}
+
+  @override
+  Future<void> setPreventClose(bool value) async {
+    preventCloseValues.add(value);
+  }
+
+  @override
+  Future<void> setTitle(String title) async {}
+}
+
+Future<void> _waitFor(bool Function() predicate) async {
+  final deadline = DateTime.now().add(const Duration(seconds: 2));
+  while (!predicate()) {
+    if (DateTime.now().isAfter(deadline)) {
+      throw TimeoutException('condition was not reached');
+    }
+    await Future<void>.delayed(Duration.zero);
+  }
+}

--- a/test/unit/app_window_lifecycle_coordinator_test.dart
+++ b/test/unit/app_window_lifecycle_coordinator_test.dart
@@ -65,6 +65,46 @@ void main() {
       expect(window.preventCloseValues, <bool>[true, false]);
     });
 
+    test('reports save failures while the close gate is pending', () async {
+      final saveStarted = Completer<void>();
+      final finishSave = Completer<void>();
+      final gate = Completer<bool>();
+      final repository = _RecordingStateRepository()
+        ..saveStarted = saveStarted
+        ..saveBarrier = finishSave.future
+        ..saveError = StateError('disk full');
+      final window = _RecordingWindowController();
+      final logger = Logger.detached('pending-close');
+      final records = <LogRecord>[];
+      final subscription = logger.onRecord.listen(records.add);
+      addTearDown(subscription.cancel);
+      var gateCalls = 0;
+      final coordinator = AppWindowLifecycleCoordinator(
+        repository: repository,
+        window: window,
+        saveDebounce: Duration.zero,
+        logger: logger,
+        closeGate: () {
+          gateCalls += 1;
+          return gate.future;
+        },
+      );
+      await coordinator.start();
+
+      window.emit((listener) => listener.onWindowResized());
+      await saveStarted.future;
+      window.emit((listener) => listener.onWindowClose());
+      finishSave.complete();
+      await _waitFor(() => records.isNotEmpty);
+      gate.complete(false);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(records.single.message, 'failed to save app window state');
+      expect(window.destroyCalls, 0);
+      window.emit((listener) => listener.onWindowClose());
+      await _waitFor(() => gateCalls == 2);
+    });
+
     test('closes once and ignores post-close state work', () async {
       final repository = _RecordingStateRepository();
       final window = _RecordingWindowController();
@@ -103,6 +143,8 @@ void main() {
 class _RecordingStateRepository implements AppWindowStateRepository {
   AppWindowState? state;
   Object? saveError;
+  Completer<void>? saveStarted;
+  Future<void>? saveBarrier;
   final List<AppWindowState> saved = <AppWindowState>[];
 
   @override
@@ -115,6 +157,8 @@ class _RecordingStateRepository implements AppWindowStateRepository {
 
   @override
   Future<void> save(AppWindowState state) async {
+    saveStarted?.complete();
+    await saveBarrier;
     final error = saveError;
     if (error != null) {
       throw error;


### PR DESCRIPTION
## Summary

- make app-window shutdown state explicit and irreversible after close commits
- reset close state before synchronous gate-failure logging can re-enter the lifecycle
- skip lifecycle warnings and state saves after committed teardown
- cover synchronous re-entry, shutdown logging, duplicate close events, and post-close work

## Validation

- `dart format --output=none --set-exit-if-changed lib/src/features/app_window/application/app_window_controller.dart test/unit/app_window_lifecycle_coordinator_test.dart`
- `dart run tool/quality/check_max_lines.dart`
- `flutter analyze`
- `flutter test test/unit/app_window_state_test.dart test/unit/app_window_lifecycle_coordinator_test.dart`
- full `flutter test`: 3,010 passed, one unrelated `mobile_emulator_playback_monitor_test.dart` failure passed immediately in isolation
- `gh act pull_request -W .github/workflows/pr.yml -j static`: infrastructure-only failure in the linked worktree at submodule setup (`fatal: not a git repository: (null)`); hosted checks are authoritative

## Risk / Notes

- scoped to `AppWindowLifecycleCoordinator`; general stdout and file-sink hardening remains in ALERA-DESKTOP-APP-E
- no Riverpod, generated, Rust, mobile, protocol, or UI surface changed

Sentry: https://alera.sentry.io/issues/7655424736/

Fixes ALERA-DESKTOP-APP-9
