### PR TITLE
fix: read cloud storage versioning status

### DIFF
--- a/.github/workflows/cloud-deploy.yml
+++ b/.github/workflows/cloud-deploy.yml
@@ -197,9 +197,9 @@ jobs:
 
           bucket_versioning="$(
             gcloud storage buckets describe "gs://$STATE_BUCKET" \
-              --format='value(versioning.enabled)'
+              --format='value(versioning_enabled)'
           )"
-          if [[ "$bucket_versioning" != "True" ]]; then
+          if [[ "${bucket_versioning,,}" != "true" ]]; then
             echo "OpenTofu state bucket $STATE_BUCKET must have object versioning enabled." >&2
             exit 1
           fi


### PR DESCRIPTION
## Summary
- read the Cloud Storage CLI `versioning_enabled` field during production preflight
- compare the boolean case-insensitively

## Validation
- `git diff --check`
- `actionlint`
- `gh act pull_request -W .github/workflows/cloud.yml -j infrastructure`

## Context
The first hosted preflight reached the bucket successfully but rejected its versioning state because the workflow queried the legacy nested field name.