### PR TITLE
fix: retry ambiguous tab removal requests

### DIFF
--- a/lib/src/features/workbench/infra/runtime_workbench_repository.dart
+++ b/lib/src/features/workbench/infra/runtime_workbench_repository.dart
@@ -4,6 +4,7 @@ import 'package:alera/src/features/workbench/application/workbench_repository.da
 import 'package:alera/src/features/workbench/domain/workbench_layout.dart';
 import 'package:alera/src/features/workbench/domain/workspace.dart';
 import 'package:alera/src/features/workbench/domain/workspace_tab_record.dart';
+import 'package:alera/src/features/workbench/infra/terminal_host/terminal_host_client_models.dart';
 import 'package:alera/src/features/workbench/infra/terminal_host/terminal_host_protocol.dart';
 import 'package:alera/src/shared/infra/runtime/runtime_change_coalescer.dart';
 import 'package:alera/src/shared/infra/runtime/runtime_snapshot_stream.dart';
@@ -146,6 +147,24 @@ class RuntimeWorkbenchRepository implements WorkbenchRepository {
   @override
   Future<void> removeWorkspaceTab(String tabId) async {
     await _ensureReady();
+    try {
+      await _removeWorkspaceTab(tabId);
+    } on TerminalHostRequestTimeoutException catch (error) {
+      if (error.requestType != 'tab.remove') {
+        rethrow;
+      }
+      // The host may commit after the client stops waiting. Replaying this
+      // idempotent removal obtains an authoritative response instead of
+      // treating an ambiguous timeout as success.
+      await _removeWorkspaceTab(tabId);
+    } on TerminalHostConnectionClosedException {
+      // The request may have reached the host before the disconnect. The
+      // sidecar's remove contract is idempotent, so one replay is safe.
+      await _removeWorkspaceTab(tabId);
+    }
+  }
+
+  Future<void> _removeWorkspaceTab(String tabId) async {
     await _client.runtimeRequest('tab.remove', <String, Object?>{'id': tabId});
   }
 

--- a/lib/src/features/workbench/infra/terminal_host/terminal_host_client_models.dart
+++ b/lib/src/features/workbench/infra/terminal_host/terminal_host_client_models.dart
@@ -120,7 +120,7 @@ final class TerminalHostRequestTimeoutException implements Exception {
   @override
   String toString() {
     return 'Terminal host request "$requestType" timed out after '
-        '${duration.inMilliseconds} ms. The connection was closed.';
+        '${duration.inMilliseconds} ms.';
   }
 }
 

--- a/rust/alera-core/src/runtime/workbench_shared_state_store_tests.rs
+++ b/rust/alera-core/src/runtime/workbench_shared_state_store_tests.rs
@@ -177,6 +177,30 @@ async fn tab_rename_preserves_payload_and_marks_manual_title() {
 }
 
 #[tokio::test]
+async fn workspace_tab_removal_is_idempotent() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = RuntimeStore::open(dir.path()).await.unwrap();
+    let now = Utc::now();
+    store
+        .upsert_workspace_tab(WorkspaceTabRecord {
+            id: "tab-1".to_string(),
+            workspace_id: "workspace-1".to_string(),
+            kind: "terminal".to_string(),
+            title: "Terminal".to_string(),
+            created_at: now,
+            updated_at: now,
+            payload: serde_json::json!({}),
+        })
+        .await
+        .unwrap();
+
+    store.remove_workspace_tab("tab-1").await.unwrap();
+    store.remove_workspace_tab("tab-1").await.unwrap();
+
+    assert!(store.find_workspace_tab("tab-1").await.unwrap().is_none());
+}
+
+#[tokio::test]
 async fn generic_browser_tab_upsert_sanitizes_or_removes_unsafe_urls() {
     let dir = tempfile::tempdir().unwrap();
     let store = RuntimeStore::open(dir.path()).await.unwrap();

--- a/test/unit/crash_reporting_test.dart
+++ b/test/unit/crash_reporting_test.dart
@@ -54,8 +54,7 @@ void main() {
     expect(CrashReporting.filterEvent(event), same(event));
     expect(
       timeout.toString(),
-      'Terminal host request "tab.remove" timed out after 10000 ms. '
-      'The connection was closed.',
+      'Terminal host request "tab.remove" timed out after 10000 ms.',
     );
   });
 

