### PR TITLE
fix: harden relay transport recovery

### DIFF
--- a/rust/alera-cli/src/terminal_host/mod.rs
+++ b/rust/alera-cli/src/terminal_host/mod.rs
@@ -14,6 +14,7 @@ pub mod orchestration;
 pub mod protocol;
 #[path = "../push_notifications/mod.rs"]
 pub(crate) mod push_notifications;
+mod relay_connection;
 pub mod relay_crypto;
 mod relay_runtime;
 mod relay_runtime_auth;

--- a/rust/alera-cli/src/terminal_host/relay_connection.rs
+++ b/rust/alera-cli/src/terminal_host/relay_connection.rs
@@ -1,0 +1,45 @@
+use std::time::Duration;
+
+use tokio_tungstenite::tungstenite::{
+    client::IntoClientRequest,
+    http::{header, HeaderValue, Request},
+};
+
+const RETRY_DELAYS: [Duration; 6] = [
+    Duration::from_secs(1),
+    Duration::from_secs(2),
+    Duration::from_secs(4),
+    Duration::from_secs(8),
+    Duration::from_secs(16),
+    Duration::from_secs(30),
+];
+
+#[derive(Default)]
+pub(super) struct RelayRetryBackoff {
+    index: usize,
+}
+
+impl RelayRetryBackoff {
+    pub(super) fn next_delay(&mut self) -> Duration {
+        let delay = RETRY_DELAYS[self.index];
+        self.index = (self.index + 1).min(RETRY_DELAYS.len() - 1);
+        delay
+    }
+
+    pub(super) fn reset(&mut self) {
+        self.index = 0;
+    }
+}
+
+pub(super) fn relay_request(relay_url: &str, grant: &str) -> anyhow::Result<Request<()>> {
+    let mut request = relay_url.into_client_request()?;
+    request.headers_mut().insert(
+        header::AUTHORIZATION,
+        HeaderValue::from_str(&format!("Bearer {grant}"))?,
+    );
+    request.headers_mut().insert(
+        header::ORIGIN,
+        HeaderValue::from_static("https://app.alera.build"),
+    );
+    Ok(request)
+}

--- a/rust/alera-cli/src/terminal_host/relay_runtime.rs
+++ b/rust/alera-cli/src/terminal_host/relay_runtime.rs
@@ -7,15 +7,7 @@ use futures_util::{SinkExt as _, StreamExt as _};
 use tokio::sync::mpsc::{self, Receiver, UnboundedReceiver, UnboundedSender};
 use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
