### PR TITLE
fix: shorten windows native scratch paths

### DIFF
--- a/.github/actions/tune-windows-build/action.yml
+++ b/.github/actions/tune-windows-build/action.yml
@@ -35,6 +35,22 @@ runs:
       shell: pwsh
       run: git config --system core.longpaths true
 
+    # Ninja avoids MSBuild FileTracker, but the MSVC compiler still has legacy
+    # path limits for some generated CMake try-compile sources. Use a short
+    # drive-backed path for Cargokit's native scratch files.
+    - name: Use short Cargokit scratch path
+      shell: pwsh
+      run: |
+        subst R: /d 2>$null | Out-Null
+        subst R: $env:RUNNER_TEMP | Out-Null
+        if ($LASTEXITCODE -ne 0) {
+          throw "Could not map R: to $env:RUNNER_TEMP."
+        }
+        $scratchPath = 'R:\alera-cargokit'
+        New-Item -ItemType Directory -Force -Path $scratchPath | Out-Null
+        "ALERA_CARGOKIT_TEMP_DIR=$scratchPath" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        Write-Host "Using $scratchPath for Cargokit native scratch files"
+
     - name: Make Ninja available for native Rust builds
       shell: pwsh
       run: |

--- a/rust_builder/cargokit/cmake/cargokit.cmake
+++ b/rust_builder/cargokit/cmake/cargokit.cmake
@@ -27,7 +27,13 @@ function(apply_cargokit target manifest_dir lib_name any_symbol_name)
     endif()
     if(WIN32)
         # Native dependency scratch paths can exceed MSBuild's 260-character FileTracker limit.
-        set(CARGOKIT_TEMP_DIR "${CMAKE_BINARY_DIR}/ck/${CARGOKIT_LIB_NAME}")
+        if(DEFINED ENV{ALERA_CARGOKIT_TEMP_DIR})
+            # CI can provide a short, user-writable drive-backed directory for
+            # compilers that still reject paths above MAX_PATH.
+            set(CARGOKIT_TEMP_DIR "$ENV{ALERA_CARGOKIT_TEMP_DIR}/${CARGOKIT_LIB_NAME}")
+        else()
+            set(CARGOKIT_TEMP_DIR "${CMAKE_BINARY_DIR}/ck/${CARGOKIT_LIB_NAME}")
+        endif()
     else()
         set(CARGOKIT_TEMP_DIR "${CMAKE_CURRENT_BINARY_DIR}/cargokit_build")
     endif()


### PR DESCRIPTION
## Summary

Fixes the remaining Windows build failure from [Actions run 32512884514](https://github.com/leynier/alera/actions/runs/32512884514/job/96867854425), which occurred after PR #440 merged.

## Root cause

PR #440 successfully moved the nested CMake generator to Ninja, eliminating the MSBuild FileTracker error. The build still failed because MSVC's compiler probe received a 263-character path for `testCCompiler.c` under Cargokit's `build\\windows\\x64\\ck` directory. Ninja avoids FileTracker, but it does not remove the compiler's legacy path-length limitation.

## Code changes

- Added an `ALERA_CARGOKIT_TEMP_DIR` override to Cargokit's Windows scratch-directory selection.
- Updated the Windows tuning action to map the runner temp directory to the short `R:` drive and export `R:\\alera-cargokit` for the build.
- Kept the repository-relative scratch path as the local fallback, so normal developer builds do not require a drive mapping.

## Validation

- `git diff --check`
- `cmake -P rust_builder/cargokit/cmake/cargokit.cmake`
- Windows CMake configuration with the short-path override
- `cargo metadata --locked --no-deps --manifest-path rust/Cargo.toml --format-version 1`

The Windows Actions job should be rerun on this branch to confirm the full Flutter release build.