### PR TITLE
fix: set file modes with a syscall instead of a chmod process

### DIFF
--- a/lib/src/features/agent_status/infra/agent_hook_endpoint_file.dart
+++ b/lib/src/features/agent_status/infra/agent_hook_endpoint_file.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:alera/src/shared/infra/files/posix_file_mode.dart';
 import 'package:path/path.dart' as p;
 import 'package:uuid/uuid.dart';
 
@@ -103,9 +104,7 @@ Future<void> writeAgentHookEndpointFile({
     mode: FileMode.writeOnly,
   );
   if (!Platform.isWindows) {
-    try {
-      await Process.run('chmod', <String>['600', tmpPath]);
-    } catch (_) {}
+    setPosixFileMode(tmpPath, posixPrivateFileMode);
   }
   await tmp.rename(filePath);
 }

--- a/lib/src/features/agent_status/infra/agent_runtime_overlay_service.dart
+++ b/lib/src/features/agent_status/infra/agent_runtime_overlay_service.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 
 import 'package:alera/src/features/agent_status/domain/agent_status.dart';
 import 'package:alera/src/features/agent_status/infra/managed_agent_hook_installer.dart';
+import 'package:alera/src/shared/infra/files/posix_file_mode.dart';
 import 'package:crypto/crypto.dart';
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;

--- a/lib/src/features/agent_status/infra/agent_runtime_overlay_wrappers.dart
+++ b/lib/src/features/agent_status/infra/agent_runtime_overlay_wrappers.dart
@@ -16,7 +16,7 @@ extension _AgentRuntimeOverlayWrappers on AgentRuntimeOverlayService {
     final path = p.join(directory.path, _wrapperFileName(executableName));
     _writeManagedFile(path, source);
     if (_platform != ManagedAgentHookPlatform.windows && !Platform.isWindows) {
-      Process.runSync('chmod', <String>['755', path]);
+      setPosixFileMode(path, posixExecutableFileMode);
     }
   }
 

--- a/lib/src/features/agent_status/infra/claude_runtime_home_service.dart
+++ b/lib/src/features/agent_status/infra/claude_runtime_home_service.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 import 'package:alera/src/features/agent_status/domain/agent_status.dart';
 import 'package:alera/src/features/agent_status/infra/agent_hook_endpoint_file.dart';
 import 'package:alera/src/features/agent_status/infra/managed_agent_hook_installer.dart';
+import 'package:alera/src/shared/infra/files/posix_file_mode.dart';
 import 'package:crypto/crypto.dart';
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;

--- a/lib/src/features/agent_status/infra/claude_runtime_hooks.dart
+++ b/lib/src/features/agent_status/infra/claude_runtime_hooks.dart
@@ -190,7 +190,7 @@ extension _ClaudeRuntimeHooks on ClaudeRuntimeHomeService {
     file.parent.createSync(recursive: true);
     if (file.existsSync() && file.readAsStringSync() == content) {
       if (_platform == ManagedAgentHookPlatform.posix && !Platform.isWindows) {
-        Process.runSync('chmod', <String>['755', path]);
+        setPosixFileMode(path, posixExecutableFileMode);
       }
       return;
     }
@@ -200,7 +200,7 @@ extension _ClaudeRuntimeHooks on ClaudeRuntimeHomeService {
     );
     final tmp = File(tmpPath)..writeAsStringSync(content);
     if (_platform == ManagedAgentHookPlatform.posix && !Platform.isWindows) {
-      Process.runSync('chmod', <String>['755', tmpPath]);
+      setPosixFileMode(tmpPath, posixExecutableFileMode);
     }
     tmp.renameSync(path);
   }

--- a/lib/src/features/agent_status/infra/codex_runtime_home_service.dart
+++ b/lib/src/features/agent_status/infra/codex_runtime_home_service.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 import 'package:alera/src/features/agent_status/domain/agent_status.dart';
 import 'package:alera/src/features/agent_status/infra/agent_hook_endpoint_file.dart';
 import 'package:alera/src/features/agent_status/infra/managed_agent_hook_installer.dart';
+import 'package:alera/src/shared/infra/files/posix_file_mode.dart';
 import 'package:crypto/crypto.dart';
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;

--- a/lib/src/features/agent_status/infra/codex_runtime_io.dart
+++ b/lib/src/features/agent_status/infra/codex_runtime_io.dart
@@ -37,7 +37,7 @@ extension _CodexRuntimeHomeServiceIo on CodexRuntimeHomeService {
     file.parent.createSync(recursive: true);
     if (file.existsSync() && file.readAsStringSync() == content) {
       if (_platform == ManagedAgentHookPlatform.posix && !Platform.isWindows) {
-        Process.runSync('chmod', <String>['755', path]);
+        setPosixFileMode(path, posixExecutableFileMode);
       }
       return;
     }
@@ -47,7 +47,7 @@ extension _CodexRuntimeHomeServiceIo on CodexRuntimeHomeService {
     );
     final tmp = File(tmpPath)..writeAsStringSync(content);
     if (_platform == ManagedAgentHookPlatform.posix && !Platform.isWindows) {
-      Process.runSync('chmod', <String>['755', tmpPath]);
+      setPosixFileMode(tmpPath, posixExecutableFileMode);
     }
     tmp.renameSync(path);
   }

