### PR TITLE
ci: bootstrap cloud relay durable object

### DIFF
--- a/.github/workflows/cloud-deploy.yml
+++ b/.github/workflows/cloud-deploy.yml
@@ -30,6 +30,14 @@ on:
         description: Known Cloudflare Worker version id for rollback mode
         required: false
         type: string
+      rollback_relay_state:
+        description: Expected relay state in the rollback Worker version
+        required: true
+        default: disabled
+        type: choice
+        options:
+          - disabled
+          - enabled
 
 permissions:
   contents: read
@@ -167,6 +175,56 @@ jobs:
       - name: Setup Google Cloud
         uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3
 
+      - name: Bootstrap State Metadata Access
+        run: |
+          gcloud projects add-iam-policy-binding "$GCP_PROJECT_ID" \
+            --member="serviceAccount:$GCP_SERVICE_ACCOUNT" \
+            --role=roles/storage.legacyBucketReader \
+            --condition=None \
+            --quiet >/dev/null
+
+      - name: Production Preflight
+        run: |
+          set -euo pipefail
+          gcloud run services describe alera-cloud \
+            --project="$GCP_PROJECT_ID" \
+            --region="$GCP_REGION" \
+            --format='value(metadata.name)' >/dev/null
+          gcloud artifacts repositories describe alera-cloud \
+            --project="$GCP_PROJECT_ID" \
+            --location="$GCP_REGION" \
+            --format='value(name)' >/dev/null
+
+          bucket_versioning="$(
+            gcloud storage buckets describe "gs://$STATE_BUCKET" \
+              --format='value(versioning.enabled)'
+          )"
+          if [[ "$bucket_versioning" != "True" ]]; then
+            echo "OpenTofu state bucket $STATE_BUCKET must have object versioning enabled." >&2
+            exit 1
+          fi
+
+          required_secrets=(
+            alera-database-url
+            alera-edge-origin-token
+            alera-github-oauth-client-secret
+            alera-google-oauth-client-secret
+            alera-tombstone-pepper
+          )
+          for secret in "${required_secrets[@]}"; do
+            enabled_version="$(
+              gcloud secrets versions list "$secret" \
+                --project="$GCP_PROJECT_ID" \
+                --filter='state=ENABLED' \
+                --limit=1 \
+                --format='value(name)'
+            )"
+            if [[ -z "$enabled_version" ]]; then
+              echo "Secret $secret has no enabled version." >&2
+              exit 1
+            fi
+          done
+
       - name: Setup OpenTofu
         uses: opentofu/setup-opentofu@a1320f892987e89d278cc92dc5adc984fb93aca4 # v2.0.2
         with:
@@ -218,8 +276,49 @@ jobs:
               | .version_id
             ' <<<"$deployments"
           )"
-          echo "previous_image=$previous_image" >>"$GITHUB_OUTPUT"
-          echo "previous_worker_version=$previous_worker_version" >>"$GITHUB_OUTPUT"
+          previous_relay_status=""
+          for _ in 1 2 3; do
+            if previous_relay_status="$(
+              curl \
+                --silent \
+                --show-error \
+                --output /dev/null \
+                --write-out '%{http_code}' \
+                --max-time 20 \
+                "$PUBLIC_API_URL/v1/relay/deploy-probe"
+            )" && [[ "$previous_relay_status" == "404" || "$previous_relay_status" == "426" ]]; then
+              break
+            fi
+            sleep 5
+          done
+          case "$previous_relay_status" in
+            404)
+              previous_relay_state=disabled
+              ;;
+            426)
+              previous_relay_state=enabled
+              ;;
+            *)
+              echo "Cannot determine the current relay state from HTTP $previous_relay_status." >&2
+              exit 1
+              ;;
+          esac
+          {
+            echo "previous_image=$previous_image"
+            echo "previous_relay_state=$previous_relay_state"
+            echo "previous_worker_version=$previous_worker_version"
+          } >>"$GITHUB_OUTPUT"
+
+      - name: Select Relay State
+        id: relay
+        run: |
+          set -euo pipefail
+          if [[ "$(jq -r '.vars.RELAY_ENABLED // ""' edge/wrangler.jsonc)" == "true" ]]; then
+            relay_state=enabled
+          else
+            relay_state=disabled
+          fi
+          echo "state=$relay_state" >>"$GITHUB_OUTPUT"
 
       - name: Configure Artifact Registry
         if: ${{ env.DEPLOY_MODE != 'rollback' }}
@@ -326,17 +425,31 @@ jobs:
           )"
           echo "worker_version=$worker_version" >>"$GITHUB_OUTPUT"
 
-      - name: Verify Deployment
-        id: verify
+      - name: Verify Worker Namespace
+        id: namespace
         if: ${{ env.DEPLOY_MODE == 'deploy' && steps.worker.outcome == 'success' }}
         continue-on-error: true
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_WRANGLER_API_TOKEN }}
+        run: |
+          tool/cloud/verify_worker_namespace.sh \
+            "$CLOUDFLARE_ACCOUNT_ID" \
+            "$WORKER_NAME" \
+            RuntimeRelayDurableObject
+
+      - name: Verify Deployment
+        id: verify
+        if: ${{ env.DEPLOY_MODE == 'deploy' && steps.worker.outcome == 'success' && steps.namespace.outcome == 'success' }}
+        continue-on-error: true
+        env:
+          EXPECTED_RELAY_STATE: ${{ steps.relay.outputs.state }}
         run: |
           origin_url="$(tofu -chdir=infra/production output -raw cloud_run_origin_url)"
-          tool/cloud/verify_production.sh "$PUBLIC_API_URL" "$origin_url"
+          tool/cloud/verify_production.sh "$PUBLIC_API_URL" "$origin_url" "$EXPECTED_RELAY_STATE"
 
       - name: Roll Back Worker Automatically
         id: automatic_worker_rollback
-        if: ${{ env.DEPLOY_MODE == 'deploy' && steps.apply.outputs.applied == 'true' && (steps.worker.outcome == 'failure' || steps.verify.outcome == 'failure') }}
+        if: ${{ env.DEPLOY_MODE == 'deploy' && steps.apply.outputs.applied == 'true' && (steps.worker.outcome == 'failure' || steps.namespace.outcome == 'failure' || steps.verify.outcome == 'failure') }}
         continue-on-error: true
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_WRANGLER_API_TOKEN }}
@@ -347,9 +460,29 @@ jobs:
             --message "automatic rollback for GitHub run $GITHUB_RUN_ID" \
             --yes
 
+      - name: Recover Worker Forward With Relay Disabled
+        id: automatic_worker_forward_recovery
+        if: ${{ always() && env.DEPLOY_MODE == 'deploy' && steps.apply.outputs.applied == 'true' && (steps.worker.outcome == 'failure' || steps.namespace.outcome == 'failure' || steps.verify.outcome == 'failure') && steps.automatic_worker_rollback.outcome != 'success' }}
+        continue-on-error: true
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_WRANGLER_API_TOKEN }}
+        run: tool/cloud/deploy_worker_relay_disabled.sh edge
+
+      - name: Verify Recovered Worker Namespace
+        id: automatic_recovery_namespace
+        if: ${{ always() && env.DEPLOY_MODE == 'deploy' && (steps.automatic_worker_rollback.outcome == 'success' || steps.automatic_worker_forward_recovery.outcome == 'success') }}
+        continue-on-error: true
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_WRANGLER_API_TOKEN }}
+        run: |
+          tool/cloud/verify_worker_namespace.sh \
+            "$CLOUDFLARE_ACCOUNT_ID" \
+            "$WORKER_NAME" \
+            RuntimeRelayDurableObject
+
       - name: Roll Back Cloud Run Automatically
         id: automatic_cloud_run_rollback
