### PR TITLE
fix: repair desktop whisper builds

### DIFF
--- a/.github/actions/tune-windows-build/action.yml
+++ b/.github/actions/tune-windows-build/action.yml
@@ -34,3 +34,24 @@ runs:
     - name: Allow long paths
       shell: pwsh
       run: git config --system core.longpaths true
+
+    - name: Make Ninja available for native Rust builds
+      shell: pwsh
+      run: |
+        $ninja = Get-Command ninja.exe -ErrorAction SilentlyContinue
+        if ($null -eq $ninja) {
+          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+          $installationPath = & $vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
+          if ($LASTEXITCODE -ne 0 -or -not $installationPath) {
+            throw 'Visual Studio installation with C++ tools is required to locate Ninja.'
+          }
+          $ninjaPath = Join-Path $installationPath 'Common7\IDE\CommonExtensions\Microsoft\CMake\Ninja\ninja.exe'
+          if (-not (Test-Path -LiteralPath $ninjaPath -PathType Leaf)) {
+            throw "Ninja was not found at $ninjaPath."
+          }
+          $ninjaDirectory = Split-Path -Parent $ninjaPath
+          $ninjaDirectory | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          Write-Host "Added Ninja from $ninjaPath"
+        } else {
+          Write-Host "Using Ninja from $($ninja.Source)"
+        }

--- a/rust_builder/cargokit/cmake/cargokit.cmake
+++ b/rust_builder/cargokit/cmake/cargokit.cmake
@@ -49,6 +49,20 @@ function(apply_cargokit target manifest_dir lib_name any_symbol_name)
         "CARGOKIT_ROOT_PROJECT_DIR=${CMAKE_SOURCE_DIR}"
     )
 
+    if(WIN32 AND CARGOKIT_TARGET_PLATFORM STREQUAL "windows-x64")
+        # whisper-rs-sys builds a nested Vulkan shader generator. Keep that
+        # inner build on Ninja so MSBuild's legacy FileTracker path limit in
+        # the outer Flutter build cannot reject its generated .tlog files.
+        find_program(CARGOKIT_NINJA_EXECUTABLE ninja)
+        if(NOT CARGOKIT_NINJA_EXECUTABLE)
+            message(FATAL_ERROR "Ninja is required for Windows native Rust builds")
+        endif()
+        list(APPEND CARGOKIT_ENV
+            "CMAKE_GENERATOR_x86_64_pc_windows_msvc=Ninja"
+            "CMAKE_MAKE_PROGRAM_x86_64_pc_windows_msvc=${CARGOKIT_NINJA_EXECUTABLE}"
+        )
+    endif()
+
     if (WIN32)
         set(SCRIPT_EXTENSION ".cmd")
         set(IMPORT_LIB_EXTENSION ".lib")

--- a/rust_builder/macos/alera_native.podspec
+++ b/rust_builder/macos/alera_native.podspec
@@ -41,7 +41,10 @@ A new Flutter FFI plugin project.
     'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386',
     # Cargokit only produces the Rust static library, so native dependencies
     # used inside it must be repeated when CocoaPods links the plugin framework.
-    # libgit2 needs zlib/iconv, while whisper.cpp needs libc++ and Accelerate.
-    'OTHER_LDFLAGS' => '-force_load ${BUILT_PRODUCTS_DIR}/libalera_native.a -lz -liconv -lc++ -framework Accelerate',
+    # libgit2 needs zlib/iconv, while whisper.cpp needs libc++, Accelerate,
+    # Foundation, Core ML, Metal, and MetalKit. Cargokit only produces the
+    # Rust static library, so these framework dependencies must be repeated
+    # when CocoaPods links the plugin framework.
+    'OTHER_LDFLAGS' => '-force_load ${BUILT_PRODUCTS_DIR}/libalera_native.a -lz -liconv -lc++ -framework Accelerate -framework Foundation -framework CoreML -framework Metal -framework MetalKit',
   }
 end

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -68,8 +68,17 @@ endif()
 set(ALERA_CLI_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../rust")
 set(ALERA_CLI_PROFILE_DIR "$<IF:$<CONFIG:Release>,release,debug>")
 set(ALERA_CLI_OUTPUT "${ALERA_CLI_DIR}/target/${ALERA_CLI_PROFILE_DIR}/alera.exe")
+find_program(ALERA_NINJA_EXECUTABLE ninja)
+if(NOT ALERA_NINJA_EXECUTABLE)
+  message(FATAL_ERROR "Ninja is required to build the Windows Whisper backend")
+endif()
 add_custom_target(alera_cli_sidecar ALL
-  COMMAND "${CARGO_EXECUTABLE}" build --locked -p alera-cli
+  # The sidecar shares whisper-rs-sys with the Flutter plugin. Use Ninja for
+  # that nested CMake build to avoid MSBuild FileTracker's legacy path limit.
+  COMMAND "${CMAKE_COMMAND}" -E env
+    "CMAKE_GENERATOR_x86_64_pc_windows_msvc=Ninja"
+    "CMAKE_MAKE_PROGRAM_x86_64_pc_windows_msvc=${ALERA_NINJA_EXECUTABLE}"
+    "${CARGO_EXECUTABLE}" build --locked -p alera-cli
     --profile $<IF:$<CONFIG:Release>,release,dev>
   BYPRODUCTS "${ALERA_CLI_OUTPUT}"
   WORKING_DIRECTORY "${ALERA_CLI_DIR}"


### PR DESCRIPTION
## Summary

Fixes the Windows and macOS desktop build failures reported by [Actions run 32509206246](https://github.com/leynier/alera/actions/runs/32509206246).

## Root cause

- macOS: the Rust static library enables Whisper Core ML and Metal support, but the CocoaPods plugin linker flags did not repeat the native framework dependencies. The final arm64 link therefore failed with undefined `ML*` symbols from Core ML.
- Windows: `whisper-rs-sys` runs a nested CMake build for Vulkan shader generation. It inherited the Visual Studio generator and generated FileTracker `.tlog` paths longer than MSBuild's legacy 260-character limit, causing `FTK1011`. Git long-path support does not change MSBuild FileTracker behavior.

## Code changes

- Added Foundation, CoreML, Metal, and MetalKit to the macOS podspec linker flags alongside the existing Accelerate and C++ dependencies.
- Configured the nested Windows Rust/CMake builds to use Ninja through the target-specific CMake environment variables, while leaving the outer Flutter Visual Studio generator unchanged.
- Added Windows CI setup to locate the Visual Studio-bundled Ninja executable and add it to `PATH`.
- Added an explicit Ninja availability check for the Windows sidecar build.

## Validation

- `git diff --check`
- `cmake -P rust_builder/cargokit/cmake/cargokit.cmake`
- `cmake -S rust_builder/windows -B build/cmake-validation -G Ninja -DCMAKE_BUILD_TYPE=Release`
- `cargo metadata --locked --no-deps --manifest-path rust/Cargo.toml --format-version 1`
- `release_workflow_config_test.dart`: 11 tests passed

The focused native helper test is currently blocked by an unrelated pre-existing fixture hash mismatch. Full Windows and macOS native builds should be confirmed by this PR's Actions matrix.