--- a/lib/src/features/agent_status/infra/codex_runtime_resource_sync.dart
+++ b/lib/src/features/agent_status/infra/codex_runtime_resource_sync.dart
@@ -21,7 +21,7 @@ extension _CodexRuntimeHomeServiceResourceSync on CodexRuntimeHomeService {
     target.parent.createSync(recursive: true);
     source.copySync(target.path);
     if (_platform == ManagedAgentHookPlatform.posix && !Platform.isWindows) {
-      Process.runSync('chmod', <String>['600', target.path]);
+      setPosixFileMode(target.path, posixPrivateFileMode);
     }
   }
 

--- a/lib/src/features/agent_status/infra/managed_agent_hook_installer.dart
+++ b/lib/src/features/agent_status/infra/managed_agent_hook_installer.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 
 import 'package:alera/src/features/agent_status/domain/agent_status.dart';
 import 'package:alera/src/features/agent_status/infra/agent_hook_endpoint_file.dart';
+import 'package:alera/src/shared/infra/files/posix_file_mode.dart';
 import 'package:path/path.dart' as p;
 
 part 'managed_agent_hook_descriptors.dart';

--- a/lib/src/features/agent_status/infra/managed_agent_hook_json.dart
+++ b/lib/src/features/agent_status/infra/managed_agent_hook_json.dart
@@ -42,7 +42,7 @@ extension _ManagedAgentHookJson on ManagedAgentHookInstallService {
     file.parent.createSync(recursive: true);
     if (file.existsSync() && file.readAsStringSync() == content) {
       if (_platform == ManagedAgentHookPlatform.posix && !Platform.isWindows) {
-        Process.runSync('chmod', <String>['755', path]);
+        setPosixFileMode(path, posixExecutableFileMode);
       }
       return;
     }
@@ -52,7 +52,7 @@ extension _ManagedAgentHookJson on ManagedAgentHookInstallService {
     );
     final tmp = File(tmpPath)..writeAsStringSync(content);
     if (_platform == ManagedAgentHookPlatform.posix && !Platform.isWindows) {
-      Process.runSync('chmod', <String>['755', tmpPath]);
+      setPosixFileMode(tmpPath, posixExecutableFileMode);
     }
     tmp.renameSync(path);
   }

--- a/lib/src/features/workbench/infra/alera_cli_terminal_shim.dart
+++ b/lib/src/features/workbench/infra/alera_cli_terminal_shim.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:alera/src/features/workbench/infra/terminal_host/alera_cli_sidecar.dart';
+import 'package:alera/src/shared/infra/files/posix_file_mode.dart';
 import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
 
@@ -57,7 +58,7 @@ class AleraCliTerminalShimService {
       '',
     ];
     await file.writeAsString(lines.join('\n'), flush: true);
