### PR TITLE
fix: preserve emulator dependencies during disposal

### DIFF
--- a/lib/src/features/mobile_emulator/presentation/mobile_emulator_surface.dart
+++ b/lib/src/features/mobile_emulator/presentation/mobile_emulator_surface.dart
@@ -39,6 +39,8 @@ class MobileEmulatorSurface extends ConsumerStatefulWidget {
 class _MobileEmulatorSurfaceState extends ConsumerState<MobileEmulatorSurface>
     with WidgetsBindingObserver {
   final FocusNode _focusNode = FocusNode(debugLabel: 'Mobile Emulator');
+  late final MobileEmulatorLeaseCoordinator _leases;
+  late final MobileEmulatorService _service;
   Player? _player;
   VideoController? _videoController;
   StreamSubscription<VideoParams>? _videoParamsSubscription;
@@ -64,13 +66,11 @@ class _MobileEmulatorSurfaceState extends ConsumerState<MobileEmulatorSurface>
     tabId: widget.tab.id,
     workspaceId: widget.workspace.id,
   );
-  MobileEmulatorLeaseCoordinator get _leases =>
-      ref.read(mobileEmulatorLeaseCoordinatorProvider);
-  MobileEmulatorService get _service => ref.read(mobileEmulatorServiceProvider);
-
   @override
   void initState() {
     super.initState();
+    _leases = ref.read(mobileEmulatorLeaseCoordinatorProvider);
+    _service = ref.read(mobileEmulatorServiceProvider);
     WidgetsBinding.instance.addObserver(this);
     _changeSubscription = _service.changes.listen(_handleRuntimeChange);
     unawaited(_acquire());

--- a/test/widget/mobile_emulator_surface_test.dart
+++ b/test/widget/mobile_emulator_surface_test.dart
@@ -1,0 +1,118 @@
+import 'package:alera/src/app/theme/alera_dark_theme.dart';
+import 'package:alera/src/features/mobile_emulator/application/mobile_emulator_lease_coordinator.dart';
+import 'package:alera/src/features/mobile_emulator/application/mobile_emulator_providers.dart';
+import 'package:alera/src/features/mobile_emulator/infra/mobile_emulator_service.dart';
+import 'package:alera/src/features/mobile_emulator/presentation/mobile_emulator_surface.dart';
+import 'package:alera/src/features/workbench/domain/workspace.dart';
+import 'package:alera/src/features/workbench/domain/workspace_tab_record.dart';
+import 'package:alera/src/features/workbench/infra/terminal_host/terminal_host_protocol.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('releases the emulator lease after the surface is unmounted', (
+    tester,
+  ) async {
+    final client = _SurfaceRuntimeHostClient();
+    final service = MobileEmulatorService(client);
+    final leases = MobileEmulatorLeaseCoordinator(service);
+    addTearDown(leases.dispose);
+    addTearDown(service.dispose);
+
+    Widget buildSurface(Widget child) {
+      return ProviderScope(
+        overrides: [
+          mobileEmulatorServiceProvider.overrideWithValue(service),
+          mobileEmulatorLeaseCoordinatorProvider.overrideWithValue(leases),
+        ],
+        child: MaterialApp(theme: buildAleraDarkTheme(), home: child),
+      );
+    }
+
+    await tester.pumpWidget(
+      buildSurface(
+        MobileEmulatorSurface(
+          workspace: _workspace,
+          tab: _tab,
+          autofocus: false,
+        ),
+      ),
+    );
+    await tester.pump();
+    expect(client.acquireRequests, 1);
+
+    await tester.pumpWidget(buildSurface(const SizedBox.shrink()));
+
+    expect(tester.takeException(), isNull);
+
+    await tester.pump(MobileEmulatorLeaseCoordinator.releaseGrace);
+    expect(client.releaseRequests, 1);
+  });
+}
+
+final DateTime _now = DateTime.utc(2026, 8, 22);
+
+final Workspace _workspace = Workspace(
+  id: 'workspace-1',
+  projectId: 'project-1',
+  name: 'Alera',
+  path: '/workspace',
+  createdAt: _now,
+  updatedAt: _now,
+  kind: WorkspaceKind.main,
+  status: WorkspaceStatus.active,
+);
+
+final WorkspaceTabRecord _tab = WorkspaceTabRecord(
+  id: 'tab-1',
+  workspaceId: _workspace.id,
+  title: 'Pixel 9',
+  createdAt: _now,
+  updatedAt: _now,
+  kind: WorkspaceTabKind.mobileEmulator,
+);
+
+final class _SurfaceRuntimeHostClient implements RuntimeHostClient {
+  int acquireRequests = 0;
+  int releaseRequests = 0;
+
+  @override
+  Stream<RuntimeHostEvent> get runtimeEvents =>
+      const Stream<RuntimeHostEvent>.empty();
+
+  @override
+  Future<Object?> runtimeRequest(
+    String type, [
+    Map<String, Object?> payload = const <String, Object?>{},
+    Duration? timeout,
+  ]) async {
+    return switch (type) {
+      'status.get' => <String, Object?>{
+        'runtimeCapabilities': <String>[
+          aleraRuntimeHostMobileEmulatorCapability,
+        ],
+      },
+      'emulator.acquire' => _session(acquired: true),
+      'emulator.release' => _session(acquired: false),
+      _ => throw StateError('Unexpected runtime request: $type'),
+    };
+  }
+
+  Map<String, Object?> _session({required bool acquired}) {
+    if (acquired) {
+      acquireRequests += 1;
+    } else {
+      releaseRequests += 1;
+    }
+    return <String, Object?>{
+      'ok': true,
+      'session': <String, Object?>{
+        'id': 'session-1',
+        'state': acquired ? 'running' : 'released',
+        'platform': 'android',
+        'deviceId': 'pixel-9',
+      },
+    };
+  }
+}


### PR DESCRIPTION
## Summary

- cache the mobile emulator service and lease coordinator while the ConsumerState is mounted
- release the emulator lease during teardown without reading WidgetRef after unmount
- add a deterministic widget regression for teardown and delayed lease release

## Validation

- dart format --set-exit-if-changed lib test integration_test tool
- dart tool/quality/check_max_lines.dart
- flutter analyze
- focused mobile emulator and workbench suites: 112 tests passed
- PR test shard 3 with coverage: 843 tests passed
- gh act pull_request -W .github/workflows/pr.yml -j static could not start because Docker registry authentication rejected the runner image pull; no workflow step ran

Sentry: ALERA-DESKTOP-APP-H / issue 7669119093