### PR TITLE
fix: verify android native dependencies without ndk readelf lookup

### DIFF
--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -739,21 +739,7 @@ jobs:
 
       - name: Verify Android native dependencies
         shell: bash
-        run: |
-          set -euo pipefail
-          readelf="$(find "$ANDROID_NDK_HOME/toolchains/llvm/prebuilt" -name llvm-readelf -type f | head -1)"
-          test -n "$readelf"
-          extract_dir="$(mktemp -d)"
-          trap 'rm -rf "$extract_dir"' EXIT
-          for apk in mobile/build/app/outputs/flutter-apk/*-release.apk; do
-            apk_dir="$extract_dir/$(basename "$apk" .apk)"
-            unzip -q "$apk" 'lib/*/libalera_mobile_native.so' 'lib/*/libc++_shared.so' -d "$apk_dir"
-            while IFS= read -r native; do
-              abi="$(basename "$(dirname "$native")")"
-              "$readelf" -d "$native" | grep -q 'Shared library: \[libc++_shared.so\]'
-              test -f "$apk_dir/lib/$abi/libc++_shared.so"
-            done < <(find "$apk_dir/lib" -name libalera_mobile_native.so -type f)
-          done
+        run: bash tool/release/verify_android_native_dependencies.sh mobile/build/app/outputs/flutter-apk
 
       - name: Verify Android APK signatures
         shell: bash

--- a/test/unit/android_native_dependency_verification_test.dart
+++ b/test/unit/android_native_dependency_verification_test.dart
@@ -1,0 +1,202 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+
+void main() {
+  final script = File('tool/release/verify_android_native_dependencies.sh');
+
+  test(
+    'release cuts verify Android native dependencies through the script',
+    () {
+      final workflow = File(
+        '.github/workflows/release-cut.yml',
+      ).readAsStringSync();
+
+      expect(
+        workflow,
+        contains(
+          'bash tool/release/verify_android_native_dependencies.sh '
+          'mobile/build/app/outputs/flutter-apk',
+        ),
+      );
+      expect(
+        workflow,
+        isNot(contains(r'find "$ANDROID_NDK_HOME/toolchains/llvm/prebuilt"')),
+      );
+    },
+  );
+
+  test('rejects a directory with no release APKs', () {
+    if (Platform.isWindows) {
+      return;
+    }
+    final temp = Directory.systemTemp.createTempSync(
+      'alera-android-native-verify-empty-',
+    );
+    addTearDown(() => temp.deleteSync(recursive: true));
+
+    final result = Process.runSync('bash', <String>[script.path, temp.path]);
+    expect(result.exitCode, isNot(0), reason: result.stderr.toString());
+    expect(result.stderr, contains('No Android release APKs found'));
+  });
+
+  test('rejects an APK that omits the shared C++ runtime', () {
+    if (Platform.isWindows) {
+      return;
+    }
+
+    final temp = Directory.systemTemp.createTempSync(
+      'alera-android-native-verify-missing-cxx-',
+    );
+    addTearDown(() => temp.deleteSync(recursive: true));
+    final native = File(p.join(temp.path, 'libalera_mobile_native.so'))
+      ..writeAsStringSync('not a real elf');
+    final apk = File(p.join(temp.path, 'app-arm64-v8a-release.apk'));
+    _zipApk(apk, <String, File>{
+      'lib/arm64-v8a/libalera_mobile_native.so': native,
+    });
+
+    final result = Process.runSync('bash', <String>[script.path, temp.path]);
+    expect(result.exitCode, isNot(0), reason: result.stderr.toString());
+    expect(result.stderr, contains('missing lib/*/libc++_shared.so'));
+  });
+
+  test('rejects a native library that does not need libc++_shared.so', () {
+    if (Platform.isWindows) {
+      return;
+    }
+    final gcc = _gcc();
+    if (gcc == null) {
+      return;
+    }
+
+    final temp = Directory.systemTemp.createTempSync(
+      'alera-android-native-verify-unlinked-cxx-',
+    );
+    addTearDown(() => temp.deleteSync(recursive: true));
+    final native = _compileSharedLibrary(
+      gcc: gcc,
+      directory: temp,
+      name: 'libalera_mobile_native.so',
+      needed: const <String>[],
+    );
+    final runtime = _compileSharedLibrary(
+      gcc: gcc,
+      directory: temp,
+      name: 'libc++_shared.so',
+      needed: const <String>[],
+    );
+    final apk = File(p.join(temp.path, 'app-arm64-v8a-release.apk'));
+    _zipApk(apk, <String, File>{
+      'lib/arm64-v8a/libalera_mobile_native.so': native,
+      'lib/arm64-v8a/libc++_shared.so': runtime,
+    });
+
+    final result = Process.runSync('bash', <String>[script.path, temp.path]);
+    expect(result.exitCode, isNot(0), reason: result.stderr.toString());
+    expect(result.stderr, contains('does not declare NEEDED libc++_shared.so'));
+  });
+
+  test('accepts APKs that bundle libc++_shared.so for every ABI', () {
+    if (Platform.isWindows) {
+      return;
+    }
+    final gcc = _gcc();
+    if (gcc == null) {
+      return;
+    }
+
+    final temp = Directory.systemTemp.createTempSync(
+      'alera-android-native-verify-ok-',
+    );
+    addTearDown(() => temp.deleteSync(recursive: true));
+    final runtime = _compileSharedLibrary(
+      gcc: gcc,
+      directory: temp,
+      name: 'libc++_shared.so',
+      needed: const <String>[],
+    );
+    final native = _compileSharedLibrary(
+      gcc: gcc,
+      directory: temp,
+      name: 'libalera_mobile_native.so',
+      needed: <String>[runtime.path],
+    );
+
+    for (final apkName in <String>[
+      'app-release.apk',
+      'app-arm64-v8a-release.apk',
+    ]) {
+      final apk = File(p.join(temp.path, apkName));
+      _zipApk(apk, <String, File>{
+        'lib/arm64-v8a/libalera_mobile_native.so': native,
+        'lib/arm64-v8a/libc++_shared.so': runtime,
+        'lib/armeabi-v7a/libalera_mobile_native.so': native,
+        'lib/armeabi-v7a/libc++_shared.so': runtime,
+      });
+    }
+
+    final result = Process.runSync('bash', <String>[script.path, temp.path]);
+    expect(result.exitCode, 0, reason: '${result.stdout}\n${result.stderr}');
+    expect(result.stdout, contains('links against bundled libc++_shared.so'));
+  });
+}
+
+String? _gcc() {
+  final result = Process.runSync('gcc', const <String>['--version']);
+  if (result.exitCode != 0) {
+    return null;
+  }
+  return 'gcc';
+}
+
+File _compileSharedLibrary({
+  required String gcc,
+  required Directory directory,
+  required String name,
+  required List<String> needed,
+}) {
+  final marker = name.replaceAll(RegExp('[^A-Za-z]'), '_');
+  final source = File(p.join(directory.path, '$name.c'))
+    ..writeAsStringSync('void ${marker}_marker(void) {}\n');
+  final output = File(p.join(directory.path, name));
+  final args = <String>[
+    '-fPIC',
+    '-shared',
+    '-Wl,-soname,$name',
+    '-o',
+    output.path,
+    source.path,
+  ];
+  if (needed.isNotEmpty) {
+    args.add('-Wl,--no-as-needed');
+    for (final library in needed) {
+      final fileName = p.basename(library);
+      final linkName = fileName
+          .replaceFirst(RegExp('^lib'), '')
+          .replaceFirst(RegExp(r'\.so$'), '');
+      args.addAll(<String>['-L${p.dirname(library)}', '-l$linkName']);
+    }
+  }
+  final result = Process.runSync(gcc, args);
+  expect(result.exitCode, 0, reason: result.stderr.toString());
+  expect(output.existsSync(), isTrue);
+  return output;
+}
+
+void _zipApk(File apk, Map<String, File> entries) {
+  final staging = Directory(p.join(apk.parent.path, '${apk.path}.staging'))
+    ..createSync();
+  for (final entry in entries.entries) {
+    final destination = File(p.join(staging.path, entry.key))
+      ..parent.createSync(recursive: true);
+    entry.value.copySync(destination.path);
+  }
+  final result = Process.runSync('zip', <String>[
+    '-qr',
+    apk.path,
+    '.',
+  ], workingDirectory: staging.path);
+  expect(result.exitCode, 0, reason: result.stderr.toString());
+}

