### PR TITLE
fix: retry transient runtime mutation conflicts

### DIFF
--- a/lib/src/features/workbench/infra/terminal_host/terminal_host_client.dart
+++ b/lib/src/features/workbench/infra/terminal_host/terminal_host_client.dart
@@ -293,7 +293,7 @@ final class SocketTerminalHostClient
     String type,
     Map<String, Object?> payload, {
     Duration? timeout,
-  }) => _sendTerminalHostRequest(
+  }) => _sendTerminalHostRequestWithMutationRetry(
     this,
     connection,
     type,
@@ -686,7 +686,7 @@ final class SocketTerminalHostClient
       completer.complete(message['payload']);
     } else {
       completer.completeError(
-        StateError((message['error'] as String?) ?? 'Terminal host error.'),
+        _terminalHostRequestError(message['error'] as String?),
       );
     }
   }

--- a/lib/src/features/workbench/infra/terminal_host/terminal_host_client_requests.dart
+++ b/lib/src/features/workbench/infra/terminal_host/terminal_host_client_requests.dart
@@ -12,12 +12,52 @@ Future<T> _guardHostFuture<T>(Future<T> future) {
   return future;
 }
 
+Future<Object?> _sendTerminalHostRequestWithMutationRetry(
+  SocketTerminalHostClient client,
+  _TerminalHostConnection connection,
+  String type,
+  Map<String, Object?> payload, {
+  Duration? timeout,
+}) async {
+  final requestTimeout = timeout ?? _terminalHostRequestTimeout;
+  final elapsed = Stopwatch()..start();
+  while (true) {
+    if (client._disposed) {
+      throw StateError('Terminal host client is disposed.');
+    }
+    final remaining = requestTimeout - elapsed.elapsed;
+    if (remaining <= Duration.zero) {
+      client._noteRequestTimedOut(connection);
+      throw TerminalHostRequestTimeoutException(type, requestTimeout);
+    }
+    try {
+      return await _sendTerminalHostRequest(
+        client,
+        connection,
+        type,
+        payload,
+        timeout: remaining,
+        reportedTimeout: requestTimeout,
+      );
+    } on _RuntimeMutationInProgressError {
+      final delayRemaining = requestTimeout - elapsed.elapsed;
+      final delay = delayRemaining < _runtimeMutationRetryDelay
+          ? delayRemaining
+          : _runtimeMutationRetryDelay;
+      if (delay > Duration.zero) {
+        await Future<void>.delayed(delay);
+      }
+    }
+  }
+}
+
 Future<Object?> _sendTerminalHostRequest(
   SocketTerminalHostClient client,
   _TerminalHostConnection connection,
   String type,
   Map<String, Object?> payload, {
   Duration? timeout,
+  Duration? reportedTimeout,
 }) {
   final id = client._nextRequestId++;
   final completer = Completer<Object?>();
@@ -38,7 +78,10 @@ Future<Object?> _sendTerminalHostRequest(
       // host that is merely saturated. Real death is reported by the socket
       // itself, and by the heartbeat for a peer that is alive but wedged.
       client._noteRequestTimedOut(connection);
-      throw TerminalHostRequestTimeoutException(type, requestTimeout);
+      throw TerminalHostRequestTimeoutException(
+        type,
+        reportedTimeout ?? requestTimeout,
+      );
     },
   );
   unawaited(response.catchError((Object _) => null));
@@ -56,4 +99,12 @@ Future<Object?> _sendTerminalHostRequest(
     }
   }
   return response;
+}
+
+Object _terminalHostRequestError(String? responseMessage) {
+  final message = responseMessage ?? 'Terminal host error.';
+  if (message == _runtimeMutationInProgressMessage) {
+    return _RuntimeMutationInProgressError();
+  }
+  return StateError(message);
 }

--- a/lib/src/features/workbench/infra/terminal_host/terminal_host_client_types.dart
+++ b/lib/src/features/workbench/infra/terminal_host/terminal_host_client_types.dart
@@ -173,9 +173,16 @@ final class _PendingHostRequest {
   final Completer<Object?> completer;
 }
 
