### PR TITLE
fix: restore relay websocket connectivity

### DIFF
--- a/edge/src/index.ts
+++ b/edge/src/index.ts
@@ -300,7 +300,7 @@ export async function handleRequest(
   request: Request,
   env: EdgeEnvironment,
   fetchOrigin: OriginFetch = fetch,
-  fetchRelay: RelayFetch = (relayRequest) => fetch(relayRequest),
+  fetchRelay?: RelayFetch,
 ): Promise<Response> {
   const url = new URL(request.url);
   if (
@@ -308,7 +308,13 @@ export async function handleRequest(
     url.pathname.startsWith(RELAY_PREFIX) &&
     !RELAY_CONTROL_PATHS.has(url.pathname)
   ) {
-    return handleRelayRequest(request, env, fetchRelay);
+    const fetchJwks =
+      fetchRelay ??
+      ((jwksRequest: Request) => {
+        const jwksUrl = new URL(jwksRequest.url);
+        return fetchOrigin(originRequest(jwksRequest, env, jwksUrl));
+      });
+    return handleRelayRequest(request, env, fetchJwks);
   }
   const configurationError = validateEnvironment(env);
   if (configurationError) return configurationError;

--- a/edge/test/index.test.ts
+++ b/edge/test/index.test.ts
@@ -342,6 +342,7 @@ describe('Alera API edge', () => {
   test('verifies a grant and forwards only claims to the runtime object', async () => {
     const { grant, publicJwk } = await signedRelayGrant();
     const forwarded: Request[] = [];
+    const originRequests: Request[] = [];
     const stub = {
       fetch(request: Request) {
         forwarded.push(request);
@@ -357,11 +358,17 @@ describe('Alera API edge', () => {
         },
       }),
       environmentWithRelay,
-      undefined,
-      relayJwks(publicJwk),
+      async (originRequest) => {
+        originRequests.push(originRequest);
+        return relayJwks(publicJwk)();
+      },
     );
 
     expect(response.status).toBe(200);
+    expect(originRequests).toHaveLength(1);
+    expect(originRequests[0].url).toBe('https://alera-cloud.example.run.app/.well-known/jwks.json');
+    expect(originRequests[0].headers.get('x-alera-origin-auth')).toBe('edge-secret');
+    expect(originRequests[0].headers.get('x-forwarded-host')).toBe('api.alera.build');
     expect(forwarded).toHaveLength(1);
     expect(forwarded[0].headers.get('authorization')).toBeNull();
     expect(forwarded[0].headers.get('x-alera-relay-claims')).toBeTruthy();

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -5464,7 +5464,7 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "url",
- "webpki-roots",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -5971,8 +5971,12 @@ checksum = "17a073bfed563fa236697a068031408a93cd9522e08abf9933ead3e73411bd71"
 dependencies = [
  "futures-util",
  "log",
+ "rustls",
+ "rustls-pki-types",
  "tokio",
+ "tokio-rustls",
  "tungstenite",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -6169,6 +6173,8 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.10.2",
+ "rustls",
+ "rustls-pki-types",
  "sha1 0.11.0",
  "thiserror 2.0.19",
 ]
@@ -6314,7 +6320,7 @@ dependencies = [
  "rustls-pki-types",
  "ureq-proto",
  "utf8-zero",
- "webpki-roots",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -6541,6 +6547,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]

--- a/rust/alera-cli/Cargo.toml
+++ b/rust/alera-cli/Cargo.toml
@@ -31,7 +31,7 @@ portable-pty = "0.9"
 sqlx = { version = "0.9", default-features = false, features = [
     "sqlite",
     "runtime-tokio",
-    "tls-rustls",
+    "tls-rustls-aws-lc-rs",
 ] }
 anyhow = "1"
 thiserror = "2"
@@ -49,7 +49,7 @@ rand_core = "0.6"
 zeroize = "1"
 png = "0.18"
 jsonschema = { version = "0.49", default-features = false }
-tokio-tungstenite = "0.30"
+tokio-tungstenite = { version = "0.30", features = ["rustls-tls-webpki-roots"] }
 toml = "1.1"
 url = "2.5"
 dirs = "6"

--- a/rust/alera-cli/src/terminal_host/relay_runtime.rs
+++ b/rust/alera-cli/src/terminal_host/relay_runtime.rs
@@ -483,43 +483,5 @@ fn encoded(bytes: impl AsRef<[u8]>) -> String {
 }
 
 #[cfg(test)]
-mod tests {
-    use tokio::net::TcpListener;
-    use tokio_tungstenite::tungstenite::{error::UrlError, http::header, Error};
-
-    use super::{connect_async, relay_request};
-
-    #[test]
-    fn relay_request_preserves_websocket_handshake_headers() {
-        let request = relay_request("wss://relay.example/v1/relay/runtime", "relay-grant")
-            .expect("relay request");
-
-        assert_eq!(request.headers()[header::CONNECTION], "Upgrade");
-        assert_eq!(request.headers()[header::UPGRADE], "websocket");
-        assert_eq!(request.headers()[header::SEC_WEBSOCKET_VERSION], "13");
-        assert!(request.headers().contains_key(header::SEC_WEBSOCKET_KEY));
-        assert_eq!(
-            request.headers()[header::AUTHORIZATION],
-            "Bearer relay-grant"
-        );
-        assert_eq!(request.headers()[header::ORIGIN], "https://app.alera.build");
-    }
-
-    #[tokio::test]
-    async fn websocket_client_supports_wss() {
-        let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
-        let address = listener.local_addr().unwrap();
-        let server = tokio::spawn(async move {
-            let (stream, _) = listener.accept().await.unwrap();
-            drop(stream);
-        });
-
-        let request = relay_request(&format!("wss://{address}"), "relay-grant").unwrap();
-        let error = connect_async(request)
-            .await
-            .expect_err("the local test server does not complete a TLS handshake");
-        server.abort();
-
-        assert!(!matches!(error, Error::Url(UrlError::TlsFeatureNotEnabled)));
-    }
-}
+#[path = "relay_runtime_tests.rs"]
+mod tests;

--- a/rust/alera-cli/src/terminal_host/relay_runtime.rs
+++ b/rust/alera-cli/src/terminal_host/relay_runtime.rs
@@ -9,8 +9,13 @@ use tokio::sync::mpsc::{self, Receiver, UnboundedReceiver, UnboundedSender};
 use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
 use tokio_tungstenite::{
-    connect_async, tungstenite::http::Request, tungstenite::Message, MaybeTlsStream,
-    WebSocketStream,
+    connect_async,
+    tungstenite::{
+        client::IntoClientRequest,
+        http::{header, HeaderValue, Request},
+        Message,
+    },
+    MaybeTlsStream, WebSocketStream,
 };
 
 use crate::terminal_host::alera_account::{AleraAccountService, RelayGrant};
@@ -95,12 +100,10 @@ async fn run(
             &mut stop,
         )
         .await;
-        if result.is_ok() {
-            return;
-        }
+        let Err(error) = result else { return };
         let delay = RETRY_DELAYS[retry_index];
         retry_index = (retry_index + 1).min(RETRY_DELAYS.len() - 1);
-        tracing::warn!("remote mobile relay disconnected; retrying in {:?}", delay);
+        tracing::warn!(%error, "remote mobile relay disconnected; retrying in {:?}", delay);
         tokio::select! {
             _ = tokio::time::sleep(delay) => {}
             _ = &mut stop => return,
@@ -127,11 +130,7 @@ async fn connect_and_serve(
     {
         anyhow::bail!("cloud returned an invalid runtime relay grant");
     }
-    let request = Request::builder()
-        .uri(&grant.relay_url)
-        .header("authorization", format!("Bearer {}", grant.grant))
-        .header("origin", "https://app.alera.build")
-        .body(())?;
+    let request = relay_request(&grant.relay_url, &grant.grant)?;
     let (socket, _) = connect_async(request).await?;
     let (mut write, mut read) = socket.split();
     let (outbound_tx, mut outbound_rx) = mpsc::unbounded_channel::<RelayOutbound>();
@@ -187,6 +186,19 @@ async fn connect_and_serve(
             }
         }
     }
+}
+
+fn relay_request(relay_url: &str, grant: &str) -> anyhow::Result<Request<()>> {
+    let mut request = relay_url.into_client_request()?;
+    request.headers_mut().insert(
+        header::AUTHORIZATION,
+        HeaderValue::from_str(&format!("Bearer {grant}"))?,
+    );
+    request.headers_mut().insert(
+        header::ORIGIN,
+        HeaderValue::from_static("https://app.alera.build"),
+    );
+    Ok(request)
 }
 
 async fn handle_inbound(frame: &[u8], context: RelayInbound<'_>) -> anyhow::Result<()> {
@@ -468,4 +480,46 @@ async fn dispose_peers(
 
 fn encoded(bytes: impl AsRef<[u8]>) -> String {
     URL_SAFE_NO_PAD.encode(bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use tokio::net::TcpListener;
+    use tokio_tungstenite::tungstenite::{error::UrlError, http::header, Error};
+
+    use super::{connect_async, relay_request};
+
+    #[test]
+    fn relay_request_preserves_websocket_handshake_headers() {
+        let request = relay_request("wss://relay.example/v1/relay/runtime", "relay-grant")
+            .expect("relay request");
+
+        assert_eq!(request.headers()[header::CONNECTION], "Upgrade");
+        assert_eq!(request.headers()[header::UPGRADE], "websocket");
+        assert_eq!(request.headers()[header::SEC_WEBSOCKET_VERSION], "13");
+        assert!(request.headers().contains_key(header::SEC_WEBSOCKET_KEY));
+        assert_eq!(
+            request.headers()[header::AUTHORIZATION],
+            "Bearer relay-grant"
+        );
+        assert_eq!(request.headers()[header::ORIGIN], "https://app.alera.build");
+    }
+
+    #[tokio::test]
+    async fn websocket_client_supports_wss() {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            drop(stream);
+        });
+
+        let request = relay_request(&format!("wss://{address}"), "relay-grant").unwrap();
+        let error = connect_async(request)
+            .await
+            .expect_err("the local test server does not complete a TLS handshake");
+        server.abort();
+
+        assert!(!matches!(error, Error::Url(UrlError::TlsFeatureNotEnabled)));
+    }
 }

--- a/rust/alera-cli/src/terminal_host/relay_runtime_tests.rs
+++ b/rust/alera-cli/src/terminal_host/relay_runtime_tests.rs
@@ -1,0 +1,38 @@
+use tokio::net::TcpListener;
+use tokio_tungstenite::tungstenite::{error::UrlError, http::header, Error};
+
+use super::{connect_async, relay_request};
+
+#[test]
+fn relay_request_preserves_websocket_handshake_headers() {
+    let request = relay_request("wss://relay.example/v1/relay/runtime", "relay-grant")
+        .expect("relay request");
+
+    assert_eq!(request.headers()[header::CONNECTION], "Upgrade");
+    assert_eq!(request.headers()[header::UPGRADE], "websocket");
+    assert_eq!(request.headers()[header::SEC_WEBSOCKET_VERSION], "13");
+    assert!(request.headers().contains_key(header::SEC_WEBSOCKET_KEY));
+    assert_eq!(
+        request.headers()[header::AUTHORIZATION],
+        "Bearer relay-grant"
+    );
+    assert_eq!(request.headers()[header::ORIGIN], "https://app.alera.build");
+}
+
+#[tokio::test]
+async fn websocket_client_supports_wss() {
+    let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let server = tokio::spawn(async move {
+        let (stream, _) = listener.accept().await.unwrap();
+        drop(stream);
+    });
+
+    let request = relay_request(&format!("wss://{address}"), "relay-grant").unwrap();
+    let error = connect_async(request)
+        .await
+        .expect_err("the local test server does not complete a TLS handshake");
+    server.abort();
+
+    assert!(!matches!(error, Error::Url(UrlError::TlsFeatureNotEnabled)));
+}

--- a/rust/alera-core/Cargo.toml
+++ b/rust/alera-core/Cargo.toml
@@ -24,7 +24,7 @@ serde_json = "1"
 sqlx = { version = "0.9", default-features = false, features = [
     "sqlite",
     "runtime-tokio",
-    "tls-rustls",
+    "tls-rustls-aws-lc-rs",
     "chrono",
 ], optional = true }
 thiserror = { version = "2", optional = true }


### PR DESCRIPTION
## summary

- compile the desktop runtime with rustls WebSocket support and preserve generated handshake headers
- route Worker JWKS verification through the authenticated Cloud Run origin
- retain relay disconnect errors and cover TLS, handshake headers, and origin JWKS routing

## validation

- `cargo fmt --all -- --check`
- release `cargo clippy -p alera-cli --all-targets --locked -- -D warnings`
- focused release relay tests
- Edge typecheck and 21 tests
- `wrangler deploy --dry-run`
- local Cloud Edge Actions job

## risk

The Worker change affects only relay grant verification. The runtime change aligns all Rust TLS users on the existing aws-lc provider.