### PR TITLE
feat: add safe workspace storage cleanup

### DIFF
--- a/docs/workspace-storage.md
+++ b/docs/workspace-storage.md
@@ -1,0 +1,13 @@
+# Workspace Storage
+
+Alera measures a linked workspace on demand before offering manual cleanup. Measurement runs in a sidecar worker rather than on Flutter's main isolate or the terminal-host actor. Directory symlinks are counted but never followed.
+
+Cleanup is refused when the workspace is selected in the requesting workbench, has a live terminal, process, or browser session, is owned by an active automation definition or run, belongs to another host, is the main/source repository of any project, has another runtime owner, or resolves outside Alera's configured managed-workspace root. Once accepted, the runtime mutation barrier rejects new owner-creating requests until cleanup completes. Ownership, path containment, and Git worktree branch identity are checked again immediately before mutation. Cleanup removes the registered Git worktree first and only then removes runtime records. A failed Git operation leaves the records available for a retry. There is no scheduled or automatic cleanup.
+
+## Measurement Limitations
+
+- Reported bytes are allocated entry lengths from filesystem metadata, not guaranteed physical disk usage. Sparse files, compression, deduplication, copy-on-write clones, filesystem block size, and hard links can make actual reclaimed space differ.
+- Directory metadata contributes a small platform- and filesystem-dependent amount.
+- Files changing during a scan can make the result approximate. The cleanup request rechecks ownership and path safety, but it does not freeze the filesystem.
+- Unreadable or concurrently removed entries fail the scan instead of presenting a cleanup confirmation.
+- Windows junctions and other reparse-point behavior depends on Rust's filesystem classification for the installed toolchain. Alera does not follow entries classified as symbolic links, and path containment is still checked using the platform canonical path.

--- a/lib/src/features/workbench/application/workbench_controller_projects.dart
+++ b/lib/src/features/workbench/application/workbench_controller_projects.dart
@@ -137,6 +137,7 @@ mixin _WorkbenchControllerProjects
     required Project project,
     required Workspace workspace,
     bool deleteBranch = true,
