### PR TITLE
fix: verify relay deployment routing

### DIFF
--- a/.github/workflows/cloud-deploy.yml
+++ b/.github/workflows/cloud-deploy.yml
@@ -38,6 +38,14 @@ on:
         options:
           - disabled
           - enabled
+      rollback_relay_control_state:
+        description: Expected relay control routing in the rollback Worker version
+        required: true
+        default: backend
+        type: choice
+        options:
+          - backend
+          - worker
 
 permissions:
   contents: read
@@ -303,8 +311,38 @@ jobs:
               exit 1
               ;;
           esac
+          previous_relay_control_status=""
+          for _ in 1 2 3; do
+            if previous_relay_control_status="$(
+              curl \
+                --silent \
+                --show-error \
+                --output /dev/null \
+                --write-out '%{http_code}' \
+                --max-time 20 \
+                --header 'content-type: application/json' \
+                --data '{"publicKey":"deploy-probe","keyVersion":1}' \
+                "$PUBLIC_API_URL/v1/relay/identity"
+            )" && [[ "$previous_relay_control_status" == "401" || "$previous_relay_control_status" == "426" ]]; then
+              break
+            fi
+            sleep 5
+          done
+          case "$previous_relay_control_status" in
+            401)
+              previous_relay_control_state=backend
+              ;;
+            426)
+              previous_relay_control_state=worker
+              ;;
+            *)
+              echo "Cannot determine the current relay control state from HTTP $previous_relay_control_status." >&2
+              exit 1
+              ;;
+          esac
           {
             echo "previous_image=$previous_image"
+            echo "previous_relay_control_state=$previous_relay_control_state"
             echo "previous_relay_state=$previous_relay_state"
             echo "previous_worker_version=$previous_worker_version"
           } >>"$GITHUB_OUTPUT"
@@ -445,7 +483,7 @@ jobs:
           EXPECTED_RELAY_STATE: ${{ steps.relay.outputs.state }}
         run: |
           origin_url="$(tofu -chdir=infra/production output -raw cloud_run_origin_url)"
-          tool/cloud/verify_production.sh "$PUBLIC_API_URL" "$origin_url" "$EXPECTED_RELAY_STATE"
+          tool/cloud/verify_production.sh "$PUBLIC_API_URL" "$origin_url" "$EXPECTED_RELAY_STATE" backend
 
       - name: Roll Back Worker Automatically
         id: automatic_worker_rollback
@@ -507,6 +545,7 @@ jobs:
         continue-on-error: true
         env:
           FORWARD_RECOVERY: ${{ steps.automatic_worker_forward_recovery.outcome }}
+          PREVIOUS_RELAY_CONTROL_STATE: ${{ steps.current.outputs.previous_relay_control_state }}
           PREVIOUS_RELAY_STATE: ${{ steps.current.outputs.previous_relay_state }}
           RECOVERY_NAMESPACE: ${{ steps.automatic_recovery_namespace.outcome }}
           WORKER_ROLLBACK: ${{ steps.automatic_worker_rollback.outcome }}
@@ -517,15 +556,17 @@ jobs:
             exit 1
           fi
           if [[ "$WORKER_ROLLBACK" == "success" ]]; then
+            expected_relay_control_state="$PREVIOUS_RELAY_CONTROL_STATE"
             expected_relay_state="$PREVIOUS_RELAY_STATE"
           elif [[ "$FORWARD_RECOVERY" == "success" ]]; then
+            expected_relay_control_state=backend
             expected_relay_state=disabled
           else
             echo "Neither Worker rollback nor forward recovery succeeded." >&2
             exit 1
           fi
           origin_url="$(tofu -chdir=infra/production output -raw cloud_run_origin_url)"
-          tool/cloud/verify_production.sh "$PUBLIC_API_URL" "$origin_url" "$expected_relay_state"
+          tool/cloud/verify_production.sh "$PUBLIC_API_URL" "$origin_url" "$expected_relay_state" "$expected_relay_control_state"
 
       - name: Report Failed Deployment
         if: ${{ always() && env.DEPLOY_MODE == 'deploy' && (steps.worker.outcome == 'failure' || steps.namespace.outcome == 'failure' || steps.verify.outcome == 'failure') }}
@@ -603,6 +644,7 @@ jobs:
         env:
           FORWARD_RECOVERY: ${{ steps.manual_worker_forward_recovery.outcome }}
           NAMESPACE_RECOVERY: ${{ steps.manual_namespace.outcome }}
+          REQUESTED_RELAY_CONTROL_STATE: ${{ inputs.rollback_relay_control_state }}
           REQUESTED_RELAY_STATE: ${{ inputs.rollback_relay_state }}
           WORKER_ROLLBACK: ${{ steps.manual_worker.outcome }}
         run: |