-        if: ${{ always() && env.DEPLOY_MODE == 'deploy' && steps.apply.outputs.applied == 'true' && (steps.worker.outcome == 'failure' || steps.verify.outcome == 'failure') }}
+        if: ${{ always() && env.DEPLOY_MODE == 'deploy' && steps.apply.outputs.applied == 'true' && (steps.worker.outcome == 'failure' || steps.namespace.outcome == 'failure' || steps.verify.outcome == 'failure') }}
         continue-on-error: true
         working-directory: infra/production
         env:
@@ -372,14 +505,34 @@ jobs:
         id: automatic_rollback_verify
         if: ${{ always() && env.DEPLOY_MODE == 'deploy' && steps.automatic_cloud_run_rollback.outcome == 'success' }}
         continue-on-error: true
+        env:
+          FORWARD_RECOVERY: ${{ steps.automatic_worker_forward_recovery.outcome }}
+          PREVIOUS_RELAY_STATE: ${{ steps.current.outputs.previous_relay_state }}
+          RECOVERY_NAMESPACE: ${{ steps.automatic_recovery_namespace.outcome }}
+          WORKER_ROLLBACK: ${{ steps.automatic_worker_rollback.outcome }}
         run: |
+          set -euo pipefail
+          if [[ "$RECOVERY_NAMESPACE" != "success" ]]; then
+            echo "Recovered Worker namespace verification did not succeed." >&2
+            exit 1
+          fi
+          if [[ "$WORKER_ROLLBACK" == "success" ]]; then
+            expected_relay_state="$PREVIOUS_RELAY_STATE"
+          elif [[ "$FORWARD_RECOVERY" == "success" ]]; then
+            expected_relay_state=disabled
+          else
+            echo "Neither Worker rollback nor forward recovery succeeded." >&2
+            exit 1
+          fi
           origin_url="$(tofu -chdir=infra/production output -raw cloud_run_origin_url)"
-          tool/cloud/verify_production.sh "$PUBLIC_API_URL" "$origin_url"
+          tool/cloud/verify_production.sh "$PUBLIC_API_URL" "$origin_url" "$expected_relay_state"
 
       - name: Report Failed Deployment
-        if: ${{ always() && env.DEPLOY_MODE == 'deploy' && (steps.worker.outcome == 'failure' || steps.verify.outcome == 'failure') }}
+        if: ${{ always() && env.DEPLOY_MODE == 'deploy' && (steps.worker.outcome == 'failure' || steps.namespace.outcome == 'failure' || steps.verify.outcome == 'failure') }}
         env:
           CLOUD_RUN_ROLLBACK: ${{ steps.automatic_cloud_run_rollback.outcome }}
+          FORWARD_RECOVERY: ${{ steps.automatic_worker_forward_recovery.outcome }}
+          NAMESPACE_RECOVERY: ${{ steps.automatic_recovery_namespace.outcome }}
           PREVIOUS_IMAGE: ${{ steps.current.outputs.previous_image }}
           PREVIOUS_WORKER_VERSION: ${{ steps.current.outputs.previous_worker_version }}
           ROLLBACK_VERIFICATION: ${{ steps.automatic_rollback_verify.outcome }}
@@ -389,6 +542,8 @@ jobs:
             echo "### Deployment Failed"
             echo
             echo "Automatic rollback was attempted."
+            echo "- Worker forward recovery: $FORWARD_RECOVERY"
+            echo "- Recovered namespace: $NAMESPACE_RECOVERY"
             echo
             echo "- Worker rollback: \`$WORKER_ROLLBACK\`"
             echo "- Cloud Run rollback: \`$CLOUD_RUN_ROLLBACK\`"
@@ -412,6 +567,26 @@ jobs:
             --message "manual rollback from GitHub run $GITHUB_RUN_ID" \
             --yes
 
+      - name: Recover Worker Forward Manually With Relay Disabled
+        id: manual_worker_forward_recovery
+        if: ${{ always() && env.DEPLOY_MODE == 'rollback' && steps.manual_worker.outcome != 'success' }}
+        continue-on-error: true
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_WRANGLER_API_TOKEN }}
+        run: tool/cloud/deploy_worker_relay_disabled.sh edge
+
+      - name: Verify Manually Recovered Worker Namespace
+        id: manual_namespace
+        if: ${{ always() && env.DEPLOY_MODE == 'rollback' && (steps.manual_worker.outcome == 'success' || steps.manual_worker_forward_recovery.outcome == 'success') }}
+        continue-on-error: true
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_WRANGLER_API_TOKEN }}
+        run: |
+          tool/cloud/verify_worker_namespace.sh \
+            "$CLOUDFLARE_ACCOUNT_ID" \
+            "$WORKER_NAME" \
+            RuntimeRelayDurableObject
+
       - name: Roll Back Cloud Run Manually
         id: manual_cloud_run
         if: ${{ env.DEPLOY_MODE == 'rollback' && always() }}
@@ -425,18 +600,38 @@ jobs:
         id: manual_verify
         if: ${{ env.DEPLOY_MODE == 'rollback' && steps.manual_cloud_run.outcome == 'success' }}
         continue-on-error: true
+        env:
+          FORWARD_RECOVERY: ${{ steps.manual_worker_forward_recovery.outcome }}
+          NAMESPACE_RECOVERY: ${{ steps.manual_namespace.outcome }}
+          REQUESTED_RELAY_STATE: ${{ inputs.rollback_relay_state }}
+          WORKER_ROLLBACK: ${{ steps.manual_worker.outcome }}
         run: |
+          set -euo pipefail
+          if [[ "$NAMESPACE_RECOVERY" != "success" ]]; then
+            echo "Recovered Worker namespace verification did not succeed." >&2
+            exit 1
+          fi
+          if [[ "$WORKER_ROLLBACK" == "success" ]]; then
+            expected_relay_state="$REQUESTED_RELAY_STATE"
+          elif [[ "$FORWARD_RECOVERY" == "success" ]]; then
+            expected_relay_state=disabled
+          else
+            echo "Neither Worker rollback nor forward recovery succeeded." >&2
+            exit 1
+          fi
           origin_url="$(tofu -chdir=infra/production output -raw cloud_run_origin_url)"
-          tool/cloud/verify_production.sh "$PUBLIC_API_URL" "$origin_url"
+          tool/cloud/verify_production.sh "$PUBLIC_API_URL" "$origin_url" "$expected_relay_state"
 
       - name: Require Successful Manual Rollback
