### PR TITLE
fix: open android update downloads in the standalone browser

### DIFF
--- a/mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/android/app/src/main/AndroidManifest.xml
@@ -55,7 +55,9 @@
             <data android:mimeType="text/plain"/>
         </intent>
         <!-- Android 11 package visibility: without these entries url_launcher
-             cannot discover a browser before opening web links. -->
+             cannot discover a browser before opening web links. APP_BROWSER
+             is required so the update Download button can target the
+             standalone browser instead of a Custom Tab or the GitHub app. -->
         <intent>
             <action android:name="android.intent.action.VIEW"/>
             <data android:scheme="http"/>
@@ -63,6 +65,15 @@
         <intent>
             <action android:name="android.intent.action.VIEW"/>
             <data android:scheme="https"/>
+        </intent>
+        <intent>
+            <action android:name="android.intent.action.VIEW"/>
+            <category android:name="android.intent.category.BROWSABLE"/>
+            <data android:scheme="https"/>
+        </intent>
+        <intent>
+            <action android:name="android.intent.action.MAIN"/>
+            <category android:name="android.intent.category.APP_BROWSER"/>
         </intent>
         <intent>
             <action android:name="android.intent.action.VIEW"/>

--- a/mobile/android/app/src/main/kotlin/dev/leynier/alera_mobile/ExternalBrowserLauncher.kt
+++ b/mobile/android/app/src/main/kotlin/dev/leynier/alera_mobile/ExternalBrowserLauncher.kt
@@ -1,0 +1,78 @@
+package dev.leynier.alera_mobile
+
+import android.app.Activity
+import android.content.ActivityNotFoundException
+import android.content.Intent
+import android.net.Uri
+import io.flutter.plugin.common.BinaryMessenger
+import io.flutter.plugin.common.MethodChannel
+
+/**
+ * Opens http(s) URLs in the device's standalone browser.
+ *
+ * `url_launcher`'s ACTION_VIEW stays in Alera's task and can resolve to Chrome
+ * Custom Tabs or a host-specific app (GitHub's in-app browser for APK links).
+ * The selector matches generic browsers only, and NEW_TASK puts that browser
+ * in its own recents entry.
+ */
+internal object ExternalBrowserLauncher {
+    const val CHANNEL = "dev.leynier.alera/external_browser"
+
+    fun register(messenger: BinaryMessenger, activity: Activity) {
+        MethodChannel(messenger, CHANNEL).setMethodCallHandler { call, result ->
+            if (call.method != "open") {
+                result.notImplemented()
+                return@setMethodCallHandler
+            }
+            val url = call.argument<String>("url")
+            if (url.isNullOrBlank()) {
+                result.error("invalid_url", "A URL is required.", null)
+                return@setMethodCallHandler
+            }
+            result.success(open(activity, url))
+        }
+    }
+
+    fun open(activity: Activity, url: String): Boolean {
+        val uri = Uri.parse(url)
+        val scheme = uri.scheme?.lowercase()
+        if (scheme != "http" && scheme != "https") {
+            return false
+        }
+        if (start(activity, browserViewIntent(uri))) {
+            return true
+        }
+        val selectorIntent =
+            Intent.makeMainSelectorActivity(
+                Intent.ACTION_MAIN,
+                Intent.CATEGORY_APP_BROWSER,
+            ).apply {
+                data = uri
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            }
+        return start(activity, selectorIntent)
+    }
+
+    private fun browserViewIntent(uri: Uri): Intent {
+        return Intent(Intent.ACTION_VIEW, uri).apply {
+            addCategory(Intent.CATEGORY_BROWSABLE)
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            // Match handlers of generic https URLs (browsers), not github.com
+            // apps that swallow the link into an in-app WebView.
+            selector =
+                Intent(Intent.ACTION_VIEW).apply {
+                    addCategory(Intent.CATEGORY_BROWSABLE)
+                    data = Uri.parse("https:")
+                }
+        }
+    }
+
+    private fun start(activity: Activity, intent: Intent): Boolean {
+        return try {
+            activity.startActivity(intent)
+            true
+        } catch (_: ActivityNotFoundException) {
+            false
+        }
+    }
+}