@@ -612,26 +654,30 @@ jobs:
             exit 1
           fi
           if [[ "$WORKER_ROLLBACK" == "success" ]]; then
+            expected_relay_control_state="$REQUESTED_RELAY_CONTROL_STATE"
             expected_relay_state="$REQUESTED_RELAY_STATE"
           elif [[ "$FORWARD_RECOVERY" == "success" ]]; then
+            expected_relay_control_state=backend
             expected_relay_state=disabled
           else
             echo "Neither Worker rollback nor forward recovery succeeded." >&2
             exit 1
           fi
           origin_url="$(tofu -chdir=infra/production output -raw cloud_run_origin_url)"
-          tool/cloud/verify_production.sh "$PUBLIC_API_URL" "$origin_url" "$expected_relay_state"
+          tool/cloud/verify_production.sh "$PUBLIC_API_URL" "$origin_url" "$expected_relay_state" "$expected_relay_control_state"
 
       - name: Require Successful Manual Rollback
         if: ${{ env.DEPLOY_MODE == 'rollback' && ((steps.manual_worker.outcome != 'success' && steps.manual_worker_forward_recovery.outcome != 'success') || steps.manual_namespace.outcome != 'success' || steps.manual_cloud_run.outcome != 'success' || steps.manual_verify.outcome != 'success') }}
         env:
           ROLLBACK_IMAGE: ${{ inputs.rollback_image }}
+          ROLLBACK_RELAY_CONTROL_STATE: ${{ inputs.rollback_relay_control_state }}
           ROLLBACK_RELAY_STATE: ${{ inputs.rollback_relay_state }}
           ROLLBACK_WORKER_VERSION: ${{ inputs.rollback_worker_version }}
         run: |
           {
             echo "### Manual Rollback Failed"
             echo "- Requested relay state: $ROLLBACK_RELAY_STATE"
+            echo "- Requested relay control state: $ROLLBACK_RELAY_CONTROL_STATE"
             echo
             echo "- Requested image: \`$ROLLBACK_IMAGE\`"
             echo "- Requested Worker version: \`$ROLLBACK_WORKER_VERSION\`"

--- a/.github/workflows/cloud.yml
+++ b/.github/workflows/cloud.yml
@@ -145,7 +145,10 @@ jobs:
         run: python3 -m unittest -v test_validate_tofu_plan.py
 
       - name: Validate Deployment Scripts
-        run: bash -n tool/cloud/deploy_worker_relay_disabled.sh tool/cloud/verify_production.sh tool/cloud/verify_worker_namespace.sh
+        run: bash -n tool/cloud/deploy_worker_relay_disabled.sh tool/cloud/test_verify_production.sh tool/cloud/verify_production.sh tool/cloud/verify_worker_namespace.sh
+
+      - name: Test Production Verifier
+        run: bash tool/cloud/test_verify_production.sh
 
   cloud-ready:
     name: cloud-ready

--- a/tool/cloud/test_verify_production.sh
+++ b/tool/cloud/test_verify_production.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+public_url=https://public.test
+origin_url=https://origin.test
+
+curl() {
+  local data=""
+  local url=""
+  while (($# > 0)); do
+    case "$1" in
+      --data)
+        data="$2"
+        shift 2
+        continue
+        ;;
+      http*)
+        url="$1"
+        ;;
+    esac
+    shift
+  done
+
+  case "$url" in
+    "$public_url/health"|"$public_url/.well-known/jwks.json")
+      ;;
+    "$public_url/v1/relay/deploy-probe")
+      printf '%s' "$TEST_RELAY_STATUS"
+      ;;
+    "$public_url/v1/relay/identity")
+      [[ "$data" == '{"publicKey":"deploy-probe","keyVersion":1}' ]]
+      printf '%s' "$TEST_RELAY_CONTROL_STATUS"
+      ;;
+    "$public_url/v1/relay/grants")
+      [[ "$data" == '{"runtimeId":"deploy-probe"}' ]]
+      printf '%s' "$TEST_RELAY_CONTROL_STATUS"
+      ;;
+    "$origin_url/.well-known/jwks.json")
+      printf '401'
+      ;;
+    *)
+      echo "unexpected verifier URL: $url" >&2
+      return 1
+      ;;
+  esac
+}
+export -f curl
+
+TEST_RELAY_STATUS=404 TEST_RELAY_CONTROL_STATUS=401 \
+  tool/cloud/verify_production.sh "$public_url" "$origin_url" disabled backend
+TEST_RELAY_STATUS=426 TEST_RELAY_CONTROL_STATUS=401 \
+  tool/cloud/verify_production.sh "$public_url" "$origin_url" enabled backend
+TEST_RELAY_STATUS=426 TEST_RELAY_CONTROL_STATUS=426 \
+  tool/cloud/verify_production.sh "$public_url" "$origin_url" enabled worker
+
+set +e
+tool/cloud/verify_production.sh "$public_url" "$origin_url" enabled invalid >/dev/null 2>&1
+invalid_status=$?
+set -e
+if [[ "$invalid_status" -ne 2 ]]; then
+  echo "invalid relay control state returned $invalid_status; expected 2" >&2
+  exit 1
+fi
+
+echo "verify_production tests passed"

