### PR TITLE
fix: enable windows arm64 c++ exceptions

### DIFF
--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -515,6 +515,7 @@ jobs:
             "CMAKE_MAKE_PROGRAM=$ninja"
             "CC_aarch64_pc_windows_msvc=$clangCl"
             "CXX_aarch64_pc_windows_msvc=$clangCl"
+            'CXXFLAGS_aarch64_pc_windows_msvc=/EHsc'
           ) | Out-File `
             -FilePath $env:GITHUB_ENV `
             -Encoding utf8 `


### PR DESCRIPTION
## Summary
- enable C++ exception handling for the Windows ARM64 ClangCL cross-build
- keep the flag scoped to `aarch64-pc-windows-msvc`

## Validation
- release run 31624245949 reached ClangCL compilation and failed only because `whisper.cpp` uses `try` while exceptions were disabled
- `git diff --check`
- `gh act workflow_dispatch -W .github/workflows/release-cut.yml --list`

## Risk
- low: one target-specific compiler flag in the release workflow