--- a/test/unit/runtime_workbench_repository_tab_removal_test.dart
+++ b/test/unit/runtime_workbench_repository_tab_removal_test.dart
@@ -1,0 +1,102 @@
+import 'dart:async';
+
+import 'package:alera/src/features/workbench/infra/runtime_workbench_repository.dart';
+import 'package:alera/src/features/workbench/infra/terminal_host/terminal_host_client_models.dart';
+import 'package:alera/src/features/workbench/infra/terminal_host/terminal_host_protocol.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('replays tab removal once after an ambiguous timeout', () async {
+    final client = _SequencedRuntimeHostClient(<Future<Object?> Function()>[
+      () => Future<Object?>.error(
+        const TerminalHostRequestTimeoutException(
+          'tab.remove',
+          Duration(seconds: 10),
+        ),
+      ),
+      () async => null,
+    ]);
+    final repository = RuntimeWorkbenchRepository(client);
+
+    await repository.removeWorkspaceTab('tab-1');
+
+    expect(client.requests, <String>['tab.remove', 'tab.remove']);
+    expect(client.payloads, <Map<String, Object?>>[
+      <String, Object?>{'id': 'tab-1'},
+      <String, Object?>{'id': 'tab-1'},
+    ]);
+  });
+
+  test('replays tab removal once after the connection closes', () async {
+    final client = _SequencedRuntimeHostClient(<Future<Object?> Function()>[
+      () =>
+          Future<Object?>.error(const TerminalHostConnectionClosedException()),
+      () async => null,
+    ]);
+    final repository = RuntimeWorkbenchRepository(client);
+
+    await repository.removeWorkspaceTab('tab-1');
+
+    expect(client.requests, <String>['tab.remove', 'tab.remove']);
+  });
+
+  test('propagates a second tab removal timeout', () async {
+    const first = TerminalHostRequestTimeoutException(
+      'tab.remove',
+      Duration(seconds: 10),
+    );
+    const second = TerminalHostRequestTimeoutException(
+      'tab.remove',
+      Duration(seconds: 10),
+    );
+    final client = _SequencedRuntimeHostClient(<Future<Object?> Function()>[
+      () => Future<Object?>.error(first),
+      () => Future<Object?>.error(second),
+    ]);
+    final repository = RuntimeWorkbenchRepository(client);
+
+    await expectLater(
+      repository.removeWorkspaceTab('tab-1'),
+      throwsA(same(second)),
+    );
+
+    expect(client.requests, <String>['tab.remove', 'tab.remove']);
+  });
+
+  test('does not replay a non-transport tab removal failure', () async {
+    final failure = StateError('tab removal was rejected');
+    final client = _SequencedRuntimeHostClient(<Future<Object?> Function()>[
+      () => Future<Object?>.error(failure),
+    ]);
+    final repository = RuntimeWorkbenchRepository(client);
+
+    await expectLater(
+      repository.removeWorkspaceTab('tab-1'),
+      throwsA(same(failure)),
+    );
+
+    expect(client.requests, <String>['tab.remove']);
+  });
+}
+
+final class _SequencedRuntimeHostClient implements RuntimeHostClient {
+  _SequencedRuntimeHostClient(this._responses);
+
+  final List<Future<Object?> Function()> _responses;
+  final requests = <String>[];
+  final payloads = <Map<String, Object?>>[];
+
+  @override
+  Stream<RuntimeHostEvent> get runtimeEvents => const Stream.empty();
+
+  @override
+  Future<Object?> runtimeRequest(
+    String type, [
+    Map<String, Object?> payload = const <String, Object?>{},
+    Duration? timeout,
+  ]) {
+    requests.add(type);
+    payloads.add(payload);
+    return _responses.removeAt(0)();
+  }
+}


### PR DESCRIPTION
## Summary

- replay `tab.remove` once after an ambiguous timeout or connection closure, relying on the sidecar delete contract being idempotent
- keep repeated timeouts and functional errors actionable instead of converting them to success
- correct the timeout message and cover the Dart retry boundary plus Rust store idempotency

## Validation

- `flutter test test/unit/runtime_workbench_repository_tab_removal_test.dart test/unit/runtime_repositories_test.dart test/unit/terminal_host_client_test.dart test/unit/crash_reporting_test.dart --reporter expanded` (67 passed)
- `flutter analyze`
- `dart run tool/quality/check_max_lines.dart`
- `cargo test --manifest-path rust/Cargo.toml -p alera-core --features runtime workspace_tab_removal_is_idempotent` (1 passed)
- `cargo fmt --manifest-path rust/Cargo.toml --all -- --check`
- `git diff --check`

## Notes

- `gh act pull_request -W .github/workflows/pr.yml` was attempted. Local emulation was blocked by Docker registry authentication for two matrices and linked-worktree Git/submodule discovery; hosted exact-head checks are authoritative.