### PR TITLE
fix: reconnect relay mobiles after runtime restart

### DIFF
--- a/edge/src/index.ts
+++ b/edge/src/index.ts
@@ -379,6 +379,9 @@ export class RuntimeRelayDurableObject {
         if (peerAttachment.role === 'mobile') {
           peer.serializeAttachment({ ...peerAttachment, suppressDisconnect: true });
           this.notifyRuntimeOfMobileDisconnect(peerAttachment);
+        } else {
+          peer.serializeAttachment({ ...peerAttachment, suppressDisconnect: true });
+          this.disconnectMobilesForRuntime(peerAttachment);
         }
         peer.close(
           4001,
@@ -443,17 +446,21 @@ export class RuntimeRelayDurableObject {
   }
 
   webSocketClose(socket: WebSocket): void {
-    this.notifyRuntimeOfMobileDisconnectOnce(socket);
+    this.handlePeerDisconnectOnce(socket);
   }
 
   webSocketError(socket: WebSocket): void {
-    this.notifyRuntimeOfMobileDisconnectOnce(socket);
+    this.handlePeerDisconnectOnce(socket);
   }
 
-  private notifyRuntimeOfMobileDisconnectOnce(socket: WebSocket): void {
-    const mobile = socket.deserializeAttachment() as RelayAttachment;
-    if (mobile.suppressDisconnect) return;
-    this.notifyRuntimeOfMobileDisconnect(mobile);
+  private handlePeerDisconnectOnce(socket: WebSocket): void {
+    const peer = socket.deserializeAttachment() as RelayAttachment;
+    if (peer.suppressDisconnect) return;
+    if (peer.role === 'mobile') {
+      this.notifyRuntimeOfMobileDisconnect(peer);
+    } else {
+      this.disconnectMobilesForRuntime(peer);
+    }
   }
 
   private notifyRuntimeOfMobileDisconnect(mobile: RelayAttachment): void {
@@ -467,6 +474,22 @@ export class RuntimeRelayDurableObject {
       } catch {
         peer.close(1011, 'relay forwarding failed');
       }
+    }
+  }
+
+  private disconnectMobilesForRuntime(runtime: RelayAttachment): void {
+    if (runtime.role !== 'runtime') return;
+    for (const peer of this.ctx.getWebSockets('mobile')) {
+      const mobile = peer.deserializeAttachment() as RelayAttachment;
+      if (
+        mobile.role !== 'mobile' ||
+        mobile.accountId !== runtime.accountId ||
+        mobile.runtimeId !== runtime.runtimeId
+      ) {
+        continue;
+      }
+      peer.serializeAttachment({ ...mobile, suppressDisconnect: true });
+      peer.close(4002, 'runtime disconnected');
     }
   }
 }

--- a/edge/test/index.test.ts
+++ b/edge/test/index.test.ts
@@ -185,6 +185,36 @@ describe('Alera API edge', () => {
     expect(runtime.sent).toBeEmpty();
   });
 
+  test('disconnects matching mobiles when the runtime disconnects', () => {
+    const runtime = new TestSocket(relayAttachment('runtime', 'runtime-1'));
+    const mobile = new TestSocket(relayAttachment('mobile', 'mobile-1'));
+    const otherRuntimeMobile = new TestSocket({
+      ...relayAttachment('mobile', 'mobile-2'),
+      runtimeId: 'runtime-2',
+    });
+
+    relayObject([runtime, mobile, otherRuntimeMobile]).webSocketClose(runtime as unknown as WebSocket);
+
+    expect(mobile.attachment.suppressDisconnect).toBeTrue();
+    expect(mobile.closed).toEqual({
+      code: 4002,
+      reason: 'runtime disconnected',
+    });
+    expect(otherRuntimeMobile.closed).toBeNull();
+  });
+
+  test('does not disconnect a new mobile when a replaced runtime closes later', () => {
+    const oldRuntime = new TestSocket({
+      ...relayAttachment('runtime', 'runtime-1'),
+      suppressDisconnect: true,
+    });
+    const mobile = new TestSocket(relayAttachment('mobile', 'mobile-1'));
+
+    relayObject([oldRuntime, mobile]).webSocketClose(oldRuntime as unknown as WebSocket);
+
+    expect(mobile.closed).toBeNull();
+  });
+
   test('rejects paths outside the public API', async () => {
     const response = await handleRequest(new Request('https://api.alera.build/admin'), environment());
     expect(response.status).toBe(404);


### PR DESCRIPTION
Summary:
- disconnect relay mobile sockets when their runtime disconnects or is replaced
- suppress stale close callbacks so they cannot tear down a newly reconnected mobile
- cover runtime disconnect and delayed-close isolation

Validation:
- bun test
- bun run check
- bunx wrangler deploy --dry-run
- gh act pull_request -W .github/workflows/pr.yml -j static
- gh act pull_request -W .github/workflows/cloud.yml -j edge

Risk:
- mobile relay clients reconnect once when a runtime connection restarts, rebuilding the encrypted session instead of hanging on stale state.