### PR TITLE
fix: enforce runtime profile ownership

### DIFF
--- a/rust/alera-cli/src/cli.rs
+++ b/rust/alera-cli/src/cli.rs
@@ -217,6 +217,24 @@ pub struct TerminalHostArgs {
     /// Send crashes to Sentry. Off unless the user opted in.
     #[arg(long = "crash-reporting")]
     pub crash_reporting: bool,
+
+    /// PID of the exact runtime owner this intentional handoff replaces.
+    #[arg(
+        long = "handoff-owner-pid",
+        value_name = "pid",
+        requires = "handoff_owner_start_marker",
+        hide = true
+    )]
+    pub handoff_owner_pid: Option<u32>,
+
+    /// Process start marker of the exact runtime owner this handoff replaces.
+    #[arg(
+        long = "handoff-owner-start-marker",
+        value_name = "marker",
+        requires = "handoff_owner_pid",
+        hide = true
+    )]
+    pub handoff_owner_start_marker: Option<u64>,
 }
 
 #[derive(Debug, Args)]

--- a/rust/alera-cli/src/cli_tests.rs
+++ b/rust/alera-cli/src/cli_tests.rs
@@ -52,6 +52,10 @@ fn replacement_runtime_host_arguments_preserve_effective_configuration() {
         "false",
         "--persistent",
         "--crash-reporting",
+        "--handoff-owner-pid",
+        "1234",
+        "--handoff-owner-start-marker",
+        "5678",
     ])
     .unwrap();
 
@@ -65,9 +69,40 @@ fn replacement_runtime_host_arguments_preserve_effective_configuration() {
             login_shell: Some(false),
             persistent: true,
             crash_reporting: true,
+            handoff_owner_pid: Some(1234),
+            handoff_owner_start_marker: Some(5678),
             ..
         })
     ));
+}
+
+#[test]
+fn replacement_runtime_host_arguments_require_a_complete_owner_identity() {
+    for incomplete in [
+        ["--handoff-owner-pid", "1234"],
+        ["--handoff-owner-start-marker", "5678"],
+    ] {
+        let error = Cli::try_parse_from(
+            [
+                "alera",
+                "runtime-host",
+                "--runtime-dir",
+                "/tmp/alera",
+                "--control-file",
+                "/tmp/alera/runtime-host.json",
+                "--token",
+                "replacement-token",
+            ]
+            .into_iter()
+            .chain(incomplete),
+        )
+        .expect_err("a partial owner identity must be rejected");
+
+        assert_eq!(
+            error.kind(),
+            clap::error::ErrorKind::MissingRequiredArgument
+        );
+    }
 }
 
 #[test]