+final class _RuntimeMutationInProgressError extends StateError {
+  _RuntimeMutationInProgressError() : super(_runtimeMutationInProgressMessage);
+}
+
 enum _HostConnectionRole { terminal, runtime }
 
 const Duration _terminalHostConnectTimeout = Duration(seconds: 2);
 const Duration _terminalHostRequestTimeout = Duration(seconds: 10);
+const Duration _runtimeMutationRetryDelay = Duration(milliseconds: 50);
+const String _runtimeMutationInProgressMessage =
+    'A runtime mutation is in progress. Wait for it to finish and retry.';
 const String _orchestrationHostRestartRequiredMessage =
     'The running terminal host does not support orchestration. Restart Alera to replace the terminal host before using orchestration.';

--- a/test/unit/terminal_host_client_runtime_mutation_cases.dart
+++ b/test/unit/terminal_host_client_runtime_mutation_cases.dart
@@ -1,0 +1,75 @@
+part of 'terminal_host_client_test.dart';
+
+void _registerTerminalHostClientRuntimeMutationTests() {
+  test('retries a request blocked by a concurrent runtime mutation', () async {
+    final tempDir = await Directory.systemTemp.createTemp(
+      'alera-host-client-runtime-mutation-',
+    );
+    addTearDown(() async {
+      if (await tempDir.exists()) {
+        await tempDir.delete(recursive: true);
+      }
+    });
+    final server = await _TerminalHostTestServer.start(
+      runtimeMutationBusyForType: 'tab.upsert',
+      runtimeMutationBusyResponses: 1,
+    );
+    addTearDown(server.dispose);
+    await _writeControlFile(
+      tempDir: tempDir,
+      port: server.port,
+      token: 'existing-token',
+    );
+    final client = SocketTerminalHostClient(
+      launcher: _NoopTerminalHostLauncher(),
+      applicationSupportDirectory: () async => tempDir,
+    );
+    addTearDown(client.dispose);
+
+    await client.runtimeRequest('tab.upsert', <String, Object?>{'id': 'tab-1'});
+
+    expect(server.requestTypes, <String>['hello', 'tab.upsert', 'tab.upsert']);
+  });
+
+  test('bounds runtime mutation retries by the request timeout', () async {
+    final tempDir = await Directory.systemTemp.createTemp(
+      'alera-host-client-runtime-mutation-timeout-',
+    );
+    addTearDown(() async {
+      if (await tempDir.exists()) {
+        await tempDir.delete(recursive: true);
+      }
+    });
+    final server = await _TerminalHostTestServer.start(
+      runtimeMutationBusyForType: 'tab.upsert',
+      runtimeMutationBusyResponses: 100,
+    );
+    addTearDown(server.dispose);
+    await _writeControlFile(
+      tempDir: tempDir,
+      port: server.port,
+      token: 'existing-token',
+    );
+    final client = SocketTerminalHostClient(
+      launcher: _NoopTerminalHostLauncher(),
+      applicationSupportDirectory: () async => tempDir,
+    );
+    addTearDown(client.dispose);
+    const timeout = Duration(milliseconds: 70);
+
+    await expectLater(
+      client.runtimeRequest('tab.upsert', const <String, Object?>{
+        'id': 'tab-1',
+      }, timeout),
+      throwsA(
+        isA<TerminalHostRequestTimeoutException>().having(
+          (error) => error.duration,
+          'duration',
+          timeout,
+        ),
+      ),
+    );
+
+    expect(server.requestTypes.where((type) => type == 'tab.upsert').length, 2);
+  });
+}

--- a/test/unit/terminal_host_client_test.dart
+++ b/test/unit/terminal_host_client_test.dart
@@ -15,6 +15,7 @@ part 'terminal_host_client_resilience_cases.dart';
 part 'terminal_host_client_timeout_cases.dart';
 part 'terminal_host_client_binary_frames_cases.dart';
 part 'terminal_host_client_protocol_mismatch_cases.dart';
