### PR TITLE
test: add historical host conformance

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -223,6 +223,13 @@ jobs:
         with:
           check: ${{ matrix.name }}
 
+      # One pinned historical host on the existing test leg, not a version
+      # matrix. The script verifies the release tag's commit and builds its
+      # locked source before exercising the current compatibility client.
+      - name: Previous host conformance
+        if: matrix.name == 'test'
+        run: bash tool/ci/host_compatibility.sh
+
       - name: Report sccache statistics
         if: always()
         run: |

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -123,6 +123,14 @@ make cli-help
 
 The repository `makefile` exposes cross-platform debug targets around the same flow. `make help` lists available targets. For foreground host debugging, `make host-debug` accepts `ALERA_HOST_EMPTY_SHUTDOWN_SECONDS`, `ALERA_HOST_DETACHED_SHUTDOWN_SECONDS`, and `ALERA_HOST_SCROLLBACK_BYTES`, which are forwarded to the runtime host. `alera terminal-host` remains a compatibility alias, but new product behavior should be validated through `alera runtime-host` and the `project`, `workspace`, `tag`, `tab`, and `ssh-target` CLI groups.
 
+Cross-version host conformance is intentionally one pinned Linux combination rather than a release matrix. `tool/ci/host_compatibility.sh` shallow-fetches tag `v0.49.0` into a disposable repository, verifies that it resolves to commit `e60c96ec7522052e9af81ab15ae5d6da2443dac4`, and builds that source in an isolated target directory with its committed `rust/Cargo.lock` and pinned toolchain. The current protocol client then covers `status.get`, capability negotiation, agent profile upsert/list, and terminal launch/output. It also proves that the older host does not advertise `agentProfileOrderingV1` and returns a named error if that newer verb is sent accidentally; `runtime_agent_profile_repository_test.dart` separately holds the Flutter client contract that capability absence produces a user-facing newer-host message without sending the unsupported verb. The normal Rust suite drives the current host with the same field set accepted by `v0.49.0`, covering the reverse direction without another build.
+
+Run the historical combination locally from a checkout with access to `origin`:
+
+```bash
+bash tool/ci/host_compatibility.sh
+```
+
 Runtime-owned Projects, Workspaces, Tabs, Layouts, tags, relations, and SSH targets should include Rust store tests plus Dart repository/provider tests. Relation tests must cover self-link rejection, cycle prevention, cross-project links, tag assignment, and cascade previews for descendants and tags. SSH target tests should use fakes or local fixtures unless the test is explicitly marked as a manual remote-host smoke.
 
 ## Mocking

