### PR TITLE
fix: hydrate the login shell through the rust process runner

### DIFF
--- a/lib/src/shared/infra/process/command_environment_resolver.dart
+++ b/lib/src/shared/infra/process/command_environment_resolver.dart
@@ -2,6 +2,9 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:alera/src/shared/infra/process/process_runner.dart';
+import 'package:alera/src/shared/infra/process/rust_process_runner.dart';
+
 const String shellPathHydrationDelimiter = '__ALERA_SHELL_PATH__';
 const String shellVariableHydrationDelimiter = '__ALERA_SHELL_VAR__';
 const Duration shellPathHydrationTimeout = Duration(seconds: 5);
@@ -65,6 +68,7 @@ class UserCommandEnvironmentResolver implements CommandEnvironmentResolver {
     this.isMacOS,
     this.hydrator,
     this.variablesHydrator,
+    this.processRunner = const RustProcessRunner(),
   });
 
   final Map<String, String>? platformEnvironment;
@@ -72,6 +76,7 @@ class UserCommandEnvironmentResolver implements CommandEnvironmentResolver {
   final bool? isMacOS;
   final ShellPathHydrator? hydrator;
   final ShellVariablesHydrator? variablesHydrator;
+  final ProcessRunner processRunner;
   Future<CommandEnvironmentHydrationResult>? _hydration;
   final Map<String, Future<Map<String, String>>> _variableHydrations =
       <String, Future<Map<String, String>>>{};
@@ -106,7 +111,10 @@ class UserCommandEnvironmentResolver implements CommandEnvironmentResolver {
         ),
       );
     }
-    return _hydration = (hydrator ?? hydrateShellPath)(shell);
+    final hydrate = hydrator;
+    return _hydration = hydrate != null
+        ? hydrate(shell)
+        : hydrateShellPath(shell, processRunner: processRunner);
   }
 
   @override
@@ -123,8 +131,10 @@ class UserCommandEnvironmentResolver implements CommandEnvironmentResolver {
       return Future<Map<String, String>>.value(const <String, String>{});
     }
     final key = valid.join('\u0000');
