### PR TITLE
fix: preserve terminal attachment during replacement

### DIFF
--- a/lib/src/features/workbench/infra/terminal_host/terminal_host_pty_session.dart
+++ b/lib/src/features/workbench/infra/terminal_host/terminal_host_pty_session.dart
@@ -6,6 +6,8 @@ import 'package:alera/src/features/workbench/presentation/terminal_runtime.dart'
 import 'package:ghostty_vte_flutter/ghostty_vte_flutter.dart';
 
 part 'terminal_host_pty_session_pulse.dart';
+part 'terminal_host_pty_session_lease.dart';
+part 'terminal_host_pty_session_errors.dart';
 
 final class TerminalHostPtySessionFactory implements TerminalPtySessionFactory {
   factory TerminalHostPtySessionFactory({required TerminalHostClient client}) {
@@ -15,6 +17,7 @@ final class TerminalHostPtySessionFactory implements TerminalPtySessionFactory {
   TerminalHostPtySessionFactory._(this._client);
 
   final TerminalHostClient _client;
+  final _TerminalHostPtySessionLeases _leases = _TerminalHostPtySessionLeases();
 
   @override
   TerminalPtySession create({
@@ -22,11 +25,12 @@ final class TerminalHostPtySessionFactory implements TerminalPtySessionFactory {
     required String workspaceId,
     required String tabId,
   }) {
-    return TerminalHostPtySession(
-      client: _client,
-      sessionId: sessionId,
-      workspaceId: workspaceId,
-      tabId: tabId,
+    return TerminalHostPtySession._(
+      _client,
+      sessionId,
+      workspaceId,
+      tabId,
+      _leases.acquire(sessionId),
     );
   }
 }
@@ -43,7 +47,13 @@ final class TerminalHostPtySession
     required String workspaceId,
     required String tabId,
   }) {
-    return TerminalHostPtySession._(client, sessionId, workspaceId, tabId);
+    return TerminalHostPtySession._(
+      client,
+      sessionId,
+      workspaceId,
+      tabId,
+      null,
+    );
   }
 
   TerminalHostPtySession._(
@@ -51,6 +61,7 @@ final class TerminalHostPtySession
     this._sessionId,
     this._workspaceId,
     this._tabId,
+    this._lease,
   );
 
   @override
@@ -59,6 +70,7 @@ final class TerminalHostPtySession
   final String _sessionId;
   final String _workspaceId;
   final String _tabId;
+  final _TerminalHostPtySessionLease? _lease;
   final StreamController<TerminalPtySessionEvent> _events =
       StreamController<TerminalPtySessionEvent>.broadcast();
 
@@ -391,25 +403,6 @@ final class TerminalHostPtySession
     return next;
   }
 
-  bool _shouldRecoverFromHostError(Object error) {
-    final message = _hostErrorMessage(error);
-    return message.contains('Terminal session is not attached') ||
-        message.contains('Terminal host connection closed');
-  }
-
-  bool _isDefinitivelyNotAttached(Object error) {
-    return _hostErrorMessage(
-      error,
-    ).contains('Terminal session is not attached');
-  }
-
-  String _hostErrorMessage(Object error) {
-    if (error is StateError) {
-      return error.message;
-    }
-    return error.toString();
-  }
-
   @override
   void dispose() {
     if (_disposed) {
@@ -419,7 +412,9 @@ final class TerminalHostPtySession
     _started = false;
     unawaited(_hostSub?.cancel());
     _hostSub = null;
-    unawaited(_client.detach(_sessionId).catchError((_) {}));
+    if (_lease?.release() ?? true) {
+      unawaited(_client.detach(_sessionId).catchError((_) {}));
+    }
     unawaited(_events.close());
   }
 
@@ -432,6 +427,7 @@ final class TerminalHostPtySession
     _started = false;
     unawaited(_hostSub?.cancel());
     _hostSub = null;
+    _lease?.terminate();
     _client.releaseSession(_sessionId);
     unawaited(_client.terminate(_sessionId).catchError((_) {}));
     unawaited(_events.close());
@@ -474,15 +470,5 @@ final class TerminalHostPtySession
       }
     });
     _outputResyncFuture = resync;
-  }
-
-  void _emitHostError(Object error) {
-    if (!_disposed && !_events.isClosed && !_isInputBackpressure(error)) {
-      _events.add(TerminalPtyErrorEvent(error));
-    }
-  }
-
-  bool _isInputBackpressure(Object error) {
-    return _hostErrorMessage(error).contains('terminal_input_backpressure');
   }
 }

