### PR TITLE
fix: complete mobile relay fallback

### DIFF
--- a/mobile/lib/src/features/accounts/application/cloud_accounts_controller.dart
+++ b/mobile/lib/src/features/accounts/application/cloud_accounts_controller.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:alera_mobile/src/features/accounts/application/cloud_account_providers.dart';
@@ -12,6 +13,9 @@ part 'cloud_accounts_controller.g.dart';
 
 @Riverpod(keepAlive: true)
 class CloudAccountsController extends _$CloudAccountsController {
+  final Map<String, Future<CloudAccountSession?>> _sessionRefreshes =
+      <String, Future<CloudAccountSession?>>{};
+
   @override
   Future<List<CloudAccountSession>> build() {
     return ref.watch(cloudAccountRepositoryProvider).loadSessions();
@@ -119,37 +123,75 @@ class CloudAccountsController extends _$CloudAccountsController {
     state = AsyncData(_replace(current, updated));
   }
 
-  Future<void> replaceSession(CloudAccountSession session) async {
+  Future<CloudAccountSession?> sessionForRequest(
+    String accountId, {
+    Duration refreshWithin = const Duration(minutes: 5),
+  }) async {
+    final pending = _sessionRefreshes[accountId];
+    if (pending != null) {
+      return pending;
+    }
+    final operation = _refreshSessionForRequest(accountId, refreshWithin);
+    _sessionRefreshes[accountId] = operation;
+    try {
+      return await operation;
+    } finally {
+      if (identical(_sessionRefreshes[accountId], operation)) {
+        _sessionRefreshes.remove(accountId);
+      }
+    }
+  }
+
+  Future<CloudAccountSession?> _refreshSessionForRequest(
+    String accountId,
+    Duration refreshWithin,
+  ) async {
     final current = await future;
     final existing = current
-        .where((item) => item.account.id == session.account.id)
+        .where((item) => item.account.id == accountId)
         .firstOrNull;
-    if (existing == session) {
-      return;
+    if (existing == null ||
+        !existing.expiresWithin(refreshWithin, DateTime.now().toUtc())) {
+      return existing;
     }
-    await ref.read(cloudAccountRepositoryProvider).saveSession(session);
-    state = AsyncData(_replace(current, session));
+    final refreshed = await ref
+        .read(aleraCloudApiProvider)
+        .refreshSession(existing);
+    return _replaceIfCurrent(
+      refreshed,
+      expectedRefreshToken: existing.refreshToken,
+    );
+  }
+
+  Future<CloudAccountSession?> _replaceIfCurrent(
+    CloudAccountSession replacement, {
+    required String expectedRefreshToken,
+  }) async {
+    final current = await future;
+    final existing = current
+        .where((item) => item.account.id == replacement.account.id)
+        .firstOrNull;
+    if (existing == null || existing.refreshToken != expectedRefreshToken) {
+      return existing;
+    }
+    await ref.read(cloudAccountRepositoryProvider).saveSession(replacement);
+    state = AsyncData(_replace(current, replacement));
+    return replacement;
   }
 
   Future<void> refreshAccount(String accountId) async {
-    final current = await future;
-    var session = current
-        .where((item) => item.account.id == accountId)
-        .firstOrNull;
+    final session = await sessionForRequest(accountId);
     if (session == null) {
       return;
-    }
-    if (session.expiresWithin(
-      const Duration(minutes: 5),
-      DateTime.now().toUtc(),
-    )) {
-      session = await ref.read(aleraCloudApiProvider).refreshSession(session);
     }
     final profile = await ref
         .read(aleraCloudApiProvider)
         .accountStatus(session);
     final updated = session.copyWith(account: profile);
-    await replaceSession(updated);
+    await _replaceIfCurrent(
+      updated,
+      expectedRefreshToken: session.refreshToken,
+    );
   }
 
   Future<void> removeFromThisPhone(String accountId) async {

--- a/mobile/lib/src/features/accounts/application/cloud_accounts_controller.dart
+++ b/mobile/lib/src/features/accounts/application/cloud_accounts_controller.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:alera_mobile/src/features/accounts/application/cloud_account_providers.dart';
 import 'package:alera_mobile/src/features/accounts/domain/cloud_account_session.dart';
 import 'package:alera_mobile/src/features/accounts/domain/runtime_push_preferences.dart';
+import 'package:alera_mobile/src/features/accounts/infra/alera_cloud_api.dart';
 import 'package:alera_mobile/src/features/accounts/infra/mobile_cloud_sign_in.dart';
 import 'package:alera_mobile/src/features/runtime/infra/relay_crypto.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -159,13 +160,18 @@ class CloudAccountsController extends _$CloudAccountsController {
     if (session == null) {
       return;
     }
-    for (final runtimeId in session.subscriptions.keys) {
-      await ref
-          .read(aleraCloudApiProvider)
-          .deleteSubscription(session: session, runtimeId: runtimeId);
+    final api = ref.read(aleraCloudApiProvider);
+    try {
+      for (final runtimeId in session.subscriptions.keys) {
+        await api.deleteSubscription(session: session, runtimeId: runtimeId);
+      }
+      await api.deletePushToken(session);
+      await api.revokeSession(session);
+    } on AleraCloudException catch (error) {
+      if (error.statusCode != 401) {
+        rethrow;
+      }
     }
-    await ref.read(aleraCloudApiProvider).deletePushToken(session);
-    await ref.read(aleraCloudApiProvider).revokeSession(session);
     await ref.read(cloudAccountRepositoryProvider).removeSession(accountId);
     state = AsyncData(<CloudAccountSession>[
       for (final item in current)

--- a/mobile/lib/src/features/accounts/application/cloud_accounts_controller.g.dart
+++ b/mobile/lib/src/features/accounts/application/cloud_accounts_controller.g.dart
@@ -38,7 +38,7 @@ final class CloudAccountsControllerProvider
 }
 
 String _$cloudAccountsControllerHash() =>
-    r'261ab26055d4d7a7db532d9b49c33b98e8242a6a';
+    r'0a7770cb2bc57c422c6ca79dcaafc90a8f6eea37';
 
 abstract class _$CloudAccountsController
     extends $AsyncNotifier<List<CloudAccountSession>> {

--- a/mobile/lib/src/features/accounts/application/cloud_accounts_controller.g.dart
+++ b/mobile/lib/src/features/accounts/application/cloud_accounts_controller.g.dart
@@ -38,7 +38,7 @@ final class CloudAccountsControllerProvider
 }
 
 String _$cloudAccountsControllerHash() =>
-    r'0a7770cb2bc57c422c6ca79dcaafc90a8f6eea37';
+    r'f8cc380a1978e76f3060ee3b365174c6d8737333';
 
 abstract class _$CloudAccountsController
     extends $AsyncNotifier<List<CloudAccountSession>> {

--- a/mobile/lib/src/features/accounts/presentation/accounts_screen.dart
+++ b/mobile/lib/src/features/accounts/presentation/accounts_screen.dart
@@ -116,11 +116,37 @@ class AccountsScreen extends ConsumerWidget {
     if (confirmed != true) {
       return;
     }
-    await ref
-        .read(cloudAccountsControllerProvider.notifier)
-        .removeFromThisPhone(session.account.id);
+    try {
+      await ref
+          .read(cloudAccountsControllerProvider.notifier)
+          .removeFromThisPhone(session.account.id);
+    } on Object catch (error) {
+      if (context.mounted) {
+        _showMessage(context, error.toString());
+      }
+      return;
+    }
     for (final runtimeId in session.subscriptions.keys) {
       await _refreshPairedRuntime(ref, runtimeId);
+    }
+  }
+
+  Future<void> _refreshAccount(
+    BuildContext context,
+    WidgetRef ref,
+    String accountId,
+  ) async {
+    try {
+      await ref
+          .read(cloudAccountsControllerProvider.notifier)
+          .refreshAccount(accountId);
+      if (context.mounted) {
+        _showMessage(context, 'Account refreshed');
+      }
+    } on Object catch (error) {
+      if (context.mounted) {
+        _showMessage(context, error.toString());
+      }
     }
   }
 
@@ -188,9 +214,11 @@ class AccountsScreen extends ConsumerWidget {
                       switch (action) {
                         case CloudAccountAction.refresh:
                           unawaited(
-                            ref
-                                .read(cloudAccountsControllerProvider.notifier)
-                                .refreshAccount(sessions[index].account.id),
+                            _refreshAccount(
+                              context,
+                              ref,
+                              sessions[index].account.id,
+                            ),
                           );
                         case CloudAccountAction.remove:
                           unawaited(

--- a/mobile/lib/src/features/accounts/presentation/cloud_account_card.dart
+++ b/mobile/lib/src/features/accounts/presentation/cloud_account_card.dart
@@ -140,59 +140,61 @@ class _RuntimeRail extends StatelessWidget {
         AleraTokens.space12,
         AleraTokens.space12,
       ),
-      child: Row(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: <Widget>[
-          SizedBox(
-            width: AleraTokens.space16,
-            child: Stack(
-              alignment: Alignment.topCenter,
-              children: <Widget>[
-                Positioned.fill(
-                  left: AleraTokens.space6,
-                  right: AleraTokens.space8,
-                  child: ColoredBox(color: AleraTokens.border),
-                ),
-                for (var index = 0; index < entries.length; index++)
-                  Positioned(
-                    top:
-                        index *
-                            (AleraTokens.minTapTarget + AleraTokens.space32) +
-                        AleraTokens.space16,
-                    child: AleraStatusDot(
-                      active: entries[index].value.hasEnabledCategory,
-                      size: AleraTokens.space8,
-                    ),
+      child: IntrinsicHeight(
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: <Widget>[
+            SizedBox(
+              width: AleraTokens.space16,
+              child: Stack(
+                alignment: Alignment.topCenter,
+                children: <Widget>[
+                  Positioned.fill(
+                    left: AleraTokens.space6,
+                    right: AleraTokens.space8,
+                    child: ColoredBox(color: AleraTokens.border),
                   ),
-              ],
-            ),
-          ),
-          const SizedBox(width: AleraTokens.space8),
-          Expanded(
-            child: Column(
-              children: <Widget>[
-                for (
-                  var index = 0;
-                  index < entries.length;
-                  index++
-                ) ...<Widget>[
-                  _RuntimeNotificationRow(
-                    runtimeId: entries[index].key,
-                    host: hosts
-                        .where((host) => host.runtimeId == entries[index].key)
-                        .firstOrNull,
-                    preferences: entries[index].value,
-                    onChanged: (preferences) => unawaited(
-                      onPreferencesChanged(entries[index].key, preferences),
+                  for (var index = 0; index < entries.length; index++)
+                    Positioned(
+                      top:
+                          index *
+                              (AleraTokens.minTapTarget + AleraTokens.space32) +
+                          AleraTokens.space16,
+                      child: AleraStatusDot(
+                        active: entries[index].value.hasEnabledCategory,
+                        size: AleraTokens.space8,
+                      ),
                     ),
-                  ),
-                  if (index < entries.length - 1)
-                    const SizedBox(height: AleraTokens.space8),
                 ],
-              ],
+              ),
             ),
-          ),
-        ],
+            const SizedBox(width: AleraTokens.space8),
+            Expanded(
+              child: Column(
+                children: <Widget>[
+                  for (
+                    var index = 0;
+                    index < entries.length;
+                    index++
+                  ) ...<Widget>[
+                    _RuntimeNotificationRow(
+                      runtimeId: entries[index].key,
+                      host: hosts
+                          .where((host) => host.runtimeId == entries[index].key)
+                          .firstOrNull,
+                      preferences: entries[index].value,
+                      onChanged: (preferences) => unawaited(
+                        onPreferencesChanged(entries[index].key, preferences),
+                      ),
+                    ),
+                    if (index < entries.length - 1)
+                      const SizedBox(height: AleraTokens.space8),
+                  ],
+                ],
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/mobile/lib/src/features/automations/application/mobile_automation_providers.dart
+++ b/mobile/lib/src/features/automations/application/mobile_automation_providers.dart
@@ -7,9 +7,7 @@ part 'mobile_automation_providers.g.dart';
 
 @riverpod
 Future<List<MobileAutomation>> mobileAutomations(Ref ref, String hostId) async {
-  final client = await ref.watch(
-    hostConnectionControllerProvider(hostId).future,
-  );
+  final client = await watchHostConnection(ref, hostId);
   if (!client.supportsAutomations) {
     throw UnsupportedError('This host does not support automations');
   }
@@ -22,9 +20,7 @@ Future<List<MobileAutomation>> mobileAutomationCatalog(
   String hostId,
   bool includeTrashed,
 ) async {
-  final client = await ref.watch(
-    hostConnectionControllerProvider(hostId).future,
-  );
+  final client = await watchHostConnection(ref, hostId);
   if (!client.supportsAutomations) {
     throw UnsupportedError('This host does not support automations');
   }

--- a/mobile/lib/src/features/automations/application/mobile_automation_providers.g.dart
+++ b/mobile/lib/src/features/automations/application/mobile_automation_providers.g.dart
@@ -66,7 +66,7 @@ final class MobileAutomationsProvider
   }
 }
 
-String _$mobileAutomationsHash() => r'b0001963675dce105086f22a802149d82c64f3fd';
+String _$mobileAutomationsHash() => r'4da715888dcde64ee813aebe6ae77346034ef55f';
 
 final class MobileAutomationsFamily extends $Family
     with $FunctionalFamilyOverride<FutureOr<List<MobileAutomation>>, String> {
@@ -145,7 +145,7 @@ final class MobileAutomationCatalogProvider
 }
 
 String _$mobileAutomationCatalogHash() =>
-    r'c2e65e105f06b359d2d8cd6e63b27b1a1c4dacb8';
+    r'8217fb71a0d98e77d4234025f80d7a53105cfa80';
 
 final class MobileAutomationCatalogFamily extends $Family
     with

--- a/mobile/lib/src/features/codex_chat/application/mobile_codex_controller.dart
+++ b/mobile/lib/src/features/codex_chat/application/mobile_codex_controller.dart
@@ -28,7 +28,7 @@ part 'mobile_codex_controller_capabilities.dart';
 
 @riverpod
 Future<MobileCodexClient> mobileCodexClient(Ref ref, String hostId) =>
-    ref.watch(hostConnectionControllerProvider(hostId).future);
+    watchHostConnection(ref, hostId);
 
 @riverpod
 class MobileCodexController extends _$MobileCodexController

--- a/mobile/lib/src/features/codex_chat/application/mobile_codex_controller.g.dart
+++ b/mobile/lib/src/features/codex_chat/application/mobile_codex_controller.g.dart
@@ -66,7 +66,7 @@ final class MobileCodexClientProvider
   }
 }
 
-String _$mobileCodexClientHash() => r'1e9047dedce0d695bf53888effad4575e2eaccd4';
+String _$mobileCodexClientHash() => r'b02565c8529d80510f07fdc9ae34349aab804c71';
 
 final class MobileCodexClientFamily extends $Family
     with $FunctionalFamilyOverride<FutureOr<MobileCodexClient>, String> {

--- a/mobile/lib/src/features/projects/application/projects_controller.dart
+++ b/mobile/lib/src/features/projects/application/projects_controller.dart
@@ -26,9 +26,7 @@ class ProjectsController extends _$ProjectsController {
 
   @override
   Future<ProjectManagementSnapshot> build(String hostId) async {
-    final client = await ref.watch(
-      hostConnectionControllerProvider(hostId).future,
-    );
+    final client = await watchHostConnection(ref, hostId);
     _eventsSubscription ??= client.events.listen((event) {
       if (event.name == 'projectsChanged' ||
           event.name == 'workspacesChanged' ||
@@ -124,9 +122,7 @@ class HostDirectoryBrowserData {
 class HostDirectoryBrowserController extends _$HostDirectoryBrowserController {
   @override
   Future<HostDirectoryBrowserData> build(String hostId) async {
-    final client = await ref.watch(
-      hostConnectionControllerProvider(hostId).future,
-    );
+    final client = await watchHostConnection(ref, hostId);
     return HostDirectoryBrowserData(roots: await client.hostDirectoryRoots());
   }
 

--- a/mobile/lib/src/features/projects/application/projects_controller.g.dart
+++ b/mobile/lib/src/features/projects/application/projects_controller.g.dart
@@ -52,7 +52,7 @@ final class ProjectsControllerProvider
 }
 
 String _$projectsControllerHash() =>
-    r'd44ea03574a4d8abf4438976062b4e3a92867781';
+    r'e402582e6feb60743d92271f327acd5876767562';
 
 final class ProjectsControllerFamily extends $Family
     with
@@ -157,7 +157,7 @@ final class HostDirectoryBrowserControllerProvider
 }
 
 String _$hostDirectoryBrowserControllerHash() =>
-    r'743f31806bc1ce50242458b82529593e7e7b1910';
+    r'c1c7ceb8af2f330462e01b696c906d30345def0d';
 
 final class HostDirectoryBrowserControllerFamily extends $Family
     with

--- a/mobile/lib/src/features/push_notifications/application/push_coordinator.dart
+++ b/mobile/lib/src/features/push_notifications/application/push_coordinator.dart
@@ -130,8 +130,8 @@ class PushCoordinator extends _$PushCoordinator {
     List<CloudAccountSession> sessions,
   ) async {
     final messaging = ref.read(pushMessagingServiceProvider);
-    final api = ref.read(aleraCloudApiProvider);
     final accounts = ref.read(cloudAccountsControllerProvider.notifier);
+    final api = ref.read(aleraCloudApiProvider);
     if (!messaging.isAvailable) {
       return const PushCoordinationState(
         PushCoordinationStatus.unavailable,
@@ -140,16 +140,14 @@ class PushCoordinator extends _$PushCoordinator {
     }
     final currentSessions = <CloudAccountSession>[];
     for (var session in sessions) {
-      if (session.expiresWithin(
-        const Duration(minutes: 5),
-        DateTime.now().toUtc(),
-      )) {
-        session = await api.refreshSession(session);
-        if (_disposed) {
-          return const PushCoordinationState(PushCoordinationStatus.idle);
-        }
-        await accounts.replaceSession(session);
+      final current = await accounts.sessionForRequest(session.account.id);
+      if (_disposed) {
+        return const PushCoordinationState(PushCoordinationStatus.idle);
       }
+      if (current == null) {
+        continue;
+      }
+      session = current;
       currentSessions.add(session);
       for (final entry in session.subscriptions.entries) {
         if (!entry.value.hasEnabledCategory) {

--- a/mobile/lib/src/features/push_notifications/application/push_coordinator.g.dart
+++ b/mobile/lib/src/features/push_notifications/application/push_coordinator.g.dart
@@ -33,7 +33,7 @@ final class PushCoordinatorProvider
   PushCoordinator create() => PushCoordinator();
 }
 
-String _$pushCoordinatorHash() => r'b4bd535d1e43e4fd334c7143c1364133258257a6';
+String _$pushCoordinatorHash() => r'9af804eebbdfe94b1d694f68aefd20b1b316dac3';
 
 abstract class _$PushCoordinator extends $AsyncNotifier<PushCoordinationState> {
   FutureOr<PushCoordinationState> build();

--- a/mobile/lib/src/features/quotas/application/agent_quota_controller.dart
+++ b/mobile/lib/src/features/quotas/application/agent_quota_controller.dart
@@ -12,9 +12,7 @@ const Duration mobileQuotaRefreshInterval = Duration(minutes: 5);
 class AgentQuotaController extends _$AgentQuotaController {
   @override
   Future<QuotaSnapshotState> build(String hostId) async {
-    final client = await ref.watch(
-      hostConnectionControllerProvider(hostId).future,
-    );
+    final client = await watchHostConnection(ref, hostId);
     if (!client.supportsAgentQuotas) {
       throw UnsupportedError('Update the runtime to view quotas.');
     }

--- a/mobile/lib/src/features/quotas/application/agent_quota_controller.g.dart
+++ b/mobile/lib/src/features/quotas/application/agent_quota_controller.g.dart
@@ -51,7 +51,7 @@ final class AgentQuotaControllerProvider
 }
 
 String _$agentQuotaControllerHash() =>
-    r'db37dbcf6b6b470b184595e9fa5a23af99d49670';
+    r'67f0fee8a2d9173dfd4e29deb52118fe6d6c3a3d';
 
 final class AgentQuotaControllerFamily extends $Family
     with

--- a/mobile/lib/src/features/runtime/application/host_connection_controller.dart
+++ b/mobile/lib/src/features/runtime/application/host_connection_controller.dart
@@ -22,6 +22,7 @@ part 'host_connection_controller.g.dart';
 
 const Duration _probeTimeout = Duration(seconds: 8);
 const Duration _runtimeRestartReconnectDelay = Duration(milliseconds: 300);
+const Duration _connectionCleanupTimeout = Duration(seconds: 2);
 const List<Duration> _retryDelays = <Duration>[
   Duration(seconds: 1),
   Duration(seconds: 2),
@@ -31,6 +32,33 @@ const List<Duration> _retryDelays = <Duration>[
   Duration(seconds: 30),
 ];
 
+Future<MobileRuntimeClient> watchHostConnection(Ref ref, String hostId) {
+  final provider = hostConnectionControllerProvider(hostId);
+  ref.listen(provider, (previous, next) {
+    if (previous != null && (previous.hasValue || previous.hasError)) {
+      ref.invalidateSelf();
+    }
+  });
+  final state = ref.read(provider);
+  final client = state.value;
+  if (client != null &&
+      !state.isLoading &&
+      !state.hasError &&
+      client.isConnectionUsable) {
+    return Future<MobileRuntimeClient>.value(client);
+  }
+  if (state.isLoading && !state.hasValue && !state.hasError) {
+    return ref.read(provider.future);
+  }
+  if (state.hasError && !state.isLoading) {
+    return Future<MobileRuntimeClient>.error(
+      state.error!,
+      state.stackTrace ?? StackTrace.current,
+    );
+  }
+  return ref.read(provider.notifier).requireUsableClient();
+}
+
 /// Owns the WebSocket connection to one paired runtime host. The client is
 /// connected and authenticated before it is exposed. Transport failures recover
 /// while the app is in the foreground, and leaving every host surface disposes
@@ -39,8 +67,9 @@ const List<Duration> _retryDelays = <Duration>[
 class HostConnectionController extends _$HostConnectionController {
   final Logger _logger = Logger('HostConnectionController');
   MobileRuntimeClient? _client;
-  StreamSubscription<MobileRuntimeEvent>? _closeSub;
+  StreamSubscription<(Object, StackTrace?)>? _closeSub;
   Timer? _retryTimer;
+  Completer<void>? _buildAttempt;
   Future<void>? _connectionAttempt;
   AppLifecycleState _lifecycleState = AppLifecycleState.resumed;
   int _retryIndex = 0;
@@ -49,6 +78,8 @@ class HostConnectionController extends _$HostConnectionController {
 
   @override
   Future<MobileRuntimeClient> build(String hostId) async {
+    final buildAttempt = Completer<void>();
+    _buildAttempt = buildAttempt;
     _building = true;
     _lifecycleState = ref.read(appLifecycleControllerProvider);
     ref.listen(appLifecycleControllerProvider, _handleLifecycleChange);
@@ -62,7 +93,29 @@ class HostConnectionController extends _$HostConnectionController {
       Error.throwWithStackTrace(error, stackTrace);
     } finally {
       _building = false;
+      buildAttempt.complete();
+      if (identical(_buildAttempt, buildAttempt)) {
+        _buildAttempt = null;
+      }
     }
+  }
+
+  Future<MobileRuntimeClient> requireUsableClient() async {
+    await _buildAttempt?.future;
+    var client = _client;
+    if (client != null && client.isConnectionUsable) {
+      return client;
+    }
+    await reconnectNow();
+    client = _client;
+    if (client != null && client.isConnectionUsable) {
+      return client;
+    }
+    final error = state.error;
+    if (error != null) {
+      throw error;
+    }
+    throw const RuntimeConnectionLost();
   }
 
   Future<void> reconnectNow() {
@@ -195,17 +248,20 @@ class HostConnectionController extends _$HostConnectionController {
     }
     final previousClient = _client;
     _client = null;
-    await _closeSub?.cancel();
+    final previousCloseSub = _closeSub;
     _closeSub = null;
+    await _cancelCloseSubscription(previousCloseSub);
     if (previousClient != null && !identical(previousClient, client)) {
       await previousClient.dispose();
     }
     _client = client;
     _retryIndex = 0;
-    final closeSub = client.events.listen(
-      (_) {},
-      onError: (Object error, StackTrace stackTrace) =>
-          _handleClientEnded(client, error, stackTrace),
+    final closeSub = client.connectionFailures.listen(
+      (failure) => _handleClientEnded(
+        client,
+        failure.$1,
+        failure.$2 ?? StackTrace.current,
+      ),
       onDone: () => _handleClientEnded(
         client,
         const RuntimeConnectionLost(),
@@ -317,15 +373,18 @@ class HostConnectionController extends _$HostConnectionController {
     _retryTimer = null;
     final previousClient = _client;
     _client = null;
-    await _closeSub?.cancel();
+    final previousCloseSub = _closeSub;
     _closeSub = null;
+    if (!_disposed) {
+      state = const AsyncLoading<MobileRuntimeClient>();
+    }
+    await _cancelCloseSubscription(previousCloseSub);
     if (previousClient != null) {
       await previousClient.dispose();
     }
     if (_disposed) {
       return;
     }
-    state = const AsyncLoading<MobileRuntimeClient>();
     try {
       final client = await _openClient();
       await _bindClient(client);
@@ -339,6 +398,23 @@ class HostConnectionController extends _$HostConnectionController {
       _logger.warning('could not reconnect to host $hostId', error, stackTrace);
       state = AsyncError(error, stackTrace);
       _scheduleRetry(error);
+    }
+  }
+
+  Future<void> _cancelCloseSubscription(
+    StreamSubscription<(Object, StackTrace?)>? subscription,
+  ) async {
+    if (subscription == null) {
+      return;
+    }
+    try {
+      await subscription.cancel().timeout(_connectionCleanupTimeout);
+    } on Object catch (error, stackTrace) {
+      _logger.warning(
+        'runtime event subscription did not cancel cleanly for $hostId',
+        error,
+        stackTrace,
+      );
     }
   }
 

--- a/mobile/lib/src/features/runtime/application/host_connection_controller.g.dart
+++ b/mobile/lib/src/features/runtime/application/host_connection_controller.g.dart
@@ -65,7 +65,7 @@ final class HostConnectionControllerProvider
 }
 
 String _$hostConnectionControllerHash() =>
-    r'ed20c28b06ccdc7ad9a292ea10f3938ecd5a6fd3';
+    r'57f255ec68b7b6c54f4009cd99878196f98412f9';
 
 /// Owns the WebSocket connection to one paired runtime host. The client is
 /// connected and authenticated before it is exposed. Transport failures recover

--- a/mobile/lib/src/features/runtime/application/host_dashboard_controller.dart
+++ b/mobile/lib/src/features/runtime/application/host_dashboard_controller.dart
@@ -27,9 +27,12 @@ class HostDashboardData {
 
 @riverpod
 Future<HostDashboardData> hostDashboardData(Ref ref, String hostId) async {
-  final client = await ref.watch(
-    hostConnectionControllerProvider(hostId).future,
-  );
+  final connectionProvider = hostConnectionControllerProvider(hostId);
+  var client = await ref.watch(connectionProvider.future);
+  if (!client.isConnectionUsable) {
+    await ref.read(connectionProvider.notifier).reconnectNow();
+    client = await ref.read(connectionProvider.future);
+  }
   final status = await client.mobileStatus();
   final projects = sortProjectsForSelection(await client.listProjects());
   final workspaces = await client.listWorkspaces();

--- a/mobile/lib/src/features/runtime/application/host_dashboard_controller.g.dart
+++ b/mobile/lib/src/features/runtime/application/host_dashboard_controller.g.dart
@@ -66,7 +66,7 @@ final class HostDashboardDataProvider
   }
 }
 
-String _$hostDashboardDataHash() => r'fe7491beb985a349227d51c060a6e495380f784d';
+String _$hostDashboardDataHash() => r'3e0e33183f0b869128443908f9c7f25dd3528bcd';
 
 final class HostDashboardDataFamily extends $Family
     with $FunctionalFamilyOverride<FutureOr<HostDashboardData>, String> {

--- a/mobile/lib/src/features/runtime/domain/host_reachability.dart
+++ b/mobile/lib/src/features/runtime/domain/host_reachability.dart
@@ -51,6 +51,9 @@ bool _isTransportReachabilityFailure(Object error) {
   if (error is TimeoutException || error is SocketException) {
     return true;
   }
+  if (error is HttpException) {
+    return _looksLikeReachabilityMessage(error.message.toLowerCase());
+  }
   if (error is HandshakeException ||
       error is TlsException ||
       error is CertificateException) {
@@ -75,6 +78,7 @@ bool _looksLikeReachabilityMessage(String text) {
     'connection timed out',
     'connection time out',
     'connection reset',
+    'connection closed before full header was received',
     'connection abort',
     'software caused connection abort',
     'broken pipe',

--- a/mobile/lib/src/features/runtime/infra/mobile_binary_output_payload.dart
+++ b/mobile/lib/src/features/runtime/infra/mobile_binary_output_payload.dart
@@ -28,3 +28,13 @@ MobileTerminalOutputEvent? decodeMobileBinaryOutput(List<int> raw) {
     Uint8List.fromList(raw.sublist(idEnd)),
   );
 }
+
+bool looksLikeJsonBytes(List<int> bytes) {
+  for (final byte in bytes) {
+    if (byte == 0x20 || byte == 0x09 || byte == 0x0a || byte == 0x0d) {
+      continue;
+    }
+    return byte == 0x7b || byte == 0x5b;
+  }
+  return false;
+}

--- a/mobile/lib/src/features/runtime/infra/mobile_runtime_client.dart
+++ b/mobile/lib/src/features/runtime/infra/mobile_runtime_client.dart
@@ -29,6 +29,7 @@ import 'package:web_socket_channel/io.dart';
 export 'package:alera_mobile/src/features/runtime/domain/runtime_client_surfaces.dart';
 
 part 'mobile_runtime_client_host_tools.dart';
+part 'mobile_runtime_client_lifecycle.dart';
 part 'mobile_runtime_client_relay.dart';
 part 'mobile_runtime_dictation_requests.dart';
 part 'mobile_runtime_terminal_requests.dart';
@@ -37,6 +38,7 @@ part 'mobile_runtime_codex_requests.dart';
 part 'mobile_runtime_codex_workspace_requests.dart';
 
 const Duration _defaultRequestTimeout = Duration(seconds: 20);
+const Duration _defaultTransportCloseTimeout = Duration(seconds: 2);
 
 class MobileRuntimeClient
     with
@@ -58,6 +60,7 @@ class MobileRuntimeClient
   MobileRuntimeClient._(
     this._channel, {
     this._requestTimeout = _defaultRequestTimeout,
+    this._transportCloseTimeout = _defaultTransportCloseTimeout,
   }) {
     _subscription = _channel.stream.listen(
       _handleMessage,
@@ -69,7 +72,12 @@ class MobileRuntimeClient
   MobileRuntimeClient.forTesting(
     WebSocketChannel channel, {
     Duration requestTimeout = _defaultRequestTimeout,
-  }) : this._(channel, requestTimeout: requestTimeout);
+    Duration transportCloseTimeout = _defaultTransportCloseTimeout,
+  }) : this._(
+         channel,
+         requestTimeout: requestTimeout,
+         transportCloseTimeout: transportCloseTimeout,
+       );
 
   static Future<MobileRuntimeClient> connect(String endpoint) async {
     final client = MobileRuntimeClient._(
@@ -135,11 +143,14 @@ class MobileRuntimeClient
   final WebSocketChannel _channel;
   @override
   final Duration _requestTimeout;
+  final Duration _transportCloseTimeout;
   final Map<int, Completer<Object?>> _pending = <int, Completer<Object?>>{};
   final StreamController<MobileRuntimeEvent> _events =
       StreamController<MobileRuntimeEvent>.broadcast();
   final StreamController<MobileTerminalOutputEvent> _terminalOutput =
       StreamController<MobileTerminalOutputEvent>.broadcast();
+  final StreamController<(Object, StackTrace?)> _connectionFailures =
+      StreamController<(Object, StackTrace?)>.broadcast(sync: true);
 
   late final StreamSubscription<Object?> _subscription;
   int _nextRequestId = 1;
@@ -154,6 +165,8 @@ class MobileRuntimeClient
   @override
   Stream<MobileTerminalOutputEvent> get terminalOutput =>
       _terminalOutput.stream;
+  Stream<(Object, StackTrace?)> get connectionFailures =>
+      _connectionFailures.stream;
   int get debugPendingRequestCount => _pending.length;
 
   @override
@@ -361,23 +374,6 @@ class MobileRuntimeClient
     return const <Object?>[];
   }
 
-  Future<void> dispose() async {
-    if (_disposed) {
-      return;
-    }
-    _disposed = true;
-    for (final completer in _pending.values) {
-      if (!completer.isCompleted) {
-        completer.completeError(StateError('Mobile runtime client closed.'));
-      }
-    }
-    _pending.clear();
-    await _subscription.cancel();
-    await _events.close();
-    await _terminalOutput.close();
-    await _channel.sink.close();
-  }
-
   void _handleMessage(Object? raw) {
     if (_relayHandshake != null) {
       unawaited(_handleRelayHandshakeMessage(raw));
@@ -397,7 +393,9 @@ class MobileRuntimeClient
       return;
     }
     final payload = await session.seal(utf8.encode(encoded));
-    _channel.sink.add(wrapRelayFrame(_relayClientId!, payload));
+    for (final fragment in fragmentRelayPayload(payload)) {
+      _channel.sink.add(wrapRelayFrame(_relayClientId!, fragment));
+    }
   }
 
   @override
@@ -408,17 +406,15 @@ class MobileRuntimeClient
 
   @override
   void _handleDecodedMessage(Object? raw) {
-    // Once negotiated, a binary message is terminal output and never JSON, so
-    // it skips jsonDecode and base64Decode entirely.
-    if (_binaryFrames && raw is List<int>) {
+    // Relay control responses are decrypted into bytes even though direct
+    // WebSockets normally carry them as text. Recognize JSON first because a
+    // large JSON object can otherwise look like a valid binary output frame.
+    if (_binaryFrames && raw is List<int> && !looksLikeJsonBytes(raw)) {
       final output = decodeMobileBinaryOutput(raw);
       if (output != null) {
         emitTerminalOutput(output);
-        return;
       }
-      if (!looksLikeJsonBytes(raw)) {
-        return;
-      }
+      return;
     }
     final decoded = switch (raw) {
       String text => jsonDecode(text),
@@ -467,6 +463,7 @@ class MobileRuntimeClient
     // The single funnel every transport failure passes through, and the most
     // common thing a user reports about this app.
     final normalized = normalizeHostConnectionError(error);
+    final firstFailure = _closedError == null;
     Logger('MobileRuntimeClient').warning(
       'runtime connection failed with ${_pending.length} pending requests',
       error,
@@ -474,6 +471,9 @@ class MobileRuntimeClient
     );
     _closedError ??= normalized;
     _closedStackTrace ??= stackTrace;
+    if (firstFailure && !_connectionFailures.isClosed) {
+      _connectionFailures.add((normalized, stackTrace));
+    }
     final handshake = _relayHandshake;
     if (handshake != null && !handshake.isCompleted) {
       handshake.completeError(error, stackTrace);

--- a/mobile/lib/src/features/runtime/infra/mobile_runtime_client.dart
+++ b/mobile/lib/src/features/runtime/infra/mobile_runtime_client.dart
@@ -416,7 +416,7 @@ class MobileRuntimeClient
         emitTerminalOutput(output);
         return;
       }
-      if (!_looksLikeJsonBytes(raw)) {
+      if (!looksLikeJsonBytes(raw)) {
         return;
       }
     }
@@ -497,14 +497,4 @@ class MobileRuntimeClient
     // rather than a StateError that would look like a programming fault.
     _handleSocketError(const RuntimeConnectionLost());
   }
-}
-
-bool _looksLikeJsonBytes(List<int> bytes) {
-  for (final byte in bytes) {
-    if (byte == 0x20 || byte == 0x09 || byte == 0x0a || byte == 0x0d) {
-      continue;
-    }
-    return byte == 0x7b || byte == 0x5b;
-  }
-  return false;
 }

--- a/mobile/lib/src/features/runtime/infra/mobile_runtime_client.dart
+++ b/mobile/lib/src/features/runtime/infra/mobile_runtime_client.dart
@@ -414,8 +414,11 @@ class MobileRuntimeClient
       final output = decodeMobileBinaryOutput(raw);
       if (output != null) {
         emitTerminalOutput(output);
+        return;
       }
-      return;
+      if (!_looksLikeJsonBytes(raw)) {
+        return;
+      }
     }
     final decoded = switch (raw) {
       String text => jsonDecode(text),
@@ -494,4 +497,14 @@ class MobileRuntimeClient
     // rather than a StateError that would look like a programming fault.
     _handleSocketError(const RuntimeConnectionLost());
   }
+}
+
+bool _looksLikeJsonBytes(List<int> bytes) {
+  for (final byte in bytes) {
+    if (byte == 0x20 || byte == 0x09 || byte == 0x0a || byte == 0x0d) {
+      continue;
+    }
+    return byte == 0x7b || byte == 0x5b;
+  }
+  return false;
 }

--- a/mobile/lib/src/features/runtime/infra/mobile_runtime_client_lifecycle.dart
+++ b/mobile/lib/src/features/runtime/infra/mobile_runtime_client_lifecycle.dart
@@ -1,0 +1,32 @@
+part of 'mobile_runtime_client.dart';
+
+extension MobileRuntimeClientLifecycle on MobileRuntimeClient {
+  Future<void> dispose() async {
+    if (_disposed) {
+      return;
+    }
+    _disposed = true;
+    for (final completer in _pending.values) {
+      if (!completer.isCompleted) {
+        completer.completeError(StateError('Mobile runtime client closed.'));
+      }
+    }
+    _pending.clear();
+    final transportClose = () async {
+      await _subscription.cancel();
+      await _channel.sink.close();
+    }();
+    // A paused consumer delays a StreamController close future indefinitely.
+    // Transport teardown must still complete so the host can reconnect.
+    unawaited(_events.close());
+    unawaited(_terminalOutput.close());
+    unawaited(_connectionFailures.close());
+    try {
+      await transportClose.timeout(_transportCloseTimeout);
+    } on Object catch (error, stackTrace) {
+      Logger(
+        'MobileRuntimeClient',
+      ).warning('runtime transport did not close cleanly', error, stackTrace);
+    }
+  }
+}

--- a/mobile/lib/src/features/runtime/infra/mobile_runtime_client_relay.dart
+++ b/mobile/lib/src/features/runtime/infra/mobile_runtime_client_relay.dart
@@ -4,6 +4,7 @@ mixin MobileRuntimeClientRelay {
   RelayCryptoSession? _relaySession;
   String? _relayClientId;
   Completer<Map<String, Object?>>? _relayHandshake;
+  final RelayFragmentReassembler _relayFragments = RelayFragmentReassembler();
 
   WebSocketChannel get _channel;
   Duration get _requestTimeout;
@@ -61,7 +62,11 @@ mixin MobileRuntimeClientRelay {
       if (clientId != _relayClientId) {
         return;
       }
-      final clear = await _relaySession!.open(payload);
+      final envelope = _relayFragments.accept(payload);
+      if (envelope == null) {
+        return;
+      }
+      final clear = await _relaySession!.open(envelope);
       _handleDecodedMessage(clear);
     } on Object catch (error, stackTrace) {
       _handleSocketError(error, stackTrace);

--- a/mobile/lib/src/features/runtime/infra/relay_crypto.dart
+++ b/mobile/lib/src/features/runtime/infra/relay_crypto.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:typed_data';
 
@@ -71,6 +72,8 @@ class RelayCryptoSession {
   final int _receiveDirection;
   int _nextSendCounter = 0;
   int _nextReceiveCounter = 0;
+  Future<void> _sendTail = Future<void>.value();
+  Future<void> _receiveTail = Future<void>.value();
 
   static Future<RelayCryptoSession> derive({
     required RelayIdentityKeyPair localStatic,
@@ -200,7 +203,13 @@ class RelayCryptoSession {
     ], secretKey: SecretKey(_confirmationKey))).bytes;
   }
 
-  Future<Uint8List> seal(List<int> plaintext) async {
+  Future<Uint8List> seal(List<int> plaintext) {
+    final result = _sendTail.then((_) => _seal(plaintext));
+    _sendTail = result.then<void>((_) {}, onError: (_, _) {});
+    return result;
+  }
+
+  Future<Uint8List> _seal(List<int> plaintext) async {
     final counter = _nextSendCounter;
     final nonce = _nonce(_sendDirection, counter);
     final aad = _associatedData(_sendDirection, counter);
@@ -221,7 +230,13 @@ class RelayCryptoSession {
     ]);
   }
 
-  Future<Uint8List> open(List<int> envelope) async {
+  Future<Uint8List> open(List<int> envelope) {
+    final result = _receiveTail.then((_) => _open(envelope));
+    _receiveTail = result.then<void>((_) {}, onError: (_, _) {});
+    return result;
+  }
+
+  Future<Uint8List> _open(List<int> envelope) async {
     if (envelope.length < _headerBytes + 16 ||
         envelope[0] != relayProtocolVersion ||
         envelope[1] != _receiveDirection) {

--- a/mobile/lib/src/features/runtime/infra/relay_wire.dart
+++ b/mobile/lib/src/features/runtime/infra/relay_wire.dart
@@ -2,6 +2,108 @@ import 'dart:convert';
 import 'dart:typed_data';
 
 const int relayHelloVersion = 1;
+const List<int> _fragmentMagic = <int>[0x41, 0x4c, 0x52, 0x46, 0x01];
+const int _fragmentHeaderBytes = 13;
+const int _relayFragmentPayloadBytes = 48 * 1024;
+const int maxRelayEnvelopeBytes = 1024 * 1024;
+
+class RelayFragmentReassembler {
+  int? _total;
+  BytesBuilder _bytes = BytesBuilder(copy: false);
+
+  Uint8List? accept(List<int> payload) {
+    if (!_startsWithFragmentMagic(payload)) {
+      if (_total != null) {
+        _reset();
+        throw const FormatException('Relay fragment sequence was interrupted.');
+      }
+      return Uint8List.fromList(payload);
+    }
+    if (payload.length <= _fragmentHeaderBytes) {
+      _reset();
+      throw const FormatException('Relay fragment is truncated.');
+    }
+    final total = _readUint32(payload, 5);
+    final offset = _readUint32(payload, 9);
+    final chunk = payload.sublist(_fragmentHeaderBytes);
+    if (total <= _relayFragmentPayloadBytes ||
+        total > maxRelayEnvelopeBytes ||
+        chunk.length > _relayFragmentPayloadBytes ||
+        offset + chunk.length > total) {
+      _reset();
+      throw const FormatException(
+        'Relay fragment is outside the supported range.',
+      );
+    }
+    if (offset == 0) {
+      _total = total;
+      _bytes = BytesBuilder(copy: false);
+    } else if (_total != total || offset != _bytes.length) {
+      _reset();
+      throw const FormatException('Relay fragment sequence is invalid.');
+    }
+    _bytes.add(chunk);
+    if (_bytes.length != total) {
+      return null;
+    }
+    final complete = _bytes.takeBytes();
+    _reset();
+    return complete;
+  }
+
+  void _reset() {
+    _total = null;
+    _bytes = BytesBuilder(copy: false);
+  }
+}
+
+List<Uint8List> fragmentRelayPayload(List<int> payload) {
+  if (payload.length > maxRelayEnvelopeBytes) {
+    throw const FormatException('Relay envelope is too large.');
+  }
+  if (payload.length <= _relayFragmentPayloadBytes) {
+    return <Uint8List>[Uint8List.fromList(payload)];
+  }
+  return <Uint8List>[
+    for (
+      var offset = 0;
+      offset < payload.length;
+      offset += _relayFragmentPayloadBytes
+    )
+      Uint8List.fromList(<int>[
+        ..._fragmentMagic,
+        ..._uint32(payload.length),
+        ..._uint32(offset),
+        ...payload.sublist(
+          offset,
+          offset + _relayFragmentPayloadBytes < payload.length
+              ? offset + _relayFragmentPayloadBytes
+              : payload.length,
+        ),
+      ]),
+  ];
+}
+
+bool _startsWithFragmentMagic(List<int> payload) {
+  if (payload.length < _fragmentMagic.length) return false;
+  for (var index = 0; index < _fragmentMagic.length; index++) {
+    if (payload[index] != _fragmentMagic[index]) return false;
+  }
+  return true;
+}
+
+List<int> _uint32(int value) => <int>[
+  (value >> 24) & 0xff,
+  (value >> 16) & 0xff,
+  (value >> 8) & 0xff,
+  value & 0xff,
+];
+
+int _readUint32(List<int> bytes, int offset) =>
+    (bytes[offset] << 24) |
+    (bytes[offset + 1] << 16) |
+    (bytes[offset + 2] << 8) |
+    bytes[offset + 3];
 
 Uint8List wrapRelayFrame(String clientId, List<int> payload) {
   final id = utf8.encode(clientId);

--- a/mobile/lib/src/features/runtime/presentation/host_dashboard_screen.dart
+++ b/mobile/lib/src/features/runtime/presentation/host_dashboard_screen.dart
@@ -85,7 +85,10 @@ class HostDashboardScreen extends ConsumerWidget {
               unawaited(
                 ref
                     .read(hostConnectionControllerProvider(host.id).notifier)
-                    .reconnectNow(),
+                    .reconnectNow()
+                    .whenComplete(() {
+                      ref.invalidate(hostDashboardDataProvider(host.id));
+                    }),
               );
             },
           ),

--- a/mobile/lib/src/features/settings/application/host_settings_controller.dart
+++ b/mobile/lib/src/features/settings/application/host_settings_controller.dart
@@ -11,9 +11,7 @@ part 'host_settings_controller.g.dart';
 class HostSettingsController extends _$HostSettingsController {
   @override
   Future<PortableHostSettings> build(String hostId) async {
-    final client = await ref.watch(
-      hostConnectionControllerProvider(hostId).future,
-    );
+    final client = await watchHostConnection(ref, hostId);
     if (!client.supportsPortableSettings) {
       throw UnsupportedError('Update the runtime to manage settings.');
     }

--- a/mobile/lib/src/features/settings/application/host_settings_controller.g.dart
+++ b/mobile/lib/src/features/settings/application/host_settings_controller.g.dart
@@ -53,7 +53,7 @@ final class HostSettingsControllerProvider
 }
 
 String _$hostSettingsControllerHash() =>
-    r'43a57c4b268651d55ef13bfb2609376733ef095a';
+    r'4256d7938f88dc9f311261c351aba8854d874e4c';
 
 final class HostSettingsControllerFamily extends $Family
     with

--- a/mobile/lib/src/features/settings/application/host_tools_controllers.dart
+++ b/mobile/lib/src/features/settings/application/host_tools_controllers.dart
@@ -21,9 +21,7 @@ class SkillRunnerSelection extends _$SkillRunnerSelection {
 class CliRegistrationController extends _$CliRegistrationController {
   @override
   Future<CliRegistrationStatus> build(String hostId) async {
-    final client = await ref.watch(
-      hostConnectionControllerProvider(hostId).future,
-    );
+    final client = await watchHostConnection(ref, hostId);
     if (!client.supportsHostTools) {
       throw UnsupportedError('Update the runtime to manage host tools.');
     }

--- a/mobile/lib/src/features/settings/application/host_tools_controllers.g.dart
+++ b/mobile/lib/src/features/settings/application/host_tools_controllers.g.dart
@@ -155,7 +155,7 @@ final class CliRegistrationControllerProvider
 }
 
 String _$cliRegistrationControllerHash() =>
-    r'31459b40048992589ee7318e646de05a37f3f019';
+    r'11f22898588558c326c21dad2618b73fdaaf9504';
 
 final class CliRegistrationControllerFamily extends $Family
     with

--- a/mobile/lib/src/features/terminal/application/terminal_providers.dart
+++ b/mobile/lib/src/features/terminal/application/terminal_providers.dart
@@ -8,5 +8,5 @@ part 'terminal_providers.g.dart';
 /// fake so tab and session controllers can run without a live gateway.
 @riverpod
 Future<MobileTerminalClient> terminalClient(Ref ref, String hostId) {
-  return ref.watch(hostConnectionControllerProvider(hostId).future);
+  return watchHostConnection(ref, hostId);
 }

--- a/mobile/lib/src/features/terminal/application/terminal_providers.g.dart
+++ b/mobile/lib/src/features/terminal/application/terminal_providers.g.dart
@@ -73,7 +73,7 @@ final class TerminalClientProvider
   }
 }
 
-String _$terminalClientHash() => r'65a9f80d83eddbc9c662f98d16b9d5c76668e095';
+String _$terminalClientHash() => r'eaaa496030db951d841ec9e73bb1f8ece56e617d';
 
 /// The terminal surface of the host connection. Tests override this with a
 /// fake so tab and session controllers can run without a live gateway.

--- a/mobile/lib/src/features/workbench/application/workbench_providers.dart
+++ b/mobile/lib/src/features/workbench/application/workbench_providers.dart
@@ -8,5 +8,5 @@ part 'workbench_providers.g.dart';
 /// fake so workbench controllers can run without a live gateway.
 @riverpod
 Future<MobileWorkspaceClient> workspaceClient(Ref ref, String hostId) {
-  return ref.watch(hostConnectionControllerProvider(hostId).future);
+  return watchHostConnection(ref, hostId);
 }

--- a/mobile/lib/src/features/workbench/application/workbench_providers.g.dart
+++ b/mobile/lib/src/features/workbench/application/workbench_providers.g.dart
@@ -73,7 +73,7 @@ final class WorkspaceClientProvider
   }
 }
 
-String _$workspaceClientHash() => r'9090961936ae5bfb9c5391dde4f850b5fbcb396e';
+String _$workspaceClientHash() => r'b5341003821c53a53d92071b38dda218e89bab23';
 
 /// The workspace surface of the host connection. Tests override this with a
 /// fake so workbench controllers can run without a live gateway.

--- a/mobile/lib/src/features/workbench/presentation/runtime_workspaces_screen.dart
+++ b/mobile/lib/src/features/workbench/presentation/runtime_workspaces_screen.dart
@@ -65,7 +65,9 @@ class RuntimeWorkspacesScreen extends ConsumerWidget {
               child: AleraStatusDot(
                 // Riverpod keeps the previous value on an error state, so
                 // hasValue alone would keep the dot green on a dead socket.
-                active: connection.hasValue && !connection.hasError,
+                active:
+                    connection is AsyncData &&
+                    connection.value?.isConnectionUsable == true,
                 size: AleraTokens.spaceSm,
               ),
             ),
@@ -132,13 +134,7 @@ class RuntimeWorkspacesScreen extends ConsumerWidget {
                 child: _ConnectionError(
                   error: error,
                   onRetry: () {
-                    unawaited(
-                      ref
-                          .read(
-                            hostConnectionControllerProvider(host.id).notifier,
-                          )
-                          .reconnectNow(),
-                    );
+                    unawaited(_retryConnection(ref, host.id));
                   },
                 ),
               ),
@@ -179,6 +175,19 @@ class RuntimeWorkspacesScreen extends ConsumerWidget {
             )
           : null,
     );
+  }
+
+  Future<void> _retryConnection(WidgetRef ref, String hostId) async {
+    try {
+      await ref
+          .read(hostConnectionControllerProvider(hostId).notifier)
+          .requireUsableClient();
+    } on Object {
+      // The invalidated surface providers below render the connection error.
+    } finally {
+      ref.invalidate(workspaceListControllerProvider(hostId));
+      ref.invalidate(mobileViewPrefsControllerProvider(hostId));
+    }
   }
 
   Future<void> _handleMenu(

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -1397,7 +1397,7 @@ packages:
     source: hosted
     version: "1.0.0"
   stream_channel:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: stream_channel
       sha256: "969e04c80b8bcdf826f8f16579c7b14d780458bd97f56d107d3950fdbeef059d"

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -82,6 +82,7 @@ dev_dependencies:
   plugin_platform_interface: ^2.1.8
   riverpod_generator: ^4.0.4
   riverpod_lint: ^3.1.4
+  stream_channel: ^2.1.4
   url_launcher_platform_interface: ^2.3.2
 
 # For information on the generic Dart part of this file, see the

--- a/mobile/test/cloud_account_card_test.dart
+++ b/mobile/test/cloud_account_card_test.dart
@@ -1,0 +1,48 @@
+import 'package:alera_mobile/src/features/accounts/domain/cloud_account_session.dart';
+import 'package:alera_mobile/src/features/accounts/domain/runtime_push_preferences.dart';
+import 'package:alera_mobile/src/features/accounts/presentation/cloud_account_card.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('lays out subscribed runtimes inside a scrolling account list', (
+    tester,
+  ) async {
+    final session = CloudAccountSession(
+      account: const CloudAccountProfile(
+        id: 'account-1',
+        email: 'account@example.com',
+        providers: <String>['google'],
+      ),
+      accessToken: 'access-token',
+      refreshToken: 'refresh-token',
+      accessTokenExpiresAt: DateTime.utc(2030),
+      subscriptions: const <String, RuntimePushPreferences>{
+        'runtime-1': RuntimePushPreferences(),
+      },
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData.dark(),
+        home: Scaffold(
+          body: ListView(
+            children: <Widget>[
+              CloudAccountCard(
+                session: session,
+                hosts: const [],
+                onPreferencesChanged: (_, _) async {},
+                onAction: (_) {},
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(tester.takeException(), isNull);
+    expect(find.text('account@example.com'), findsOneWidget);
+    expect(find.text('Unpaired runtime'), findsOneWidget);
+  });
+}

--- a/mobile/test/cloud_accounts_controller_test.dart
+++ b/mobile/test/cloud_accounts_controller_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:alera_mobile/src/features/accounts/application/cloud_account_providers.dart';
 import 'package:alera_mobile/src/features/accounts/application/cloud_account_repository.dart';
 import 'package:alera_mobile/src/features/accounts/application/cloud_accounts_controller.dart';
@@ -86,6 +88,62 @@ void main() {
     expect(container.read(cloudAccountsControllerProvider).value, isEmpty);
     expect(api.pushTokenDeleteCalls, 0);
   });
+
+  test(
+    'Session Refresh Is Serialized And Cannot Replace Reenrollment',
+    () async {
+      final expired = CloudAccountSession(
+        account: const CloudAccountProfile(
+          id: 'account-1',
+          email: 'owner@example.com',
+        ),
+        accessToken: 'expired-access',
+        refreshToken: 'expired-refresh',
+        accessTokenExpiresAt: DateTime.now().toUtc(),
+      );
+      final reenrolled = expired.copyWith(
+        accessToken: 'new-access',
+        refreshToken: 'new-refresh',
+        accessTokenExpiresAt: DateTime.now().toUtc().add(
+          const Duration(minutes: 15),
+        ),
+      );
+      final repository = _MemoryRepository(expired);
+      final api = _RefreshApi(reenrolled);
+      final container = ProviderContainer(
+        overrides: [
+          cloudAccountRepositoryProvider.overrideWithValue(repository),
+          aleraCloudApiProvider.overrideWithValue(api),
+        ],
+      );
+      addTearDown(container.dispose);
+      await container.read(cloudAccountsControllerProvider.future);
+      final controller = container.read(
+        cloudAccountsControllerProvider.notifier,
+      );
+
+      final firstRefresh = controller.sessionForRequest('account-1');
+      await api.refreshStarted.future;
+      final secondRefresh = controller.sessionForRequest('account-1');
+      await controller.redeemEnrollment('enrollment-code');
+      api.refreshRelease.complete();
+      await Future.wait(<Future<CloudAccountSession?>>[
+        firstRefresh,
+        secondRefresh,
+      ]);
+
+      expect(api.refreshCalls, 1);
+      expect(repository.sessions.single.refreshToken, 'new-refresh');
+      expect(
+        container
+            .read(cloudAccountsControllerProvider)
+            .value
+            ?.single
+            .refreshToken,
+        'new-refresh',
+      );
+    },
+  );
 }
 
 class _MemoryRepository implements CloudAccountRepository {
@@ -107,7 +165,76 @@ class _MemoryRepository implements CloudAccountRepository {
   }
 
   @override
-  Future<void> saveSession(CloudAccountSession session) async {}
+  Future<void> saveSession(CloudAccountSession session) async {
+    sessions.removeWhere((item) => item.account.id == session.account.id);
+    sessions.add(session);
+  }
+}
+
+class _RefreshApi implements AleraCloudApi {
+  _RefreshApi(this.reenrolled);
+
+  final CloudAccountSession reenrolled;
+  final Completer<void> refreshStarted = Completer<void>();
+  final Completer<void> refreshRelease = Completer<void>();
+  int refreshCalls = 0;
+
+  @override
+  Future<CloudAccountSession> refreshSession(
+    CloudAccountSession session,
+  ) async {
+    refreshCalls += 1;
+    if (!refreshStarted.isCompleted) {
+      refreshStarted.complete();
+    }
+    await refreshRelease.future;
+    return session.copyWith(
+      accessToken: 'rotated-access',
+      refreshToken: 'rotated-refresh',
+      accessTokenExpiresAt: DateTime.now().toUtc().add(
+        const Duration(minutes: 15),
+      ),
+    );
+  }
+
+  @override
+  Future<CloudEnrollmentResult> redeemEnrollment({
+    required String code,
+    required String deviceId,
+    required String deviceName,
+  }) async =>
+      CloudEnrollmentResult(session: reenrolled, runtimeId: 'runtime-1');
+
+  @override
+  Future<CloudAccountProfile> accountStatus(
+    CloudAccountSession session,
+  ) async => session.account;
+
+  @override
+  Future<void> deletePushToken(CloudAccountSession session) async {}
+
+  @override
+  Future<void> deleteSubscription({
+    required CloudAccountSession session,
+    required String runtimeId,
+  }) async {}
+
+  @override
+  Future<void> putSubscription({
+    required CloudAccountSession session,
+    required String runtimeId,
+    required RuntimePushPreferences preferences,
+  }) async {}
+
+  @override
+  Future<void> registerPushToken({
+    required CloudAccountSession session,
+    required String token,
+    required String platform,
+  }) async {}
+
+  @override
+  Future<void> revokeSession(CloudAccountSession session) async {}
 }
 
 class _RemovalApi implements AleraCloudApi {

--- a/mobile/test/cloud_accounts_controller_test.dart
+++ b/mobile/test/cloud_accounts_controller_test.dart
@@ -45,6 +45,47 @@ void main() {
     expect(container.read(cloudAccountsControllerProvider).value, hasLength(1));
     expect(api.pushTokenDeleteCalls, 0);
   });
+
+  test('Revoked Session Can Still Be Removed From The Phone', () async {
+    final session = CloudAccountSession(
+      account: const CloudAccountProfile(
+        id: 'account-1',
+        email: 'owner@example.com',
+      ),
+      accessToken: 'access',
+      refreshToken: 'refresh',
+      accessTokenExpiresAt: DateTime.now().toUtc().add(
+        const Duration(hours: 1),
+      ),
+      subscriptions: const <String, RuntimePushPreferences>{
+        'runtime-1': RuntimePushPreferences(),
+      },
+    );
+    final repository = _MemoryRepository(session);
+    final api = _RemovalApi(
+      removalError: const AleraCloudException(
+        'The account session has been revoked.',
+        statusCode: 401,
+        code: 'session_revoked',
+      ),
+    );
+    final container = ProviderContainer(
+      overrides: [
+        cloudAccountRepositoryProvider.overrideWithValue(repository),
+        aleraCloudApiProvider.overrideWithValue(api),
+      ],
+    );
+    addTearDown(container.dispose);
+    await container.read(cloudAccountsControllerProvider.future);
+
+    await container
+        .read(cloudAccountsControllerProvider.notifier)
+        .removeFromThisPhone('account-1');
+
+    expect(repository.sessions, isEmpty);
+    expect(container.read(cloudAccountsControllerProvider).value, isEmpty);
+    expect(api.pushTokenDeleteCalls, 0);
+  });
 }
 
 class _MemoryRepository implements CloudAccountRepository {
@@ -70,6 +111,9 @@ class _MemoryRepository implements CloudAccountRepository {
 }
 
 class _RemovalApi implements AleraCloudApi {
+  _RemovalApi({this.removalError});
+
+  final Object? removalError;
   int pushTokenDeleteCalls = 0;
 
   @override
@@ -77,7 +121,7 @@ class _RemovalApi implements AleraCloudApi {
     required CloudAccountSession session,
     required String runtimeId,
   }) {
-    throw StateError('cloud unavailable');
+    throw removalError ?? StateError('cloud unavailable');
   }
 
   @override

--- a/mobile/test/host_connection_controller_test.dart
+++ b/mobile/test/host_connection_controller_test.dart
@@ -7,6 +7,7 @@ import 'package:alera_mobile/src/features/accounts/application/cloud_account_pro
 import 'package:alera_mobile/src/features/hosts/application/host_providers.dart';
 import 'package:alera_mobile/src/features/hosts/domain/paired_host_profile.dart';
 import 'package:alera_mobile/src/features/runtime/application/host_connection_controller.dart';
+import 'package:alera_mobile/src/features/terminal/application/terminal_providers.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -136,17 +137,13 @@ void main() {
       ],
     );
     addTearDown(container.dispose);
-    var sawLostConnection = false;
-    final connection = container.listen(
-      hostConnectionControllerProvider('runtime-1'),
-      (_, next) {
-        if (next.error is RuntimeConnectionLost) {
-          sawLostConnection = true;
-        }
-      },
-    );
-    addTearDown(connection.close);
-    await container.read(hostConnectionControllerProvider('runtime-1').future);
+    final dependentProvider = terminalClientProvider('runtime-1');
+    final dependent = container.listen(dependentProvider, (_, _) {});
+    addTearDown(dependent.close);
+    final firstClient = await container.read(dependentProvider.future);
+    final pausedEvents = firstClient.events.listen((_) {});
+    pausedEvents.pause();
+    addTearDown(pausedEvents.cancel);
 
     await sockets.single.close();
     await reconnected.future.timeout(const Duration(seconds: 5));
@@ -157,11 +154,17 @@ void main() {
       return state.hasValue && !state.hasError;
     });
 
-    expect(sawLostConnection, isTrue);
+    expect(helloCount, 2);
+    await Future<void>.delayed(const Duration(milliseconds: 200));
     expect(helloCount, 2);
     final state = container.read(hostConnectionControllerProvider('runtime-1'));
     expect(state.hasValue, isTrue);
     expect(state.hasError, isFalse);
+    await _waitUntil(() {
+      final nextClient = container.read(dependentProvider).value;
+      return nextClient != null && !identical(nextClient, firstClient);
+    });
+    expect(container.read(dependentProvider).value, same(state.requireValue));
   });
 
   test(
@@ -222,14 +225,10 @@ void main() {
         ],
       );
       addTearDown(container.dispose);
-      final connection = container.listen(
-        hostConnectionControllerProvider('runtime-1'),
-        (_, _) {},
-      );
-      addTearDown(connection.close);
-      await container.read(
-        hostConnectionControllerProvider('runtime-1').future,
-      );
+      final dependentProvider = terminalClientProvider('runtime-1');
+      final dependent = container.listen(dependentProvider, (_, _) {});
+      addTearDown(dependent.close);
+      final firstClient = await container.read(dependentProvider.future);
 
       await sockets.single.close();
       await Future<void>.delayed(const Duration(milliseconds: 100));
@@ -247,6 +246,17 @@ void main() {
             .hasValue,
       );
       expect(helloCount, 2);
+      await _waitUntil(() {
+        final nextClient = container.read(dependentProvider).value;
+        return nextClient != null && !identical(nextClient, firstClient);
+      });
+      expect(
+        container
+            .read(hostConnectionControllerProvider('runtime-1'))
+            .requireValue
+            .isConnectionUsable,
+        isTrue,
+      );
     },
   );
 

--- a/mobile/test/host_connection_dependency_recovery_test.dart
+++ b/mobile/test/host_connection_dependency_recovery_test.dart
@@ -1,0 +1,132 @@
+import 'dart:async';
+
+import 'package:alera_mobile/src/features/runtime/application/host_connection_controller.dart';
+import 'package:alera_mobile/src/features/runtime/infra/mobile_runtime_client.dart';
+import 'package:alera_mobile/src/features/terminal/application/terminal_providers.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+void main() {
+  test('Dependents replace a client across error and loading states', () async {
+    final firstClient = MobileRuntimeClient.forTesting(
+      _PassiveWebSocketChannel(),
+    );
+    final secondClient = MobileRuntimeClient.forTesting(
+      _PassiveWebSocketChannel(),
+    );
+    addTearDown(firstClient.dispose);
+    addTearDown(secondClient.dispose);
+
+    late _MutableHostConnection connection;
+    final container = ProviderContainer(
+      overrides: [
+        hostConnectionControllerProvider.overrideWith2((_) {
+          connection = _MutableHostConnection(firstClient);
+          return connection;
+        }),
+      ],
+    );
+    addTearDown(container.dispose);
+    final dependentProvider = terminalClientProvider('runtime-1');
+    final dependent = container.listen(dependentProvider, (_, _) {});
+    addTearDown(dependent.close);
+
+    expect(await container.read(dependentProvider.future), same(firstClient));
+    connection.fail();
+    await pumpEventQueue();
+    connection.beginReconnect();
+    await pumpEventQueue();
+    connection.completeReconnect(secondClient);
+
+    await _waitUntil(
+      () => identical(container.read(dependentProvider).value, secondClient),
+    );
+    expect(container.read(dependentProvider).requireValue, same(secondClient));
+  });
+}
+
+final class _MutableHostConnection extends HostConnectionController {
+  _MutableHostConnection(this.initialClient);
+
+  final MobileRuntimeClient initialClient;
+
+  @override
+  Future<MobileRuntimeClient> build(String hostId) async => initialClient;
+
+  void fail() {
+    state = AsyncError<MobileRuntimeClient>(
+      const RuntimeConnectionLost(),
+      StackTrace.current,
+    );
+  }
+
+  void beginReconnect() {
+    state = const AsyncLoading<MobileRuntimeClient>();
+  }
+
+  void completeReconnect(MobileRuntimeClient client) {
+    state = AsyncData<MobileRuntimeClient>(client);
+  }
+}
+
+final class _PassiveWebSocketChannel implements WebSocketChannel {
+  final StreamController<Object?> _incoming =
+      StreamController<Object?>.broadcast(sync: true);
+  final StreamController<Object?> _outgoing =
+      StreamController<Object?>.broadcast(sync: true);
+
+  @override
+  int? get closeCode => null;
+
+  @override
+  String? get closeReason => null;
+
+  @override
+  String? get protocol => null;
+
+  @override
+  Future<void> get ready => Future<void>.value();
+
+  @override
+  Stream<Object?> get stream => _incoming.stream;
+
+  @override
+  late final WebSocketSink sink = _PassiveWebSocketSink(_outgoing.sink);
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+final class _PassiveWebSocketSink implements WebSocketSink {
+  _PassiveWebSocketSink(this._sink);
+
+  final StreamSink<Object?> _sink;
+
+  @override
+  Future<void> get done => _sink.done;
+
+  @override
+  void add(Object? data) => _sink.add(data);
+
+  @override
+  void addError(Object error, [StackTrace? stackTrace]) {
+    _sink.addError(error, stackTrace);
+  }
+
+  @override
+  Future<void> addStream(Stream<Object?> stream) => _sink.addStream(stream);
+
+  @override
+  Future<void> close([int? closeCode, String? closeReason]) => _sink.close();
+}
+
+Future<void> _waitUntil(bool Function() condition) async {
+  final deadline = DateTime.now().add(const Duration(seconds: 5));
+  while (!condition()) {
+    if (DateTime.now().isAfter(deadline)) {
+      throw TimeoutException('Condition was not reached.');
+    }
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+  }
+}

--- a/mobile/test/host_reachability_test.dart
+++ b/mobile/test/host_reachability_test.dart
@@ -45,6 +45,19 @@ void main() {
       expect(normalized, isA<HostUnreachableException>());
     });
 
+    test('classifies a socket closed before websocket headers', () {
+      final channelError = WebSocketChannelException.from(
+        const HttpException(
+          'Connection closed before full header was received',
+        ),
+      );
+
+      final normalized = normalizeHostConnectionError(channelError);
+
+      expect(normalized, isA<HostUnreachableException>());
+      expect(isRelayFallbackTransportFailure(channelError), isTrue);
+    });
+
     test('preserves TLS, protocol, and programming failures', () {
       final tlsError = WebSocketChannelException.from(
         const HandshakeException('Certificate verification failed.'),

--- a/mobile/test/mobile_runtime_binary_output_test.dart
+++ b/mobile/test/mobile_runtime_binary_output_test.dart
@@ -9,6 +9,7 @@ import 'package:flutter_test/flutter_test.dart';
 Future<({HttpServer server, List<Map<String, Object?>> requests})> _runtime({
   required bool grantBinaryFrames,
   required void Function(WebSocket socket) onAuthenticated,
+  bool binaryJsonResponses = false,
 }) async {
   final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
   final requests = <Map<String, Object?>>[];
@@ -25,17 +26,20 @@ Future<({HttpServer server, List<Map<String, Object?>> requests})> _runtime({
     socket.listen((raw) {
       final message = jsonDecode(raw as String) as Map<String, Object?>;
       requests.add(message);
+      final response = jsonEncode(<String, Object?>{
+        'id': message['id'],
+        'ok': true,
+        'payload': <String, Object?>{
+          'runtimeCapabilities': <String>[
+            if (grantBinaryFrames) mobileBinaryFramesCapability,
+          ],
+          if (grantBinaryFrames) 'binaryFrames': true,
+        },
+      });
       socket.add(
-        jsonEncode(<String, Object?>{
-          'id': message['id'],
-          'ok': true,
-          'payload': <String, Object?>{
-            'runtimeCapabilities': <String>[
-              if (grantBinaryFrames) mobileBinaryFramesCapability,
-            ],
-            if (grantBinaryFrames) 'binaryFrames': true,
-          },
-        }),
+        binaryJsonResponses && message['type'] != 'mobile.hello'
+            ? Uint8List.fromList(utf8.encode(response))
+            : response,
       );
       if (message['type'] == 'mobile.hello') {
         onAuthenticated(socket);
@@ -112,6 +116,23 @@ void main() {
 
     final event = await output;
     expect(event.data, <int>[1, 2, 3]);
+  });
+
+  test('binary mode still accepts JSON responses carried as bytes', () async {
+    final runtime = await _runtime(
+      grantBinaryFrames: true,
+      binaryJsonResponses: true,
+      onAuthenticated: (_) {},
+    );
+    final client = await MobileRuntimeClient.connect(
+      'ws://${runtime.server.address.address}:${runtime.server.port}',
+    );
+    addTearDown(client.dispose);
+    await client.authenticate(deviceId: 'device-1', deviceToken: 'token-1');
+
+    final response = await client.requestMap('mobile.status.get');
+
+    expect(response['binaryFrames'], isTrue);
   });
 
   test('a truncated binary message is ignored, not fatal', () async {

--- a/mobile/test/mobile_runtime_binary_output_test.dart
+++ b/mobile/test/mobile_runtime_binary_output_test.dart
@@ -10,6 +10,7 @@ Future<({HttpServer server, List<Map<String, Object?>> requests})> _runtime({
   required bool grantBinaryFrames,
   required void Function(WebSocket socket) onAuthenticated,
   bool binaryJsonResponses = false,
+  int binaryJsonPaddingBytes = 0,
 }) async {
   final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
   final requests = <Map<String, Object?>>[];
@@ -34,6 +35,12 @@ Future<({HttpServer server, List<Map<String, Object?>> requests})> _runtime({
             if (grantBinaryFrames) mobileBinaryFramesCapability,
           ],
           if (grantBinaryFrames) 'binaryFrames': true,
+          if (binaryJsonPaddingBytes > 0)
+            'padding': List<String>.filled(
+              binaryJsonPaddingBytes,
+              'x',
+              growable: false,
+            ).join(),
         },
       });
       socket.add(
@@ -134,6 +141,27 @@ void main() {
 
     expect(response['binaryFrames'], isTrue);
   });
+
+  test(
+    'binary mode does not mistake large JSON bytes for terminal output',
+    () async {
+      final runtime = await _runtime(
+        grantBinaryFrames: true,
+        binaryJsonResponses: true,
+        binaryJsonPaddingBytes: 70 * 1024,
+        onAuthenticated: (_) {},
+      );
+      final client = await MobileRuntimeClient.connect(
+        'ws://${runtime.server.address.address}:${runtime.server.port}',
+      );
+      addTearDown(client.dispose);
+      await client.authenticate(deviceId: 'device-1', deviceToken: 'token-1');
+
+      final response = await client.requestMap('workspaceSidebar.snapshot');
+
+      expect((response['padding'] as String).length, 70 * 1024);
+    },
+  );
 
   test('a truncated binary message is ignored, not fatal', () async {
     late WebSocket runtimeSocket;

--- a/mobile/test/mobile_runtime_client_dispose_test.dart
+++ b/mobile/test/mobile_runtime_client_dispose_test.dart
@@ -1,0 +1,74 @@
+import 'dart:async';
+
+import 'package:alera_mobile/src/features/runtime/infra/mobile_runtime_client.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:stream_channel/stream_channel.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+void main() {
+  test(
+    'Dispose does not wait forever for a transport close handshake',
+    () async {
+      final channel = _HangingCloseWebSocketChannel();
+      final client = MobileRuntimeClient.forTesting(
+        channel,
+        transportCloseTimeout: const Duration(milliseconds: 20),
+      );
+
+      await client.dispose().timeout(const Duration(seconds: 1));
+
+      expect(channel.closeCalled, isTrue);
+    },
+  );
+}
+
+final class _HangingCloseWebSocketChannel
+    with StreamChannelMixin<Object?>
+    implements WebSocketChannel {
+  final StreamController<Object?> _incoming = StreamController<Object?>();
+  final Completer<void> _close = Completer<void>();
+
+  bool closeCalled = false;
+
+  @override
+  int? get closeCode => null;
+
+  @override
+  String? get closeReason => null;
+
+  @override
+  String? get protocol => null;
+
+  @override
+  Future<void> get ready => Future<void>.value();
+
+  @override
+  Stream<Object?> get stream => _incoming.stream;
+
+  @override
+  late final WebSocketSink sink = _HangingCloseWebSocketSink(this);
+}
+
+final class _HangingCloseWebSocketSink implements WebSocketSink {
+  _HangingCloseWebSocketSink(this.channel);
+
+  final _HangingCloseWebSocketChannel channel;
+
+  @override
+  Future<void> get done => channel._close.future;
+
+  @override
+  void add(Object? data) {}
+
+  @override
+  void addError(Object error, [StackTrace? stackTrace]) {}
+
+  @override
+  Future<void> addStream(Stream<Object?> stream) async {}
+
+  @override
+  Future<void> close([int? closeCode, String? closeReason]) {
+    channel.closeCalled = true;
+    return channel._close.future;
+  }
+}

--- a/mobile/test/relay_crypto_test.dart
+++ b/mobile/test/relay_crypto_test.dart
@@ -67,4 +67,52 @@ void main() {
       throwsA(isA<RelayCryptoException>()),
     );
   });
+
+  test('serializes concurrent envelopes in each direction', () async {
+    final clientStatic = await RelayIdentityKeyPair.fromPrivate(
+      List<int>.filled(32, 1),
+    );
+    final runtimeStatic = await RelayIdentityKeyPair.fromPrivate(
+      List<int>.filled(32, 2),
+    );
+    final clientEphemeral = await RelayIdentityKeyPair.fromPrivate(
+      List<int>.filled(32, 3),
+    );
+    final runtimeEphemeral = await RelayIdentityKeyPair.fromPrivate(
+      List<int>.filled(32, 4),
+    );
+    final client = await RelayCryptoSession.derive(
+      localStatic: clientStatic,
+      localEphemeral: clientEphemeral,
+      peerStatic: runtimeStatic.publicBytes,
+      peerEphemeral: runtimeEphemeral.publicBytes,
+      runtimeId: 'runtime',
+      clientId: 'mobile',
+      nonce: List<int>.filled(16, 5),
+      initiator: true,
+    );
+    final runtime = await RelayCryptoSession.derive(
+      localStatic: runtimeStatic,
+      localEphemeral: runtimeEphemeral,
+      peerStatic: clientStatic.publicBytes,
+      peerEphemeral: clientEphemeral.publicBytes,
+      runtimeId: 'runtime',
+      clientId: 'mobile',
+      nonce: List<int>.filled(16, 5),
+      initiator: false,
+    );
+
+    final envelopes = await Future.wait(<Future<List<int>>>[
+      client.seal('first'.codeUnits),
+      client.seal('second'.codeUnits),
+      client.seal('third'.codeUnits),
+    ]);
+    final clear = await Future.wait(envelopes.map(runtime.open));
+
+    expect(clear.map(String.fromCharCodes), <String>[
+      'first',
+      'second',
+      'third',
+    ]);
+  });
 }

--- a/mobile/test/relay_wire_test.dart
+++ b/mobile/test/relay_wire_test.dart
@@ -1,0 +1,45 @@
+import 'package:alera_mobile/src/features/runtime/infra/relay_wire.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('large relay envelopes round trip through fragments', () {
+    final payload = List<int>.filled(70 * 1024, 7);
+    final fragments = fragmentRelayPayload(payload);
+    final reassembler = RelayFragmentReassembler();
+    List<int>? complete;
+
+    for (final fragment in fragments) {
+      complete = reassembler.accept(fragment);
+    }
+
+    expect(fragments, hasLength(2));
+    expect(fragments.first.sublist(0, 13), <int>[
+      0x41,
+      0x4c,
+      0x52,
+      0x46,
+      0x01,
+      0,
+      1,
+      0x18,
+      0,
+      0,
+      0,
+      0,
+      0,
+    ]);
+    expect(complete, payload);
+  });
+
+  test('relay fragmentation rejects oversized and out-of-order input', () {
+    expect(
+      () =>
+          fragmentRelayPayload(List<int>.filled(maxRelayEnvelopeBytes + 1, 0)),
+      throwsFormatException,
+    );
+    final fragments = fragmentRelayPayload(List<int>.filled(70 * 1024, 7));
+    final reassembler = RelayFragmentReassembler();
+
+    expect(() => reassembler.accept(fragments[1]), throwsFormatException);
+  });
+}


### PR DESCRIPTION
## Summary
- fall back to the relay only for recognized direct-transport reachability failures
- serialize relay encryption and decryption counters and support fragmented encrypted relay payloads
- keep mobile runtime clients alive through concurrent work and dispose them with bounded cleanup
- reconnect stale host clients and invalidate dependent providers across data, error, and loading transitions
- improve workspace retry and revoked cloud account recovery behavior
- add regression coverage for fragmentation, disposal, reconnection, and provider recovery

## Validation
- `puro -e v3_44_8 dart run build_runner build`
- `puro -e v3_44_8 dart format --output=none --set-exit-if-changed lib test`
- `puro -e v3_44_8 flutter analyze`
- `puro -e v3_44_8 flutter test` (531 tests)
- `dart run tool/quality/check_max_lines.dart`
- `git diff --check`
- production E2E with the direct transport blocked: relay connection, large fragmented workspace response, runtime restart, and automatic reconnection
- local `gh act` could not start because Docker rejected the cached image credentials; hosted checks are authoritative

## Dependency and risk
- native relay retry and fragmentation support is merged in #497
- relay fallback remains limited to recognized transport failures; TLS, certificate, protocol, and authorization errors still fail closed
- only HTTP 401 skips remote account cleanup; other cloud failures keep the local session for retry