### PR TITLE
fix: capture android native crash tombstones

### DIFF
--- a/mobile/lib/src/features/diagnostics/infra/crash_reporting.dart
+++ b/mobile/lib/src/features/diagnostics/infra/crash_reporting.dart
@@ -151,11 +151,20 @@ abstract final class CrashReporting {
     return false;
   }
 
+  @visibleForTesting
+  static void applyOptionsForTesting(
+    SentryFlutterOptions options,
+    String release,
+  ) => _applyOptions(options, release);
+
   static void _applyOptions(SentryFlutterOptions options, String release) {
     options.dsn = kAleraMobileSentryDsn;
     // The app handles repository paths, branch names and command lines; there
     // is no reason to attach IPs or request headers on top of that.
     options.sendDefaultPii = false;
+    // Android 12+ retains a native tombstone after SIGABRT/SIGSEGV. Without
+    // this, Sentry can receive only the signal and an unusable address list.
+    options.enableTombstone = true;
     options.environment = kDebugMode ? 'dev' : 'release';
     options.release = release;
     options.dist = _appBuild == 'unknown' ? null : _appBuild;

--- a/mobile/test/crash_reporting_test.dart
+++ b/mobile/test/crash_reporting_test.dart
@@ -15,6 +15,14 @@ void main() {
     expect(CrashReporting.filterEvent(event), isNull);
   });
 
+  test('enables Android tombstone collection for native crashes', () {
+    final options = SentryFlutterOptions();
+
+    CrashReporting.applyOptionsForTesting(options, 'alera-mobile@0.30.2+119');
+
+    expect(options.enableTombstone, isTrue);
+  });
+
   test('redacts text-bearing event fields before sending', () {
     CrashReporting.setEnabled(true);
     final event = SentryEvent(


### PR DESCRIPTION
## Summary

- enable Android 12+ tombstone capture for native `SIGABRT` and `SIGSEGV` events
- keep the existing opt-in and redaction boundary unchanged
- add a regression for the Sentry initialization option

## Validation

- Flutter 3.44.8: `dart format --set-exit-if-changed lib test`
- Flutter 3.44.8: `flutter analyze`
- Flutter 3.44.8: `flutter test` (538 tests)
- `git diff --check`
- `gh act pull_request -W .github/workflows/pr.yml -j mobile` reached setup, then hit the known external-gitdir limitation before workflow steps: `fatal: not a git repository: (null)`

## Sentry

- ALERA-MOBILE-APP-C: https://alera.sentry.io/issues/7687664772/
- The existing event is unsymbolicated and cannot identify the aborting Alera function retroactively. This change captures the OS tombstone on a subsequent launch so future occurrences include the native crash context needed for root-cause analysis.