--- a/mobile/android/app/src/main/kotlin/dev/leynier/alera_mobile/MainActivity.kt
+++ b/mobile/android/app/src/main/kotlin/dev/leynier/alera_mobile/MainActivity.kt
@@ -22,5 +22,9 @@ class MainActivity : FlutterActivity() {
                     SpeechRecognizer.isOnDeviceRecognitionAvailable(this),
             )
         }
+        ExternalBrowserLauncher.register(
+            flutterEngine.dartExecutor.binaryMessenger,
+            this,
+        )
     }
 }

--- a/mobile/lib/src/features/updater/infra/mobile_external_browser.dart
+++ b/mobile/lib/src/features/updater/infra/mobile_external_browser.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/services.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+const mobileExternalBrowserChannelName = 'dev.leynier.alera/external_browser';
+
+/// Opens [url] in the device's standalone browser, not a Custom Tab.
+///
+/// Android's default `ACTION_VIEW` can land in Chrome Custom Tabs or a
+/// host-specific in-app browser (GitHub for APK links). The native channel
+/// forces a real browser in its own task. url_launcher remains the fallback
+/// for tests and for a host without that channel.
+Future<bool> openMobileExternalBrowser(
+  Uri url, {
+  MethodChannel? channel,
+  Future<bool> Function(Uri url)? fallback,
+}) async {
+  if (!url.isScheme('http') && !url.isScheme('https')) {
+    return false;
+  }
+  try {
+    final opened =
+        await (channel ?? const MethodChannel(mobileExternalBrowserChannelName))
+            .invokeMethod<bool>('open', <String, Object>{
+              'url': url.toString(),
+            });
+    if (opened == true) {
+      return true;
+    }
+  } on MissingPluginException {
+    // Widget tests and platforms without the Android channel.
+  } on PlatformException {
+    // Native refused the URL; try the generic launcher next.
+  }
+  final launch = fallback ?? _launchUrlLauncherExternal;
+  return launch(url);
+}
+
+Future<bool> _launchUrlLauncherExternal(Uri url) {
+  return launchUrl(url, mode: LaunchMode.externalApplication);
+}

--- a/mobile/lib/src/features/updater/presentation/mobile_update_prompt.dart
+++ b/mobile/lib/src/features/updater/presentation/mobile_update_prompt.dart
@@ -2,10 +2,10 @@ import 'package:alera_mobile/src/app/theme/alera_tokens.dart';
 import 'package:alera_mobile/src/design_system/layout/alera_dialog.dart';
 import 'package:alera_mobile/src/features/updater/application/mobile_update_providers.dart';
 import 'package:alera_mobile/src/features/updater/domain/mobile_release.dart';
+import 'package:alera_mobile/src/features/updater/infra/mobile_external_browser.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:url_launcher/url_launcher.dart';
 
 enum _MobileUpdateAction { copyLink, download }
 
@@ -20,7 +20,7 @@ class MobileUpdatePrompt extends ConsumerStatefulWidget {
     super.key,
     required this.child,
     this.copyLink = _copyToClipboard,
-    this.openUrl = _launchExternalBrowser,
+    this.openUrl = openMobileExternalBrowser,
   });
 
   final Widget child;
