### PR TITLE
fix: read the macos keychain through the rust process runner

### DIFF
--- a/lib/src/features/agent_status/infra/claude_runtime_home_service.dart
+++ b/lib/src/features/agent_status/infra/claude_runtime_home_service.dart
@@ -5,6 +5,8 @@ import 'package:alera/src/features/agent_status/domain/agent_status.dart';
 import 'package:alera/src/features/agent_status/infra/agent_hook_endpoint_file.dart';
 import 'package:alera/src/features/agent_status/infra/managed_agent_hook_installer.dart';
 import 'package:alera/src/shared/infra/files/posix_file_mode.dart';
+import 'package:alera/src/shared/infra/process/process_runner.dart';
+import 'package:alera/src/shared/infra/process/rust_process_runner.dart';
 import 'package:crypto/crypto.dart';
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
@@ -19,14 +21,14 @@ typedef ClaudeResourceLinkCreator =
     void Function({required String sourcePath, required String targetPath});
 
 abstract interface class ClaudeKeychainCredentialsStore {
-  String? readLegacyCredentials();
+  Future<String?> readLegacyCredentials();
 
-  void writeScopedCredentials({
+  Future<void> writeScopedCredentials({
     required String configDir,
     required String credentials,
   });
 
-  void deleteScopedCredentials(String configDir);
+  Future<void> deleteScopedCredentials(String configDir);
 }
 
 final class ClaudeRuntimeHomePreparation {
@@ -128,7 +130,7 @@ final class ClaudeRuntimeHomeService {
     final runtime = runtimeHome ?? await _runtimeHomeDirectory();
     final source = _sourceConfigDirectory(runtime);
     _syncRuntimeResources(runtime, source);
-    _syncKeychainCredentials(runtime);
+    await _syncKeychainCredentials(runtime);
 
     final descriptor = _descriptor(runtime);
     final sourceSettingsPath = p.join(source.path, 'settings.json');
@@ -212,18 +214,19 @@ final class _MacOSClaudeKeychainCredentialsStore
   const _MacOSClaudeKeychainCredentialsStore();
 
   static const String _legacyService = 'Claude Code-credentials';
+  static const ProcessRunner _processRunner = RustProcessRunner();
 
   @override
-  String? readLegacyCredentials() {
+  Future<String?> readLegacyCredentials() {
     return _readPassword(_legacyService);
   }
 
   @override
-  void writeScopedCredentials({
+  Future<void> writeScopedCredentials({
     required String configDir,
     required String credentials,
   }) {
-    _runSecurity(<String>[
+    return _runSecurity(<String>[
       'add-generic-password',
       '-U',
       '-s',
@@ -236,8 +239,8 @@ final class _MacOSClaudeKeychainCredentialsStore
   }
 
   @override
-  void deleteScopedCredentials(String configDir) {
-    _runSecurity(<String>[
+  Future<void> deleteScopedCredentials(String configDir) {
+    return _runSecurity(<String>[
       'delete-generic-password',
       '-s',
       _scopedService(configDir),
@@ -246,8 +249,8 @@ final class _MacOSClaudeKeychainCredentialsStore
     ], ignoreNotFound: true);
   }
 
-  String? _readPassword(String service) {
-    final result = Process.runSync('security', <String>[
+  Future<String?> _readPassword(String service) async {
+    final result = await _processRunner.run('security', <String>[
       'find-generic-password',
       '-s',
       service,
@@ -256,7 +259,7 @@ final class _MacOSClaudeKeychainCredentialsStore
       '-w',
     ]);
     if (result.exitCode == 0) {
-      final password = (result.stdout as String).trim();
+      final password = result.stdout.trim();
       return password.isEmpty ? null : password;
     }
     if (_isSecurityNotFound(result)) {
@@ -265,8 +268,11 @@ final class _MacOSClaudeKeychainCredentialsStore
     throw const FileSystemException('Could not read Claude credentials.');
   }
 
-  void _runSecurity(List<String> arguments, {bool ignoreNotFound = false}) {
-    final result = Process.runSync('security', arguments);
+  Future<void> _runSecurity(
+    List<String> arguments, {
+    bool ignoreNotFound = false,
+  }) async {
+    final result = await _processRunner.run('security', arguments);
     if (result.exitCode == 0) {
       return;
     }
@@ -276,7 +282,7 @@ final class _MacOSClaudeKeychainCredentialsStore
     throw const FileSystemException('Could not update Claude credentials.');
   }
 
-  bool _isSecurityNotFound(ProcessResult result) {
+  bool _isSecurityNotFound(ProcessRunOutput result) {
     final output = '${result.stdout} ${result.stderr}'.toLowerCase();
     return result.exitCode == 44 ||
         output.contains('could not be found') ||

--- a/lib/src/features/agent_status/infra/claude_runtime_resources.dart
+++ b/lib/src/features/agent_status/infra/claude_runtime_resources.dart
@@ -133,18 +133,18 @@ extension _ClaudeRuntimeResources on ClaudeRuntimeHomeService {
     _removeStaleRuntimeResources(runtimeHome, expected);
   }
 
-  void _syncKeychainCredentials(Directory runtimeHome) {
+  Future<void> _syncKeychainCredentials(Directory runtimeHome) async {
     final keychain = _keychainCredentialsStore;
     if (keychain == null) {
       return;
     }
     try {
-      final legacyCredentials = keychain.readLegacyCredentials();
+      final legacyCredentials = await keychain.readLegacyCredentials();
       if (legacyCredentials == null || legacyCredentials.isEmpty) {
-        keychain.deleteScopedCredentials(runtimeHome.path);
+        await keychain.deleteScopedCredentials(runtimeHome.path);
         return;
       }
-      keychain.writeScopedCredentials(
+      await keychain.writeScopedCredentials(
         configDir: runtimeHome.path,
         credentials: legacyCredentials,
       );

--- a/test/unit/claude_runtime_home_service_test.dart
+++ b/test/unit/claude_runtime_home_service_test.dart
@@ -684,18 +684,18 @@ final class _FakeClaudeKeychainCredentialsStore
   final deletedConfigDirs = <String>[];
 
   @override
-  String? readLegacyCredentials() => legacyCredentials;
+  Future<String?> readLegacyCredentials() async => legacyCredentials;
 
   @override
-  void writeScopedCredentials({
+  Future<void> writeScopedCredentials({
     required String configDir,
     required String credentials,
-  }) {
+  }) async {
     scopedCredentials[configDir] = credentials;
   }
 
   @override
-  void deleteScopedCredentials(String configDir) {
+  Future<void> deleteScopedCredentials(String configDir) async {
     deletedConfigDirs.add(configDir);
     scopedCredentials.remove(configDir);
   }
@@ -704,16 +704,16 @@ final class _FakeClaudeKeychainCredentialsStore
 final class _ThrowingClaudeKeychainCredentialsStore
     implements ClaudeKeychainCredentialsStore {
   @override
-  String? readLegacyCredentials() {
+  Future<String?> readLegacyCredentials() async {
     throw const FileSystemException('keychain unavailable');
   }
 
   @override
-  void writeScopedCredentials({
+  Future<void> writeScopedCredentials({
     required String configDir,
     required String credentials,
-  }) {}
+  }) async {}
 
   @override
-  void deleteScopedCredentials(String configDir) {}
+  Future<void> deleteScopedCredentials(String configDir) async {}
 }


### PR DESCRIPTION
## Summary

The `security` calls in `ClaudeRuntimeHomeService` were the last `dart:io` spawns left in the app. Same failure class as the rest of the stack: a live `dart:io` child lets the VM's reaper claim a child Rust is waiting on. They ran synchronously too, so each one blocked the main isolate for the length of a keychain lookup.

`ClaudeKeychainCredentialsStore` returns futures now. The propagation stops one level up at `_syncKeychainCredentials`, which is already awaited from an async `install`.

Stacked on #420.

## Validation

- `flutter analyze`, `flutter test`
- `claude_runtime_home_service_test.dart` green with both fakes moved to futures, including the keychain-failure case.

## Notes

macOS only and on demand, so it never contributed to the cold-start symptom. Included because it is the same defect and leaves `lib/` with no `dart:io` spawn other than the detached sidecar launch.

The credential still lives in memory as a `String` exactly as it did with `ProcessResult`, and nothing here is logged, so exposure is unchanged.

`_MacOSClaudeKeychainCredentialsStore` remains untested by design (it would mutate the developer keychain), so E2E on macOS is the only check for it.