### PR TITLE
fix: recover unreachable mobile hosts

### DIFF
--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -61,6 +61,8 @@ The sidecar installs a panic hook that writes the message, location and backtrac
 
 Both Flutter apps install `FlutterError.onError`, `PlatformDispatcher.instance.onError` and a guarding zone, and the desktop adds a Riverpod `ProviderObserver` so a failing provider is recorded rather than only rendered as an `AsyncError`.
 
+Mobile classifies unavailable WebSocket transports at the runtime boundary as `HostUnreachableException` or `RuntimeConnectionLost`. Those typed failures stay in the local log and drive the existing Retry UI, but `beforeSend` and the zone handler drop them from Sentry so issues like "No route to host" do not file as crashes. Authentication, TLS, protocol, programming, and unrelated network errors are not filtered.
+
 ## Rules For Contributors
 
 - New diagnostics in the sidecar use `tracing::warn!`/`error!`/`info!`, never `eprintln!`. The `println!`/`eprintln!` calls in `main.rs` and the `*_commands.rs` files are user-facing command output, which is a different thing and stays as it is.

--- a/mobile/lib/src/core/logging/global_error_handlers.dart
+++ b/mobile/lib/src/core/logging/global_error_handlers.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:alera_mobile/src/core/logging/mobile_logger.dart';
+import 'package:alera_mobile/src/features/runtime/domain/host_reachability.dart';
 import 'package:flutter/foundation.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 
