### PR TITLE
feat: accelerate desktop whisper inference

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -15,7 +15,7 @@ All platforms require Flutter 3.44.8 or newer with Dart 3.12.1 or newer, Git, Ru
 
 ### Windows
 
-Install Visual Studio 2022 with the **Desktop development with C++** workload and a Windows 10 or 11 SDK, Git for Windows, Flutter, and Rustup. PowerShell 7 is recommended. The repository setup checks those prerequisites, enables Git long paths, installs Zig and LLVM when requested, configures LLVM headers for Bindgen, pins native builds to the supported Visual Studio 2022 CMake generator, repairs nested submodules, resolves dependencies, and runs the native-asset preflight:
+Install Visual Studio 2022 with the **Desktop development with C++** workload and a Windows 10 or 11 SDK, Git for Windows, Flutter, and Rustup. PowerShell 7 is recommended. The repository setup checks those prerequisites, enables Git long paths, installs Zig, LLVM, and the pinned Vulkan SDK when requested, configures LLVM headers for Bindgen, pins native builds to the supported Visual Studio 2022 CMake generator, repairs nested submodules, resolves dependencies, and runs the native-asset preflight:
 
 ```powershell
 pwsh -File tool/development/setup_windows.ps1 -InstallMissingTools
@@ -42,10 +42,12 @@ sudo apt-get install -y \
   libsqlite3-dev \
   libssl-dev \
   libepoxy-dev \
-  libmpv-dev
+  libmpv-dev \
+  libvulkan-dev \
+  glslc
 ```
 
-These packages provide the compiler toolchain and the native browser, video, storage, and security libraries used by the desktop plugins.
+These packages provide the compiler toolchain and the native browser, video, storage, security, and Vulkan compute libraries used by the desktop app. Cargo builds outside Flutter should set `VULKAN_SDK=/usr`.
 
 ### Common setup
 

--- a/.github/actions/setup-flutter-workspace/action.yml
+++ b/.github/actions/setup-flutter-workspace/action.yml
@@ -72,12 +72,13 @@ runs:
       shell: bash
       run: |
         set -euo pipefail
-        packages="clang libclang-dev cmake ninja-build pkg-config libgtk-3-dev libwebkit2gtk-4.1-dev libjson-glib-dev libsecret-1-dev libsqlite3-dev libssl-dev libepoxy-dev libmpv-dev"
+        packages="clang libclang-dev cmake ninja-build pkg-config libgtk-3-dev libwebkit2gtk-4.1-dev libjson-glib-dev libsecret-1-dev libsqlite3-dev libssl-dev libepoxy-dev libmpv-dev libvulkan-dev glslc"
         if [ "${{ inputs.xvfb }}" = "true" ]; then
           packages="${packages} xvfb"
         fi
         sudo apt-get update
         sudo apt-get install -y ${packages} ${{ inputs.extra-linux-packages }}
+        echo "VULKAN_SDK=/usr" >> "$GITHUB_ENV"
 
     - name: Install libclang on macOS
       if: runner.os == 'macOS'
@@ -93,6 +94,22 @@ runs:
       run: |
         choco install llvm --no-progress --yes
         "LIBCLANG_PATH=C:\Program Files\LLVM\bin" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
+    - name: Install Vulkan SDK on Windows
+      if: runner.os == 'Windows' && inputs.rust == 'true'
+      shell: pwsh
+      run: |
+        $version = '1.4.350.0'
+        winget install --exact --id KhronosGroup.VulkanSDK --version $version --silent --accept-package-agreements --accept-source-agreements --disable-interactivity
+        if ($LASTEXITCODE -ne 0) {
+          throw "Vulkan SDK installation failed with code $LASTEXITCODE."
+        }
+        $sdk = "C:\VulkanSDK\$version"
+        if (-not (Test-Path -LiteralPath "$sdk\Lib\vulkan-1.lib") -or -not (Test-Path -LiteralPath "$sdk\Bin\glslc.exe")) {
+          throw "Vulkan SDK $version is incomplete at $sdk."
+        }
+        "VULKAN_SDK=$sdk" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        "$sdk\Bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
     - name: Enable Linux desktop
       if: inputs.enable-linux-desktop == 'true'

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -173,7 +173,10 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Install Linux dependencies
-        run: sudo apt-get update && sudo apt-get install --yes libdbus-1-dev pkg-config
+        run: sudo apt-get update && sudo apt-get install --yes libdbus-1-dev pkg-config libvulkan-dev glslc
+
+      - name: Configure Vulkan SDK
+        run: echo "VULKAN_SDK=/usr" >> "$GITHUB_ENV"
 
       - name: Setup Rust and sccache
         uses: ./.github/actions/setup-rust-sccache

--- a/lib/src/features/ai_dictation/application/ai_dictation_model_transfers.dart
+++ b/lib/src/features/ai_dictation/application/ai_dictation_model_transfers.dart
@@ -96,7 +96,9 @@ class AiDictationModelTransfers extends _$AiDictationModelTransfers {
     return AiDictationModelTransfersState(
       models: <String, AiDictationModelTransfer>{
         for (final model in AiDictationModelStore.models)
-          model.id: AiDictationModelTransfer(totalBytes: model.sizeBytes),
+          model.id: AiDictationModelTransfer(
+            totalBytes: _store.downloadSizeBytes(model.id),
+          ),
       },
     );
   }
