### PR TITLE
fix: configure android cmake abi

### DIFF
--- a/rust_builder/cargokit/build_tool/lib/src/android_environment.dart
+++ b/rust_builder/cargokit/build_tool/lib/src/android_environment.dart
@@ -171,16 +171,31 @@ class AndroidEnvironment {
       '_CARGOKIT_NDK_LINK_TARGET': targetArg,
       '_CARGOKIT_NDK_LINK_CLANG': ccValue,
       'ANDROID_NDK_HOME': ndkPath,
-      'CMAKE_TOOLCHAIN_FILE': path.join(
-        ndkPath,
-        'build',
-        'cmake',
-        'android.toolchain.cmake',
-      ),
+      'CMAKE_TOOLCHAIN_FILE': _createCmakeToolchain(ndkPath),
       'BINDGEN_EXTRA_CLANG_ARGS_${target.rust}':
           '$targetArg --sysroot=$sysrootPath',
       'CARGOKIT_TOOL_TEMP_DIR': toolTempDir,
     };
+  }
+
+  String _createCmakeToolchain(String ndkPath) {
+    final toolchainDirectory = Directory(
+      path.join(targetTempDir, 'cargokit', 'android_toolchain'),
+    )..createSync(recursive: true);
+    final ndkToolchainPath = path
+        .join(ndkPath, 'build', 'cmake', 'android.toolchain.cmake')
+        .replaceAll(r'\', '/');
+    final toolchainFile = File(
+      path.join(toolchainDirectory.path, '${target.rust}.cmake'),
+    );
+
+    // NDK 28 defaults its legacy toolchain to armeabi-v7a unless ANDROID_ABI
+    // is cached before the toolchain is included and forwarded to try_compile.
+    toolchainFile.writeAsStringSync(
+      'set(ANDROID_ABI [=[${target.android}]=] CACHE STRING [[]] FORCE)\n'
+      'include([=[$ndkToolchainPath]=])\n',
+    );
+    return toolchainFile.path;
   }
 
   // Workaround for libgcc missing in NDK23, inspired by cargo-ndk

--- a/rust_builder/cargokit/build_tool/test/android_environment_test.dart
+++ b/rust_builder/cargokit/build_tool/test/android_environment_test.dart
@@ -1,0 +1,58 @@
+import 'dart:io';
+
+import 'package:build_tool/src/android_environment.dart';
+import 'package:build_tool/src/target.dart';
+import 'package:path/path.dart' as path;
+import 'package:test/test.dart';
+
+void main() {
+  test('provides the matching CMake ABI for every Android target', () async {
+    final sdkDirectory = Directory.systemTemp.createTempSync(
+      'alera-android-environment-test-',
+    );
+    addTearDown(() => sdkDirectory.deleteSync(recursive: true));
+
+    const ndkVersion = '28.2.13676358';
+    final hostArchitecture = Platform.isMacOS
+        ? 'darwin-x86_64'
+        : Platform.isLinux
+            ? 'linux-x86_64'
+            : 'windows-x86_64';
+    final toolchainDirectory = Directory(
+      path.join(
+        sdkDirectory.path,
+        'ndk',
+        ndkVersion,
+        'toolchains',
+        'llvm',
+        'prebuilt',
+        hostArchitecture,
+        'bin',
+      ),
+    )..createSync(recursive: true);
+    File(
+      path.join(
+        toolchainDirectory.path,
+        Platform.isWindows ? 'llvm-ar.exe' : 'llvm-ar',
+      ),
+    ).createSync();
+
+    for (final target in Target.androidTargets()) {
+      final environment = await AndroidEnvironment(
+        sdkPath: sdkDirectory.path,
+        ndkVersion: ndkVersion,
+        minSdkVersion: 24,
+        targetTempDir: path.join(sdkDirectory.path, 'target'),
+        target: target,
+      ).buildEnvironment();
+
+      final toolchainFile = File(environment['CMAKE_TOOLCHAIN_FILE']!);
+      expect(
+        toolchainFile.readAsStringSync(),
+        contains(
+          'set(ANDROID_ABI [=[${target.android}]=] CACHE STRING [[]] FORCE)',
+        ),
+      );
+    }
+  });
+}


### PR DESCRIPTION
## Summary

- generate a target-specific CMake toolchain wrapper that pins `ANDROID_ABI` before loading the NDK toolchain
- cover every Android target with a Cargokit regression test

## Root Cause

The NDK 28 legacy toolchain defaulted to `armeabi-v7a` while Cargokit was building `aarch64-linux-android`, which mixed ARMv7 and ARM64 compiler flags in the release APK build.

## Validation

- `dart format --set-exit-if-changed lib/src/android_environment.dart test/android_environment_test.dart`
- `dart analyze`
- `dart test`
- `flutter build apk --release`
- `flutter build apk --release --split-per-abi`
- `gh act pull_request -W .github/workflows/pr.yml -j static`
