### PR TITLE
fix: remove release cache poisoning path

### DIFF
--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -834,12 +834,8 @@ jobs:
           ref: ${{ needs.plan.outputs.target_sha }}
           submodules: false
 
-      - name: Setup Flutter workspace
-        uses: ./.github/actions/setup-flutter-workspace
-        with:
-          linux-toolchain: 'false'
-          native-assets: 'false'
-          preflight: 'false'
+      - name: Setup Dart
+        uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
 
       - name: Download runtime inputs
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c

--- a/test/unit/release_workflow_config_test.dart
+++ b/test/unit/release_workflow_config_test.dart
@@ -184,6 +184,8 @@ void main() {
 
       expect(packageJob, contains('- build_desktop_app'));
       expect(packageJob, contains('- build_runtime_cross'));
+      expect(packageJob, contains('uses: dart-lang/setup-dart@'));
+      expect(packageJob, isNot(contains('setup-flutter-workspace')));
       expect(packageJob, contains('Expected 6 runtime input archives'));
       expect(packageJob, contains('package_runtime_sidecars.dart'));
       expect(packageJob, contains('name: release-runtime'));


### PR DESCRIPTION
## Summary

- replace the cached Flutter workspace setup in `package_runtime` with the pinned Dart setup
- prevent the privileged release job from executing the cache-enabled local composite after checking out the planned release SHA
- add a regression assertion that keeps the composite out of the packaging job

## Validation

- `git diff --check`
- `gh act pull_request -W .github/workflows/pr.yml -j static`
- Docker runner container and image removed after the local Actions run

## Notes

- direct host `flutter test test/unit/release_workflow_config_test.dart` could not start because the host has Dart 3.11.5 while the repository requires 3.12.0; the hosted PR test matrix uses the pinned Flutter 3.44.8 toolchain