@@ -115,6 +117,7 @@ class AiDictationModelTransfers extends _$AiDictationModelTransfers {
     final updated = <String, AiDictationModelTransfer>{};
     for (final model in AiDictationModelStore.models) {
       final current = state.forModel(model.id);
+      final totalBytes = _store.downloadSizeBytes(model.id);
       final installed = await _store.isInstalled(model.id);
       final partial = await _store.partialBytes(model.id);
       final status = state.activeModelId == model.id
@@ -128,8 +131,8 @@ class AiDictationModelTransfers extends _$AiDictationModelTransfers {
           : AiDictationModelTransferStatus.idle;
       updated[model.id] = current.copyWith(
         installed: installed,
-        receivedBytes: installed ? model.sizeBytes : partial,
-        totalBytes: model.sizeBytes,
+        receivedBytes: installed ? totalBytes : partial,
+        totalBytes: totalBytes,
         status: status,
       );
     }
@@ -161,6 +164,7 @@ class AiDictationModelTransfers extends _$AiDictationModelTransfers {
     required bool automatic,
   }) async {
     final model = _store.modelFor(normalized);
+    final totalBytes = _store.downloadSizeBytes(model.id);
     final partial = await _store.partialBytes(normalized);
     _update(
       normalized,
@@ -170,7 +174,7 @@ class AiDictationModelTransfers extends _$AiDictationModelTransfers {
             status: AiDictationModelTransferStatus.downloading,
             installed: false,
             receivedBytes: partial,
-            totalBytes: model.sizeBytes,
+            totalBytes: totalBytes,
             clearMessage: true,
           ),
       activeModelId: normalized,
@@ -188,7 +192,7 @@ class AiDictationModelTransfers extends _$AiDictationModelTransfers {
                   status: progress >= 1
                       ? AiDictationModelTransferStatus.verifying
                       : AiDictationModelTransferStatus.downloading,
-                  receivedBytes: (progress * model.sizeBytes).round(),
+                  receivedBytes: (progress * totalBytes).round(),
                 ),
           );
         },
@@ -201,7 +205,7 @@ class AiDictationModelTransfers extends _$AiDictationModelTransfers {
             .copyWith(
               status: AiDictationModelTransferStatus.idle,
               installed: true,
-              receivedBytes: model.sizeBytes,
+              receivedBytes: totalBytes,
               clearMessage: true,
             ),
         clearActiveModel: true,

--- a/lib/src/features/ai_dictation/application/ai_dictation_model_transfers.g.dart
+++ b/lib/src/features/ai_dictation/application/ai_dictation_model_transfers.g.dart
@@ -48,7 +48,7 @@ final class AiDictationModelTransfersProvider
 }
 
 String _$aiDictationModelTransfersHash() =>
-    r'b174c3373ecf366ae7f3327ee0f00933d8e3316d';
+    r'782fd0fa25621651e9be3e1dbe60363fd63552fb';
 
 abstract class _$AiDictationModelTransfers
     extends $Notifier<AiDictationModelTransfersState> {

--- a/lib/src/features/ai_dictation/infra/ai_dictation_core_ml_store.dart
+++ b/lib/src/features/ai_dictation/infra/ai_dictation_core_ml_store.dart
@@ -1,0 +1,187 @@
+import 'dart:io';
+import 'dart:isolate';
+
+import 'package:archive/archive_io.dart';
+import 'package:crypto/crypto.dart';
+import 'package:http/http.dart' as http;
+import 'package:path/path.dart' as p;
+
+import 'ai_dictation_model.dart';
+
+class AiDictationCoreMlStore {
+  const AiDictationCoreMlStore();
+
+  String encoderPath(String modelPath, AiDictationCoreMlEncoder encoder) =>
+      p.join(p.dirname(modelPath), encoder.directoryName);
+
+  String partialPath(String modelPath) => '$modelPath.coreml.part.zip';
+
+  String stagingPath(String modelPath) => '$modelPath.coreml.installing';
+
+  Future<bool> isInstalled(
+    String modelPath,
+    AiDictationCoreMlEncoder encoder,
+  ) async {
+    final destination = Directory(encoderPath(modelPath, encoder));
+    final marker = File(p.join(destination.path, '.archive.sha256'));
+    if (!await destination.exists() || !await marker.exists()) return false;
+    return (await marker.readAsString()).trim() == encoder.archiveSha256;
+  }
+
+  Future<int> partialBytes(
+    String modelPath,
+    AiDictationCoreMlEncoder encoder,
+  ) async {
+    if (await isInstalled(modelPath, encoder)) return encoder.archiveSizeBytes;
+    final partial = File(partialPath(modelPath));
+    return await partial.exists() ? partial.length() : 0;
+  }
+
+  Future<void> download({
+    required http.Client client,
+    required String modelPath,
+    required AiDictationCoreMlEncoder encoder,
+    required bool Function() isCancelled,
+    required void Function(int receivedBytes) onProgress,
+  }) async {
+    if (await isInstalled(modelPath, encoder)) {
+      onProgress(encoder.archiveSizeBytes);
+      return;
+    }
+
+    final partial = File(partialPath(modelPath));
+    var offset = await partial.exists() ? await partial.length() : 0;
+    if (offset > encoder.archiveSizeBytes) {
+      await partial.delete();
+      offset = 0;
+    }
+    onProgress(offset);
+
+    if (offset < encoder.archiveSizeBytes) {
+      final request = http.Request('GET', Uri.parse(encoder.archiveUri));
+      if (offset > 0) {
+        request.headers[HttpHeaders.rangeHeader] = 'bytes=$offset-';
+      }
+      final response = await client.send(request);
+      if (offset > 0 && response.statusCode == HttpStatus.partialContent) {
+        _validateContentRange(response, offset, encoder.archiveSizeBytes);
+      } else if (response.statusCode == HttpStatus.ok) {
+        if (offset > 0 && await partial.exists()) await partial.delete();
+        offset = 0;
+      } else if (response.statusCode !=
+              HttpStatus.requestedRangeNotSatisfiable ||
+          offset != encoder.archiveSizeBytes) {
+        throw HttpException(
+          'Whisper Core ML encoder download failed: ${response.statusCode}.',
+        );
+      }
+
+      if (response.statusCode != HttpStatus.requestedRangeNotSatisfiable) {
+        final sink = partial.openWrite(
+          mode: offset == 0 ? FileMode.write : FileMode.append,
+        );
+        var received = offset;
+        try {
+          await for (final chunk in response.stream) {
+            if (isCancelled()) throw const AiDictationDownloadCancelled();
+            sink.add(chunk);
+            received += chunk.length;
+            onProgress(received);
+          }
+        } finally {
+          await sink.close();
+        }
+      }
+    }
+
+    if (isCancelled()) throw const AiDictationDownloadCancelled();
+    if (!await partial.exists() ||
+        await partial.length() != encoder.archiveSizeBytes) {
+      throw StateError(
+        'The Whisper Core ML encoder download ended before it was complete.',
+      );
+    }
+    final digest = await Isolate.run(_Sha256Computation(partial.path).call);
+    if (digest != encoder.archiveSha256) {
+      throw StateError(
+        'The downloaded Whisper Core ML encoder failed checksum verification.',
+      );
+    }
+
+    final staging = Directory(stagingPath(modelPath));
+    if (await staging.exists()) await staging.delete(recursive: true);
+    await staging.create(recursive: true);
+    try {
+      final extraction = _CoreMlArchiveExtraction(
+        archivePath: partial.path,
+        outputPath: staging.path,
+      );
+      await Isolate.run(extraction.call);
+      final extracted = Directory(p.join(staging.path, encoder.directoryName));
+      if (!await extracted.exists()) {
+        throw StateError(
+          'The Whisper Core ML encoder archive did not contain the expected model.',
+        );
+      }
+      if (isCancelled()) throw const AiDictationDownloadCancelled();
+      await File(
+        p.join(extracted.path, '.archive.sha256'),
+      ).writeAsString(digest, flush: true);
+      final destination = Directory(encoderPath(modelPath, encoder));
+      if (await destination.exists()) await destination.delete(recursive: true);
+      await extracted.rename(destination.path);
+      await partial.delete();
+    } finally {
+      if (await staging.exists()) await staging.delete(recursive: true);
+    }
+    onProgress(encoder.archiveSizeBytes);
+  }
+
+  Future<void> discardPartial(String modelPath) async {
+    final partial = File(partialPath(modelPath));
+    if (await partial.exists()) await partial.delete();
+    final staging = Directory(stagingPath(modelPath));
+    if (await staging.exists()) await staging.delete(recursive: true);
+  }
+}
+
+void _validateContentRange(
+  http.StreamedResponse response,
+  int expectedStart,
+  int expectedTotal,
+) {
+  final value = response.headers[HttpHeaders.contentRangeHeader];
+  final match = value == null
+      ? null
+      : RegExp(r'^bytes (\d+)-(\d+)/(\d+)$').firstMatch(value);
+  if (match == null ||
+      int.parse(match.group(1)!) != expectedStart ||
+      int.parse(match.group(3)!) != expectedTotal) {
+    throw const HttpException(
+      'Whisper Core ML encoder resume response was invalid.',
+    );
+  }
+}
+
+Future<String> _sha256File(String path) async =>
+    (await sha256.bind(File(path).openRead()).first).toString();
+
+class _Sha256Computation {
+  const _Sha256Computation(this.path);
+
+  final String path;
+
+  Future<String> call() => _sha256File(path);
+}
+
+class _CoreMlArchiveExtraction {
+  const _CoreMlArchiveExtraction({
+    required this.archivePath,
+    required this.outputPath,
+  });
+
+  final String archivePath;
+  final String outputPath;
+
+  Future<void> call() => extractFileToDisk(archivePath, outputPath);
+}

--- a/lib/src/features/ai_dictation/infra/ai_dictation_model.dart
+++ b/lib/src/features/ai_dictation/infra/ai_dictation_model.dart
@@ -1,0 +1,41 @@
+class AiDictationModel {
+  const AiDictationModel({
+    required this.id,
+    required this.label,
+    required this.description,
+    required this.fileName,
+    required this.sha256,
+    required this.uri,
+    required this.sizeBytes,
+    this.coreMlEncoder,
+    this.storageVersion = 1,
+  });
+
+  final String id;
+  final String label;
+  final String description;
+  final String fileName;
+  final String sha256;
+  final String uri;
+  final int sizeBytes;
+  final AiDictationCoreMlEncoder? coreMlEncoder;
+  final int storageVersion;
+}
+
+class AiDictationCoreMlEncoder {
+  const AiDictationCoreMlEncoder({
+    required this.directoryName,
+    required this.archiveUri,
+    required this.archiveSha256,
+    required this.archiveSizeBytes,
+  });
+
+  final String directoryName;
+  final String archiveUri;
+  final String archiveSha256;
+  final int archiveSizeBytes;
+}
+
+class AiDictationDownloadCancelled implements Exception {
+  const AiDictationDownloadCancelled();
+}

--- a/lib/src/features/ai_dictation/infra/ai_dictation_model_store.dart
+++ b/lib/src/features/ai_dictation/infra/ai_dictation_model_store.dart
@@ -8,15 +8,24 @@ import 'package:http/http.dart' as http;
 import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
 
+import 'ai_dictation_core_ml_store.dart';
+import 'ai_dictation_model.dart';
+
+export 'ai_dictation_model.dart';
+
 class AiDictationModelStore {
   AiDictationModelStore({
     http.Client Function()? clientFactory,
     Future<Directory> Function()? supportDirectory,
     List<AiDictationModel>? modelCatalog,
+    bool? installCoreMlEncoder,
+    AiDictationCoreMlStore? coreMlStore,
   }) : _clientFactory = clientFactory ?? http.Client.new,
        _supportDirectory =
            supportDirectory ?? (() => getApplicationSupportDirectory()),
-       _modelCatalog = modelCatalog ?? models;
+       _modelCatalog = modelCatalog ?? models,
+       _installCoreMlEncoder = installCoreMlEncoder ?? Platform.isMacOS,
+       _coreMlStore = coreMlStore ?? const AiDictationCoreMlStore();
 
   static const legacyModelId = 'whisper-cpp-base';
   static const modelId = 'whisper-base';
@@ -38,6 +47,14 @@ class AiDictationModelStore {
       uri:
           'https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-tiny.bin?download=true',
       sizeBytes: 77691713,
+      coreMlEncoder: AiDictationCoreMlEncoder(
+        directoryName: 'ggml-tiny-encoder.mlmodelc',
+        archiveUri:
+            'https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-tiny-encoder.mlmodelc.zip?download=true',
+        archiveSha256:
+            'c88cbd2648e1f5415092bcf5256add463a0f19943e6938f46e8d4ffdebd47739',
+        archiveSizeBytes: 15037446,
+      ),
     ),
     AiDictationModel(
       id: modelId,
@@ -48,6 +65,14 @@ class AiDictationModelStore {
       uri:
           'https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-base.bin?download=true',
       sizeBytes: 147951465,
+      coreMlEncoder: AiDictationCoreMlEncoder(
+        directoryName: 'ggml-base-encoder.mlmodelc',
+        archiveUri:
+            'https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-base-encoder.mlmodelc.zip?download=true',
+        archiveSha256:
+            '7e6ab77041942572f239b5b602f8aaa1c3ed29d73e3d8f20abea03a773541089',
+        archiveSizeBytes: 37922638,
+      ),
     ),
     AiDictationModel(
       id: 'whisper-small',
@@ -59,6 +84,14 @@ class AiDictationModelStore {
       uri:
           'https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-small.bin?download=true',
       sizeBytes: 487601967,
+      coreMlEncoder: AiDictationCoreMlEncoder(
+        directoryName: 'ggml-small-encoder.mlmodelc',
+        archiveUri:
+            'https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-small-encoder.mlmodelc.zip?download=true',
+        archiveSha256:
+            'de43fb9fed471e95c19e60ae67575c2bf09e8fb607016da171b06ddad313988b',
+        archiveSizeBytes: 163083239,
+      ),
     ),
     AiDictationModel(
       id: 'whisper-large-v3-turbo-q5-0',
@@ -70,12 +103,22 @@ class AiDictationModelStore {
       uri:
           'https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v3-turbo-q5_0.bin?download=true',
       sizeBytes: 574041195,
+      coreMlEncoder: AiDictationCoreMlEncoder(
+        directoryName: 'ggml-large-v3-turbo-encoder.mlmodelc',
+        archiveUri:
+            'https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v3-turbo-encoder.mlmodelc.zip?download=true',
+        archiveSha256:
+            '84bedfe895bd7b5de6e8e89a0803dfc5addf8c0c5bc4c937451716bf7cf7988a',
+        archiveSizeBytes: 1173393014,
+      ),
     ),
   ];
 
   final http.Client Function() _clientFactory;
   final Future<Directory> Function() _supportDirectory;
   final List<AiDictationModel> _modelCatalog;
+  final bool _installCoreMlEncoder;
+  final AiDictationCoreMlStore _coreMlStore;
   http.Client? _activeClient;
   String? _activeModelId;
   Completer<void>? _activeFinished;
@@ -91,6 +134,12 @@ class AiDictationModelStore {
   }
 
   static String modelForId(String id) => id == legacyModelId ? modelId : id;
+
+  int downloadSizeBytes(String id) {
+    final model = modelFor(id);
+    final encoder = _requiredCoreMlEncoder(model);
+    return model.sizeBytes + (encoder?.archiveSizeBytes ?? 0);
+  }
 
   Future<String> modelPath([String? id]) async {
     final model = modelFor(id ?? modelId);
@@ -114,6 +163,12 @@ class AiDictationModelStore {
   Future<bool> isInstalled([String? id]) async {
     final model = modelFor(id ?? modelId);
     final path = await modelPath(model.id);
+    if (!await _isModelInstalled(model, path)) return false;
+    final encoder = _requiredCoreMlEncoder(model);
+    return encoder == null || await _coreMlStore.isInstalled(path, encoder);
+  }
+
+  Future<bool> _isModelInstalled(AiDictationModel model, String path) async {
     final file = File(path);
     final marker = File('$path.sha256');
     if (!await file.exists() || !await marker.exists()) return false;
@@ -122,7 +177,16 @@ class AiDictationModelStore {
   }
 
   Future<int> partialBytes([String? id]) async {
-    final file = File(await partialPath(id));
+    final model = modelFor(id ?? modelId);
+    final path = await modelPath(model.id);
+    if (await _isModelInstalled(model, path)) {
+      final encoder = _requiredCoreMlEncoder(model);
+      return model.sizeBytes +
+          (encoder == null
+              ? 0
+              : await _coreMlStore.partialBytes(path, encoder));
+    }
+    final file = File(await partialPath(model.id));
     return await file.exists() ? file.length() : 0;
   }
 
@@ -152,7 +216,7 @@ class AiDictationModelStore {
       jsonEncode(<String, Object?>{
         'modelId': model.id,
         'sha256': model.sha256,
-        'sizeBytes': model.sizeBytes,
+        'sizeBytes': downloadSizeBytes(model.id),
         'storageVersion': model.storageVersion,
       }),
       flush: true,
@@ -165,7 +229,12 @@ class AiDictationModelStore {
     _activeFinished = finished;
     _cancelRequested = false;
     try {
-      var offset = await partialBytes(model.id);
+      final totalBytes = downloadSizeBytes(model.id);
+      var offset = await _isModelInstalled(model, destination)
+          ? model.sizeBytes
+          : await partial.exists()
+          ? await partial.length()
+          : 0;
       if (offset > model.sizeBytes) {
         await partial.delete();
         offset = 0;
@@ -200,30 +269,44 @@ class AiDictationModelStore {
               if (_cancelRequested) throw const AiDictationDownloadCancelled();
               sink.add(chunk);
               received += chunk.length;
-              onProgress?.call((received / model.sizeBytes).clamp(0, 1));
+              onProgress?.call((received / totalBytes).clamp(0, 1));
             }
           } finally {
             await sink.close();
           }
         }
       }
-      if (_cancelRequested) throw const AiDictationDownloadCancelled();
-      if (!await partial.exists() ||
-          await partial.length() != model.sizeBytes) {
-        throw StateError(
-          'The Whisper model download ended before it was complete.',
+      if (!await _isModelInstalled(model, destination)) {
+        if (_cancelRequested) throw const AiDictationDownloadCancelled();
+        if (!await partial.exists() ||
+            await partial.length() != model.sizeBytes) {
+          throw StateError(
+            'The Whisper model download ended before it was complete.',
+          );
+        }
+        final digest = await Isolate.run(_Sha256Computation(partial.path).call);
+        if (digest != model.sha256) {
+          throw StateError(
+            'The downloaded Whisper model failed checksum verification.',
+          );
+        }
+        final installed = File(destination);
+        if (await installed.exists()) await installed.delete();
+        await partial.rename(destination);
+        await File('$destination.sha256').writeAsString(digest, flush: true);
+      }
+      final encoder = _requiredCoreMlEncoder(model);
+      if (encoder != null) {
+        await _coreMlStore.download(
+          client: client,
+          modelPath: destination,
+          encoder: encoder,
+          isCancelled: () => _cancelRequested,
+          onProgress: (received) => onProgress?.call(
+            ((model.sizeBytes + received) / totalBytes).clamp(0, 1),
+          ),
         );
       }
-      final digest = await Isolate.run(() => _sha256File(partial.path));
-      if (digest != model.sha256) {
-        throw StateError(
-          'The downloaded Whisper model failed checksum verification.',
-        );
-      }
-      final installed = File(destination);
-      if (await installed.exists()) await installed.delete();
-      await partial.rename(destination);
-      await File('$destination.sha256').writeAsString(digest, flush: true);
       if (await intent.exists()) await intent.delete();
       onProgress?.call(1);
       return destination;
@@ -250,6 +333,7 @@ class AiDictationModelStore {
   }
 
   Future<void> _discardPartial(String id) async {
+    final modelPath = await this.modelPath(id);
     for (final path in <String>[
       await partialPath(id),
       await resumeIntentPath(id),
@@ -257,6 +341,7 @@ class AiDictationModelStore {
       final file = File(path);
       if (await file.exists()) await file.delete();
     }
+    await _coreMlStore.discardPartial(modelPath);
   }
 
   Future<void> remove([String? id]) async {
@@ -269,32 +354,9 @@ class AiDictationModelStore {
     _cancelRequested = true;
     _activeClient?.close();
   }
-}
 
-class AiDictationModel {
-  const AiDictationModel({
-    required this.id,
-    required this.label,
-    required this.description,
-    required this.fileName,
-    required this.sha256,
-    required this.uri,
-    required this.sizeBytes,
-    this.storageVersion = 1,
-  });
-
-  final String id;
-  final String label;
-  final String description;
-  final String fileName;
-  final String sha256;
-  final String uri;
-  final int sizeBytes;
-  final int storageVersion;
-}
-
-class AiDictationDownloadCancelled implements Exception {
-  const AiDictationDownloadCancelled();
+  AiDictationCoreMlEncoder? _requiredCoreMlEncoder(AiDictationModel model) =>
+      _installCoreMlEncoder ? model.coreMlEncoder : null;
 }
 
 void _validateContentRange(
@@ -315,3 +377,11 @@ void _validateContentRange(
 
 Future<String> _sha256File(String path) async =>
     (await sha256.bind(File(path).openRead()).first).toString();
+
+class _Sha256Computation {
+  const _Sha256Computation(this.path);
+
+  final String path;
+
+  Future<String> call() => _sha256File(path);
+}

--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -83,8 +83,14 @@ else()
   set(ALERA_CLI_PROFILE_DIR "debug")
 endif()
 set(ALERA_CLI_OUTPUT "${ALERA_CLI_DIR}/target/${ALERA_CLI_PROFILE_DIR}/alera")
+if(DEFINED ENV{VULKAN_SDK} AND NOT "$ENV{VULKAN_SDK}" STREQUAL "")
+  set(ALERA_VULKAN_SDK "$ENV{VULKAN_SDK}")
+else()
+  set(ALERA_VULKAN_SDK "/usr")
+endif()
 add_custom_target(alera_cli_sidecar ALL
-  COMMAND "${CARGO_EXECUTABLE}" build --locked -p alera-cli ${ALERA_CLI_CARGO_PROFILE_ARG}
+  COMMAND "${CMAKE_COMMAND}" -E env "VULKAN_SDK=${ALERA_VULKAN_SDK}"
+    "${CARGO_EXECUTABLE}" build --locked -p alera-cli ${ALERA_CLI_CARGO_PROFILE_ARG}
   BYPRODUCTS "${ALERA_CLI_OUTPUT}"
   WORKING_DIRECTORY "${ALERA_CLI_DIR}"
   COMMENT "Building Alera CLI sidecar (Rust)"

--- a/readme.md
+++ b/readme.md
@@ -162,7 +162,7 @@ Requires x86_64 and Ubuntu 24.04 or newer, Debian 13 or newer, or Fedora. On RHE
 
 To add the repository by hand instead, see the manual setup on the [download page](https://alera.build/download). The signing key is published at `https://updates.alera.build/linux/alera-archive-keyring.asc` with fingerprint `5DE97E7CFE234A1C5869EC54708DA940734CF23A`.
 
-On a distribution with no package of ours, download `alera-<version>-linux-x64.tar.gz` from [GitHub Releases](https://github.com/leynier/alera/releases) and extract it somewhere you own, such as `~/.local/share/alera`. Install `libmpv`, `webkit2gtk-4.1` and `gtk3` through your own package manager first, since a tarball declares no dependencies. Alera updates a tarball installation in place; a repository installation keeps updating through apt or dnf, which is what resolves those dependencies.
+On a distribution with no package of ours, download `alera-<version>-linux-x64.tar.gz` from [GitHub Releases](https://github.com/leynier/alera/releases) and extract it somewhere you own, such as `~/.local/share/alera`. Install `libmpv`, `webkit2gtk-4.1`, `gtk3`, and the Vulkan loader through your own package manager first, since a tarball declares no dependencies. Alera updates a tarball installation in place; a repository installation keeps updating through apt or dnf, which is what resolves those dependencies.
 
 ### macOS
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -6474,6 +6474,7 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2088172d00f936c348d6a72f488dc2660ab3f507263a195df308a3c2383229f6"
 dependencies = [
+ "libc",
  "whisper-rs-sys",
 ]
 

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -40,6 +40,14 @@ merman = { version = "0.7", default-features = false, features = ["render"] }
 png = "0.18"
 tempfile = "3"
 hound = "3.5"
+
+[target.'cfg(target_os = "macos")'.dependencies]
+whisper-rs = { version = "0.16.0", features = ["coreml", "metal"] }
+
+[target.'cfg(all(target_arch = "x86_64", any(target_os = "linux", target_os = "windows")))'.dependencies]
+whisper-rs = { version = "0.16.0", features = ["vulkan"] }
+
+[target.'cfg(not(any(target_os = "macos", all(target_arch = "x86_64", any(target_os = "linux", target_os = "windows")))))'.dependencies]
 whisper-rs = "0.16.0"
 
 [target.'cfg(unix)'.dependencies]

--- a/rust/alera-cli/Cargo.toml
+++ b/rust/alera-cli/Cargo.toml
@@ -55,7 +55,6 @@ axum = { version = "0.8", features = ["http1", "tokio"] }
 bytes = "1"
 if-addrs = "0.13"
 hound = "3.5"
-whisper-rs = "0.16.0"
 serde_urlencoded = "0.7"
 sysinfo = { version = "0.39.6", default-features = false, features = ["system"] }
 async-trait = "0.1.91"
@@ -83,6 +82,12 @@ keyring = { version = "3.6.3", features = [
     "vendored",
 ] }
 
+[target.'cfg(all(target_arch = "x86_64", any(target_os = "linux", target_os = "windows")))'.dependencies]
+whisper-rs = { version = "0.16.0", features = ["vulkan"] }
+
+[target.'cfg(not(any(target_os = "macos", all(target_arch = "x86_64", any(target_os = "linux", target_os = "windows")))))'.dependencies]
+whisper-rs = "0.16.0"
+
 # Signalling a PTY shell's descendants. Already in the tree through
 # portable-pty, so declaring it directly adds no crate.
 [target.'cfg(unix)'.dependencies]
@@ -98,6 +103,7 @@ windows = { version = "0.62.2", features = ["Win32_System_RemoteDesktop", "Win32
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2-application-services = "0.3"
 objc2-core-foundation = "0.3"
+whisper-rs = { version = "0.16.0", features = ["coreml", "metal"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/rust/alera-cli/src/terminal_host/server/ai_dictation_requests.rs
+++ b/rust/alera-cli/src/terminal_host/server/ai_dictation_requests.rs
@@ -197,7 +197,7 @@ fn transcribe_inner(
     let mut audio = vec![0.0; samples.len()];
     convert_integer_to_float_audio(&samples, &mut audio)
         .map_err(|error| HostError::state(format!("audio decode failed: {error:?}")))?;
-    let context = WhisperContext::new_with_params(model, WhisperContextParameters::default())
+    let context = WhisperContext::new_with_params(model, desktop_whisper_context_parameters())
         .map_err(|error| {
             HostError::state(format!("Whisper model could not be loaded: {error:?}"))
         })?;
@@ -239,6 +239,16 @@ fn transcribe_inner(
         return Err(HostError::format("Whisper did not detect speech"));
     }
     Ok((text, language.map(str::to_string), duration))
+}
+
+fn desktop_whisper_context_parameters() -> WhisperContextParameters<'static> {
+    let mut parameters = WhisperContextParameters::default();
+    parameters.use_gpu = cfg!(target_os = "macos")
+        || cfg!(all(
+            target_arch = "x86_64",
+            any(target_os = "linux", target_os = "windows")
+        ));
+    parameters
 }
 
 fn normalize_whisper_language(language: Option<&str>) -> Option<String> {
@@ -317,5 +327,15 @@ mod tests {
             normalize_whisper_language(Some("pt_BR")).as_deref(),
             Some("pt")
         );
+    }
+
+    #[test]
+    fn hardware_acceleration_matches_the_supported_desktop_targets() {
+        let expected = cfg!(target_os = "macos")
+            || cfg!(all(
+                target_arch = "x86_64",
+                any(target_os = "linux", target_os = "windows")
+            ));
+        assert_eq!(desktop_whisper_context_parameters().use_gpu, expected);
     }
 }

--- a/rust/alera-cli/src/terminal_host/server/ai_dictation_requests.rs
+++ b/rust/alera-cli/src/terminal_host/server/ai_dictation_requests.rs
@@ -242,13 +242,14 @@ fn transcribe_inner(
 }
 
 fn desktop_whisper_context_parameters() -> WhisperContextParameters<'static> {
-    let mut parameters = WhisperContextParameters::default();
-    parameters.use_gpu = cfg!(target_os = "macos")
-        || cfg!(all(
-            target_arch = "x86_64",
-            any(target_os = "linux", target_os = "windows")
-        ));
-    parameters
+    WhisperContextParameters {
+        use_gpu: cfg!(target_os = "macos")
+            || cfg!(all(
+                target_arch = "x86_64",
+                any(target_os = "linux", target_os = "windows")
+            )),
+        ..Default::default()
+    }
 }
 
 fn normalize_whisper_language(language: Option<&str>) -> Option<String> {

--- a/rust/src/api/ai_dictation.rs
+++ b/rust/src/api/ai_dictation.rs
@@ -201,13 +201,14 @@ fn transcribe_inner(
 }
 
 fn desktop_whisper_context_parameters() -> WhisperContextParameters<'static> {
-    let mut parameters = WhisperContextParameters::default();
-    parameters.use_gpu = cfg!(target_os = "macos")
-        || cfg!(all(
-            target_arch = "x86_64",
-            any(target_os = "linux", target_os = "windows")
-        ));
-    parameters
+    WhisperContextParameters {
+        use_gpu: cfg!(target_os = "macos")
+            || cfg!(all(
+                target_arch = "x86_64",
+                any(target_os = "linux", target_os = "windows")
+            )),
+        ..Default::default()
+    }
 }
 
 fn read_audio(path: &str) -> Result<(Vec<f32>, i64), AiDictationError> {

--- a/rust/src/api/ai_dictation.rs
+++ b/rust/src/api/ai_dictation.rs
@@ -118,13 +118,13 @@ fn transcribe_inner(
     }
 
     let context =
-        WhisperContext::new_with_params(&request.model_path, WhisperContextParameters::default())
+        WhisperContext::new_with_params(&request.model_path, desktop_whisper_context_parameters())
             .map_err(|native_error| {
-            error(
-                AiDictationErrorKind::Model,
-                format!("The Whisper model could not be loaded: {native_error:?}"),
-            )
-        })?;
+                error(
+                    AiDictationErrorKind::Model,
+                    format!("The Whisper model could not be loaded: {native_error:?}"),
+                )
+            })?;
     let mut state = context.create_state().map_err(|native_error| {
         error(
             AiDictationErrorKind::Model,
@@ -198,6 +198,16 @@ fn transcribe_inner(
         detected_language,
         duration_millis,
     })
+}
+
+fn desktop_whisper_context_parameters() -> WhisperContextParameters<'static> {
+    let mut parameters = WhisperContextParameters::default();
+    parameters.use_gpu = cfg!(target_os = "macos")
+        || cfg!(all(
+            target_arch = "x86_64",
+            any(target_os = "linux", target_os = "windows")
+        ));
+    parameters
 }
 
 fn read_audio(path: &str) -> Result<(Vec<f32>, i64), AiDictationError> {
@@ -310,5 +320,15 @@ mod tests {
     #[test]
     fn cancellation_is_idempotent_for_unknown_request() {
         cancel_whisper("missing".to_string());
+    }
+
+    #[test]
+    fn hardware_acceleration_matches_the_supported_desktop_targets() {
+        let expected = cfg!(target_os = "macos")
+            || cfg!(all(
+                target_arch = "x86_64",
+                any(target_os = "linux", target_os = "windows")
+            ));
+        assert_eq!(desktop_whisper_context_parameters().use_gpu, expected);
     }
 }

--- a/rust_builder/cargokit/build_tool/lib/src/builder.dart
+++ b/rust_builder/cargokit/build_tool/lib/src/builder.dart
@@ -1,6 +1,8 @@
 // This is copied from Cargokit (which is the official way to use it currently)
 // Details: https://fzyzcjy.github.io/flutter_rust_bridge/manual/integrate/builtin
 
+import 'dart:io';
+
 import 'package:collection/collection.dart';
 import 'package:logging/logging.dart';
 import 'package:path/path.dart' as path;
@@ -179,6 +181,11 @@ class RustBuilder {
 
   Future<Map<String, String>> _buildEnvironment() async {
     if (target.android == null) {
+      if (target.rust == 'x86_64-unknown-linux-gnu') {
+        return {
+          'VULKAN_SDK': Platform.environment['VULKAN_SDK'] ?? '/usr',
+        };
+      }
       return {};
     } else {
       final sdkPath = environment.androidSdkPath;

--- a/test/unit/ai_dictation_model_store_test.dart
+++ b/test/unit/ai_dictation_model_store_test.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:alera/src/features/ai_dictation/infra/ai_dictation_model_store.dart';
+import 'package:archive/archive.dart';
 import 'package:crypto/crypto.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
@@ -43,6 +44,65 @@ void main() {
     expect(await store.isInstalled(model.id), isTrue);
     expect(await store.resumeIntentIds(), isEmpty);
   });
+
+  test('installs the matching Core ML encoder beside the model', () async {
+    final encoderBytes = _coreMlArchive('fixture-encoder.mlmodelc');
+    final acceleratedModel = _withCoreMlEncoder(model, encoderBytes);
+    final progress = <double>[];
+    final store = AiDictationModelStore(
+      clientFactory: () => MockClient((request) async {
+        if (request.url.toString() == acceleratedModel.uri) {
+          return http.Response.bytes(bytes, HttpStatus.ok);
+        }
+        return http.Response.bytes(encoderBytes, HttpStatus.ok);
+      }),
+      supportDirectory: () async => directory,
+      modelCatalog: <AiDictationModel>[acceleratedModel],
+      installCoreMlEncoder: true,
+    );
+
+    final path = await store.download(
+      id: acceleratedModel.id,
+      onProgress: progress.add,
+    );
+
+    final encoder = Directory(
+      '${File(path).parent.path}${Platform.pathSeparator}fixture-encoder.mlmodelc',
+    );
+    expect(await File('${encoder.path}/model.mil').readAsBytes(), bytes);
+    expect(await store.isInstalled(acceleratedModel.id), isTrue);
+    expect(progress.last, 1);
+  });
+
+  test(
+    'adds Core ML to an existing model without downloading it again',
+    () async {
+      final encoderBytes = _coreMlArchive('fixture-encoder.mlmodelc');
+      final acceleratedModel = _withCoreMlEncoder(model, encoderBytes);
+      final requested = <Uri>[];
+      final store = AiDictationModelStore(
+        clientFactory: () => MockClient((request) async {
+          requested.add(request.url);
+          return http.Response.bytes(encoderBytes, HttpStatus.ok);
+        }),
+        supportDirectory: () async => directory,
+        modelCatalog: <AiDictationModel>[acceleratedModel],
+        installCoreMlEncoder: true,
+      );
+      final path = await store.modelPath(acceleratedModel.id);
+      await File(path).create(recursive: true);
+      await File(path).writeAsBytes(bytes);
+      await File('$path.sha256').writeAsString(acceleratedModel.sha256);
+
+      expect(await store.partialBytes(acceleratedModel.id), bytes.length);
+      await store.download(id: acceleratedModel.id);
+
+      expect(requested, <Uri>[
+        Uri.parse(acceleratedModel.coreMlEncoder!.archiveUri),
+      ]);
+      expect(await store.isInstalled(acceleratedModel.id), isTrue);
+    },
+  );
 
   test('resumes a partial model with a validated range response', () async {
     late String? range;
@@ -139,7 +199,33 @@ AiDictationModelStore _store(
   clientFactory: () => MockClient(handler),
   supportDirectory: () async => directory,
   modelCatalog: <AiDictationModel>[model],
+  installCoreMlEncoder: false,
 );
+
+AiDictationModel _withCoreMlEncoder(
+  AiDictationModel model,
+  List<int> archiveBytes,
+) => AiDictationModel(
+  id: model.id,
+  label: model.label,
+  description: model.description,
+  fileName: model.fileName,
+  sha256: model.sha256,
+  uri: model.uri,
+  sizeBytes: model.sizeBytes,
+  coreMlEncoder: AiDictationCoreMlEncoder(
+    directoryName: 'fixture-encoder.mlmodelc',
+    archiveUri: 'https://example.test/fixture-encoder.mlmodelc.zip',
+    archiveSha256: sha256.convert(archiveBytes).toString(),
+    archiveSizeBytes: archiveBytes.length,
+  ),
+);
+
+List<int> _coreMlArchive(String directoryName) {
+  final archive = Archive()
+    ..addFile(ArchiveFile('$directoryName/model.mil', 4, <int>[1, 2, 3, 4]));
+  return ZipEncoder().encode(archive);
+}
 
 class _HangingClient extends http.BaseClient {
   final started = Completer<void>();

--- a/test/unit/linux_release_packaging_test.dart
+++ b/test/unit/linux_release_packaging_test.dart
@@ -45,6 +45,8 @@ void main() {
     expect(packageScript, contains('Depends:'));
     expect(packageScript, contains('libmpv2'));
     expect(packageScript, contains('Requires: mpv-libs'));
+    expect(packageScript, contains('libvulkan1'));
+    expect(packageScript, contains('Requires: vulkan-loader'));
   });
 
   test(

--- a/test/unit/native_helper_assets_test.dart
+++ b/test/unit/native_helper_assets_test.dart
@@ -313,11 +313,14 @@ void main() {
         '.github/actions/setup-flutter-workspace/action.yml',
       ).readAsStringSync();
       expect(setup, contains('libepoxy-dev libmpv-dev'));
+      expect(setup, contains('libvulkan-dev glslc'));
       final linuxPackage = File(
         'tool/release/package_linux.sh',
       ).readAsStringSync();
       expect(linuxPackage, contains('libmpv2'));
       expect(linuxPackage, contains('mpv-libs'));
+      expect(linuxPackage, contains('libvulkan1'));
+      expect(linuxPackage, contains('vulkan-loader'));
     });
 
     test('verifies hash-pinned Windows video files', () async {

--- a/test/widget/ai_dictation_pane_test.dart
+++ b/test/widget/ai_dictation_pane_test.dart
@@ -131,6 +131,9 @@ class _FakeAiDictationModelStore implements AiDictationModelStore {
   }
 
   @override
+  int downloadSizeBytes(String id) => modelFor(id).sizeBytes;
+
+  @override
   Future<bool> isInstalled([String? id]) async => _installed.contains(
     AiDictationModelStore.modelForId(id ?? 'whisper-base'),
   );

--- a/tool/development/setup_windows.ps1
+++ b/tool/development/setup_windows.ps1
@@ -13,6 +13,7 @@ $requiredFlutterVersion = [version]'3.44.8'
 $minimumDartVersion = [version]'3.12.1'
 $requiredZigVersion = [version]'0.16.0'
 $requiredRustToolchain = '1.96'
+$requiredVulkanSdkVersion = '1.4.350.0'
 
 function Write-Step([string]$Message) {
     Write-Host "`n==> $Message" -ForegroundColor Cyan
@@ -112,6 +113,40 @@ function Get-LibClangIncludeDirectory([string]$libClangDirectory) {
         ForEach-Object { Join-Path $_.FullName 'include' } |
         Where-Object { Test-Path -LiteralPath (Join-Path $_ 'stdbool.h') } |
         Select-Object -First 1
+}
+
+function Get-VulkanSdkDirectory {
+    $candidates = @(
+        $env:VULKAN_SDK,
+        (Join-Path 'C:\VulkanSDK' $requiredVulkanSdkVersion)
+    ) | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+    $candidates += Get-ChildItem -LiteralPath 'C:\VulkanSDK' -Directory -ErrorAction SilentlyContinue |
+        Sort-Object Name -Descending |
+        Select-Object -ExpandProperty FullName
+
+    foreach ($candidate in $candidates) {
+        if ((Test-Path -LiteralPath (Join-Path $candidate 'Lib\vulkan-1.lib')) -and
+            (Test-Path -LiteralPath (Join-Path $candidate 'Bin\glslc.exe'))) {
+            return (Resolve-Path $candidate).Path
+        }
+    }
+    return $null
+}
+
+function Install-VulkanSdk {
+    if (-not $InstallMissingTools) {
+        throw "Missing Vulkan SDK. Rerun with -InstallMissingTools or install Vulkan SDK $requiredVulkanSdkVersion manually."
+    }
+    $winget = Get-Command winget -ErrorAction SilentlyContinue
+    if ($null -eq $winget) {
+        throw 'WinGet is required to install the Vulkan SDK automatically.'
+    }
+    Invoke-Native $winget.Source @(
+        'install', '--exact', '--id', 'KhronosGroup.VulkanSDK',
+        '--version', $requiredVulkanSdkVersion, '--silent',
+        '--accept-package-agreements', '--accept-source-agreements',
+        '--disable-interactivity'
+    )
 }
 
 function Get-DartVersion([System.Management.Automation.CommandInfo]$Dart) {
@@ -264,6 +299,22 @@ if (-not $CheckOnly) {
 }
 Write-Host "LIBCLANG_PATH=$libClangDirectory"
 Write-Host "BINDGEN_EXTRA_CLANG_ARGS=$bindgenClangArguments"
+
+Write-Step 'Checking the Vulkan SDK'
+$vulkanSdkDirectory = Get-VulkanSdkDirectory
+if ($null -eq $vulkanSdkDirectory -and -not $CheckOnly) {
+    Install-VulkanSdk
+    $vulkanSdkDirectory = Get-VulkanSdkDirectory
+}
+if ($null -eq $vulkanSdkDirectory) {
+    throw "Vulkan SDK $requiredVulkanSdkVersion with glslc was not found."
+}
+$env:VULKAN_SDK = $vulkanSdkDirectory
+$env:PATH = "$(Join-Path $vulkanSdkDirectory 'Bin');$env:PATH"
+if (-not $CheckOnly) {
+    [Environment]::SetEnvironmentVariable('VULKAN_SDK', $vulkanSdkDirectory, 'User')
+}
+Write-Host "VULKAN_SDK=$vulkanSdkDirectory"
 
 if ($CheckOnly) {
     Write-Host "`nWindows prerequisites are ready." -ForegroundColor Green

--- a/tool/native_helpers/video_runtime_assets.json
+++ b/tool/native_helpers/video_runtime_assets.json
@@ -80,14 +80,18 @@
   "linux": {
     "buildPackages": [
       "libepoxy-dev",
-      "libmpv-dev"
+      "libmpv-dev",
+      "libvulkan-dev",
+      "glslc"
     ],
     "runtimePackages": {
       "deb": [
-        "libmpv2"
+        "libmpv2",
+        "libvulkan1"
       ],
       "rpm": [
-        "mpv-libs"
+        "mpv-libs",
+        "vulkan-loader"
       ]
     },
     "requiredLibraries": [

--- a/tool/native_helpers/video_runtime_verifier.dart
+++ b/tool/native_helpers/video_runtime_verifier.dart
@@ -116,6 +116,22 @@ Future<void> _verifyWindowsVideoRuntime(
         '$relativePath SHA-256 mismatch: expected $expected, got $actual.',
       );
     }
+    if (relativePath == 'vulkan-1.dll') {
+      final sidecarLoader = File(
+        p.join(bundle.path, 'resources', 'alera', relativePath),
+      );
+      if (!sidecarLoader.existsSync()) {
+        throw StateError(
+          'Missing Windows Whisper Vulkan runtime: ${sidecarLoader.path}',
+        );
+      }
+      final sidecarDigest = await fileSha256(sidecarLoader);
+      if (sidecarDigest != expected) {
+        throw StateError(
+          '$relativePath sidecar SHA-256 mismatch: expected $expected, got $sidecarDigest.',
+        );
+      }
+    }
   }
 }
 

--- a/tool/release/package_linux.sh
+++ b/tool/release/package_linux.sh
@@ -84,7 +84,7 @@ Priority: optional
 Architecture: ${arch_deb}
 Maintainer: ${maintainer}
 Installed-Size: ${installed_size}
-Depends: libgtk-3-0, libwebkit2gtk-4.1-0, libjson-glib-1.0-0, libsecret-1-0, libsqlite3-0, libssl3, libmpv2
+Depends: libgtk-3-0, libwebkit2gtk-4.1-0, libjson-glib-1.0-0, libsecret-1-0, libsqlite3-0, libssl3, libmpv2, libvulkan1
 Description: ${description}
 DEB
 dpkg-deb --build "$deb_root" "$output_dir/alera-${release_version}-linux.deb"
@@ -115,6 +115,7 @@ Requires: libsecret
 Requires: sqlite
 Requires: openssl-libs
 Requires: mpv-libs
+Requires: vulkan-loader
 
 %description
 ${description}

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -157,6 +157,15 @@ if(PLUGIN_BUNDLED_LIBRARIES)
   install(FILES "${PLUGIN_BUNDLED_LIBRARIES}"
     DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
     COMPONENT Runtime)
+  foreach(ALERA_PLUGIN_LIBRARY ${PLUGIN_BUNDLED_LIBRARIES})
+    get_filename_component(ALERA_PLUGIN_LIBRARY_NAME
+      "${ALERA_PLUGIN_LIBRARY}" NAME)
+    if(ALERA_PLUGIN_LIBRARY_NAME STREQUAL "vulkan-1.dll")
+      install(FILES "${ALERA_PLUGIN_LIBRARY}"
+        DESTINATION "${CMAKE_INSTALL_PREFIX}/resources/alera"
+        COMPONENT Runtime)
+    endif()
+  endforeach()
 endif()
 
 # Copy the native assets provided by the build.dart from all packages.


### PR DESCRIPTION
## root cause

- Both desktop Whisper entry points were compiled with CPU-only defaults, so the native bridge and paired runtime could not initialize Metal, Core ML, or Vulkan backends.
- macOS model installs contained only the GGML model and omitted the adjacent compiled Core ML encoder required for Apple Neural Engine execution.
- Desktop build and package setup did not provide the Vulkan SDK at build time or guarantee the loader beside the Windows runtime sidecar.

## code changes

- Enable Core ML plus Metal on macOS and Vulkan on native x64 Windows/Linux for both `alera_native` and `alera-cli`; explicitly request the GPU backend while retaining whisper.cpp's CPU fallback.
- Keep `alera_mobile_native`, Android, and non-native cross targets CPU-only.
- Add resumable, SHA-256 verified Core ML encoder downloads with traversal-safe staging, atomic installation beside each model, existing-model upgrades, cancellation, and combined progress accounting.
- Add pinned Vulkan build setup, Linux runtime dependencies, Windows sidecar loader packaging and verification, contributor setup documentation, and regression coverage.

## validation

- `puro -e alera-3448 flutter analyze`
- Focused model store, dictation pane, runtime manifest/verifier, and Linux packaging tests
- `cargo fmt --check --manifest-path rust/Cargo.toml`
- `cargo metadata --locked --no-deps --manifest-path rust/Cargo.toml --format-version 1`
- Cargo feature graph checks for macOS Core ML/Metal, x64 Windows/Linux Vulkan, and Android CPU-only
- PowerShell parser validation for `tool/development/setup_windows.ps1`
- Official tiny Core ML archive checksum and directory-layout verification

## risks and notes

- No visual changes.
- Hardware execution still needs validation on representative Apple Neural Engine and Vulkan devices; the native desktop build matrix validates each backend compiles and packages on its target OS.
- The Large V3 Turbo Core ML encoder is a large optional download, and transfer totals now include it on macOS.
- Security review: model and encoder artifacts are HTTPS-hosted and SHA-256 pinned; archives extract into a traversal-checked staging directory before installation; no credentials, permissions, or network listeners were added.
- AI review: scope is limited to desktop acceleration and supporting build/model infrastructure, with Android intentionally unchanged.