+    String? activeWorkspaceId,
   }) async {
     try {
       final workspaceTabs = state.tabsFor(workspace.id);
@@ -150,6 +151,7 @@ mixin _WorkbenchControllerProjects
         project: project,
         workspace: workspace,
         deleteBranch: deleteBranch,
+        activeWorkspaceId: activeWorkspaceId,
       );
       for (final tab in workspaceTabs) {
         await _releaseHostedReviewTab(

--- a/lib/src/features/workbench/application/workspace_service.dart
+++ b/lib/src/features/workbench/application/workspace_service.dart
@@ -68,6 +68,7 @@ abstract interface class ManagedWorkspaceRuntime {
   Future<void> removeWorkspace({
     required Workspace workspace,
     bool? deleteBranch,
+    String? activeWorkspaceId,
   });
 }
 

--- a/lib/src/features/workbench/application/workspace_service_removal.dart
+++ b/lib/src/features/workbench/application/workspace_service_removal.dart
@@ -5,6 +5,7 @@ extension WorkspaceServiceRemoval on WorkspaceService {
     required Project project,
     required Workspace workspace,
     required bool deleteBranch,
+    String? activeWorkspaceId,
   }) async {
     if (workspace.isMain) {
       throw WorkspaceException('The main workspace cannot be removed');
@@ -15,6 +16,7 @@ extension WorkspaceServiceRemoval on WorkspaceService {
       await managedRuntime.removeWorkspace(
         workspace: workspace,
         deleteBranch: shouldDeleteBranch,
+        activeWorkspaceId: activeWorkspaceId,
       );
       return;
     }

--- a/lib/src/features/workbench/domain/workspace_storage_impact.dart
+++ b/lib/src/features/workbench/domain/workspace_storage_impact.dart
@@ -1,0 +1,28 @@
+class WorkspaceStorageImpact {
+  const WorkspaceStorageImpact({
+    required this.workspaceId,
+    required this.path,
+    required this.sizeBytes,
+    required this.entryCount,
+    required this.measuredAt,
+    required this.lastActivityAt,
+    required this.safeToClean,
+    required this.blockers,
+  });
+
+  final String workspaceId;
+  final String path;
+  final int sizeBytes;
+  final int entryCount;
+  final DateTime measuredAt;
+  final DateTime lastActivityAt;
+  final bool safeToClean;
+  final List<String> blockers;
+}
+
+abstract interface class WorkspaceStorageRuntime {
+  Future<WorkspaceStorageImpact> storageImpact({
+    required String workspaceId,
+    String? activeWorkspaceId,
+  });
+}

--- a/lib/src/features/workbench/infra/runtime_managed_workspace_client.dart
+++ b/lib/src/features/workbench/infra/runtime_managed_workspace_client.dart
@@ -2,16 +2,47 @@ import 'package:alera/src/features/projects/domain/project.dart';
 import 'package:alera/src/features/workbench/application/workspace_service.dart';
 import 'package:alera/src/features/workbench/domain/workspace.dart';
 import 'package:alera/src/features/workbench/domain/workspace_creation_result.dart';
+import 'package:alera/src/features/workbench/domain/workspace_storage_impact.dart';
 import 'package:alera/src/features/workbench/infra/terminal_host/terminal_host_protocol.dart';
 
 const Duration _managedWorkspaceCreateTimeout = Duration(minutes: 30);
 const Duration _managedWorkspaceRemoveTimeout = Duration(minutes: 10);
 
-class RuntimeManagedWorkspaceClient implements ManagedWorkspaceRuntime {
+class RuntimeManagedWorkspaceClient
+    implements ManagedWorkspaceRuntime, WorkspaceStorageRuntime {
   RuntimeManagedWorkspaceClient(this._client, {this.beforeAccess});
 
   final RuntimeHostClient _client;
   final Future<void> Function()? beforeAccess;
+
+  @override
+  Future<WorkspaceStorageImpact> storageImpact({
+    required String workspaceId,
+    String? activeWorkspaceId,
+  }) async {
+    await _ensureReady();
+    final request = <String, Object?>{'id': workspaceId};
+    if (activeWorkspaceId != null) {
+      request['activeWorkspaceId'] = activeWorkspaceId;
+    }
+    final json = _asMap(
+      await _client.runtimeRequest(
+        'workspace.storageImpact',
+        request,
+        _managedWorkspaceRemoveTimeout,
+      ),
+    );
+    return WorkspaceStorageImpact(
+      workspaceId: json['workspaceId'] as String,
+      path: json['path'] as String,
+      sizeBytes: (json['sizeBytes'] as num).toInt(),
+      entryCount: (json['entryCount'] as num).toInt(),
+      measuredAt: DateTime.parse(json['measuredAt'] as String).toUtc(),
+      lastActivityAt: DateTime.parse(json['lastActivityAt'] as String).toUtc(),
+      safeToClean: json['safeToClean'] == true,
+      blockers: _stringList(json['blockers']),
+    );
+  }
 
   @override
   Future<WorkspaceCreationResult> createLinkedWorkspace({
@@ -49,9 +80,13 @@ class RuntimeManagedWorkspaceClient implements ManagedWorkspaceRuntime {
   Future<void> removeWorkspace({
     required Workspace workspace,
     bool? deleteBranch,
+    String? activeWorkspaceId,
   }) async {
     await _ensureReady();
     final request = <String, Object?>{'id': workspace.id};
+    if (activeWorkspaceId != null) {
+      request['activeWorkspaceId'] = activeWorkspaceId;
+    }
     if (deleteBranch != null) {
       request['deleteBranch'] = deleteBranch;
     }

--- a/lib/src/features/workbench/presentation/project_workbench_sidebar.dart
+++ b/lib/src/features/workbench/presentation/project_workbench_sidebar.dart
@@ -27,6 +27,8 @@ import 'package:alera/src/features/pull_requests/application/pull_request_provid
 import 'package:alera/src/shared/git_hosting/domain/git_hosting_provider.dart';
 import 'package:alera/src/features/workbench/domain/workspace_tab_record.dart';
 import 'package:alera/src/features/workbench/domain/workspace.dart';
+import 'package:alera/src/features/workbench/domain/workspace_storage_impact.dart';
+import 'package:alera/src/features/resource_manager/presentation/resource_value_format.dart';
 import 'package:alera/src/features/workbench/presentation/widgets/agent_run_state_indicator.dart';
 import 'package:alera/src/features/workbench/presentation/widgets/workspace_agent_compact_summary.dart';
 import 'package:alera/src/features/workbench/presentation/workbench_dialog_launchers.dart';

--- a/lib/src/features/workbench/presentation/project_workbench_sidebar_actions.dart
+++ b/lib/src/features/workbench/presentation/project_workbench_sidebar_actions.dart
@@ -135,20 +135,64 @@ mixin _ProjectWorkbenchSidebarActions
     }
     final branch = workspace.branch;
     final deleteBranch = !workspace.reusesExistingBranch;
-    final shouldConfirm = ref
-        .read(settingsControllerProvider)
-        .general
-        .confirmWorkspaceRemoval;
+    final managedRuntime = ref.read(managedWorkspaceRuntimeProvider);
+    WorkspaceStorageImpact? impact;
+    if (managedRuntime is WorkspaceStorageRuntime) {
+      try {
+        impact = await managedRuntime.storageImpact(
+          workspaceId: workspace.id,
+          activeWorkspaceId: ref
+              .read(workbenchControllerProvider)
+              .activeWorkspaceId,
+        );
+      } catch (error) {
+        if (!mounted) return;
+        AleraToast.show(
+          context,
+          message: 'Could not inspect workspace storage: $error',
+          tone: AleraToastTone.error,
+        );
+        return;
+      }
+      if (!mounted) return;
+      if (!impact.safeToClean) {
+        await showDialog<bool>(
+          context: context,
+          builder: (_) => AleraConfirmDialog(
+            title: 'Cleanup Unavailable',
+            message:
+                'Alera measured ${formatResourceMemory(impact!.sizeBytes)} across '
+                '${impact.entryCount} entries. Cleanup is blocked:\n\n'
+                '${impact.blockers.map((blocker) => '• $blocker').join('\n')}',
+            confirmLabel: 'Close',
+            cancelLabel: 'Cancel',
+          ),
+        );
+        return;
+      }
+    }
+    final shouldConfirm =
+        impact != null ||
+        ref.read(settingsControllerProvider).general.confirmWorkspaceRemoval;
+    final lastActivity =
+        ref.read(workspaceActivityControllerProvider)[workspace.id] ??
+        impact?.lastActivityAt ??
+        workspace.updatedAt;
+    final impactSummary = impact == null
+        ? ''
+        : 'Measured size: ${formatResourceMemory(impact.sizeBytes)} '
+              'across ${impact.entryCount} entries.\n'
+              'Last activity: ${_workspaceStorageTimestamp(lastActivity)}.\n\n';
     final confirmed = shouldConfirm
         ? await showDialog<bool>(
             context: context,
             builder: (_) => AleraConfirmDialog(
-              title: 'Remove Workspace?',
-              message: !deleteBranch || branch == null || branch.isEmpty
-                  ? 'This removes the worktree for "${workspace.name}".'
-                  : 'This removes the worktree for "${workspace.name}" and deletes '
-                        'branch "$branch".',
-              confirmLabel: 'Remove',
+              title: impact == null
+                  ? 'Remove Workspace?'
+                  : 'Clean Up Workspace?',
+              message:
+                  '$impactSummary${!deleteBranch || branch == null || branch.isEmpty ? 'This removes the worktree for "${workspace.name}".' : 'This removes the worktree for "${workspace.name}" and deletes branch "$branch".'}',
+              confirmLabel: impact == null ? 'Remove' : 'Clean Up',
               destructive: true,
             ),
           )
@@ -163,6 +207,9 @@ mixin _ProjectWorkbenchSidebarActions
             project: project,
             workspace: workspace,
             deleteBranch: deleteBranch,
+            activeWorkspaceId: ref
+                .read(workbenchControllerProvider)
+                .activeWorkspaceId,
           );
       await ref
           .read(browserSessionRegistryProvider)
@@ -188,6 +235,13 @@ mixin _ProjectWorkbenchSidebarActions
         tone: AleraToastTone.error,
       );
     }
+  }
+
+  String _workspaceStorageTimestamp(DateTime value) {
+    final local = value.toLocal();
+    String twoDigits(int part) => part.toString().padLeft(2, '0');
+    return '${local.year}-${twoDigits(local.month)}-${twoDigits(local.day)} '
+        '${twoDigits(local.hour)}:${twoDigits(local.minute)}';
   }
 
   Future<void> _manageWorkspaceTags(Workspace workspace) async {

--- a/lib/src/features/workbench/presentation/project_workbench_sidebar_actions.dart
+++ b/lib/src/features/workbench/presentation/project_workbench_sidebar_actions.dart
@@ -139,34 +139,36 @@ mixin _ProjectWorkbenchSidebarActions
     WorkspaceStorageImpact? impact;
     if (managedRuntime is WorkspaceStorageRuntime) {
       try {
-        impact = await managedRuntime.storageImpact(
-          workspaceId: workspace.id,
-          activeWorkspaceId: ref
-              .read(workbenchControllerProvider)
-              .activeWorkspaceId,
-        );
+        final measuredImpact = await (managedRuntime as WorkspaceStorageRuntime)
+            .storageImpact(
+              workspaceId: workspace.id,
+              activeWorkspaceId: ref
+                  .read(workbenchControllerProvider)
+                  .activeWorkspaceId,
+            );
+        impact = measuredImpact;
+        if (!mounted) return;
+        if (!measuredImpact.safeToClean) {
+          await showDialog<bool>(
+            context: context,
+            builder: (_) => AleraConfirmDialog(
+              title: 'Cleanup Unavailable',
+              message:
+                  'Alera measured ${formatResourceMemory(measuredImpact.sizeBytes)} across '
+                  '${measuredImpact.entryCount} entries. Cleanup is blocked:\n\n'
+                  '${measuredImpact.blockers.map((blocker) => '• $blocker').join('\n')}',
+              confirmLabel: 'Close',
+              cancelLabel: 'Cancel',
+            ),
+          );
+          return;
+        }
       } catch (error) {
         if (!mounted) return;
         AleraToast.show(
           context,
           message: 'Could not inspect workspace storage: $error',
           tone: AleraToastTone.error,
-        );
-        return;
-      }
-      if (!mounted) return;
-      if (!impact.safeToClean) {
-        await showDialog<bool>(
-          context: context,
-          builder: (_) => AleraConfirmDialog(
-            title: 'Cleanup Unavailable',
-            message:
-                'Alera measured ${formatResourceMemory(impact!.sizeBytes)} across '
-                '${impact.entryCount} entries. Cleanup is blocked:\n\n'
-                '${impact.blockers.map((blocker) => '• $blocker').join('\n')}',
-            confirmLabel: 'Close',
-            cancelLabel: 'Cancel',
-          ),
         );
         return;
       }

--- a/rust/alera-cli/src/managed_workspace.rs
+++ b/rust/alera-cli/src/managed_workspace.rs
@@ -472,7 +472,7 @@ async fn managed_workspace_removal(
     if workspace_has_active_automation_owner(store, &workspace.id).await? {
         bail!("Workspace is owned by an active automation");
     }
-    if filesystem_entry_is_missing(&workspace.path)? == false {
+    if !filesystem_entry_is_missing(&workspace.path)? {
         let registered = core_git::list_worktrees(&project.repo_path)?
             .into_iter()
             .find(|entry| path_equals(&entry.path, &workspace.path))

--- a/rust/alera-cli/src/managed_workspace.rs
+++ b/rust/alera-cli/src/managed_workspace.rs
@@ -8,12 +8,12 @@ use std::path::{Path, PathBuf};
 
 use alera_core::git::{self as core_git, GitErrorKind};
 use alera_core::runtime::{
-    Project, ProjectKind, RuntimeStore, Workspace, WorkspaceCreationResult, WorkspaceKind,
-    WorkspaceStatus, LOCAL_HOST_ID,
+    AutomationState, AutomationTarget, Project, ProjectKind, RuntimeStore, Workspace,
+    WorkspaceCreationResult, WorkspaceKind, WorkspaceStatus, LOCAL_HOST_ID,
 };
 use anyhow::{anyhow, bail, Context, Result};
 use chrono::Utc;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use crate::worktree_setup::{prepare_deferred_worktree_setup, run_worktree_setup};
@@ -56,6 +56,21 @@ pub struct ManagedWorkspaceRemoveRequest {
     pub id: String,
     #[serde(default)]
     pub delete_branch: Option<bool>,
+    #[serde(default)]
+    pub active_workspace_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkspaceStorageImpact {
+    pub workspace_id: String,
+    pub path: String,
+    pub size_bytes: u64,
+    pub entry_count: u64,
+    pub measured_at: chrono::DateTime<Utc>,
+    pub last_activity_at: chrono::DateTime<Utc>,
+    pub safe_to_clean: bool,
+    pub blockers: Vec<String>,
 }
 
 struct ManagedWorkspaceRemoval {
@@ -250,11 +265,174 @@ pub async fn remove_managed_workspace(
     Ok(workspace)
 }
 
+pub async fn workspace_has_active_automation_owner(
+    store: &RuntimeStore,
+    workspace_id: &str,
+) -> Result<bool> {
+    let definitions = store.list_automations(false).await?;
+    if definitions.iter().any(|automation| {
+        automation.state == AutomationState::Active
+            && match &automation.target {
+                AutomationTarget::ExistingTab {
+                    workspace_id: target,
+                    ..
+                }
+                | AutomationTarget::FreshTab {
+                    workspace_id: target,
+                    ..
+                } => target == workspace_id,
+                AutomationTarget::ManagedWorkspace {
+                    source_workspace_id,
+                    ..
+                } => source_workspace_id == workspace_id,
+            }
+    }) {
+        return Ok(true);
+    }
+    Ok(store
+        .list_active_automation_runs()
+        .await?
+        .iter()
+        .any(|run| {
+            run.workspace_id.as_deref() == Some(workspace_id)
+                || run
+                    .target_identity
+                    .as_ref()
+                    .and_then(|identity| identity.workspace_id.as_deref())
+                    == Some(workspace_id)
+        }))
+}
+
 pub async fn validate_managed_workspace_removal(
     store: &RuntimeStore,
     request: &ManagedWorkspaceRemoveRequest,
 ) -> Result<()> {
     managed_workspace_removal(store, request).await.map(drop)
+}
+
+/// Measures only the managed worktree itself. Directory links are counted as
+/// entries and never followed, so measurement cannot escape into source repos
+/// or network mounts through a workspace symlink.
+pub async fn measure_workspace_storage(
+    store: &RuntimeStore,
+    workspace_id: &str,
+    mut blockers: Vec<String>,
+) -> Result<WorkspaceStorageImpact> {
+    let workspace = store
+        .find_workspace(workspace_id)
+        .await?
+        .ok_or_else(|| anyhow!("Workspace not found: {workspace_id}"))?;
+    let project = store
+        .find_project(&workspace.project_id)
+        .await?
+        .ok_or_else(|| anyhow!("Project not found: {}", workspace.project_id))?;
+    if workspace.kind == WorkspaceKind::Main {
+        blockers.push("The main workspace is a source repository".to_string());
+    }
+    let path = PathBuf::from(&workspace.path);
+    if let Err(error) = validate_workspace_storage_ownership(store, &workspace, &project).await {
+        blockers.push(error.to_string());
+    }
+    let updated_at = workspace.updated_at;
+    let measured = tokio::task::spawn_blocking(move || measure_tree_without_following_links(&path))
+        .await
+        .context("workspace measurement task failed")??;
+    Ok(WorkspaceStorageImpact {
+        workspace_id: workspace.id,
+        path: workspace.path,
+        size_bytes: measured.0,
+        entry_count: measured.1,
+        measured_at: Utc::now(),
+        last_activity_at: updated_at,
+        safe_to_clean: blockers.is_empty(),
+        blockers,
+    })
+}
+
+pub async fn validate_workspace_storage_path(
+    store: &RuntimeStore,
+    workspace_id: &str,
+) -> Result<()> {
+    let workspace = store
+        .find_workspace(workspace_id)
+        .await?
+        .ok_or_else(|| anyhow!("Workspace not found: {workspace_id}"))?;
+    let project = store
+        .find_project(&workspace.project_id)
+        .await?
+        .ok_or_else(|| anyhow!("Project not found: {}", workspace.project_id))?;
+    if workspace.kind == WorkspaceKind::Main {
+        bail!("The main workspace cannot be removed");
+    }
+    validate_workspace_storage_ownership(store, &workspace, &project).await
+}
+
+fn is_host_owned_workspace_path(root: &Path, target: &Path) -> Result<bool> {
+    let root = match std::fs::canonicalize(root) {
+        Ok(root) => root,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(error) => return Err(error).context("Could not resolve managed workspace root"),
+    };
+    let metadata = match std::fs::symlink_metadata(target) {
+        Ok(metadata) => Some(metadata),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+        Err(error) => return Err(error).context("Could not inspect workspace path"),
+    };
+    if metadata
+        .as_ref()
+        .is_some_and(|metadata| metadata.file_type().is_symlink())
+    {
+        return Ok(false);
+    }
+    let resolved = match std::fs::canonicalize(target) {
+        Ok(path) => path,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            let Some(parent) = target.parent() else {
+                return Ok(false);
+            };
+            let Some(name) = target.file_name() else {
+                return Ok(false);
+            };
+            match std::fs::canonicalize(parent) {
+                Ok(parent) => parent.join(name),
+                Err(_) => return Ok(false),
+            }
+        }
+        Err(error) => return Err(error).context("Could not resolve workspace path"),
+    };
+    Ok(resolved != root && resolved.starts_with(root))
+}
+
+fn measure_tree_without_following_links(root: &Path) -> Result<(u64, u64)> {
+    let metadata = match std::fs::symlink_metadata(root) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok((0, 0)),
+        Err(error) => return Err(error.into()),
+    };
+    if metadata.file_type().is_symlink() {
+        return Ok((metadata.len(), 1));
+    }
+    let mut bytes = metadata.len();
+    let mut entries = 1;
+    let mut pending = vec![root.to_path_buf()];
+    while let Some(directory) = pending.pop() {
+        for entry in std::fs::read_dir(directory)? {
+            let entry = entry?;
+            let metadata = entry.file_type().and_then(|kind| {
+                if kind.is_symlink() {
+                    std::fs::symlink_metadata(entry.path())
+                } else {
+                    entry.metadata()
+                }
+            })?;
+            entries += 1;
+            bytes = bytes.saturating_add(metadata.len());
+            if metadata.is_dir() && !metadata.file_type().is_symlink() {
+                pending.push(entry.path());
+            }
+        }
+    }
+    Ok((bytes, entries))
 }
 
 async fn managed_workspace_removal(
@@ -267,6 +445,9 @@ async fn managed_workspace_removal(
         .ok_or_else(|| anyhow!("Workspace not found: {}", request.id))?;
     if workspace.kind == WorkspaceKind::Main {
         bail!("The main workspace cannot be removed");
+    }
+    if workspace.host_id != LOCAL_HOST_ID {
+        bail!("Workspace is not owned by the local host");
     }
     let project = store
         .find_project(&workspace.project_id)
@@ -287,11 +468,63 @@ async fn managed_workspace_removal(
     } else {
         None
     };
+    validate_workspace_storage_ownership(store, &workspace, &project).await?;
+    if workspace_has_active_automation_owner(store, &workspace.id).await? {
+        bail!("Workspace is owned by an active automation");
+    }
+    if filesystem_entry_is_missing(&workspace.path)? == false {
+        let registered = core_git::list_worktrees(&project.repo_path)?
+            .into_iter()
+            .find(|entry| path_equals(&entry.path, &workspace.path))
+            .ok_or_else(|| anyhow!("Workspace path is not a registered Git worktree"))?;
+        if let Some(expected_branch) = workspace.branch.as_deref() {
+            if registered.branch != expected_branch {
+                bail!(
+                    "Workspace branch does not match registered worktree: expected {expected_branch}, found {}",
+                    registered.branch
+                );
+            }
+        }
+    }
     Ok(ManagedWorkspaceRemoval {
         workspace,
         project,
         branch_to_delete,
     })
+}
+
+async fn validate_workspace_storage_ownership(
+    store: &RuntimeStore,
+    workspace: &Workspace,
+    project: &Project,
+) -> Result<()> {
+    if workspace.host_id != LOCAL_HOST_ID {
+        bail!("Workspace is not owned by the local host");
+    }
+    let root = store
+        .get_workspace_directory()
+        .await?
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(default_workspace_root);
+    if path_equals(&workspace.path, &project.repo_path)
+        || !is_host_owned_workspace_path(Path::new(&root), Path::new(&workspace.path))?
+    {
+        bail!("Workspace path is outside Alera-managed storage");
+    }
+    if store
+        .list_projects()
+        .await?
+        .iter()
+        .any(|candidate| path_equals(&candidate.repo_path, &workspace.path))
+    {
+        bail!("Workspace path is registered as a project source repository");
+    }
+    if store.list_all_workspaces().await?.iter().any(|candidate| {
+        candidate.id != workspace.id && path_equals(&candidate.path, &workspace.path)
+    }) {
+        bail!("Workspace path has another runtime owner");
+    }
+    Ok(())
 }
 
 fn filesystem_entry_is_missing(path: &str) -> Result<bool> {

--- a/rust/alera-cli/src/managed_workspace_removal_tests.rs
+++ b/rust/alera-cli/src/managed_workspace_removal_tests.rs
@@ -2,12 +2,16 @@ use std::path::Path;
 use std::process::Command as StdCommand;
 
 use alera_core::runtime::{
-    Project, ProjectKind, RuntimeStore, Workspace, WorkspaceKind, WorkspaceStatus, LOCAL_HOST_ID,
+    AutomationActor, AutomationActorKind, AutomationDefinition, AutomationMisfirePolicy,
+    AutomationOccurrence, AutomationOverlapPolicy, AutomationRunTrigger, AutomationSchedule,
+    AutomationSetupPolicy, AutomationState, AutomationTarget, Project, ProjectKind, RuntimeStore,
+    Workspace, WorkspaceKind, WorkspaceStatus, LOCAL_HOST_ID,
 };
 use chrono::Utc;
 
 use crate::managed_workspace::{
-    create_managed_workspace, remove_managed_workspace, validate_managed_workspace_removal,
+    create_managed_workspace, measure_workspace_storage, remove_managed_workspace,
+    validate_managed_workspace_removal, validate_workspace_storage_path,
     ManagedWorkspaceCreateRequest, ManagedWorkspaceRemoveRequest,
 };
 
@@ -48,6 +52,7 @@ async fn rejects_main_workspace_during_removal_validation() {
         &ManagedWorkspaceRemoveRequest {
             id: "main-workspace".to_string(),
             delete_branch: None,
+            active_workspace_id: None,
         },
     )
     .await
@@ -105,10 +110,193 @@ async fn preserves_unregistered_filesystem_entry() {
 
     let error = fixture.remove_managed_workspace().await.unwrap_err();
 
-    assert!(error.to_string().contains("git worktree remove failed"));
+    assert!(error.to_string().contains("not a registered Git worktree"));
     assert!(sentinel.exists());
     assert!(fixture.workspace_record().await.is_some());
     assert!(fixture.branch_exists());
+}
+
+#[tokio::test]
+async fn rejects_workspace_path_outside_host_owned_root() {
+    let fixture = RemovalFixture::new("contained").await;
+    let outside = fixture._root.path().join("outside");
+    std::fs::create_dir_all(&outside).unwrap();
+    let mut workspace = fixture.workspace_record().await.unwrap();
+    workspace.path = outside.to_string_lossy().into_owned();
+    fixture.store.upsert_workspace(workspace).await.unwrap();
+
+    let error = validate_workspace_storage_path(&fixture.store, &fixture.workspace_id)
+        .await
+        .unwrap_err();
+
+    assert!(error.to_string().contains("outside Alera-managed storage"));
+    assert!(outside.exists());
+}
+
+#[tokio::test]
+async fn removal_rechecks_path_containment_at_destructive_boundary() {
+    let fixture = RemovalFixture::new("moved-outside").await;
+    let outside = fixture._root.path().join("outside-removal");
+    std::fs::create_dir_all(&outside).unwrap();
+    let sentinel = outside.join("keep.txt");
+    std::fs::write(&sentinel, "keep").unwrap();
+    let mut workspace = fixture.workspace_record().await.unwrap();
+    workspace.path = outside.to_string_lossy().into_owned();
+    fixture.store.upsert_workspace(workspace).await.unwrap();
+
+    let error = fixture.remove_managed_workspace().await.unwrap_err();
+
+    assert!(error.to_string().contains("outside Alera-managed storage"));
+    assert!(sentinel.exists());
+    assert!(fixture.workspace_record().await.is_some());
+}
+
+#[tokio::test]
+async fn rejects_path_registered_as_another_project_source() {
+    let fixture = RemovalFixture::new("second-source").await;
+    let now = Utc::now();
+    fixture
+        .store
+        .upsert_project(Project {
+            id: "project-2".to_string(),
+            name: "Second".to_string(),
+            repo_path: fixture.worktree_path.to_string_lossy().into_owned(),
+            created_at: now,
+            updated_at: now,
+            kind: ProjectKind::GitRepository,
+        })
+        .await
+        .unwrap();
+
+    let error = fixture.remove_managed_workspace().await.unwrap_err();
+
+    assert!(error
+        .to_string()
+        .contains("registered as a project source repository"));
+    assert!(fixture.worktree_path.exists());
+    assert!(fixture.workspace_record().await.is_some());
+}
+
+#[tokio::test]
+async fn rejects_stale_branch_identity_before_cleanup() {
+    let fixture = RemovalFixture::new("stale-branch").await;
+    let mut workspace = fixture.workspace_record().await.unwrap();
+    workspace.branch = Some("main".to_string());
+    fixture.store.upsert_workspace(workspace).await.unwrap();
+
+    let error = fixture.remove_managed_workspace().await.unwrap_err();
+
+    assert!(error.to_string().contains("branch does not match"));
+    assert!(fixture.worktree_path.exists());
+    assert!(fixture.branch_exists());
+}
+
+#[tokio::test]
+async fn rejects_workspace_owned_by_another_host() {
+    let fixture = RemovalFixture::new("remote-host").await;
+    let mut workspace = fixture.workspace_record().await.unwrap();
+    workspace.host_id = "remote".to_string();
+    fixture.store.upsert_workspace(workspace).await.unwrap();
+
+    let error = fixture.remove_managed_workspace().await.unwrap_err();
+
+    assert!(error.to_string().contains("not owned by the local host"));
+    assert!(fixture.worktree_path.exists());
+}
+
+#[tokio::test]
+async fn rejects_workspace_owned_by_an_active_automation_run() {
+    let fixture = RemovalFixture::new("automation-run").await;
+    let definition = automation_definition(&fixture.workspace_id);
+    let actor = definition.created_by.clone();
+    fixture
+        .store
+        .upsert_automation(definition.clone(), actor)
+        .await
+        .unwrap();
+    fixture
+        .store
+        .create_automation_run(
+            &definition,
+            &AutomationOccurrence {
+                automation_id: definition.id.clone(),
+                key: "manual|cleanup-owner".to_string(),
+                scheduled_at: Utc::now(),
+                local_time: "UTC".to_string(),
+            },
+            AutomationRunTrigger::Manual,
+        )
+        .await
+        .unwrap();
+
+    let error = fixture.remove_managed_workspace().await.unwrap_err();
+
+    assert!(error.to_string().contains("active automation"));
+    assert!(fixture.worktree_path.exists());
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn measurement_does_not_follow_workspace_symlinks() {
+    use std::os::unix::fs::symlink;
+
+    let fixture = RemovalFixture::new("linked-entry").await;
+    let outside = fixture._root.path().join("outside-large");
+    std::fs::create_dir_all(&outside).unwrap();
+    std::fs::write(outside.join("large.bin"), vec![0_u8; 256 * 1024]).unwrap();
+    symlink(&outside, fixture.worktree_path.join("external")).unwrap();
+
+    let impact = measure_workspace_storage(&fixture.store, &fixture.workspace_id, Vec::new())
+        .await
+        .unwrap();
+
+    assert!(impact.safe_to_clean);
+    assert!(impact.size_bytes < 256 * 1024);
+}
+
+#[tokio::test]
+async fn active_workspace_blocker_disables_cleanup() {
+    let fixture = RemovalFixture::new("active").await;
+
+    let impact = measure_workspace_storage(
+        &fixture.store,
+        &fixture.workspace_id,
+        vec!["Workspace is active in the workbench".to_string()],
+    )
+    .await
+    .unwrap();
+
+    assert!(!impact.safe_to_clean);
+    assert_eq!(impact.blockers, ["Workspace is active in the workbench"]);
+}
+
+#[tokio::test]
+async fn missing_orphaned_worktree_is_measured_as_zero_and_remains_cleanable() {
+    let fixture = RemovalFixture::new("orphaned").await;
+    fixture.remove_worktree();
+
+    let impact = measure_workspace_storage(&fixture.store, &fixture.workspace_id, Vec::new())
+        .await
+        .unwrap();
+
+    assert!(impact.safe_to_clean);
+    assert_eq!(impact.size_bytes, 0);
+    assert_eq!(impact.entry_count, 0);
+}
+
+#[tokio::test]
+async fn successful_cleanup_after_safe_impact_removes_worktree_and_record() {
+    let fixture = RemovalFixture::new("cleanup").await;
+    let impact = measure_workspace_storage(&fixture.store, &fixture.workspace_id, Vec::new())
+        .await
+        .unwrap();
+    assert!(impact.safe_to_clean);
+
+    fixture.remove_managed_workspace().await.unwrap();
+
+    assert!(!fixture.worktree_path.exists());
+    assert!(fixture.workspace_record().await.is_none());
+    assert!(!fixture.branch_exists());
 }
 
 struct RemovalFixture {
@@ -193,6 +381,7 @@ impl RemovalFixture {
             ManagedWorkspaceRemoveRequest {
                 id: self.workspace_id.clone(),
                 delete_branch,
+                active_workspace_id: None,
             },
         )
         .await
@@ -201,6 +390,12 @@ impl RemovalFixture {
 
 async fn seed_project(root: &Path, repo: &Path) -> RuntimeStore {
     let store = RuntimeStore::open(&root.join("runtime")).await.unwrap();
+    let workspace_root = root.join("workspaces");
+    std::fs::create_dir_all(&workspace_root).unwrap();
+    store
+        .set_workspace_directory(Some(&workspace_root.to_string_lossy()))
+        .await
+        .unwrap();
     let now = Utc::now();
     store
         .upsert_project(Project {
@@ -214,6 +409,54 @@ async fn seed_project(root: &Path, repo: &Path) -> RuntimeStore {
         .await
         .unwrap();
     store
+}
+
+fn automation_definition(workspace_id: &str) -> AutomationDefinition {
+    let now = Utc::now();
+    let actor = AutomationActor {
+        kind: AutomationActorKind::LocalCli,
+        id: None,
+        label: None,
+    };
+    AutomationDefinition {
+        id: "cleanup-owner".to_string(),
+        slug: "cleanup-owner".to_string(),
+        name: "Cleanup Owner".to_string(),
+        description: String::new(),
+        project_id: None,
+        tag_ids: Vec::new(),
+        prompt_template: "Run".to_string(),
+        schedule: AutomationSchedule::OneTime {
+            at: now + chrono::Duration::hours(1),
+            timezone: "UTC".to_string(),
+        },
+        target: AutomationTarget::FreshTab {
+            workspace_id: workspace_id.to_string(),
+            agent_profile_id: "profile".to_string(),
+        },
+        setup_policy: AutomationSetupPolicy::Wait,
+        cleanup_policy: None,
+        overlap_policy: AutomationOverlapPolicy::Skip,
+        queue_cap: 10,
+        inactivity_timeout_seconds: 7200,
+        heartbeat_interval_seconds: 60,
+        misfire_grace_seconds: 900,
+        misfire_policy: AutomationMisfirePolicy::Skip,
+        retry_max_attempts: 3,
+        retry_backoff_seconds: 60,
+        circuit_failure_threshold: 3,
+        circuit_open_seconds: 900,
+        precheck: None,
+        notify_on_success: false,
+        circuit_opened: false,
+        state: AutomationState::Draft,
+        revision: 1,
+        approved_revision: None,
+        created_by: actor.clone(),
+        modified_by: actor,
+        created_at: now,
+        updated_at: now,
+    }
 }
 
 fn init_git_repo(repo: &Path) {

--- a/rust/alera-cli/src/terminal_host/server.rs
+++ b/rust/alera-cli/src/terminal_host/server.rs
@@ -505,6 +505,11 @@ impl ServerActor {
                 self.handle_managed_workspace_created(client_id, request_id, result)
                     .await
             }
+            ServerCommand::WorkspaceStorageMeasured {
+                client_id,
+                request_id,
+                result,
+            } => self.handle_workspace_storage_measured(client_id, request_id, result),
             ServerCommand::WorkspaceSetupFinished {
                 client_id,
                 request_id,

--- a/rust/alera-cli/src/terminal_host/server/automation_dispatch.rs
+++ b/rust/alera-cli/src/terminal_host/server/automation_dispatch.rs
@@ -31,6 +31,12 @@ fn next_due_occurrence(
 
 impl ServerActor {
     pub(super) async fn handle_automation_tick(&mut self) {
+        // Runtime mutations may delete a workspace on a worker while this
+        // actor remains responsive. Do not create a new durable run or owner
+        // after the mutation's ownership checks have started.
+        if self.emulator_requests.has_runtime_mutations() {
+            return;
+        }
         let maintenance_now = Utc::now();
         if let Err(error) = self
             .runtime_store

--- a/rust/alera-cli/src/terminal_host/server/automation_run_target_requests.rs
+++ b/rust/alera-cli/src/terminal_host/server/automation_run_target_requests.rs
@@ -136,11 +136,45 @@ impl ServerActor {
         }
         if safe_workspace_cleanup {
             if let Some(workspace_id) = &run.workspace_id {
+                let has_live_session = self
+                    .sessions
+                    .values()
+                    .any(|session| session.workspace_id == *workspace_id && session.running());
+                let has_live_browser = self.browser.has_pages_for_workspace(workspace_id);
+                if has_live_session
+                    || has_live_browser
+                    || self.emulator_requests.has_runtime_mutations()
+                {
+                    let reason = if has_live_session {
+                        "managed workspace still has a live terminal session or process"
+                    } else if has_live_browser {
+                        "managed workspace still has a live browser session"
+                    } else {
+                        "another runtime mutation is in progress"
+                    };
+                    let _ = self
+                        .runtime_store
+                        .insert_automation_audit_event(
+                            Some(&run.automation_id),
+                            Some(&run.id),
+                            "cleanupPreserved",
+                            AutomationActor {
+                                kind: AutomationActorKind::ManagedAgent,
+                                id: run.actor_id.clone(),
+                                label: Some("automation cleanup guard".to_string()),
+                            },
+                            None,
+                            Value::String(reason.to_string()),
+                        )
+                        .await;
+                    return;
+                }
                 let _ = crate::managed_workspace::remove_managed_workspace(
                     &self.runtime_store,
                     crate::managed_workspace::ManagedWorkspaceRemoveRequest {
                         id: workspace_id.clone(),
                         delete_branch: Some(true),
+                        active_workspace_id: None,
                     },
                 )
                 .await;

--- a/rust/alera-cli/src/terminal_host/server/browser_broker.rs
+++ b/rust/alera-cli/src/terminal_host/server/browser_broker.rs
@@ -154,6 +154,12 @@ impl BrowserBroker {
         pages
     }
 
+    pub(super) fn has_pages_for_workspace(&self, workspace_id: &str) -> bool {
+        self.pages
+            .values()
+            .any(|page| page.workspace_id == workspace_id)
+    }
+
     pub(super) fn register_driver(&mut self, driver: BrowserDriver) -> BrowserDrain {
         let drain = self.remove_driver(driver.owner_client_id);
         self.drivers.insert(driver.owner_client_id, driver);

--- a/rust/alera-cli/src/terminal_host/server/coordinator_requests.rs
+++ b/rust/alera-cli/src/terminal_host/server/coordinator_requests.rs
@@ -259,6 +259,12 @@ impl ServerActor {
     /// process messages -> re-assert gate blocks -> warn stale dispatches ->
     /// dispatch ready tasks -> check convergence.
     pub(super) async fn handle_coordinator_tick(&mut self, run_id: String) {
+        // A queued runtime mutation may be removing the coordinator's target
+        // workspace on another task. The periodic ticker will retry after the
+        // mutation completes.
+        if self.emulator_requests.has_runtime_mutations() {
+            return;
+        }
         let Some(handle) = self.coordinators.get(&run_id) else {
             return;
         };

--- a/rust/alera-cli/src/terminal_host/server/coordinator_requests.rs
+++ b/rust/alera-cli/src/terminal_host/server/coordinator_requests.rs
@@ -259,9 +259,6 @@ impl ServerActor {
     /// process messages -> re-assert gate blocks -> warn stale dispatches ->
     /// dispatch ready tasks -> check convergence.
     pub(super) async fn handle_coordinator_tick(&mut self, run_id: String) {
-        // A queued runtime mutation may be removing the coordinator's target
-        // workspace on another task. The periodic ticker will retry after the
-        // mutation completes.
         if self.emulator_requests.has_runtime_mutations() {
             return;
         }

--- a/rust/alera-cli/src/terminal_host/server/deferred_requests.rs
+++ b/rust/alera-cli/src/terminal_host/server/deferred_requests.rs
@@ -75,13 +75,63 @@ impl ServerActor {
                 self.start_workspace_setup(client_id, request_id, workspace_id, copies_only);
                 Ok(true)
             }
+            "workspace.storageImpact" => {
+                self.require_auth(client_id)?;
+                self.require_request_allowed(client_id, request_type)?;
+                let workspace_id = require_string_key(payload, "id")?;
+                let active_workspace_id = payload
+                    .get("activeWorkspaceId")
+                    .and_then(Value::as_str)
+                    .filter(|value| !value.trim().is_empty())
+                    .map(str::to_string);
+                self.start_workspace_storage_measurement(
+                    client_id,
+                    request_id,
+                    workspace_id,
+                    active_workspace_id,
+                );
+                Ok(true)
+            }
             "workspace.removeManaged" => {
                 self.require_auth(client_id)?;
                 self.require_request_allowed(client_id, request_type)?;
                 let request: ManagedWorkspaceRemoveRequest = parse_payload(payload)?;
+                if request.active_workspace_id.as_deref() == Some(request.id.as_str()) {
+                    return Err(HostError::state("Workspace is active in the workbench"));
+                }
+                if self
+                    .sessions
+                    .values()
+                    .any(|session| session.workspace_id == request.id && session.running())
+                {
+                    return Err(HostError::state(
+                        "Workspace has a live terminal session or process",
+                    ));
+                }
+                if self.browser.has_pages_for_workspace(&request.id) {
+                    return Err(HostError::state("Workspace has a live browser session"));
+                }
+                let has_active_automation =
+                    crate::managed_workspace::workspace_has_active_automation_owner(
+                        &self.runtime_store,
+                        &request.id,
+                    )
+                    .await
+                    .map_err(|error| HostError::state(error.to_string()))?;
+                if has_active_automation {
+                    return Err(HostError::state(
+                        "Workspace is owned by an active automation",
+                    ));
+                }
                 crate::managed_workspace::validate_managed_workspace_removal(
                     &self.runtime_store,
                     &request,
+                )
+                .await
+                .map_err(|error| HostError::state(error.to_string()))?;
+                crate::managed_workspace::validate_workspace_storage_path(
+                    &self.runtime_store,
+                    &request.id,
                 )
                 .await
                 .map_err(|error| HostError::state(error.to_string()))?;

--- a/rust/alera-cli/src/terminal_host/server/managed_workspace_requests.rs
+++ b/rust/alera-cli/src/terminal_host/server/managed_workspace_requests.rs
@@ -6,7 +6,10 @@
 
 use serde_json::Value;
 
-use crate::managed_workspace::{create_managed_workspace, ManagedWorkspaceCreateRequest};
+use crate::managed_workspace::{
+    create_managed_workspace, measure_workspace_storage, workspace_has_active_automation_owner,
+    ManagedWorkspaceCreateRequest,
+};
 use crate::terminal_host::host_error::HostResult;
 use crate::terminal_host::protocol::{error_response, ok_response};
 use crate::worktree_setup::run_workspace_setup;
@@ -16,6 +19,61 @@ use super::runtime_change_broadcasts::string_scope;
 use super::{ServerActor, ServerCommand};
 
 impl ServerActor {
+    pub(super) fn start_workspace_storage_measurement(
+        &mut self,
+        client_id: u64,
+        request_id: i64,
+        workspace_id: String,
+        active_workspace_id: Option<String>,
+    ) {
+        let mut blockers = Vec::new();
+        if active_workspace_id.as_deref() == Some(workspace_id.as_str()) {
+            blockers.push("Workspace is active in the workbench".to_string());
+        }
+        if self
+            .sessions
+            .values()
+            .any(|session| session.workspace_id == workspace_id && session.running())
+        {
+            blockers.push("Workspace has a live terminal session or process".to_string());
+        }
+        if self.browser.has_pages_for_workspace(&workspace_id) {
+            blockers.push("Workspace has a live browser session".to_string());
+        }
+        self.managed_workspace_jobs += 1;
+        self.cancel_shutdown_timer();
+        let store = self.runtime_store.clone();
+        let inbox = self.inbox.clone();
+        tokio::spawn(async move {
+            match workspace_has_active_automation_owner(&store, &workspace_id).await {
+                Ok(true) => blockers.push("Workspace is owned by an active automation".to_string()),
+                Err(error) => blockers.push(format!("Could not verify automations: {error}")),
+                _ => {}
+            }
+            let result =
+                json_result(measure_workspace_storage(&store, &workspace_id, blockers).await);
+            let _ = inbox.send(ServerCommand::WorkspaceStorageMeasured {
+                client_id,
+                request_id,
+                result,
+            });
+        });
+    }
+
+    pub(super) fn handle_workspace_storage_measured(
+        &mut self,
+        client_id: u64,
+        request_id: i64,
+        result: HostResult<Value>,
+    ) {
+        self.managed_workspace_jobs = self.managed_workspace_jobs.saturating_sub(1);
+        match result {
+            Ok(payload) => self.client_write(client_id, ok_response(request_id, payload)),
+            Err(error) => self.client_write(client_id, error_response(request_id, &error)),
+        }
+        self.schedule_shutdown_if_idle();
+    }
+
     /// Where deferred setup scripts are written: next to the control file, the
     /// host's own on-disk state, so a sweep at startup can clear leftovers.
     pub(super) fn setup_script_directory(&self) -> Option<std::path::PathBuf> {

--- a/rust/alera-cli/src/terminal_host/server/mobile_gateway_surface.rs
+++ b/rust/alera-cli/src/terminal_host/server/mobile_gateway_surface.rs
@@ -106,6 +106,7 @@ pub(super) fn mobile_request_allowed(request_type: &str) -> bool {
             | "workspace.sleep"
             | "workspace.repositoryWebUrl"
             | "workspace.createManaged"
+            | "workspace.storageImpact"
             | "workspace.removeManaged"
             | "agentProfile.list"
             | "agentProfile.launch"

--- a/rust/alera-cli/src/terminal_host/server/requests/tests.rs
+++ b/rust/alera-cli/src/terminal_host/server/requests/tests.rs
@@ -222,6 +222,7 @@ async fn authenticated_mobile_client_can_request_a_safe_runtime_restart() {
 fn mobile_allowlist_includes_workspace_mutations() {
     assert!(mobile_request_allowed("workspace.setPinned"));
     assert!(mobile_request_allowed("workspace.createManaged"));
+    assert!(mobile_request_allowed("workspace.storageImpact"));
     assert!(mobile_request_allowed("workspace.removeManaged"));
     assert!(mobile_request_allowed("workspaceRelation.link"));
     assert!(mobile_request_allowed("workspaceRelation.unlink"));

--- a/rust/alera-cli/src/terminal_host/server/runtime_mutation_barrier.rs
+++ b/rust/alera-cli/src/terminal_host/server/runtime_mutation_barrier.rs
@@ -67,6 +67,12 @@ pub(super) fn conflicts_with_runtime_mutation(request_type: &str) -> bool {
                 | "browser.closedTabs.reopen"
                 | "browser.driver.sync"
                 | "browser.driver.pageChanged"
+                | "automation.upsert"
+                | "automation.approve"
+                | "automation.resume"
+                | "automation.restore"
+                | "automation.runNow"
+                | "automation.import"
         )
         || matches!(
             request_type,
@@ -128,6 +134,12 @@ mod tests {
             "browser.closedTabs.reopen",
             "browser.driver.sync",
             "browser.driver.pageChanged",
+            "automation.upsert",
+            "automation.approve",
+            "automation.resume",
+            "automation.restore",
+            "automation.runNow",
+            "automation.import",
         ] {
             assert!(
                 conflicts_with_runtime_mutation(writer),

--- a/rust/alera-cli/src/terminal_host/server/server_command.rs
+++ b/rust/alera-cli/src/terminal_host/server/server_command.rs
@@ -74,6 +74,11 @@ pub enum ServerCommand {
         request_id: i64,
         result: HostResult<Value>,
     },
+    WorkspaceStorageMeasured {
+        client_id: u64,
+        request_id: i64,
+        result: HostResult<Value>,
+    },
     WorkspaceSetupFinished {
         client_id: u64,
         request_id: i64,

--- a/rust/alera-cli/src/terminal_host/server/terminal_spawn.rs
+++ b/rust/alera-cli/src/terminal_host/server/terminal_spawn.rs
@@ -275,6 +275,15 @@ impl ServerActor {
         initial_output_stream_bytes: u64,
         forced_agent_hook: Option<&str>,
     ) -> HostResult<()> {
+        // This is the final owner-creation boundary for client, automation,
+        // and orchestration launches. Runtime mutations perform filesystem
+        // cleanup concurrently with the actor, so no new terminal owner may
+        // cross this fence while one is outstanding.
+        if self.emulator_requests.has_runtime_mutations() {
+            return Err(HostError::state(
+                "A runtime mutation is in progress. Wait for it to finish and retry.",
+            ));
+        }
         self.disarm_terminal_pulse(&session_id);
         self.account_push.damper.reset_session(&session_id);
         let mut agent_settings = self

--- a/test/unit/runtime_managed_workspace_client_test_cases.dart
+++ b/test/unit/runtime_managed_workspace_client_test_cases.dart
@@ -6,6 +6,38 @@ part of 'runtime_repositories_test.dart';
 /// Split out of `runtime_repositories_test.dart`, which covers the rest of the
 /// runtime-host backed repositories.
 void _registerRuntimeManagedWorkspaceClientTests() {
+  test('RuntimeManagedWorkspaceClient parses storage impact', () async {
+    final client = _FakeRuntimeHostClient();
+    final repository = RuntimeManagedWorkspaceClient(client);
+    client.responses['workspace.storageImpact'] = <String, Object?>{
+      'workspaceId': 'workspace-1',
+      'path': '/managed/workspace-1',
+      'sizeBytes': 4096,
+      'entryCount': 12,
+      'measuredAt': '2026-08-22T10:00:00Z',
+      'lastActivityAt': '2026-08-21T09:00:00Z',
+      'safeToClean': false,
+      'blockers': <String>['Workspace is active in the workbench'],
+    };
+
+    final impact = await repository.storageImpact(
+      workspaceId: 'workspace-1',
+      activeWorkspaceId: 'workspace-1',
+    );
+
+    expect(impact.sizeBytes, 4096);
+    expect(impact.entryCount, 12);
+    expect(impact.safeToClean, isFalse);
+    expect(impact.blockers, <String>['Workspace is active in the workbench']);
+    expect(
+      client.payloads['workspace.storageImpact']!.single,
+      <String, Object?>{
+        'id': 'workspace-1',
+        'activeWorkspaceId': 'workspace-1',
+      },
+    );
+  });
+
   test(
     'RuntimeManagedWorkspaceClient uses long-running RPC timeouts',
     () async {
@@ -25,6 +57,7 @@ void _registerRuntimeManagedWorkspaceClientTests() {
       await repository.removeWorkspace(
         workspace: _workspace(id: 'workspace-1', projectId: 'project-1'),
         deleteBranch: true,
+        activeWorkspaceId: 'workspace-2',
       );
 
       expect(client.timeouts['workspace.createManaged'], <Duration?>[
@@ -33,6 +66,14 @@ void _registerRuntimeManagedWorkspaceClientTests() {
       expect(client.timeouts['workspace.removeManaged'], <Duration?>[
         const Duration(minutes: 10),
       ]);
+      expect(
+        client.payloads['workspace.removeManaged']!.single,
+        <String, Object?>{
+          'id': 'workspace-1',
+          'activeWorkspaceId': 'workspace-2',
+          'deleteBranch': true,
+        },
+      );
     },
   );
 

--- a/test/unit/workbench_controller_create_workspace_test_cases.dart
+++ b/test/unit/workbench_controller_create_workspace_test_cases.dart
@@ -237,6 +237,7 @@ class _ManagedWorkspaceRuntimeWithoutWatcher
   Future<void> removeWorkspace({
     required Workspace workspace,
     bool? deleteBranch,
+    String? activeWorkspaceId,
   }) async {}
 }
 
@@ -280,5 +281,6 @@ class _ManagedWorkspaceRuntimeWithDeferredSetup
   Future<void> removeWorkspace({
     required Workspace workspace,
     bool? deleteBranch,
+    String? activeWorkspaceId,
   }) async {}
 }

--- a/test/unit/workspace_service_test_harness.dart
+++ b/test/unit/workspace_service_test_harness.dart
@@ -155,6 +155,7 @@ class _FakeManagedWorkspaceRuntime implements ManagedWorkspaceRuntime {
   Future<void> removeWorkspace({
     required Workspace workspace,
     bool? deleteBranch,
+    String? activeWorkspaceId,
   }) async {
     removedWorkspace = workspace;
     this.deleteBranch = deleteBranch;

--- a/test/widget/alera_shell_page_runtime_test_harness.dart
+++ b/test/widget/alera_shell_page_runtime_test_harness.dart
@@ -21,6 +21,42 @@ class _ShellPumpHarness {
   final _ShellTestAgentStatusController agentStatus;
 }
 
+class _FakeManagedWorkspaceRuntime
+    implements ManagedWorkspaceRuntime, WorkspaceStorageRuntime {
+  const _FakeManagedWorkspaceRuntime();
+
+  @override
+  Future<WorkspaceCreationResult> createLinkedWorkspace({
+    required Project project,
+    required String sourceBranch,
+    required String newBranchName,
+    required bool reuseExistingBranch,
+    String? name,
+  }) => throw UnsupportedError('Workspace creation is not used by shell tests');
+
+  @override
+  Future<void> removeWorkspace({
+    required Workspace workspace,
+    bool? deleteBranch,
+    String? activeWorkspaceId,
+  }) async {}
+
+  @override
+  Future<WorkspaceStorageImpact> storageImpact({
+    required String workspaceId,
+    String? activeWorkspaceId,
+  }) async => WorkspaceStorageImpact(
+    workspaceId: workspaceId,
+    path: '/host-owned/workspaces/$workspaceId',
+    sizeBytes: 4096,
+    entryCount: 3,
+    measuredAt: DateTime.utc(2026, 8, 22, 12),
+    lastActivityAt: DateTime.utc(2026, 8, 22, 11),
+    safeToClean: true,
+    blockers: const <String>[],
+  );
+}
+
 class _FakeTerminalRuntime implements TerminalRuntime {
   final Map<String, _FakeTerminalSessionHandle> _sessions =
       <String, _FakeTerminalSessionHandle>{};

--- a/test/widget/alera_shell_page_sidebar_actions_test_cases.dart
+++ b/test/widget/alera_shell_page_sidebar_actions_test_cases.dart
@@ -461,7 +461,7 @@ void _registerAleraShellSidebarActionTests() {
     await tester.pumpAndSettle();
     await tester.tap(find.text('Remove'));
     await tester.pumpAndSettle();
-    await tester.tap(find.widgetWithText(FilledButton, 'Remove'));
+    await tester.tap(find.widgetWithText(FilledButton, 'Clean Up'));
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 300));
 

--- a/test/widget/alera_shell_page_sidebar_states_test_cases.dart
+++ b/test/widget/alera_shell_page_sidebar_states_test_cases.dart
@@ -150,7 +150,7 @@ void _registerAleraShellSidebarStateTests() {
     await tester.pumpAndSettle();
 
     expect(
-      find.text('This removes the worktree for "Feature login".'),
+      find.textContaining('This removes the worktree for "Feature login".'),
       findsOneWidget,
     );
     expect(find.textContaining('deletes branch'), findsNothing);
@@ -491,7 +491,7 @@ void _registerAleraShellSidebarStateTests() {
     await tester.pumpAndSettle();
     await tester.tap(find.text('Remove'));
     await tester.pumpAndSettle();
-    await tester.tap(find.widgetWithText(FilledButton, 'Remove'));
+    await tester.tap(find.widgetWithText(FilledButton, 'Clean Up'));
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 300));
 

--- a/test/widget/alera_shell_page_test.dart
+++ b/test/widget/alera_shell_page_test.dart
@@ -16,10 +16,13 @@ import 'package:alera/src/features/workbench/application/workbench_state.dart';
 import 'package:alera/src/features/workbench/application/workspace_file_service.dart';
 import 'package:alera/src/features/workbench/application/workspace_folder_opener.dart';
 import 'package:alera/src/features/workbench/application/workspace_graph_repository.dart';
+import 'package:alera/src/features/workbench/application/workspace_service.dart';
 import 'package:alera/src/features/workbench/domain/workspace_tab_record.dart';
 import 'package:alera/src/features/workbench/domain/workbench_layout.dart';
 import 'package:alera/src/features/workbench/domain/workbench_view_prefs.dart';
 import 'package:alera/src/features/workbench/domain/workspace.dart';
+import 'package:alera/src/features/workbench/domain/workspace_creation_result.dart';
+import 'package:alera/src/features/workbench/domain/workspace_storage_impact.dart';
 import 'package:alera/src/features/workbench/presentation/terminal_runtime.dart';
 import 'package:alera/src/features/workbench/presentation/widgets/agent_run_spinner_scope.dart';
 import 'package:alera/src/features/workbench/presentation/project_workbench_sidebar.dart';
@@ -78,6 +81,9 @@ Future<_ShellPumpHarness> _pumpShell(
         agentQuotaStateProvider.overrideWith(
           (ref) async =>
               AgentQuotaState.empty(state.activeWorkspace?.hostId ?? 'local'),
+        ),
+        managedWorkspaceRuntimeProvider.overrideWithValue(
+          const _FakeManagedWorkspaceRuntime(),
         ),
         terminalRuntimeProvider.overrideWith((ref) => runtime),
         if (editorSessionRegistry != null)

--- a/test/widget/alera_shell_page_test_harness.dart
+++ b/test/widget/alera_shell_page_test_harness.dart
@@ -252,6 +252,7 @@ class _ShellTestWorkbenchController extends WorkbenchController {
     required Project project,
     required Workspace workspace,
     bool deleteBranch = true,
+    String? activeWorkspaceId,
   }) async {
     if (deleteWorkspaceFailure case final Object failure) {
       throw failure;


### PR DESCRIPTION
## Summary

- measure managed workspace storage on demand in a blocking worker, then show estimated size and last activity before a required cleanup confirmation
- restrict cleanup to local host-owned managed worktrees using canonical containment, non-followed symlinks, project source and duplicate-owner checks, and Git worktree/branch identity validation
- reject active workspaces, live terminal/process/browser sessions, active automation definitions or runs, and owner creation races while cleanup is queued
- keep cleanup manual and recoverable: remove the registered Git worktree and optional branch before deleting runtime records, preserving records when filesystem or Git cleanup fails

## Measurement semantics

The reported size is an estimate based on filesystem metadata. It may differ from reclaimed physical disk space because of sparse files, compression, deduplication, copy-on-write clones, block sizes, hard links, concurrent changes, and platform-specific directory/reparse-point behavior. Directory symlinks are counted but never traversed. Full platform limitations are documented in `docs/workspace-storage.md`.

## Validation

- `cargo test -p alera-cli -- managed_workspace_removal_tests` - 15 passed
- `cargo test -p alera-cli -- runtime_mutation_barrier` - 1 passed
- `cargo fmt --all -- --check`
- `git diff --check origin/main..HEAD`
- Oracle follow-up review found no remaining blockers in the ownership race or internal automation cleanup paths

## Environment limitations

- Rust tests in this Linux orb required temporarily disabling the `whisper-rs` Vulkan feature because the installed Vulkan headers lack `VK_EXT_layer_settings`; that temporary Cargo change was restored and is not part of this PR.
- Flutter tests and representative UI execution could not run because the preexisting dirty `third_party/xterm` and `third_party/dart_terminal` submodules have no checked-out `pubspec.yaml`. Those submodule changes are excluded from this branch.