-use tokio_tungstenite::{
-    connect_async,
-    tungstenite::{
-        client::IntoClientRequest,
-        http::{header, HeaderValue, Request},
-        Message,
-    },
-    MaybeTlsStream, WebSocketStream,
-};
+use tokio_tungstenite::{connect_async, tungstenite::Message, MaybeTlsStream, WebSocketStream};
 
 use crate::terminal_host::alera_account::{AleraAccountService, RelayGrant};
 use crate::terminal_host::client::{
@@ -23,20 +15,13 @@ use crate::terminal_host::client::{
 };
 use crate::terminal_host::frame_codec::encode_output_payload;
 
+use super::relay_connection::{relay_request, RelayRetryBackoff};
 use super::relay_runtime_auth::{decode_fixed, decode_nonce, encode, verify_grant};
 use super::server::ServerCommand;
 use super::{relay_crypto::IdentityKeyPair, relay_wire};
 
 const MAX_MOBILE_CLIENTS: usize = 8;
 const RELAY_PRESENCE_INTERVAL: Duration = Duration::from_secs(60);
-const RETRY_DELAYS: [Duration; 6] = [
-    Duration::from_secs(1),
-    Duration::from_secs(2),
-    Duration::from_secs(4),
-    Duration::from_secs(8),
-    Duration::from_secs(16),
-    Duration::from_secs(30),
-];
 
 struct PendingPeer {
     client_id: String,
@@ -70,6 +55,7 @@ struct RelayInbound<'a> {
     write: &'a mut RelayWrite,
     pending: &'a mut HashMap<String, PendingPeer>,
     active: &'a mut HashMap<String, ActivePeer>,
+    fragments: &'a mut HashMap<String, relay_wire::FragmentReassembler>,
 }
 
 pub fn spawn(
@@ -90,7 +76,7 @@ async fn run(
     next_client_id: Arc<AtomicU64>,
     mut stop: oneshot::Receiver<()>,
 ) {
-    let mut retry_index = 0_usize;
+    let mut retry_backoff = RelayRetryBackoff::default();
     loop {
         let result = connect_and_serve(
             &service,
@@ -98,11 +84,11 @@ async fn run(
             inbox.clone(),
             next_client_id.clone(),
             &mut stop,
+            &mut retry_backoff,
         )
         .await;
         let Err(error) = result else { return };
-        let delay = RETRY_DELAYS[retry_index];
-        retry_index = (retry_index + 1).min(RETRY_DELAYS.len() - 1);
+        let delay = retry_backoff.next_delay();
         tracing::warn!(%error, "remote mobile relay disconnected; retrying in {:?}", delay);
         tokio::select! {
             _ = tokio::time::sleep(delay) => {}
@@ -117,6 +103,7 @@ async fn connect_and_serve(
     inbox: UnboundedSender<ServerCommand>,
     next_client_id: Arc<AtomicU64>,
     stop: &mut oneshot::Receiver<()>,
+    retry_backoff: &mut RelayRetryBackoff,
 ) -> anyhow::Result<()> {
     let identity = service.relay_identity().await?;
     let grant = service.relay_grant().await?;
@@ -132,10 +119,12 @@ async fn connect_and_serve(
     }
     let request = relay_request(&grant.relay_url, &grant.grant)?;
     let (socket, _) = connect_async(request).await?;
+    retry_backoff.reset();
     let (mut write, mut read) = socket.split();
     let (outbound_tx, mut outbound_rx) = mpsc::unbounded_channel::<RelayOutbound>();
     let mut pending = HashMap::<String, PendingPeer>::new();
     let mut active = HashMap::<String, ActivePeer>::new();
+    let mut fragments = HashMap::<String, relay_wire::FragmentReassembler>::new();
     let mut presence = tokio::time::interval(RELAY_PRESENCE_INTERVAL);
     presence.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
     presence.tick().await;
@@ -147,7 +136,9 @@ async fn connect_and_serve(
             }
             outbound = outbound_rx.recv() => {
                 let Some(outbound) = outbound else { return Ok(()); };
-                write.send(Message::Binary(relay_wire::wrap(&outbound.client_id, &outbound.payload)?.into())).await?;
+                for payload in relay_wire::fragment(&outbound.payload)? {
+                    write.send(Message::Binary(relay_wire::wrap(&outbound.client_id, &payload)?.into())).await?;
+                }
             }
             _ = presence.tick() => {
                 // Discovery expires runtimes independently of the relay socket lifetime.
@@ -174,6 +165,7 @@ async fn connect_and_serve(
                             write: &mut write,
                             pending: &mut pending,
                             active: &mut active,
+                            fragments: &mut fragments,
                         }).await {
                             tracing::warn!(%error, "rejected a remote mobile relay frame");
                         }
@@ -189,6 +181,7 @@ async fn connect_and_serve(
                             write: &mut write,
                             pending: &mut pending,
                             active: &mut active,
+                            fragments: &mut fragments,
                         }).await {
                             tracing::warn!(%error, "rejected a remote mobile relay frame");
                         }
@@ -203,19 +196,6 @@ async fn connect_and_serve(
     }
 }
 
-fn relay_request(relay_url: &str, grant: &str) -> anyhow::Result<Request<()>> {
-    let mut request = relay_url.into_client_request()?;
-    request.headers_mut().insert(
-        header::AUTHORIZATION,
-        HeaderValue::from_str(&format!("Bearer {grant}"))?,
-    );
-    request.headers_mut().insert(
-        header::ORIGIN,
-        HeaderValue::from_static("https://app.alera.build"),
-    );
-    Ok(request)
-}
-
 async fn handle_inbound(frame: &[u8], context: RelayInbound<'_>) -> anyhow::Result<()> {
     let RelayInbound {
         identity,
@@ -227,9 +207,11 @@ async fn handle_inbound(frame: &[u8], context: RelayInbound<'_>) -> anyhow::Resu
         write,
         pending,
         active,
+        fragments,
     } = context;
     let (client_id, payload) = relay_wire::unwrap(frame)?;
     if payload.is_empty() {
+        fragments.remove(&client_id);
         pending.remove(&client_id);
         if let Some(peer) = active.remove(&client_id) {
             peer.writer.abort();
@@ -239,6 +221,14 @@ async fn handle_inbound(frame: &[u8], context: RelayInbound<'_>) -> anyhow::Resu
         }
         return Ok(());
     }
+    let Some(payload) = fragments
+        .entry(client_id.clone())
+        .or_default()
+        .accept(payload)?
+    else {
+        return Ok(());
+    };
+    let payload = payload.as_slice();
     if active.contains_key(&client_id) {
         let (numeric_id, opened) = {
             let peer = active

--- a/rust/alera-cli/src/terminal_host/relay_runtime_tests.rs
+++ b/rust/alera-cli/src/terminal_host/relay_runtime_tests.rs
@@ -1,11 +1,22 @@
 use tokio::net::TcpListener;
 use tokio_tungstenite::tungstenite::{error::UrlError, http::header, Error};
 
-use super::{connect_async, relay_request, RELAY_PRESENCE_INTERVAL};
+use super::{connect_async, relay_request, RelayRetryBackoff, RELAY_PRESENCE_INTERVAL};
 
 #[test]
 fn relay_presence_refreshes_before_cloud_expiry() {
     assert!(RELAY_PRESENCE_INTERVAL < std::time::Duration::from_secs(180));
+}
+
+#[test]
+fn relay_retry_backoff_resets_after_a_successful_connection() {
+    let mut backoff = RelayRetryBackoff::default();
+
+    assert_eq!(backoff.next_delay(), std::time::Duration::from_secs(1));
+    assert_eq!(backoff.next_delay(), std::time::Duration::from_secs(2));
+    backoff.reset();
+
+    assert_eq!(backoff.next_delay(), std::time::Duration::from_secs(1));
 }
 
 #[test]

--- a/rust/alera-cli/src/terminal_host/relay_wire.rs
+++ b/rust/alera-cli/src/terminal_host/relay_wire.rs
@@ -9,6 +9,89 @@ pub const RELAY_HELLO_VERSION: u8 = 1;
 const CLIENT_ID_BYTES: usize = 2;
 const MAX_CLIENT_ID_BYTES: usize = 128;
 const MAX_HANDSHAKE_BYTES: usize = 16 * 1024;
+const FRAGMENT_MAGIC: &[u8; 5] = b"ALRF\x01";
+const FRAGMENT_HEADER_BYTES: usize = FRAGMENT_MAGIC.len() + 4 + 4;
+const RELAY_FRAGMENT_PAYLOAD_BYTES: usize = 48 * 1024;
+const MAX_RELAY_ENVELOPE_BYTES: usize = 1024 * 1024;
+
+#[derive(Default)]
+pub struct FragmentReassembler {
+    total: Option<usize>,
+    bytes: Vec<u8>,
+}
+
+impl FragmentReassembler {
+    pub fn accept(&mut self, payload: &[u8]) -> Result<Option<Vec<u8>>> {
+        if !payload.starts_with(FRAGMENT_MAGIC) {
+            if self.total.is_some() {
+                self.reset();
+                bail!("relay fragment sequence was interrupted");
+            }
+            return Ok(Some(payload.to_vec()));
+        }
+        if payload.len() <= FRAGMENT_HEADER_BYTES {
+            self.reset();
+            bail!("relay fragment is truncated");
+        }
+        let total = u32::from_be_bytes(payload[5..9].try_into()?) as usize;
+        let offset = u32::from_be_bytes(payload[9..13].try_into()?) as usize;
+        let chunk = &payload[FRAGMENT_HEADER_BYTES..];
+        if total <= RELAY_FRAGMENT_PAYLOAD_BYTES
+            || total > MAX_RELAY_ENVELOPE_BYTES
+            || chunk.len() > RELAY_FRAGMENT_PAYLOAD_BYTES
+            || offset
+                .checked_add(chunk.len())
+                .is_none_or(|end| end > total)
+        {
+            self.reset();
+            bail!("relay fragment is outside the supported range");
+        }
+        if offset == 0 {
+            self.total = Some(total);
+            self.bytes.clear();
+            self.bytes.reserve(total);
+        } else if self.total != Some(total) || offset != self.bytes.len() {
+            self.reset();
+            bail!("relay fragment sequence is invalid");
+        }
+        self.bytes.extend_from_slice(chunk);
+        if self.bytes.len() != total {
+            return Ok(None);
+        }
+        self.total = None;
+        Ok(Some(std::mem::take(&mut self.bytes)))
+    }
+
+    fn reset(&mut self) {
+        self.total = None;
+        self.bytes.clear();
+    }
+}
+
+pub fn fragment(payload: &[u8]) -> Result<Vec<Vec<u8>>> {
+    if payload.len() > MAX_RELAY_ENVELOPE_BYTES {
+        bail!("relay envelope is too large");
+    }
+    if payload.len() <= RELAY_FRAGMENT_PAYLOAD_BYTES {
+        return Ok(vec![payload.to_vec()]);
+    }
+    let total = u32::try_from(payload.len())?.to_be_bytes();
+    Ok(payload
+        .chunks(RELAY_FRAGMENT_PAYLOAD_BYTES)
+        .enumerate()
+        .map(|(index, chunk)| {
+            let offset = u32::try_from(index * RELAY_FRAGMENT_PAYLOAD_BYTES)
+                .expect("bounded relay fragment offset")
+                .to_be_bytes();
+            let mut frame = Vec::with_capacity(FRAGMENT_HEADER_BYTES + chunk.len());
+            frame.extend_from_slice(FRAGMENT_MAGIC);
+            frame.extend_from_slice(&total);
+            frame.extend_from_slice(&offset);
+            frame.extend_from_slice(chunk);
+            frame
+        })
+        .collect())
+}
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -112,7 +195,7 @@ pub fn derive_sessions(
 
 #[cfg(test)]
 mod tests {
-    use super::{unwrap, wrap};
+    use super::{fragment, unwrap, wrap, FragmentReassembler, MAX_RELAY_ENVELOPE_BYTES};
 
     #[test]
     fn outer_frame_keeps_client_identity_and_payload_boundaries() {
@@ -126,5 +209,32 @@ mod tests {
     fn outer_frame_rejects_invalid_identity_lengths() {
         assert!(unwrap(&[0, 0]).is_err());
         assert!(wrap("", b"payload").is_err());
+    }
+
+    #[test]
+    fn large_envelopes_round_trip_through_fragments() {
+        let payload = vec![7_u8; 70 * 1024];
+        let fragments = fragment(&payload).unwrap();
+        let mut reassembler = FragmentReassembler::default();
+        let mut complete = None;
+        for fragment in &fragments {
+            complete = reassembler.accept(fragment).unwrap();
+        }
+
+        assert_eq!(fragments.len(), 2);
+        assert_eq!(
+            &fragments[0][..13],
+            &[0x41, 0x4c, 0x52, 0x46, 0x01, 0, 1, 0x18, 0, 0, 0, 0, 0]
+        );
+        assert_eq!(complete.unwrap(), payload);
+    }
+
+    #[test]
+    fn fragment_reassembly_rejects_oversized_and_out_of_order_input() {
+        assert!(fragment(&vec![0_u8; MAX_RELAY_ENVELOPE_BYTES + 1]).is_err());
+        let fragments = fragment(&vec![7_u8; 70 * 1024]).unwrap();
+        let mut reassembler = FragmentReassembler::default();
+
+        assert!(reassembler.accept(&fragments[1]).is_err());
     }
 }


### PR DESCRIPTION
## summary
- fragment large encrypted relay envelopes across bounded websocket frames
- reassemble relay fragments on the runtime and mobile sides with strict limits
- reset runtime relay retry backoff after a successful websocket connection

## validation
- `make rust-test`
- fixed cross-language fragment header vector tests
- live Android acceptance with direct transport blocked, large workspace payloads, runtime disconnect and relay reconnect
- `git diff --check`

## notes
- local `gh act` could not reproduce hosted Rust jobs because its container lacked libclang and Docker authentication; the repository-native Rust gate passed in full
- merge directly after exact-head hosted checks; do not use Mergify