-        if: ${{ env.DEPLOY_MODE == 'rollback' && (steps.manual_worker.outcome != 'success' || steps.manual_cloud_run.outcome != 'success' || steps.manual_verify.outcome != 'success') }}
+        if: ${{ env.DEPLOY_MODE == 'rollback' && ((steps.manual_worker.outcome != 'success' && steps.manual_worker_forward_recovery.outcome != 'success') || steps.manual_namespace.outcome != 'success' || steps.manual_cloud_run.outcome != 'success' || steps.manual_verify.outcome != 'success') }}
         env:
           ROLLBACK_IMAGE: ${{ inputs.rollback_image }}
+          ROLLBACK_RELAY_STATE: ${{ inputs.rollback_relay_state }}
           ROLLBACK_WORKER_VERSION: ${{ inputs.rollback_worker_version }}
         run: |
           {
             echo "### Manual Rollback Failed"
+            echo "- Requested relay state: $ROLLBACK_RELAY_STATE"
             echo
             echo "- Requested image: \`$ROLLBACK_IMAGE\`"
             echo "- Requested Worker version: \`$ROLLBACK_WORKER_VERSION\`"

--- a/.github/workflows/cloud.yml
+++ b/.github/workflows/cloud.yml
@@ -106,6 +106,12 @@ jobs:
       - name: Test
         run: bun test
 
+      - name: Bundle Worker
+        run: bunx wrangler deploy --dry-run
+
+      - name: Bundle Relay-Disabled Recovery
+        run: ../tool/cloud/deploy_worker_relay_disabled.sh . --dry-run
+
   infrastructure:
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -137,6 +143,9 @@ jobs:
       - name: Test Plan Guard
         working-directory: tool/cloud
         run: python3 -m unittest -v test_validate_tofu_plan.py
+
+      - name: Validate Deployment Scripts
+        run: bash -n tool/cloud/deploy_worker_relay_disabled.sh tool/cloud/verify_production.sh tool/cloud/verify_worker_namespace.sh
 
   cloud-ready:
     name: cloud-ready

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -32,7 +32,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
         with:
+          fetch-depth: 0
           submodules: false
+
+      - name: Whitespace
+        run: git diff --check "${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}"
 
       - name: Setup Flutter workspace
         uses: ./.github/actions/setup-flutter-workspace

--- a/docs/cloud-operations.md
+++ b/docs/cloud-operations.md
@@ -15,17 +15,17 @@ Use a dedicated versioned Google Cloud Storage bucket for OpenTofu state. State 
 
 ## Production CD
 
-The normal production path is `.github/workflows/cloud-deploy.yml`. A merge into `main` that changes `cloud/`, `edge/`, `infra/production/`, `tool/cloud/`, or the workflow runs the full backend, PostgreSQL, container, Edge, and OpenTofu gates before deploying. The workflow builds and publishes a `linux/amd64` image, resolves its immutable digest, applies the guarded OpenTofu plan, deploys the Worker, and verifies public health, public JWKS, and the direct-origin JWKS rejection.
+The normal production path is `.github/workflows/cloud-deploy.yml`. A merge into `main` that changes `cloud/`, `edge/`, `infra/production/`, `tool/cloud/`, or the workflow runs the full backend, PostgreSQL, container, Edge, and OpenTofu gates before deploying. Before any build or apply, the hosted identity checks the Cloud Run service, Artifact Registry repository, versioned state bucket, and enabled versions of every required runtime secret. The workflow then builds and publishes a `linux/amd64` image, resolves its immutable digest, applies the guarded OpenTofu plan, deploys the Worker, and verifies public health, public JWKS, the expected relay state, the SQLite Durable Object namespace, and the direct-origin JWKS rejection.
 
-The deployment job uses the `cloud-production` GitHub Environment. Google authentication is keyless through the WIF bootstrap under `infra/bootstrap/github`; Cloudflare uses independent DNS and Worker tokens. The environment is limited to `main` and has no manual approval. A push event is authorized only when its SHA is the merge commit of a pull request merged into `main`; `workflow_dispatch` from `main` is the explicit operational exception.
+The deployment job uses the `cloud-production` GitHub Environment. Google authentication is keyless through the WIF bootstrap under `infra/bootstrap/github`; Cloudflare uses independent DNS and Worker tokens. The bootstrap deployment uses its existing project IAM administration grant once to add the read-only bucket metadata role represented by `google_project_iam_member.production_state_metadata_reader`, allowing the subsequent production preflight to remain read-only. The environment is limited to `main` and has no manual approval. A push event is authorized only when its SHA is the merge commit of a pull request merged into `main`; `workflow_dispatch` from `main` is the explicit operational exception.
 
 Manual runs support:
 
 - `plan`: build and publish an immutable candidate image, then produce and validate the production plan without applying it.
 - `deploy`: run the same path used after an authorized merge.
-- `rollback`: restore an explicitly supplied full image digest and Worker version id.
+- `rollback`: restore an explicitly supplied full image digest and Worker version id, with the expected `disabled` or `enabled` relay state.
 
-If verification fails after apply, the workflow rolls the Worker back to the version captured before deployment, reapplies OpenTofu with the previous Cloud Run digest, and repeats the probes. Structural infrastructure changes are not automatically undone. The failed run summary preserves the identifiers required for a manual rollback.
+If verification fails after apply, the workflow first asks Cloudflare to restore the Worker version captured before deployment. Cloudflare rejects a version rollback across a Durable Object class lifecycle migration. In that case the workflow deploys the current Worker code forward with `RELAY_ENABLED=false`, which preserves the migrated namespace without exposing the relay. It then reapplies OpenTofu with the previous Cloud Run digest and repeats the namespace, health, JWKS, relay, and direct-origin probes. Structural infrastructure changes are not automatically undone. The failed run summary preserves the identifiers and expected relay state required for a manual rollback.
 
 ## Local Backend
 
@@ -152,9 +152,13 @@ Before the Worker route exists, the public hostname fails closed because it is n
 ```sh
 curl --fail https://api.alera.build/health
 curl --fail https://api.alera.build/.well-known/jwks.json
+tool/cloud/verify_production.sh \
+  https://api.alera.build \
+  "$(tofu -chdir=infra/production output -raw cloud_run_origin_url)" \
+  disabled
 ```
 
-The direct Cloud Run `/health` may answer, but a direct request to any account or JWKS route must fail without the private header.
+Use `disabled` while the bootstrap Worker proxies `/v1/relay/deploy-probe` to the backend for a 404, and `enabled` after relay activation makes the Worker return 426 without a WebSocket upgrade. The direct Cloud Run `/health` may answer, but a direct request to any account or JWKS route must fail without the private header.
 
 ## Firebase Client Files
 

--- a/edge/readme.md
+++ b/edge/readme.md
@@ -1,6 +1,6 @@
 # Alera API Edge
 
-This Cloudflare Worker is the only supported public route to the Alera Cloud Run service. It admits `/v1/*`, `/.well-known/jwks.json`, and `/health`; applies a short mutation burst limit; removes cookies; overwrites the origin-authentication header; and proxies the request without interpreting Alera protocol payloads.
+This Cloudflare Worker is the only supported public route to the Alera Cloud Run service. It admits `/v1/*`, `/.well-known/jwks.json`, and `/health`; applies a short mutation burst limit; removes cookies; overwrites the origin-authentication header; and proxies the request without interpreting Alera protocol payloads. The `/v1/relay/{runtimeId}` route is the exception in transport only: it verifies a short-lived cloud grant and forwards opaque WebSocket frames to one per-runtime Durable Object.
 
 Production deployment is owned by `.github/workflows/cloud-deploy.yml`. Wrangler receives a dedicated `cloud-production` Environment token limited to `Workers Scripts: Edit` on the Leynier account and `Workers Routes: Edit` on `alera.build`. Local `wrangler deploy` is a break-glass operation.
 
@@ -12,6 +12,8 @@ bun run check
 bun test
 ```
 
+Relay checks use the WebSocket Hibernation API. Each Object accepts one runtime connection and at most eight mobile connections, forwards only between opposite roles, enforces a 1 MiB frame bound, and keeps only verified claims in WebSocket attachments. It does not use Durable Object storage, alarms, timers, outbound sockets, or payload logging. The runtime and mobile endpoints provide the E2E encryption layer; the Worker and Object never decrypt protocol content. Only the exact value `RELAY_ENABLED=true` exposes the relay route; every other value preserves the ordinary backend proxy behavior.
+
 ## Production Secrets
 
 Wrangler manages both runtime values so neither appears in source or OpenTofu state:
@@ -20,6 +22,8 @@ Wrangler manages both runtime values so neither appears in source or OpenTofu st
 bunx wrangler secret put ORIGIN_BASE_URL
 bunx wrangler secret put EDGE_ORIGIN_TOKEN
 ```
+
+The relay issuer and JWKS URL are non-secret Worker variables in `wrangler.jsonc`. They must match `ALERA_ISSUER` and the public cloud JWKS route. The relay WebSocket path is derived from `ALERA_RELAY_BASE_URL`; keep its host on the Worker route.
 
 `ORIGIN_BASE_URL` is the generated Cloud Run `run.app` URL. `EDGE_ORIGIN_TOKEN` must match the latest version of the `alera-edge-origin-token` Google Secret Manager secret. Deploy only after both values are set:
 

--- a/edge/src/index.ts
+++ b/edge/src/index.ts
@@ -2,19 +2,52 @@ interface RateLimitBinding {
   limit(options: { key: string }): Promise<{ success: boolean }>;
 }
 
+export interface RelayNamespace {
+  idFromName(name: string): DurableObjectId;
+  get(id: DurableObjectId): DurableObjectStub;
+}
+
 export interface EdgeEnvironment {
   EDGE_BURST_LIMITER: RateLimitBinding;
   EDGE_ORIGIN_TOKEN: string;
   ORIGIN_BASE_URL: string;
+  RELAY_ENABLED?: string;
+  RELAY_OBJECTS?: RelayNamespace;
+  RELAY_ISSUER?: string;
+  RELAY_JWKS_URL?: string;
 }
 
+interface RelayClaims {
+  iss: string;
+  aud: string;
+  exp: number;
+  iat: number;
+  nbf: number;
+  jti: string;
+  accountId: string;
+  runtimeId: string;
+  clientId: string;
+  role: 'runtime' | 'mobile';
+  keyVersion: number;
+  clientPublicKey: string;
+  runtimePublicKey: string;
+}
+
+interface RelayAttachment extends RelayClaims {}
+
 type OriginFetch = (request: Request) => Promise<Response>;
+type RelayFetch = (request: Request) => Promise<Response>;
 
 const ALLOWED_METHODS = new Set(['GET', 'POST', 'PUT', 'DELETE']);
 const SAFE_METHODS = new Set(['GET']);
 const ORIGIN_HEADER = 'x-alera-origin-auth';
 const PUBLIC_EXACT_PATHS = new Set(['/health', '/.well-known/jwks.json']);
 const PUBLIC_PREFIXES = ['/v1/'];
+const RELAY_PREFIX = '/v1/relay/';
+const RELAY_AUDIENCE = 'alera-relay';
+const MAX_RELAY_FRAME_BYTES = 1024 * 1024;
+const MAX_RELAY_MOBILE_CONNECTIONS = 8;
+const MAX_RELAY_CLIENT_ID_BYTES = 128;
 
 function jsonError(status: number, code: string, message: string): Response {
   return new Response(JSON.stringify({ error: { code, message } }), {
@@ -82,15 +115,199 @@ function secureResponse(response: Response): Response {
   });
 }
 
+function base64UrlBytes(value: string): Uint8Array {
+  const normalized = value.replace(/-/g, '+').replace(/_/g, '/');
+  const padded = normalized.padEnd(Math.ceil(normalized.length / 4) * 4, '=');
+  const binary = atob(padded);
+  return Uint8Array.from(binary, (character) => character.charCodeAt(0));
+}
+
+function decodeJsonPart<T>(value: string): T {
+  return JSON.parse(new TextDecoder().decode(base64UrlBytes(value))) as T;
+}
+
+function bearerToken(request: Request): string | null {
+  const value = request.headers.get('authorization');
+  return value?.startsWith('Bearer ') ? value.slice('Bearer '.length) : null;
+}
+
+async function verifyRelayGrant(
+  token: string,
+  env: EdgeEnvironment,
+  fetcher: RelayFetch = (request) => fetch(request),
+): Promise<RelayAttachment | null> {
+  const parts = token.split('.');
+  if (parts.length !== 3 || !env.RELAY_JWKS_URL) return null;
+  let header: { alg?: string; typ?: string; kid?: string };
+  let claims: RelayClaims;
+  try {
+    header = decodeJsonPart(parts[0]);
+    claims = decodeJsonPart(parts[1]);
+  } catch {
+    return null;
+  }
+  let publicKeyBytes: Uint8Array;
+  let runtimeKeyBytes: Uint8Array;
+  try {
+    publicKeyBytes = base64UrlBytes(claims.clientPublicKey);
+    runtimeKeyBytes = base64UrlBytes(claims.runtimePublicKey);
+  } catch {
+    return null;
+  }
+  if (
+    header.alg !== 'EdDSA' ||
+    header.typ !== 'relay+jwt' ||
+    !header.kid ||
+    claims.aud !== RELAY_AUDIENCE ||
+    claims.iss !== (env.RELAY_ISSUER ?? '') ||
+    claims.exp <= Math.floor(Date.now() / 1000) ||
+    claims.nbf > Math.floor(Date.now() / 1000) + 30 ||
+    claims.iat > Math.floor(Date.now() / 1000) + 30 ||
+    !claims.jti ||
+    !claims.accountId ||
+    !claims.runtimeId ||
+    !claims.clientId ||
+    !['runtime', 'mobile'].includes(claims.role) ||
+    !Number.isInteger(claims.keyVersion) ||
+    claims.keyVersion <= 0 ||
+    publicKeyBytes.byteLength !== 32 ||
+    runtimeKeyBytes.byteLength !== 32
+  ) {
+    return null;
+  }
+
+  let jwks: {
+    keys?: Array<{
+      kid?: string;
+      kty?: string;
+      crv?: string;
+      x?: string;
+      alg?: string;
+    }>;
+  };
+  try {
+    const response = await fetcher(
+      new Request(env.RELAY_JWKS_URL, {
+        headers: { accept: 'application/json' },
+      }),
+    );
+    if (!response.ok) return null;
+    jwks = (await response.json()) as typeof jwks;
+  } catch {
+    return null;
+  }
+  const key = jwks.keys?.find(
+    (candidate) =>
+      candidate.kid === header.kid &&
+      candidate.kty === 'OKP' &&
+      candidate.crv === 'Ed25519' &&
+      candidate.alg === 'EdDSA' &&
+      typeof candidate.x === 'string',
+  );
+  if (!key?.x) return null;
+  try {
+    const cryptoKey = await crypto.subtle.importKey(
+      'raw',
+      base64UrlBytes(key.x),
+      { name: 'Ed25519', namedCurve: 'Ed25519' },
+      false,
+      ['verify'],
+    );
+    const valid = await crypto.subtle.verify(
+      { name: 'Ed25519' },
+      cryptoKey,
+      base64UrlBytes(parts[2]),
+      new TextEncoder().encode(`${parts[0]}.${parts[1]}`),
+    );
+    return valid ? claims : null;
+  } catch {
+    return null;
+  }
+}
+
+function relayRuntimeId(pathname: string): string | null {
+  if (!pathname.startsWith(RELAY_PREFIX)) return null;
+  const encoded = pathname.slice(RELAY_PREFIX.length);
+  if (!encoded || encoded.includes('/')) return null;
+  try {
+    const runtimeId = decodeURIComponent(encoded);
+    return runtimeId.length > 0 && runtimeId.length <= 128 ? runtimeId : null;
+  } catch {
+    return null;
+  }
+}
+
+function isWebSocketUpgrade(request: Request): boolean {
+  return request.headers.get('upgrade')?.toLowerCase() === 'websocket';
+}
+
+function encodedClaims(claims: RelayAttachment): string {
+  return btoa(String.fromCharCode(...new TextEncoder().encode(JSON.stringify(claims))))
+    .replace(/=/g, '')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_');
+}
+
+export function relayFrameClientId(message: Uint8Array): string | null {
+  if (message.byteLength < 3) return null;
+  const idLength = (message[0] << 8) | message[1];
+  if (idLength === 0 || idLength > MAX_RELAY_CLIENT_ID_BYTES || message.byteLength <= idLength + 2) {
+    return null;
+  }
+  try {
+    return new TextDecoder('utf-8', { fatal: true, ignoreBOM: true }).decode(message.subarray(2, idLength + 2));
+  } catch {
+    return null;
+  }
+}
+
+function relayDisconnectFrame(clientId: string): Uint8Array {
+  const id = new TextEncoder().encode(clientId);
+  return new Uint8Array([(id.length >> 8) & 0xff, id.length & 0xff, ...id]);
+}
+
+async function handleRelayRequest(
+  request: Request,
+  env: EdgeEnvironment,
+  fetcher: RelayFetch = (relayRequest) => fetch(relayRequest),
+): Promise<Response> {
+  const runtimeId = relayRuntimeId(new URL(request.url).pathname);
+  if (!runtimeId) return jsonError(404, 'route_not_found', 'The relay route does not exist.');
+  if (request.method !== 'GET' || !isWebSocketUpgrade(request)) {
+    return jsonError(426, 'websocket_required', 'The relay requires a WebSocket connection.');
+  }
+  if (!env.RELAY_OBJECTS) {
+    return jsonError(503, 'relay_not_configured', 'The relay is not configured.');
+  }
+  const token = bearerToken(request);
+  if (!token) return jsonError(401, 'missing_bearer', 'A relay grant is required.');
+  const claims = await verifyRelayGrant(token, env, fetcher);
+  if (!claims || claims.runtimeId !== runtimeId) {
+    return jsonError(403, 'invalid_relay_grant', 'The relay grant is invalid or out of scope.');
+  }
+  const forwarded = new Request(request, {
+    headers: new Headers({
+      upgrade: 'websocket',
+      'x-alera-relay-claims': encodedClaims(claims),
+    }),
+  });
+  const objectId = env.RELAY_OBJECTS.idFromName(runtimeId);
+  return env.RELAY_OBJECTS.get(objectId).fetch(forwarded);
+}
+
 export async function handleRequest(
   request: Request,
   env: EdgeEnvironment,
   fetchOrigin: OriginFetch = fetch,
+  fetchRelay: RelayFetch = (relayRequest) => fetch(relayRequest),
 ): Promise<Response> {
+  const url = new URL(request.url);
+  if (env.RELAY_ENABLED === 'true' && url.pathname.startsWith(RELAY_PREFIX)) {
+    return handleRelayRequest(request, env, fetchRelay);
+  }
   const configurationError = validateEnvironment(env);
   if (configurationError) return configurationError;
 
-  const url = new URL(request.url);
   if (!isPublicPath(url.pathname)) {
     return jsonError(404, 'route_not_found', 'The requested API route does not exist.');
   }
@@ -113,6 +330,124 @@ export async function handleRequest(
     return secureResponse(response);
   } catch {
     return jsonError(502, 'origin_unavailable', 'The Alera service is temporarily unavailable.');
+  }
+}
+
+export class RuntimeRelayDurableObject {
+  private readonly ctx: DurableObjectState;
+
+  constructor(ctx: DurableObjectState) {
+    this.ctx = ctx;
+  }
+
+  async fetch(request: Request): Promise<Response> {
+    if (!isWebSocketUpgrade(request)) {
+      return jsonError(426, 'websocket_required', 'The relay requires a WebSocket connection.');
+    }
+    const encoded = request.headers.get('x-alera-relay-claims');
+    if (!encoded) return jsonError(403, 'missing_relay_claims', 'Relay claims are missing.');
+    let attachment: RelayAttachment;
+    try {
+      const bytes = base64UrlBytes(encoded);
+      attachment = JSON.parse(new TextDecoder().decode(bytes)) as RelayAttachment;
+    } catch {
+      return jsonError(403, 'invalid_relay_claims', 'Relay claims are invalid.');
+    }
+    const webSocketPair = new WebSocketPair();
+    const [client, server] = Object.values(webSocketPair) as [WebSocket, WebSocket];
+    const peers = this.ctx.getWebSockets();
+    const peerAttachments = peers.map((peer) => peer.deserializeAttachment() as RelayAttachment);
+    const replacingDuplicate = peerAttachments.some(
+      (peer) => peer.role === attachment.role && peer.clientId === attachment.clientId,
+    );
+    for (const peer of peers) {
+      const peerAttachment = peer.deserializeAttachment() as RelayAttachment;
+      if (peerAttachment.role === attachment.role && peerAttachment.clientId === attachment.clientId) {
+        if (peerAttachment.role === 'mobile') {
+          this.notifyRuntimeOfMobileDisconnect(peerAttachment);
+        }
+        peer.close(
+          4001,
+          attachment.role === 'runtime' ? 'replaced by a newer runtime' : 'replaced by a newer mobile connection',
+        );
+      }
+    }
+    if (
+      attachment.role === 'mobile' &&
+      peerAttachments.filter((peer) => peer.role === 'mobile').length >= MAX_RELAY_MOBILE_CONNECTIONS &&
+      !replacingDuplicate
+    ) {
+      return jsonError(429, 'relay_mobile_limit', 'This runtime has reached its mobile connection limit.');
+    }
+    this.ctx.acceptWebSocket(server, [attachment.role, attachment.clientId]);
+    server.serializeAttachment(attachment);
+    return new Response(null, { status: 101, webSocket: client });
+  }
+
+  webSocketMessage(socket: WebSocket, message: ArrayBuffer | string): void {
+    const bytes = typeof message === 'string' ? new TextEncoder().encode(message) : new Uint8Array(message);
+    if (bytes.byteLength > MAX_RELAY_FRAME_BYTES) {
+      socket.close(1009, 'relay frame too large');
+      return;
+    }
+    const sender = socket.deserializeAttachment() as RelayAttachment;
+    const now = Math.floor(Date.now() / 1000);
+    if (sender.exp <= now) {
+      socket.close(4003, 'relay grant expired');
+      return;
+    }
+    const clientId = relayFrameClientId(bytes);
+    if (!clientId) {
+      socket.close(1007, 'invalid relay frame');
+      return;
+    }
+    if (sender.role === 'mobile' && sender.clientId !== clientId) {
+      socket.close(1008, 'relay client id mismatch');
+      return;
+    }
+    for (const peer of this.ctx.getWebSockets()) {
+      if (peer === socket) continue;
+      const target = peer.deserializeAttachment() as RelayAttachment;
+      if (target.exp <= now) {
+        peer.close(4003, 'relay grant expired');
+        continue;
+      }
+      if (
+        sender.role === target.role ||
+        sender.accountId !== target.accountId ||
+        sender.runtimeId !== target.runtimeId ||
+        (sender.role === 'runtime' && target.clientId !== clientId)
+      ) {
+        continue;
+      }
+      try {
+        peer.send(bytes);
+      } catch {
+        peer.close(1011, 'relay forwarding failed');
+      }
+    }
+  }
+
+  webSocketClose(socket: WebSocket): void {
+    this.notifyRuntimeOfMobileDisconnect(socket.deserializeAttachment() as RelayAttachment);
+  }
+
+  webSocketError(socket: WebSocket): void {
+    this.notifyRuntimeOfMobileDisconnect(socket.deserializeAttachment() as RelayAttachment);
+  }
+
+  private notifyRuntimeOfMobileDisconnect(mobile: RelayAttachment): void {
+    if (mobile.role !== 'mobile') return;
+    const frame = relayDisconnectFrame(mobile.clientId);
+    for (const peer of this.ctx.getWebSockets('runtime')) {
+      const runtime = peer.deserializeAttachment() as RelayAttachment;
+      if (runtime.accountId !== mobile.accountId || runtime.runtimeId !== mobile.runtimeId) continue;
+      try {
+        peer.send(frame);
+      } catch {
+        peer.close(1011, 'relay forwarding failed');
+      }
+    }
   }
 }
 

--- a/edge/test/index.test.ts
+++ b/edge/test/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { handleRequest, type EdgeEnvironment } from '../src/index';
+import { handleRequest, relayFrameClientId, RuntimeRelayDurableObject, type EdgeEnvironment } from '../src/index';
 
 function environment(success = true): EdgeEnvironment {
   return {
@@ -13,12 +13,123 @@ function environment(success = true): EdgeEnvironment {
   };
 }
 
+function base64Url(value: string | Uint8Array): string {
+  const bytes = typeof value === 'string' ? new TextEncoder().encode(value) : value;
+  return btoa(String.fromCharCode(...bytes))
+    .replace(/=/g, '')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_');
+}
+
+function relayFrame(clientId: string, payload: number[] = [1]): Uint8Array {
+  const id = new TextEncoder().encode(clientId);
+  return new Uint8Array([(id.length >> 8) & 0xff, id.length & 0xff, ...id, ...payload]);
+}
+
+function relayAttachment(role: 'runtime' | 'mobile', clientId: string, expiresIn = 120) {
+  const now = Math.floor(Date.now() / 1000);
+  return {
+    iss: 'https://api.alera.build',
+    aud: 'alera-relay',
+    exp: now + expiresIn,
+    iat: now,
+    nbf: now,
+    jti: `${role}-${clientId}`,
+    accountId: 'account-1',
+    runtimeId: 'runtime-1',
+    clientId,
+    role,
+    keyVersion: 1,
+    clientPublicKey: base64Url(new Uint8Array(32).fill(1)),
+    runtimePublicKey: base64Url(new Uint8Array(32).fill(2)),
+  };
+}
+
+class TestSocket {
+  constructor(readonly attachment: ReturnType<typeof relayAttachment>) {}
+
+  readonly sent: Uint8Array[] = [];
+  closed: { code: number; reason: string } | null = null;
+
+  deserializeAttachment() {
+    return this.attachment;
+  }
+
+  send(value: Uint8Array) {
+    this.sent.push(value);
+  }
+
+  close(code: number, reason: string) {
+    this.closed = { code, reason };
+  }
+}
+
+function relayObject(sockets: TestSocket[]): RuntimeRelayDurableObject {
+  return new RuntimeRelayDurableObject({
+    getWebSockets: () => sockets as unknown as WebSocket[],
+  } as unknown as DurableObjectState);
+}
+
 describe('Alera API edge', () => {
-  test('rejects paths outside the public API', async () => {
-    const response = await handleRequest(
-      new Request('https://api.alera.build/admin'),
-      environment(),
+  test('routes runtime frames only to the addressed mobile', () => {
+    const runtime = new TestSocket(relayAttachment('runtime', 'runtime-1'));
+    const mobileOne = new TestSocket(relayAttachment('mobile', 'mobile-1'));
+    const mobileTwo = new TestSocket(relayAttachment('mobile', 'mobile-2'));
+    const frame = relayFrame('mobile-1');
+
+    relayObject([runtime, mobileOne, mobileTwo]).webSocketMessage(
+      runtime as unknown as WebSocket,
+      frame.buffer as ArrayBuffer,
     );
+
+    expect(relayFrameClientId(frame)).toBe('mobile-1');
+    expect(mobileOne.sent).toEqual([frame]);
+    expect(mobileTwo.sent).toBeEmpty();
+  });
+
+  test('rejects a mobile frame that claims another client id', () => {
+    const runtime = new TestSocket(relayAttachment('runtime', 'runtime-1'));
+    const mobile = new TestSocket(relayAttachment('mobile', 'mobile-1'));
+
+    relayObject([runtime, mobile]).webSocketMessage(
+      mobile as unknown as WebSocket,
+      relayFrame('mobile-2').buffer as ArrayBuffer,
+    );
+
+    expect(mobile.closed).toEqual({
+      code: 1008,
+      reason: 'relay client id mismatch',
+    });
+    expect(runtime.sent).toBeEmpty();
+  });
+
+  test('stops forwarding when a relay grant expires', () => {
+    const runtime = new TestSocket(relayAttachment('runtime', 'runtime-1', -1));
+    const mobile = new TestSocket(relayAttachment('mobile', 'mobile-1'));
+
+    relayObject([runtime, mobile]).webSocketMessage(
+      runtime as unknown as WebSocket,
+      relayFrame('mobile-1').buffer as ArrayBuffer,
+    );
+
+    expect(runtime.closed).toEqual({
+      code: 4003,
+      reason: 'relay grant expired',
+    });
+    expect(mobile.sent).toBeEmpty();
+  });
+
+  test('notifies the runtime when a mobile disconnects', () => {
+    const runtime = new TestSocket(relayAttachment('runtime', 'runtime-1'));
+    const mobile = new TestSocket(relayAttachment('mobile', 'mobile-1'));
+
+    relayObject([runtime, mobile]).webSocketClose(mobile as unknown as WebSocket);
+
+    expect(runtime.sent).toEqual([relayFrame('mobile-1', [])]);
+  });
+
+  test('rejects paths outside the public API', async () => {
+    const response = await handleRequest(new Request('https://api.alera.build/admin'), environment());
     expect(response.status).toBe(404);
   });
 
@@ -42,13 +153,9 @@ describe('Alera API edge', () => {
 
     const response = await handleRequest(request, environment(), async (originRequest) => {
       const proxied = originRequest as Request;
-      expect(proxied.url).toBe(
-        'https://alera-cloud.example.run.app/v1/account?view=full',
-      );
+      expect(proxied.url).toBe('https://alera-cloud.example.run.app/v1/account?view=full');
       expect(proxied.headers.get('x-alera-origin-auth')).toBe('edge-secret');
-      expect(proxied.headers.get('authorization')).toBe(
-        'Bearer account-token',
-      );
+      expect(proxied.headers.get('authorization')).toBe('Bearer account-token');
       expect(proxied.headers.get('cookie')).toBeNull();
       return new Response('ok');
     });
@@ -76,13 +183,136 @@ describe('Alera API edge', () => {
   });
 
   test('maps an unreachable origin to a bounded error', async () => {
+    const response = await handleRequest(new Request('https://api.alera.build/health'), environment(), async () => {
+      throw new Error('network unavailable');
+    });
+    expect(response.status).toBe(502);
+  });
+
+  for (const relayEnabled of [undefined, 'false']) {
+    test(`proxies the relay route to the backend when RELAY_ENABLED is ${relayEnabled ?? 'absent'}`, async () => {
+      const response = await handleRequest(
+        new Request('https://api.alera.build/v1/relay/deploy-probe'),
+        {
+          ...environment(),
+          RELAY_ENABLED: relayEnabled,
+        },
+        async (originRequest) => {
+          expect(originRequest.url).toBe('https://alera-cloud.example.run.app/v1/relay/deploy-probe');
+          return new Response('backend route not found', { status: 404 });
+        },
+      );
+
+      expect(response.status).toBe(404);
+      expect(await response.text()).toBe('backend route not found');
+    });
+  }
+
+  test('requires WebSocket only when RELAY_ENABLED is exactly true', async () => {
+    const response = await handleRequest(new Request('https://api.alera.build/v1/relay/deploy-probe'), {
+      ...environment(),
+      RELAY_ENABLED: 'true',
+    });
+
+    expect(response.status).toBe(426);
+  });
+
+  test('rejects enabled relay connections when the Durable Object binding is missing', async () => {
     const response = await handleRequest(
-      new Request('https://api.alera.build/health'),
-      environment(),
-      async () => {
-        throw new Error('network unavailable');
+      new Request('https://api.alera.build/v1/relay/runtime-1', {
+        headers: { upgrade: 'websocket' },
+      }),
+      {
+        ...environment(),
+        RELAY_ENABLED: 'true',
       },
     );
-    expect(response.status).toBe(502);
+
+    expect(response.status).toBe(503);
+  });
+
+  test('requires a bearer grant for relay connections', async () => {
+    const response = await handleRequest(
+      new Request('https://api.alera.build/v1/relay/runtime-1', {
+        headers: { upgrade: 'websocket' },
+      }),
+      {
+        ...environment(),
+        RELAY_ENABLED: 'true',
+        RELAY_ISSUER: 'https://api.alera.build',
+        RELAY_JWKS_URL: 'https://api.alera.build/.well-known/jwks.json',
+        RELAY_OBJECTS: {} as EdgeEnvironment['RELAY_OBJECTS'],
+      },
+    );
+    expect(response.status).toBe(401);
+  });
+
+  test('verifies a grant and forwards only claims to the runtime object', async () => {
+    const keyPair = (await crypto.subtle.generateKey({ name: 'Ed25519', namedCurve: 'Ed25519' }, true, [
+      'sign',
+      'verify',
+    ])) as CryptoKeyPair;
+    const publicJwk = (await crypto.subtle.exportKey('jwk', keyPair.publicKey)) as JsonWebKey;
+    const now = Math.floor(Date.now() / 1000);
+    const claims = {
+      iss: 'https://api.alera.build',
+      aud: 'alera-relay',
+      exp: now + 120,
+      iat: now,
+      nbf: now,
+      jti: 'grant-1',
+      accountId: 'account-1',
+      runtimeId: 'runtime-1',
+      clientId: 'mobile-1',
+      role: 'mobile',
+      keyVersion: 1,
+      clientPublicKey: base64Url(new Uint8Array(32).fill(1)),
+      runtimePublicKey: base64Url(new Uint8Array(32).fill(2)),
+    };
+    const header = base64Url(JSON.stringify({ alg: 'EdDSA', typ: 'relay+jwt', kid: 'key-1' }));
+    const encodedClaims = base64Url(JSON.stringify(claims));
+    const signingInput = `${header}.${encodedClaims}`;
+    const signature = new Uint8Array(
+      await crypto.subtle.sign({ name: 'Ed25519' }, keyPair.privateKey, new TextEncoder().encode(signingInput)),
+    );
+    const grant = `${signingInput}.${base64Url(signature)}`;
+    const forwarded: Request[] = [];
+    const stub = {
+      fetch(request: Request) {
+        forwarded.push(request);
+        return Promise.resolve(new Response('connected'));
+      },
+    } as unknown as DurableObjectStub;
+    const environmentWithRelay = {
+      ...environment(),
+      RELAY_ENABLED: 'true',
+      RELAY_ISSUER: 'https://api.alera.build',
+      RELAY_JWKS_URL: 'https://api.alera.build/.well-known/jwks.json',
+      RELAY_OBJECTS: {
+        idFromName: () => ({}) as DurableObjectId,
+        get: () => stub,
+      },
+    } as EdgeEnvironment;
+    const response = await handleRequest(
+      new Request('https://api.alera.build/v1/relay/runtime-1', {
+        headers: {
+          authorization: `Bearer ${grant}`,
+          upgrade: 'websocket',
+        },
+      }),
+      environmentWithRelay,
+      undefined,
+      async () =>
+        new Response(
+          JSON.stringify({
+            keys: [{ ...publicJwk, kid: 'key-1', alg: 'EdDSA' }],
+          }),
+        ),
+    );
+
+    expect(response.status).toBe(200);
+    expect(forwarded).toHaveLength(1);
+    expect(forwarded[0].headers.get('authorization')).toBeNull();
+    expect(forwarded[0].headers.get('x-alera-relay-claims')).toBeTruthy();
   });
 });

--- a/edge/wrangler.jsonc
+++ b/edge/wrangler.jsonc
@@ -10,6 +10,25 @@
       "zone_name": "alera.build"
     }
   ],
+  "vars": {
+    "RELAY_ENABLED": "false",
+    "RELAY_ISSUER": "https://api.alera.build",
+    "RELAY_JWKS_URL": "https://api.alera.build/.well-known/jwks.json"
+  },
+  "durable_objects": {
+    "bindings": [
+      {
+        "name": "RELAY_OBJECTS",
+        "class_name": "RuntimeRelayDurableObject"
+      }
+    ]
+  },
+  "migrations": [
+    {
+      "tag": "v1",
+      "new_sqlite_classes": ["RuntimeRelayDurableObject"]
+    }
+  ],
   "observability": {
     "enabled": true,
     "head_sampling_rate": 0.1

--- a/infra/bootstrap/github/main.tf
+++ b/infra/bootstrap/github/main.tf
@@ -98,6 +98,12 @@ resource "google_storage_bucket_iam_member" "production_state" {
   member = google_service_account.github_deployer.member
 }
 
+resource "google_project_iam_member" "production_state_metadata_reader" {
+  project = var.gcp_project_id
+  role    = "roles/storage.legacyBucketReader"
+  member  = google_service_account.github_deployer.member
+}
+
 data "google_service_account" "cloud_runtime" {
   account_id = var.runtime_service_account_id
 }

--- a/tool/cloud/deploy_worker_relay_disabled.sh
+++ b/tool/cloud/deploy_worker_relay_disabled.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 1 || $# -gt 2 || (${2:-} != "" && ${2:-} != "--dry-run") ]]; then
+  echo "usage: deploy_worker_relay_disabled.sh <edge-directory> [--dry-run]" >&2
+  exit 2
+fi
+
+edge_directory="$(cd "$1" && pwd)"
+deploy_arguments=()
+if [[ ${2:-} == "--dry-run" ]]; then
+  deploy_arguments+=(--dry-run)
+fi
+recovery_config="$(mktemp "$edge_directory/.wrangler-relay-disabled.XXXXXX.jsonc")"
+trap 'rm -f "$recovery_config"' EXIT
+
+jq '.vars = (.vars // {}) | .vars.RELAY_ENABLED = "false"' \
+  "$edge_directory/wrangler.jsonc" >"$recovery_config"
+
+(
+  cd "$edge_directory"
+  bunx wrangler deploy --config "$recovery_config" "${deploy_arguments[@]}"
+)

--- a/tool/cloud/verify_production.sh
+++ b/tool/cloud/verify_production.sh
@@ -1,14 +1,28 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [[ $# -ne 2 ]]; then
-  echo "usage: verify_production.sh <public-url> <origin-url>" >&2
+if [[ $# -ne 3 ]]; then
+  echo "usage: verify_production.sh <public-url> <origin-url> <relay-state>" >&2
   exit 2
 fi
 
 public_url="${1%/}"
 origin_url="${2%/}"
+relay_state="$3"
 attempts=12
+
+case "$relay_state" in
+  disabled)
+    expected_relay_status=404
+    ;;
+  enabled)
+    expected_relay_status=426
+    ;;
+  *)
+    echo "relay-state must be disabled or enabled" >&2
+    exit 2
+    ;;
+esac
 
 retry_curl() {
   local url="$1"
@@ -25,6 +39,26 @@ retry_curl() {
 retry_curl "$public_url/health"
 retry_curl "$public_url/.well-known/jwks.json"
 
+relay_status=""
+for ((attempt = 1; attempt <= attempts; attempt++)); do
+  if relay_status="$(
+    curl \
+      --silent \
+      --show-error \
+      --output /dev/null \
+      --write-out '%{http_code}' \
+      --max-time 20 \
+      "$public_url/v1/relay/deploy-probe"
+  )" && [[ "$relay_status" == "$expected_relay_status" ]]; then
+    break
+  fi
+  sleep 5
+done
+if [[ "$relay_status" != "$expected_relay_status" ]]; then
+  echo "public relay probe returned $relay_status; expected $expected_relay_status for $relay_state" >&2
+  exit 1
+fi
+
 origin_status="$(
   curl \
     --silent \
@@ -39,4 +73,4 @@ if [[ "$origin_status" != "401" ]]; then
   exit 1
 fi
 
-echo "public health and JWKS succeeded; direct origin JWKS remained closed"
+echo "public health and JWKS succeeded; relay was $relay_state; direct origin JWKS remained closed"

--- a/tool/cloud/verify_worker_namespace.sh
+++ b/tool/cloud/verify_worker_namespace.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 3 ]]; then
+  echo "usage: verify_worker_namespace.sh <account-id> <worker-name> <class-name>" >&2
+  exit 2
+fi
+
+if [[ -z "${CLOUDFLARE_API_TOKEN:-}" ]]; then
+  echo "CLOUDFLARE_API_TOKEN is required" >&2
+  exit 2
+fi
+
+account_id="$1"
+worker_name="$2"
+class_name="$3"
+
+namespace=""
+for attempt in {1..12}; do
+  if response="$(
+    curl \
+      --fail-with-body \
+      --silent \
+      --show-error \
+      --max-time 30 \
+      --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+      "https://api.cloudflare.com/client/v4/accounts/$account_id/workers/durable_objects/namespaces?per_page=1000"
+  )" && namespace="$(
+    jq -cer \
+      --arg worker "$worker_name" \
+      --arg class "$class_name" \
+      '
+        select(.success == true)
+        | .result
+        | map(select(.class == $class))
+        | if length != 1 then
+            error("expected exactly one namespace for " + $class)
+          else
+            .[0]
+          end
+        | select(.script == $worker)
+        | select(.use_sqlite == true)
+      ' <<<"$response" 2>/dev/null
+  )"; then
+    break
+  fi
+  namespace=""
+  sleep 5
+done
+
+if [[ -z "$namespace" ]]; then
+  echo "expected one SQLite namespace for $worker_name/$class_name" >&2
+  exit 1
+fi
+
+namespace_id="$(jq -r '.id' <<<"$namespace")"
+echo "verified SQLite Durable Object namespace $namespace_id for $worker_name/$class_name"


### PR DESCRIPTION
## Summary
- create the SQLite RuntimeRelayDurableObject namespace while RELAY_ENABLED remains false
- add state-aware production verification and forward recovery when Cloudflare rejects a version rollback
- preflight Cloud Run, Artifact Registry, state versioning, and enabled secrets before build or apply
- add exact PR whitespace checking and hosted Worker dry-runs

## Validation
- gh act: PR Checks/static
- gh act: Cloud/edge
- gh act: Cloud/infrastructure
- actionlint on changed workflows
- bun run check and bun test
- wrangler deploy --dry-run for configured and relay-disabled recovery modes
- live disabled-state production verification

## Risk
The Durable Object namespace migration is intentionally irreversible. Public relay behavior remains disabled, and recovery deploys the current Worker forward with RELAY_ENABLED=false if a version rollback crosses the migration.