--- a/lib/src/features/workbench/infra/terminal_host/terminal_host_pty_session_errors.dart
+++ b/lib/src/features/workbench/infra/terminal_host/terminal_host_pty_session_errors.dart
@@ -1,0 +1,32 @@
+part of 'terminal_host_pty_session.dart';
+
+extension _TerminalHostPtySessionErrors on TerminalHostPtySession {
+  bool _shouldRecoverFromHostError(Object error) {
+    final message = _hostErrorMessage(error);
+    return message.contains('Terminal session is not attached') ||
+        message.contains('Terminal host connection closed');
+  }
+
+  bool _isDefinitivelyNotAttached(Object error) {
+    return _hostErrorMessage(
+      error,
+    ).contains('Terminal session is not attached');
+  }
+
+  String _hostErrorMessage(Object error) {
+    if (error is StateError) {
+      return error.message;
+    }
+    return error.toString();
+  }
+
+  void _emitHostError(Object error) {
+    if (!_disposed && !_events.isClosed && !_isInputBackpressure(error)) {
+      _events.add(TerminalPtyErrorEvent(error));
+    }
+  }
+
+  bool _isInputBackpressure(Object error) {
+    return _hostErrorMessage(error).contains('terminal_input_backpressure');
+  }
+}

--- a/lib/src/features/workbench/infra/terminal_host/terminal_host_pty_session_lease.dart
+++ b/lib/src/features/workbench/infra/terminal_host/terminal_host_pty_session_lease.dart
@@ -1,0 +1,53 @@
+part of 'terminal_host_pty_session.dart';
+
+final class _TerminalHostPtySessionLeases {
+  final Map<String, Set<_TerminalHostPtySessionLease>> _active =
+      <String, Set<_TerminalHostPtySessionLease>>{};
+
+  _TerminalHostPtySessionLease acquire(String sessionId) {
+    final lease = _TerminalHostPtySessionLease._(this, sessionId);
+    _active
+        .putIfAbsent(sessionId, () => <_TerminalHostPtySessionLease>{})
+        .add(lease);
+    return lease;
+  }
+
+  bool release(_TerminalHostPtySessionLease lease) {
+    if (lease._released) {
+      return false;
+    }
+    lease._released = true;
+    final leases = _active[lease._sessionId];
+    if (leases == null || !leases.remove(lease) || leases.isNotEmpty) {
+      return false;
+    }
+    _active.remove(lease._sessionId);
+    return true;
+  }
+
+  void terminate(_TerminalHostPtySessionLease lease) {
+    if (lease._released) {
+      return;
+    }
+    final leases = _active.remove(lease._sessionId);
+    if (leases == null) {
+      lease._released = true;
+      return;
+    }
+    for (final activeLease in leases) {
+      activeLease._released = true;
+    }
+  }
+}
+
+final class _TerminalHostPtySessionLease {
+  _TerminalHostPtySessionLease._(this._owner, this._sessionId);
+
+  final _TerminalHostPtySessionLeases _owner;
+  final String _sessionId;
+  bool _released = false;
+
+  bool release() => _owner.release(this);
+
+  void terminate() => _owner.terminate(this);
+}

--- a/test/unit/terminal_host_pty_session_lease_cases.dart
+++ b/test/unit/terminal_host_pty_session_lease_cases.dart
@@ -1,0 +1,75 @@
+part of 'terminal_host_pty_session_test.dart';
+
+void _registerTerminalHostPtySessionLeaseTests() {
+  test('factory creates sessions with the provided ids', () {
+    final client = FakeTerminalHostClient(
+      attachment: TerminalHostAttachment(
+        sessionId: 'session-1',
+        created: true,
+        running: true,
+        snapshot: Uint8List(0),
+      ),
+    );
+    final factory = TerminalHostPtySessionFactory(client: client);
+
+    final session = factory.create(
+      sessionId: 'session-1',
+      workspaceId: 'workspace-1',
+      tabId: 'tab-1',
+    );
+    addTearDown(session.dispose);
+
+    expect(session, isA<TerminalHostPtySession>());
+  });
+
+  test('replacement session keeps the shared host attachment alive', () async {
+    final client = FakeTerminalHostClient(
+      attachment: TerminalHostAttachment(
+        sessionId: 'session-1',
+        created: false,
+        running: true,
+        snapshot: Uint8List(0),
+      ),
+    );
+    final factory = TerminalHostPtySessionFactory(client: client);
+    final previous = factory.create(
+      sessionId: 'session-1',
+      workspaceId: 'workspace-1',
+      tabId: 'tab-1',
+    );
+    final replacement = factory.create(
+      sessionId: 'session-1',
+      workspaceId: 'workspace-1',
+      tabId: 'tab-1',
+    );
+    addTearDown(previous.dispose);
+    addTearDown(replacement.dispose);
+
+    await previous.start(
+      launch: _launch(),
+      workingDirectory: '/repo',
+      cols: 80,
+      rows: 24,
+    );
+    await replacement.start(
+      launch: _launch(),
+      workingDirectory: '/repo',
+      cols: 80,
+      rows: 24,
+    );
+
+    previous.dispose();
+    await _flushAsync();
+
+    expect(client.detached, isEmpty);
+    expect(replacement.writeBytes(<int>[7]), isTrue);
+    await _flushAsync();
+    expect(client.writes, <List<int>>[
+      <int>[7],
+    ]);
+
+    replacement.dispose();
+    await _flushAsync();
+    expect(client.detached, <String>['session-1']);
+  });
+}