+part 'terminal_host_client_runtime_mutation_cases.dart';
 part 'terminal_host_test_server.dart';
 
 void main() {
@@ -22,7 +23,7 @@ void main() {
   _registerTerminalHostClientTimeoutTests();
   _registerTerminalHostClientBinaryFrameTests();
   _registerTerminalHostClientProtocolMismatchTests();
-
+  _registerTerminalHostClientRuntimeMutationTests();
   test('connects through launcher and sends lifecycle requests', () async {
     final tempDir = await Directory.systemTemp.createTemp('alera-host-client-');
     addTearDown(() async {

--- a/test/unit/terminal_host_test_server.dart
+++ b/test/unit/terminal_host_test_server.dart
@@ -1,5 +1,8 @@
 part of 'terminal_host_client_test.dart';
 
+const String _runtimeMutationBusyMessage =
+    'A runtime mutation is in progress. Wait for it to finish and retry.';
+
 final class _TerminalHostTestServer {
   _TerminalHostTestServer._(
     this._server, {
@@ -7,13 +10,17 @@ final class _TerminalHostTestServer {
     this.closeForType,
     this.beforeResponse,
     this.negotiateBinaryFrames = false,
-  });
+    this._runtimeMutationBusyForType,
+    int runtimeMutationBusyResponses = 0,
+  }) : _remainingRuntimeMutationBusyResponses = runtimeMutationBusyResponses;
 
   static Future<_TerminalHostTestServer> start({
     String? errorForType,
     String? closeForType,
     Future<void> Function(String type)? beforeResponse,
     bool negotiateBinaryFrames = false,
+    String? runtimeMutationBusyForType,
+    int runtimeMutationBusyResponses = 0,
   }) async {
     final socket = await ServerSocket.bind(InternetAddress.loopbackIPv4, 0);
     final server = _TerminalHostTestServer._(
@@ -22,6 +29,8 @@ final class _TerminalHostTestServer {
       closeForType: closeForType,
       beforeResponse: beforeResponse,
       negotiateBinaryFrames: negotiateBinaryFrames,
+      runtimeMutationBusyForType: runtimeMutationBusyForType,
+      runtimeMutationBusyResponses: runtimeMutationBusyResponses,
     );
     server._sub = socket.listen(server._accept, onError: (_) {});
     return server;
@@ -32,6 +41,8 @@ final class _TerminalHostTestServer {
   final String? closeForType;
   final Future<void> Function(String type)? beforeResponse;
   final bool negotiateBinaryFrames;
+  final String? _runtimeMutationBusyForType;
+  int _remainingRuntimeMutationBusyResponses;
   final List<Map<String, Object?>> requests = <Map<String, Object?>>[];
   StreamSubscription<Socket>? _sub;
   Socket? _client;
@@ -118,6 +129,16 @@ final class _TerminalHostTestServer {
     }
     if (type == closeForType) {
       socket.destroy();
+      return;
+    }
+    if (type == _runtimeMutationBusyForType &&
+        _remainingRuntimeMutationBusyResponses > 0) {
+      _remainingRuntimeMutationBusyResponses -= 1;
+      _respond(socket, <String, Object?>{
+        'id': id,
+        'ok': false,
+        'error': _runtimeMutationBusyMessage,
+      });
       return;
     }
     if (type == errorForType) {


### PR DESCRIPTION
## Summary

- classify the terminal host runtime-mutation barrier response as a transient client condition
- retry blocked requests within their original timeout budget
- cover successful retry and bounded-timeout behavior deterministically

## Validation

- `dart format --set-exit-if-changed lib test integration_test tool`
- `flutter analyze`
- `dart run tool/quality/check_max_lines.dart`
- `flutter test test/unit/terminal_host_client_test.dart --reporter expanded` (42 passed)
- `flutter test --coverage --exclude-tags golden` (3,047 passed)
- `dart run tool/quality/coverage_report.dart --input coverage/lcov.info --min-lines 100 --worst 25` (100.00%, 5,208/5,208)
- promptless `codex review --base origin/main` (zero findings)

## Notes

- `gh act pull_request -W .github/workflows/pr.yml` was attempted without secrets. Local emulation was blocked by linked-worktree submodule discovery, Docker registry authentication, and missing libclang in the act container; hosted exact-head checks remain authoritative.