### PR TITLE
fix: configure release arm64 toolchains

### DIFF
--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -457,6 +457,69 @@ jobs:
         if: runner.os == 'Windows'
         uses: ./.github/actions/tune-windows-build
 
+      - name: Configure Windows ARM64 native toolchain
+        if: matrix.platform == 'windows'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+          $installationPath = & $vswhere `
+            -latest `
+            -products * `
+            -requires Microsoft.VisualStudio.Component.VC.Tools.ARM64 `
+            -property installationPath
+          if (-not $installationPath) {
+            throw 'Visual Studio ARM64 build tools are unavailable.'
+          }
+
+          $devCmd = Join-Path $installationPath 'Common7\Tools\VsDevCmd.bat'
+          $devEnvironment = & cmd.exe /d /s /c `
+            "`"$devCmd`" -no_logo -arch=arm64 -host_arch=x64 && set"
+          if ($LASTEXITCODE -ne 0) {
+            throw 'Failed to resolve the Visual Studio ARM64 environment.'
+          }
+
+          $environment = @{}
+          foreach ($line in $devEnvironment) {
+            $separator = $line.IndexOf('=')
+            if ($separator -gt 0) {
+              $environment[$line.Substring(0, $separator)] = $line.Substring($separator + 1)
+            }
+          }
+          foreach ($name in @('INCLUDE', 'LIB', 'LIBPATH')) {
+            if (-not $environment[$name]) {
+              throw "Visual Studio did not provide $name for ARM64."
+            }
+            "$name=$($environment[$name])" | Out-File `
+              -FilePath $env:GITHUB_ENV `
+              -Encoding utf8 `
+              -Append
+          }
+
+          $linker = Join-Path `
+            $environment['VCToolsInstallDir'] `
+            'bin\Hostx64\arm64\link.exe'
+          $ninja = Join-Path `
+            $installationPath `
+            'Common7\IDE\CommonExtensions\Microsoft\CMake\Ninja\ninja.exe'
+          $clangCl = (Get-Command clang-cl.exe -ErrorAction Stop).Source
+          foreach ($path in @($linker, $ninja, $clangCl)) {
+            if (-not (Test-Path $path -PathType Leaf)) {
+              throw "Required Windows ARM64 tool is unavailable: $path"
+            }
+          }
+
+          @(
+            "CARGO_TARGET_AARCH64_PC_WINDOWS_MSVC_LINKER=$linker"
+            'CMAKE_GENERATOR_aarch64_pc_windows_msvc=Ninja'
+            "CMAKE_MAKE_PROGRAM=$ninja"
+            "CC_aarch64_pc_windows_msvc=$clangCl"
+            "CXX_aarch64_pc_windows_msvc=$clangCl"
+          ) | Out-File `
+            -FilePath $env:GITHUB_ENV `
+            -Encoding utf8 `
+            -Append
+
       - name: Setup Rust and sccache
         uses: ./.github/actions/setup-rust-sccache
 

--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -451,7 +451,7 @@ jobs:
         run: |
           set -euo pipefail
           sudo apt-get update
-          sudo apt-get install -y gcc-aarch64-linux-gnu
+          sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
 
       - name: Tune Windows build environment
         if: runner.os == 'Windows'


### PR DESCRIPTION
## Summary

- install the GNU C++ ARM64 cross-compiler alongside GCC in the release job
- configure Windows ARM64 builds to use Ninja and ClangCL as required by `whisper.cpp`
- select the Visual Studio ARM64 linker and library environment explicitly

## Root Cause

The release image only installed `gcc-aarch64-linux-gnu`, so Linux lacked `aarch64-linux-gnu-g++`. On Windows ARM64, CMake selected MSVC even though `whisper.cpp` explicitly requires Clang for ARM targets.

## Validation

- `git diff --check`
- installed both packages in a clean Ubuntu 24.04 container and resolved `aarch64-linux-gnu-g++`
- compiled `whisper.cpp` and the Rust dependency graph for Windows ARM64 with Ninja and ClangCL on a real Windows machine; final linking was bounded by that machine not having the optional Visual Studio ARM64 libraries installed
- parsed the exact PowerShell workflow block on the Windows machine and confirmed its Visual Studio ARM64 component guard
- `gh act workflow_dispatch -W .github/workflows/release-cut.yml -j build_runtime_cross ...` reached the workflow checkout, then hit a local `HEAD` ref emulation limitation before the selected job

## Risk

Low. The changes only complete the native toolchains for existing Linux and Windows ARM64 release matrix entries.
