### PR TITLE
fix: use project-scoped bucket viewer

### DIFF
--- a/.github/workflows/cloud-deploy.yml
+++ b/.github/workflows/cloud-deploy.yml
@@ -179,7 +179,7 @@ jobs:
         run: |
           gcloud projects add-iam-policy-binding "$GCP_PROJECT_ID" \
             --member="serviceAccount:$GCP_SERVICE_ACCOUNT" \
-            --role=roles/storage.legacyBucketReader \
+            --role=roles/storage.bucketViewer \
             --condition=None \
             --quiet >/dev/null
 

--- a/infra/bootstrap/github/main.tf
+++ b/infra/bootstrap/github/main.tf
@@ -100,7 +100,7 @@ resource "google_storage_bucket_iam_member" "production_state" {
 
 resource "google_project_iam_member" "production_state_metadata_reader" {
   project = var.gcp_project_id
-  role    = "roles/storage.legacyBucketReader"
+  role    = "roles/storage.bucketViewer"
   member  = google_service_account.github_deployer.member
 }
 


### PR DESCRIPTION
## Summary
- replace the bucket-only legacy role with project-scoped Storage Bucket Viewer
- keep the production preflight limited to read-only bucket metadata

## Validation
- git diff --check
- OpenTofu fmt and validate
- actionlint
- gh act Cloud/infrastructure

## Incident note
The first bootstrap deploy stopped at the IAM binding before preflight, build, apply, or Worker deployment. Production was unchanged.