-    await Process.run('chmod', <String>['755', file.path]);
+    setPosixFileMode(file.path, posixExecutableFileMode);
   }
 
   Future<void> _writeWindowsShim(

--- a/lib/src/features/workbench/infra/terminal_host/alera_cli_sidecar.dart
+++ b/lib/src/features/workbench/infra/terminal_host/alera_cli_sidecar.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:alera/src/features/workbench/infra/terminal_host/terminal_host_protocol.dart';
+import 'package:alera/src/shared/infra/files/posix_file_mode.dart';
 import 'package:path/path.dart' as p;
 
 final class AleraCliCommand {
@@ -173,7 +174,7 @@ final class DefaultAleraCliResolver implements AleraCliResolver {
     final bytes = gzip.decode(await archive.readAsBytes());
     await target.writeAsBytes(bytes, flush: true);
     if (_operatingSystemName != 'windows' && !Platform.isWindows) {
-      await Process.run('chmod', <String>['755', target.path]);
+      setPosixFileMode(target.path, posixExecutableFileMode);
     }
     return target.path;
   }

--- a/lib/src/shared/infra/files/posix_file_mode.dart
+++ b/lib/src/shared/infra/files/posix_file_mode.dart
@@ -1,0 +1,42 @@
+import 'dart:ffi' as ffi;
+import 'dart:io';
+
+import 'package:ffi/ffi.dart';
+
+/// Dart has no octal literals, so the POSIX modes are spelled in hex.
+const int posixExecutableFileMode = 0x1ED; // 0o755
+const int posixPrivateFileMode = 0x180; // 0o600
+
+/// `mode_t` is 16 bits on Darwin and 32 on Linux. Passing 32 is safe for both:
+/// the callee reads the low bits, and every mode used here fits in 16.
+typedef _ChmodNative =
+    ffi.Int32 Function(ffi.Pointer<Utf8> path, ffi.Uint32 mode);
+typedef _ChmodDart = int Function(ffi.Pointer<Utf8> path, int mode);
+
+/// Resolved from the running process rather than a named library, because the
+/// libc file name differs between glibc, musl and macOS.
+final ffi.DynamicLibrary _libc = ffi.DynamicLibrary.process();
+final _ChmodDart _chmod = _libc.lookupFunction<_ChmodNative, _ChmodDart>(
+  'chmod',
+);
+
+/// Applies [mode] to [path], reporting whether the call succeeded.
+///
+/// This is a syscall rather than a `chmod` process on purpose. A `dart:io`
+/// child, however short-lived, wakes the VM's reaper thread, which waits on
+/// *any* child of the process and discards the pids it does not own after
+/// reaping them. The next `waitpid` from the Rust side then fails with ECHILD,
+/// which surfaced as "failed to run ...: No child processes (os error 10)".
+bool setPosixFileMode(String path, int mode) {
+  // Checked before the lazy `final`s are touched: Windows names the symbol
+  // `_chmod`, so resolving it there would throw instead of returning false.
+  if (Platform.isWindows) {
+    return false;
+  }
+  final nativePath = path.toNativeUtf8();
+  try {
+    return _chmod(nativePath, mode) == 0;
+  } finally {
+    malloc.free(nativePath);
+  }
+}

--- a/test/unit/posix_file_mode_test.dart
+++ b/test/unit/posix_file_mode_test.dart
@@ -1,0 +1,56 @@
+import 'dart:io';
+
+import 'package:alera/src/shared/infra/files/posix_file_mode.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+
+void main() {
+  group('posix file modes', () {
+    test('spells the documented octal modes', () {
+      expect(posixExecutableFileMode, 493); // 0o755
+      expect(posixPrivateFileMode, 384); // 0o600
+    });
+
+    test('applies both modes to a real file', () {
+      final directory = Directory.systemTemp.createTempSync(
+        'alera-posix-file-mode',
+      );
+      addTearDown(() => directory.deleteSync(recursive: true));
+      final file = File(p.join(directory.path, 'script.sh'))
+        ..writeAsStringSync('#!/bin/sh\n');
+
+      expect(setPosixFileMode(file.path, posixPrivateFileMode), isTrue);
+      expect(file.statSync().mode & 0xFFF, posixPrivateFileMode);
+
+      expect(setPosixFileMode(file.path, posixExecutableFileMode), isTrue);
+      expect(file.statSync().mode & 0xFFF, posixExecutableFileMode);
+    }, skip: Platform.isWindows);
+
+    test(
+      'reports failure instead of throwing for a missing path',
+      () {
+        final directory = Directory.systemTemp.createTempSync(
+          'alera-posix-file-mode-missing',
+        );
+        addTearDown(() => directory.deleteSync(recursive: true));
+
+        expect(
+          setPosixFileMode(
+            p.join(directory.path, 'absent.sh'),
+            posixExecutableFileMode,
+          ),
+          isFalse,
+        );
+      },
+      skip: Platform.isWindows,
+    );
+
+    test(
+      'reports failure on Windows without resolving the symbol',
+      () {
+        expect(setPosixFileMode(r'C:\Windows\notepad.exe', 493), isFalse);
+      },
+      skip: !Platform.isWindows,
+    );
+  });
+}


### PR DESCRIPTION
## Summary

Every `chmod` the app ran was a `dart:io` child. While such a child is alive, the Dart VM's reaper thread waits on **any** child of the process and discards the pids it does not own after reaping them, so the next `waitpid` tokio makes for a Rust-side spawn fails with ECHILD. That is the `failed to run /opt/alera/resources/alera/alera: No child processes (os error 10)` the Runtime panel showed after a cold start.

`setPosixFileMode` calls `chmod(2)` through `dart:ffi` instead, following the libc pattern already in `terminal_runtime_posix_io.dart`. Six of the nine call sites were `Process.runSync`, so this also stops blocking the main isolate while the workbench mounts: 0.68ms per call as a process against 0.00085ms as a syscall, measured locally.

First of four stacked PRs; the rest remove the remaining `dart:io` spawns and add a guard.

## Validation

- `flutter analyze`, `flutter test`
- New `posix_file_mode_test.dart`: both modes round-trip through `File.statSync().mode`, which is what guards the 16-bit `mode_t` ABI on Darwin; a missing path reports failure instead of throwing.
- `alera_cli_sidecar_test.dart` exercises the extraction path for real and stays green.

## Notes

Windows returns `false` before the lazy `final`s are touched, since the symbol is named `_chmod` there and every call site is already guarded by `!Platform.isWindows`.