--- a/test/unit/terminal_host_pty_session_test.dart
+++ b/test/unit/terminal_host_pty_session_test.dart
@@ -12,33 +12,13 @@ import 'package:ghostty_vte_flutter/ghostty_vte_flutter.dart';
 import 'terminal_host_test_fakes.dart';
 
 part 'terminal_host_pty_output_resync_cases.dart';
+part 'terminal_host_pty_session_lease_cases.dart';
 part 'terminal_host_pty_pulse_cases.dart';
 part 'terminal_host_pty_refresh_cases.dart';
 part 'terminal_host_pty_resume_cases.dart';
 
 void main() {
   _registerTerminalHostPtyPulseTests();
-
-  test('factory creates sessions with the provided ids', () {
-    final client = FakeTerminalHostClient(
-      attachment: TerminalHostAttachment(
-        sessionId: 'session-1',
-        created: true,
-        running: true,
-        snapshot: Uint8List(0),
-      ),
-    );
-    final factory = TerminalHostPtySessionFactory(client: client);
-
-    final session = factory.create(
-      sessionId: 'session-1',
-      workspaceId: 'workspace-1',
-      tabId: 'tab-1',
-    );
-    addTearDown(session.dispose);
-
-    expect(session, isA<TerminalHostPtySession>());
-  });
 
   test(
     'host PTY session replays snapshots and suppresses restored exits',
@@ -139,6 +119,8 @@ void main() {
       expect(client.terminated, <String>['session-2']);
     },
   );
+
+  _registerTerminalHostPtySessionLeaseTests();
 
   _registerTerminalHostPtyRefreshTests();
 


### PR DESCRIPTION
## Summary

Prevent an evicted terminal handle from detaching the shared host client after a replacement handle has already attached to the same session. The factory now leases attachment ownership per session, so only the last live handle detaches while termination invalidates every lease. This fixes Sentry ALERA-DESKTOP-APP-8 without suppressing the host error.

## Screenshots

No visual change.

## Testing

- [x] `dart format --set-exit-if-changed lib test integration_test tool`
- [x] `flutter analyze`
- [x] `flutter test --coverage --exclude-tags golden`
- [x] `dart run tool/quality/coverage_report.dart --input coverage/lcov.info --min-lines 100 --worst 25`
- [ ] Golden tests, if UI changed: not applicable, no UI change
- [ ] Desktop E2E, if app-shell flow changed: not applicable, no app-shell flow change
- [ ] Relevant desktop build: local Linux build could not configure `whisper-rs-sys` because this host lacks `glslc`; the hosted setup installs it
- [ ] Landing build, if applicable: not applicable
- [x] Added a regression test that overlaps old and replacement handles and verifies the replacement remains writable before the final detach

## AI Review Report

Traced eviction, asynchronous subscription cancellation, replacement attachment, and host detach semantics. Verified that host attachment identity is per client and session, while Dart can temporarily own multiple handles for one session. Reviewed lease disposal and termination ordering, direct-constructor compatibility, and cross-platform behavior; the fix is platform-neutral and changes no shell, path, or UI behavior.

## Security Audit

No new input handling, command execution, path handling, authentication, secrets, dependencies, signing, updater, or process-spawn behavior. The change only coordinates existing terminal attachment lifetimes in memory.

## Notes

`gh act` could not start its Docker image because the local Docker authentication configuration was rejected. Native format, analysis, max-lines, focused tests, full tests, and coverage gates passed; hosted PR checks are authoritative for the exact head SHA.