@@ -28,5 +29,10 @@ void installGlobalErrorHandlers() {
 /// Records an error that escaped an async gap and reached the guarding zone.
 void recordZoneError(Object error, StackTrace stack) {
   MobileLogger.recordError(error, stack, context: 'Zone');
+  // Reachability failures already become connection state with retry UI; sending
+  // them to Sentry just files noise like ALERA-MOBILE-APP-3.
+  if (isHostReachabilityFailure(error)) {
+    return;
+  }
   unawaited(Sentry.captureException(error, stackTrace: stack));
 }

--- a/mobile/lib/src/features/diagnostics/infra/crash_reporting.dart
+++ b/mobile/lib/src/features/diagnostics/infra/crash_reporting.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:alera_mobile/src/core/diagnostics/sentry_dsn.dart';
 import 'package:alera_mobile/src/core/logging/log_redaction.dart';
+import 'package:alera_mobile/src/features/runtime/domain/host_reachability.dart';
 import 'package:flutter/foundation.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 
@@ -28,6 +29,10 @@ abstract final class CrashReporting {
     if (!_enabled) {
       return null;
     }
+    // Ordinary host reachability is connection state with retry UI, not a crash.
+    if (_isReachabilityNoise(event)) {
+      return null;
+    }
     final message = event.message;
     if (message != null) {
       event.message = SentryMessage(
@@ -49,6 +54,20 @@ abstract final class CrashReporting {
       }
     }
     return event;
+  }
+
+  static bool _isReachabilityNoise(SentryEvent event) {
+    final throwable = event.throwable;
+    if (throwable != null && isHostReachabilityFailure(throwable)) {
+      return true;
+    }
+    for (final exception in event.exceptions ?? const <SentryException>[]) {
+      final nested = exception.throwable;
+      if (nested != null && isHostReachabilityFailure(nested)) {
+        return true;
+      }
+    }
+    return false;
   }
 
   static void _applyOptions(SentryFlutterOptions options, String release) {

--- a/mobile/lib/src/features/runtime/application/host_connection_controller.dart
+++ b/mobile/lib/src/features/runtime/application/host_connection_controller.dart
@@ -4,11 +4,15 @@ import 'package:alera_mobile/src/app/lifecycle/app_lifecycle_controller.dart';
 import 'package:alera_mobile/src/features/accounts/application/cloud_account_providers.dart';
 import 'package:alera_mobile/src/features/hosts/application/host_providers.dart';
 import 'package:alera_mobile/src/features/hosts/application/paired_hosts_controller.dart';
+import 'package:alera_mobile/src/features/runtime/domain/host_reachability.dart';
 import 'package:alera_mobile/src/features/runtime/domain/runtime_restart_result.dart';
 import 'package:alera_mobile/src/features/runtime/infra/mobile_runtime_client.dart';
 import 'package:flutter/widgets.dart';
 import 'package:logging/logging.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+export 'package:alera_mobile/src/features/runtime/domain/host_reachability.dart'
+    show HostUnreachableException, RuntimeConnectionLost;
 
 part 'host_connection_controller.g.dart';
 
@@ -22,16 +26,6 @@ const List<Duration> _retryDelays = <Duration>[
   Duration(seconds: 16),
   Duration(seconds: 30),
 ];
-
-/// The runtime socket ended without the app asking it to, so every stream and
-/// pending request on that client is dead. Raised into the provider so screens
-/// stop showing a live-looking connection and offer their Retry instead.
-class RuntimeConnectionLost implements Exception {
-  const RuntimeConnectionLost();
-
-  @override
-  String toString() => 'Lost the connection to the host';
-}
 
 /// Owns the WebSocket connection to one paired runtime host. The client is
 /// connected and authenticated before it is exposed. Transport failures recover

--- a/mobile/lib/src/features/runtime/domain/host_reachability.dart
+++ b/mobile/lib/src/features/runtime/domain/host_reachability.dart
@@ -1,0 +1,105 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+/// The runtime socket ended without the app asking it to, so every stream and
+/// pending request on that client is dead. Raised into the provider so screens
+/// stop showing a live-looking connection and offer their Retry instead.
+class RuntimeConnectionLost implements Exception {
+  const RuntimeConnectionLost();
+
+  @override
+  String toString() => 'Lost the connection to the host';
+}
+
+/// Recoverable transport failure while talking to a paired runtime host.
+///
+/// VPN down, host asleep, wrong network, or a closed socket are connection
+/// state, not application crashes. Screens already render [AsyncError] with
+/// Retry; this type just gives them a stable, short message.
+class HostUnreachableException implements Exception {
+  const HostUnreachableException([this.cause]);
+
+  final Object? cause;
+
+  @override
+  String toString() => 'Could not reach the host';
+}
+
+/// True only after a host transport error has crossed the runtime boundary and
+/// been classified as recoverable connection state.
+bool isHostReachabilityFailure(Object error) {
+  return error is HostUnreachableException || error is RuntimeConnectionLost;
+}
+
+/// Maps an unavailable runtime transport to [HostUnreachableException].
+///
+/// Call this only at the WebSocket boundary. Authentication, TLS, protocol,
+/// and programming errors retain their original types so they stay visible.
+Object normalizeHostConnectionError(Object error) {
+  if (isHostReachabilityFailure(error)) {
+    return error;
+  }
+  if (_isTransportReachabilityFailure(error)) {
+    return HostUnreachableException(error);
+  }
+  return error;
+}
+
+bool _isTransportReachabilityFailure(Object error) {
+  if (error is TimeoutException || error is SocketException) {
+    return true;
+  }
+  if (error is HandshakeException ||
+      error is TlsException ||
+      error is CertificateException) {
+    return false;
+  }
+  if (error is! WebSocketChannelException) {
+    return false;
+  }
+  final inner = error.inner;
+  if (inner != null) {
+    return _isTransportReachabilityFailure(inner);
+  }
+  return _looksLikeReachabilityMessage(error.toString().toLowerCase());
+}
+
+bool _looksLikeReachabilityMessage(String text) {
+  const markers = <String>[
+    'no route to host',
+    'network is unreachable',
+    'network unreachable',
+    'connection refused',
+    'connection timed out',
+    'connection time out',
+    'connection reset',
+    'connection abort',
+    'software caused connection abort',
+    'broken pipe',
+    'host is down',
+    'failed host lookup',
+    'name or service not known',
+    'nodename nor servname',
+    'temporary failure in name resolution',
+    'errno = 101',
+    'errno = 104',
+    'errno = 110',
+    'errno = 111',
+    'errno = 112',
+    'errno = 113',
+    'os error: 101',
+    'os error: 104',
+    'os error: 110',
+    'os error: 111',
+    'os error: 112',
+    'os error: 113',
+  ];
+  for (final marker in markers) {
+    if (text.contains(marker)) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/mobile/lib/src/features/runtime/infra/mobile_runtime_client.dart
+++ b/mobile/lib/src/features/runtime/infra/mobile_runtime_client.dart
@@ -6,6 +6,7 @@ import 'package:alera_mobile/src/core/mobile_protocol.dart';
 import 'package:alera_mobile/src/features/hosts/domain/paired_device_credentials.dart';
 import 'package:alera_mobile/src/features/runtime/infra/mobile_binary_output_payload.dart';
 import 'package:alera_mobile/src/features/hosts/domain/pairing_offer.dart';
+import 'package:alera_mobile/src/features/runtime/domain/host_reachability.dart';
 import 'package:alera_mobile/src/features/runtime/domain/mobile_runtime_status.dart';
 import 'package:alera_mobile/src/features/runtime/domain/mobile_codex_workspace.dart';
 import 'package:alera_mobile/src/features/runtime/domain/runtime_restart_result.dart';
@@ -68,9 +69,14 @@ class MobileRuntimeClient
     try {
       await client._channel.ready.timeout(client._requestTimeout);
       return client;
-    } on Object {
+    } on Object catch (error, stackTrace) {
       await client.dispose();
-      rethrow;
+      // Convert only transport reachability at this boundary. Authentication
+      // and protocol errors happen later and retain their original types.
+      Error.throwWithStackTrace(
+        normalizeHostConnectionError(error),
+        stackTrace,
+      );
     }
   }
 
@@ -391,16 +397,17 @@ class MobileRuntimeClient
   void _handleSocketError(Object error, [StackTrace? stackTrace]) {
     // The single funnel every transport failure passes through, and the most
     // common thing a user reports about this app.
+    final normalized = normalizeHostConnectionError(error);
     Logger('MobileRuntimeClient').warning(
       'runtime connection failed with ${_pending.length} pending requests',
       error,
       stackTrace,
     );
-    _closedError ??= error;
+    _closedError ??= normalized;
     _closedStackTrace ??= stackTrace;
     for (final completer in _pending.values) {
       if (!completer.isCompleted) {
-        completer.completeError(error, stackTrace);
+        completer.completeError(normalized, stackTrace);
       }
     }
     _pending.clear();
@@ -413,6 +420,8 @@ class MobileRuntimeClient
   }
 
   void _handleSocketClosed() {
-    _handleSocketError(StateError('Mobile runtime connection closed.'));
+    // Expected end of a live socket: surface as recoverable connection loss
+    // rather than a StateError that would look like a programming fault.
+    _handleSocketError(const RuntimeConnectionLost());
   }
 }

--- a/mobile/test/crash_reporting_test.dart
+++ b/mobile/test/crash_reporting_test.dart
@@ -1,6 +1,10 @@
+import 'dart:io';
+
 import 'package:alera_mobile/src/features/diagnostics/infra/crash_reporting.dart';
+import 'package:alera_mobile/src/features/runtime/domain/host_reachability.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
 
 void main() {
   tearDown(CrashReporting.resetForTesting);
@@ -30,5 +34,47 @@ void main() {
       filtered.breadcrumbs!.single.message,
       isNot(contains('abcdef123456')),
     );
+  });
+
+  test('drops typed host reachability events', () {
+    CrashReporting.setEnabled(true);
+    final failure = HostUnreachableException(
+      SocketException(
+        'No route to host',
+        osError: const OSError('No route to host', 113),
+      ),
+    );
+
+    expect(CrashReporting.filterEvent(SentryEvent(throwable: failure)), isNull);
+    expect(
+      CrashReporting.filterEvent(
+        SentryEvent(
+          exceptions: <SentryException>[
+            SentryException(
+              type: 'HostUnreachableException',
+              value: failure.toString(),
+              throwable: failure,
+            ),
+          ],
+        ),
+      ),
+      isNull,
+    );
+  });
+
+  test('keeps unclassified transport and programming errors reportable', () {
+    CrashReporting.setEnabled(true);
+    final rawTransport = WebSocketChannelException(
+      'SocketException: No route to host (errno = 113)',
+    );
+    final tlsError = WebSocketChannelException.from(
+      const HandshakeException('Certificate verification failed.'),
+    );
+    final programmingError = StateError('Unexpected response state.');
+
+    for (final error in <Object>[rawTransport, tlsError, programmingError]) {
+      final event = SentryEvent(throwable: error);
+      expect(CrashReporting.filterEvent(event), same(event));
+    }
   });
 }

--- a/mobile/test/host_connection_controller_test.dart
+++ b/mobile/test/host_connection_controller_test.dart
@@ -329,6 +329,94 @@ void main() {
     expect(helloCount, 2);
   });
 