--- a/tool/cloud/verify_production.sh
+++ b/tool/cloud/verify_production.sh
@@ -1,14 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [[ $# -ne 3 ]]; then
-  echo "usage: verify_production.sh <public-url> <origin-url> <relay-state>" >&2
+if [[ $# -lt 3 || $# -gt 4 ]]; then
+  echo "usage: verify_production.sh <public-url> <origin-url> <relay-state> [relay-control-state]" >&2
   exit 2
 fi
 
 public_url="${1%/}"
 origin_url="${2%/}"
 relay_state="$3"
+relay_control_state="${4:-backend}"
 attempts=12
 
 case "$relay_state" in
@@ -20,6 +21,19 @@ case "$relay_state" in
     ;;
   *)
     echo "relay-state must be disabled or enabled" >&2
+    exit 2
+    ;;
+esac
+
+case "$relay_control_state" in
+  backend)
+    expected_relay_control_status=401
+    ;;
+  worker)
+    expected_relay_control_status=426
+    ;;
+  *)
+    echo "relay-control-state must be backend or worker" >&2
     exit 2
     ;;
 esac
@@ -59,7 +73,11 @@ if [[ "$relay_status" != "$expected_relay_status" ]]; then
   exit 1
 fi
 
-for relay_control_path in /v1/relay/identity /v1/relay/grants; do
+for relay_control_probe in \
+  '/v1/relay/identity|{"publicKey":"deploy-probe","keyVersion":1}' \
+  '/v1/relay/grants|{"runtimeId":"deploy-probe"}'; do
+  relay_control_path="${relay_control_probe%%|*}"
+  relay_control_body="${relay_control_probe#*|}"
   relay_control_status=""
   for ((attempt = 1; attempt <= attempts; attempt++)); do
     if relay_control_status="$(
@@ -70,15 +88,15 @@ for relay_control_path in /v1/relay/identity /v1/relay/grants; do
         --write-out '%{http_code}' \
         --max-time 20 \
         --header 'content-type: application/json' \
-        --data '{}' \
+        --data "$relay_control_body" \
         "$public_url$relay_control_path"
-    )" && [[ "$relay_control_status" == "401" ]]; then
+    )" && [[ "$relay_control_status" == "$expected_relay_control_status" ]]; then
       break
     fi
     sleep 5
   done
-  if [[ "$relay_control_status" != "401" ]]; then
-    echo "public relay control path $relay_control_path returned $relay_control_status; expected 401" >&2
+  if [[ "$relay_control_status" != "$expected_relay_control_status" ]]; then
+    echo "public relay control path $relay_control_path returned $relay_control_status; expected $expected_relay_control_status for $relay_control_state" >&2
     exit 1
   fi
 done
@@ -97,4 +115,4 @@ if [[ "$origin_status" != "401" ]]; then
   exit 1
 fi
 
-echo "public health and JWKS succeeded; relay was $relay_state; relay control paths reached the backend; direct origin JWKS remained closed"
+echo "public health and JWKS succeeded; relay was $relay_state; relay control state was $relay_control_state; direct origin JWKS remained closed"


### PR DESCRIPTION
## summary

- send structurally valid relay control requests so backend authentication returns 401
- capture relay control routing before deployment and verify the same contract after rollback
- add explicit manual rollback control routing and focused verifier tests

## validation

- `bash tool/cloud/test_verify_production.sh`
- `bash -n` for all deployment scripts
- `git diff --check`
- `gh act pull_request --pull=false -W .github/workflows/cloud.yml -j infrastructure`
- `gh act pull_request --pull=false -W .github/workflows/pr.yml -j static`
- live verification of the recovered `enabled + worker` production contract

## risk

Workflow-only recovery and verification change. The prior deployment correctly rolled Cloud Run and Worker back; this change prevents valid backend 422 responses from being mistaken for routing failures and verifies legacy rollback targets against their captured control-plane behavior.