### PR TITLE
feat: filter active workspaces

### DIFF
--- a/lib/src/features/workbench/application/workbench_controller_view_prefs.dart
+++ b/lib/src/features/workbench/application/workbench_controller_view_prefs.dart
@@ -42,6 +42,13 @@ mixin _WorkbenchControllerViewPrefs
     _updateViewPrefs(state.viewPrefs.copyWith(workspaceKindFilter: filter));
   }
 
+  void setShowActiveWorkspacesOnly(bool show) {
+    if (state.viewPrefs.showActiveWorkspacesOnly == show) {
+      return;
+    }
+    _updateViewPrefs(state.viewPrefs.copyWith(showActiveWorkspacesOnly: show));
+  }
+
   void setShowPinnedWorkspacesBelow(bool show) {
     if (state.viewPrefs.showPinnedWorkspacesBelow == show) {
       return;

--- a/lib/src/features/workbench/application/workbench_listing.dart
+++ b/lib/src/features/workbench/application/workbench_listing.dart
@@ -82,6 +82,9 @@ List<WorkbenchSidebarRow> buildSidebarRows(
     if (!workspaceMatchesTagFilter(prefs, workspace)) {
       return false;
     }
+    if (!workspaceMatchesActiveFilter(prefs, state.tabsFor(workspace.id))) {
+      return false;
+    }
     if (query.isEmpty) {
       return true;
     }
@@ -178,6 +181,7 @@ List<WorkbenchSidebarRow> buildSidebarRows(
       query.isNotEmpty ||
       prefs.selectedTagIds.isNotEmpty ||
       prefs.workspaceKindFilter != WorkspaceKindFilter.all ||
+      prefs.showActiveWorkspacesOnly ||
       !prefs.showPinnedWorkspacesBelow;
 
   final pinnedRows = <WorkbenchSidebarRow>[];
@@ -345,7 +349,8 @@ WorkbenchSidebarCollapseTargets visibleSidebarCollapseTargets(
   final filtersHideEmptyProjects =
       query.isNotEmpty ||
       prefs.selectedTagIds.isNotEmpty ||
-      prefs.workspaceKindFilter != WorkspaceKindFilter.all;
+      prefs.workspaceKindFilter != WorkspaceKindFilter.all ||
+      prefs.showActiveWorkspacesOnly;
   final visibleProjects = state.projects
       .where((project) => _projectVisible(prefs, project))
       .toList(growable: false);
@@ -357,7 +362,13 @@ WorkbenchSidebarCollapseTargets visibleSidebarCollapseTargets(
     return state
         .workspacesFor(project.id)
         .where(
-          (workspace) => _workspaceVisible(prefs, query, project, workspace),
+          (workspace) => _workspaceVisible(
+            prefs,
+            query,
+            project,
+            workspace,
+            state.tabsFor(workspace.id),
+          ),
         );
   }
 
@@ -417,11 +428,15 @@ bool _workspaceVisible(
   String query,
   Project project,
   Workspace workspace,
+  Iterable<WorkspaceTabRecord> tabs,
 ) {
   if (!workspaceMatchesKindFilter(prefs, workspace)) {
     return false;
   }
   if (!workspaceMatchesTagFilter(prefs, workspace)) {
+    return false;
+  }
+  if (!workspaceMatchesActiveFilter(prefs, tabs)) {
     return false;
   }
   if (query.isEmpty) {
@@ -462,7 +477,13 @@ int countVisibleWorkspaces(WorkbenchState state) {
       continue;
     }
     for (final workspace in state.workspacesFor(project.id)) {
-      if (_workspaceVisible(prefs, query, project, workspace)) {
+      if (_workspaceVisible(
+        prefs,
+        query,
+        project,
+        workspace,
+        state.tabsFor(workspace.id),
+      )) {
         count++;
       }
     }

--- a/lib/src/features/workbench/application/workbench_workspace_filters.dart
+++ b/lib/src/features/workbench/application/workbench_workspace_filters.dart
@@ -1,5 +1,6 @@
 import 'package:alera/src/features/workbench/domain/workbench_view_prefs.dart';
 import 'package:alera/src/features/workbench/domain/workspace.dart';
+import 'package:alera/src/features/workbench/domain/workspace_tab_record.dart';
 
 /// OR semantics over the selected tag filter: an empty selection shows every
 /// workspace; otherwise a workspace must carry at least one selected tag.
@@ -18,4 +19,20 @@ bool workspaceMatchesKindFilter(WorkbenchViewPrefs prefs, Workspace workspace) {
     WorkspaceKindFilter.defaultOnly => workspace.isMain,
     WorkspaceKindFilter.nonDefaultOnly => !workspace.isMain,
   };
+}
+
+/// Whether [tabs] make a workspace active for sidebar filtering and activity
+/// sorting. Other workbench tabs do not represent a running agent session.
+bool workspaceMatchesActiveFilter(
+  WorkbenchViewPrefs prefs,
+  Iterable<WorkspaceTabRecord> tabs,
+) {
+  if (!prefs.showActiveWorkspacesOnly) {
+    return true;
+  }
+  return tabs.any(
+    (tab) =>
+        tab.kind == WorkspaceTabKind.terminal ||
+        tab.kind == WorkspaceTabKind.codex,
+  );
 }

--- a/lib/src/features/workbench/domain/workbench_view_prefs.dart
+++ b/lib/src/features/workbench/domain/workbench_view_prefs.dart
@@ -62,6 +62,7 @@ class WorkbenchViewPrefs with WorkbenchViewPrefsMappable {
     this.gitDiffGroupMode = GitDiffGroupMode.byArea,
     this.pullRequestCreateAction = PullRequestCreateAction.publish,
     this.workspaceKindFilter = WorkspaceKindFilter.all,
+    this.showActiveWorkspacesOnly = false,
   });
 
   final WorkbenchGroupBy groupBy;
@@ -125,6 +126,11 @@ class WorkbenchViewPrefs with WorkbenchViewPrefsMappable {
   /// so previously persisted prefs (missing the key) keep today's behavior.
   final WorkspaceKindFilter workspaceKindFilter;
 
+  /// Whether the sidebar hides workspaces without an open terminal or Codex
+  /// tab. Defaults to false so older persisted preferences keep showing all
+  /// workspaces.
+  final bool showActiveWorkspacesOnly;
+
   static const WorkbenchViewPrefs defaults = WorkbenchViewPrefs(
     groupBy: WorkbenchGroupBy.project,
     projectSort: WorkbenchSortBy.name,
@@ -147,6 +153,7 @@ class WorkbenchViewPrefs with WorkbenchViewPrefsMappable {
     gitDiffGroupMode: GitDiffGroupMode.byArea,
     pullRequestCreateAction: PullRequestCreateAction.publish,
     workspaceKindFilter: WorkspaceKindFilter.all,
+    showActiveWorkspacesOnly: false,
   );
 
   factory WorkbenchViewPrefs.fromJson(Map<String, Object?> json) =>

--- a/lib/src/features/workbench/domain/workbench_view_prefs.mapper.dart
+++ b/lib/src/features/workbench/domain/workbench_view_prefs.mapper.dart
@@ -582,6 +582,15 @@ class WorkbenchViewPrefsMapper extends ClassMapperBase<WorkbenchViewPrefs> {
     opt: true,
     def: WorkspaceKindFilter.all,
   );
+  static bool _$showActiveWorkspacesOnly(WorkbenchViewPrefs v) =>
+      v.showActiveWorkspacesOnly;
+  static const Field<WorkbenchViewPrefs, bool> _f$showActiveWorkspacesOnly =
+      Field(
+        'showActiveWorkspacesOnly',
+        _$showActiveWorkspacesOnly,
+        opt: true,
+        def: false,
+      );
 
   @override
   final MappableFields<WorkbenchViewPrefs> fields = const {
@@ -606,6 +615,7 @@ class WorkbenchViewPrefsMapper extends ClassMapperBase<WorkbenchViewPrefs> {
     #gitDiffGroupMode: _f$gitDiffGroupMode,
     #pullRequestCreateAction: _f$pullRequestCreateAction,
     #workspaceKindFilter: _f$workspaceKindFilter,
+    #showActiveWorkspacesOnly: _f$showActiveWorkspacesOnly,
   };
 
   static WorkbenchViewPrefs _instantiate(DecodingData data) {
@@ -633,6 +643,7 @@ class WorkbenchViewPrefsMapper extends ClassMapperBase<WorkbenchViewPrefs> {
       gitDiffGroupMode: data.dec(_f$gitDiffGroupMode),
       pullRequestCreateAction: data.dec(_f$pullRequestCreateAction),
       workspaceKindFilter: data.dec(_f$workspaceKindFilter),
+      showActiveWorkspacesOnly: data.dec(_f$showActiveWorkspacesOnly),
     );
   }
 
@@ -731,6 +742,7 @@ abstract class WorkbenchViewPrefsCopyWith<
     GitDiffGroupMode? gitDiffGroupMode,
     PullRequestCreateAction? pullRequestCreateAction,
     WorkspaceKindFilter? workspaceKindFilter,
+    bool? showActiveWorkspacesOnly,
   });
   WorkbenchViewPrefsCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(
     Then<$Out2, $R2> t,
@@ -775,6 +787,7 @@ class _WorkbenchViewPrefsCopyWithImpl<$R, $Out>
     GitDiffGroupMode? gitDiffGroupMode,
     PullRequestCreateAction? pullRequestCreateAction,
     WorkspaceKindFilter? workspaceKindFilter,
+    bool? showActiveWorkspacesOnly,
   }) => $apply(
     FieldCopyWithData({
       if (groupBy != null) #groupBy: groupBy,
@@ -809,6 +822,8 @@ class _WorkbenchViewPrefsCopyWithImpl<$R, $Out>
         #pullRequestCreateAction: pullRequestCreateAction,
       if (workspaceKindFilter != null)
         #workspaceKindFilter: workspaceKindFilter,
+      if (showActiveWorkspacesOnly != null)
+        #showActiveWorkspacesOnly: showActiveWorkspacesOnly,
     }),
   );
   @override
@@ -872,6 +887,10 @@ class _WorkbenchViewPrefsCopyWithImpl<$R, $Out>
     workspaceKindFilter: data.get(
       #workspaceKindFilter,
       or: $value.workspaceKindFilter,
+    ),
+    showActiveWorkspacesOnly: data.get(
+      #showActiveWorkspacesOnly,
+      or: $value.showActiveWorkspacesOnly,
     ),
   );
 

--- a/lib/src/features/workbench/infra/runtime_workbench_view_prefs_repository.dart
+++ b/lib/src/features/workbench/infra/runtime_workbench_view_prefs_repository.dart
@@ -85,6 +85,7 @@ Map<String, Object?> _sharedJson(WorkbenchViewPrefs prefs) {
     'allSectionCollapsed': prefs.allSectionCollapsed,
     'showPinnedWorkspacesBelow': prefs.showPinnedWorkspacesBelow,
     'workspaceKindFilter': prefs.workspaceKindFilter.name,
+    'showActiveWorkspacesOnly': prefs.showActiveWorkspacesOnly,
   };
 }
 
@@ -124,6 +125,9 @@ WorkbenchViewPrefs _mergeShared(
       shared['workspaceKindFilter'],
       local.workspaceKindFilter,
     ),
+    showActiveWorkspacesOnly:
+        shared['showActiveWorkspacesOnly'] as bool? ??
+        local.showActiveWorkspacesOnly,
   );
 }
 

--- a/lib/src/features/workbench/presentation/widgets/workbench_view_options_menu.dart
+++ b/lib/src/features/workbench/presentation/widgets/workbench_view_options_menu.dart
@@ -37,6 +37,8 @@ class WorkbenchViewOptionsButton extends ConsumerWidget {
         prefs.selectedTagIds.isNotEmpty ||
         prefs.workspaceKindFilter !=
             WorkbenchViewPrefs.defaults.workspaceKindFilter ||
+        prefs.showActiveWorkspacesOnly !=
+            WorkbenchViewPrefs.defaults.showActiveWorkspacesOnly ||
         prefs.showPinnedWorkspacesBelow !=
             WorkbenchViewPrefs.defaults.showPinnedWorkspacesBelow ||
         prefs.groupBy != WorkbenchViewPrefs.defaults.groupBy ||
@@ -286,6 +288,15 @@ class _WorkbenchViewOptionsPanelState
                   _WorkspaceKindSegmented(
                     value: prefs.workspaceKindFilter,
                     onChanged: controller.setWorkspaceKindFilter,
+                  ),
+                  const SizedBox(height: AleraTokens.space6),
+                  Align(
+                    alignment: Alignment.centerLeft,
+                    child: AleraCheckbox(
+                      value: prefs.showActiveWorkspacesOnly,
+                      onChanged: controller.setShowActiveWorkspacesOnly,
+                      label: 'Active Workspaces Only',
+                    ),
                   ),
                   const SizedBox(height: AleraTokens.space6),
                   Align(

--- a/mobile/lib/src/features/workbench/application/mobile_view_prefs_controller.dart
+++ b/mobile/lib/src/features/workbench/application/mobile_view_prefs_controller.dart
@@ -53,6 +53,10 @@ class MobileViewPrefsController extends _$MobileViewPrefsController {
     return _update((prefs) => prefs.copyWith(workspaceKindFilter: value));
   }
 
+  Future<void> setShowActiveWorkspacesOnly(bool show) {
+    return _update((prefs) => prefs.copyWith(showActiveWorkspacesOnly: show));
+  }
+
   Future<void> setShowPinnedWorkspacesBelow(bool show) {
     return _update((prefs) => prefs.copyWith(showPinnedWorkspacesBelow: show));
   }

--- a/mobile/lib/src/features/workbench/application/mobile_view_prefs_controller.g.dart
+++ b/mobile/lib/src/features/workbench/application/mobile_view_prefs_controller.g.dart
@@ -52,7 +52,7 @@ final class MobileViewPrefsControllerProvider
 }
 
 String _$mobileViewPrefsControllerHash() =>
-    r'df81410238d90b7af4d05bb32c7812ad03707a4a';
+    r'ba93428e2c35022cd27daf2e2f48984c4b1bd9a6';
 
 final class MobileViewPrefsControllerFamily extends $Family
     with

--- a/mobile/lib/src/features/workbench/application/mobile_workspace_rows.dart
+++ b/mobile/lib/src/features/workbench/application/mobile_workspace_rows.dart
@@ -80,9 +80,20 @@ List<MobileWorkspaceRow> buildMobileWorkspaceRows({
     );
   }
 
+  final workspacesWithAgentPresence = <String>{
+    for (final status in agentPresence) status.workspaceId,
+  };
+
   final visibleWorkspaces = <WorkspaceSummary>[
     for (final workspace in workspaces)
-      if (_matchesFilters(workspace, projectById[workspace.projectId], prefs) &&
+      if (_matchesFilters(
+            workspace,
+            projectById[workspace.projectId],
+            prefs,
+            hasActivity:
+                (terminalTabCountByWorkspaceId[workspace.id] ?? 0) > 0 ||
+                workspacesWithAgentPresence.contains(workspace.id),
+          ) &&
           _matchesSearch(
             workspace,
             projectById[workspace.projectId],
@@ -90,9 +101,6 @@ List<MobileWorkspaceRow> buildMobileWorkspaceRows({
           ))
         workspace,
   ];
-  final workspacesWithAgentPresence = <String>{
-    for (final status in agentPresence) status.workspaceId,
-  };
   final directActivityByWorkspaceId = <String, MobileAgentActivityRank?>{
     for (final workspace in visibleWorkspaces)
       workspace.id:
@@ -226,14 +234,18 @@ List<MobileWorkspaceRow> buildMobileWorkspaceRows({
 bool _matchesFilters(
   WorkspaceSummary workspace,
   ProjectSummary? project,
-  MobileViewPrefs prefs,
-) {
+  MobileViewPrefs prefs, {
+  required bool hasActivity,
+}) {
   if (prefs.selectedProjectIds.isNotEmpty &&
       !prefs.selectedProjectIds.contains(workspace.projectId)) {
     return false;
   }
   if (prefs.selectedTagIds.isNotEmpty &&
       !workspace.tagIds.any(prefs.selectedTagIds.contains)) {
+    return false;
+  }
+  if (prefs.showActiveWorkspacesOnly && !hasActivity) {
     return false;
   }
   return switch (prefs.workspaceKindFilter) {

--- a/mobile/lib/src/features/workbench/domain/mobile_view_prefs.dart
+++ b/mobile/lib/src/features/workbench/domain/mobile_view_prefs.dart
@@ -17,6 +17,7 @@ class MobileViewPrefs {
     this.projectSort = MobileWorkbenchSortBy.name,
     this.workspaceSort = MobileWorkbenchSortBy.name,
     this.workspaceKindFilter = MobileWorkspaceKindFilter.all,
+    this.showActiveWorkspacesOnly = false,
     this.selectedProjectIds = const <String>{},
     this.selectedTagIds = const <String>{},
     this.collapsedProjectIds = const <String>{},
@@ -32,6 +33,7 @@ class MobileViewPrefs {
   final MobileWorkbenchSortBy projectSort;
   final MobileWorkbenchSortBy workspaceSort;
   final MobileWorkspaceKindFilter workspaceKindFilter;
+  final bool showActiveWorkspacesOnly;
   final Set<String> selectedProjectIds;
   final Set<String> selectedTagIds;
   final Set<String> collapsedProjectIds;
@@ -47,6 +49,7 @@ class MobileViewPrefs {
     MobileWorkbenchSortBy? projectSort,
     MobileWorkbenchSortBy? workspaceSort,
     MobileWorkspaceKindFilter? workspaceKindFilter,
+    bool? showActiveWorkspacesOnly,
     Set<String>? selectedProjectIds,
     Set<String>? selectedTagIds,
     Set<String>? collapsedProjectIds,
@@ -64,6 +67,8 @@ class MobileViewPrefs {
       projectSort: projectSort ?? this.projectSort,
       workspaceSort: workspaceSort ?? this.workspaceSort,
       workspaceKindFilter: workspaceKindFilter ?? this.workspaceKindFilter,
+      showActiveWorkspacesOnly:
+          showActiveWorkspacesOnly ?? this.showActiveWorkspacesOnly,
       selectedProjectIds: selectedProjectIds ?? this.selectedProjectIds,
       selectedTagIds: selectedTagIds ?? this.selectedTagIds,
       collapsedProjectIds: collapsedProjectIds ?? this.collapsedProjectIds,
@@ -93,6 +98,7 @@ class MobileViewPrefs {
       workspaceKindFilter: MobileWorkspaceKindFilter.values.byName(
         json.optionalString('workspaceKindFilter') ?? 'all',
       ),
+      showActiveWorkspacesOnly: json['showActiveWorkspacesOnly'] == true,
       selectedProjectIds: json.stringList('selectedProjectIds').toSet(),
       selectedTagIds: json.stringList('selectedTagIds').toSet(),
       collapsedProjectIds: json.stringList('collapsedProjectIds').toSet(),
@@ -118,6 +124,7 @@ class MobileViewPrefs {
       'projectSort': projectSort.name,
       'workspaceSort': workspaceSort.name,
       'workspaceKindFilter': workspaceKindFilter.name,
+      'showActiveWorkspacesOnly': showActiveWorkspacesOnly,
       'selectedProjectIds': selectedProjectIds.toList(),
       'selectedTagIds': selectedTagIds.toList(),
       'collapsedProjectIds': collapsedProjectIds.toList(),

--- a/mobile/lib/src/features/workbench/presentation/workspace_view_options_sheet.dart
+++ b/mobile/lib/src/features/workbench/presentation/workspace_view_options_sheet.dart
@@ -115,6 +115,12 @@ class _WorkspaceViewOptions extends ConsumerWidget {
             ),
             SwitchListTile(
               contentPadding: EdgeInsets.zero,
+              title: const Text('Active Workspaces Only'),
+              value: prefs.showActiveWorkspacesOnly,
+              onChanged: controller.setShowActiveWorkspacesOnly,
+            ),
+            SwitchListTile(
+              contentPadding: EdgeInsets.zero,
               title: const Text('Repeat Pinned Workspaces'),
               value: prefs.showPinnedWorkspacesBelow,
               onChanged: controller.setShowPinnedWorkspacesBelow,

--- a/mobile/test/mobile_workspace_rows_test.dart
+++ b/mobile/test/mobile_workspace_rows_test.dart
@@ -121,6 +121,27 @@ void main() {
     expect(_workspaceIds(rows), <String>['terminal', 'inactive']);
   });
 
+  test('Active filter keeps terminal and agent workspaces only', () {
+    final now = DateTime.utc(2026, 7, 18, 12);
+    final rows = buildMobileWorkspaceRows(
+      workspaces: <WorkspaceSummary>[
+        _workspace('inactive', now),
+        _workspace('terminal', now),
+        _workspace('codex', now),
+      ],
+      projects: const [],
+      prefs: const MobileViewPrefs(
+        groupBy: MobileWorkspaceGroupBy.none,
+        showActiveWorkspacesOnly: true,
+      ),
+      terminalTabCountByWorkspaceId: const <String, int>{'terminal': 1},
+      agentPresence: <AgentPresenceSummary>[_presence('codex', 'working', now)],
+      now: now,
+    );
+
+    expect(_workspaceIds(rows), <String>['codex', 'terminal']);
+  });
+
   test('Inactive projects sort alphabetically after active projects', () {
     final now = DateTime.utc(2026, 7, 18, 12);
     final rows = buildMobileWorkspaceRows(

--- a/mobile/test/workspace_sidebar_snapshot_test.dart
+++ b/mobile/test/workspace_sidebar_snapshot_test.dart
@@ -14,6 +14,17 @@ void main() {
     expect(legacy.showPinnedWorkspacesBelow, isTrue);
   });
 
+  test('View prefs preserve the active workspace filter', () {
+    final activeOnly = MobileViewPrefs.fromJson(<String, Object?>{
+      'showActiveWorkspacesOnly': true,
+    });
+    final legacy = MobileViewPrefs.fromJson(const <String, Object?>{});
+
+    expect(activeOnly.showActiveWorkspacesOnly, isTrue);
+    expect(activeOnly.toJson()['showActiveWorkspacesOnly'], isTrue);
+    expect(legacy.showActiveWorkspacesOnly, isFalse);
+  });
+
   test('Parses runtime terminal counts and full agent details', () {
     final snapshot = WorkspaceSidebarSnapshot.fromJson(<String, Object?>{
       'projects': <Object?>[],

--- a/rust/alera-core/src/runtime/workbench_shared_state_models.rs
+++ b/rust/alera-core/src/runtime/workbench_shared_state_models.rs
@@ -47,6 +47,8 @@ pub struct SharedWorkbenchViewPrefs {
     #[serde(default = "default_true")]
     pub show_pinned_workspaces_below: bool,
     pub workspace_kind_filter: SharedWorkspaceKindFilter,
+    #[serde(default)]
+    pub show_active_workspaces_only: bool,
 }
 
 fn default_true() -> bool {
@@ -67,6 +69,7 @@ impl Default for SharedWorkbenchViewPrefs {
             all_section_collapsed: false,
             show_pinned_workspaces_below: true,
             workspace_kind_filter: SharedWorkspaceKindFilter::All,
+            show_active_workspaces_only: false,
         }
     }
 }

--- a/rust/alera-core/src/runtime/workbench_shared_state_store_tests.rs
+++ b/rust/alera-core/src/runtime/workbench_shared_state_store_tests.rs
@@ -12,6 +12,7 @@ async fn desktop_initializes_shared_prefs_and_mobile_rejects_stale_revision() {
     let prefs = SharedWorkbenchViewPrefs {
         workspace_sort: SharedWorkbenchSortBy::Activity,
         show_pinned_workspaces_below: false,
+        show_active_workspaces_only: true,
         ..SharedWorkbenchViewPrefs::default()
     };
 
@@ -26,6 +27,7 @@ async fn desktop_initializes_shared_prefs_and_mobile_rejects_stale_revision() {
     assert!(desktop.desktop_initialized);
     assert_eq!(desktop.revision, 1);
     assert!(!desktop.prefs.show_pinned_workspaces_below);
+    assert!(desktop.prefs.show_active_workspaces_only);
 
     let error = store
         .update_shared_workbench_view_prefs(prefs, Some(0), SharedWorkbenchPrefsWriter::Mobile)
@@ -45,6 +47,19 @@ fn legacy_shared_view_prefs_show_pinned_workspaces_below() {
     let restored: SharedWorkbenchViewPrefs = serde_json::from_value(encoded).unwrap();
 
     assert!(restored.show_pinned_workspaces_below);
+}
+
+#[test]
+fn legacy_shared_view_prefs_show_all_workspaces() {
+    let mut encoded = serde_json::to_value(SharedWorkbenchViewPrefs::default()).unwrap();
+    encoded
+        .as_object_mut()
+        .unwrap()
+        .remove("showActiveWorkspacesOnly");
+
+    let restored: SharedWorkbenchViewPrefs = serde_json::from_value(encoded).unwrap();
+
+    assert!(!restored.show_active_workspaces_only);
 }
 
 #[tokio::test]

--- a/test/unit/runtime_workbench_view_prefs_repository_test.dart
+++ b/test/unit/runtime_workbench_view_prefs_repository_test.dart
@@ -1,0 +1,69 @@
+import 'package:alera/src/features/workbench/application/workbench_view_prefs_repository.dart';
+import 'package:alera/src/features/workbench/domain/workbench_view_prefs.dart';
+import 'package:alera/src/features/workbench/infra/runtime_workbench_view_prefs_repository.dart';
+import 'package:alera/src/features/workbench/infra/terminal_host/terminal_host_protocol.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('loads and saves the shared active workspace filter', () async {
+    final client = _FakeRuntimeHostClient()
+      ..responses['workbenchViewPrefs.get'] = <String, Object?>{
+        'revision': 4,
+        'desktopInitialized': true,
+        'prefs': <String, Object?>{'showActiveWorkspacesOnly': true},
+      }
+      ..responses['workbenchViewPrefs.update'] = <String, Object?>{
+        'revision': 5,
+      };
+    final legacy = _MemoryViewPrefsRepository();
+    final repository = RuntimeWorkbenchViewPrefsRepository(
+      client: client,
+      legacyRepository: legacy,
+    );
+
+    final loaded = await repository.load();
+    expect(loaded.showActiveWorkspacesOnly, isTrue);
+
+    await repository.save(loaded.copyWith(showActiveWorkspacesOnly: false));
+    expect(
+      client.payloads['workbenchViewPrefs.update']?.single['prefs'],
+      containsPair('showActiveWorkspacesOnly', false),
+    );
+    expect(legacy.prefs.showActiveWorkspacesOnly, isFalse);
+  });
+}
+
+final class _MemoryViewPrefsRepository implements WorkbenchViewPrefsRepository {
+  WorkbenchViewPrefs prefs = WorkbenchViewPrefs.defaults;
+
+  @override
+  Stream<WorkbenchViewPrefs> get changes =>
+      const Stream<WorkbenchViewPrefs>.empty();
+
+  @override
+  Future<WorkbenchViewPrefs> load() async => prefs;
+
+  @override
+  Future<void> save(WorkbenchViewPrefs prefs) async {
+    this.prefs = prefs;
+  }
+}
+
+final class _FakeRuntimeHostClient implements RuntimeHostClient {
+  final responses = <String, Object?>{};
+  final payloads = <String, List<Map<String, Object?>>>{};
+
+  @override
+  Stream<RuntimeHostEvent> get runtimeEvents =>
+      const Stream<RuntimeHostEvent>.empty();
+
+  @override
+  Future<Object?> runtimeRequest(
+    String type, [
+    Map<String, Object?> payload = const <String, Object?>{},
+    Duration? timeout,
+  ]) async {
+    payloads.putIfAbsent(type, () => <Map<String, Object?>>[]).add(payload);
+    return responses[type];
+  }
+}

--- a/test/unit/workbench_controller_active_filter_test_cases.dart
+++ b/test/unit/workbench_controller_active_filter_test_cases.dart
@@ -1,0 +1,13 @@
+part of 'workbench_controller_test.dart';
+
+void _registerWorkbenchControllerActiveFilterTests() {
+  test('active workspace filter updates state and persists', () async {
+    await _controller.bootstrap();
+
+    _controller.setShowActiveWorkspacesOnly(true);
+    await _flush();
+
+    expect(_controller.state.viewPrefs.showActiveWorkspacesOnly, isTrue);
+    expect(_harness.viewPrefsRepository.prefs.showActiveWorkspacesOnly, isTrue);
+  });
+}

--- a/test/unit/workbench_controller_test.dart
+++ b/test/unit/workbench_controller_test.dart
@@ -47,6 +47,7 @@ part 'workbench_controller_sleep_test_cases.dart';
 part 'workbench_controller_layout_persistence_test_cases.dart';
 part 'workbench_controller_mobile_emulator_test_cases.dart';
 part 'workbench_controller_view_prefs_test_cases.dart';
+part 'workbench_controller_active_filter_test_cases.dart';
 part 'workbench_controller_failure_test_cases.dart';
 part 'workbench_controller_create_workspace_test_cases.dart';
 part 'workbench_controller_workspace_graph_test_cases.dart';
@@ -77,6 +78,7 @@ void main() {
     _registerWorkbenchControllerLayoutPersistenceTests();
     _registerWorkbenchControllerMobileEmulatorTests();
     _registerWorkbenchControllerViewPrefsTests();
+    _registerWorkbenchControllerActiveFilterTests();
     _registerWorkbenchControllerFailureTests();
     _registerWorkbenchControllerCreateWorkspaceTests();
     _registerWorkbenchControllerWorkspaceGraphTests();

--- a/test/unit/workbench_listing_active_filter_test.dart
+++ b/test/unit/workbench_listing_active_filter_test.dart
@@ -1,0 +1,181 @@
+import 'package:alera/src/features/projects/domain/project.dart';
+import 'package:alera/src/features/workbench/application/workbench_listing.dart';
+import 'package:alera/src/features/workbench/application/workbench_state.dart';
+import 'package:alera/src/features/workbench/domain/workbench_view_prefs.dart';
+import 'package:alera/src/features/workbench/domain/workspace.dart';
+import 'package:alera/src/features/workbench/domain/workspace_tab_record.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+final DateTime _now = DateTime.utc(2026, 8, 21);
+
+void main() {
+  group('active workspace filter', () {
+    test('shows terminal and Codex workspaces and hides empty projects', () {
+      final alera = _project('p-alera');
+      final orca = _project('p-orca');
+      final terminal = _workspace('w-terminal', alera.id);
+      final codex = _workspace('w-codex', alera.id);
+      final editor = _workspace('w-editor', alera.id);
+      final inactive = _workspace('w-inactive', orca.id);
+      final state = WorkbenchState(
+        projects: <Project>[alera, orca],
+        workspacesByProject: <String, List<Workspace>>{
+          alera.id: <Workspace>[terminal, codex, editor],
+          orca.id: <Workspace>[inactive],
+        },
+        tabsByWorkspace: <String, List<WorkspaceTabRecord>>{
+          terminal.id: <WorkspaceTabRecord>[
+            _tab('t-terminal', terminal.id, WorkspaceTabKind.terminal),
+          ],
+          codex.id: <WorkspaceTabRecord>[
+            _tab('t-codex', codex.id, WorkspaceTabKind.codex),
+          ],
+          editor.id: <WorkspaceTabRecord>[
+            _tab('t-editor', editor.id, WorkspaceTabKind.editor),
+          ],
+        },
+        viewPrefs: WorkbenchViewPrefs.defaults.copyWith(
+          showActiveWorkspacesOnly: true,
+        ),
+        bootstrapped: true,
+      );
+
+      final rows = buildSidebarRows(state);
+
+      expect(workspaceOrderOfRows(rows), <String>['w-codex', 'w-terminal']);
+      expect(
+        rows.whereType<WorkbenchProjectHeaderRow>().map(
+          (row) => row.project.id,
+        ),
+        <String>['p-alera'],
+      );
+      expect(countVisibleWorkspaces(state), 2);
+      final targets = visibleSidebarCollapseTargets(state);
+      expect(targets.projectIds, <String>{'p-alera'});
+      expect(targets.workspaceIds, <String>{'w-terminal', 'w-codex'});
+    });
+
+    test('combines with kind, tag, and search filters', () {
+      final project = _project('p-alera');
+      final main = _workspace(
+        'w-main',
+        project.id,
+        kind: WorkspaceKind.main,
+        tagIds: <String>['review'],
+      );
+      final linked = _workspace(
+        'w-feature',
+        project.id,
+        tagIds: <String>['review'],
+      );
+      final state = WorkbenchState(
+        projects: <Project>[project],
+        workspacesByProject: <String, List<Workspace>>{
+          project.id: <Workspace>[main, linked],
+        },
+        tabsByWorkspace: <String, List<WorkspaceTabRecord>>{
+          main.id: <WorkspaceTabRecord>[
+            _tab('t-main', main.id, WorkspaceTabKind.terminal),
+          ],
+          linked.id: <WorkspaceTabRecord>[
+            _tab('t-feature', linked.id, WorkspaceTabKind.terminal),
+          ],
+        },
+        viewPrefs: WorkbenchViewPrefs.defaults.copyWith(
+          showActiveWorkspacesOnly: true,
+          workspaceKindFilter: WorkspaceKindFilter.nonDefaultOnly,
+          selectedTagIds: <String>{'review'},
+        ),
+        searchQuery: 'feature',
+        bootstrapped: true,
+      );
+
+      expect(workspaceOrderOfRows(buildSidebarRows(state)), <String>[
+        'w-feature',
+      ]);
+      expect(countVisibleWorkspaces(state), 1);
+    });
+
+    test('filters pinned copies and promotes active children', () {
+      final project = _project('p-alera');
+      final inactivePinned = _workspace('w-pinned', project.id, isPinned: true);
+      final inactiveParent = _workspace('w-parent', project.id);
+      final activeChild = _workspace(
+        'w-child',
+        project.id,
+        parentWorkspaceId: inactiveParent.id,
+      );
+      final state = WorkbenchState(
+        projects: <Project>[project],
+        workspacesByProject: <String, List<Workspace>>{
+          project.id: <Workspace>[inactivePinned, inactiveParent, activeChild],
+        },
+        tabsByWorkspace: <String, List<WorkspaceTabRecord>>{
+          activeChild.id: <WorkspaceTabRecord>[
+            _tab('t-child', activeChild.id, WorkspaceTabKind.codex),
+          ],
+        },
+        viewPrefs: WorkbenchViewPrefs.defaults.copyWith(
+          showActiveWorkspacesOnly: true,
+        ),
+        bootstrapped: true,
+      );
+
+      final rows = buildSidebarRows(state);
+      expect(
+        rows.whereType<WorkbenchWorkspaceRow>().where(
+          (row) => row.isPinnedCopy,
+        ),
+        isEmpty,
+      );
+      final child = rows.whereType<WorkbenchWorkspaceRow>().single;
+      expect(child.workspace.id, activeChild.id);
+      expect(child.indent, 1);
+    });
+  });
+}
+
+Project _project(String id) {
+  return Project(
+    id: id,
+    name: id,
+    repoPath: '/repo/$id',
+    createdAt: _now,
+    updatedAt: _now,
+  );
+}
+
+Workspace _workspace(
+  String id,
+  String projectId, {
+  WorkspaceKind kind = WorkspaceKind.linked,
+  List<String> tagIds = const <String>[],
+  String? parentWorkspaceId,
+  bool isPinned = false,
+}) {
+  return Workspace(
+    id: id,
+    projectId: projectId,
+    name: id,
+    branch: id,
+    path: '/repo/$projectId/$id',
+    createdAt: _now,
+    updatedAt: _now,
+    kind: kind,
+    status: WorkspaceStatus.active,
+    tagIds: tagIds,
+    parentWorkspaceId: parentWorkspaceId,
+    isPinned: isPinned,
+  );
+}
+
+WorkspaceTabRecord _tab(String id, String workspaceId, WorkspaceTabKind kind) {
+  return WorkspaceTabRecord(
+    id: id,
+    workspaceId: workspaceId,
+    kind: kind,
+    title: id,
+    createdAt: _now,
+    updatedAt: _now,
+  );
+}

--- a/test/unit/workbench_view_prefs_test.dart
+++ b/test/unit/workbench_view_prefs_test.dart
@@ -15,6 +15,7 @@ void main() {
       expect(WorkbenchViewPrefs.defaults.selectedTagIds, isEmpty);
       expect(WorkbenchViewPrefs.defaults.collapsedParentWorkspaceIds, isEmpty);
       expect(WorkbenchViewPrefs.defaults.showPinnedWorkspacesBelow, isTrue);
+      expect(WorkbenchViewPrefs.defaults.showActiveWorkspacesOnly, isFalse);
       expect(
         WorkbenchViewPrefs.defaults.sourceControlRootByWorkspaceId,
         isEmpty,
@@ -46,6 +47,7 @@ void main() {
         selectedTagIds: <String>{'tag-1'},
         collapsedParentWorkspaceIds: <String>{'w-parent'},
         showPinnedWorkspacesBelow: false,
+        showActiveWorkspacesOnly: true,
         sourceControlRootByWorkspaceId: <String, String>{
           'w-folder': 'packages/app',
         },
@@ -67,6 +69,7 @@ void main() {
       expect(restored.selectedTagIds, <String>{'tag-1'});
       expect(restored.collapsedParentWorkspaceIds, <String>{'w-parent'});
       expect(restored.showPinnedWorkspacesBelow, isFalse);
+      expect(restored.showActiveWorkspacesOnly, isTrue);
       expect(restored.sourceControlRootByWorkspaceId, <String, String>{
         'w-folder': 'packages/app',
       });
@@ -115,6 +118,7 @@ void main() {
       expect(restored.workspaceSort, WorkbenchSortBy.recent);
       expect(restored.workspaceKindFilter, WorkspaceKindFilter.all);
       expect(restored.showPinnedWorkspacesBelow, isTrue);
+      expect(restored.showActiveWorkspacesOnly, isFalse);
       expect(restored.gitDiffGroupMode, GitDiffGroupMode.byArea);
     });
 

--- a/test/widget/workbench_view_options_menu_test.dart
+++ b/test/widget/workbench_view_options_menu_test.dart
@@ -189,6 +189,28 @@ void main() {
       expect(_activeDot(), findsOneWidget);
     });
 
+    testWidgets('toggles the active workspaces filter', (tester) async {
+      final controller = _ViewOptionsTestController(
+        WorkbenchState(projects: <Project>[_project('project-1', 'Alera')]),
+      );
+
+      await _pumpButton(tester, controller);
+      await tester.tap(_viewOptionsButton());
+      await tester.pumpAndSettle();
+
+      final option = find.text('Active Workspaces Only');
+      expect(option, findsOneWidget);
+      expect(controller.state.viewPrefs.showActiveWorkspacesOnly, isFalse);
+
+      await tester.tap(option);
+      await tester.pumpAndSettle();
+      expect(controller.state.viewPrefs.showActiveWorkspacesOnly, isTrue);
+
+      await tester.tap(find.byTooltip('Close'));
+      await tester.pumpAndSettle();
+      expect(_activeDot(), findsOneWidget);
+    });
+
     testWidgets('available project rows animate their hover state', (
       tester,
     ) async {
@@ -351,6 +373,13 @@ class _ViewOptionsTestController extends WorkbenchController {
   void setWorkspaceKindFilter(WorkspaceKindFilter filter) {
     state = state.copyWith(
       viewPrefs: state.viewPrefs.copyWith(workspaceKindFilter: filter),
+    );
+  }
+
+  @override
+  void setShowActiveWorkspacesOnly(bool show) {
+    state = state.copyWith(
+      viewPrefs: state.viewPrefs.copyWith(showActiveWorkspacesOnly: show),
     );
   }
 


### PR DESCRIPTION
## Summary

- add an optional Active Workspaces Only filter to desktop and mobile workspace view options
- define active workspaces consistently as those with an open terminal or Codex tab
- persist the preference through the shared runtime model while preserving legacy defaults
- combine the filter with search, project, tag, kind, pinning, grouping, and workspace trees

## Screenshots

- No screenshot attached. The control and filtered listing behavior are covered by widget, unit, snapshot, and golden tests. Argent was not installed in the local environment.

## Testing

- [x] `dart format --set-exit-if-changed lib test integration_test tool`
- [x] `flutter analyze`
- [x] root Flutter tests: 3,099 passed, 1 repository-defined skip
- [x] mobile format, analyze, and Flutter tests: 507 passed
- [x] golden tests: 3 passed
- [x] max-lines ratchet
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p alera-core --features runtime --all-targets -- -D warnings`
- [x] focused Rust shared preference tests
- [x] added regression coverage for filtering, persistence, compatibility, hierarchy, combined filters, desktop UI, and mobile snapshots

`make rust-test` is locally blocked while building the unrelated Whisper/Vulkan dependency because `glslc` is not installed. The PR Rust job installs `glslc` before running the full workspace checks. `gh act` also could not resolve linked-worktree Git metadata inside its container; the job commands were run directly instead.

## AI Review Report

Reviewed activity semantics against the existing Agent Activity ordering and sidebar indicators, shared desktop/mobile serialization compatibility, empty-group behavior, pinned copies, promoted children, and interactions with all existing filters. The max-lines ratchet initially identified growth in an oversized test file, so the new controller regression was split into a focused file.

## Security Audit

No new command execution, path handling, authentication, secrets, dependencies, or external input surfaces. The change only filters already-loaded workspace metadata and persists a boolean preference.

## Notes

The preference is shared across desktop and mobile. Existing saved state and older runtime payloads default to showing all workspaces. There is no platform-specific behavior.