### PR TITLE
fix: constrain restored terminal cursor

### DIFF
--- a/lib/src/features/workbench/presentation/terminal_runtime_testing.dart
+++ b/lib/src/features/workbench/presentation/terminal_runtime_testing.dart
@@ -63,6 +63,15 @@ void flushTerminalOutputForTesting(TerminalSessionHandle session) {
   );
 }
 
+@visibleForTesting
+void resizeTerminalForTesting(
+  TerminalSessionHandle session,
+  int width,
+  int height,
+) {
+  (session as _XtermTerminalSessionHandle)._terminal.resize(width, height);
+}
+
 /// Delivers a scheduled frame with production visibility checks intact.
 @visibleForTesting
 void deliverTerminalOutputFrameForTesting(TerminalSessionHandle session) {

--- a/test/unit/terminal_runtime_native_test.dart
+++ b/test/unit/terminal_runtime_native_test.dart
@@ -27,6 +27,7 @@ part 'terminal_login_shell_group.dart';
 part 'terminal_runtime_factory_group.dart';
 part 'terminal_runtime_clipboard_cases.dart';
 part 'terminal_runtime_xterm_session_cases.dart';
+part 'terminal_runtime_xterm_buffer_boundary_cases.dart';
 part 'terminal_runtime_snapshot_cases.dart';
 part 'terminal_buffer_eviction_cases.dart';
 part 'terminal_runtime_output_backpressure_cases.dart';
@@ -42,6 +43,7 @@ void main() {
   group('XtermTerminalRuntime', () {
     _registerXtermRuntimeClipboardTests();
     _registerXtermRuntimeSessionTests();
+    _registerXtermRuntimeBufferBoundaryTests();
     _registerTerminalRuntimeSnapshotTests();
     _registerTerminalBufferEvictionTests();
     _registerTerminalRuntimeOutputBackpressureTests();

--- a/test/unit/terminal_runtime_xterm_buffer_boundary_cases.dart
+++ b/test/unit/terminal_runtime_xterm_buffer_boundary_cases.dart
@@ -1,0 +1,52 @@
+part of 'terminal_runtime_native_test.dart';
+
+void _registerXtermRuntimeBufferBoundaryTests() {
+  test(
+    'batches printable output after a resized cursor restore at capacity',
+    () {
+      final session = _sessionWithCursorRestoredAtBufferCapacity();
+
+      queueTerminalOutputForTesting(session, 'x');
+
+      expect(() => flushTerminalOutputForTesting(session), returnsNormally);
+      expect(terminalBufferTextForTesting(session), endsWith('x'));
+    },
+  );
+
+  test('batches line erase after a resized cursor restore at capacity', () {
+    final session = _sessionWithCursorRestoredAtBufferCapacity(
+      lastLineText: 'stale',
+    );
+
+    queueTerminalOutputForTesting(session, '\x1b[K');
+
+    expect(() => flushTerminalOutputForTesting(session), returnsNormally);
+    expect(terminalBufferTextForTesting(session), endsWith('\n'));
+  });
+}
+
+TerminalSessionHandle _sessionWithCursorRestoredAtBufferCapacity({
+  String lastLineText = '',
+}) {
+  final runtime = XtermTerminalRuntime(
+    ptySessionFactory: _FakeTerminalPtySessionFactory(),
+    initialSettings: TerminalSettings.defaults.copyWith(scrollbackLines: 5000),
+    shellLaunchesBuilder: () => <GhosttyTerminalShellLaunch>[
+      _launch('shell', shell: '/bin/sh'),
+    ],
+  );
+  addTearDown(runtime.dispose);
+  final session = runtime.sessionFor(workspace: _workspace(), tab: _tab());
+
+  resizeTerminalForTesting(session, 8, 5);
+  queueTerminalOutputForTesting(session, '\x1b[5;1H\x1b7');
+  flushTerminalOutputForTesting(session);
+  resizeTerminalForTesting(session, 8, 3);
+  queueTerminalOutputForTesting(session, '\r\n' * 5000);
+  flushTerminalOutputForTesting(session);
+  queueTerminalOutputForTesting(session, '$lastLineText\x1b8');
+  flushTerminalOutputForTesting(session);
+
+  expect(terminalBufferTextForTesting(session).split('\n'), hasLength(5000));
+  return session;
+}


### PR DESCRIPTION
## Summary

- constrain restored xterm cursor coordinates to the current viewport at the 5000-line circular-buffer boundary
- preserve valid pending-wrap behavior across width changes
- add xterm and production output-batcher regressions for printable writes and line erasure

## Validation

- root and mobile formatting, max-lines ratchet, and analysis
- xterm analysis, 6 focused cursor-restore regressions, and 62 buffer tests
- parent terminal runtime suite: 79 tests
- mobile suite: 471 tests
- aggregate root coverage: 100%
- nested and parent Codex review loops: no findings
- local gh act attempted; linked-worktree Git metadata and missing libclang in the act image prevented workflow emulation before project validation

## Notes

- third_party/xterm points to cd7a998131eeb2078e8a74cdc8b18ba58be9d0b5 on fix/mobile-cursor-restore-buffer-boundary; no nested PR was opened because origin/master is behind the parent-pinned lineage
- the full xterm run completed 154 functional tests; two unrelated text-scaler goldens differ by 0.13% in this environment
- no generated surfaces or public documentation changed