### PR TITLE
feat: surface fx across landing and mobile

### DIFF
--- a/landing/public/agents/fx.svg
+++ b/landing/public/agents/fx.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
+  <path d="M3 18.5 8.6 5.5h4.2L7.2 18.5H3Zm7.6 0 4.1-6.5-3.4-6.5h4.2l1.7 3.4 2.1-3.4H24l-4.7 6.6 3.5 6.4h-4.2l-1.8-3.3-2 3.3h-4.2Z" fill="#fff"/>
+</svg>

--- a/landing/src/components/Agents.astro
+++ b/landing/src/components/Agents.astro
@@ -9,6 +9,7 @@ const agents = [
   { name: 'Copilot', src: '/agents/copilot.svg' },
   { name: 'Pi', src: '/agents/pi.svg' },
   { name: 'Grok Build', src: '/agents/grok.svg' },
+  { name: 'fx', src: '/agents/fx.svg' },
 ];
 ---
 
@@ -18,13 +19,13 @@ const agents = [
       Works with every CLI agent
     </p>
     <p class="text-center text-body-md text-foreground-muted max-w-xl mx-auto mb-12">
-      First-class integration today: icons, lifecycle hooks, and live activity tracking. Anything else that runs in a terminal works out of the box.
+      First-class integration today: icons, lifecycle integrations, and live activity tracking. Anything else that runs in a terminal works out of the box.
     </p>
 
-    <div class="flex flex-wrap justify-center items-center gap-8 md:gap-12">
+    <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-x-8 gap-y-8 md:gap-x-12">
       {agents.map((agent, i) => (
         <div
-          class="flex flex-col items-center gap-3 group opacity-0-initial animate-fade-in-up"
+          class="flex flex-col items-center gap-3 group opacity-0-initial animate-fade-in-up min-w-0"
           style={`animation-delay: ${200 + i * 60}ms`}
         >
           <div class="w-14 h-14 rounded-xl bg-surface border border-border flex items-center justify-center transition-all duration-mid group-hover:border-foreground-faint group-hover:bg-surface-variant group-hover:scale-105">

--- a/landing/src/components/Faq.astro
+++ b/landing/src/components/Faq.astro
@@ -6,7 +6,7 @@ const faqs = [
   },
   {
     question: 'How do I bring my own agent?',
-    answer: 'If it runs in a terminal, it runs in Alera. Open a new terminal tab in a workspace and launch your agent CLI like you would in any shell. Agents like Claude Code, Codex, Amp, Antigravity, OpenCode, Cursor, Copilot, and Pi also get live activity tracking through managed lifecycle hooks.',
+    answer: 'If it runs in a terminal, it runs in Alera. Open a new terminal tab in a workspace and launch your agent CLI like you would in any shell. Agents like Claude Code, Codex, Amp, Antigravity, OpenCode, Cursor, Copilot, Pi, Grok Build, and fx also get live activity tracking through managed lifecycle integrations.',
   },
   {
     question: 'Do I need Git to use Alera?',

--- a/landing/src/components/Features.astro
+++ b/landing/src/components/Features.astro
@@ -8,7 +8,7 @@ const features = [
   {
     icon: '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4 7v10a2 2 0 002 2h12a2 2 0 002-2V9a2 2 0 00-2-2h-5l-2-2H6a2 2 0 00-2 2z M9 13h6" />',
     title: 'Worktree-native multi-agent',
-    description: 'Every task gets its own Git worktree. Run Claude, Codex, Amp, and friends side-by-side in tabs and split panes. No stashing, no branch juggling, no agents stepping on each other\'s files.',
+    description: 'Every task gets its own Git worktree. Run Claude, Codex, Amp, fx, and friends side-by-side in tabs and split panes. No stashing, no branch juggling, no agents stepping on each other\'s files.',
   },
   {
     icon: '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M20 7H4a2 2 0 00-2 2v8a2 2 0 002 2h16a2 2 0 002-2V9a2 2 0 00-2-2zM6 11h.01M10 11h.01M14 11h.01M18 11h.01" />',

--- a/landing/src/components/Hero.astro
+++ b/landing/src/components/Hero.astro
@@ -56,7 +56,7 @@ const staticTagline = ['in parallel', 'at native performance', 'without Electron
 
     <!-- Subtitle -->
     <p class="text-[14px] md:text-[16px] text-foreground-muted max-w-2xl mx-auto mb-8 leading-relaxed text-balance opacity-0-initial animate-fade-in-up animation-delay-200">
-      From Claude Code and Codex to Amp and Antigravity, every agent gets its own Git worktree, its own terminals, its own context. Cross-platform desktop for macOS, Windows, and Linux. No Electron. No Chromium.
+      From Claude Code and Codex to Amp, fx, and Antigravity, every agent gets its own Git worktree, its own terminals, its own context. Cross-platform desktop for macOS, Windows, and Linux. No Electron. No Chromium.
     </p>
 
     <!-- CTA buttons -->

--- a/landing/src/components/Workflow.astro
+++ b/landing/src/components/Workflow.astro
@@ -13,7 +13,7 @@ const steps = [
   {
     number: '03',
     title: 'Run agents in parallel terminals',
-    description: 'Open as many tabs as you want per workspace. Launch Claude, Codex, Amp, or any CLI agent in its own native PTY and watch their activity live in one workbench.',
+    description: 'Open as many tabs as you want per workspace. Launch Claude, Codex, Amp, fx, or any CLI agent in its own native PTY and watch their activity live in one workbench.',
   },
 ];
 ---

--- a/landing/src/content/blog/bring-your-own-cli-agent-to-alera.md
+++ b/landing/src/content/blog/bring-your-own-cli-agent-to-alera.md
@@ -10,7 +10,7 @@ That is not a dodge. It is the design. We never wanted Alera to be a product you
 
 ## First-Class Today
 
-Some agents get more than a PTY. These ship with icons, managed lifecycle hooks, and live activity tracking in the workbench:
+Some agents get more than a PTY. These ship with icons, managed lifecycle integrations, and live activity tracking in the workbench:
 
 - Claude Code
 - Codex
@@ -21,8 +21,9 @@ Some agents get more than a PTY. These ship with icons, managed lifecycle hooks,
 - Copilot
 - Pi
 - Grok Build
+- fx
 
-The hooks stream status into Alera, which is what lets the sidebar and activity surfaces tell you who is working and who is quietly waiting for your input. When you run a handful of agents at once, that glanceable state is the difference between conducting and guessing.
+These integrations stream status into Alera, which is what lets the sidebar and activity surfaces tell you who is working and who is quietly waiting for your input. When you run a handful of agents at once, that glanceable state is the difference between conducting and guessing.
 
 ## Everything Else
 
@@ -32,7 +33,7 @@ We like this rule because it ages well. The agent landscape reshuffles monthly. 
 
 ## Orchestration Adapters
 
-If you go further and coordinate agents through [orchestration](/blog/inter-agent-orchestration-in-alera), agent profiles bind to a built-in adapter registry (`codex`, `claude`, `copilot`, `cursor`, `agy`, `opencode`, `pi`, `amp`, `grok`, and related defaults). Profiles are your configuration: you approve the launch command, the coordinator dispatches to it, and nobody invents commands on your behalf.
+If you go further and coordinate agents through [orchestration](/blog/inter-agent-orchestration-in-alera), agent profiles bind to a built-in adapter registry (`codex`, `claude`, `copilot`, `cursor`, `agy`, `opencode`, `pi`, `amp`, `grok`, `fx`, and related defaults). Profiles are your configuration: you approve the launch command, the coordinator dispatches to it, and nobody invents commands on your behalf.
 
 ## Tips From Our Own Setup
 

--- a/landing/src/content/blog/run-cli-agents-in-parallel-with-git-worktrees.md
+++ b/landing/src/content/blog/run-cli-agents-in-parallel-with-git-worktrees.md
@@ -34,7 +34,7 @@ The loop itself is three steps:
 
 1. Register a project (local folder or clone)
 2. Open a linked worktree workspace for each task you want in flight
-3. Launch Claude, Codex, Amp, or any other CLI agent in that workspace's terminals
+3. Launch Claude, Codex, Amp, fx, or any other CLI agent in that workspace's terminals
 
 The one annoyance left in this loop used to be setup: every new worktree needs its `.env`, its dependencies, its bootstrap commands. We automated that ritual with [`alera.toml`](/blog/automate-new-worktree-setup-with-alera-toml), and when the work is done, [pull requests and CI checks stay scoped to the same worktree](/blog/pull-requests-and-ci-checks-per-worktree) so what you review is exactly what the agent produced.
 

--- a/landing/src/content/blog/welcome-to-alera.md
+++ b/landing/src/content/blog/welcome-to-alera.md
@@ -10,7 +10,7 @@ Our days already revolved around CLI coding agents. Claude Code in one terminal,
 
 The new wave of AI IDEs did not solve it for us. They wrap a single chat backend inside an Electron shell and ask you to leave your CLI behind. We did not want to leave the CLI behind. The CLI is where the agents live.
 
-So Alera takes the opposite bet. It is a native, performance-first workbench for CLI coding agents: Claude Code, Codex, Amp, Antigravity, OpenCode, Cursor, Copilot, Pi, or anything else that runs in a terminal. Flutter and Rust under the hood, Ghostty's VTE for terminal parsing. No Electron, no bundled Chromium, no browser pretending to be a terminal.
+So Alera takes the opposite bet. It is a native, performance-first workbench for CLI coding agents: Claude Code, Codex, Amp, Antigravity, OpenCode, Cursor, Copilot, Pi, Grok Build, fx, or anything else that runs in a terminal. Flutter and Rust under the hood, Ghostty's VTE for terminal parsing. No Electron, no bundled Chromium, no browser pretending to be a terminal.
 
 ## What You Can Do Today
 

--- a/landing/src/content/blog/why-alera-is-terminal-first-not-another-ai-ide.md
+++ b/landing/src/content/blog/why-alera-is-terminal-first-not-another-ai-ide.md
@@ -6,7 +6,7 @@ pubDate: 2026-07-28T19:00:00.000Z
 
 Here is an opinion we hold strongly enough to build a product on: the CLI is the real interface for coding agents, and it will stay that way for a while.
 
-Every agent team that matters ships a terminal client first. Claude Code, Codex, Amp, Cursor Agent, Copilot CLI, OpenCode, Pi. The terminal is where new capabilities show up earliest, where power users already live, and where the agents compose with the rest of your tools. So when we see an AI IDE embed one provider's chat in a web view and call it the future, our reaction is: that is a wrapper, not a workbench.
+Every agent team that matters ships a terminal client first. Claude Code, Codex, Amp, Cursor Agent, Copilot CLI, OpenCode, Pi, fx. The terminal is where new capabilities show up earliest, where power users already live, and where the agents compose with the rest of your tools. So when we see an AI IDE embed one provider's chat in a web view and call it the future, our reaction is: that is a wrapper, not a workbench.
 
 ## What A Single Chat Shell Costs You
 

--- a/landing/src/layouts/Layout.astro
+++ b/landing/src/layouts/Layout.astro
@@ -21,7 +21,7 @@ const {
   modifiedTime,
 } = Astro.props;
 
-const defaultDescription = 'Run every CLI coding agent in parallel: Claude Code, Codex, Amp, Antigravity, OpenCode, Cursor, Copilot, Pi, or any other CLI agent. Native performance with Flutter + Rust + Ghostty. No Electron, no Chromium. Available for macOS, Windows, and Linux.';
+const defaultDescription = 'Run every CLI coding agent in parallel: Claude Code, Codex, Amp, Antigravity, OpenCode, Cursor, Copilot, Pi, Grok Build, fx, or any other CLI agent. Native performance with Flutter + Rust + Ghostty. No Electron, no Chromium. Available for macOS, Windows, and Linux.';
 const description = Astro.props.description ?? defaultDescription;
 const shortDescription = 'Native, performance-first workbench for CLI coding agents. Built with Flutter + Rust + Ghostty. macOS, Windows, and Linux.';
 const siteUrl = 'https://alera.build';

--- a/mobile/assets/agents/fx.svg
+++ b/mobile/assets/agents/fx.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
+  <path d="M3 18.5 8.6 5.5h4.2L7.2 18.5H3Zm7.6 0 4.1-6.5-3.4-6.5h4.2l1.7 3.4 2.1-3.4H24l-4.7 6.6 3.5 6.4h-4.2l-1.8-3.3-2 3.3h-4.2Z" fill="currentColor"/>
+</svg>

--- a/mobile/lib/src/features/settings/domain/portable_host_settings.dart
+++ b/mobile/lib/src/features/settings/domain/portable_host_settings.dart
@@ -12,6 +12,7 @@ const List<String> supportedAgentHooks = <String>[
   'pi',
   'amp',
   'grok',
+  'fx',
 ];
 
 const Map<String, String> agentHookLabels = <String, String>{
@@ -25,6 +26,7 @@ const Map<String, String> agentHookLabels = <String, String>{
   'pi': 'Pi',
   'amp': 'Amp',
   'grok': 'Grok Build',
+  'fx': 'fx',
 };
 
 class PortableHostSettings {

--- a/mobile/lib/src/features/settings/presentation/host_settings_screen.dart
+++ b/mobile/lib/src/features/settings/presentation/host_settings_screen.dart
@@ -178,8 +178,16 @@ class _SettingsBody extends ConsumerWidget {
                 SwitchListTile(
                   value: settings.agentStatusHooks[agent] == true,
                   onChanged: (value) => controller.setAgentHook(agent, value),
-                  title: Text('${agentHookLabels[agent]} Hooks'),
-                  subtitle: const Text('Report direct terminal agent status.'),
+                  title: Text(
+                    agent == 'fx'
+                        ? 'fx Status'
+                        : '${agentHookLabels[agent]} Hooks',
+                  ),
+                  subtitle: Text(
+                    agent == 'fx'
+                        ? 'Report status through the built-in Herdr integration on macOS and Linux.'
+                        : 'Report direct terminal agent status.',
+                  ),
                 ),
             ],
           ),

--- a/mobile/lib/src/features/workbench/presentation/agent_identity_icon.dart
+++ b/mobile/lib/src/features/workbench/presentation/agent_identity_icon.dart
@@ -68,6 +68,7 @@ String agentDisplayName(String agentType) => switch (agentType) {
   'pi' => 'Pi',
   'amp' => 'Amp',
   'grok' => 'Grok Build',
+  'fx' => 'fx',
   _ => 'Agent',
 };
 
@@ -90,5 +91,6 @@ _AgentIconAsset? _agentAsset(String agentType) => switch (agentType) {
   'pi' => const _AgentIconAsset(path: 'assets/agents/pi.svg'),
   'amp' => const _AgentIconAsset(path: 'assets/agents/amp.png', raster: true),
   'grok' => const _AgentIconAsset(path: 'assets/agents/grok.svg'),
+  'fx' => const _AgentIconAsset(path: 'assets/agents/fx.svg'),
   _ => null,
 };

--- a/mobile/test/agent_identity_icon_test.dart
+++ b/mobile/test/agent_identity_icon_test.dart
@@ -1,0 +1,35 @@
+import 'package:alera_mobile/src/features/workbench/presentation/agent_identity_icon.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('renders local icon assets for every supported agent', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Row(
+          children: <Widget>[
+            AgentIdentityIcon(agentType: 'codex'),
+            AgentIdentityIcon(agentType: 'claude'),
+            AgentIdentityIcon(agentType: 'copilot'),
+            AgentIdentityIcon(agentType: 'cursor'),
+            AgentIdentityIcon(agentType: 'agy'),
+            AgentIdentityIcon(agentType: 'opencode'),
+            AgentIdentityIcon(agentType: 'pi'),
+            AgentIdentityIcon(agentType: 'amp'),
+            AgentIdentityIcon(agentType: 'grok'),
+            AgentIdentityIcon(agentType: 'fx'),
+          ],
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.byType(SvgPicture), findsNWidgets(6));
+    expect(find.byType(Image), findsNWidgets(4));
+    expect(find.byTooltip('fx'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+}

--- a/mobile/test/portable_host_settings_test.dart
+++ b/mobile/test/portable_host_settings_test.dart
@@ -1,0 +1,15 @@
+import 'package:alera_mobile/src/features/settings/domain/portable_host_settings.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('includes fx in the supported status integrations', () {
+    expect(supportedAgentHooks, contains('fx'));
+    expect(agentHookLabels['fx'], 'fx');
+
+    final settings = PortableHostSettings.fromJson(<String, Object?>{
+      'agentStatusHooks': <String, Object?>{'fx': true},
+    });
+
+    expect(settings.agentStatusHooks['fx'], isTrue);
+  });
+}

--- a/mobile/test/runtime_restart_test.dart
+++ b/mobile/test/runtime_restart_test.dart
@@ -71,8 +71,19 @@ void main() {
       ),
     );
     await _pumpUntil(tester, find.text('General'));
-    await tester.scrollUntilVisible(find.text('Restart Runtime'), 200);
+    await tester.scrollUntilVisible(find.text('fx Status'), 200);
     await tester.pump();
+
+    expect(find.text('fx Status'), findsOneWidget);
+    expect(
+      find.text(
+        'Report status through the built-in Herdr integration on macOS and Linux.',
+      ),
+      findsOneWidget,
+    );
+
+    await tester.fling(find.byType(ListView), const Offset(0, 3000), 2000);
+    await tester.pumpAndSettle();
 
     expect(find.text('Restart Runtime'), findsOneWidget);
     await tester.tap(find.text('Restart Runtime'));


### PR DESCRIPTION
## Summary
- add fx branding and support copy across the landing page, SEO metadata, and current agent articles
- expose fx status settings and branded identity in the mobile app
- keep quota surfaces unchanged because fx quota tracking is not supported

## Validation
- `bun run build`
- `flutter analyze` in `mobile/`
- `flutter test` in `mobile/` (509 tests)
- `gh act pull_request -W .github/workflows/landing.yml -j build`
- desktop and mobile-width Chromium visual inspection
