### PR TITLE
fix: cover the mobile terminal while its history restores

### DIFF
--- a/mobile/lib/src/app/theme/alera_tokens.dart
+++ b/mobile/lib/src/app/theme/alera_tokens.dart
@@ -88,6 +88,7 @@ abstract final class AleraTokens {
   static const double emptyIcon = 44;
   static const double successIcon = 64;
   static const double terminalPreviewHeight = 280;
+  static const double terminalRestoreProgressWidth = 180;
   static const double keyColumnWidth = 104;
   static const double strokeSm = 2;
   static const double strokeMd = 3;

--- a/mobile/lib/src/features/terminal/domain/terminal_output_batcher.dart
+++ b/mobile/lib/src/features/terminal/domain/terminal_output_batcher.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:collection';
 
+import 'package:alera_mobile/src/features/terminal/domain/terminal_restore_progress.dart';
 import 'package:flutter/scheduler.dart';
 
 /// Coalesces terminal output into one write per frame.
@@ -15,6 +16,7 @@ import 'package:flutter/scheduler.dart';
 class TerminalOutputBatcher {
   TerminalOutputBatcher({
     required this.write,
+    this.onRestoreProgress,
     this.maxCharsPerFrame = _defaultMaxCharsPerFrame,
     this.maxPendingChars = _defaultMaxPendingChars,
     this.minFlushInterval = _defaultMinFlushInterval,
@@ -26,6 +28,11 @@ class TerminalOutputBatcher {
   static const Duration _defaultMinFlushInterval = Duration(milliseconds: 33);
 
   final void Function(String text) write;
+
+  /// Reports how far a restored snapshot has been written, and null once it is
+  /// fully in. The surface covers the emulator until then, because a restore
+  /// spans many frames and watching history scroll past reads as a bug.
+  final void Function(TerminalRestoreProgress? progress)? onRestoreProgress;
   final int maxCharsPerFrame;
   final int maxPendingChars;
   final Duration minFlushInterval;
@@ -37,11 +44,15 @@ class TerminalOutputBatcher {
   final Stopwatch _sinceFlushRequest = Stopwatch();
   int _pendingChars = 0;
   int _pendingLiveChars = 0;
+  int _restoreTotalChars = 0;
+  int _restoreWrittenChars = 0;
   bool _flushScheduled = false;
   bool _disposed = false;
   Timer? _flushTimer;
 
   int get pendingChars => _pendingChars;
+
+  bool get debugRestoring => _restoreTotalChars > 0;
 
   /// Test-only evidence that a partial drain advances inside the original
   /// string instead of allocating a fresh tail after every frame.
@@ -59,8 +70,14 @@ class TerminalOutputBatcher {
 
   /// Queues a restored snapshot, which is a bounded one-shot payload and so is
   /// exempt from the cap that exists to contain a live process.
-  void addSnapshot(String text) =>
-      _enqueue(text, source: _OutputSource.restore);
+  void addSnapshot(String text) {
+    if (_disposed || text.isEmpty) {
+      return;
+    }
+    _restoreTotalChars += text.length;
+    _publishRestoreProgress();
+    _enqueue(text, source: _OutputSource.restore);
+  }
 
   void _enqueue(String text, {required _OutputSource source}) {
     if (_disposed || text.isEmpty) {
@@ -144,14 +161,19 @@ class TerminalOutputBatcher {
     }
     final frame = StringBuffer();
     var written = 0;
+    var restoreWritten = 0;
     while (_pending.isNotEmpty && written < maxCharsPerFrame) {
       final chunk = _pending.first;
       final remaining = maxCharsPerFrame - written;
       if (chunk.remaining <= remaining) {
         final available = chunk.remaining;
         frame.write(chunk.remainingText);
+        final restore = chunk.source == _OutputSource.restore;
         _consume(chunk, available);
         written += available;
+        if (restore) {
+          restoreWritten += available;
+        }
         continue;
       }
       final cutoff = _chunkCutoff(chunk.text, chunk.head + remaining);
@@ -160,15 +182,45 @@ class TerminalOutputBatcher {
       }
       final consumed = cutoff - chunk.head;
       frame.write(chunk.text.substring(chunk.head, cutoff));
+      final restore = chunk.source == _OutputSource.restore;
       _consume(chunk, consumed);
       written += consumed;
+      if (restore) {
+        restoreWritten += consumed;
+      }
     }
     if (written > 0) {
       write(frame.toString());
     }
+    _advanceRestore(restoreWritten);
     if (_pending.isNotEmpty) {
       _schedule();
     }
+  }
+
+  void _advanceRestore(int chars) {
+    if (_restoreTotalChars <= 0) {
+      return;
+    }
+    _restoreWrittenChars += chars;
+    // Anything still queued behind the restore is live output that arrived
+    // while it drained, so the cover comes down as soon as the history is in.
+    if (_restoreWrittenChars >= _restoreTotalChars) {
+      _restoreTotalChars = 0;
+      _restoreWrittenChars = 0;
+      onRestoreProgress?.call(null);
+      return;
+    }
+    _publishRestoreProgress();
+  }
+
+  void _publishRestoreProgress() {
+    onRestoreProgress?.call(
+      TerminalRestoreProgress(
+        writtenChars: _restoreWrittenChars,
+        totalChars: _restoreTotalChars,
+      ),
+    );
   }
 
   void dispose() {
@@ -179,6 +231,14 @@ class TerminalOutputBatcher {
     _pending.clear();
     _pendingChars = 0;
     _pendingLiveChars = 0;
+    // A batcher discarded mid-restore has to take its own cover down: nothing
+    // else clears it, and the emulator it belonged to is already gone.
+    final restoring = _restoreTotalChars > 0;
+    _restoreTotalChars = 0;
+    _restoreWrittenChars = 0;
+    if (restoring) {
+      onRestoreProgress?.call(null);
+    }
   }
 
   void _consume(_PendingOutputChunk chunk, int count) {

--- a/mobile/lib/src/features/terminal/domain/terminal_restore_progress.dart
+++ b/mobile/lib/src/features/terminal/domain/terminal_restore_progress.dart
@@ -1,0 +1,30 @@
+/// How far a restored snapshot has been written into the emulator.
+///
+/// A restore is drained over several frames, so the surface needs to know how
+/// far along it is to show something better than history scrolling past.
+class TerminalRestoreProgress {
+  const TerminalRestoreProgress({
+    required this.writtenChars,
+    required this.totalChars,
+  });
+
+  final int writtenChars;
+  final int totalChars;
+
+  double get fraction {
+    if (totalChars <= 0) {
+      return 1;
+    }
+    final value = writtenChars / totalChars;
+    return value < 0 ? 0 : (value > 1 ? 1 : value);
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      other is TerminalRestoreProgress &&
+      other.writtenChars == writtenChars &&
+      other.totalChars == totalChars;
+
+  @override
+  int get hashCode => Object.hash(writtenChars, totalChars);
+}

--- a/mobile/lib/src/features/terminal/presentation/terminal_tab_state_widgets.dart
+++ b/mobile/lib/src/features/terminal/presentation/terminal_tab_state_widgets.dart
@@ -61,6 +61,35 @@ class _DirectModeBanner extends StatelessWidget {
   }
 }
 
+class _TerminalRestoreState extends StatelessWidget {
+  const _TerminalRestoreState({required this.progress});
+
+  final TerminalRestoreProgress progress;
+
+  @override
+  Widget build(BuildContext context) {
+    return DecoratedBox(
+      decoration: const BoxDecoration(color: AleraTokens.background),
+      child: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            Text(
+              'Restoring terminal',
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
+            const SizedBox(height: AleraTokens.spaceMd),
+            SizedBox(
+              width: AleraTokens.terminalRestoreProgressWidth,
+              child: LinearProgressIndicator(value: progress.fraction),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
 enum _TerminalLoadingOperation { starting, reconnecting, restarting }
 
 class _SessionLoading extends StatefulWidget {

--- a/mobile/lib/src/features/terminal/presentation/terminal_tab_view.dart
+++ b/mobile/lib/src/features/terminal/presentation/terminal_tab_view.dart
@@ -10,6 +10,7 @@ import 'package:alera_mobile/src/features/terminal/application/terminal_input_mo
 import 'package:alera_mobile/src/features/terminal/application/terminal_session_controller.dart';
 import 'package:alera_mobile/src/features/terminal/domain/terminal_accessory_key.dart';
 import 'package:alera_mobile/src/features/terminal/domain/terminal_input_mode.dart';
+import 'package:alera_mobile/src/features/terminal/domain/terminal_restore_progress.dart';
 import 'package:alera_mobile/src/features/terminal/presentation/terminal_accessory_bar.dart';
 import 'package:alera_mobile/src/features/terminal/presentation/terminal_compose_bar.dart';
 import 'package:flutter/material.dart';
@@ -217,6 +218,8 @@ class _TerminalSurfaceState extends State<_TerminalSurface> {
   final TerminalController _controller = TerminalController();
   final ScrollController _scrollController = ScrollController();
   final FocusNode _focusNode = FocusNode(debugLabel: 'MobileTerminal');
+  final ValueNotifier<TerminalRestoreProgress?> _restoreProgress =
+      ValueNotifier<TerminalRestoreProgress?>(null);
   TerminalOutputBatcher? _batcher;
   StreamSubscription<MobileTerminalOutputEvent>? _outputSub;
   bool _outputEnded = false;
@@ -245,6 +248,7 @@ class _TerminalSurfaceState extends State<_TerminalSurface> {
   void dispose() {
     unawaited(_outputSub?.cancel());
     _batcher?.dispose();
+    _restoreProgress.dispose();
     _controller.dispose();
     _scrollController.dispose();
     _focusNode.dispose();
@@ -280,7 +284,10 @@ class _TerminalSurfaceState extends State<_TerminalSurface> {
     );
     // One write per frame. Writing every chunk straight through made a noisy
     // build parse and repaint many times inside a single frame.
-    _batcher = TerminalOutputBatcher(write: next.write);
+    _batcher = TerminalOutputBatcher(
+      write: next.write,
+      onRestoreProgress: _handleRestoreProgress,
+    );
     if (notify) {
       setState(() => _terminal = next);
     } else {
@@ -296,6 +303,24 @@ class _TerminalSurfaceState extends State<_TerminalSurface> {
       return;
     }
     _batcher!.add(text);
+  }
+
+  void _handleRestoreProgress(TerminalRestoreProgress? progress) {
+    if (!mounted) {
+      return;
+    }
+    final finished = _restoreProgress.value != null && progress == null;
+    _restoreProgress.value = progress;
+    if (!finished) {
+      return;
+    }
+    // The emulator was written to while it was covered, so the view it is
+    // about to reveal was never laid out against the restored buffer.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted && _restoreProgress.value == null) {
+        unawaited(refreshRendering());
+      }
+    });
   }
 
   void _markOutputEnded() {
@@ -336,21 +361,36 @@ class _TerminalSurfaceState extends State<_TerminalSurface> {
         Expanded(
           child: ColoredBox(
             color: AleraTokens.background,
-            child: TerminalView(
-              _terminal,
-              key: ValueKey<int>(_viewGeneration),
-              controller: _controller,
-              scrollController: _scrollController,
-              focusNode: _focusNode,
-              // Compose mode keeps the terminal read-only so tapping it scrolls
-              // instead of raising the soft keyboard; direct mode streams keys.
-              readOnly: !direct,
-              autofocus: direct && _viewGeneration == 0,
-              backgroundOpacity: 0,
-              textStyle: const TerminalStyle(
-                fontFamily: AleraTokens.monoFontFamily,
-              ),
-              padding: const EdgeInsets.all(AleraTokens.spaceSm),
+            child: Stack(
+              fit: StackFit.expand,
+              children: <Widget>[
+                TerminalView(
+                  _terminal,
+                  key: ValueKey<int>(_viewGeneration),
+                  controller: _controller,
+                  scrollController: _scrollController,
+                  focusNode: _focusNode,
+                  // Compose mode keeps the terminal read-only so tapping it
+                  // scrolls instead of raising the soft keyboard; direct mode
+                  // streams keys.
+                  readOnly: !direct,
+                  autofocus: direct && _viewGeneration == 0,
+                  backgroundOpacity: 0,
+                  textStyle: const TerminalStyle(
+                    fontFamily: AleraTokens.monoFontFamily,
+                  ),
+                  padding: const EdgeInsets.all(AleraTokens.spaceSm),
+                ),
+                // Restoring a tab replays its whole scrollback over many
+                // frames. Uncovered, that reads as the terminal scrolling
+                // itself from the top of history down to the live screen.
+                ValueListenableBuilder<TerminalRestoreProgress?>(
+                  valueListenable: _restoreProgress,
+                  builder: (context, progress, _) => progress == null
+                      ? const SizedBox.shrink()
+                      : _TerminalRestoreState(progress: progress),
+                ),
+              ],
             ),
           ),
         ),

--- a/mobile/test/terminal_output_batcher_test.dart
+++ b/mobile/test/terminal_output_batcher_test.dart
@@ -1,6 +1,7 @@
 import 'dart:collection';
 
 import 'package:alera_mobile/src/features/terminal/domain/terminal_output_batcher.dart';
+import 'package:alera_mobile/src/features/terminal/domain/terminal_restore_progress.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -177,5 +178,85 @@ void main() {
 
     expect(writes, isEmpty);
     expect(subject.pendingChars, 0);
+  });
+
+  group('restore progress', () {
+    late List<TerminalRestoreProgress?> reported;
+
+    TerminalOutputBatcher restoring({int maxCharsPerFrame = 100}) {
+      final subject = TerminalOutputBatcher(
+        write: writes.add,
+        onRestoreProgress: reported.add,
+        maxCharsPerFrame: maxCharsPerFrame,
+        maxPendingChars: 4096,
+      );
+      addTearDown(subject.dispose);
+      return subject;
+    }
+
+    setUp(() => reported = <TerminalRestoreProgress?>[]);
+
+    test('is reported before the first frame draws any of the snapshot', () {
+      // The cover has to be up before the emulator is written to, or the first
+      // 64 KB of history is already on screen when it appears.
+      final subject = restoring();
+
+      subject.addSnapshot('s' * 250);
+
+      expect(writes, isEmpty);
+      expect(reported.single?.totalChars, 250);
+      expect(reported.single?.writtenChars, 0);
+    });
+
+    test('advances per frame and clears once the snapshot is fully in', () {
+      final subject = restoring();
+
+      subject.addSnapshot('s' * 250);
+      subject.flushFrame();
+      subject.flushFrame();
+      subject.flushFrame();
+
+      expect(reported.map((progress) => progress?.writtenChars), <int?>[
+        0,
+        100,
+        200,
+        null,
+      ]);
+      expect(subject.debugRestoring, isFalse);
+    });
+
+    test('live output queued behind a restore does not hold the cover up', () {
+      // The cover is for the history replay. Output that arrived while it
+      // drained is ordinary live output and must not extend the wait.
+      final subject = restoring();
+
+      subject.addSnapshot('s' * 100);
+      subject.add('l' * 500);
+      subject.flushFrame();
+
+      expect(reported.last, isNull);
+      expect(subject.pendingChars, 500);
+    });
+
+    test('a batcher discarded mid-restore takes its own cover down', () {
+      // Replacing the emulator disposes the batcher; nothing else would clear
+      // a progress value left behind, and the cover would never lift.
+      final subject = restoring();
+
+      subject.addSnapshot('s' * 250);
+      subject.dispose();
+
+      expect(reported.last, isNull);
+    });
+
+    test('a batcher that never restored reports nothing on dispose', () {
+      final subject = restoring();
+
+      subject.add('live');
+      subject.flushFrame();
+      subject.dispose();
+
+      expect(reported, isEmpty);
+    });
   });
 }

--- a/mobile/test/terminal_tab_view_test.dart
+++ b/mobile/test/terminal_tab_view_test.dart
@@ -125,6 +125,43 @@ void main() {
     expect(session.retainedSnapshotBytes, 0);
   });
 
+  testWidgets('Restoring a tab covers the terminal until its history is in', (
+    tester,
+  ) async {
+    // Uncovered, this replay reads as the terminal scrolling itself from the
+    // top of history down to the live screen every time a tab is opened.
+    final client = FakeTerminalClient()
+      ..tabs = <WorkspaceTabSummary>[fakeTab(id: 'tab-1', title: 'Terminal 1')]
+      // Past the per-frame budget, so the restore spans frames like a real
+      // scrollback does rather than landing in the first one.
+      ..attachmentSnapshot = utf8.encode('a' * (200 * 1024));
+    await _pumpTab(tester, client, settle: false);
+
+    expect(find.text('Restoring terminal'), findsOneWidget);
+    final first = _restoreFraction(tester);
+
+    await tester.pump(const Duration(milliseconds: 50));
+
+    expect(find.text('Restoring terminal'), findsOneWidget);
+    expect(_restoreFraction(tester), greaterThan(first));
+
+    await tester.pumpAndSettle();
+
+    expect(find.text('Restoring terminal'), findsNothing);
+    expect(_terminalOf(tester).buffer.lines.length, greaterThan(0));
+  });
+
+  testWidgets('A tab with no history to restore is never covered', (
+    tester,
+  ) async {
+    final client = FakeTerminalClient()
+      ..tabs = <WorkspaceTabSummary>[fakeTab(id: 'tab-1', title: 'Terminal 1')];
+
+    await _pumpTab(tester, client, settle: false);
+
+    expect(find.text('Restoring terminal'), findsNothing);
+  });
+
   testWidgets('Paste quick action writes clipboard text without Enter', (
     tester,
   ) async {
@@ -217,7 +254,18 @@ Terminal _terminalOf(WidgetTester tester) {
   return tester.widget<TerminalView>(find.byType(TerminalView)).terminal;
 }
 
-Future<void> _pumpTab(WidgetTester tester, FakeTerminalClient client) async {
+double _restoreFraction(WidgetTester tester) {
+  return tester
+          .widget<LinearProgressIndicator>(find.byType(LinearProgressIndicator))
+          .value ??
+      0;
+}
+
+Future<void> _pumpTab(
+  WidgetTester tester,
+  FakeTerminalClient client, {
+  bool settle = true,
+}) async {
   await tester.pumpWidget(
     ProviderScope(
       overrides: [
@@ -231,5 +279,16 @@ Future<void> _pumpTab(WidgetTester tester, FakeTerminalClient client) async {
       ),
     ),
   );
-  await tester.pumpAndSettle();
+  if (settle) {
+    await tester.pumpAndSettle();
+    return;
+  }
+  // Settling would drain the whole restore, which is the state under test.
+  for (var frame = 0; frame < 10; frame++) {
+    await tester.pump();
+    if (find.byType(TerminalView).evaluate().isNotEmpty) {
+      return;
+    }
+  }
+  fail('the terminal never attached');
 }


### PR DESCRIPTION
## Summary

Opening a tab on mobile replays the session's whole scrollback into a fresh emulator, and the batcher writes at most 64 KB per frame, so the replay was visible: the terminal appeared to scroll itself from the top of history down to the live screen every time.

The desktop already solved this by covering the surface until the restore drains (`_TerminalRestoreState`). Mobile had the same batching and none of the cover. This reports restore progress from the batcher and uses it the same way, then refreshes the view once the history is in, since it was written while nothing was laid out against it.

First of a six-PR stack fixing the mobile terminal restore. Merge in order.

## Validation

`flutter analyze` clean, 477 mobile tests pass. New tests cover the progress lifecycle: reported before the first byte reaches the emulator, advancing per frame, cleared once the snapshot is in, not held up by live output queued behind it, and taken down by a batcher discarded mid-restore.

## Notes

No behaviour change to the emulator itself, only to what is shown while it fills.