@@ -125,7 +125,7 @@ class _MobileUpdateDialog extends StatelessWidget {
             const SizedBox(height: AleraTokens.space12),
             Text(
               'Alera $version is available. Downloading opens the APK in your '
-              'browser, and Android asks to install it.',
+              'device\'s browser, and Android asks to install it.',
               style: theme.textTheme.bodyMedium?.copyWith(
                 color: AleraTokens.foregroundMuted,
               ),
@@ -167,8 +167,4 @@ class _MobileUpdateDialog extends StatelessWidget {
 
 Future<void> _copyToClipboard(String link) {
   return Clipboard.setData(ClipboardData(text: link));
-}
-
-Future<bool> _launchExternalBrowser(Uri url) {
-  return launchUrl(url, mode: LaunchMode.externalApplication);
 }

--- a/mobile/test/mobile_external_browser_test.dart
+++ b/mobile/test/mobile_external_browser_test.dart
@@ -1,0 +1,117 @@
+import 'package:alera_mobile/src/features/updater/infra/mobile_external_browser.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+import 'package:url_launcher_platform_interface/link.dart';
+import 'package:url_launcher_platform_interface/url_launcher_platform_interface.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const apkUrl =
+      'https://github.com/leynier/alera/releases/download/'
+      'v0.10.0-mobile/alera-0.10.0-android.apk';
+  const channel = MethodChannel(mobileExternalBrowserChannelName);
+  final uri = Uri.parse(apkUrl);
+
+  tearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, null);
+  });
+
+  test('asks the native channel to open https urls', () async {
+    MethodCall? call;
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (methodCall) async {
+          call = methodCall;
+          return true;
+        });
+    final fallback = <Uri>[];
+
+    final opened = await openMobileExternalBrowser(
+      uri,
+      fallback: (url) async {
+        fallback.add(url);
+        return false;
+      },
+    );
+
+    expect(opened, isTrue);
+    expect(call?.method, 'open');
+    expect(call?.arguments, <String, Object>{'url': apkUrl});
+    expect(fallback, isEmpty);
+  });
+
+  test('rejects non-web schemes without calling native or fallback', () async {
+    var nativeCalls = 0;
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (_) async {
+          nativeCalls += 1;
+          return true;
+        });
+    final fallback = <Uri>[];
+
+    final opened = await openMobileExternalBrowser(
+      Uri.parse('intent://github.com/leynier/alera'),
+      fallback: (url) async {
+        fallback.add(url);
+        return true;
+      },
+    );
+
+    expect(opened, isFalse);
+    expect(nativeCalls, 0);
+    expect(fallback, isEmpty);
+  });
+
+  test(
+    'falls back to url_launcher when the native channel is missing',
+    () async {
+      final previousPlatform = UrlLauncherPlatform.instance;
+      final fakePlatform = _RecordingUrlLauncherPlatform();
+      UrlLauncherPlatform.instance = fakePlatform;
+      addTearDown(() => UrlLauncherPlatform.instance = previousPlatform);
+
+      final opened = await openMobileExternalBrowser(uri);
+
+      expect(opened, isTrue);
+      expect(fakePlatform.launchedUrls, <String>[apkUrl]);
+      expect(fakePlatform.modes, <PreferredLaunchMode>[
+        PreferredLaunchMode.externalApplication,
+      ]);
+    },
+  );
+
+  test('falls back when the native channel reports failure', () async {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (_) async => false);
+    final fallback = <Uri>[];
+
+    final opened = await openMobileExternalBrowser(
+      uri,
+      fallback: (url) async {
+        fallback.add(url);
+        return true;
+      },
+    );
+
+    expect(opened, isTrue);
+    expect(fallback, <Uri>[uri]);
+  });
+}
+
+class _RecordingUrlLauncherPlatform extends UrlLauncherPlatform
+    with MockPlatformInterfaceMixin {
+  final List<String> launchedUrls = <String>[];
+  final List<PreferredLaunchMode> modes = <PreferredLaunchMode>[];
+
+  @override
+  LinkDelegate? get linkDelegate => null;
+
+  @override
+  Future<bool> launchUrl(String url, LaunchOptions options) async {
+    launchedUrls.add(url);
+    modes.add(options.mode);
+    return true;
+  }
+}

--- a/mobile/test/mobile_update_prompt_test.dart
+++ b/mobile/test/mobile_update_prompt_test.dart
@@ -1,7 +1,9 @@
 import 'package:alera_mobile/src/features/updater/application/mobile_update_providers.dart';
 import 'package:alera_mobile/src/features/updater/domain/mobile_release.dart';
+import 'package:alera_mobile/src/features/updater/infra/mobile_external_browser.dart';
 import 'package:alera_mobile/src/features/updater/presentation/mobile_update_prompt.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