-    return _variableHydrations[key] ??=
-        (variablesHydrator ?? hydrateShellVariables)(shell, valid);
+    final hydrate = variablesHydrator;
+    return _variableHydrations[key] ??= hydrate != null
+        ? hydrate(shell, valid)
+        : hydrateShellVariables(shell, valid, processRunner: processRunner);
   }
 
   String? _pickShell() {
@@ -152,8 +162,9 @@ bool isValidEnvironmentVariableName(String name) {
 
 Future<Map<String, String>> hydrateShellVariables(
   String shell,
-  List<String> names,
-) async {
+  List<String> names, {
+  ProcessRunner processRunner = const RustProcessRunner(),
+}) async {
   final valid = names.where(isValidEnvironmentVariableName).toList();
   if (valid.isEmpty) {
     return const <String, String>{};
@@ -165,12 +176,12 @@ Future<Map<String, String>> hydrateShellVariables(
       ..write('printf \'$name=%s\' "\$$name"; ')
       ..write("printf '%s' '$shellVariableHydrationDelimiter'; ");
   }
-  Process process;
+  StartedProcess process;
   try {
-    process = await Process.start(shell, <String>[
+    process = await processRunner.start(shell, <String>[
       '-ilc',
       command.toString(),
-    ], mode: ProcessStartMode.normal);
+    ]);
   } catch (_) {
     return const <String, String>{};
   }
@@ -183,12 +194,14 @@ Future<Map<String, String>> hydrateShellVariables(
     await process.exitCode.timeout(
       shellPathHydrationTimeout,
       onTimeout: () {
-        process.kill(ProcessSignal.sigkill);
+        process.kill();
         throw TimeoutException('Shell variable hydration timed out.');
       },
     );
     await Future.wait(<Future<void>>[stdoutDone, stderrDone]);
-  } on TimeoutException {
+  } catch (_) {
+    // Covers the timeout above and a spawn failure the runner reports through
+    // the exit code, where `Process.start` used to throw from the call itself.
     return const <String, String>{};
   }
 
@@ -232,17 +245,17 @@ Map<String, String> parseHydratedShellVariables(
   return values;
 }
 
-Future<CommandEnvironmentHydrationResult> hydrateShellPath(String shell) async {
+Future<CommandEnvironmentHydrationResult> hydrateShellPath(
+  String shell, {
+  ProcessRunner processRunner = const RustProcessRunner(),
+}) async {
   final command =
       "printf '%s' '$shellPathHydrationDelimiter'; "
       'printf \'%s\' "\$PATH"; '
       "printf '%s' '$shellPathHydrationDelimiter'";
-  Process process;
+  StartedProcess process;
   try {
-    process = await Process.start(shell, <String>[
-      '-ilc',
-      command,
-    ], mode: ProcessStartMode.normal);
+    process = await processRunner.start(shell, <String>['-ilc', command]);
   } catch (_) {
     return const CommandEnvironmentHydrationResult.failure(
       CommandEnvironmentHydrationFailureReason.spawnError,
@@ -257,7 +270,7 @@ Future<CommandEnvironmentHydrationResult> hydrateShellPath(String shell) async {
     await process.exitCode.timeout(
       shellPathHydrationTimeout,
       onTimeout: () {
-        process.kill(ProcessSignal.sigkill);
+        process.kill();
         throw TimeoutException('Shell PATH hydration timed out.');
       },
     );
@@ -265,6 +278,12 @@ Future<CommandEnvironmentHydrationResult> hydrateShellPath(String shell) async {
   } on TimeoutException {
     return const CommandEnvironmentHydrationResult.failure(
       CommandEnvironmentHydrationFailureReason.timeout,
+    );
+  } catch (_) {
+    // The runner reports a spawn that failed after `start` returned through
+    // the exit code, where `Process.start` used to throw from the call itself.
+    return const CommandEnvironmentHydrationResult.failure(
+      CommandEnvironmentHydrationFailureReason.spawnError,
     );
   }
 

--- a/test/unit/command_environment_resolver_test.dart
+++ b/test/unit/command_environment_resolver_test.dart
@@ -1,4 +1,10 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
 import 'package:alera/src/shared/infra/process/command_environment_resolver.dart';
+import 'package:alera/src/shared/infra/process/process_runner.dart';
+import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -198,4 +204,159 @@ void main() {
       },
     );
   });
+
+  group('login shell hydration', () {
+    test('probes the login shell through the injected runner', () async {
+      final runner = _FakeProcessRunner(
+        stdout:
+            '$shellPathHydrationDelimiter'
+            '/opt/homebrew/bin:/usr/bin'
+            '$shellPathHydrationDelimiter',
+      )..exit.complete(0);
+
+      final result = await hydrateShellPath('/bin/zsh', processRunner: runner);
+
+      expect(result.ok, isTrue);
+      expect(result.segments, <String>['/opt/homebrew/bin', '/usr/bin']);
+      expect(runner.executable, '/bin/zsh');
+      expect(runner.arguments.first, '-ilc');
+      expect(runner.arguments.last, contains(shellPathHydrationDelimiter));
+    });
+
+    test('reports a spawn error when the shell cannot start', () async {
+      final runner = _FakeProcessRunner(
+        startError: const ProcessException('/bin/zsh', <String>[]),
+      );
+
+      final result = await hydrateShellPath('/bin/zsh', processRunner: runner);
+
+      expect(
+        result.failureReason,
+        CommandEnvironmentHydrationFailureReason.spawnError,
+      );
+    });
+
+    test('reports a spawn error raised after the shell started', () async {
+      final runner = _FakeProcessRunner();
+
+      final pending = hydrateShellPath('/bin/zsh', processRunner: runner);
+      await pumpEventQueue();
+      runner.exit.completeError(const ProcessException('/bin/zsh', <String>[]));
+
+      expect(
+        (await pending).failureReason,
+        CommandEnvironmentHydrationFailureReason.spawnError,
+      );
+    });
+
+    test('reports an empty PATH when the probe prints no delimiters', () async {
+      final runner = _FakeProcessRunner(stdout: 'welcome to zsh')
+        ..exit.complete(0);
+
+      final result = await hydrateShellPath('/bin/zsh', processRunner: runner);
+
+      expect(
+        result.failureReason,
+        CommandEnvironmentHydrationFailureReason.emptyPath,
+      );
+    });
+
+    test('kills the probe and reports a timeout when the shell hangs', () {
+      final runner = _FakeProcessRunner();
+      CommandEnvironmentHydrationResult? result;
+
+      fakeAsync((async) {
+        unawaited(
+          hydrateShellPath(
+            '/bin/zsh',
+            processRunner: runner,
+          ).then((value) => result = value),
+        );
+        async.elapse(shellPathHydrationTimeout * 2);
+        async.flushMicrotasks();
+      });
+
+      expect(runner.killCount, 1);
+      expect(
+        result?.failureReason,
+        CommandEnvironmentHydrationFailureReason.timeout,
+      );
+    });
+
+    test('hydrates requested variables through the injected runner', () async {
+      final runner = _FakeProcessRunner(
+        stdout:
+            '${shellVariableHydrationDelimiter}CCS_DIR=/home/test/.ccs'
+            '$shellVariableHydrationDelimiter',
+      )..exit.complete(0);
+
+      final values = await hydrateShellVariables('/bin/zsh', <String>[
+        'CCS_DIR',
+      ], processRunner: runner);
+
+      expect(values, <String, String>{'CCS_DIR': '/home/test/.ccs'});
+      expect(runner.arguments.first, '-ilc');
+    });
+
+    test('returns no variables when the shell cannot start', () async {
+      final runner = _FakeProcessRunner(
+        startError: const ProcessException('/bin/zsh', <String>[]),
+      );
+
+      expect(
+        await hydrateShellVariables('/bin/zsh', <String>[
+          'CCS_DIR',
+        ], processRunner: runner),
+        isEmpty,
+      );
+    });
+  });
+}
+
+class _FakeProcessRunner implements ProcessRunner {
+  _FakeProcessRunner({this.stdout = '', this.startError});
+
+  final String stdout;
+  final Object? startError;
+  final Completer<int> exit = Completer<int>();
+
+  String? executable;
+  List<String> arguments = const <String>[];
+  int killCount = 0;
+
+  @override
+  Future<ProcessRunOutput> run(
+    String executable,
+    List<String> arguments, {
+    String? workingDirectory,
+    Map<String, String>? environment,
+  }) {
+    throw UnimplementedError('Hydration only starts processes.');
+  }
+
+  @override
+  Future<StartedProcess> start(
+    String executable,
+    List<String> arguments, {
+    String? workingDirectory,
+    Map<String, String>? environment,
+  }) async {
+    this.executable = executable;
+    this.arguments = arguments;
+    final failure = startError;
+    if (failure != null) {
+      throw failure;
+    }
+    return StartedProcess(
+      stdinWrite: (_) {},
+      stdout: Stream<List<int>>.value(utf8.encode(stdout)),
+      stderr: const Stream<List<int>>.empty(),
+      pid: 4242,
+      exitCode: exit.future,
+      kill: ([dynamic signal]) {
+        killCount += 1;
+        return true;
+      },
+    );
+  }
 }


### PR DESCRIPTION
## Summary

The PATH and variable probes spawned `<shell> -ilc <script>` with `dart:io`. That is the widest window in which the VM's reaper thread is parked in a wait that reaps any child of the process, so every spawn Rust made while a login shell was warming up could come back with ECHILD.

Routing the probe through `ProcessRunner` also improves the timeout path: the runner puts each child in its own process group and kills the group, where `process.kill(sigkill)` reached only the shell and left its children running.

Stacked on #419.

## Validation

- `flutter analyze`, `flutter test`
- Seven new cases in `command_environment_resolver_test.dart` with a fake `ProcessRunner`: probe arguments, PATH parsing, spawn failure, a failure raised after the start, an empty PATH, a hang that must kill and time out, and variable hydration. Both hydration functions had no coverage at all before, because they hard-coded `Process.start`.

## Notes

A spawn failure now arrives through the exit code rather than from the `start` call, so both functions grew a `catch` next to the existing `on TimeoutException`. Without it a late failure would escape instead of degrading to `spawnError`.