### PR TITLE
fix: avoid msys arm64 flag conversion

### DIFF
--- a/.github/actions/setup-rust-sccache/action.yml
+++ b/.github/actions/setup-rust-sccache/action.yml
@@ -13,6 +13,7 @@ runs:
         components: rustfmt, clippy
 
     - name: Install sccache
+      continue-on-error: true
       uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba
       with:
         version: v0.15.0
@@ -22,6 +23,11 @@ runs:
       shell: bash
       run: |
         set -euo pipefail
+        if ! command -v sccache >/dev/null 2>&1; then
+          echo "::warning::sccache could not be installed; continuing without a Rust compiler cache."
+          exit 0
+        fi
+
         {
           echo "RUSTC_WRAPPER=sccache"
           echo "CARGO_INCREMENTAL=0"

--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -515,7 +515,7 @@ jobs:
             "CMAKE_MAKE_PROGRAM=$ninja"
             "CC_aarch64_pc_windows_msvc=$clangCl"
             "CXX_aarch64_pc_windows_msvc=$clangCl"
-            'CXXFLAGS_aarch64_pc_windows_msvc=/EHsc'
+            'CXXFLAGS_aarch64_pc_windows_msvc=-Xclang -fexceptions -Xclang -fcxx-exceptions'
           ) | Out-File `
             -FilePath $env:GITHUB_ENV `
             -Encoding utf8 `


### PR DESCRIPTION
## Summary
- replace `/EHsc` with equivalent Clang frontend flags for the Windows ARM64 cross-build
- avoid Git Bash rewriting the exception flag as a filesystem path
- continue builds without `sccache` when its optional download fails

## Validation
- release run 31625990387 showed MSYS rewriting `/EHsc` to `C:/Program Files/Git/EHsc`
- compiled a C++ `try`/`catch` source on the Windows machine with `-Xclang -fexceptions -Xclang -fcxx-exceptions`
- PR Rust check 94214581985 exposed repeated `sccache` download socket hangups; the composite now guards the missing binary before setting `RUSTC_WRAPPER`
- `git diff --check`
- `gh act workflow_dispatch -W .github/workflows/release-cut.yml --list`

## Risk
- low: target-specific equivalent Clang flags and a cache-only fallback that preserves uncached builds