### PR TITLE
fix: stabilize relay runtime presence and reconnects

### DIFF
--- a/edge/src/index.ts
+++ b/edge/src/index.ts
@@ -33,7 +33,9 @@ interface RelayClaims {
   runtimePublicKey: string;
 }
 
-interface RelayAttachment extends RelayClaims {}
+interface RelayAttachment extends RelayClaims {
+  suppressDisconnect?: boolean;
+}
 
 type OriginFetch = (request: Request) => Promise<Response>;
 type RelayFetch = (request: Request) => Promise<Response>;
@@ -375,6 +377,7 @@ export class RuntimeRelayDurableObject {
       const peerAttachment = peer.deserializeAttachment() as RelayAttachment;
       if (peerAttachment.role === attachment.role && peerAttachment.clientId === attachment.clientId) {
         if (peerAttachment.role === 'mobile') {
+          peer.serializeAttachment({ ...peerAttachment, suppressDisconnect: true });
           this.notifyRuntimeOfMobileDisconnect(peerAttachment);
         }
         peer.close(
@@ -440,11 +443,17 @@ export class RuntimeRelayDurableObject {
   }
 
   webSocketClose(socket: WebSocket): void {
-    this.notifyRuntimeOfMobileDisconnect(socket.deserializeAttachment() as RelayAttachment);
+    this.notifyRuntimeOfMobileDisconnectOnce(socket);
   }
 
   webSocketError(socket: WebSocket): void {
-    this.notifyRuntimeOfMobileDisconnect(socket.deserializeAttachment() as RelayAttachment);
+    this.notifyRuntimeOfMobileDisconnectOnce(socket);
+  }
+
+  private notifyRuntimeOfMobileDisconnectOnce(socket: WebSocket): void {
+    const mobile = socket.deserializeAttachment() as RelayAttachment;
+    if (mobile.suppressDisconnect) return;
+    this.notifyRuntimeOfMobileDisconnect(mobile);
   }
 
   private notifyRuntimeOfMobileDisconnect(mobile: RelayAttachment): void {

--- a/edge/test/index.test.ts
+++ b/edge/test/index.test.ts
@@ -87,13 +87,17 @@ function relayEnvironment(stub: DurableObjectStub): EdgeEnvironment {
 }
 
 class TestSocket {
-  constructor(readonly attachment: ReturnType<typeof relayAttachment>) {}
+  constructor(public attachment: ReturnType<typeof relayAttachment> & { suppressDisconnect?: boolean }) {}
 
   readonly sent: Uint8Array[] = [];
   closed: { code: number; reason: string } | null = null;
 
   deserializeAttachment() {
     return this.attachment;
+  }
+
+  serializeAttachment(attachment: ReturnType<typeof relayAttachment> & { suppressDisconnect?: boolean }) {
+    this.attachment = attachment;
   }
 
   send(value: Uint8Array) {
@@ -167,6 +171,18 @@ describe('Alera API edge', () => {
     relayObject([runtime, mobile]).webSocketClose(mobile as unknown as WebSocket);
 
     expect(runtime.sent).toEqual([relayFrame('mobile-1', [])]);
+  });
+
+  test('does not notify the runtime again when a replaced mobile closes', () => {
+    const runtime = new TestSocket(relayAttachment('runtime', 'runtime-1'));
+    const mobile = new TestSocket({
+      ...relayAttachment('mobile', 'mobile-1'),
+      suppressDisconnect: true,
+    });
+
+    relayObject([runtime, mobile]).webSocketClose(mobile as unknown as WebSocket);
+
+    expect(runtime.sent).toBeEmpty();
   });
 
   test('rejects paths outside the public API', async () => {

--- a/rust/alera-cli/src/alera_account/cloud_client.rs
+++ b/rust/alera-cli/src/alera_account/cloud_client.rs
@@ -3,8 +3,25 @@ use chrono::{DateTime, Utc};
 use reqwest::{Client, Method, StatusCode};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_json::Value;
+use thiserror::Error;
 
 pub(crate) const DEFAULT_CLOUD_BASE_URL: &str = "https://api.alera.build";
+
+#[derive(Debug, Error)]
+#[error("{path}: {message}")]
+pub(crate) struct CloudRequestError {
+    status: StatusCode,
+    code: Option<String>,
+    path: String,
+    message: String,
+}
+
+impl CloudRequestError {
+    pub(crate) fn is_relay_key_rotation_conflict(&self) -> bool {
+        self.status == StatusCode::CONFLICT
+            && self.code.as_deref() == Some("relay_key_rotation_conflict")
+    }
+}
 
 #[derive(Debug, Clone, Copy, Deserialize, Serialize)]
 #[serde(rename_all = "lowercase")]
@@ -384,16 +401,55 @@ impl CloudAccountClient {
 }
 
 fn cloud_error(status: StatusCode, body: &str, path: &str) -> anyhow::Error {
-    let message = serde_json::from_str::<Value>(body)
-        .ok()
-        .and_then(|value| {
-            value
-                .get("error")
-                .and_then(|error| error.get("message").or(Some(error)))
-                .and_then(Value::as_str)
-                .map(str::to_string)
-        })
+    let parsed = serde_json::from_str::<Value>(body).ok();
+    let error = parsed.as_ref().and_then(|value| value.get("error"));
+    let code = error
+        .and_then(|value| value.get("code"))
+        .and_then(Value::as_str)
+        .map(str::to_string);
+    let message = error
+        .and_then(|value| value.get("message").or(Some(value)))
+        .and_then(Value::as_str)
+        .map(str::to_string)
         .filter(|value| !value.trim().is_empty())
         .unwrap_or_else(|| format!("cloud request failed with HTTP {status}"));
-    anyhow!("{path}: {message}")
+    CloudRequestError {
+        status,
+        code,
+        path: path.to_owned(),
+        message,
+    }
+    .into()
+}
+
+#[cfg(test)]
+mod tests {
+    use reqwest::StatusCode;
+
+    use super::{cloud_error, CloudRequestError};
+
+    #[test]
+    fn relay_key_conflicts_remain_machine_readable() {
+        let error = cloud_error(
+            StatusCode::CONFLICT,
+            r#"{"error":{"code":"relay_key_rotation_conflict","message":"conflict"}}"#,
+            "/v1/relay/identity",
+        );
+        let request = error.downcast_ref::<CloudRequestError>().unwrap();
+
+        assert!(request.is_relay_key_rotation_conflict());
+        assert_eq!(error.to_string(), "/v1/relay/identity: conflict");
+    }
+
+    #[test]
+    fn unrelated_conflicts_do_not_rotate_relay_keys() {
+        let error = cloud_error(
+            StatusCode::CONFLICT,
+            r#"{"error":{"code":"different_conflict","message":"conflict"}}"#,
+            "/v1/relay/identity",
+        );
+        let request = error.downcast_ref::<CloudRequestError>().unwrap();
+
+        assert!(!request.is_relay_key_rotation_conflict());
+    }
 }

--- a/rust/alera-cli/src/alera_account/service.rs
+++ b/rust/alera-cli/src/alera_account/service.rs
@@ -10,11 +10,14 @@ use tokio::sync::Mutex;
 use crate::mobile_access::runtime_id;
 
 use super::cloud_client::{
-    AuthEnvelope, AuthProvider, AuthTransaction, CloudAccountClient, MobileEnrollment,
-    PushEventRequest, DEFAULT_CLOUD_BASE_URL,
+    AuthEnvelope, AuthProvider, AuthTransaction, CloudAccountClient, CloudRequestError,
+    MobileEnrollment, PushEventRequest, DEFAULT_CLOUD_BASE_URL,
 };
 use super::credential_store::{AccountCredentialStore, StoredAccountCredential};
 use crate::terminal_host::relay_crypto::IdentityKeyPair;
+
+const MAX_RELAY_IDENTITY_ROTATIONS: usize = 8;
+const MAX_RELAY_KEY_VERSION: i32 = 1_000_000;
 
 #[derive(Debug, Clone)]
 struct AccessSession {
@@ -29,6 +32,7 @@ pub(crate) struct AleraAccountService {
     cloud: CloudAccountClient,
     credentials: AccountCredentialStore,
     session: Arc<Mutex<Option<AccessSession>>>,
+    relay_identity_registration: Arc<Mutex<()>>,
 }
 
 impl AleraAccountService {
@@ -42,6 +46,7 @@ impl AleraAccountService {
             store,
             cloud: CloudAccountClient::new(base_url)?,
             session: Arc::new(Mutex::new(None)),
+            relay_identity_registration: Arc::new(Mutex::new(())),
         })
     }
 
@@ -241,13 +246,14 @@ impl AleraAccountService {
     }
 
     pub(crate) async fn relay_identity(&self) -> Result<IdentityKeyPair> {
-        let credential = self
+        let _registration = self.relay_identity_registration.lock().await;
+        let mut credential = self
             .credentials
             .load()
             .await?
             .ok_or_else(|| anyhow!("Alera account is signed out"))?;
-        let key_version = credential.relay_key_version.max(1);
-        let (identity, encoded) = match credential.relay_private_key_b64.as_deref() {
+        let mut key_version = credential.relay_key_version.max(1);
+        let (mut identity, encoded) = match credential.relay_private_key_b64.as_deref() {
             Some(encoded) => match URL_SAFE_NO_PAD.decode(encoded) {
                 Ok(bytes) if bytes.len() == 32 => {
                     let mut private = [0_u8; 32];
@@ -270,31 +276,52 @@ impl AleraAccountService {
         if credential.relay_private_key_b64.as_deref() != Some(encoded.as_str())
             || credential.relay_key_version != key_version
         {
-            self.credentials
-                .save(&StoredAccountCredential {
-                    refresh_token: credential.refresh_token,
-                    relay_private_key_b64: Some(encoded),
-                    relay_key_version: key_version,
-                })
-                .await?;
+            credential.relay_private_key_b64 = Some(encoded);
+            credential.relay_key_version = key_version;
+            self.credentials.save(&credential).await?;
         }
-        let token = self.access_token().await?;
-        let response = self
-            .cloud
-            .register_relay_identity(
-                &token,
-                &URL_SAFE_NO_PAD.encode(identity.public_bytes()),
-                key_version,
-            )
-            .await?;
-        if response.client_id != self.runtime_id
-            || response.client_kind != "runtime"
-            || response.public_key != URL_SAFE_NO_PAD.encode(identity.public_bytes())
-            || response.key_version != key_version
-        {
-            return Err(anyhow!("cloud returned an invalid relay identity"));
+
+        for rotation in 0..=MAX_RELAY_IDENTITY_ROTATIONS {
+            let public_key = URL_SAFE_NO_PAD.encode(identity.public_bytes());
+            let token = self.access_token().await?;
+            match self
+                .cloud
+                .register_relay_identity(&token, &public_key, key_version)
+                .await
+            {
+                Ok(response) => {
+                    if response.client_id != self.runtime_id
+                        || response.client_kind != "runtime"
+                        || response.public_key != public_key
+                        || response.key_version != key_version
+                    {
+                        return Err(anyhow!("cloud returned an invalid relay identity"));
+                    }
+                    return Ok(identity);
+                }
+                Err(error)
+                    if rotation < MAX_RELAY_IDENTITY_ROTATIONS
+                        && error
+                            .downcast_ref::<CloudRequestError>()
+                            .is_some_and(CloudRequestError::is_relay_key_rotation_conflict) =>
+                {
+                    credential = self
+                        .credentials
+                        .load()
+                        .await?
+                        .ok_or_else(|| anyhow!("Alera account is signed out"))?;
+                    key_version =
+                        next_relay_key_version(credential.relay_key_version.max(key_version))?;
+                    identity = IdentityKeyPair::generate();
+                    credential.relay_private_key_b64 =
+                        Some(URL_SAFE_NO_PAD.encode(identity.private_bytes()));
+                    credential.relay_key_version = key_version;
+                    self.credentials.save(&credential).await?;
+                }
+                Err(error) => return Err(error),
+            }
         }
-        Ok(identity)
+        unreachable!("relay identity rotation loop always returns")
     }
 
     pub(crate) async fn relay_grant(&self) -> Result<super::cloud_client::RelayGrant> {
@@ -340,5 +367,28 @@ impl AleraAccountService {
         self.credentials.delete().await?;
         *self.session.lock().await = None;
         self.store.clear_alera_account().await
+    }
+}
+
+fn next_relay_key_version(current: i32) -> Result<i32> {
+    let next = current
+        .checked_add(1)
+        .filter(|version| *version <= MAX_RELAY_KEY_VERSION)
+        .ok_or_else(|| anyhow!("relay identity key version is exhausted"))?;
+    Ok(next)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{next_relay_key_version, MAX_RELAY_KEY_VERSION};
+
+    #[test]
+    fn relay_key_versions_advance_monotonically() {
+        assert_eq!(next_relay_key_version(1).unwrap(), 2);
+        assert_eq!(
+            next_relay_key_version(MAX_RELAY_KEY_VERSION - 1).unwrap(),
+            MAX_RELAY_KEY_VERSION
+        );
+        assert!(next_relay_key_version(MAX_RELAY_KEY_VERSION).is_err());
     }
 }

--- a/rust/alera-cli/src/terminal_host/relay_runtime.rs
+++ b/rust/alera-cli/src/terminal_host/relay_runtime.rs
@@ -3,7 +3,6 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
-use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
 use futures_util::{SinkExt as _, StreamExt as _};
 use tokio::sync::mpsc::{self, Receiver, UnboundedReceiver, UnboundedSender};
 use tokio::sync::oneshot;
@@ -24,7 +23,7 @@ use crate::terminal_host::client::{
 };
 use crate::terminal_host::frame_codec::encode_output_payload;
 
-use super::relay_runtime_auth::{decode_fixed, decode_nonce, verify_grant};
+use super::relay_runtime_auth::{decode_fixed, decode_nonce, encode, verify_grant};
 use super::server::ServerCommand;
 use super::{relay_crypto::IdentityKeyPair, relay_wire};
 
@@ -127,7 +126,7 @@ async fn connect_and_serve(
         || grant.expires_in <= 0
         || grant.client_key_version <= 0
         || grant.runtime_public_key.is_some()
-        || grant.client_public_key != encoded(identity.public_bytes())
+        || grant.client_public_key != encode(identity.public_bytes())
     {
         anyhow::bail!("cloud returned an invalid runtime relay grant");
     }
@@ -320,7 +319,7 @@ async fn handle_inbound(frame: &[u8], context: RelayInbound<'_>) -> anyhow::Resu
         || claims.account_id != runtime_grant.account_id
         || hello.key_version != claims.key_version
         || hello.identity_public_key != claims.client_public_key
-        || claims.runtime_public_key != encoded(identity.public_bytes())
+        || claims.runtime_public_key != encode(identity.public_bytes())
     {
         anyhow::bail!("relay mobile grant is out of scope");
     }
@@ -343,10 +342,10 @@ async fn handle_inbound(frame: &[u8], context: RelayInbound<'_>) -> anyhow::Resu
         version: relay_wire::RELAY_HELLO_VERSION,
         runtime_id: runtime_id.to_owned(),
         client_id: client_id.clone(),
-        identity_public_key: encoded(identity.public_bytes()),
-        ephemeral_public_key: encoded(runtime_ephemeral.public_bytes()),
-        nonce: encoded(nonce),
-        confirmation: encoded(confirmation),
+        identity_public_key: encode(identity.public_bytes()),
+        ephemeral_public_key: encode(runtime_ephemeral.public_bytes()),
+        nonce: encode(nonce),
+        confirmation: encode(confirmation),
     };
     write
         .send(Message::Binary(
@@ -492,10 +491,6 @@ async fn dispose_peers(
             id: peer.numeric_id,
         });
     }
-}
-
-fn encoded(bytes: impl AsRef<[u8]>) -> String {
-    URL_SAFE_NO_PAD.encode(bytes)
 }
 
 #[cfg(test)]

--- a/rust/alera-cli/src/terminal_host/relay_runtime.rs
+++ b/rust/alera-cli/src/terminal_host/relay_runtime.rs
@@ -29,6 +29,7 @@ use super::server::ServerCommand;
 use super::{relay_crypto::IdentityKeyPair, relay_wire};
 
 const MAX_MOBILE_CLIENTS: usize = 8;
+const RELAY_PRESENCE_INTERVAL: Duration = Duration::from_secs(60);
 const RETRY_DELAYS: [Duration; 6] = [
     Duration::from_secs(1),
     Duration::from_secs(2),
@@ -136,6 +137,9 @@ async fn connect_and_serve(
     let (outbound_tx, mut outbound_rx) = mpsc::unbounded_channel::<RelayOutbound>();
     let mut pending = HashMap::<String, PendingPeer>::new();
     let mut active = HashMap::<String, ActivePeer>::new();
+    let mut presence = tokio::time::interval(RELAY_PRESENCE_INTERVAL);
+    presence.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    presence.tick().await;
     loop {
         tokio::select! {
             _ = &mut *stop => {
@@ -145,6 +149,18 @@ async fn connect_and_serve(
             outbound = outbound_rx.recv() => {
                 let Some(outbound) = outbound else { return Ok(()); };
                 write.send(Message::Binary(relay_wire::wrap(&outbound.client_id, &outbound.payload)?.into())).await?;
+            }
+            _ = presence.tick() => {
+                // Discovery expires runtimes independently of the relay socket lifetime.
+                match service.relay_identity().await {
+                    Ok(refreshed) if refreshed.public_bytes() != identity.public_bytes() => {
+                        anyhow::bail!("relay identity rotated; reconnecting");
+                    }
+                    Ok(_) => {}
+                    Err(error) => {
+                        tracing::warn!(%error, "could not refresh remote mobile relay presence");
+                    }
+                }
             }
             inbound = read.next() => {
                 match inbound {

--- a/rust/alera-cli/src/terminal_host/relay_runtime_auth.rs
+++ b/rust/alera-cli/src/terminal_host/relay_runtime_auth.rs
@@ -119,3 +119,7 @@ pub(super) fn decode_nonce(value: &str) -> anyhow::Result<[u8; 16]> {
         .try_into()
         .map_err(|_| anyhow::anyhow!("relay nonce length is invalid"))
 }
+
+pub(super) fn encode(bytes: impl AsRef<[u8]>) -> String {
+    URL_SAFE_NO_PAD.encode(bytes)
+}

--- a/rust/alera-cli/src/terminal_host/relay_runtime_tests.rs
+++ b/rust/alera-cli/src/terminal_host/relay_runtime_tests.rs
@@ -1,7 +1,12 @@
 use tokio::net::TcpListener;
 use tokio_tungstenite::tungstenite::{error::UrlError, http::header, Error};
 
-use super::{connect_async, relay_request};
+use super::{connect_async, relay_request, RELAY_PRESENCE_INTERVAL};
+
+#[test]
+fn relay_presence_refreshes_before_cloud_expiry() {
+    assert!(RELAY_PRESENCE_INTERVAL < std::time::Duration::from_secs(180));
+}
 
 #[test]
 fn relay_request_preserves_websocket_handshake_headers() {


### PR DESCRIPTION
## summary

- keep runtime relay registrations alive and rotate credentials safely
- suppress stale disconnect notifications when replacing a mobile relay socket
- preserve typed cloud errors for relay recovery decisions

## validation

- `make rust-test`
- `cargo test --manifest-path rust/Cargo.toml -p alera-cli terminal_host::relay_runtime --locked`
- `bun test` and `bun run check` in `cloud/edge`
- `gh act pull_request -W .github/workflows/pr.yml -j static --pull=false`
- `git diff --check`

## risk

The change is limited to relay presence and duplicate mobile replacement. Existing direct runtime connections are unchanged.