### PR TITLE
fix: prevent windows msvc pdb contention

### DIFF
--- a/.github/actions/tune-windows-build/action.yml
+++ b/.github/actions/tune-windows-build/action.yml
@@ -35,6 +35,22 @@ runs:
       shell: pwsh
       run: git config --system core.longpaths true
 
+    # Ninja avoids MSBuild FileTracker, but the MSVC compiler still has legacy
+    # path limits for some generated CMake try-compile sources. Use a short
+    # drive-backed path for Cargokit's native scratch files.
+    - name: Use short Cargokit scratch path
+      shell: pwsh
+      run: |
+        subst R: /d 2>$null | Out-Null
+        subst R: $env:RUNNER_TEMP | Out-Null
+        if ($LASTEXITCODE -ne 0) {
+          throw "Could not map R: to $env:RUNNER_TEMP."
+        }
+        $scratchPath = 'R:\alera-cargokit'
+        New-Item -ItemType Directory -Force -Path $scratchPath | Out-Null
+        "ALERA_CARGOKIT_TEMP_DIR=$scratchPath" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        Write-Host "Using $scratchPath for Cargokit native scratch files"
+
     - name: Make Ninja available for native Rust builds
       shell: pwsh
       run: |

--- a/rust_builder/cargokit/cmake/cargokit.cmake
+++ b/rust_builder/cargokit/cmake/cargokit.cmake
@@ -27,7 +27,13 @@ function(apply_cargokit target manifest_dir lib_name any_symbol_name)
     endif()
     if(WIN32)
         # Native dependency scratch paths can exceed MSBuild's 260-character FileTracker limit.
-        set(CARGOKIT_TEMP_DIR "${CMAKE_BINARY_DIR}/ck/${CARGOKIT_LIB_NAME}")
+        if(DEFINED ENV{ALERA_CARGOKIT_TEMP_DIR})
+            # CI can provide a short, user-writable drive-backed directory for
+            # compilers that still reject paths above MAX_PATH.
+            set(CARGOKIT_TEMP_DIR "$ENV{ALERA_CARGOKIT_TEMP_DIR}/${CARGOKIT_LIB_NAME}")
+        else()
+            set(CARGOKIT_TEMP_DIR "${CMAKE_BINARY_DIR}/ck/${CARGOKIT_LIB_NAME}")
+        endif()
     else()
         set(CARGOKIT_TEMP_DIR "${CMAKE_CURRENT_BINARY_DIR}/cargokit_build")
     endif()

--- a/rust_builder/cargokit/cmake/cargokit.cmake
+++ b/rust_builder/cargokit/cmake/cargokit.cmake
@@ -66,6 +66,11 @@ function(apply_cargokit target manifest_dir lib_name any_symbol_name)
         list(APPEND CARGOKIT_ENV
             "CMAKE_GENERATOR_x86_64_pc_windows_msvc=Ninja"
             "CMAKE_MAKE_PROGRAM_x86_64_pc_windows_msvc=${CARGOKIT_NINJA_EXECUTABLE}"
+            # MSVC's compiler PDB is shared by parallel Ninja compile jobs.
+            # /FS makes the compiler synchronize access instead of failing
+            # with C1041 when the Vulkan shader generator configures checks.
+            "CFLAGS=/FS"
+            "CXXFLAGS=/FS"
         )
     endif()
 

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -78,6 +78,9 @@ add_custom_target(alera_cli_sidecar ALL
   COMMAND "${CMAKE_COMMAND}" -E env
     "CMAKE_GENERATOR_x86_64_pc_windows_msvc=Ninja"
     "CMAKE_MAKE_PROGRAM_x86_64_pc_windows_msvc=${ALERA_NINJA_EXECUTABLE}"
+    # Keep parallel MSVC jobs from racing on the compiler PDB.
+    "CFLAGS=/FS"
+    "CXXFLAGS=/FS"
     "${CARGO_EXECUTABLE}" build --locked -p alera-cli
     --profile $<IF:$<CONFIG:Release>,release,dev>
   BYPRODUCTS "${ALERA_CLI_OUTPUT}"


### PR DESCRIPTION
## Root cause

The Windows warm-cache desktop build failed inside the nested `whisper-rs-sys` Vulkan shader build with MSVC error `C1041`: multiple parallel compiler processes attempted to write the same program database (PDB). The earlier short scratch-path change removed the path-length blocker, exposing this remaining PDB contention under Ninja parallelism.

## Code changes applied

- Pass `CFLAGS=/FS` and `CXXFLAGS=/FS` to the Windows x64 Cargokit Cargo environment so nested MSVC CMake builds synchronize compiler PDB access.
- Pass the same flags to the standalone `alera-cli` sidecar Cargo build in `windows/CMakeLists.txt`.
- Keep Ninja parallelism enabled; `/FS` serializes only PDB writes and prevents the `C1041` failure.

## Validation

- `git diff --check` passed.
- CMake configuration parsed successfully on Windows before dependency download.
- Full Flutter tests were unavailable locally because the installed Flutter 3.22.3 rejects the repository's existing `flutter.config`; CI uses Flutter 3.44.8.