### PR TITLE
fix: show workspace status from the most urgent agent

### DIFF
--- a/lib/src/features/workbench/application/workbench_sidebar_rows.dart
+++ b/lib/src/features/workbench/application/workbench_sidebar_rows.dart
@@ -107,7 +107,7 @@ class WorkbenchWorkspaceRow extends WorkbenchSidebarRow {
   final bool hasTerminalTabs;
 
   AgentStatusEntry? get aggregateStatus =>
-      agentRuns.isEmpty ? null : agentRuns.first.status;
+      mostUrgentWorkspaceAgentRun(agentRuns)?.status;
 
   final Project project;
   final Workspace workspace;

--- a/lib/src/features/workbench/application/workspace_agent_status_projection.dart
+++ b/lib/src/features/workbench/application/workspace_agent_status_projection.dart
@@ -32,20 +32,31 @@ AgentStatusEntry? aggregateWorkspaceAgentStatus({
   required Iterable<WorkspaceTabRecord> tabs,
   required Map<String, AgentStatusEntry> agentStatuses,
 }) {
-  final runs = visibleWorkspaceAgentRuns(
-    tabs: tabs,
-    agentStatuses: agentStatuses,
-  );
-  if (runs.isEmpty) {
+  return mostUrgentWorkspaceAgentRun(
+    visibleWorkspaceAgentRuns(tabs: tabs, agentStatuses: agentStatuses),
+  )?.status;
+}
+
+/// Picks the run that should drive the workspace glyph.
+///
+/// Visible runs stay in creation order so expanded sidebar rows do not
+/// reshuffle; this ranking is only for the single status shown beside the
+/// workspace name.
+WorkspaceAgentRun? mostUrgentWorkspaceAgentRun(
+  Iterable<WorkspaceAgentRun> runs,
+) {
+  final iterator = runs.iterator;
+  if (!iterator.moveNext()) {
     return null;
   }
-  var mostUrgent = runs.first;
-  for (final run in runs.skip(1)) {
+  var mostUrgent = iterator.current;
+  while (iterator.moveNext()) {
+    final run = iterator.current;
     if (_compareAgentRuns(run, mostUrgent) < 0) {
       mostUrgent = run;
     }
   }
-  return mostUrgent.status;
+  return mostUrgent;
 }
 
 AgentStatusEntry? matchingAgentStatusForTab({

--- a/lib/src/features/workbench/application/workspace_agent_status_projection.dart
+++ b/lib/src/features/workbench/application/workspace_agent_status_projection.dart
@@ -91,8 +91,8 @@ AgentStatusEntry? matchingAgentStatusForTab({
 // Urgency ranking for the aggregate workspace status only; row order stays
 // in creation order.
 int _compareAgentRuns(WorkspaceAgentRun a, WorkspaceAgentRun b) {
-  final aPriority = _workspaceStatusPriority(a.status.state);
-  final bPriority = _workspaceStatusPriority(b.status.state);
+  final aPriority = _workspaceStatusPriority(a.status);
+  final bPriority = _workspaceStatusPriority(b.status);
   if (aPriority != bPriority) {
     return bPriority.compareTo(aPriority);
   }
@@ -103,10 +103,16 @@ int _compareAgentRuns(WorkspaceAgentRun a, WorkspaceAgentRun b) {
   return a.tab.createdAt.compareTo(b.tab.createdAt);
 }
 
-int _workspaceStatusPriority(AgentStatusState state) {
-  return switch (state) {
-    AgentStatusState.blocked => 4,
-    AgentStatusState.waiting => 3,
+// Compact tray and Agent Activity treat interruption as attention, not as
+// a finished run. Ranking it above working/done keeps the glyph from
+// turning green (or spinning) over a leftover interrupted tab.
+int _workspaceStatusPriority(AgentStatusEntry status) {
+  if (status.interrupted ?? false) {
+    return 3;
+  }
+  return switch (status.state) {
+    AgentStatusState.blocked => 5,
+    AgentStatusState.waiting => 4,
     AgentStatusState.working => 2,
     AgentStatusState.done => 1,
   };

--- a/test/unit/workbench_listing_test.dart
+++ b/test/unit/workbench_listing_test.dart
@@ -657,6 +657,53 @@ void main() {
     });
   });
 
+  group('buildSidebarRows · workspace status', () {
+    test(
+      'aggregate status prefers a later working agent over an earlier done one',
+      () {
+        final state = _fixtureState();
+        final first = state
+            .tabsFor('w-alera-main')
+            .firstWhere((tab) => tab.id == 't-1');
+        final second = state
+            .tabsFor('w-alera-main')
+            .firstWhere((tab) => tab.id == 't-2');
+        final rows = buildSidebarRows(
+          state,
+          agentStatuses: <String, AgentStatusEntry>{
+            first.terminalSessionId: AgentStatusEntry(
+              terminalSessionId: first.terminalSessionId,
+              workspaceId: first.workspaceId,
+              tabId: first.id,
+              agentType: AgentType.codex,
+              state: AgentStatusState.done,
+              prompt: 'Finished first',
+              updatedAt: _t0,
+              stateStartedAt: _t0,
+            ),
+            second.terminalSessionId: AgentStatusEntry(
+              terminalSessionId: second.terminalSessionId,
+              workspaceId: second.workspaceId,
+              tabId: second.id,
+              agentType: AgentType.claude,
+              state: AgentStatusState.working,
+              prompt: 'Still running',
+              updatedAt: _t0,
+              stateStartedAt: _t0,
+            ),
+          },
+        );
+        final main = rows.whereType<WorkbenchWorkspaceRow>().firstWhere(
+          (row) => row.workspace.id == 'w-alera-main',
+        );
+
+        expect(main.agentRuns.map((run) => run.tab.id), <String>['t-1', 't-2']);
+        expect(main.aggregateStatus?.state, AgentStatusState.working);
+        expect(main.aggregateStatus?.tabId, 't-2');
+      },
+    );
+  });
+
   group('countVisibleWorkspaces', () {
     test('counts every visible workspace ignoring group collapse', () {
       final state = _fixtureState();

--- a/test/unit/workbench_listing_test.dart
+++ b/test/unit/workbench_listing_test.dart
@@ -657,53 +657,6 @@ void main() {
     });
   });
 
-  group('buildSidebarRows · workspace status', () {
-    test(
-      'aggregate status prefers a later working agent over an earlier done one',
-      () {
-        final state = _fixtureState();
-        final first = state
-            .tabsFor('w-alera-main')
-            .firstWhere((tab) => tab.id == 't-1');
-        final second = state
-            .tabsFor('w-alera-main')
-            .firstWhere((tab) => tab.id == 't-2');
-        final rows = buildSidebarRows(
-          state,
-          agentStatuses: <String, AgentStatusEntry>{
-            first.terminalSessionId: AgentStatusEntry(
-              terminalSessionId: first.terminalSessionId,
-              workspaceId: first.workspaceId,
-              tabId: first.id,
-              agentType: AgentType.codex,
-              state: AgentStatusState.done,
-              prompt: 'Finished first',
-              updatedAt: _t0,
-              stateStartedAt: _t0,
-            ),
-            second.terminalSessionId: AgentStatusEntry(
-              terminalSessionId: second.terminalSessionId,
-              workspaceId: second.workspaceId,
-              tabId: second.id,
-              agentType: AgentType.claude,
-              state: AgentStatusState.working,
-              prompt: 'Still running',
-              updatedAt: _t0,
-              stateStartedAt: _t0,
-            ),
-          },
-        );
-        final main = rows.whereType<WorkbenchWorkspaceRow>().firstWhere(
-          (row) => row.workspace.id == 'w-alera-main',
-        );
-
-        expect(main.agentRuns.map((run) => run.tab.id), <String>['t-1', 't-2']);
-        expect(main.aggregateStatus?.state, AgentStatusState.working);
-        expect(main.aggregateStatus?.tabId, 't-2');
-      },
-    );
-  });
-
   group('countVisibleWorkspaces', () {
     test('counts every visible workspace ignoring group collapse', () {
       final state = _fixtureState();

--- a/test/unit/workbench_workspace_status_listing_test.dart
+++ b/test/unit/workbench_workspace_status_listing_test.dart
@@ -1,0 +1,86 @@
+import 'package:alera/src/features/agent_status/domain/agent_status.dart';
+import 'package:alera/src/features/projects/domain/project.dart';
+import 'package:alera/src/features/workbench/application/workbench_listing.dart';
+import 'package:alera/src/features/workbench/application/workbench_state.dart';
+import 'package:alera/src/features/workbench/domain/workbench_view_prefs.dart';
+import 'package:alera/src/features/workbench/domain/workspace.dart';
+import 'package:alera/src/features/workbench/domain/workspace_tab_record.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+final DateTime _t0 = DateTime.utc(2026, 5, 1);
+
+void main() {
+  test(
+    'workspace glyph prefers a later working agent over an earlier done one',
+    () {
+      final project = Project(
+        id: 'p-alera',
+        name: 'alera',
+        repoPath: '/repo/p-alera',
+        createdAt: _t0,
+        updatedAt: _t0,
+      );
+      final workspace = Workspace(
+        id: 'w-alera-main',
+        projectId: project.id,
+        name: 'Main',
+        branch: 'main',
+        path: '/repo/p-alera/w-alera-main',
+        createdAt: _t0,
+        updatedAt: _t0,
+        kind: WorkspaceKind.main,
+        status: WorkspaceStatus.active,
+      );
+      final first = _tab('t-1', workspace.id);
+      final second = _tab('t-2', workspace.id);
+      final state = WorkbenchState(
+        projects: <Project>[project],
+        workspacesByProject: <String, List<Workspace>>{
+          project.id: <Workspace>[workspace],
+        },
+        tabsByWorkspace: <String, List<WorkspaceTabRecord>>{
+          workspace.id: <WorkspaceTabRecord>[first, second],
+        },
+        viewPrefs: WorkbenchViewPrefs.defaults,
+        bootstrapped: true,
+      );
+
+      final rows = buildSidebarRows(
+        state,
+        agentStatuses: <String, AgentStatusEntry>{
+          first.terminalSessionId: _status(first, AgentStatusState.done),
+          second.terminalSessionId: _status(second, AgentStatusState.working),
+        },
+      );
+      final main = rows.whereType<WorkbenchWorkspaceRow>().single;
+
+      expect(main.agentRuns.map((run) => run.tab.id), <String>['t-1', 't-2']);
+      expect(main.aggregateStatus?.state, AgentStatusState.working);
+      expect(main.aggregateStatus?.tabId, 't-2');
+    },
+  );
+}
+
+WorkspaceTabRecord _tab(String id, String workspaceId) {
+  return WorkspaceTabRecord(
+    id: id,
+    workspaceId: workspaceId,
+    kind: WorkspaceTabKind.terminal,
+    title: id,
+    createdAt: _t0,
+    updatedAt: _t0,
+  );
+}
+
+AgentStatusEntry _status(WorkspaceTabRecord tab, AgentStatusState state) {
+  return AgentStatusEntry(
+    terminalSessionId: tab.terminalSessionId,
+    workspaceId: tab.workspaceId,
+    tabId: tab.id,
+    agentType: AgentType.codex,
+    state: state,
+    prompt: state.name,
+    updatedAt: _t0,
+    stateStartedAt: _t0,
+  );
+}

--- a/test/unit/workspace_agent_status_projection_test.dart
+++ b/test/unit/workspace_agent_status_projection_test.dart
@@ -117,6 +117,30 @@ void main() {
       expect(status, isNull);
     });
 
+    test('ranks a later working run above an earlier done run', () {
+      final doneTab = _tab('tab-done');
+      final workingTab = _tab('tab-working');
+      final runs = visibleWorkspaceAgentRuns(
+        tabs: <WorkspaceTabRecord>[doneTab, workingTab],
+        agentStatuses: <String, AgentStatusEntry>{
+          doneTab.terminalSessionId: _entry(doneTab, AgentStatusState.done),
+          workingTab.terminalSessionId: _entry(
+            workingTab,
+            AgentStatusState.working,
+          ),
+        },
+      );
+
+      expect(runs.map((run) => run.tab.id), <String>[
+        'tab-done',
+        'tab-working',
+      ]);
+      expect(
+        mostUrgentWorkspaceAgentRun(runs)?.status.state,
+        AgentStatusState.working,
+      );
+    });
+
     test('matches Codex tabs through their synthetic presence handle', () {
       final tab = _tab('codex-tab', kind: WorkspaceTabKind.codex);
       final handle = 'codex:${tab.id}';

--- a/test/unit/workspace_agent_status_projection_test.dart
+++ b/test/unit/workspace_agent_status_projection_test.dart
@@ -117,6 +117,34 @@ void main() {
       expect(status, isNull);
     });
 
+    test('ranks an interrupted run above later working and done runs', () {
+      final interruptedTab = _tab('tab-interrupted');
+      final workingTab = _tab('tab-working');
+      final doneTab = _tab('tab-done');
+      final runs = visibleWorkspaceAgentRuns(
+        tabs: <WorkspaceTabRecord>[interruptedTab, workingTab, doneTab],
+        agentStatuses: <String, AgentStatusEntry>{
+          interruptedTab.terminalSessionId: _entry(
+            interruptedTab,
+            AgentStatusState.done,
+            interrupted: true,
+          ),
+          workingTab.terminalSessionId: _entry(
+            workingTab,
+            AgentStatusState.working,
+            updatedAt: DateTime.utc(2026, 5, 26, 12),
+          ),
+          doneTab.terminalSessionId: _entry(
+            doneTab,
+            AgentStatusState.done,
+            updatedAt: DateTime.utc(2026, 5, 26, 12, 1),
+          ),
+        },
+      );
+
+      expect(mostUrgentWorkspaceAgentRun(runs)?.tab.id, interruptedTab.id);
+    });
+
     test('ranks a later working run above an earlier done run', () {
       final doneTab = _tab('tab-done');
       final workingTab = _tab('tab-working');
@@ -194,6 +222,7 @@ AgentStatusEntry _entry(
   DateTime? updatedAt,
   String? tabId,
   String? terminalSessionId,
+  bool? interrupted,
 }) {
   final timestamp = updatedAt ?? DateTime.utc(2026, 5, 26);
   return AgentStatusEntry(
@@ -205,5 +234,6 @@ AgentStatusEntry _entry(
     prompt: '',
     updatedAt: timestamp,
     stateStartedAt: timestamp,
+    interrupted: interrupted,
   );
 }


### PR DESCRIPTION
## Summary

A workspace with a leftover done agent stayed green even when later agents were still working or waiting.

The sidebar glyph used the first created agent after visible runs stopped being urgency-sorted. The compact tray already showed the live agents; the leading glyph did not. This wires the glyph through the existing urgency ranking (`blocked` > `waiting` > `interrupted` > `working` > `done`) without reshuffling expanded agent rows.

`interrupted` is a flag, usually on `done`. Compact tray and Agent Activity already treat it as attention; the glyph now ranks it the same way so a leftover interrupted tab cannot stay green over a later working run, or spin over an interrupted one.

## Screenshots

No visual change beyond the workspace glyph now matching the most urgent live agent instead of the oldest done one.

## Testing

- [x] `dart format` on the changed files
- [x] `flutter analyze` on the changed files
- [x] focused unit tests: `test/unit/workspace_agent_status_projection_test.dart` and `test/unit/workbench_workspace_status_listing_test.dart`
- [x] `dart tool/quality/check_max_lines.dart`
- [ ] `dart format --set-exit-if-changed lib test integration_test tool`
- [ ] `flutter analyze`
- [ ] `flutter test --coverage --exclude-tags golden`
- [ ] `dart run tool/quality/coverage_report.dart --input coverage/lcov.info --min-lines 100 --worst 25`
- [ ] Golden tests, if UI changed: `flutter test --tags golden`
- [ ] Desktop E2E, if app-shell flow changed: `flutter test integration_test -d macos`
- [ ] Relevant desktop build: `flutter build macos`, `flutter build windows`, or `flutter build linux`
- [ ] Landing build, if applicable: `cd landing && bun run build`
- [x] Added or updated tests that would catch regressions, or explained why tests were not needed

## AI Review Report

Reviewed the desktop sidebar status path and the unused urgency aggregator. Main risk checked: the glyph using creation order after `visibleWorkspaceAgentRuns` stopped being urgency-sorted. The compact tray and expanded rows already show per-agent state, so they were left in creation order on purpose.

Follow-up from review: ranking only by `AgentStatusState` treated `interrupted` as plain `done`. The glyph now ranks interruption above working and done so it stays aligned with the compact tray.

Cross-platform: the glyph ranking is platform-neutral Dart. Mobile already ranks by urgency (`_mostUrgentState`) and was not changed.

## Security Audit

No input handling, command execution, path, auth, secrets, updater, or process-execution changes.

## Notes

- Child-workspace agents still do not roll into a parent workspace glyph.
- Expanded agent rows stay in creation order so they do not reshuffle on every hook event.
- Docs already described the intended urgency ranking; no documentation update.