--- a/tool/release/verify_android_native_dependencies.sh
+++ b/tool/release/verify_android_native_dependencies.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Fails when a release APK ships libalera_mobile_native.so without the shared
+# C++ runtime Whisper links against. Cargokit copies only the Rust cdylib by
+# default, so Android's loader rejects the library before dictation can start.
+#
+# The check lives here instead of inline in the workflow so it can be run
+# against fixtures: the previous inline version looked up llvm-readelf with
+# `find -type f | head`, which misses the NDK symlink and can SIGPIPE under
+# `pipefail`, so the release job failed with no diagnostic.
+
+apk_dir="${1:?apk directory is required}"
+
+if [[ ! -d "$apk_dir" ]]; then
+  echo "::error::Missing Android APK directory: $apk_dir" >&2
+  exit 1
+fi
+
+resolve_readelf() {
+  if command -v readelf >/dev/null 2>&1; then
+    command -v readelf
+    return
+  fi
+  if command -v llvm-readelf >/dev/null 2>&1; then
+    command -v llvm-readelf
+    return
+  fi
+
+  local search_roots=()
+  local sdk="${ANDROID_HOME:-${ANDROID_SDK_ROOT:-}}"
+  if [[ -n "$sdk" && -d "$sdk/ndk" ]]; then
+    search_roots+=("$sdk/ndk")
+  fi
+  local candidate
+  for candidate in "${ANDROID_NDK_HOME:-}" "${ANDROID_NDK_LATEST_HOME:-}" "${ANDROID_NDK_ROOT:-}"; do
+    if [[ -n "$candidate" && -d "$candidate" ]]; then
+      search_roots+=("$candidate")
+    fi
+  done
+
+  local root found
+  for root in "${search_roots[@]}"; do
+    # llvm-readelf is a symlink to llvm-readobj in the NDK, so -type f misses it.
+    found="$(find "$root" \( -type f -o -type l \) -name llvm-readelf -print -quit 2>/dev/null || true)"
+    if [[ -n "$found" ]]; then
+      printf '%s\n' "$found"
+      return
+    fi
+  done
+
+  echo "::error::readelf was not found. Install binutils or the Android NDK." >&2
+  exit 1
+}
+
+readelf="$(resolve_readelf)"
+echo "Using readelf: $readelf"
+
+shopt -s nullglob
+apks=("$apk_dir"/*-release.apk)
+if (( ${#apks[@]} == 0 )); then
+  echo "::error::No Android release APKs found in $apk_dir" >&2
+  exit 1
+fi
+
+extract_dir="$(mktemp -d)"
+trap 'rm -rf "$extract_dir"' EXIT
+
+for apk in "${apks[@]}"; do
+  apk_name="$(basename "$apk")"
+  echo "Verifying native dependencies in $apk_name"
+  listing="$(unzip -Z1 "$apk" 'lib/*' || true)"
+  if ! grep -E -q '^lib/[^/]+/libalera_mobile_native\.so$' <<<"$listing"; then
+    echo "::error::$apk_name is missing lib/*/libalera_mobile_native.so" >&2
+    printf '%s\n' "$listing" >&2
+    exit 1
+  fi
+  if ! grep -E -q '^lib/[^/]+/libc\+\+_shared\.so$' <<<"$listing"; then
+    echo "::error::$apk_name is missing lib/*/libc++_shared.so" >&2
+    printf '%s\n' "$listing" >&2
+    exit 1
+  fi
+
+  apk_extract="$extract_dir/${apk_name%.apk}"
+  unzip -q "$apk" 'lib/*/libalera_mobile_native.so' 'lib/*/libc++_shared.so' -d "$apk_extract"
+
+  native_found=0
+  while IFS= read -r native; do
+    native_found=1
+    abi="$(basename "$(dirname "$native")")"
+    dynamic_section="$("$readelf" -d "$native")"
+    if ! grep -Fq 'Shared library: [libc++_shared.so]' <<<"$dynamic_section"; then
+      echo "::error::$apk_name lib/$abi/libalera_mobile_native.so does not declare NEEDED libc++_shared.so" >&2
+      printf '%s\n' "$dynamic_section" >&2
+      exit 1
+    fi
+    if [[ ! -f "$apk_extract/lib/$abi/libc++_shared.so" ]]; then
+      echo "::error::$apk_name is missing lib/$abi/libc++_shared.so beside the native library" >&2
+      exit 1
+    fi
+    echo "Verified $apk_name lib/$abi links against bundled libc++_shared.so"
+  done < <(find "$apk_extract/lib" -name libalera_mobile_native.so -type f)
+
+  if (( native_found == 0 )); then
+    echo "::error::$apk_name listed libalera_mobile_native.so but none was extracted" >&2
+    exit 1
+  fi
+done


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The latest Cut Release failed in `build android` after the APKs built successfully. The new "Verify Android native dependencies" step looked up `llvm-readelf` with `find -type f` under `ANDROID_NDK_HOME`. In the NDK that binary is a symlink to `llvm-readobj`, so the probe found nothing, `test -n` exited 1, and the job died with no diagnostic.

This moves the check into `tool/release/verify_android_native_dependencies.sh`, which uses the runner `readelf`, reports missing `libalera_mobile_native.so` / `libc++_shared.so` / `NEEDED` entries explicitly, and is covered by fixture tests. Packaging of the shared C++ runtime from #437 is unchanged.

## Screenshots

- No visual change

## Testing

- [x] `dart format --set-exit-if-changed test/unit/android_native_dependency_verification_test.dart`
- [x] PR CI: all 23 checks passed on `c70b58273f3ccb5b7553a557969dfbde9a6fe0a9`
- [x] `flutter test test/unit/android_native_dependency_verification_test.dart test/unit/release_workflow_config_test.dart`
- [ ] Golden tests: not applicable
- [ ] Desktop E2E: not applicable
- [ ] Desktop build: not applicable
- [ ] Landing build: not applicable
- [x] Added tests that reject missing/unlinked `libc++_shared.so` and accept a well-formed APK fixture

## Validation

- Reproduced that `find -name llvm-readelf -type f` returns nothing when the NDK tool is a symlink
- New script verifies fake APKs that bundle `libc++_shared.so` and fail when it is absent or not a `NEEDED` dependency
- Confirmed the workflow no longer inlines the broken `ANDROID_NDK_HOME` lookup
- GitHub Actions on this branch completed 23/23 checks

## AI Review Report

Checked the failing Cut Release job `build android` (run 32585473213). The APKs built; only the native-dependency probe failed, with no stderr. Risks reviewed: a false pass if `readelf` is missing (the script now errors), Windows unit tests skipping the bash fixtures (same pattern as other release script tests), and whether `libc++_shared.so` itself was missing from the APK (the previous probe never got that far). Release/updater behavior is Linux CI-only and does not change desktop packaging.

## Security Audit

The script only reads APKs from a caller-supplied directory, extracts two known `.so` names into a temp dir, and runs `readelf -d`. No secrets, signing, or network access. `unzip` patterns are fixed literals, not user-controlled globs.

## Notes

This unblocks Cut Release Android verification. After merge, re-run Cut Release to publish the mobile artifacts that failed on 2026-08-22. No product docs change: runtime packaging from #437 is unchanged.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0841fc93-dfa7-412b-8f07-6bfa3908df60?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0841fc93-dfa7-412b-8f07-6bfa3908df60&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

