### PR TITLE
fix: ignore browser visibility during page close

### DIFF
--- a/lib/src/features/browser/application/browser_session_handle.dart
+++ b/lib/src/features/browser/application/browser_session_handle.dart
@@ -128,6 +128,10 @@ final class BrowserSessionHandle {
   BrowserVisibilityLease acquireVisibility(BrowserVisibilityReason reason) =>
       _registry._acquireVisibility(_entry, reason);
 
+  BrowserVisibilityLease? tryAcquireVisibility(
+    BrowserVisibilityReason reason,
+  ) => _registry._tryAcquireVisibility(_entry, reason);
+
   BrowserObscurationLease acquireObscuration(BrowserObscurationReason reason) =>
       _registry._acquireObscuration(_entry, reason);
 

--- a/lib/src/features/browser/application/browser_session_leases.dart
+++ b/lib/src/features/browser/application/browser_session_leases.dart
@@ -1,6 +1,17 @@
 part of 'browser_session_registry.dart';
 
 extension _BrowserSessionRegistryLeases on BrowserSessionRegistry {
+  BrowserVisibilityLease? _tryAcquireVisibility(
+    _BrowserSessionEntry entry,
+    BrowserVisibilityReason reason,
+  ) {
+    _checkNotDisposed();
+    if (entry.closing || entry.closed) {
+      return null;
+    }
+    return _acquireVisibility(entry, reason);
+  }
+
   BrowserVisibilityLease _acquireVisibility(
     _BrowserSessionEntry entry,
     BrowserVisibilityReason reason,

--- a/lib/src/features/browser/presentation/browser_tab_surface.dart
+++ b/lib/src/features/browser/presentation/browser_tab_surface.dart
@@ -302,7 +302,11 @@ class _BrowserTabSurfaceState extends ConsumerState<BrowserTabSurface> {
     if (identity == null || !_visibilityAcquisitions.add(identity)) {
       return;
     }
-    final lease = handle.acquireVisibility(BrowserVisibilityReason.user);
+    final lease = handle.tryAcquireVisibility(BrowserVisibilityReason.user);
+    if (lease == null) {
+      _visibilityAcquisitions.remove(identity);
+      return;
+    }
     unawaited(() async {
       try {
         await lease.ready;

--- a/test/unit/features/browser/browser_session_registry_test.dart
+++ b/test/unit/features/browser/browser_session_registry_test.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:alera/src/features/browser/application/browser_session_registry.dart';
 import 'package:alera/src/features/browser/domain/browser_automation.dart';
 import 'package:alera/src/features/browser/domain/browser_engine_event.dart';
+import 'package:alera/src/features/browser/domain/browser_error.dart';
 import 'package:alera/src/features/browser/domain/browser_page_state.dart';
 import 'package:alera/src/features/browser/domain/browser_navigation.dart';
 import 'package:alera/src/features/browser/domain/browser_page.dart';
@@ -167,6 +168,32 @@ void main() {
     expect(closed, isTrue);
     expect(engine.calls, contains('close:page-1'));
   });
+
+  test(
+    'presentation visibility skips a session that started closing',
+    () async {
+      final handle = await registry.sessionFor(_tab());
+      final lifecycle = handle.acquireLifecycle(BrowserLifecycleReason.popup);
+      final closing = handle.close();
+
+      await Future<void>.delayed(Duration.zero);
+
+      expect(handle.tryAcquireVisibility(BrowserVisibilityReason.user), isNull);
+      expect(
+        () => handle.acquireVisibility(BrowserVisibilityReason.user),
+        throwsA(
+          isA<BrowserFailure>().having(
+            (failure) => failure.code,
+            'code',
+            BrowserErrorCode.pageNotFound,
+          ),
+        ),
+      );
+
+      await lifecycle.dispose();
+      await closing;
+    },
+  );
 
   test(
     'registry disposal does not close under an active native command',


### PR DESCRIPTION
## Summary

- skip presentation visibility acquisition after a browser page starts closing
- preserve strict visibility errors for non-presentation callers
- add a deterministic regression for the close and reconciliation race from ALERA-DESKTOP-APP-J

## Validation

- `flutter analyze`
- `flutter test test/unit/features/browser test/widget/browser_*.dart test/widget/workspace_workbench_view_test.dart` (186 passed)
- `dart format --set-exit-if-changed lib test integration_test tool`
- `dart tool/quality/check_max_lines.dart`
- `gh act pull_request -W .github/workflows/pr.yml -j static` reached the workflow but the linked-worktree git directory was unavailable inside the emulator container; hosted checks remain authoritative