### PR TITLE
fix: route relay control requests to cloud

### DIFF
--- a/edge/src/index.ts
+++ b/edge/src/index.ts
@@ -44,6 +44,7 @@ const ORIGIN_HEADER = 'x-alera-origin-auth';
 const PUBLIC_EXACT_PATHS = new Set(['/health', '/.well-known/jwks.json']);
 const PUBLIC_PREFIXES = ['/v1/'];
 const RELAY_PREFIX = '/v1/relay/';
+const RELAY_CONTROL_PATHS = new Set(['/v1/relay/identity', '/v1/relay/grants']);
 const RELAY_AUDIENCE = 'alera-relay';
 const MAX_RELAY_FRAME_BYTES = 1024 * 1024;
 const MAX_RELAY_MOBILE_CONNECTIONS = 8;
@@ -302,7 +303,11 @@ export async function handleRequest(
   fetchRelay: RelayFetch = (relayRequest) => fetch(relayRequest),
 ): Promise<Response> {
   const url = new URL(request.url);
-  if (env.RELAY_ENABLED === 'true' && url.pathname.startsWith(RELAY_PREFIX)) {
+  if (
+    env.RELAY_ENABLED === 'true' &&
+    url.pathname.startsWith(RELAY_PREFIX) &&
+    !RELAY_CONTROL_PATHS.has(url.pathname)
+  ) {
     return handleRelayRequest(request, env, fetchRelay);
   }
   const configurationError = validateEnvironment(env);

--- a/edge/test/index.test.ts
+++ b/edge/test/index.test.ts
@@ -258,6 +258,32 @@ describe('Alera API edge', () => {
     expect(response.status).toBe(426);
   });
 
+  for (const controlPath of ['/v1/relay/identity', '/v1/relay/grants']) {
+    test(`proxies ${controlPath} to the control plane when the relay is enabled`, async () => {
+      let originCalled = false;
+      const response = await handleRequest(
+        new Request(`https://api.alera.build${controlPath}`, {
+          body: '{}',
+          headers: { authorization: 'Bearer account-token' },
+          method: 'POST',
+        }),
+        {
+          ...environment(),
+          RELAY_ENABLED: 'true',
+        },
+        async (originRequest) => {
+          originCalled = true;
+          expect(originRequest.url).toBe(`https://alera-cloud.example.run.app${controlPath}`);
+          expect(originRequest.headers.get('x-alera-origin-auth')).toBe('edge-secret');
+          return new Response(null, { status: 204 });
+        },
+      );
+
+      expect(response.status).toBe(204);
+      expect(originCalled).toBeTrue();
+    });
+  }
+
   for (const [missingValue, relayConfiguration] of [
     [
       'Durable Object binding',

--- a/tool/cloud/verify_production.sh
+++ b/tool/cloud/verify_production.sh
@@ -59,6 +59,30 @@ if [[ "$relay_status" != "$expected_relay_status" ]]; then
   exit 1
 fi
 
+for relay_control_path in /v1/relay/identity /v1/relay/grants; do
+  relay_control_status=""
+  for ((attempt = 1; attempt <= attempts; attempt++)); do
+    if relay_control_status="$(
+      curl \
+        --silent \
+        --show-error \
+        --output /dev/null \
+        --write-out '%{http_code}' \
+        --max-time 20 \
+        --header 'content-type: application/json' \
+        --data '{}' \
+        "$public_url$relay_control_path"
+    )" && [[ "$relay_control_status" == "401" ]]; then
+      break
+    fi
+    sleep 5
+  done
+  if [[ "$relay_control_status" != "401" ]]; then
+    echo "public relay control path $relay_control_path returned $relay_control_status; expected 401" >&2
+    exit 1
+  fi
+done
+
 origin_status="$(
   curl \
     --silent \
@@ -73,4 +97,4 @@ if [[ "$origin_status" != "401" ]]; then
   exit 1
 fi
 
-echo "public health and JWKS succeeded; relay was $relay_state; direct origin JWKS remained closed"
+echo "public health and JWKS succeeded; relay was $relay_state; relay control paths reached the backend; direct origin JWKS remained closed"


### PR DESCRIPTION
## Summary
- keep relay identity and grant requests on the Cloud Run control plane
- preserve WebSocket enforcement for runtime relay routes
- cover both enabled control-plane routes with edge tests

## Validation
- `bun test`
- `bunx wrangler deploy --dry-run`
- `gh act pull_request -W .github/workflows/cloud.yml -j edge`
- `git diff --check`

## Risk
Without this exception, enabling the relay returns 426 for identity registration and grant issuance, so runtime and mobile clients cannot establish a relay session.