### PR TITLE
fix: stop the mobile attach from resizing the pty to 80x24

### DIFF
--- a/mobile/lib/src/features/runtime/domain/runtime_client_surfaces.dart
+++ b/mobile/lib/src/features/runtime/domain/runtime_client_surfaces.dart
@@ -94,10 +94,18 @@ abstract interface class MobileTerminalClient {
     int rows,
     bool autoCloseOnSuccess = false,
   });
+
+  /// Attaches to [tabId]'s session, claiming the viewport driver seat.
+  ///
+  /// [cols] and [rows] are null until the terminal has been laid out, and stay
+  /// off the request when they are: the host resizes the live PTY to whatever
+  /// viewport a phone claims, so sending a placeholder resizes the session
+  /// twice per tab open and makes a full-screen agent redraw itself at a
+  /// geometry nobody is looking at.
   Future<MobileTerminalSession> attachTerminal(
     String tabId, {
-    int cols,
-    int rows,
+    int? cols,
+    int? rows,
   });
   Future<MobileTerminalSession> restartTerminal(
     String tabId, {

--- a/mobile/lib/src/features/runtime/infra/mobile_runtime_terminal_requests.dart
+++ b/mobile/lib/src/features/runtime/infra/mobile_runtime_terminal_requests.dart
@@ -50,13 +50,17 @@ mixin MobileRuntimeTerminalRequests {
 
   Future<MobileTerminalSession> attachTerminal(
     String tabId, {
-    int cols = defaultTerminalCols,
-    int rows = defaultTerminalRows,
+    int? cols,
+    int? rows,
   }) async {
+    // Omitted rather than defaulted: the host reads a stated viewport as a
+    // resize of the live PTY, and a placeholder there is a resize to a size
+    // nobody is looking at. An older host still falls back to 80x24 for an
+    // absent viewport, so it keeps behaving as it does today.
     final payload = await requestMap('terminal.attach', <String, Object?>{
       'tabId': tabId,
-      'cols': cols,
-      'rows': rows,
+      'cols': ?cols,
+      'rows': ?rows,
     });
     return MobileTerminalSession.fromJson(payload);
   }

--- a/mobile/lib/src/features/terminal/application/terminal_session_controller.dart
+++ b/mobile/lib/src/features/terminal/application/terminal_session_controller.dart
@@ -26,8 +26,10 @@ class TerminalSessionController extends _$TerminalSessionController {
   bool _desktopReclaimed = false;
   Completer<void>? _recoveryCompletion;
   MobileTerminalClient? _pendingRecoveryClient;
-  int _cols = defaultTerminalCols;
-  int _rows = defaultTerminalRows;
+  // Null until the terminal has been laid out. Claiming a viewport resizes the
+  // live PTY, so a guess here is a resize to a size nobody is looking at.
+  int? _cols;
+  int? _rows;
 
   bool get supportsRestart => _client?.supportsTerminalRestart ?? false;
 
@@ -59,7 +61,11 @@ class TerminalSessionController extends _$TerminalSessionController {
     final client = await ref.read(terminalClientProvider(hostId).future);
     // The runtime restarts exited sessions under the same handle during
     // attach, so a single attach always yields a usable session.
-    final session = await client.attachTerminal(tabId);
+    final session = await client.attachTerminal(
+      tabId,
+      cols: _cols,
+      rows: _rows,
+    );
     return _bindSession(client, session);
   }
 
@@ -299,11 +305,13 @@ class TerminalSessionController extends _$TerminalSessionController {
     }
     state = const AsyncLoading<TerminalTabSession>(progress: 0.75);
     try {
+      // A restart mints a new PTY, so unlike attach it always needs a size;
+      // an unmeasured terminal has nothing better than the default to give.
       final session = await client.restartTerminal(
         tabId,
         sessionId: _sessionId,
-        cols: _cols,
-        rows: _rows,
+        cols: _cols ?? defaultTerminalCols,
+        rows: _rows ?? defaultTerminalRows,
       );
       if (_disposed) {
         _logger.warning(

--- a/mobile/test/support/fake_terminal_client.dart
+++ b/mobile/test/support/fake_terminal_client.dart
@@ -47,8 +47,8 @@ class FakeTerminalClient
   /// The raw payload of each `writeTerminal`, for tests that care about the
   /// bytes and not just their count.
   final List<List<int>> writes = <List<int>>[];
-  final List<({String tabId, int cols, int rows})> attachments =
-      <({String tabId, int cols, int rows})>[];
+  final List<({String tabId, int? cols, int? rows})> attachments =
+      <({String tabId, int? cols, int? rows})>[];
   final List<Object> writeErrors = <Object>[];
   final List<Object> resizeErrors = <Object>[];
   Future<void>? attachCompletion;
@@ -216,8 +216,8 @@ class FakeTerminalClient
   @override
   Future<MobileTerminalSession> attachTerminal(
     String tabId, {
-    int cols = defaultTerminalCols,
-    int rows = defaultTerminalRows,
+    int? cols,
+    int? rows,
   }) async {
     calls.add('attach $tabId');
     attachments.add((tabId: tabId, cols: cols, rows: rows));

--- a/mobile/test/terminal_tab_view_test.dart
+++ b/mobile/test/terminal_tab_view_test.dart
@@ -162,6 +162,26 @@ void main() {
     expect(find.text('Restoring terminal'), findsNothing);
   });
 
+  testWidgets('The first attach claims no viewport until one is measured', (
+    tester,
+  ) async {
+    // The host resizes the live PTY to whatever viewport a phone claims, so a
+    // placeholder here resized the session to 80x24 and then again to the real
+    // size a layout later, redrawing a full-screen agent at both.
+    final client = FakeTerminalClient()
+      ..tabs = <WorkspaceTabSummary>[fakeTab(id: 'tab-1', title: 'Terminal 1')];
+
+    await _pumpTab(tester, client);
+
+    expect(client.attachments.single.cols, isNull);
+    expect(client.attachments.single.rows, isNull);
+    // The measured size still reaches the host, just once and only when real.
+    final resize = client.calls.firstWhere(
+      (call) => call.startsWith('resize '),
+    );
+    expect(resize, isNot(endsWith(' 80 24')));
+  });
+
   testWidgets('Paste quick action writes clipboard text without Enter', (
     tester,
   ) async {

--- a/rust/alera-cli/src/terminal_host/server.rs
+++ b/rust/alera-cli/src/terminal_host/server.rs
@@ -117,6 +117,8 @@ mod lifecycle;
 mod managed_workspace_requests;
 mod mobile_gateway_surface;
 mod mobile_terminal_requests;
+#[cfg(test)]
+mod mobile_terminal_viewport_tests;
 mod mobile_workspace_file_paths;
 mod mobile_workspace_file_requests;
 mod orchestration_agent_spawn_requests;

--- a/rust/alera-cli/src/terminal_host/server/mobile_terminal_requests.rs
+++ b/rust/alera-cli/src/terminal_host/server/mobile_terminal_requests.rs
@@ -104,16 +104,27 @@ impl ServerActor {
     /// Claims the driver seat for the phone right after a mobile attach or
     /// create, and refreshes the attachment's driver field so the response
     /// reflects the post-claim state.
-    fn claim_mobile_terminal_viewport(
+    ///
+    /// A phone that has not measured its terminal yet omits `cols`/`rows`, and
+    /// that MUST leave the PTY alone rather than fall back to 80x24: defaulting
+    /// resized the live session twice per tab open, once to a size nobody was
+    /// looking at and again to the real one a layout later, so a full-screen
+    /// agent redrew itself into the scrollback at a geometry it never had.
+    pub(super) fn claim_mobile_terminal_viewport(
         &mut self,
         client_id: u64,
         session_id: &str,
         payload: &Value,
         attachment: &mut Value,
     ) {
-        let cols = int_or(payload, "cols", 80) as u16;
-        let rows = int_or(payload, "rows", 24) as u16;
-        self.claim_mobile_driver(client_id, session_id, Some((cols, rows)));
+        let viewport = match (payload.get("cols"), payload.get("rows")) {
+            (Some(_), Some(_)) => Some((
+                int_or(payload, "cols", 80) as u16,
+                int_or(payload, "rows", 24) as u16,
+            )),
+            _ => None,
+        };
+        self.claim_mobile_driver(client_id, session_id, viewport);
         if let (Some(object), Some(session)) =
             (attachment.as_object_mut(), self.sessions.get(session_id))
         {

--- a/rust/alera-cli/src/terminal_host/server/mobile_terminal_viewport_tests.rs
+++ b/rust/alera-cli/src/terminal_host/server/mobile_terminal_viewport_tests.rs
@@ -1,0 +1,102 @@
+//! What a mobile attach does to the live PTY's size.
+//!
+//! A phone claims the viewport driver seat when it attaches, and the host
+//! applies whatever size it claims to the running session. A phone that has
+//! not laid its terminal out yet has no size to state, and the host must leave
+//! the session alone rather than substitute 80x24.
+
+use std::collections::HashMap;
+
+use serde_json::json;
+
+use crate::terminal_host::client::ClientHandle;
+use crate::terminal_host::session::Session;
+
+use super::actor_test_harness::{local_client, mobile_client, test_actor};
+use super::ServerActor;
+
+async fn actor_with_mobile_session(dir: &tempfile::TempDir) -> ServerActor {
+    let (handle, _terminal_rx) = ClientHandle::test_terminal_channels();
+    let mut session = Session::driver_test_stub("s1", 213, 54);
+    session.attach(2);
+    test_actor(
+        dir,
+        HashMap::from([(2, mobile_client(handle, "phone-1"))]),
+        HashMap::from([("s1".to_string(), session)]),
+    )
+    .await
+}
+
+#[tokio::test]
+async fn an_attach_without_a_measured_viewport_leaves_the_session_size_alone() {
+    // Defaulting to 80x24 here resized the live session twice per tab open:
+    // once to a size nobody was looking at, and again to the real one a layout
+    // later. A full-screen agent redrew itself into the scrollback at both.
+    let dir = tempfile::tempdir().unwrap();
+    let mut actor = actor_with_mobile_session(&dir).await;
+    let mut attachment = json!({});
+
+    actor.claim_mobile_terminal_viewport(2, "s1", &json!({ "tabId": "t1" }), &mut attachment);
+
+    assert_eq!(actor.sessions.get("s1").unwrap().current_dims, (213, 54));
+    // The seat is still claimed; only the resize is withheld.
+    assert_eq!(attachment["driver"]["kind"], "mobile");
+}
+
+#[tokio::test]
+async fn an_attach_that_states_a_viewport_resizes_the_session() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut actor = actor_with_mobile_session(&dir).await;
+    let mut attachment = json!({});
+
+    actor.claim_mobile_terminal_viewport(
+        2,
+        "s1",
+        &json!({ "tabId": "t1", "cols": 45, "rows": 30 }),
+        &mut attachment,
+    );
+
+    assert_eq!(actor.sessions.get("s1").unwrap().current_dims, (45, 30));
+}
+
+#[tokio::test]
+async fn a_half_stated_viewport_is_not_a_viewport() {
+    // Neither half alone describes a terminal, and taking the stated one with a
+    // default for the other is the same wrong resize under a different name.
+    let dir = tempfile::tempdir().unwrap();
+    let mut actor = actor_with_mobile_session(&dir).await;
+    let mut attachment = json!({});
+
+    actor.claim_mobile_terminal_viewport(
+        2,
+        "s1",
+        &json!({ "tabId": "t1", "cols": 45 }),
+        &mut attachment,
+    );
+
+    assert_eq!(actor.sessions.get("s1").unwrap().current_dims, (213, 54));
+}
+
+#[tokio::test]
+async fn a_desktop_client_never_claims_the_mobile_seat() {
+    let dir = tempfile::tempdir().unwrap();
+    let (handle, _terminal_rx) = ClientHandle::test_terminal_channels();
+    let mut session = Session::driver_test_stub("s1", 213, 54);
+    session.attach(2);
+    let mut actor = test_actor(
+        &dir,
+        HashMap::from([(2, local_client(handle))]),
+        HashMap::from([("s1".to_string(), session)]),
+    )
+    .await;
+    let mut attachment = json!({});
+
+    actor.claim_mobile_terminal_viewport(
+        2,
+        "s1",
+        &json!({ "tabId": "t1", "cols": 45, "rows": 30 }),
+        &mut attachment,
+    );
+
+    assert_eq!(actor.sessions.get("s1").unwrap().current_dims, (213, 54));
+}


### PR DESCRIPTION
## Summary

A phone claims the viewport driver seat when it attaches, and the host applies whatever size it claims to the live session. The app had no measured size at that point and sent the 80x24 defaults, so opening a tab resized the running PTY twice: once to a size nobody was looking at, and again to the real one a layout later. A full-screen agent redrew itself at both, and those redraws are what the scrollback then held.

The size now stays off the request until the terminal has been laid out, and the host treats an absent viewport as "leave the session alone" rather than falling back to 80x24. Both halves must be stated for the claim to count, since one alone still describes no terminal.

Stacked on #424.

## Validation

`flutter analyze` clean, 478 mobile tests, 1153 Rust tests. New Rust tests cover the four cases of the claim: no viewport, a full viewport, a half-stated one, and a desktop client. A new mobile test asserts the first attach carries no size and that the measured one still reaches the host, once.

## Notes

Compatible in both directions. The app always sent the fields before, so an older app against this host behaves as it does today; an older host still defaults an absent viewport to 80x24, which is the behaviour this replaces.