@@ -71,13 +73,28 @@ void main() {
     expect(opened, <Uri>[_release.apkUrl]);
   });
 
-  testWidgets('default download launcher requests an external application', (
+  testWidgets('download opens the apk in the standalone browser', (
     tester,
   ) async {
     final previousPlatform = UrlLauncherPlatform.instance;
     final fakePlatform = _RecordingUrlLauncherPlatform();
     UrlLauncherPlatform.instance = fakePlatform;
     addTearDown(() => UrlLauncherPlatform.instance = previousPlatform);
+
+    final opened = <MethodCall>[];
+    tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+      const MethodChannel(mobileExternalBrowserChannelName),
+      (call) async {
+        opened.add(call);
+        return true;
+      },
+    );
+    addTearDown(
+      () => tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        const MethodChannel(mobileExternalBrowserChannelName),
+        null,
+      ),
+    );
 
     final copied = <String>[];
     await _pump(tester, release: _release, copied: copied);
@@ -86,10 +103,13 @@ void main() {
     await tester.tap(find.text('Download'));
     await tester.pumpAndSettle();
 
-    expect(fakePlatform.launchedUrls, <String>[_release.apkUrl.toString()]);
-    expect(fakePlatform.modes, <PreferredLaunchMode>[
-      PreferredLaunchMode.externalApplication,
-    ]);
+    expect(copied, isEmpty);
+    expect(opened, hasLength(1));
+    expect(opened.single.method, 'open');
+    expect(opened.single.arguments, <String, Object>{
+      'url': _release.apkUrl.toString(),
+    });
+    expect(fakePlatform.launchedUrls, isEmpty);
   });
 
   testWidgets('copies the apk link without opening it', (tester) async {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The Android update prompt's Download button now opens the APK URL in the device's standalone browser (Chrome, Firefox, or similar) as a separate app, instead of an in-app Custom Tab or the GitHub embedded browser.

`url_launcher` with `LaunchMode.externalApplication` still uses `ACTION_VIEW` from Alera's activity. On Android that often lands in Chrome Custom Tabs or a host-specific app (GitHub for `github.com` APK links). Download now goes through a native launcher that:

- matches generic https browsers only, so GitHub cannot swallow the link
- adds `FLAG_ACTIVITY_NEW_TASK` so the browser is its own task
- falls back to `CATEGORY_APP_BROWSER` if that intent cannot resolve
- keeps `url_launcher` only as a last-resort fallback

## Screenshots

No visual change to the dialog layout. Download now leaves Alera for the system browser instead of an embedded one.

## Testing

- [x] `dart format --set-exit-if-changed` on the touched mobile Dart files
- [x] `flutter analyze` from `mobile/` (no issues)
- [x] `flutter test test/mobile_external_browser_test.dart test/mobile_update_prompt_test.dart` (9 passed)
- [x] Added tests that the Download path calls the native channel and does not use `url_launcher` when that channel succeeds
- Desktop format/analyze/coverage/golden/E2E/build and landing build are not applicable (mobile-only)

## AI Review Report

Checked Custom Tabs vs standalone browser, GitHub in-app browser hijacking of APK URLs, scheme allowlisting, and the missing-plugin fallback. Widget tests confirm Download invokes `dev.leynier.alera/external_browser` `open` with the APK URL and does not call `url_launcher` when the native channel succeeds.

This is Android-only. The mobile update prompt does not run on iOS, macOS, Linux, or Windows.

## Security Audit

The native launcher accepts only `http`/`https` URLs and rejects other schemes (`intent:`, `file:`, etc.) so a compromised release payload cannot open an arbitrary intent. The APK URL still comes from the existing GitHub Releases lookup.

## Notes

Requires Android 11 package visibility for `CATEGORY_APP_BROWSER` and browsable https VIEW intents, added to the mobile manifest. No protocol or documentation change: the dialog already said Download opens the APK in the browser.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a593eaad-951b-4dd9-be87-c46e1d0bb63b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a593eaad-951b-4dd9-be87-c46e1d0bb63b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

