### PR TITLE
refactor(mobile): simplify codex timeline reducer

### DIFF
--- a/mobile/lib/src/features/codex_chat/domain/mobile_codex_state.dart
+++ b/mobile/lib/src/features/codex_chat/domain/mobile_codex_state.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/foundation.dart';
 
 part 'mobile_codex_timeline.dart';
+part 'mobile_codex_timeline_event.dart';
 part 'mobile_codex_timeline_classification.dart';
 part 'mobile_codex_timeline_compaction.dart';
 part 'mobile_codex_timeline_content.dart';

--- a/mobile/lib/src/features/codex_chat/domain/mobile_codex_timeline.dart
+++ b/mobile/lib/src/features/codex_chat/domain/mobile_codex_timeline.dart
@@ -7,303 +7,335 @@ abstract final class MobileCodexTimelineReducer {
     List<MobileCodexTimelineCell> cells,
     Map<String, Object?> message,
   ) {
-    final rawMethod = message['method']?.toString() ?? '';
-    final method = switch (rawMethod) {
-      'codex/event/item_started' => 'item/started',
-      'codex/event/item_completed' => 'item/completed',
-      'codex/event/task_complete' => 'turn/completed',
-      _ => rawMethod,
+    final event = _MobileCodexTimelineEvent.fromMessage(message);
+    return _reduceTurnEvent(cells, event) ??
+        _reduceStreamEvent(cells, event) ??
+        _reduceItemEvent(cells, event) ??
+        _reduceNoticeEvent(cells, event) ??
+        cells;
+  }
+
+  static List<MobileCodexTimelineCell>? _reduceTurnEvent(
+    List<MobileCodexTimelineCell> cells,
+    _MobileCodexTimelineEvent event,
+  ) {
+    if (event.rawMethod == 'codex/event/task_complete') {
+      return _completeLegacyTask(cells, event);
+    }
+    return switch (event.method) {
+      'thread/compacted' => _reduceLegacyMobileContextCompaction(
+        cells,
+        event.turnId,
+      ),
+      'turn/started' || 'turn/created' => _startTurn(cells, event.turnId),
+      'turn/completed' ||
+      'turn/aborted' ||
+      'turn/interrupted' => _close(cells, event.turnId, 'completed'),
+      'turn/failed' => _close(cells, event.turnId, 'failed'),
+      'turn/diff/updated' => _replaceDiffSnapshot(cells, event),
+      _ => null,
     };
-    final params = _map(message['params']);
-    final legacy = _map(params['msg']);
-    final item = _map(params['item'] ?? legacy['item']);
-    final turnId = _first(<Object?>[
-      params['turnId'],
-      _map(params['turn'])['id'],
-      item['turnId'],
-      item['turn_id'],
-      legacy['turnId'],
-      legacy['turn_id'],
-      message['turnId'],
+  }
+
+  static List<MobileCodexTimelineCell> _completeLegacyTask(
+    List<MobileCodexTimelineCell> cells,
+    _MobileCodexTimelineEvent event,
+  ) {
+    final text = _first(<Object?>[
+      event.legacy['last_agent_message'],
+      event.legacy['lastAgentMessage'],
     ]);
-    final itemId = _first(<Object?>[
-      params['itemId'],
-      params['item_id'],
-      item['id'],
-      params['id'],
-    ]);
-    final lower = method.toLowerCase();
-    final type = (item['type'] ?? params['type'] ?? '')
-        .toString()
-        .toLowerCase();
-
-    if (method == 'thread/compacted') {
-      return _reduceLegacyMobileContextCompaction(cells, turnId);
-    }
-
-    if (rawMethod == 'codex/event/task_complete') {
-      final text = _first(<Object?>[
-        legacy['last_agent_message'],
-        legacy['lastAgentMessage'],
-      ]);
-      var next = cells;
-      if (text.isNotEmpty && turnId.isNotEmpty) {
-        next = _upsert(
-          next,
-          _cell(
-            id: 'assistant-$turnId',
-            turnId: turnId,
-            kind: 'assistantMessage',
-            status: 'completed',
-            title: 'Codex',
-            markdownText: text,
-          ),
-        );
-      }
-      return _close(next, turnId, 'completed');
-    }
-    if (method == 'turn/started' || method == 'turn/created') {
-      if (turnId.isEmpty) return cells;
-      return _upsert(
-        cells,
+    var next = cells;
+    if (text.isNotEmpty && event.turnId.isNotEmpty) {
+      next = _upsert(
+        next,
         _cell(
-          id: 'turn-$turnId',
-          turnId: turnId,
-          kind: 'turnSeparator',
-          status: 'info',
-          title: 'Turn started',
-        ),
-      );
-    }
-    if (method == 'turn/completed' ||
-        method == 'turn/failed' ||
-        method == 'turn/aborted' ||
-        method == 'turn/interrupted') {
-      return _close(
-        cells,
-        turnId,
-        method == 'turn/failed' ? 'failed' : 'completed',
-      );
-    }
-    if (method == 'turn/diff/updated') {
-      final delta = _first(<Object?>[
-        params['diff'],
-        params['delta'],
-        params['text'],
-      ]);
-      final hasSnapshot =
-          params.containsKey('diff') ||
-          params.containsKey('delta') ||
-          params.containsKey('text');
-      if (turnId.isEmpty || !hasSnapshot) return cells;
-      final id = 'diff-$turnId';
-      final existing = _find(cells, id);
-      if (existing?.metadata['lastDelta'] == delta) return cells;
-      return _upsert(
-        cells,
-        _cell(
-          id: id,
-          turnId: turnId,
-          kind: 'diff',
-          status: 'inProgress',
-          title: 'File changes',
-          detailsText: delta,
-          isStreaming: true,
-          metadata: <String, Object?>{
-            ...?existing?.metadata,
-            'lastDelta': delta,
-          },
-        ),
-      );
-    }
-
-    final source = _sourceFor(lower);
-    if (source != null) {
-      return _appendDelta(
-        cells,
-        turnId: turnId,
-        itemId: itemId,
-        item: item,
-        params: params,
-        legacy: legacy,
-        source: source,
-      );
-    }
-    if ((lower.contains('subagent') || lower.contains('collab')) &&
-        turnId.isNotEmpty) {
-      final delta = _first(<Object?>[
-        params['delta'],
-        params['text'],
-        params['summary'],
-        params['message'],
-        legacy['summary'],
-        legacy['message'],
-      ]);
-      final id = itemId.isEmpty ? 'subAgent-$turnId' : 'item-$itemId';
-      final existing = _find(cells, id);
-      if (existing?.metadata['lastDelta'] == delta) return cells;
-      return _upsert(
-        cells,
-        _cell(
-          id: id,
-          itemId: itemId.isEmpty ? null : itemId,
-          turnId: turnId,
-          kind: 'subAgent',
-          status: lower.contains('completed') || lower.contains('end')
-              ? 'completed'
-              : 'inProgress',
-          title: 'Sub-agent',
-          markdownText: delta.isEmpty
-              ? existing?.markdownText
-              : '${existing?.markdownText ?? ''}$delta',
-          isStreaming: !lower.contains('completed') && !lower.contains('end'),
-          metadata: <String, Object?>{
-            ...?existing?.metadata,
-            if (delta.isNotEmpty) 'lastDelta': delta,
-          },
-        ),
-      );
-    }
-    if (method == 'item/started' ||
-        method == 'item/completed' ||
-        method == 'item/updated') {
-      if (turnId.isEmpty) return cells;
-      final baseKind = _kindFor(type, lower);
-      final provisionalId = itemId.isEmpty
-          ? '$baseKind-$turnId'
-          : 'item-$itemId';
-      final existing = _find(cells, provisionalId);
-      final phase = _first(<Object?>[
-        item['phase'],
-        params['phase'],
-        existing?.metadata['streamPhase'],
-      ]);
-      final isAgent =
-          type.contains('agentmessage') || type.contains('assistant');
-      final kind = isAgent && phase == 'commentary' ? 'progressText' : baseKind;
-      final id = itemId.isEmpty ? '$kind-$turnId' : 'item-$itemId';
-      final current = _find(cells, id) ?? existing;
-      final statusRaw = _first(<Object?>[
-        item['status'],
-        params['status'],
-      ]).toLowerCase();
-      final status = statusRaw.contains('fail')
-          ? 'failed'
-          : statusRaw.contains('declin')
-          ? 'declined'
-          : method == 'item/completed'
-          ? 'completed'
-          : 'inProgress';
-      final details = _mobileCodexItemDetails(item);
-      return _upsert(
-        cells,
-        _cell(
-          id: id,
-          itemId: itemId.isEmpty ? null : itemId,
-          turnId: turnId,
-          kind: kind,
-          status: status,
-          title: type.contains('contextcompaction')
-              ? mobileCodexContextCompactionTitle(status)
-              : _titleFor(type, lower, item),
-          subtitle: _first(<Object?>[
-            item['command'],
-            item['name'],
-            item['path'],
-          ]),
-          markdownText: _first(<Object?>[
-            item['text'],
-            item['content'],
-            item['summary'],
-            item['message'],
-          ]),
-          detailsText: details.isEmpty ? null : details,
-          isStreaming: method != 'item/completed',
-          metadata: <String, Object?>{
-            ...?current?.metadata,
-            ..._mobileCodexItemMetadata(item),
-            if (isAgent && phase.isNotEmpty) 'streamPhase': phase,
-          },
-        ),
-      );
-    }
-    if (method == 'error' ||
-        method == 'stream/error' ||
-        method == 'stream_error') {
-      final text = _first(<Object?>[
-        params['message'],
-        params['error'],
-        message['error'],
-      ]);
-      if (text.isEmpty) return cells;
-      return <MobileCodexTimelineCell>[
-        ...cells,
-        _cell(
-          id: 'error-${DateTime.now().microsecondsSinceEpoch}',
-          turnId: turnId.isEmpty ? null : turnId,
-          kind: 'systemNotice',
-          status: 'failed',
-          title: 'Codex error',
+          id: 'assistant-${event.turnId}',
+          turnId: event.turnId,
+          kind: 'assistantMessage',
+          status: 'completed',
+          title: 'Codex',
           markdownText: text,
         ),
-      ];
-    }
-    if (lower.contains('review') && turnId.isNotEmpty) {
-      final review = _first(<Object?>[params['review'], params['text']]);
-      return _upsert(
-        cells,
-        _cell(
-          id: itemId.isEmpty ? 'review-$turnId' : 'item-$itemId',
-          itemId: itemId.isEmpty ? null : itemId,
-          turnId: turnId,
-          kind: 'toolCall',
-          status: 'completed',
-          title: lower.contains('enter')
-              ? 'Entered review mode'
-              : 'Exited review mode',
-          detailsText: review.isEmpty ? null : review,
-          metadata: <String, Object?>{
-            'itemType': lower.contains('enter')
-                ? 'enteredReviewMode'
-                : 'exitedReviewMode',
-          },
-        ),
       );
     }
-    return cells;
+    return _close(next, event.turnId, 'completed');
+  }
+
+  static List<MobileCodexTimelineCell> _startTurn(
+    List<MobileCodexTimelineCell> cells,
+    String turnId,
+  ) {
+    if (turnId.isEmpty) return cells;
+    return _upsert(
+      cells,
+      _cell(
+        id: 'turn-$turnId',
+        turnId: turnId,
+        kind: 'turnSeparator',
+        status: 'info',
+        title: 'Turn started',
+      ),
+    );
+  }
+
+  static List<MobileCodexTimelineCell> _replaceDiffSnapshot(
+    List<MobileCodexTimelineCell> cells,
+    _MobileCodexTimelineEvent event,
+  ) {
+    final delta = _first(<Object?>[
+      event.params['diff'],
+      event.params['delta'],
+      event.params['text'],
+    ]);
+    final hasSnapshot =
+        event.params.containsKey('diff') ||
+        event.params.containsKey('delta') ||
+        event.params.containsKey('text');
+    if (event.turnId.isEmpty || !hasSnapshot) return cells;
+    final id = 'diff-${event.turnId}';
+    final existing = _find(cells, id);
+    if (existing?.metadata['lastDelta'] == delta) return cells;
+    return _upsert(
+      cells,
+      _cell(
+        id: id,
+        turnId: event.turnId,
+        kind: 'diff',
+        status: 'inProgress',
+        title: 'File changes',
+        detailsText: delta,
+        isStreaming: true,
+        metadata: <String, Object?>{...?existing?.metadata, 'lastDelta': delta},
+      ),
+    );
+  }
+
+  static List<MobileCodexTimelineCell>? _reduceStreamEvent(
+    List<MobileCodexTimelineCell> cells,
+    _MobileCodexTimelineEvent event,
+  ) {
+    final source = _sourceFor(event.lowerMethod);
+    if (source != null) {
+      return _appendDelta(cells, event, source);
+    }
+    final isSubAgent =
+        event.lowerMethod.contains('subagent') ||
+        event.lowerMethod.contains('collab');
+    if (!isSubAgent || event.turnId.isEmpty) return null;
+    return _reduceSubAgentEvent(cells, event);
+  }
+
+  static List<MobileCodexTimelineCell> _reduceSubAgentEvent(
+    List<MobileCodexTimelineCell> cells,
+    _MobileCodexTimelineEvent event,
+  ) {
+    final delta = _first(<Object?>[
+      event.params['delta'],
+      event.params['text'],
+      event.params['summary'],
+      event.params['message'],
+      event.legacy['summary'],
+      event.legacy['message'],
+    ]);
+    final id = event.itemId.isEmpty
+        ? 'subAgent-${event.turnId}'
+        : 'item-${event.itemId}';
+    final existing = _find(cells, id);
+    if (existing?.metadata['lastDelta'] == delta) return cells;
+    final isCompleted =
+        event.lowerMethod.contains('completed') ||
+        event.lowerMethod.contains('end');
+    return _upsert(
+      cells,
+      _cell(
+        id: id,
+        itemId: event.itemId.isEmpty ? null : event.itemId,
+        turnId: event.turnId,
+        kind: 'subAgent',
+        status: isCompleted ? 'completed' : 'inProgress',
+        title: 'Sub-agent',
+        markdownText: delta.isEmpty
+            ? existing?.markdownText
+            : '${existing?.markdownText ?? ''}$delta',
+        isStreaming: !isCompleted,
+        metadata: <String, Object?>{
+          ...?existing?.metadata,
+          if (delta.isNotEmpty) 'lastDelta': delta,
+        },
+      ),
+    );
+  }
+
+  static List<MobileCodexTimelineCell>? _reduceItemEvent(
+    List<MobileCodexTimelineCell> cells,
+    _MobileCodexTimelineEvent event,
+  ) => switch (event.method) {
+    'item/started' ||
+    'item/completed' ||
+    'item/updated' => _upsertItem(cells, event),
+    _ => null,
+  };
+
+  static List<MobileCodexTimelineCell> _upsertItem(
+    List<MobileCodexTimelineCell> cells,
+    _MobileCodexTimelineEvent event,
+  ) {
+    if (event.turnId.isEmpty) return cells;
+    final baseKind = _kindFor(event.itemType, event.lowerMethod);
+    final provisionalId = event.itemId.isEmpty
+        ? '$baseKind-${event.turnId}'
+        : 'item-${event.itemId}';
+    final existing = _find(cells, provisionalId);
+    final phase = _first(<Object?>[
+      event.item['phase'],
+      event.params['phase'],
+      existing?.metadata['streamPhase'],
+    ]);
+    final isAgent =
+        event.itemType.contains('agentmessage') ||
+        event.itemType.contains('assistant');
+    final kind = isAgent && phase == 'commentary' ? 'progressText' : baseKind;
+    final id = event.itemId.isEmpty
+        ? '$kind-${event.turnId}'
+        : 'item-${event.itemId}';
+    final current = _find(cells, id) ?? existing;
+    final statusRaw = _first(<Object?>[
+      event.item['status'],
+      event.params['status'],
+    ]).toLowerCase();
+    final status = statusRaw.contains('fail')
+        ? 'failed'
+        : statusRaw.contains('declin')
+        ? 'declined'
+        : event.method == 'item/completed'
+        ? 'completed'
+        : 'inProgress';
+    final details = _mobileCodexItemDetails(event.item);
+    return _upsert(
+      cells,
+      _cell(
+        id: id,
+        itemId: event.itemId.isEmpty ? null : event.itemId,
+        turnId: event.turnId,
+        kind: kind,
+        status: status,
+        title: event.itemType.contains('contextcompaction')
+            ? mobileCodexContextCompactionTitle(status)
+            : _titleFor(event.itemType, event.lowerMethod, event.item),
+        subtitle: _first(<Object?>[
+          event.item['command'],
+          event.item['name'],
+          event.item['path'],
+        ]),
+        markdownText: _first(<Object?>[
+          event.item['text'],
+          event.item['content'],
+          event.item['summary'],
+          event.item['message'],
+        ]),
+        detailsText: details.isEmpty ? null : details,
+        isStreaming: event.method != 'item/completed',
+        metadata: <String, Object?>{
+          ...?current?.metadata,
+          ..._mobileCodexItemMetadata(event.item),
+          if (isAgent && phase.isNotEmpty) 'streamPhase': phase,
+        },
+      ),
+    );
+  }
+
+  static List<MobileCodexTimelineCell>? _reduceNoticeEvent(
+    List<MobileCodexTimelineCell> cells,
+    _MobileCodexTimelineEvent event,
+  ) => switch (event.method) {
+    'error' || 'stream/error' || 'stream_error' => _appendError(cells, event),
+    _ when event.lowerMethod.contains('review') && event.turnId.isNotEmpty =>
+      _upsertReview(cells, event),
+    _ => null,
+  };
+
+  static List<MobileCodexTimelineCell> _appendError(
+    List<MobileCodexTimelineCell> cells,
+    _MobileCodexTimelineEvent event,
+  ) {
+    final text = _first(<Object?>[
+      event.params['message'],
+      event.params['error'],
+      event.message['error'],
+    ]);
+    if (text.isEmpty) return cells;
+    return <MobileCodexTimelineCell>[
+      ...cells,
+      _cell(
+        id: 'error-${DateTime.now().microsecondsSinceEpoch}',
+        turnId: event.turnId.isEmpty ? null : event.turnId,
+        kind: 'systemNotice',
+        status: 'failed',
+        title: 'Codex error',
+        markdownText: text,
+      ),
+    ];
+  }
+
+  static List<MobileCodexTimelineCell> _upsertReview(
+    List<MobileCodexTimelineCell> cells,
+    _MobileCodexTimelineEvent event,
+  ) {
+    final review = _first(<Object?>[
+      event.params['review'],
+      event.params['text'],
+    ]);
+    final isEntering = event.lowerMethod.contains('enter');
+    return _upsert(
+      cells,
+      _cell(
+        id: event.itemId.isEmpty
+            ? 'review-${event.turnId}'
+            : 'item-${event.itemId}',
+        itemId: event.itemId.isEmpty ? null : event.itemId,
+        turnId: event.turnId,
+        kind: 'toolCall',
+        status: 'completed',
+        title: isEntering ? 'Entered review mode' : 'Exited review mode',
+        detailsText: review.isEmpty ? null : review,
+        metadata: <String, Object?>{
+          'itemType': isEntering ? 'enteredReviewMode' : 'exitedReviewMode',
+        },
+      ),
+    );
   }
 
   static List<MobileCodexTimelineCell> _appendDelta(
-    List<MobileCodexTimelineCell> cells, {
-    required String turnId,
-    required String itemId,
-    required Map<String, Object?> item,
-    required Map<String, Object?> params,
-    required Map<String, Object?> legacy,
-    required String source,
-  }) {
-    if (turnId.isEmpty) return cells;
+    List<MobileCodexTimelineCell> cells,
+    _MobileCodexTimelineEvent event,
+    String source,
+  ) {
+    if (event.turnId.isEmpty) return cells;
     final values = <Object?>[
-      params['delta'],
-      params['text'],
-      legacy['delta'],
-      legacy['text'],
+      event.params['delta'],
+      event.params['text'],
+      event.legacy['delta'],
+      event.legacy['text'],
     ];
     if (source == 'output') {
-      values.addAll(<Object?>[params['output'], params['interaction']]);
+      values.addAll(<Object?>[
+        event.params['output'],
+        event.params['interaction'],
+      ]);
     } else if (source == 'agent') {
-      values.add(legacy['message']);
+      values.add(event.legacy['message']);
     }
     final delta = _rawFirst(values);
     if (delta.isEmpty) return cells;
-    final itemType = item['type']?.toString().toLowerCase() ?? '';
-    final provisional = itemId.isEmpty
-        ? '${_kindFor(itemType, source)}-$turnId'
-        : 'item-$itemId';
+    final itemType = event.item['type']?.toString().toLowerCase() ?? '';
+    final provisional = event.itemId.isEmpty
+        ? '${_kindFor(itemType, source)}-${event.turnId}'
+        : 'item-${event.itemId}';
     final existing = _find(cells, provisional);
     final phase = _first(<Object?>[
-      item['phase'],
-      params['phase'],
+      event.item['phase'],
+      event.params['phase'],
       existing?.metadata['streamPhase'],
     ]);
     final kind = source == 'agent'
@@ -313,21 +345,23 @@ abstract final class MobileCodexTimelineReducer {
         : source == 'reasoning'
         ? 'reasoning'
         : _kindFor(itemType, source);
-    final id = itemId.isEmpty ? '$kind-$turnId' : 'item-$itemId';
+    final id = event.itemId.isEmpty
+        ? '$kind-${event.turnId}'
+        : 'item-${event.itemId}';
     final current = _find(cells, id);
     if (current?.metadata['lastDelta'] == delta) return cells;
     return _upsert(
       cells,
       _cell(
         id: id,
-        itemId: itemId.isEmpty ? null : itemId,
-        turnId: turnId,
+        itemId: event.itemId.isEmpty ? null : event.itemId,
+        turnId: event.turnId,
         kind: kind,
         status: 'inProgress',
         title: source == 'reasoning'
             ? 'Reasoning'
             : source == 'output'
-            ? _titleFor(itemType, source, item)
+            ? _titleFor(itemType, source, event.item)
             : 'Codex',
         markdownText: source == 'output'
             ? null

--- a/mobile/lib/src/features/codex_chat/domain/mobile_codex_timeline_event.dart
+++ b/mobile/lib/src/features/codex_chat/domain/mobile_codex_timeline_event.dart
@@ -1,0 +1,64 @@
+part of 'mobile_codex_state.dart';
+
+class _MobileCodexTimelineEvent {
+  const _MobileCodexTimelineEvent({
+    required this.message,
+    required this.rawMethod,
+    required this.method,
+    required this.params,
+    required this.legacy,
+    required this.item,
+    required this.turnId,
+    required this.itemId,
+    required this.itemType,
+  });
+
+  factory _MobileCodexTimelineEvent.fromMessage(Map<String, Object?> message) {
+    final rawMethod = message['method']?.toString() ?? '';
+    final method = switch (rawMethod) {
+      'codex/event/item_started' => 'item/started',
+      'codex/event/item_completed' => 'item/completed',
+      'codex/event/task_complete' => 'turn/completed',
+      _ => rawMethod,
+    };
+    final params = _map(message['params']);
+    final legacy = _map(params['msg']);
+    final item = _map(params['item'] ?? legacy['item']);
+    return _MobileCodexTimelineEvent(
+      message: message,
+      rawMethod: rawMethod,
+      method: method,
+      params: params,
+      legacy: legacy,
+      item: item,
+      turnId: _first(<Object?>[
+        params['turnId'],
+        _map(params['turn'])['id'],
+        item['turnId'],
+        item['turn_id'],
+        legacy['turnId'],
+        legacy['turn_id'],
+        message['turnId'],
+      ]),
+      itemId: _first(<Object?>[
+        params['itemId'],
+        params['item_id'],
+        item['id'],
+        params['id'],
+      ]),
+      itemType: (item['type'] ?? params['type'] ?? '').toString().toLowerCase(),
+    );
+  }
+
+  final Map<String, Object?> message;
+  final String rawMethod;
+  final String method;
+  final Map<String, Object?> params;
+  final Map<String, Object?> legacy;
+  final Map<String, Object?> item;
+  final String turnId;
+  final String itemId;
+  final String itemType;
+
+  String get lowerMethod => method.toLowerCase();
+}

--- a/mobile/test/mobile_codex_timeline_reducer_test.dart
+++ b/mobile/test/mobile_codex_timeline_reducer_test.dart
@@ -1,0 +1,106 @@
+import 'package:alera_mobile/src/features/codex_chat/domain/mobile_codex_state.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('legacy task completion updates in place and closes only its turn', () {
+    const original = <MobileCodexTimelineCell>[
+      MobileCodexTimelineCell(
+        id: 'progress-turn-legacy',
+        kind: 'progressText',
+        status: 'inProgress',
+        turnId: 'turn-legacy',
+        markdownText: 'Working',
+        isStreaming: true,
+      ),
+      MobileCodexTimelineCell(
+        id: 'assistant-turn-legacy',
+        kind: 'assistantMessage',
+        status: 'inProgress',
+        turnId: 'turn-legacy',
+        markdownText: 'Old answer',
+        isStreaming: true,
+        metadata: <String, Object?>{'source': 'legacy'},
+      ),
+      MobileCodexTimelineCell(
+        id: 'other-turn',
+        kind: 'reasoning',
+        status: 'inProgress',
+        turnId: 'turn-other',
+        isStreaming: true,
+      ),
+    ];
+
+    final cells = MobileCodexTimelineReducer.reduce(original, <String, Object?>{
+      'method': 'codex/event/task_complete',
+      'params': <String, Object?>{
+        'msg': <String, Object?>{
+          'turn_id': 'turn-legacy',
+          'last_agent_message': 'Final answer',
+        },
+      },
+    });
+
+    expect(cells.map((cell) => cell.id), <String>[
+      'progress-turn-legacy',
+      'assistant-turn-legacy',
+      'other-turn',
+    ]);
+    expect(cells[0].status, 'completed');
+    expect(cells[0].isStreaming, isFalse);
+    expect(cells[1].markdownText, 'Final answer');
+    expect(cells[1].status, 'completed');
+    expect(cells[1].isStreaming, isFalse);
+    expect(cells[1].metadata['source'], 'legacy');
+    expect(cells[2], same(original[2]));
+  });
+
+  test('legacy item aliases merge and malformed item payloads are ignored', () {
+    var cells = MobileCodexTimelineReducer.reduce(
+      const <MobileCodexTimelineCell>[],
+      <String, Object?>{
+        'method': 'codex/event/item_started',
+        'params': <String, Object?>{
+          'msg': <String, Object?>{
+            'turn_id': 'turn-legacy',
+            'item': <String, Object?>{
+              'id': 'command-1',
+              'type': 'commandExecution',
+              'command': 'pwd',
+            },
+          },
+        },
+      },
+    );
+    cells = MobileCodexTimelineReducer.reduce(cells, <String, Object?>{
+      'method': 'codex/event/item_completed',
+      'params': <String, Object?>{
+        'msg': <String, Object?>{
+          'turn_id': 'turn-legacy',
+          'item': <String, Object?>{
+            'id': 'command-1',
+            'type': 'commandExecution',
+            'command': 'pwd',
+            'aggregatedOutput': '/workspace',
+          },
+        },
+      },
+    });
+
+    expect(cells, hasLength(1));
+    expect(cells.single.id, 'item-command-1');
+    expect(cells.single.itemId, 'command-1');
+    expect(cells.single.kind, 'command');
+    expect(cells.single.status, 'completed');
+    expect(cells.single.detailsText, '/workspace');
+    expect(cells.single.isStreaming, isFalse);
+
+    final malformed = MobileCodexTimelineReducer.reduce(
+      cells,
+      <String, Object?>{
+        'method': 'item/completed',
+        'params': <Object?>['not', 'a', 'map'],
+      },
+    );
+    expect(malformed, same(cells));
+  });
+}


### PR DESCRIPTION
## Summary

- split the mobile Codex timeline reducer into turn, stream/sub-agent, item lifecycle, and notice event families
- isolate mobile-only legacy event normalization in its own timeline `part` without changing the public API or desktop code
- preserve cell ordering, IDs, merge/status behavior, and malformed legacy payload tolerance
- reduce `MobileCodexTimelineReducer.reduce` from 269 to 11 lines and Dart Code Metrics cyclomatic complexity from 73 to 5
- add a focused reducer test file for legacy task completion, item aliases, merge ordering, and malformed item payloads

## Screenshots

No visual change.

## Testing

- [x] `dart format --output=none --set-exit-if-changed` on all changed Dart files
- [x] focused `flutter analyze --no-pub` on the state/timeline sources and reducer/chat tests
- [x] `flutter test --no-pub test/mobile_codex_state_test.dart test/mobile_codex_timeline_reducer_test.dart test/mobile_codex_chat_test.dart` (21 passed)
- [x] full `flutter test --no-pub` exercised 552 tests: 550 passed; the phone/tablet Codex chat goldens fail by the same 228 pixels on clean `origin/main`
- [x] added tests that catch legacy ordering, merge, status, ID, and malformed-payload regressions

Full local `flutter analyze` also reports the same pre-existing 2 errors and 2 warnings on clean `origin/main`: Flutter preview API incompatibilities in `alera_preview.dart`, plus `unawaited_return_in_try_block` warnings in cloud sign-in and AI dictation model storage. The focused changed-file analysis is clean.

## AI Review Report

Reviewed event dispatch precedence and compared each extracted branch with the previous reducer. The review specifically checked legacy method aliases, turn/item ID precedence, provisional-cell promotion, delta deduplication, sub-agent completion, review/error ordering, diff snapshot replacement, streaming closure, metadata merges, and malformed map handling. No behavior change was identified; two concrete characterization gaps were added.

The initial static check identified both edited files crossing the 500-line ratchet. The normalization responsibility and reducer tests were split into focused files instead of accepting new baseline debt; the resulting files are 491, 64, 417, and 106 lines.

This is mobile domain-only code. It does not touch shortcuts, paths, shell behavior, terminal behavior, release behavior, updater behavior, or platform-specific behavior.

## Security Audit

No command execution, paths, authentication, secrets, dependencies, or external input boundaries changed. Existing tolerant parsing remains unchanged and is now isolated in the normalized mobile timeline event.

## Notes

Risk is limited to accidental dispatch-order drift in legacy reconstruction. The family order remains turn → stream/sub-agent → item lifecycle → notice, matching the previous implementation. No documentation update is needed for this behavior-preserving internal refactor.
