### PR TITLE
refactor: simplify codex snapshot delta application

### DIFF
--- a/lib/src/features/codex_chat/domain/codex_chat_models.dart
+++ b/lib/src/features/codex_chat/domain/codex_chat_models.dart
@@ -9,6 +9,7 @@ part 'codex_chat_models_helpers.dart';
 part 'codex_thread_models.dart';
 part 'codex_thread_goal.dart';
 part 'codex_chat_snapshot_models.dart';
+part 'codex_chat_snapshot_delta.dart';
 part 'codex_timeline_event.dart';
 
 @immutable

--- a/lib/src/features/codex_chat/domain/codex_chat_snapshot_delta.dart
+++ b/lib/src/features/codex_chat/domain/codex_chat_snapshot_delta.dart
@@ -1,0 +1,187 @@
+part of 'codex_chat_models.dart';
+
+final class _CodexTimelineDelta {
+  const _CodexTimelineDelta({required this.removedIds, required this.upserts});
+
+  factory _CodexTimelineDelta.fromJson(Map<String, Object?> json) {
+    final removedIds = <String>{};
+    final rawRemovedIds = json['timelineRemovedIds'];
+    if (rawRemovedIds is List) {
+      for (final id in rawRemovedIds) {
+        final value = id?.toString();
+        if (value != null && value.isNotEmpty) removedIds.add(value);
+      }
+    }
+    final upserts = <String, CodexTimelineCell>{};
+    final rawUpserts = json['timelineUpserts'];
+    if (rawUpserts is List) {
+      for (final item in rawUpserts) {
+        if (item is! Map) continue;
+        final cell = CodexTimelineCell.fromJson(_map(item));
+        upserts[cell.id] = cell;
+      }
+    }
+    return _CodexTimelineDelta(removedIds: removedIds, upserts: upserts);
+  }
+
+  final Set<String> removedIds;
+  final Map<String, CodexTimelineCell> upserts;
+
+  _CodexTimelineUpdate apply(List<CodexTimelineCell> current) {
+    if (removedIds.isEmpty && upserts.isEmpty) {
+      return _CodexTimelineUpdate.unchanged(current);
+    }
+    final timeline = _MutableCodexTimeline(current);
+    final updatesPromptHistory = _affects(
+      timeline.cellFor,
+      (cell) => cell?.kind == CodexTimelineKind.userMessage,
+    );
+    final updatesMcpState = _affects(timeline.cellFor, _codexIsMcpStartup);
+    timeline.removeAll(removedIds);
+    timeline.upsertAll(upserts, removedIds: removedIds);
+    return _CodexTimelineUpdate(
+      cells: timeline.build(),
+      updatesPromptHistory: updatesPromptHistory,
+      updatesMcpState: updatesMcpState,
+    );
+  }
+
+  bool _affects(
+    CodexTimelineCell? Function(String id) currentCell,
+    bool Function(CodexTimelineCell? cell) matches,
+  ) {
+    if (removedIds.any((id) => matches(currentCell(id)))) return true;
+    return upserts.entries.any(
+      (entry) => matches(currentCell(entry.key)) || matches(entry.value),
+    );
+  }
+}
+
+final class _CodexTimelineUpdate {
+  const _CodexTimelineUpdate({
+    required this.cells,
+    required this.updatesPromptHistory,
+    required this.updatesMcpState,
+  });
+
+  const _CodexTimelineUpdate.unchanged(this.cells)
+    : updatesPromptHistory = false,
+      updatesMcpState = false;
+
+  final List<CodexTimelineCell> cells;
+  final bool updatesPromptHistory;
+  final bool updatesMcpState;
+}
+
+final class _MutableCodexTimeline {
+  _MutableCodexTimeline(List<CodexTimelineCell> cells)
+    : _segmented = cells is CodexTimelineCells ? cells : null,
+      _history = cells is CodexTimelineCells
+          ? cells.history
+          : const <CodexTimelineCell>[],
+      _live = List<CodexTimelineCell>.of(
+        cells is CodexTimelineCells ? cells.live : cells,
+      ) {
+    _indexCells();
+  }
+
+  final CodexTimelineCells? _segmented;
+  List<CodexTimelineCell> _history;
+  final List<CodexTimelineCell> _live;
+  late Map<String, int> _historyIndexes;
+  late Map<String, int> _liveIndexes;
+  var _historyChanged = false;
+
+  CodexTimelineCell? cellFor(String id) {
+    final liveIndex = _liveIndexes[id];
+    if (liveIndex != null) return _live[liveIndex];
+    final historyIndex = _historyIndexes[id];
+    return historyIndex == null ? null : _history[historyIndex];
+  }
+
+  void removeAll(Set<String> ids) {
+    if (ids.isEmpty) return;
+    if (ids.any(_historyIndexes.containsKey)) {
+      _history = <CodexTimelineCell>[
+        for (final cell in _history)
+          if (!ids.contains(cell.id)) cell,
+      ];
+      _historyChanged = true;
+    }
+    _live.removeWhere((cell) => ids.contains(cell.id));
+    _indexCells();
+  }
+
+  void upsertAll(
+    Map<String, CodexTimelineCell> upserts, {
+    required Set<String> removedIds,
+  }) {
+    for (final entry in upserts.entries) {
+      final liveIndex = _liveIndexes[entry.key];
+      if (liveIndex != null) {
+        _live[liveIndex] = entry.value;
+        continue;
+      }
+      final historyIndex = _historyIndexes[entry.key];
+      if (historyIndex != null && !removedIds.contains(entry.key)) {
+        if (!_historyChanged) {
+          _history = List<CodexTimelineCell>.of(_history);
+          _historyChanged = true;
+        }
+        _history[historyIndex] = entry.value;
+        continue;
+      }
+      _liveIndexes[entry.key] = _live.length;
+      _live.add(entry.value);
+    }
+  }
+
+  List<CodexTimelineCell> build() {
+    if (_history.isEmpty) {
+      return List<CodexTimelineCell>.unmodifiable(_live);
+    }
+    if (_historyChanged || _segmented == null) {
+      return CodexTimelineCells.segmented(history: _history, live: _live);
+    }
+    return _segmented.withLive(_live);
+  }
+
+  void _indexCells() {
+    _historyIndexes = <String, int>{
+      for (var index = 0; index < _history.length; index++)
+        _history[index].id: index,
+    };
+    _liveIndexes = <String, int>{
+      for (var index = 0; index < _live.length; index++) _live[index].id: index,
+    };
+  }
+}
+
+List<CodexTimelineEvent> _applyCodexEventDelta(
+  List<CodexTimelineEvent> current,
+  Map<String, Object?> json,
+) {
+  final replacement = json['eventsReplace'] is List
+      ? _codexTimelineEvents(json['eventsReplace'])
+      : null;
+  final appended = _codexTimelineEvents(json['eventsAppend']);
+  final eventLimit = _int(json['eventLimit']) ?? 160;
+  final combined =
+      replacement ??
+      (appended.isEmpty
+          ? current
+          : <CodexTimelineEvent>[...current, ...appended]);
+  return combined.length <= eventLimit
+      ? combined
+      : combined.sublist(combined.length - eventLimit);
+}
+
+T _codexDeltaValue<T>(
+  Map<String, Object?> json,
+  String key,
+  T current,
+  T Function(Object? value) parse,
+) => json.containsKey(key) ? parse(json[key]) : current;
+
+CodexThreadGoal? _codexThreadGoal(Object? value) =>
+    value is Map ? CodexThreadGoal.fromJson(value) : null;