--- a/rust/alera-cli/tests/host_version_compatibility.rs
+++ b/rust/alera-cli/tests/host_version_compatibility.rs
@@ -1,0 +1,230 @@
+//! Cross-version conformance for the smallest contract shared with v0.49.0.
+//!
+//! The current-host direction runs with the normal workspace tests. The
+//! previous-host direction is ignored unless `tool/ci/host_compatibility.sh`
+//! supplies the binary built from the pinned release tag.
+
+#![cfg(unix)]
+
+use std::io::{BufRead, BufReader, Write};
+use std::net::TcpStream;
+use std::process::Child;
+use std::time::{Duration, Instant};
+
+use alera_core::child_process::windowless_command;
+use base64::engine::general_purpose::STANDARD;
+use base64::Engine as _;
+use serde_json::{json, Value};
+
+const PROTOCOL_VERSION: i64 = 4;
+const PROFILE_CAPABILITY: &str = "orchestrationAgentProfilesV1";
+const PROFILE_ORDERING_CAPABILITY: &str = "agentProfileOrderingV1";
+const V049_COMMIT: &str = "e60c96ec7522052e9af81ab15ae5d6da2443dac4";
+
+struct HostGuard {
+    child: Child,
+    _runtime: tempfile::TempDir,
+}
+
+impl Drop for HostGuard {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+fn send(writer: &mut TcpStream, message: Value) {
+    let mut line = serde_json::to_vec(&message).unwrap();
+    line.push(b'\n');
+    writer.write_all(&line).unwrap();
+    writer.flush().unwrap();
+}
+
+fn read_message(reader: &mut BufReader<TcpStream>) -> Value {
+    let mut line = String::new();
+    let read = reader
+        .read_line(&mut line)
+        .expect("timed out or failed reading from compatibility host");
+    assert!(read > 0, "compatibility host closed the connection");
+    serde_json::from_str(line.trim_end()).expect("compatibility host sent invalid JSON")
+}
+
+fn read_response(reader: &mut BufReader<TcpStream>, id: i64) -> Value {
+    loop {
+        let message = read_message(reader);
+        if message.get("id") == Some(&json!(id)) {
+            return message;
+        }
+    }
+}
+
+fn spawn_host(
+    binary: &str,
+    expected_version: Option<&str>,
+) -> (HostGuard, TcpStream, BufReader<TcpStream>) {
+    let runtime = tempfile::tempdir().unwrap();
+    let control_path = runtime.path().join("runtime-host.json");
+    let home_path = runtime.path().join("home");
+    std::fs::create_dir_all(&home_path).unwrap();
+    let token = "cross-version-conformance-token";
+    let child = windowless_command(binary)
+        .args([
+            "terminal-host",
+            "--runtime-dir",
+            runtime.path().to_str().unwrap(),
+            "--control-file",
+            control_path.to_str().unwrap(),
+            "--token",
+            token,
+            "--empty-shutdown-delay-seconds",
+            "60",
+            "--detached-session-shutdown-delay-seconds",
+            "60",
+        ])
+        .env("HOME", &home_path)
+        .env("SHELL", "/bin/sh")
+        .spawn()
+        .expect("failed to spawn compatibility host");
+    let guard = HostGuard {
+        child,
+        _runtime: runtime,
+    };
+    let deadline = Instant::now() + Duration::from_secs(15);
+    let port = loop {
+        if let Ok(contents) = std::fs::read_to_string(&control_path) {
+            let control: Value = serde_json::from_str(&contents).unwrap();
+            assert_eq!(control["protocolVersion"], json!(PROTOCOL_VERSION));
+            break control["port"].as_u64().unwrap() as u16;
+        }
+        assert!(Instant::now() < deadline, "control file was never written");
+        std::thread::sleep(Duration::from_millis(50));
+    };
+    let stream = TcpStream::connect(("127.0.0.1", port)).unwrap();
+    stream
+        .set_read_timeout(Some(Duration::from_secs(10)))
+        .unwrap();
+    let mut writer = stream.try_clone().unwrap();
+    let mut reader = BufReader::new(stream);
+    send(
+        &mut writer,
+        json!({"id": 0, "type": "hello", "payload": {
+            "protocolVersion": PROTOCOL_VERSION, "token": token
+        }}),
+    );
+    let hello = read_response(&mut reader, 0);
+    assert_eq!(hello["ok"], json!(true), "handshake rejected: {hello}");
+
+    if let Some(version) = expected_version {
+        send(
+            &mut writer,
+            json!({"id": 1, "type": "status.get", "payload": {}}),
+        );
+        let status = read_response(&mut reader, 1);
+        assert_eq!(status["ok"], json!(true), "status failed: {status}");
+        assert_eq!(status["payload"]["runtimeHostVersion"], json!(version));
+        assert_eq!(status["payload"]["runtimeHostCommit"], json!(V049_COMMIT));
+    }
+    (guard, writer, reader)
+}
+
+fn assert_v049_baseline(binary: &str, expected_version: Option<&str>) -> Vec<Value> {
+    let (_guard, mut writer, mut reader) = spawn_host(binary, expected_version);
+    send(
+        &mut writer,
+        json!({"id": 2, "type": "status.get", "payload": {}}),
+    );
+    let status = read_response(&mut reader, 2);
+    assert_eq!(status["ok"], json!(true), "status failed: {status}");
+    assert_eq!(
+        status["payload"]["protocolVersion"],
+        json!(PROTOCOL_VERSION)
+    );
+    let capabilities = status["payload"]["runtimeCapabilities"]
+        .as_array()
+        .expect("status capabilities");
+    assert!(capabilities.contains(&json!(PROFILE_CAPABILITY)));
+
+    send(
+        &mut writer,
+        json!({"id": 3, "type": "agentProfile.upsert", "payload": {
+            "name": "Cross Version Profile",
+            "agentType": "codex",
+            "command": "codex"
+        }}),
+    );
+    let upsert = read_response(&mut reader, 3);
+    assert_eq!(upsert["ok"], json!(true), "profile upsert failed: {upsert}");
+    send(
+        &mut writer,
+        json!({"id": 4, "type": "agentProfile.list", "payload": {}}),
+    );
+    let catalog = read_response(&mut reader, 4);
+    assert_eq!(catalog["ok"], json!(true), "profile list failed: {catalog}");
+    assert!(catalog["payload"]["items"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|profile| profile["name"] == json!("Cross Version Profile")));
+
+    send(
+        &mut writer,
+        json!({"id": 5, "type": "createOrAttach", "payload": {
+            "sessionId": "compat-session",
+            "workspaceId": "compat-workspace",
+            "tabId": "compat-tab",
+            "workingDirectory": "/tmp",
+            "launch": {
+                "shell": "/bin/sh",
+                "arguments": ["-c", "sleep 0.2; printf compat-terminal-ok; sleep 1"],
+                "environment": {"PATH": "/usr/bin:/bin", "TERM": "xterm"}
+            },
+            "cols": 80,
+            "rows": 24
+        }}),
+    );
+    let created = read_response(&mut reader, 5);
+    assert_eq!(
+        created["ok"],
+        json!(true),
+        "terminal launch failed: {created}"
+    );
+    let mut output = Vec::new();
+    while !String::from_utf8_lossy(&output).contains("compat-terminal-ok") {
+        let message = read_message(&mut reader);
+        if message.get("event").and_then(Value::as_str) == Some("output") {
+            let encoded = message["payload"]["dataBase64"].as_str().unwrap();
+            output.extend_from_slice(&STANDARD.decode(encoded).unwrap());
+        }
+    }
+    capabilities.clone()
+}
+
+#[test]
+fn current_host_accepts_v049_baseline_contract() {
+    assert_v049_baseline(env!("CARGO_BIN_EXE_alera"), None);
+}
+
+#[test]
+#[ignore = "run through tool/ci/host_compatibility.sh with the pinned v0.49.0 host"]
+fn v049_host_accepts_current_baseline_client() {
+    let binary = std::env::var("ALERA_PREVIOUS_HOST_BINARY")
+        .expect("ALERA_PREVIOUS_HOST_BINARY must name the pinned host");
+    let version = std::env::var("ALERA_PREVIOUS_HOST_VERSION")
+        .expect("ALERA_PREVIOUS_HOST_VERSION must identify the pinned host");
+    let capabilities = assert_v049_baseline(&binary, Some(&version));
+    assert!(!capabilities.contains(&json!(PROFILE_ORDERING_CAPABILITY)));
+
+    let (_guard, mut writer, mut reader) = spawn_host(&binary, Some(&version));
+    send(
+        &mut writer,
+        json!({"id": 6, "type": "agentProfile.reorder", "payload": {"ids": []}}),
+    );
+    let response = read_response(&mut reader, 6);
+    assert_eq!(response["ok"], json!(false));
+    assert!(
+        response["error"].as_str().is_some_and(
+            |error| error.contains("Unknown terminal host request: agentProfile.reorder")
+        ),
+        "new feature returned an opaque error: {response}"
+    );
+}

--- a/tool/ci/host_compatibility.sh
+++ b/tool/ci/host_compatibility.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# v0.49.0 is the latest stable release before agentProfileOrderingV1. It still
+# speaks protocol 4 and supports the profile catalog and terminal launch flow.
+readonly previous_tag="v0.49.0"
+readonly previous_version="0.49.0"
+readonly previous_commit="e60c96ec7522052e9af81ab15ae5d6da2443dac4"
+readonly root="$(git rev-parse --show-toplevel)"
+readonly stage="$(mktemp -d)"
+trap 'rm -rf "$stage"' EXIT
+
+# Fetch only the tagged history tip into a disposable repository. This neither
+# deepens the checkout nor updates a contributor's local tag.
+readonly origin="$(git remote get-url origin)"
+readonly release_repo="$stage/release-repo"
+git init --quiet "$release_repo"
+git -C "$release_repo" fetch --quiet --depth=1 --no-tags \
+  "$origin" "refs/tags/$previous_tag"
+resolved_commit="$(git -C "$release_repo" rev-parse 'FETCH_HEAD^{commit}')"
+if [[ "$resolved_commit" != "$previous_commit" ]]; then
+  echo "$previous_tag resolved to $resolved_commit, expected $previous_commit" >&2
+  exit 1
+fi
+
+mkdir -p "$stage/source" "$stage/bin"
+git -C "$release_repo" archive "$resolved_commit" | tar -x -C "$stage/source"
+
+(
+  cd "$stage/source/rust"
+  ALERA_BUILD_VERSION="$previous_version" \
+  ALERA_BUILD_COMMIT="$previous_commit" \
+  CARGO_TARGET_DIR="$stage/target" \
+    cargo build --locked -p alera-cli
+)
+cp "$stage/target/debug/alera" "$stage/bin/alera"
+
+(
+  cd "$root/rust"
+  ALERA_PREVIOUS_HOST_BINARY="$stage/bin/alera" \
+  ALERA_PREVIOUS_HOST_VERSION="$previous_version" \
+    cargo test \
+      --locked \
+      -p alera-cli \
+      --test host_version_compatibility \
+      v049_host_accepts_current_baseline_client \
+      -- --exact --ignored
+)


### PR DESCRIPTION
## Summary
- add bidirectional compatibility coverage for the v0.49.0 runtime host contract
- build the pinned historical source at e60c96ec7522052e9af81ab15ae5d6da2443dac4 in an isolated temporary target
- run historical conformance on the existing Rust test CI leg and document local usage

## Validation
- `cargo fmt --manifest-path rust/Cargo.toml --check`
- `bash -n tool/ci/host_compatibility.sh`
- `git diff --check origin/main...HEAD`
- historical v0.49.0 host build completed locally; current-host build was blocked only by missing local `glslc`, which CI setup provides
- the recovered source previously passed the complete harness against v0.49.0
