### PR TITLE
fix: bundle android whisper c++ runtime

### DIFF
--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -737,6 +737,24 @@ jobs:
           flutter build apk --release "${firebase_defines[@]}"
           flutter build apk --release --split-per-abi "${firebase_defines[@]}"
 
+      - name: Verify Android native dependencies
+        shell: bash
+        run: |
+          set -euo pipefail
+          readelf="$(find "$ANDROID_NDK_HOME/toolchains/llvm/prebuilt" -name llvm-readelf -type f | head -1)"
+          test -n "$readelf"
+          extract_dir="$(mktemp -d)"
+          trap 'rm -rf "$extract_dir"' EXIT
+          for apk in mobile/build/app/outputs/flutter-apk/*-release.apk; do
+            apk_dir="$extract_dir/$(basename "$apk" .apk)"
+            unzip -q "$apk" 'lib/*/libalera_mobile_native.so' 'lib/*/libc++_shared.so' -d "$apk_dir"
+            while IFS= read -r native; do
+              abi="$(basename "$(dirname "$native")")"
+              "$readelf" -d "$native" | grep -q 'Shared library: \[libc++_shared.so\]'
+              test -f "$apk_dir/lib/$abi/libc++_shared.so"
+            done < <(find "$apk_dir/lib" -name libalera_mobile_native.so -type f)
+          done
+
       - name: Verify Android APK signatures
         shell: bash
         run: |

--- a/mobile/rust_builder/android/build.gradle
+++ b/mobile/rust_builder/android/build.gradle
@@ -39,4 +39,5 @@ apply from: "../../../rust_builder/cargokit/gradle/plugin.gradle"
 cargokit {
     manifestDir = "../../../rust/alera-mobile-native"
     libname = "alera_mobile_native"
+    bundleSharedCxxRuntime = true
 }

--- a/rust_builder/cargokit/build_tool/lib/src/android_environment.dart
+++ b/rust_builder/cargokit/build_tool/lib/src/android_environment.dart
@@ -54,6 +54,32 @@ class AndroidEnvironment {
   /// Target being built.
   final Target target;
 
+  File sharedCxxRuntime() {
+    final ndkLibraryTriple = switch (target.rust) {
+      'armv7-linux-androideabi' => 'arm-linux-androideabi',
+      'aarch64-linux-android' => 'aarch64-linux-android',
+      'i686-linux-android' => 'i686-linux-android',
+      'x86_64-linux-android' => 'x86_64-linux-android',
+      _ => throw StateError('Unsupported Android target: ${target.rust}'),
+    };
+    return File(
+      path.join(
+        sdkPath,
+        'ndk',
+        ndkVersion,
+        'toolchains',
+        'llvm',
+        'prebuilt',
+        _hostArchitecture,
+        'sysroot',
+        'usr',
+        'lib',
+        ndkLibraryTriple,
+        'libc++_shared.so',
+      ),
+    );
+  }
+
   bool ndkIsInstalled() {
     final ndkPath = path.join(sdkPath, 'ndk', ndkVersion);
     final ndkPackageXml = File(path.join(ndkPath, 'package.xml'));
@@ -82,17 +108,13 @@ class AndroidEnvironment {
   }
 
   Future<Map<String, String>> buildEnvironment() async {
-    final hostArch = Platform.isMacOS
-        ? "darwin-x86_64"
-        : (Platform.isLinux ? "linux-x86_64" : "windows-x86_64");
-
     final ndkPath = path.join(sdkPath, 'ndk', ndkVersion);
     final toolchainPath = path.join(
       ndkPath,
       'toolchains',
       'llvm',
       'prebuilt',
-      hostArch,
+      _hostArchitecture,
       'bin',
     );
     final sysrootPath = path.join(
@@ -100,7 +122,7 @@ class AndroidEnvironment {
       'toolchains',
       'llvm',
       'prebuilt',
-      hostArch,
+      _hostArchitecture,
       'sysroot',
     );
 
@@ -177,6 +199,10 @@ class AndroidEnvironment {
       'CARGOKIT_TOOL_TEMP_DIR': toolTempDir,
     };
   }
+
+  String get _hostArchitecture => Platform.isMacOS
+      ? 'darwin-x86_64'
+      : (Platform.isLinux ? 'linux-x86_64' : 'windows-x86_64');
 
   String _createCmakeToolchain(String ndkPath) {
     final toolchainDirectory = Directory(

--- a/rust_builder/cargokit/build_tool/lib/src/build_gradle.dart
+++ b/rust_builder/cargokit/build_tool/lib/src/build_gradle.dart
@@ -6,6 +6,7 @@ import 'dart:io';
 import 'package:logging/logging.dart';
 import 'package:path/path.dart' as path;
 
+import 'android_environment.dart';
 import 'artifacts_provider.dart';
 import 'builder.dart';
 import 'environment.dart';
@@ -43,6 +44,21 @@ class BuildGradle {
         if (lib.type == AritifactType.dylib) {
           File(lib.path).copySync(path.join(outputDir, lib.finalFileName));
         }
+      }
+      if (Environment.bundleSharedCxxRuntime) {
+        final runtime = AndroidEnvironment(
+          sdkPath: environment.androidSdkPath!,
+          ndkVersion: environment.androidNdkVersion!,
+          minSdkVersion: environment.androidMinSdkVersion!,
+          targetTempDir: environment.targetTempDir,
+          target: target,
+        ).sharedCxxRuntime();
+        if (!runtime.existsSync()) {
+          throw BuildException(
+            'Android shared C++ runtime was not found at ${runtime.path}',
+          );
+        }
+        runtime.copySync(path.join(outputDir, 'libc++_shared.so'));
       }
     }
   }

--- a/rust_builder/cargokit/build_tool/lib/src/environment.dart
+++ b/rust_builder/cargokit/build_tool/lib/src/environment.dart
@@ -45,6 +45,8 @@ class Environment {
   static String get javaHome => _getEnvPath("CARGOKIT_JAVA_HOME");
   static List<String> get targetPlatforms =>
       _getEnv("CARGOKIT_TARGET_PLATFORMS").split(',');
+  static bool get bundleSharedCxxRuntime =>
+      _getEnv("CARGOKIT_BUNDLE_SHARED_CXX_RUNTIME") == 'true';
 
   // CMAKE
   static String get targetPlatform => _getEnv("CARGOKIT_TARGET_PLATFORM");

--- a/rust_builder/cargokit/build_tool/test/android_environment_test.dart
+++ b/rust_builder/cargokit/build_tool/test/android_environment_test.dart
@@ -55,4 +55,42 @@ void main() {
       );
     }
   });
+
+  test('resolves the matching shared C++ runtime for every Android ABI', () {
+    final sdkDirectory = Directory.systemTemp.createTempSync(
+      'alera-android-cxx-runtime-test-',
+    );
+    addTearDown(() => sdkDirectory.deleteSync(recursive: true));
+
+    const ndkVersion = '28.2.13676358';
+    const expectedTriples = <String, String>{
+      'armeabi-v7a': 'arm-linux-androideabi',
+      'arm64-v8a': 'aarch64-linux-android',
+      'x86': 'i686-linux-android',
+      'x86_64': 'x86_64-linux-android',
+    };
+
+    for (final target in Target.androidTargets()) {
+      final runtime = AndroidEnvironment(
+        sdkPath: sdkDirectory.path,
+        ndkVersion: ndkVersion,
+        minSdkVersion: 24,
+        targetTempDir: path.join(sdkDirectory.path, 'target'),
+        target: target,
+      ).sharedCxxRuntime();
+
+      expect(
+        path.normalize(runtime.path),
+        endsWith(
+          path.join(
+            'sysroot',
+            'usr',
+            'lib',
+            expectedTriples[target.android]!,
+            'libc++_shared.so',
+          ),
+        ),
+      );
+    }
+  });
 }

--- a/rust_builder/cargokit/gradle/plugin.gradle
+++ b/rust_builder/cargokit/gradle/plugin.gradle
@@ -11,6 +11,7 @@ apply plugin: CargoKitPlugin
 class CargoKitExtension {
     String manifestDir; // Relative path to folder containing Cargo.toml
     String libname; // Library name within Cargo.toml. Must be a cdylib
+    boolean bundleSharedCxxRuntime = false; // Package libc++_shared.so for C++ dependencies.
 }
 
 abstract class CargoKitBuildTask extends DefaultTask {
@@ -41,6 +42,9 @@ abstract class CargoKitBuildTask extends DefaultTask {
 
     @Input
     List<String> targetPlatforms
+
+    @Input
+    boolean bundleSharedCxxRuntime
 
     @TaskAction
     def build() {
@@ -79,6 +83,7 @@ abstract class CargoKitBuildTask extends DefaultTask {
             environment "CARGOKIT_COMPILE_SDK_VERSION", compileSdkVersion
             environment "CARGOKIT_MIN_SDK_VERSION", minSdkVersion
             environment "CARGOKIT_TARGET_PLATFORMS", targetPlatforms.join(",")
+            environment "CARGOKIT_BUNDLE_SHARED_CXX_RUNTIME", bundleSharedCxxRuntime.toString()
             environment "CARGOKIT_JAVA_HOME", System.properties['java.home']
         }
     }
@@ -167,6 +172,7 @@ class CargoKitPlugin implements Plugin<Project> {
                     minSdkVersion = plugin.project.android.defaultConfig.minSdkVersion.apiLevel as int
                     compileSdkVersion = plugin.project.android.compileSdkVersion.substring(8) as int
                     targetPlatforms = platforms
+                    bundleSharedCxxRuntime = project.cargokit.bundleSharedCxxRuntime
                     pluginFile = CargoKitPlugin.file
                 }
                 def onTask = { newTask ->


### PR DESCRIPTION
## Summary

Fixes mobile transcription startup failures caused by Android packaging `libalera_mobile_native.so` without the shared C++ runtime required by `whisper.cpp`.

## Root cause

`whisper-rs-sys` links the Android native library against `libc++_shared.so`, but the Cargokit-based mobile plugin copied only the Rust cdylib into the APK. Android's loader therefore rejected `libalera_mobile_native.so` before transcription could start.

## Code changes

- add an opt-in `bundleSharedCxxRuntime` Cargokit Gradle setting
- resolve the ABI-specific runtime from the configured Android NDK
- copy `libc++_shared.so` beside `libalera_mobile_native.so` for every packaged ABI
- enable the setting only for Alera's mobile native plugin
- add build-tool coverage for all supported Android ABI mappings
- verify release APKs declare and contain the runtime for every native library

## Validation

- `puro dart analyze` in `rust_builder/cargokit/build_tool`
- `puro dart test` in `rust_builder/cargokit/build_tool`
- `puro flutter test test/unit/release_workflow_config_test.dart`

## Notes

A full Android release build on Windows remains blocked by a separate upstream `whisper-rs-sys` cross-compilation issue that passes the MSVC-only `/utf-8` flag to Android Clang. That is independent of the missing-runtime packaging defect and is intentionally not mixed into this PR.