--- a/lib/src/features/codex_chat/domain/codex_chat_snapshot_models.dart
+++ b/lib/src/features/codex_chat/domain/codex_chat_snapshot_models.dart
@@ -138,13 +138,7 @@ class CodexChatSnapshot {
 
   factory CodexChatSnapshot.fromJson(Object? value) {
     final json = _map(value);
-    final events = <CodexTimelineEvent>[
-      for (final item
-          in json['events'] is List
-              ? json['events'] as List
-              : const <Object?>[])
-        CodexTimelineEvent.fromJson(item),
-    ];
+    final events = _codexTimelineEvents(json['events']);
     var cells = <CodexTimelineCell>[
       for (final item
           in json['timelineCells'] is List
@@ -162,13 +156,7 @@ class CodexChatSnapshot {
       timelineCells: cells,
       promptHistory: _codexPromptHistory(cells),
       mcpInitializing: _codexHasInitializingMcp(cells),
-      pendingRequests: <CodexPendingRequest>[
-        for (final item
-            in json['pendingRequests'] is List
-                ? json['pendingRequests'] as List
-                : const <Object?>[])
-          CodexPendingRequest.fromJson(item),
-      ],
+      pendingRequests: _codexPendingRequests(json['pendingRequests']),
       activeTurnId: _string(json['activeTurnId']),
       contextUsed: _int(json['contextUsed']),
       contextLimit: _int(json['contextLimit']),
@@ -180,161 +168,32 @@ class CodexChatSnapshot {
   CodexChatSnapshot applyDelta(Object? value) {
     final json = _map(value);
     if (json.isEmpty) return this;
-    final removedIds = <String>{
-      for (final id
-          in json['timelineRemovedIds'] is List
-              ? json['timelineRemovedIds'] as List
-              : const <Object?>[])
-        if (id?.toString() case final String value when value.isNotEmpty) value,
-    };
-    final upserts = <String, CodexTimelineCell>{};
-    for (final item
-        in json['timelineUpserts'] is List
-            ? json['timelineUpserts'] as List
-            : const <Object?>[]) {
-      if (item is! Map) continue;
-      final cell = CodexTimelineCell.fromJson(_map(item));
-      upserts[cell.id] = cell;
-    }
-    final segmented = timelineCells is CodexTimelineCells
-        ? timelineCells as CodexTimelineCells
-        : null;
-    var historyCells = segmented?.history ?? const <CodexTimelineCell>[];
-    var liveCells = List<CodexTimelineCell>.of(
-      segmented?.live ?? timelineCells,
-      growable: true,
-    );
-    var liveIndexes = <String, int>{
-      for (var index = 0; index < liveCells.length; index++)
-        liveCells[index].id: index,
-    };
-    var historyIndexes = segmented?.historyIndexes ?? const <String, int>{};
-    CodexTimelineCell? currentCell(String id) {
-      final liveIndex = liveIndexes[id];
-      if (liveIndex != null) return liveCells[liveIndex];
-      final historyIndex = historyIndexes[id];
-      return historyIndex == null ? null : historyCells[historyIndex];
-    }
-
-    final historyChanged =
-        removedIds.any(
-          (id) => currentCell(id)?.kind == CodexTimelineKind.userMessage,
-        ) ||
-        upserts.entries.any(
-          (entry) =>
-              currentCell(entry.key)?.kind == CodexTimelineKind.userMessage ||
-              entry.value.kind == CodexTimelineKind.userMessage,
-        );
-    final mcpChanged =
-        removedIds.any((id) => _codexIsMcpStartup(currentCell(id))) ||
-        upserts.entries.any(
-          (entry) =>
-              _codexIsMcpStartup(currentCell(entry.key)) ||
-              _codexIsMcpStartup(entry.value),
-        );
-    final cellsChanged = removedIds.isNotEmpty || upserts.isNotEmpty;
-    var historySegmentChanged = false;
-    if (removedIds.isNotEmpty) {
-      final removesHistory =
-          segmented != null &&
-          removedIds.any((id) => segmented.historyIndexFor(id) != null);
-      if (removesHistory) {
-        historyCells = <CodexTimelineCell>[
-          for (final cell in historyCells)
-            if (!removedIds.contains(cell.id)) cell,
-        ];
-        historyIndexes = <String, int>{
-          for (var index = 0; index < historyCells.length; index++)
-            historyCells[index].id: index,
-        };
-        historySegmentChanged = true;
-      }
-      liveCells.removeWhere((cell) => removedIds.contains(cell.id));
-      liveIndexes = <String, int>{
-        for (var index = 0; index < liveCells.length; index++)
-          liveCells[index].id: index,
-      };
-    }
-    for (final entry in upserts.entries) {
-      final liveIndex = liveIndexes[entry.key];
-      if (liveIndex != null) {
-        liveCells[liveIndex] = entry.value;
-        continue;
-      }
-      final historyIndex = historyIndexes[entry.key];
-      if (historyIndex != null && !removedIds.contains(entry.key)) {
-        if (!historySegmentChanged) {
-          historyCells = List<CodexTimelineCell>.of(historyCells);
-          historySegmentChanged = true;
-        }
-        historyCells[historyIndex] = entry.value;
-        continue;
-      }
-      liveIndexes[entry.key] = liveCells.length;
-      liveCells.add(entry.value);
-    }
-    final nextCells = !cellsChanged
-        ? timelineCells
-        : historyCells.isEmpty
-        ? List<CodexTimelineCell>.unmodifiable(liveCells)
-        : historySegmentChanged || segmented == null
-        ? CodexTimelineCells.segmented(history: historyCells, live: liveCells)
-        : segmented.withLive(liveCells);
-    final replacementEvents = json['eventsReplace'] is List
-        ? <CodexTimelineEvent>[
-            for (final item in json['eventsReplace'] as List)
-              CodexTimelineEvent.fromJson(item),
-          ]
-        : null;
-    final appendedEvents = <CodexTimelineEvent>[
-      for (final item
-          in json['eventsAppend'] is List
-              ? json['eventsAppend'] as List
-              : const <Object?>[])
-        CodexTimelineEvent.fromJson(item),
-    ];
-    final eventLimit = _int(json['eventLimit']) ?? 160;
-    final combinedEvents =
-        replacementEvents ??
-        (appendedEvents.isEmpty
-            ? events
-            : <CodexTimelineEvent>[...events, ...appendedEvents]);
-    final nextEvents = combinedEvents.length <= eventLimit
-        ? combinedEvents
-        : combinedEvents.sublist(combinedEvents.length - eventLimit);
+    final timeline = _CodexTimelineDelta.fromJson(json).apply(timelineCells);
     return CodexChatSnapshot(
-      events: nextEvents,
-      timelineCells: nextCells,
-      promptHistory: historyChanged
-          ? _codexPromptHistory(nextCells)
+      events: _applyCodexEventDelta(events, json),
+      timelineCells: timeline.cells,
+      promptHistory: timeline.updatesPromptHistory
+          ? _codexPromptHistory(timeline.cells)
           : promptHistory,
-      mcpInitializing: mcpChanged
-          ? _codexHasInitializingMcp(nextCells)
+      mcpInitializing: timeline.updatesMcpState
+          ? _codexHasInitializingMcp(timeline.cells)
           : mcpInitializing,
-      pendingRequests: json.containsKey('pendingRequests')
-          ? <CodexPendingRequest>[
-              for (final item
-                  in json['pendingRequests'] is List
-                      ? json['pendingRequests'] as List
-                      : const <Object?>[])
-                CodexPendingRequest.fromJson(item),
-            ]
-          : pendingRequests,
-      activeTurnId: json.containsKey('activeTurnId')
-          ? _string(json['activeTurnId'])
-          : activeTurnId,
-      contextUsed: json.containsKey('contextUsed')
-          ? _int(json['contextUsed'])
-          : contextUsed,
-      contextLimit: json.containsKey('contextLimit')
-          ? _int(json['contextLimit'])
-          : contextLimit,
-      title: json.containsKey('title') ? _string(json['title']) : title,
-      goal: json.containsKey('goal')
-          ? json['goal'] is Map
-                ? CodexThreadGoal.fromJson(json['goal'])
-                : null
-          : goal,
+      pendingRequests: _codexDeltaValue(
+        json,
+        'pendingRequests',
+        pendingRequests,
+        _codexPendingRequests,
+      ),
+      activeTurnId: _codexDeltaValue(
+        json,
+        'activeTurnId',
+        activeTurnId,
+        _string,
+      ),
+      contextUsed: _codexDeltaValue(json, 'contextUsed', contextUsed, _int),
+      contextLimit: _codexDeltaValue(json, 'contextLimit', contextLimit, _int),
+      title: _codexDeltaValue(json, 'title', title, _string),
+      goal: _codexDeltaValue(json, 'goal', goal, _codexThreadGoal),
     );
   }
 
@@ -424,6 +283,18 @@ class CodexChatSnapshot {
     if (goal != null) 'goal': goal!.toJson(),
   };
 }
+
+List<CodexTimelineEvent> _codexTimelineEvents(Object? value) =>
+    <CodexTimelineEvent>[
+      for (final item in value is List ? value : const <Object?>[])
+        CodexTimelineEvent.fromJson(item),
+    ];
+
+List<CodexPendingRequest> _codexPendingRequests(Object? value) =>
+    <CodexPendingRequest>[
+      for (final item in value is List ? value : const <Object?>[])
+        CodexPendingRequest.fromJson(item),
+    ];
 
 List<String> _codexPromptHistory(List<CodexTimelineCell> cells) =>
     List<String>.unmodifiable(<String>[

--- a/test/unit/codex_chat_snapshot_coverage_test_cases.dart
+++ b/test/unit/codex_chat_snapshot_coverage_test_cases.dart
@@ -69,6 +69,93 @@ void registerCodexSnapshotCoverageTests(DateTime now) {
     ]);
   });
 
+  test(
+    'snapshot deltas preserve absent fields and normalize explicit ones',
+    () {
+      final snapshot = CodexChatSnapshot.fromJson(<String, Object?>{
+        'events': <Object?>[
+          <String, Object?>{'method': 'existing'},
+        ],
+        'timelineCells': <Object?>[
+          <String, Object?>{
+            'id': 'user',
+            'kind': 'userMessage',
+            'markdownText': 'Keep this prompt',
+          },
+        ],
+        'pendingRequests': <Object?>[
+          <String, Object?>{'id': 1, 'method': 'request'},
+        ],
+        'activeTurnId': 'turn-1',
+        'contextUsed': 10,
+        'contextLimit': 20,
+        'title': 'Existing title',
+        'goal': <String, Object?>{
+          'threadId': 'thread-1',
+          'objective': 'Existing goal',
+          'status': 'active',
+          'tokensUsed': 3,
+          'timeUsedSeconds': 4,
+        },
+      });
+
+      expect(identical(snapshot.applyDelta(null), snapshot), isTrue);
+      expect(
+        identical(snapshot.applyDelta(const <String, Object?>{}), snapshot),
+        isTrue,
+      );
+
+      final partial = snapshot.applyDelta(<String, Object?>{
+        'timelineRemovedIds': <Object?>[null, ''],
+        'timelineUpserts': <Object?>['ignored'],
+        'eventsAppend': 'ignored',
+        'contextUsed': '42',
+      });
+      expect(identical(partial.timelineCells, snapshot.timelineCells), isTrue);
+      expect(identical(partial.events, snapshot.events), isTrue);
+      expect(identical(partial.promptHistory, snapshot.promptHistory), isTrue);
+      expect(
+        identical(partial.pendingRequests, snapshot.pendingRequests),
+        isTrue,
+      );
+      expect(identical(partial.goal, snapshot.goal), isTrue);
+      expect(partial.activeTurnId, 'turn-1');
+      expect(partial.contextUsed, 42);
+      expect(partial.contextLimit, 20);
+      expect(partial.title, 'Existing title');
+
+      final cleared = partial.applyDelta(<String, Object?>{
+        'pendingRequests': null,
+        'activeTurnId': null,
+        'contextUsed': 'invalid',
+        'contextLimit': null,
+        'title': 7,
+        'goal': 'invalid',
+      });
+      expect(cleared.pendingRequests, isEmpty);
+      expect(cleared.activeTurnId, isNull);
+      expect(cleared.contextUsed, isNull);
+      expect(cleared.contextLimit, isNull);
+      expect(cleared.title, isNull);
+      expect(cleared.goal, isNull);
+
+      final withPartialGoal = cleared.applyDelta(<String, Object?>{
+        'goal': <String, Object?>{'objective': 'Replacement goal'},
+      });
+      expect(withPartialGoal.goal?.objective, 'Replacement goal');
+      expect(withPartialGoal.goal?.threadId, isEmpty);
+
+      expect(
+        () => snapshot.applyDelta(<String, Object?>{
+          'timelineUpserts': <Object?>[
+            <String, Object?>{'kind': 'assistantMessage'},
+          ],
+        }),
+        throwsFormatException,
+      );
+    },
+  );
+
   test('snapshot deltas share expanded history while updating live cells', () {
     CodexTimelineCell cell(String id, String text) =>
         CodexTimelineCell.fromJson(<String, Object?>{
@@ -153,6 +240,12 @@ void registerCodexSnapshotCoverageTests(DateTime now) {
       ],
     });
     expect(ready.mcpInitializing, isFalse);
+
+    final removed = snapshot.applyDelta(<String, Object?>{
+      'timelineRemovedIds': <Object?>['mcp-startup-filesystem'],
+    });
+    expect(removed.timelineCells, isEmpty);
+    expect(removed.mcpInitializing, isFalse);
   });
 
   test('recognizes plan questions and separates recommended option labels', () {


### PR DESCRIPTION
## Summary
- split snapshot timeline delta parsing and copy-on-write mutation into a private domain part
- keep `applyDelta` focused on coordinating timeline, event, and nullable field updates
- characterize absent/null, malformed payload, goal, pending request, MCP, history, and copy semantics

## Validation
- `dart format --set-exit-if-changed lib/src/features/codex_chat/domain/codex_chat_models.dart lib/src/features/codex_chat/domain/codex_chat_snapshot_models.dart lib/src/features/codex_chat/domain/codex_chat_snapshot_delta.dart test/unit/codex_chat_snapshot_coverage_test_cases.dart`
- `flutter analyze lib/src/features/codex_chat/domain/codex_chat_models.dart lib/src/features/codex_chat/domain/codex_chat_snapshot_models.dart lib/src/features/codex_chat/domain/codex_chat_snapshot_delta.dart test/unit/codex_chat_models_coverage_test.dart test/unit/codex_chat_snapshot_coverage_test_cases.dart test/unit/codex_chat_domain_contract_test.dart`
- `flutter test test/unit/codex_chat_models_coverage_test.dart test/unit/codex_chat_domain_contract_test.dart` (25 passed)

## Risks
- behavior-preserving domain refactor; focused characterization covers the wire and copy-semantics branches touched
- full local analysis also reports six unrelated existing issues in files outside this change; required CI remains authoritative