+  test('An unavailable host becomes retryable state and reconnects', () async {
+    final reservation = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    final address = reservation.address;
+    final port = reservation.port;
+    await reservation.close(force: true);
+
+    HttpServer? recoveryServer;
+    StreamSubscription<HttpRequest>? serverSubscription;
+    final sockets = <WebSocket>[];
+    addTearDown(() async {
+      for (final socket in sockets) {
+        await socket.close();
+      }
+      await serverSubscription?.cancel();
+      await recoveryServer?.close(force: true);
+    });
+
+    final repository = MemoryHostRepository();
+    await repository.savePairedHost(
+      PairedHostProfile(
+        id: 'runtime-1',
+        displayName: 'Alera Host',
+        endpoint: 'ws://${address.address}:$port',
+        runtimeId: 'runtime-1',
+        deviceId: 'device-1',
+        pairedAt: DateTime.now().toUtc(),
+      ),
+      'token-1',
+    );
+    final container = ProviderContainer(
+      overrides: [
+        hostRepositoryProvider.overrideWithValue(repository),
+        cloudAccountRepositoryProvider.overrideWithValue(
+          _InstallationRepository(),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+    final observedErrors = <Object>[];
+    final unreachable = Completer<Object>();
+    final connection = container.listen(
+      hostConnectionControllerProvider('runtime-1'),
+      (_, next) {
+        final error = next.error;
+        if (error != null) {
+          observedErrors.add(error);
+          if (!unreachable.isCompleted) {
+            unreachable.complete(error);
+          }
+        }
+      },
+    );
+    addTearDown(connection.close);
+
+    expect(
+      await unreachable.future.timeout(const Duration(seconds: 5)),
+      isA<HostUnreachableException>(),
+    );
+
+    recoveryServer = await HttpServer.bind(address, port);
+    serverSubscription = recoveryServer.listen((request) async {
+      final socket = await WebSocketTransformer.upgrade(request);
+      sockets.add(socket);
+      socket.listen((raw) {
+        final message = jsonDecode(raw as String) as Map<String, Object?>;
+        socket.add(
+          jsonEncode(<String, Object?>{
+            'id': message['id'],
+            'ok': true,
+            'payload': <String, Object?>{},
+          }),
+        );
+      });
+    });
+
+    await _waitUntil(
+      () => container
+          .read(hostConnectionControllerProvider('runtime-1'))
+          .hasValue,
+    );
+
+    expect(observedErrors, contains(isA<HostUnreachableException>()));
+    expect(
+      container.read(hostConnectionControllerProvider('runtime-1')).hasError,
+      isFalse,
+    );
+  });
+
   test('Fails when the host is not paired', () async {
     final container = ProviderContainer(
       overrides: [

--- a/mobile/test/host_reachability_test.dart
+++ b/mobile/test/host_reachability_test.dart
@@ -1,0 +1,64 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:alera_mobile/src/features/runtime/domain/host_reachability.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+void main() {
+  group('normalizeHostConnectionError', () {
+    test('classifies Android no-route failures as host unreachable', () {
+      final socketError = SocketException(
+        'No route to host',
+        osError: const OSError('No route to host', 113),
+        address: InternetAddress('100.110.226.69'),
+        port: 42530,
+      );
+      final channelError = WebSocketChannelException.from(socketError);
+
+      final normalized = normalizeHostConnectionError(channelError);
+
+      expect(normalized, isA<HostUnreachableException>());
+      expect(
+        (normalized as HostUnreachableException).cause,
+        same(channelError),
+      );
+      expect(isHostReachabilityFailure(normalized), isTrue);
+    });
+
+    test('classifies connection timeouts as host unreachable', () {
+      final timeout = TimeoutException('Connection timed out.');
+
+      final normalized = normalizeHostConnectionError(timeout);
+
+      expect(normalized, isA<HostUnreachableException>());
+    });
+
+    test('classifies message-only transport failures', () {
+      final channelError = WebSocketChannelException(
+        'SocketException: No route to host (OS Error: No route to host, errno = 113)',
+      );
+
+      final normalized = normalizeHostConnectionError(channelError);
+
+      expect(normalized, isA<HostUnreachableException>());
+    });
+
+    test('preserves TLS, protocol, and programming failures', () {
+      final tlsError = WebSocketChannelException.from(
+        const HandshakeException('Certificate verification failed.'),
+      );
+      final protocolError = WebSocketChannelException(
+        'The server returned HTTP status 401.',
+      );
+      final stateError = StateError('Device token is invalid.');
+      final formatError = const FormatException('Malformed host response.');
+
+      expect(normalizeHostConnectionError(tlsError), same(tlsError));
+      expect(normalizeHostConnectionError(protocolError), same(protocolError));
+      expect(normalizeHostConnectionError(stateError), same(stateError));
+      expect(normalizeHostConnectionError(formatError), same(formatError));
+      expect(isHostReachabilityFailure(tlsError), isFalse);
+    });
+  });
+}

--- a/mobile/test/mobile_runtime_client_test.dart
+++ b/mobile/test/mobile_runtime_client_test.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 
 import 'package:alera_mobile/src/core/mobile_protocol.dart';
 import 'package:alera_mobile/src/features/hosts/domain/pairing_offer.dart';
+import 'package:alera_mobile/src/features/runtime/domain/host_reachability.dart';
 import 'package:alera_mobile/src/features/runtime/infra/mobile_runtime_client.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
@@ -297,7 +298,7 @@ void main() {
       client
           .request('mobile.status.get')
           .timeout(const Duration(milliseconds: 250)),
-      throwsA(isA<StateError>()),
+      throwsA(isA<RuntimeConnectionLost>()),
     );
   });
 


### PR DESCRIPTION
## Summary

- classify unavailable mobile runtime transports as recoverable host state
- keep retry UI and local diagnostics while filtering only typed reachability failures from Sentry
- preserve TLS, authentication, protocol, and programming errors as reportable failures

## Validation

- `dart run build_runner build`
- `dart format --output=none --set-exit-if-changed lib test`
- `flutter analyze`
- `flutter test` (447 tests)
- focused connectivity and crash-reporting tests after rebasing onto `origin/main`
- `dart run tool/quality/check_max_lines.dart`
- `flutter build apk --debug`
- `gh act pull_request -W .github/workflows/pr.yml -j mobile` attempted; linked-worktree checkout failed before project steps with `fatal: not a git repository: (null)`

## Risk / Notes

- reachability classification is limited to the WebSocket transport boundary and typed domain failures
- no Rust, protocol, generated binding, or submodule changes

Sentry: https://alera.sentry.io/issues/7654413941/

Fixes ALERA-MOBILE-APP-3
