### PR TITLE
ci: run Windows PTY Job lifecycle tests

### DIFF
--- a/.github/workflows/windows-pty-job.yml
+++ b/.github/workflows/windows-pty-job.yml
@@ -1,0 +1,68 @@
+name: Windows PTY Job Tests
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - rust/alera-cli/Cargo.toml
+      - rust/alera-cli/src/pty_job_bootstrap.rs
+      - rust/alera-cli/src/terminal_host/session/**
+      - rust/Cargo.lock
+      - .github/workflows/windows-pty-job.yml
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  windows_pty_job:
+    name: windows pty job
+    runs-on: windows-latest
+    timeout-minutes: 45
+    env:
+      CARGO_TARGET_DIR: R:\c
+      CMAKE_GENERATOR: Ninja
+      _CL_: /Z7 /FS
+      GGML_CCACHE: 'OFF'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          submodules: false
+
+      - name: Setup Flutter workspace
+        uses: ./.github/actions/setup-flutter-workspace
+        with:
+          linux-toolchain: 'false'
+          native-assets: 'false'
+          preflight: 'false'
+          rust: 'true'
+
+      - name: Tune Windows build environment
+        uses: ./.github/actions/tune-windows-build
+
+      - name: Test Windows PTY Job lifecycle
+        run: >-
+          cargo test
+          --manifest-path rust/Cargo.toml
+          --locked
+          -p alera-cli
+          terminal_host::session::windows_process_job::tests
+          --
+          --nocapture
+
+      - name: Report sccache statistics
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo '### sccache Windows PTY Job tests'
+            echo '```text'
+            sccache --show-stats || true
+            echo '```'
+          } | tee -a "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
- add a targeted `windows-latest` workflow for the four real Job Object lifecycle tests
- trigger it for the Job Object implementation, bootstrap, lockfile, crate manifest, and workflow itself
- keep permissions read-only and avoid secrets

## Validation
- YAML parsed successfully
- `git diff --check origin/main...HEAD`
- verified the Job Object implementation commit ecae2c9233d5a9f79011291ad5856230cd6618a0 is in the branch ancestry
- `gh act` discovered the job but cannot execute `windows-latest` on the local Linux Docker runner; this PR should trigger the real hosted Windows run because the path filter includes this workflow
