### PR TITLE
fix: make mobile model downloads retryable

### DIFF
--- a/mobile/lib/src/features/ai_dictation/infra/mobile_ai_dictation_model_store.dart
+++ b/mobile/lib/src/features/ai_dictation/infra/mobile_ai_dictation_model_store.dart
@@ -1,21 +1,62 @@
+import 'dart:async';
 import 'dart:io';
+import 'dart:isolate';
+
 import 'package:crypto/crypto.dart';
 import 'package:http/http.dart' as http;
 import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
 
-class MobileAiDictationModelStore {
+typedef MobileSupportDirectory = Future<Directory> Function();
+
+abstract interface class MobileAiDictationModels {
+  Future<bool> isInstalled();
+
+  Future<String> download({void Function(double)? onProgress});
+
+  void dispose();
+}
+
+final class MobileAiModelDownloadCancelled implements Exception {
+  const MobileAiModelDownloadCancelled();
+}
+
+final class MobileAiModelDownloadException implements Exception {
+  const MobileAiModelDownloadException([this.cause]);
+
+  final Object? cause;
+
+  static const message =
+      'The model download was interrupted. Check your connection and retry.';
+
+  @override
+  String toString() => message;
+}
+
+class MobileAiDictationModelStore implements MobileAiDictationModels {
   static const modelId = 'whisper-base';
   static const modelUrl =
       'https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-base.bin?download=true';
   static const modelSha256 =
       '60ed5bc3dd14eea856493d334349b405782ddcaf0028d4b5df4088345fba2efe';
-  MobileAiDictationModelStore({http.Client? client})
-    : _client = client ?? http.Client();
+  MobileAiDictationModelStore({
+    http.Client? client,
+    Uri? downloadUrl,
+    String? expectedSha256,
+    MobileSupportDirectory? supportDirectory,
+  }) : _client = client ?? http.Client(),
+       _downloadUrl = downloadUrl ?? Uri.parse(modelUrl),
+       _expectedSha256 = expectedSha256 ?? modelSha256,
+       _supportDirectory = supportDirectory ?? getApplicationSupportDirectory;
+
   final http.Client _client;
+  final Uri _downloadUrl;
+  final String _expectedSha256;
+  final MobileSupportDirectory _supportDirectory;
+  bool _disposed = false;
 
   Future<String> path() async {
-    final root = await getApplicationSupportDirectory();
+    final root = await _supportDirectory();
     return p.join(
       root.path,
       'models',
@@ -25,42 +66,74 @@ class MobileAiDictationModelStore {
     );
   }
 
+  @override
   Future<bool> isInstalled() async {
     final file = File(await path());
     if (!await file.exists()) {
       return false;
     }
-    return sha256.convert(await file.readAsBytes()).toString() == modelSha256;
+    return await Isolate.run(() => _sha256File(file.path)) == _expectedSha256;
   }
 
+  @override
   Future<String> download({void Function(double)? onProgress}) async {
+    _throwIfDisposed();
     final destination = await path();
+    _throwIfDisposed();
     await Directory(p.dirname(destination)).create(recursive: true);
     final staging = File('$destination.download');
-    final response = await _client.send(
-      http.Request('GET', Uri.parse(modelUrl)),
-    );
-    if (response.statusCode != 200) {
-      throw HttpException('Whisper model download failed.');
-    }
-    final sink = staging.openWrite();
-    var received = 0;
-    await for (final chunk in response.stream) {
-      received += chunk.length;
-      sink.add(chunk);
-      if (response.contentLength != null && response.contentLength! > 0) {
-        onProgress?.call(received / response.contentLength!);
+    await _deleteIfExists(staging);
+    IOSink? sink;
+    try {
+      final response = await _client.send(http.Request('GET', _downloadUrl));
+      if (response.statusCode != 200) {
+        throw const MobileAiModelDownloadException();
       }
+      sink = staging.openWrite();
+      var received = 0;
+      await for (final chunk in response.stream) {
+        received += chunk.length;
+        sink.add(chunk);
+        if (response.contentLength != null && response.contentLength! > 0) {
+          onProgress?.call(received / response.contentLength!);
+        }
+      }
+      await sink.flush();
+      await sink.close();
+      sink = null;
+      _throwIfDisposed();
+      final digest = await Isolate.run(() => _sha256File(staging.path));
+      _throwIfDisposed();
+      if (digest != _expectedSha256) {
+        throw const MobileAiModelDownloadException();
+      }
+      await _deleteIfExists(File(destination));
+      await staging.rename(destination);
+      return destination;
+    } on Object catch (error, stackTrace) {
+      if (sink != null) {
+        try {
+          await sink.close();
+        } on Object {
+          // Preserve the transfer error that caused cleanup.
+        }
+      }
+      await _deleteIfExists(staging);
+      if (_disposed) {
+        throw const MobileAiModelDownloadCancelled();
+      }
+      if (error is MobileAiModelDownloadException) rethrow;
+      if (error is http.ClientException ||
+          error is SocketException ||
+          error is HttpException ||
+          error is TimeoutException) {
+        Error.throwWithStackTrace(
+          MobileAiModelDownloadException(error),
+          stackTrace,
+        );
+      }
+      rethrow;
     }
-    await sink.close();
-    if (await File(destination).exists()) await File(destination).delete();
-    await staging.rename(destination);
-    if (sha256.convert(await File(destination).readAsBytes()).toString() !=
-        modelSha256) {
-      await File(destination).delete();
-      throw StateError('The downloaded Whisper model failed verification.');
-    }
-    return destination;
   }
 
   Future<void> remove() async {
@@ -68,5 +141,22 @@ class MobileAiDictationModelStore {
     if (await file.exists()) await file.delete();
   }
 
-  void dispose() => _client.close();
+  @override
+  void dispose() {
+    if (_disposed) return;
+    _disposed = true;
+    _client.close();
+  }
+
+  void _throwIfDisposed() {
+    if (_disposed) throw const MobileAiModelDownloadCancelled();
+  }
+}
+
+Future<void> _deleteIfExists(File file) async {
+  if (await file.exists()) await file.delete();
+}
+
+String _sha256File(String path) {
+  return sha256.convert(File(path).readAsBytesSync()).toString();
 }

--- a/mobile/lib/src/features/ai_dictation/presentation/mobile_ai_dictation_settings_screen.dart
+++ b/mobile/lib/src/features/ai_dictation/presentation/mobile_ai_dictation_settings_screen.dart
@@ -4,10 +4,14 @@ import 'package:alera_mobile/src/app/theme/alera_tokens.dart';
 import 'package:alera_mobile/src/features/ai_dictation/domain/mobile_ai_dictation_settings.dart';
 import 'package:alera_mobile/src/features/ai_dictation/infra/mobile_ai_dictation_model_store.dart';
 import 'package:flutter/material.dart';
+import 'package:logging/logging.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 class MobileAiDictationSettingsScreen extends StatefulWidget {
-  const MobileAiDictationSettingsScreen({super.key});
+  const MobileAiDictationSettingsScreen({super.key, this.modelStore});
+
+  final MobileAiDictationModels? modelStore;
+
   @override
   State<MobileAiDictationSettingsScreen> createState() =>
       _MobileAiDictationSettingsScreenState();
@@ -16,14 +20,18 @@ class MobileAiDictationSettingsScreen extends StatefulWidget {
 class _MobileAiDictationSettingsScreenState
     extends State<MobileAiDictationSettingsScreen> {
   MobileAiDictationSettings _settings = const MobileAiDictationSettings();
-  final _modelStore = MobileAiDictationModelStore();
+  late final MobileAiDictationModels _modelStore;
   bool _modelInstalled = false;
+  bool _modelDownloading = false;
+  String? _modelDownloadError;
   final _url = TextEditingController();
   final _model = TextEditingController();
+  final _logger = Logger('MobileAiDictationSettings');
 
   @override
   void initState() {
     super.initState();
+    _modelStore = widget.modelStore ?? MobileAiDictationModelStore();
     _load();
   }
 
@@ -54,8 +62,31 @@ class _MobileAiDictationSettingsScreenState
   }
 
   Future<void> _downloadModel() async {
-    await _modelStore.download();
-    if (mounted) setState(() => _modelInstalled = true);
+    if (_modelDownloading) return;
+    setState(() {
+      _modelDownloading = true;
+      _modelDownloadError = null;
+    });
+    try {
+      await _modelStore.download();
+    } on MobileAiModelDownloadCancelled {
+      return;
+    } on Object catch (error, stackTrace) {
+      _logger.warning('Whisper model download failed', error, stackTrace);
+      if (!mounted) return;
+      setState(() {
+        _modelDownloading = false;
+        _modelDownloadError = error is MobileAiModelDownloadException
+            ? MobileAiModelDownloadException.message
+            : 'The model could not be downloaded. Retry in a moment.';
+      });
+      return;
+    }
+    if (!mounted) return;
+    setState(() {
+      _modelDownloading = false;
+      _modelInstalled = true;
+    });
   }
 
   Future<void> _save(MobileAiDictationSettings next) async {
@@ -81,14 +112,36 @@ class _MobileAiDictationSettingsScreenState
         ListTile(
           title: const Text('Whisper Base Model'),
           subtitle: Text(
-            _modelInstalled
-                ? 'Installed on this phone.'
-                : 'Download the local model before using offline dictation.',
+            _modelDownloadError ??
+                (_modelInstalled
+                    ? 'Installed on this phone.'
+                    : 'Download the local model before using offline dictation.'),
+            style: _modelDownloadError == null
+                ? null
+                : Theme.of(
+                    context,
+                  ).textTheme.bodyMedium?.copyWith(color: AleraTokens.error),
           ),
-          trailing: FilledButton(
-            onPressed: _modelInstalled ? null : _downloadModel,
-            child: Text(_modelInstalled ? 'Ready' : 'Download'),
-          ),
+          trailing: _modelDownloading
+              ? const SizedBox.square(
+                  dimension: AleraTokens.minTapTarget,
+                  child: Padding(
+                    padding: EdgeInsets.all(AleraTokens.space12),
+                    child: CircularProgressIndicator(
+                      strokeWidth: AleraTokens.strokeSm,
+                    ),
+                  ),
+                )
+              : FilledButton(
+                  onPressed: _modelInstalled ? null : _downloadModel,
+                  child: Text(
+                    _modelInstalled
+                        ? 'Ready'
+                        : _modelDownloadError == null
+                        ? 'Download'
+                        : 'Retry',
+                  ),
+                ),
         ),
         const SizedBox(height: AleraTokens.spaceXl),
         Text('Fallback Order', style: Theme.of(context).textTheme.titleMedium),

--- a/mobile/lib/src/features/updater/infra/github_mobile_release_source.dart
+++ b/mobile/lib/src/features/updater/infra/github_mobile_release_source.dart
@@ -19,21 +19,31 @@ class GitHubMobileReleaseSource {
   final http.Client _client;
   final Uri _releasesUrl;
   final bool _ownsClient;
+  bool _disposed = false;
 
   void dispose() {
-    if (_ownsClient) {
-      _client.close();
-    }
+    if (_disposed) return;
+    _disposed = true;
+    if (_ownsClient) _client.close();
   }
 
   Future<MobileRelease?> latestRelease() async {
-    final response = await _client.get(
-      _releasesUrl,
-      headers: const <String, String>{
-        'Accept': 'application/vnd.github+json',
-        'X-GitHub-Api-Version': '2022-11-28',
-      },
-    );
+    if (_disposed) return null;
+    late final http.Response response;
+    try {
+      response = await _client.get(
+        _releasesUrl,
+        headers: const <String, String>{
+          'Accept': 'application/vnd.github+json',
+          'X-GitHub-Api-Version': '2022-11-28',
+        },
+      );
+    } on http.ClientException {
+      // Closing an owned IOClient aborts its active request. That is expected
+      // provider teardown, not a failed release lookup worth reporting.
+      if (_disposed) return null;
+      rethrow;
+    }
     if (response.statusCode != 200) {
       throw http.ClientException(
         'GitHub returned ${response.statusCode} for the release listing.',

--- a/mobile/test/mobile_ai_dictation_model_store_test.dart
+++ b/mobile/test/mobile_ai_dictation_model_store_test.dart
@@ -1,0 +1,161 @@
+import 'dart:async';
+import 'dart:collection';
+import 'dart:io';
+
+import 'package:alera_mobile/src/features/ai_dictation/infra/mobile_ai_dictation_model_store.dart';
+import 'package:alera_mobile/src/features/ai_dictation/presentation/mobile_ai_dictation_settings_screen.dart';
+import 'package:crypto/crypto.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  late Directory supportDirectory;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+    supportDirectory = await Directory.systemTemp.createTemp(
+      'alera-mobile-model-test-',
+    );
+  });
+
+  tearDown(() async {
+    if (await supportDirectory.exists()) {
+      await supportDirectory.delete(recursive: true);
+    }
+  });
+
+  test(
+    'disposal cancels an active transfer and removes its staging file',
+    () async {
+      final client = _CancellableClient();
+      final store = _store(client, supportDirectory, const <int>[1]);
+      final download = store.download();
+      await client.streamListened.future;
+      client.add(const <int>[1]);
+      await Future<void>.delayed(Duration.zero);
+
+      store.dispose();
+
+      await expectLater(
+        download,
+        throwsA(isA<MobileAiModelDownloadCancelled>()),
+      );
+      expect(await File('${await store.path()}.download').exists(), isFalse);
+    },
+  );
+
+  test('an interrupted transfer cleans up and can be retried', () async {
+    const bytes = <int>[1, 2, 3];
+    final client = _QueuedClient(<http.StreamedResponse>[
+      http.StreamedResponse(
+        Stream<List<int>>.error(
+          http.ClientException('Connection closed while receiving data.'),
+        ),
+        HttpStatus.ok,
+        contentLength: bytes.length,
+      ),
+      http.StreamedResponse(
+        Stream<List<int>>.value(bytes),
+        HttpStatus.ok,
+        contentLength: bytes.length,
+      ),
+    ]);
+    final store = _store(client, supportDirectory, bytes);
+    addTearDown(store.dispose);
+
+    await expectLater(
+      store.download(),
+      throwsA(isA<MobileAiModelDownloadException>()),
+    );
+    expect(await File('${await store.path()}.download').exists(), isFalse);
+
+    final destination = await store.download();
+
+    expect(await File(destination).readAsBytes(), bytes);
+    expect(await store.isInstalled(), isTrue);
+  });
+
+  testWidgets('the settings screen offers retry after an interruption', (
+    tester,
+  ) async {
+    final store = _RetryModelStore();
+    await tester.pumpWidget(
+      MaterialApp(home: MobileAiDictationSettingsScreen(modelStore: store)),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.widgetWithText(FilledButton, 'Download'));
+    await tester.pumpAndSettle();
+
+    expect(find.text(MobileAiModelDownloadException.message), findsOneWidget);
+    expect(find.widgetWithText(FilledButton, 'Retry'), findsOneWidget);
+
+    await tester.tap(find.widgetWithText(FilledButton, 'Retry'));
+    await tester.pumpAndSettle();
+
+    expect(find.widgetWithText(FilledButton, 'Ready'), findsOneWidget);
+    expect(find.text(MobileAiModelDownloadException.message), findsNothing);
+  });
+}
+
+MobileAiDictationModelStore _store(
+  http.Client client,
+  Directory supportDirectory,
+  List<int> expectedBytes,
+) => MobileAiDictationModelStore(
+  client: client,
+  downloadUrl: Uri.parse('https://example.test/ggml-base.bin'),
+  expectedSha256: sha256.convert(expectedBytes).toString(),
+  supportDirectory: () async => supportDirectory,
+);
+
+final class _QueuedClient extends http.BaseClient {
+  _QueuedClient(Iterable<http.StreamedResponse> responses)
+    : _responses = Queue<http.StreamedResponse>.of(responses);
+
+  final Queue<http.StreamedResponse> _responses;
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) async =>
+      _responses.removeFirst();
+}
+
+final class _CancellableClient extends http.BaseClient {
+  final streamListened = Completer<void>();
+  late final StreamController<List<int>> _stream = StreamController<List<int>>(
+    onListen: streamListened.complete,
+  );
+
+  void add(List<int> bytes) => _stream.add(bytes);
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) async =>
+      http.StreamedResponse(_stream.stream, HttpStatus.ok, contentLength: 2);
+
+  @override
+  void close() {
+    _stream.addError(
+      http.ClientException('Connection closed while receiving data.'),
+    );
+    unawaited(_stream.close());
+  }
+}
+
+final class _RetryModelStore implements MobileAiDictationModels {
+  var _attempts = 0;
+
+  @override
+  Future<String> download({void Function(double)? onProgress}) async {
+    _attempts += 1;
+    if (_attempts == 1) throw const MobileAiModelDownloadException();
+    return 'ggml-base.bin';
+  }
+
+  @override
+  Future<bool> isInstalled() async => false;
+
+  @override
+  void dispose() {}
+}

--- a/mobile/test/mobile_release_lookup_test.dart
+++ b/mobile/test/mobile_release_lookup_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
@@ -157,6 +158,20 @@ void main() {
         throwsA(isA<http.ClientException>()),
       );
     });
+
+    test('treats disposal during lookup as lifecycle cancellation', () async {
+      final requestReceived = Completer<void>();
+      final server = await _servePending(requestReceived);
+      addTearDown(() => server.close());
+
+      final source = GitHubMobileReleaseSource(releasesUrl: server.url);
+      final lookup = source.latestRelease();
+      await requestReceived.future;
+
+      source.dispose();
+
+      await expectLater(lookup, completion(isNull));
+    });
   });
 }
 
@@ -167,6 +182,14 @@ Future<_StubServer> _serve(int statusCode, String body) async {
     request.response.headers.contentType = ContentType.json;
     request.response.write(body);
     await request.response.close();
+  });
+  return _StubServer(server);
+}
+
+Future<_StubServer> _servePending(Completer<void> requestReceived) async {
+  final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+  server.listen((request) {
+    if (!requestReceived.isCompleted) requestReceived.complete();
   });
   return _StubServer(server);
 }


### PR DESCRIPTION
## Summary

- distinguish owned HTTP client teardown from genuine request failures
- clean interrupted Whisper downloads and expose a retryable settings state
- add deterministic lifecycle, interruption, and retry regressions

## Validation

- `flutter analyze` in `mobile/`
- `flutter test --coverage` in `mobile/` (471 tests)
- focused mobile release/model tests (13 tests)
- `dart run tool/quality/check_max_lines.dart`
- Codex review loop against `origin/main`: zero findings
- `gh act pull_request -W .github/workflows/pr.yml -j mobile` attempted; linked-worktree submodule setup hit `fatal: not a git repository: (null)` before validation