### PR TITLE
fix: size the mobile terminal scrollback for a phone's width

### DIFF
--- a/mobile/lib/src/features/terminal/domain/mobile_terminal_scrollback.dart
+++ b/mobile/lib/src/features/terminal/domain/mobile_terminal_scrollback.dart
@@ -1,0 +1,18 @@
+/// How many lines a phone's terminal emulator keeps.
+///
+/// This is a line budget standing in for a cell budget, which is what actually
+/// costs memory: a line allocates its full width whatever it holds, at 16 bytes
+/// per cell. The desktop keeps `scrollbackLines` (10000 by default) at a
+/// desktop width of roughly 200 columns, so about 2M cells.
+///
+/// A phone is roughly a quarter as wide, so holding the same history takes
+/// about four times the lines at a quarter of the width: the same 2M cells, and
+/// the same memory the desktop already spends. 5000 lines, which is what this
+/// was, showed barely a tenth of what the desktop showed once the restored
+/// history was reflowed down to the phone's width.
+///
+/// The peak is higher than the resting cost: history is replayed at the host's
+/// width before the view reflows it, so the same lines are briefly four times
+/// wider. What bounds that is the host's own `restoreSnapshotBytes` cap on how
+/// much it will send.
+const int mobileTerminalScrollbackLines = 40000;

--- a/mobile/lib/src/features/terminal/presentation/terminal_tab_view.dart
+++ b/mobile/lib/src/features/terminal/presentation/terminal_tab_view.dart
@@ -10,6 +10,7 @@ import 'package:alera_mobile/src/features/terminal/application/terminal_input_mo
 import 'package:alera_mobile/src/features/terminal/application/terminal_session_controller.dart';
 import 'package:alera_mobile/src/features/terminal/application/terminal_tab_session.dart';
 import 'package:alera_mobile/src/features/terminal/domain/terminal_accessory_key.dart';
+import 'package:alera_mobile/src/features/terminal/domain/mobile_terminal_scrollback.dart';
 import 'package:alera_mobile/src/features/terminal/domain/terminal_input_mode.dart';
 import 'package:alera_mobile/src/features/terminal/domain/terminal_restore_progress.dart';
 import 'package:alera_mobile/src/features/terminal/presentation/terminal_accessory_bar.dart';
@@ -283,7 +284,7 @@ class _TerminalSurfaceState extends State<_TerminalSurface> {
   void _replaceEmulator({required bool notify}) {
     _batcher?.dispose();
     final next = Terminal(
-      maxLines: 5000,
+      maxLines: mobileTerminalScrollbackLines,
       onOutput: (data) => widget.onInput(data),
       onResize: (width, height, _, _) => _handleViewportResize(width, height),
       // This emulator is filled from restored history, and the program that

--- a/mobile/test/terminal_tab_view_test.dart
+++ b/mobile/test/terminal_tab_view_test.dart
@@ -212,6 +212,31 @@ void main() {
     expect(joined.indexOf('TAIL'), 179);
   });
 
+  testWidgets('Restored history is kept past what fits at the host width', (
+    tester,
+  ) async {
+    // Reflowing to the phone's width turns one host line into several, so a
+    // budget sized for the host width keeps a fraction of the history it was
+    // meant to. The scrollback the desktop shows takes roughly four times the
+    // lines here, at a quarter of the width.
+    final client = FakeTerminalClient()
+      ..tabs = <WorkspaceTabSummary>[fakeTab(id: 'tab-1', title: 'Terminal 1')]
+      ..attachmentSnapshot = utf8.encode(
+        <String>[
+          for (var line = 0; line < 8000; line++) 'line-$line',
+        ].join('\r\n'),
+      )
+      ..attachmentSnapshotCols = 200
+      ..attachmentSnapshotRows = 50;
+
+    await _pumpTab(tester, client, settle: false);
+    await _drainRestore(tester);
+
+    final terminal = _terminalOf(tester);
+    final first = terminal.buffer.lines[0].toString().trim();
+    expect(first, 'line-0', reason: 'the oldest line was dropped');
+  });
+
   testWidgets('A host that states no snapshot size replays as it always did', (
     tester,
   ) async {


### PR DESCRIPTION
## Summary

Reflowing restored history down to the phone's width turns one host line into several, so the 5000-line budget kept roughly a tenth of what the desktop shows. Holding the same history takes about four times the lines at a quarter of the width, which is the same cell count and so the same memory the desktop already spends.

Last of the stack. Stacked on #427.

## Validation

`flutter analyze` clean, 482 mobile tests. The new test restores 8000 lines and asserts the oldest survives; at 5000 it comes back as `line-3000`.

## Notes

The resting cost is what the desktop already pays for a full scrollback. The peak is higher: history is replayed at the host's width before the view reflows it, so the same lines are briefly around four times wider. What bounds that is the host's own `restoreSnapshotBytes` cap on how much it will send. Worth watching on a real device with a large scrollback.