--- a/rust/alera-cli/src/runtime_host_client.rs
+++ b/rust/alera-cli/src/runtime_host_client.rs
@@ -123,8 +123,12 @@ impl RuntimeHostRpcClient {
         persistent: bool,
     ) -> Result<Self> {
         tokio::fs::create_dir_all(runtime_dir).await?;
+        if let Some(pid) = crate::terminal_host::runtime_owner::live_owner_pid(runtime_dir)? {
+            return Err(anyhow!(
+                "A live Alera runtime host process {pid} owns this runtime directory, but its control metadata is unavailable or incompatible. Refusing to start a duplicate host."
+            ));
+        }
         let control_file = runtime_dir.join(RUNTIME_CONTROL_FILE_NAME);
-        let _ = tokio::fs::remove_file(&control_file).await;
         let token = Uuid::new_v4().to_string();
         let executable = std::env::current_exe().context("failed to resolve current alera CLI")?;
         let mut command = detached_windowless_async_command(executable);

--- a/rust/alera-cli/src/runtime_host_client.rs
+++ b/rust/alera-cli/src/runtime_host_client.rs
@@ -123,11 +123,7 @@ impl RuntimeHostRpcClient {
         persistent: bool,
     ) -> Result<Self> {
         tokio::fs::create_dir_all(runtime_dir).await?;
-        if let Some(pid) = crate::terminal_host::runtime_owner::live_owner_pid(runtime_dir)? {
-            return Err(anyhow!(
-                "A live Alera runtime host process {pid} owns this runtime directory, but its control metadata is unavailable or incompatible. Refusing to start a duplicate host."
-            ));
-        }
+        crate::terminal_host::runtime_owner::ensure_no_live_owner(runtime_dir)?;
         let control_file = runtime_dir.join(RUNTIME_CONTROL_FILE_NAME);
         let token = Uuid::new_v4().to_string();
         let executable = std::env::current_exe().context("failed to resolve current alera CLI")?;

--- a/rust/alera-cli/src/runtime_host_command.rs
+++ b/rust/alera-cli/src/runtime_host_command.rs
@@ -38,12 +38,23 @@ pub(crate) async fn run(args: TerminalHostArgs) -> i32 {
             .login_shell
             .unwrap_or_else(crate::terminal_host::protocol::default_login_shell),
     };
+    let handoff_owner = match (args.handoff_owner_pid, args.handoff_owner_start_marker) {
+        (Some(pid), Some(start_marker)) => {
+            Some(crate::terminal_host::runtime_owner::RuntimeOwnerIdentity { pid, start_marker })
+        }
+        (None, None) => None,
+        _ => {
+            eprintln!("Runtime owner handoff requires both PID and process start marker.");
+            return USAGE_EXIT_CODE;
+        }
+    };
 
     match run_terminal_host_server(
         PathBuf::from(runtime_dir),
         PathBuf::from(control_file),
         token,
         config,
+        handoff_owner,
     )
     .await
     {
@@ -107,6 +118,8 @@ pub(crate) async fn run_automation_host(args: AutomationHostArgs) -> i32 {
         persistent: true,
         log_level: "info".to_string(),
         crash_reporting: false,
+        handoff_owner_pid: None,
+        handoff_owner_start_marker: None,
     })
     .await
 }

--- a/rust/alera-cli/src/terminal_host/mod.rs
+++ b/rust/alera-cli/src/terminal_host/mod.rs
@@ -23,6 +23,7 @@ pub mod relay_wire;
 pub mod resources;
 pub(crate) mod restart;
 pub(crate) mod runtime_build_info;
+pub(crate) mod runtime_owner;
 pub mod server;
 pub mod session;
 pub mod sleep_detector;

--- a/rust/alera-cli/src/terminal_host/restart.rs
+++ b/rust/alera-cli/src/terminal_host/restart.rs
@@ -12,6 +12,7 @@ pub(crate) fn spawn_replacement_runtime_host(
 ) -> anyhow::Result<()> {
     let executable = std::env::current_exe()?;
     let token = Uuid::new_v4().to_string();
+    let owner = super::runtime_owner::current_owner_identity()?;
     let mut command = detached_windowless_async_command(executable);
     command
         .arg("runtime-host")
@@ -33,6 +34,10 @@ pub(crate) fn spawn_replacement_runtime_host(
         .arg(config.login_shell.to_string())
         .arg("--log-level")
         .arg(&args.log_level)
+        .arg("--handoff-owner-pid")
+        .arg(owner.pid.to_string())
+        .arg("--handoff-owner-start-marker")
+        .arg(owner.start_marker.to_string())
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::null());

--- a/rust/alera-cli/src/terminal_host/runtime_owner.rs
+++ b/rust/alera-cli/src/terminal_host/runtime_owner.rs
@@ -217,7 +217,16 @@ fn wait_for_owner_exit(owner: ProcessIdentity, probe: &impl ProcessIdentityProbe
     }
 }
 
-pub(crate) fn live_owner_pid(runtime_dir: &Path) -> Result<Option<u32>> {
+pub(crate) fn ensure_no_live_owner(runtime_dir: &Path) -> Result<()> {
+    if let Some(pid) = live_owner_pid(runtime_dir)? {
+        bail!(
+            "A live Alera runtime host process {pid} owns this runtime directory, but its control metadata is unavailable or incompatible. Refusing to start a duplicate host."
+        );
+    }
+    Ok(())
+}
+
+fn live_owner_pid(runtime_dir: &Path) -> Result<Option<u32>> {
     let Some(record) = read_owner_record(runtime_dir)? else {
         return Ok(None);
     };

--- a/rust/alera-cli/src/terminal_host/runtime_owner.rs
+++ b/rust/alera-cli/src/terminal_host/runtime_owner.rs
@@ -1,0 +1,362 @@
+use std::fs::{File, OpenOptions};
+use std::io::Write as _;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+use alera_core::runtime::{
+    create_private_runtime_file, prepare_private_runtime_directory, set_private_file_permissions,
+};
+use anyhow::{anyhow, bail, Context, Result};
+use serde::{Deserialize, Serialize};
+
+mod process_identity;
+
+use process_identity::{
+    current_process_identity, ProcessIdentity, ProcessIdentityProbe, ProcessLookup,
+    SystemProcessIdentityProbe, PLATFORM,
+};
+
+const LOCK_FILE_NAME: &str = "runtime-owner.lock";
+const OWNER_FILE_NAME: &str = "runtime-owner.json";
+const OWNER_SCHEMA_VERSION: u32 = 1;
+const OWNER_EXIT_TIMEOUT: Duration = Duration::from_secs(10);
+const OWNER_EXIT_RETRY_DELAY: Duration = Duration::from_millis(10);
+
+/// Holds the runtime profile's operating-system lock for the host lifetime.
+///
+/// The file is intentionally never deleted. Removing a locked file can create
+/// a second inode on Unix, letting another process lock the new inode while the
+/// original owner is still running.
+pub(crate) struct RuntimeOwnerGuard {
+    _lock: File,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct RuntimeOwnerIdentity {
+    pub(crate) pid: u32,
+    pub(crate) start_marker: u64,
+}
+
+impl From<ProcessIdentity> for RuntimeOwnerIdentity {
+    fn from(identity: ProcessIdentity) -> Self {
+        Self {
+            pid: identity.pid,
+            start_marker: identity.start_marker,
+        }
+    }
+}
+
+impl From<RuntimeOwnerIdentity> for ProcessIdentity {
+    fn from(identity: RuntimeOwnerIdentity) -> Self {
+        Self {
+            pid: identity.pid,
+            start_marker: identity.start_marker,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct RuntimeOwnerRecord {
+    #[serde(rename = "schemaVersion")]
+    schema_version: u32,
+    platform: String,
+    pid: u32,
+    #[serde(rename = "processStartMarker")]
+    process_start_marker: u64,
+}
+
+impl RuntimeOwnerRecord {
+    fn new(identity: ProcessIdentity) -> Self {
+        Self {
+            schema_version: OWNER_SCHEMA_VERSION,
+            platform: PLATFORM.to_string(),
+            pid: identity.pid,
+            process_start_marker: identity.start_marker,
+        }
+    }
+
+    fn identity(&self) -> ProcessIdentity {
+        ProcessIdentity {
+            pid: self.pid,
+            start_marker: self.process_start_marker,
+        }
+    }
+}
+
+impl RuntimeOwnerGuard {
+    pub(crate) fn acquire(runtime_dir: &Path) -> Result<Self> {
+        let identity = current_process_identity().map_err(|error| anyhow!(error))?;
+        Self::acquire_with_probe(runtime_dir, identity, &SystemProcessIdentityProbe)
+    }
+
+    pub(crate) fn acquire_handoff(
+        runtime_dir: &Path,
+        expected_owner: RuntimeOwnerIdentity,
+    ) -> Result<Self> {
+        let identity = current_process_identity().map_err(|error| anyhow!(error))?;
+        Self::acquire_handoff_with_probe(
+            runtime_dir,
+            expected_owner,
+            identity,
+            &SystemProcessIdentityProbe,
+        )
+    }
+
+    fn acquire_handoff_with_probe(
+        runtime_dir: &Path,
+        expected_owner: RuntimeOwnerIdentity,
+        identity: ProcessIdentity,
+        probe: &impl ProcessIdentityProbe,
+    ) -> Result<Self> {
+        prepare_private_runtime_directory(runtime_dir)?;
+        validate_handoff_owner(runtime_dir, expected_owner)?;
+        let lock_path = runtime_dir.join(LOCK_FILE_NAME);
+        let lock = open_lock_file(&lock_path)?;
+        lock.lock().with_context(|| {
+            format!(
+                "failed waiting for runtime ownership at {}",
+                lock_path.display()
+            )
+        })?;
+        finish_handoff(runtime_dir, expected_owner, identity, probe, lock)
+    }
+
+    fn acquire_with_probe(
+        runtime_dir: &Path,
+        identity: ProcessIdentity,
+        probe: &impl ProcessIdentityProbe,
+    ) -> Result<Self> {
+        prepare_private_runtime_directory(runtime_dir)?;
+        let lock_path = runtime_dir.join(LOCK_FILE_NAME);
+        let lock = open_lock_file(&lock_path)?;
+        match lock.try_lock() {
+            Ok(()) => {
+                validate_abandoned_owner(runtime_dir, identity, probe)?;
+                write_owner_record(runtime_dir, &RuntimeOwnerRecord::new(identity))?;
+                Ok(Self { _lock: lock })
+            }
+            Err(std::fs::TryLockError::WouldBlock) => reject_locked_owner(runtime_dir, probe),
+            Err(std::fs::TryLockError::Error(error)) => Err(error).with_context(|| {
+                format!(
+                    "failed locking runtime ownership at {}",
+                    lock_path.display()
+                )
+            }),
+        }
+    }
+}
+
+fn finish_handoff(
+    runtime_dir: &Path,
+    expected_owner: RuntimeOwnerIdentity,
+    identity: ProcessIdentity,
+    probe: &impl ProcessIdentityProbe,
+    lock: File,
+) -> Result<RuntimeOwnerGuard> {
+    validate_handoff_owner(runtime_dir, expected_owner)?;
+    wait_for_owner_exit(expected_owner.into(), probe)?;
+    validate_abandoned_owner(runtime_dir, identity, probe)?;
+    write_owner_record(runtime_dir, &RuntimeOwnerRecord::new(identity))?;
+    Ok(RuntimeOwnerGuard { _lock: lock })
+}
+
+pub(crate) fn current_owner_identity() -> Result<RuntimeOwnerIdentity> {
+    current_process_identity()
+        .map(RuntimeOwnerIdentity::from)
+        .map_err(|error| anyhow!(error))
+}
+
+fn validate_handoff_owner(runtime_dir: &Path, expected_owner: RuntimeOwnerIdentity) -> Result<()> {
+    let record = read_owner_record(runtime_dir)?.ok_or_else(|| {
+        anyhow!(
+            "runtime owner handoff expected process {}, but owner metadata is not available",
+            expected_owner.pid
+        )
+    })?;
+    if record.schema_version != OWNER_SCHEMA_VERSION || record.platform != PLATFORM {
+        bail!(
+            "runtime ownership metadata cannot be validated safely; expected schema {} on {}, found schema {} on {}",
+            OWNER_SCHEMA_VERSION,
+            PLATFORM,
+            record.schema_version,
+            record.platform
+        );
+    }
+    if record.identity() != ProcessIdentity::from(expected_owner) {
+        bail!(
+            "runtime owner handoff expected process {} with start marker {}, but owner metadata names process {} with start marker {}; refusing replacement",
+            expected_owner.pid,
+            expected_owner.start_marker,
+            record.pid,
+            record.process_start_marker
+        );
+    }
+    Ok(())
+}
+
+fn wait_for_owner_exit(owner: ProcessIdentity, probe: &impl ProcessIdentityProbe) -> Result<()> {
+    let deadline = Instant::now() + OWNER_EXIT_TIMEOUT;
+    loop {
+        match probe.lookup(owner.pid) {
+            ProcessLookup::Exited => return Ok(()),
+            ProcessLookup::Live(actual) if actual != owner => return Ok(()),
+            ProcessLookup::Live(_) if Instant::now() < deadline => {
+                std::thread::sleep(OWNER_EXIT_RETRY_DELAY);
+            }
+            ProcessLookup::Live(_) => bail!(
+                "replaced runtime owner process {} did not exit within {}s",
+                owner.pid,
+                OWNER_EXIT_TIMEOUT.as_secs()
+            ),
+            ProcessLookup::Unknown(reason) => bail!(
+                "runtime owner process {} could not be validated after releasing its lock: {}",
+                owner.pid,
+                reason
+            ),
+        }
+    }
+}
+
+pub(crate) fn live_owner_pid(runtime_dir: &Path) -> Result<Option<u32>> {
+    let Some(record) = read_owner_record(runtime_dir)? else {
+        return Ok(None);
+    };
+    if record.schema_version != OWNER_SCHEMA_VERSION || record.platform != PLATFORM {
+        bail!(
+            "runtime ownership metadata cannot be validated safely; expected schema {} on {}, found schema {} on {}",
+            OWNER_SCHEMA_VERSION,
+            PLATFORM,
+            record.schema_version,
+            record.platform
+        );
+    }
+    let recorded = record.identity();
+    match SystemProcessIdentityProbe.lookup(recorded.pid) {
+        ProcessLookup::Live(actual) if actual == recorded => Ok(Some(recorded.pid)),
+        ProcessLookup::Live(_) | ProcessLookup::Exited => Ok(None),
+        ProcessLookup::Unknown(reason) => bail!(
+            "runtime owner process {} could not be validated: {}",
+            recorded.pid,
+            reason
+        ),
+    }
+}
+
+fn open_lock_file(path: &Path) -> Result<File> {
+    let file = OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .read(true)
+        .write(true)
+        .open(path)
+        .with_context(|| format!("failed opening runtime ownership lock {}", path.display()))?;
+    set_private_file_permissions(path)?;
+    Ok(file)
+}
+
+fn validate_abandoned_owner(
+    runtime_dir: &Path,
+    current: ProcessIdentity,
+    probe: &impl ProcessIdentityProbe,
+) -> Result<()> {
+    let Some(record) = read_owner_record(runtime_dir)? else {
+        return Ok(());
+    };
+    if record.schema_version != OWNER_SCHEMA_VERSION || record.platform != PLATFORM {
+        bail!(
+            "runtime ownership metadata cannot be validated safely; expected schema {} on {}, found schema {} on {}",
+            OWNER_SCHEMA_VERSION,
+            PLATFORM,
+            record.schema_version,
+            record.platform
+        );
+    }
+    let recorded = record.identity();
+    match probe.lookup(recorded.pid) {
+        ProcessLookup::Exited => Ok(()),
+        ProcessLookup::Live(actual) if actual != recorded => Ok(()),
+        ProcessLookup::Live(actual) if actual == current => bail!(
+            "runtime directory is already attributed to this live process {}",
+            actual.pid
+        ),
+        ProcessLookup::Live(actual) => bail!(
+            "runtime ownership metadata still names live process {}; refusing stale-owner recovery",
+            actual.pid
+        ),
+        ProcessLookup::Unknown(reason) => bail!(
+            "runtime owner process {} could not be validated; refusing stale-owner recovery: {}",
+            recorded.pid,
+            reason
+        ),
+    }
+}
+
+fn reject_locked_owner(
+    runtime_dir: &Path,
+    probe: &impl ProcessIdentityProbe,
+) -> Result<RuntimeOwnerGuard> {
+    let record = read_owner_record(runtime_dir)?.ok_or_else(|| {
+        anyhow!(
+            "runtime ownership lock is held but owner metadata is not available; refusing to start"
+        )
+    })?;
+    if record.schema_version != OWNER_SCHEMA_VERSION || record.platform != PLATFORM {
+        bail!(
+            "runtime ownership lock is held by unverifiable schema {} on {}; refusing to start",
+            record.schema_version,
+            record.platform
+        );
+    }
+    let recorded = record.identity();
+    match probe.lookup(recorded.pid) {
+        ProcessLookup::Live(actual) if actual == recorded => bail!(
+            "runtime directory is already owned by live runtime host process {}",
+            actual.pid
+        ),
+        ProcessLookup::Live(_) | ProcessLookup::Exited => bail!(
+            "runtime ownership lock is still held after recorded owner process {} exited or its PID was reused; refusing to start",
+            recorded.pid
+        ),
+        ProcessLookup::Unknown(reason) => bail!(
+            "runtime ownership lock is held but owner process {} could not be validated; refusing to start: {}",
+            recorded.pid,
+            reason
+        ),
+    }
+}
+
+fn read_owner_record(runtime_dir: &Path) -> Result<Option<RuntimeOwnerRecord>> {
+    let path = runtime_dir.join(OWNER_FILE_NAME);
+    let contents = match std::fs::read_to_string(&path) {
+        Ok(contents) => contents,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => {
+            return Err(error).with_context(|| {
+                format!("failed reading runtime owner metadata {}", path.display())
+            });
+        }
+    };
+    serde_json::from_str(&contents)
+        .map(Some)
+        .with_context(|| format!("runtime owner metadata {} is invalid", path.display()))
+}
+
+fn write_owner_record(runtime_dir: &Path, record: &RuntimeOwnerRecord) -> Result<()> {
+    let path = runtime_dir.join(OWNER_FILE_NAME);
+    let temp = owner_temp_path(&path);
+    let mut file = create_private_runtime_file(&temp)?;
+    file.write_all(serde_json::to_string(record)?.as_bytes())?;
+    file.sync_all()?;
+    std::fs::rename(&temp, &path)?;
+    set_private_file_permissions(&path)?;
+    Ok(())
+}
+
+fn owner_temp_path(path: &Path) -> PathBuf {
+    let mut name = path.as_os_str().to_os_string();
+    name.push(".tmp");
+    PathBuf::from(name)
+}
+
+#[cfg(test)]
+mod tests;

--- a/rust/alera-cli/src/terminal_host/runtime_owner/process_identity.rs
+++ b/rust/alera-cli/src/terminal_host/runtime_owner/process_identity.rs
@@ -1,0 +1,241 @@
+use std::fmt;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct ProcessIdentity {
+    pub pid: u32,
+    pub start_marker: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum ProcessLookup {
+    Live(ProcessIdentity),
+    Exited,
+    Unknown(String),
+}
+
+impl fmt::Display for ProcessLookup {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ProcessLookup::Live(identity) => write!(
+                formatter,
+                "process {} is live with start marker {}",
+                identity.pid, identity.start_marker
+            ),
+            ProcessLookup::Exited => formatter.write_str("process has exited"),
+            ProcessLookup::Unknown(reason) => formatter.write_str(reason),
+        }
+    }
+}
+
+pub(super) trait ProcessIdentityProbe {
+    fn lookup(&self, pid: u32) -> ProcessLookup;
+}
+
+pub(super) struct SystemProcessIdentityProbe;
+
+impl ProcessIdentityProbe for SystemProcessIdentityProbe {
+    fn lookup(&self, pid: u32) -> ProcessLookup {
+        platform::lookup(pid)
+    }
+}
+
+pub(super) fn current_process_identity() -> Result<ProcessIdentity, String> {
+    let pid = std::process::id();
+    match SystemProcessIdentityProbe.lookup(pid) {
+        ProcessLookup::Live(identity) => Ok(identity),
+        ProcessLookup::Exited => Err(format!("current process {pid} was not found")),
+        ProcessLookup::Unknown(reason) => Err(format!(
+            "current process {pid} identity could not be read: {reason}"
+        )),
+    }
+}
+
+pub(super) const PLATFORM: &str = std::env::consts::OS;
+
+#[cfg(target_os = "linux")]
+mod platform {
+    use super::{ProcessIdentity, ProcessLookup};
+
+    pub(super) fn lookup(pid: u32) -> ProcessLookup {
+        let path = format!("/proc/{pid}/stat");
+        let stat = match std::fs::read_to_string(&path) {
+            Ok(stat) => stat,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                return ProcessLookup::Exited;
+            }
+            Err(error) => {
+                return ProcessLookup::Unknown(format!("failed reading {path}: {error}"));
+            }
+        };
+        match parse_process_record(&stat) {
+            Some(("Z" | "X", _)) => ProcessLookup::Exited,
+            Some((_, start_marker)) => ProcessLookup::Live(ProcessIdentity { pid, start_marker }),
+            None => ProcessLookup::Unknown(format!("{path} had an invalid process record")),
+        }
+    }
+
+    fn parse_process_record(stat: &str) -> Option<(&str, u64)> {
+        // The command name is parenthesized and may itself contain spaces or
+        // parentheses. Field 3 starts after the final `) `; starttime is field
+        // 22, so it is item 19 in that suffix.
+        let fields = stat.get(stat.rfind(") ")? + 2..)?;
+        let mut fields = fields.split_whitespace();
+        let state = fields.next()?;
+        let start_marker = fields.nth(18)?.parse().ok()?;
+        Some((state, start_marker))
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::parse_process_record;
+
+        #[test]
+        fn parses_linux_start_ticks_after_a_complex_process_name() {
+            let mut suffix = vec!["S"; 19];
+            suffix.push("987654");
+            assert_eq!(
+                parse_process_record(&format!("42 (name with ) paren) {}", suffix.join(" "))),
+                Some(("S", 987654))
+            );
+        }
+
+        #[test]
+        fn parses_linux_zombie_state() {
+            let mut suffix = vec!["Z"; 19];
+            suffix.push("987654");
+            assert_eq!(
+                parse_process_record(&format!("42 (zombie) {}", suffix.join(" "))),
+                Some(("Z", 987654))
+            );
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+mod platform {
+    use std::mem;
+
+    use super::{ProcessIdentity, ProcessLookup};
+
+    const ZOMBIE_PROCESS_STATUS: u32 = 5;
+
+    pub(super) fn lookup(pid: u32) -> ProcessLookup {
+        let mut info = unsafe { mem::zeroed::<libc::proc_bsdinfo>() };
+        let size = mem::size_of::<libc::proc_bsdinfo>() as libc::c_int;
+        let read = unsafe {
+            libc::proc_pidinfo(
+                pid as libc::c_int,
+                libc::PROC_PIDTBSDINFO,
+                0,
+                &mut info as *mut _ as *mut libc::c_void,
+                size,
+            )
+        };
+        if read == size {
+            if info.pbi_status == ZOMBIE_PROCESS_STATUS {
+                return ProcessLookup::Exited;
+            }
+            let Some(start_marker) = info
+                .pbi_start_tvsec
+                .checked_mul(1_000_000)
+                .and_then(|seconds| seconds.checked_add(info.pbi_start_tvusec))
+            else {
+                return ProcessLookup::Unknown(format!("process {pid} start timestamp overflowed"));
+            };
+            return ProcessLookup::Live(ProcessIdentity { pid, start_marker });
+        }
+        let errno = unsafe { *libc::__error() };
+        if errno == libc::ESRCH {
+            ProcessLookup::Exited
+        } else {
+            ProcessLookup::Unknown(format!(
+                "proc_pidinfo failed for process {pid}: errno {errno}"
+            ))
+        }
+    }
+}
+
+#[cfg(target_os = "windows")]
+mod platform {
+    use windows::Win32::Foundation::{
+        CloseHandle, GetLastError, ERROR_INVALID_PARAMETER, FILETIME,
+    };
+    use windows::Win32::System::Threading::{
+        GetExitCodeProcess, GetProcessTimes, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION,
+    };
+
+    use super::{ProcessIdentity, ProcessLookup};
+
+    pub(super) fn lookup(pid: u32) -> ProcessLookup {
+        let handle = match unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, pid) } {
+            Ok(handle) => handle,
+            Err(error) => {
+                let code = unsafe { GetLastError() };
+                return if code == ERROR_INVALID_PARAMETER {
+                    ProcessLookup::Exited
+                } else {
+                    ProcessLookup::Unknown(format!("OpenProcess failed for process {pid}: {error}"))
+                };
+            }
+        };
+        let mut created = FILETIME::default();
+        let mut exited = FILETIME::default();
+        let mut kernel = FILETIME::default();
+        let mut user = FILETIME::default();
+        let mut exit_code = 0;
+        let exit_result = unsafe { GetExitCodeProcess(handle, &mut exit_code) };
+        let time_result =
+            unsafe { GetProcessTimes(handle, &mut created, &mut exited, &mut kernel, &mut user) };
+        let _ = unsafe { CloseHandle(handle) };
+        if let Err(error) = exit_result {
+            return ProcessLookup::Unknown(format!(
+                "GetExitCodeProcess failed for process {pid}: {error}"
+            ));
+        }
+        if exit_code != windows::Win32::Foundation::STILL_ACTIVE.0 as u32 {
+            return ProcessLookup::Exited;
+        }
+        match time_result {
+            Ok(()) => ProcessLookup::Live(ProcessIdentity {
+                pid,
+                start_marker: (u64::from(created.dwHighDateTime) << 32)
+                    | u64::from(created.dwLowDateTime),
+            }),
+            Err(error) => {
+                ProcessLookup::Unknown(format!("GetProcessTimes failed for process {pid}: {error}"))
+            }
+        }
+    }
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
+mod platform {
+    use super::ProcessLookup;
+
+    pub(super) fn lookup(pid: u32) -> ProcessLookup {
+        ProcessLookup::Unknown(format!(
+            "process identity is unsupported on {} for process {pid}",
+            std::env::consts::OS
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        current_process_identity, ProcessIdentityProbe, ProcessLookup, SystemProcessIdentityProbe,
+    };
+
+    #[test]
+    fn current_process_has_a_stable_nonzero_identity() {
+        let first = current_process_identity().unwrap();
+        let second = current_process_identity().unwrap();
+        assert_eq!(first, second);
+        assert_eq!(first.pid, std::process::id());
+        assert_ne!(first.start_marker, 0);
+        assert_eq!(
+            SystemProcessIdentityProbe.lookup(first.pid),
+            ProcessLookup::Live(first)
+        );
+    }
+}

--- a/rust/alera-cli/src/terminal_host/runtime_owner/tests.rs
+++ b/rust/alera-cli/src/terminal_host/runtime_owner/tests.rs
@@ -1,0 +1,264 @@
+use std::collections::HashMap;
+
+use super::*;
+
+struct FakeProbe {
+    processes: HashMap<u32, ProcessLookup>,
+}
+
+impl ProcessIdentityProbe for FakeProbe {
+    fn lookup(&self, pid: u32) -> ProcessLookup {
+        self.processes
+            .get(&pid)
+            .cloned()
+            .unwrap_or(ProcessLookup::Exited)
+    }
+}
+
+fn identity(pid: u32, start_marker: u64) -> ProcessIdentity {
+    ProcessIdentity { pid, start_marker }
+}
+
+fn probe(entries: impl IntoIterator<Item = (u32, ProcessLookup)>) -> FakeProbe {
+    FakeProbe {
+        processes: entries.into_iter().collect(),
+    }
+}
+
+#[test]
+fn a_live_owner_rejects_a_concurrent_start_without_rewriting_metadata() {
+    let dir = tempfile::tempdir().unwrap();
+    let owner = identity(100, 1_000);
+    let challenger = identity(200, 2_000);
+    let probe = probe([(owner.pid, ProcessLookup::Live(owner))]);
+    let _guard = RuntimeOwnerGuard::acquire_with_probe(dir.path(), owner, &probe).unwrap();
+    let before = std::fs::read(dir.path().join(OWNER_FILE_NAME)).unwrap();
+
+    let error = RuntimeOwnerGuard::acquire_with_probe(dir.path(), challenger, &probe)
+        .err()
+        .expect("concurrent owner should be rejected");
+
+    assert!(error.to_string().contains("live runtime host process 100"));
+    assert_eq!(
+        std::fs::read(dir.path().join(OWNER_FILE_NAME)).unwrap(),
+        before
+    );
+}
+
+#[test]
+fn stale_owner_is_replaced_only_after_the_process_exited() {
+    let dir = tempfile::tempdir().unwrap();
+    let old = identity(100, 1_000);
+    let replacement = identity(200, 2_000);
+    let old_probe = probe([(old.pid, ProcessLookup::Live(old))]);
+    let guard = RuntimeOwnerGuard::acquire_with_probe(dir.path(), old, &old_probe).unwrap();
+    drop(guard);
+
+    let exited_probe = probe([(old.pid, ProcessLookup::Exited)]);
+    let _replacement =
+        RuntimeOwnerGuard::acquire_with_probe(dir.path(), replacement, &exited_probe).unwrap();
+    assert_eq!(
+        read_owner_record(dir.path()).unwrap().unwrap(),
+        RuntimeOwnerRecord::new(replacement)
+    );
+}
+
+#[test]
+fn pid_reuse_proves_the_recorded_owner_exited() {
+    let dir = tempfile::tempdir().unwrap();
+    let old = identity(100, 1_000);
+    let reused = identity(100, 9_000);
+    let replacement = identity(200, 2_000);
+    write_owner_record(dir.path(), &RuntimeOwnerRecord::new(old)).unwrap();
+    let reused_probe = probe([(old.pid, ProcessLookup::Live(reused))]);
+
+    let _guard =
+        RuntimeOwnerGuard::acquire_with_probe(dir.path(), replacement, &reused_probe).unwrap();
+
+    assert_eq!(
+        read_owner_record(dir.path()).unwrap().unwrap(),
+        RuntimeOwnerRecord::new(replacement)
+    );
+}
+
+#[test]
+fn handoff_rejects_missing_owner_metadata() {
+    let dir = tempfile::tempdir().unwrap();
+    let expected = RuntimeOwnerIdentity {
+        pid: 100,
+        start_marker: 1_000,
+    };
+
+    let error = RuntimeOwnerGuard::acquire_handoff_with_probe(
+        dir.path(),
+        expected,
+        identity(200, 2_000),
+        &probe([]),
+    )
+    .err()
+    .expect("a handoff without owner metadata should be rejected");
+
+    assert!(error
+        .to_string()
+        .contains("owner metadata is not available"));
+    assert!(!dir.path().join(OWNER_FILE_NAME).exists());
+}
+
+#[test]
+fn handoff_rejects_a_mismatched_owner_identity_without_rewriting_metadata() {
+    let dir = tempfile::tempdir().unwrap();
+    let old = identity(100, 1_000);
+    write_owner_record(dir.path(), &RuntimeOwnerRecord::new(old)).unwrap();
+    let before = std::fs::read(dir.path().join(OWNER_FILE_NAME)).unwrap();
+
+    let error = RuntimeOwnerGuard::acquire_handoff_with_probe(
+        dir.path(),
+        RuntimeOwnerIdentity {
+            pid: old.pid,
+            start_marker: 9_000,
+        },
+        identity(200, 2_000),
+        &probe([(old.pid, ProcessLookup::Exited)]),
+    )
+    .err()
+    .expect("a mismatched handoff should be rejected");
+
+    assert!(error.to_string().contains("refusing replacement"));
+    assert_eq!(
+        std::fs::read(dir.path().join(OWNER_FILE_NAME)).unwrap(),
+        before
+    );
+}
+
+#[test]
+fn handoff_rejects_an_owner_change_at_the_lock_boundary() {
+    let dir = tempfile::tempdir().unwrap();
+    let expected = identity(100, 1_000);
+    let intervening_owner = identity(300, 3_000);
+    let handoff = RuntimeOwnerIdentity::from(expected);
+    write_owner_record(dir.path(), &RuntimeOwnerRecord::new(expected)).unwrap();
+    validate_handoff_owner(dir.path(), handoff).unwrap();
+    let lock = open_lock_file(&dir.path().join(LOCK_FILE_NAME)).unwrap();
+    lock.lock().unwrap();
+
+    write_owner_record(dir.path(), &RuntimeOwnerRecord::new(intervening_owner)).unwrap();
+    let error = finish_handoff(
+        dir.path(),
+        handoff,
+        identity(200, 2_000),
+        &probe([(expected.pid, ProcessLookup::Exited)]),
+        lock,
+    )
+    .err()
+    .expect("a handoff must not cross into a different owner's tenure");
+
+    assert!(error.to_string().contains("refusing replacement"));
+    assert_eq!(
+        read_owner_record(dir.path()).unwrap().unwrap(),
+        RuntimeOwnerRecord::new(intervening_owner)
+    );
+}
+
+#[test]
+fn handoff_fails_closed_when_the_expected_owner_cannot_be_validated() {
+    let dir = tempfile::tempdir().unwrap();
+    let old = identity(100, 1_000);
+    write_owner_record(dir.path(), &RuntimeOwnerRecord::new(old)).unwrap();
+    let before = std::fs::read(dir.path().join(OWNER_FILE_NAME)).unwrap();
+
+    let error = RuntimeOwnerGuard::acquire_handoff_with_probe(
+        dir.path(),
+        RuntimeOwnerIdentity::from(old),
+        identity(200, 2_000),
+        &probe([(old.pid, ProcessLookup::Unknown("access denied".to_string()))]),
+    )
+    .err()
+    .expect("an unverifiable handoff should be rejected");
+
+    assert!(error.to_string().contains("could not be validated"));
+    assert_eq!(
+        std::fs::read(dir.path().join(OWNER_FILE_NAME)).unwrap(),
+        before
+    );
+}
+
+#[test]
+fn handoff_accepts_pid_reuse_only_for_the_exact_recorded_owner() {
+    let dir = tempfile::tempdir().unwrap();
+    let old = identity(100, 1_000);
+    let reused = identity(100, 9_000);
+    let replacement = identity(200, 2_000);
+    write_owner_record(dir.path(), &RuntimeOwnerRecord::new(old)).unwrap();
+
+    let _guard = RuntimeOwnerGuard::acquire_handoff_with_probe(
+        dir.path(),
+        RuntimeOwnerIdentity::from(old),
+        replacement,
+        &probe([(old.pid, ProcessLookup::Live(reused))]),
+    )
+    .unwrap();
+
+    assert_eq!(
+        read_owner_record(dir.path()).unwrap().unwrap(),
+        RuntimeOwnerRecord::new(replacement)
+    );
+}
+
+#[test]
+fn unverifiable_stale_owner_fails_closed() {
+    let dir = tempfile::tempdir().unwrap();
+    let old = identity(100, 1_000);
+    write_owner_record(dir.path(), &RuntimeOwnerRecord::new(old)).unwrap();
+    let unknown_probe = probe([(old.pid, ProcessLookup::Unknown("access denied".to_string()))]);
+
+    let error =
+        RuntimeOwnerGuard::acquire_with_probe(dir.path(), identity(200, 2_000), &unknown_probe)
+            .err()
+            .expect("unverifiable owner should be rejected");
+
+    assert!(error.to_string().contains("refusing stale-owner recovery"));
+    assert_eq!(
+        read_owner_record(dir.path()).unwrap().unwrap(),
+        RuntimeOwnerRecord::new(old)
+    );
+}
+
+#[test]
+fn malformed_owner_metadata_is_never_overwritten() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join(OWNER_FILE_NAME);
+    std::fs::write(&path, b"not json").unwrap();
+
+    let error = RuntimeOwnerGuard::acquire_with_probe(dir.path(), identity(200, 2_000), &probe([]))
+        .err()
+        .expect("malformed ownership should be rejected");
+
+    assert!(error.to_string().contains("is invalid"));
+    assert_eq!(std::fs::read(path).unwrap(), b"not json");
+}
+
+#[cfg(unix)]
+#[test]
+fn ownership_files_are_private() {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    let dir = tempfile::tempdir().unwrap();
+    let owner = identity(100, 1_000);
+    let _guard = RuntimeOwnerGuard::acquire_with_probe(
+        dir.path(),
+        owner,
+        &probe([(owner.pid, ProcessLookup::Live(owner))]),
+    )
+    .unwrap();
+
+    for name in [LOCK_FILE_NAME, OWNER_FILE_NAME] {
+        assert_eq!(
+            std::fs::metadata(dir.path().join(name))
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777,
+            0o600
+        );
+    }
+}

--- a/rust/alera-cli/src/terminal_host/server.rs
+++ b/rust/alera-cli/src/terminal_host/server.rs
@@ -39,6 +39,7 @@ use crate::terminal_host::orchestration::message_delivery::{
 use crate::terminal_host::orchestration::message_formatter::format_messages_for_injection;
 use crate::terminal_host::orchestration::message_waiters::MessageWaiterRegistry;
 use crate::terminal_host::protocol::{event, TerminalHostConfig};
+use crate::terminal_host::runtime_owner;
 use crate::terminal_host::session::{PtyWriteCompletion, Session};
 use crate::terminal_host::sleep_detector::SleepDetector;
 

--- a/rust/alera-cli/src/terminal_host/server_runner.rs
+++ b/rust/alera-cli/src/terminal_host/server_runner.rs
@@ -14,8 +14,16 @@ pub async fn run_terminal_host_server(
     control_file_path: PathBuf,
     token: String,
     config: TerminalHostConfig,
+    handoff_owner: Option<runtime_owner::RuntimeOwnerIdentity>,
 ) -> Result<TerminalHostExit> {
     prepare_private_runtime_directory(&runtime_dir)?;
+    // Ownership must be established before opening stores or constructing any
+    // account service. A rejected duplicate host must not touch profile state.
+    let _runtime_owner = if let Some(expected_owner) = handoff_owner {
+        runtime_owner::RuntimeOwnerGuard::acquire_handoff(&runtime_dir, expected_owner)?
+    } else {
+        runtime_owner::RuntimeOwnerGuard::acquire(&runtime_dir)?
+    };
     let store = TerminalHostHistoryStore::open(&runtime_dir).await?;
     let runtime_store = RuntimeStore::open(&runtime_dir).await?;
     crate::hosted_review_retention::reconcile(&runtime_store).await;

--- a/rust/alera-cli/tests/runtime_owner_conformance.rs
+++ b/rust/alera-cli/tests/runtime_owner_conformance.rs
@@ -1,0 +1,320 @@
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::sync::{Arc, Barrier};
+use std::time::{Duration, Instant};
+
+use alera_core::child_process::windowless_command;
+use serde_json::Value;
+
+struct HostGuard(Option<Child>);
+
+impl HostGuard {
+    fn new(child: Child) -> Self {
+        Self(Some(child))
+    }
+
+    fn child_mut(&mut self) -> &mut Child {
+        self.0.as_mut().unwrap()
+    }
+
+    fn stop(&mut self) {
+        let Some(mut child) = self.0.take() else {
+            return;
+        };
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+}
+
+impl Drop for HostGuard {
+    fn drop(&mut self) {
+        self.stop();
+    }
+}
+
+fn host_command(runtime_dir: &Path, control_path: &Path, token: &str) -> Command {
+    let mut command = windowless_command(env!("CARGO_BIN_EXE_alera"));
+    command.args([
+        "runtime-host",
+        "--runtime-dir",
+        runtime_dir.to_str().unwrap(),
+        "--control-file",
+        control_path.to_str().unwrap(),
+        "--token",
+        token,
+        "--empty-shutdown-delay-seconds",
+        "60",
+        "--detached-session-shutdown-delay-seconds",
+        "60",
+    ]);
+    command
+}
+
+fn spawn_host(runtime_dir: &Path, control_path: &Path, token: &str) -> Child {
+    host_command(runtime_dir, control_path, token)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap()
+}
+
+fn read_control_for_pid(path: &Path, pid: u32) -> Value {
+    let deadline = Instant::now() + Duration::from_secs(15);
+    loop {
+        if let Ok(contents) = std::fs::read_to_string(path) {
+            if let Ok(value) = serde_json::from_str::<Value>(&contents) {
+                if value["pid"].as_u64() == Some(u64::from(pid)) {
+                    return value;
+                }
+            }
+        }
+        assert!(
+            Instant::now() < deadline,
+            "control file was not published for process {pid}"
+        );
+        std::thread::sleep(Duration::from_millis(25));
+    }
+}
+
+fn wait_for_exit(child: &mut Child) -> std::process::ExitStatus {
+    let deadline = Instant::now() + Duration::from_secs(15);
+    loop {
+        if let Some(status) = child.try_wait().unwrap() {
+            return status;
+        }
+        assert!(Instant::now() < deadline, "child did not exit");
+        std::thread::sleep(Duration::from_millis(25));
+    }
+}
+
+#[test]
+fn concurrent_runtime_hosts_leave_exactly_one_owner() {
+    let dir = tempfile::tempdir().unwrap();
+    let runtime_dir = dir.path().join("runtime");
+    let control_path = runtime_dir.join("runtime-host.json");
+    std::fs::create_dir_all(&runtime_dir).unwrap();
+    let barrier = Arc::new(Barrier::new(3));
+
+    let spawn = |token: &'static str,
+                 barrier: Arc<Barrier>,
+                 runtime_dir: PathBuf,
+                 control_path: PathBuf| {
+        std::thread::spawn(move || {
+            barrier.wait();
+            spawn_host(&runtime_dir, &control_path, token)
+        })
+    };
+    let first = spawn(
+        "first-token",
+        barrier.clone(),
+        runtime_dir.clone(),
+        control_path.clone(),
+    );
+    let second = spawn(
+        "second-token",
+        barrier.clone(),
+        runtime_dir.clone(),
+        control_path.clone(),
+    );
+    barrier.wait();
+    let mut hosts = [
+        HostGuard::new(first.join().unwrap()),
+        HostGuard::new(second.join().unwrap()),
+    ];
+
+    let deadline = Instant::now() + Duration::from_secs(15);
+    let loser = loop {
+        let exited: Vec<usize> = hosts
+            .iter_mut()
+            .enumerate()
+            .filter_map(|(index, host)| {
+                host.child_mut()
+                    .try_wait()
+                    .unwrap()
+                    .map(|status| (index, status))
+            })
+            .map(|(index, status)| {
+                assert!(!status.success(), "duplicate host unexpectedly succeeded");
+                index
+            })
+            .collect();
+        if exited.len() == 1 {
+            break exited[0];
+        }
+        assert!(exited.is_empty(), "both concurrent hosts exited");
+        assert!(Instant::now() < deadline, "neither concurrent host exited");
+        std::thread::sleep(Duration::from_millis(25));
+    };
+    let winner = 1 - loser;
+    assert!(hosts[winner].child_mut().try_wait().unwrap().is_none());
+    let winner_pid = hosts[winner].child_mut().id();
+    assert_eq!(
+        read_control_for_pid(&control_path, winner_pid)["pid"],
+        winner_pid
+    );
+    let owner: Value = serde_json::from_str(
+        &std::fs::read_to_string(runtime_dir.join("runtime-owner.json")).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(owner["pid"], winner_pid);
+}
+
+#[test]
+fn duplicate_start_preserves_live_control_and_owner_metadata() {
+    let dir = tempfile::tempdir().unwrap();
+    let runtime_dir = dir.path().join("runtime");
+    let control_path = runtime_dir.join("runtime-host.json");
+    std::fs::create_dir_all(&runtime_dir).unwrap();
+    let mut owner = HostGuard::new(spawn_host(&runtime_dir, &control_path, "owner-token"));
+    read_control_for_pid(&control_path, owner.child_mut().id());
+    let control_before = std::fs::read(&control_path).unwrap();
+    let owner_path = runtime_dir.join("runtime-owner.json");
+    let owner_before = std::fs::read(&owner_path).unwrap();
+
+    let mut challenger = spawn_host(&runtime_dir, &control_path, "challenger-token");
+    let status = wait_for_exit(&mut challenger);
+
+    assert!(!status.success());
+    assert!(owner.child_mut().try_wait().unwrap().is_none());
+    assert_eq!(std::fs::read(control_path).unwrap(), control_before);
+    assert_eq!(std::fs::read(owner_path).unwrap(), owner_before);
+}
+
+fn assert_invalid_handoff_is_rejected(
+    runtime_dir: &Path,
+    control_path: &Path,
+    owner: &mut HostGuard,
+    handoff_pid: u32,
+    handoff_start_marker: u64,
+) {
+    let control_before = std::fs::read(control_path).unwrap();
+    let owner_path = runtime_dir.join("runtime-owner.json");
+    let owner_before = std::fs::read(&owner_path).unwrap();
+    let mut command = host_command(runtime_dir, control_path, "invalid-handoff-token");
+    let handoff_pid = handoff_pid.to_string();
+    let handoff_start_marker = handoff_start_marker.to_string();
+    command.args([
+        "--handoff-owner-pid",
+        &handoff_pid,
+        "--handoff-owner-start-marker",
+        &handoff_start_marker,
+    ]);
+    let output = command.output().unwrap();
+
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("refusing replacement"));
+    assert!(owner.child_mut().try_wait().unwrap().is_none());
+    assert_eq!(std::fs::read(control_path).unwrap(), control_before);
+    assert_eq!(std::fs::read(owner_path).unwrap(), owner_before);
+}
+
+#[test]
+fn handoff_rejects_the_wrong_owner_pid_without_modifying_live_metadata() {
+    let dir = tempfile::tempdir().unwrap();
+    let runtime_dir = dir.path().join("runtime");
+    let control_path = runtime_dir.join("runtime-host.json");
+    std::fs::create_dir_all(&runtime_dir).unwrap();
+    let mut owner = HostGuard::new(spawn_host(&runtime_dir, &control_path, "owner-token"));
+    read_control_for_pid(&control_path, owner.child_mut().id());
+    let owner_record: Value = serde_json::from_str(
+        &std::fs::read_to_string(runtime_dir.join("runtime-owner.json")).unwrap(),
+    )
+    .unwrap();
+    let owner_pid = owner.child_mut().id();
+
+    assert_invalid_handoff_is_rejected(
+        &runtime_dir,
+        &control_path,
+        &mut owner,
+        owner_pid.checked_add(1).unwrap(),
+        owner_record["processStartMarker"].as_u64().unwrap(),
+    );
+}
+
+#[test]
+fn handoff_rejects_the_wrong_start_marker_without_modifying_live_metadata() {
+    let dir = tempfile::tempdir().unwrap();
+    let runtime_dir = dir.path().join("runtime");
+    let control_path = runtime_dir.join("runtime-host.json");
+    std::fs::create_dir_all(&runtime_dir).unwrap();
+    let mut owner = HostGuard::new(spawn_host(&runtime_dir, &control_path, "owner-token"));
+    read_control_for_pid(&control_path, owner.child_mut().id());
+    let owner_record: Value = serde_json::from_str(
+        &std::fs::read_to_string(runtime_dir.join("runtime-owner.json")).unwrap(),
+    )
+    .unwrap();
+    let owner_pid = owner.child_mut().id();
+
+    assert_invalid_handoff_is_rejected(
+        &runtime_dir,
+        &control_path,
+        &mut owner,
+        owner_pid,
+        owner_record["processStartMarker"]
+            .as_u64()
+            .unwrap()
+            .checked_add(1)
+            .unwrap(),
+    );
+}
+
+#[test]
+fn client_start_fails_safely_when_live_control_metadata_is_incompatible() {
+    let dir = tempfile::tempdir().unwrap();
+    let runtime_dir = dir.path().join("runtime");
+    let control_path = runtime_dir.join("runtime-host.json");
+    std::fs::create_dir_all(&runtime_dir).unwrap();
+    let mut owner = HostGuard::new(spawn_host(&runtime_dir, &control_path, "owner-token"));
+    let mut incompatible = read_control_for_pid(&control_path, owner.child_mut().id());
+    incompatible["protocolVersion"] = Value::from(-1);
+    let incompatible = serde_json::to_vec(&incompatible).unwrap();
+    std::fs::write(&control_path, &incompatible).unwrap();
+    let owner_before = std::fs::read(runtime_dir.join("runtime-owner.json")).unwrap();
+
+    let output = windowless_command(env!("CARGO_BIN_EXE_alera"))
+        .args([
+            "runtime",
+            "--runtime-dir",
+            runtime_dir.to_str().unwrap(),
+            "start",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("Refusing to start a duplicate host"));
+    assert!(owner.child_mut().try_wait().unwrap().is_none());
+    assert_eq!(std::fs::read(control_path).unwrap(), incompatible);
+    assert_eq!(
+        std::fs::read(runtime_dir.join("runtime-owner.json")).unwrap(),
+        owner_before
+    );
+}
+
+#[test]
+fn stale_owner_is_recovered_after_the_process_exits() {
+    let dir = tempfile::tempdir().unwrap();
+    let runtime_dir = dir.path().join("runtime");
+    let control_path = runtime_dir.join("runtime-host.json");
+    std::fs::create_dir_all(&runtime_dir).unwrap();
+    let mut first = HostGuard::new(spawn_host(&runtime_dir, &control_path, "first-token"));
+    let first_pid = first.child_mut().id();
+    read_control_for_pid(&control_path, first_pid);
+    first.stop();
+
+    let mut replacement =
+        HostGuard::new(spawn_host(&runtime_dir, &control_path, "replacement-token"));
+    let replacement_pid = replacement.child_mut().id();
+    let control = read_control_for_pid(&control_path, replacement_pid);
+    let owner: Value = serde_json::from_str(
+        &std::fs::read_to_string(runtime_dir.join("runtime-owner.json")).unwrap(),
+    )
+    .unwrap();
+
+    assert_ne!(first_pid, replacement_pid);
+    assert_eq!(control["pid"], replacement_pid);
+    assert_eq!(control["token"], "replacement-token");
+    assert_eq!(owner["pid"], replacement_pid);
+    assert!(replacement.child_mut().try_wait().unwrap().is_none());
+}


### PR DESCRIPTION
## Summary

- add a private cross-platform OS lock and exact process identity record per runtime profile
- reject duplicate or incompatible starts before runtime stores or account services are opened
- bind intentional restart handoff to the previous owner's PID and process start marker
- recover stale ownership only after exit or proven PID reuse on Linux, macOS, and Windows

## Validation

- `make rust-test`
- focused ownership, restart, CLI handoff, concurrency, stale recovery, and PID reuse tests on Linux
- the same focused suites on native macOS and Windows builders
- local `gh act pull_request -W .github/workflows/pr.yml -j rust` attempted; the Act image lacked `libclang.so`, while native/local Rust gates passed

Fixes #485
