### PR TITLE
refactor: simplify codex timeline reducer

### DIFF
--- a/lib/src/features/codex_chat/domain/codex_timeline.dart
+++ b/lib/src/features/codex_chat/domain/codex_timeline.dart
@@ -3,6 +3,7 @@ import 'codex_timeline_cell.dart';
 export 'codex_timeline_cell.dart';
 
 part 'codex_timeline_helpers.dart';
+part 'codex_timeline_lifecycle.dart';
 part 'codex_timeline_modern.dart';
 
 /// The host and Flutter clients use this reducer as a compatibility oracle.
@@ -55,427 +56,381 @@ abstract final class CodexTimelineReducer {
     );
     if (modern != null) return modern;
 
-    if (rawMethod == 'codex/event/task_complete') {
-      final text = _firstString(<Object?>[
-        legacyMessage['last_agent_message'],
-        legacyMessage['lastAgentMessage'],
-      ]);
-      var next = cells;
-      if (text.isNotEmpty && turnId.isNotEmpty) {
-        final existing = _find(next, 'assistant-$turnId');
-        next = _upsert(
-          next,
-          _newCell(
-            id: 'assistant-$turnId',
-            turnId: turnId,
-            kind: CodexTimelineKind.assistantMessage,
-            status: CodexTimelineStatus.completed,
-            timestamp: timestamp,
-            title: 'Codex',
-            markdownText: text,
-            isStreaming: false,
-            metadata: existing?.metadata ?? const <String, Object?>{},
-          ),
-        );
-      }
-      final completed = <CodexTimelineCell>[
-        for (final cell in next)
-          if (cell.turnId == turnId && cell.isStreaming)
-            cell.copyWith(
-              status: CodexTimelineStatus.completed,
-              isStreaming: false,
-              updatedAt: timestamp,
-            )
-          else
-            cell,
-      ];
-      return _updateTurnSeparator(completed, turnId, params, timestamp);
-    }
-
-    if (method == 'turn/started' || method == 'turn/created') {
-      if (turnId.isEmpty) return cells;
-      final turn = _map(params['turn']);
-      return _upsert(
-        cells,
-        _newCell(
-          id: 'turn-$turnId',
-          turnId: turnId,
-          kind: CodexTimelineKind.turnSeparator,
-          status: CodexTimelineStatus.info,
-          timestamp: timestamp,
-          title: 'Turn started',
-          metadata: <String, Object?>{
-            'startedAt': turn['startedAt'],
-            'completedAt': turn['completedAt'],
-            'computedDurationMs': turn['durationMs'],
-          },
-        ),
-      );
-    }
-
-    if (method == 'turn/completed' ||
-        method == 'turn/failed' ||
-        method == 'turn/aborted' ||
-        method == 'turn/interrupted') {
-      final turnError = _map(params['turn'])['error'];
-      final failed =
-          method == 'turn/failed' ||
-          (turnError is String && turnError.trim().isNotEmpty) ||
-          (turnError is Map && turnError.isNotEmpty);
-      final completed = <CodexTimelineCell>[
-        for (final cell in cells)
-          if (turnId.isNotEmpty && cell.turnId == turnId && cell.isStreaming)
-            cell.copyWith(
-              status: failed
-                  ? CodexTimelineStatus.failed
-                  : CodexTimelineStatus.completed,
-              isStreaming: false,
-              updatedAt: timestamp,
-            )
-          else
-            cell,
-      ];
-      return _updateTurnSeparator(completed, turnId, params, timestamp);
-    }
-
-    if (method == 'turn/diff/updated') {
-      final diff = _firstString(<Object?>[
-        params['diff'],
-        params['delta'],
-        params['text'],
-      ]);
-      final hasSnapshot =
-          params.containsKey('diff') ||
-          params.containsKey('delta') ||
-          params.containsKey('text');
-      if (turnId.isEmpty || !hasSnapshot) return cells;
-      final id = 'diff-$turnId';
-      final existing = _find(cells, id);
-      if (existing?.metadata['lastDelta'] == diff) return cells;
-      return _upsert(
-        cells,
-        _newCell(
-          id: id,
-          turnId: turnId,
-          kind: CodexTimelineKind.diff,
-          status: CodexTimelineStatus.inProgress,
-          timestamp: timestamp,
-          title: 'File changes',
-          detailsText: diff,
-          isStreaming: true,
-          metadata: <String, Object?>{
-            ...?existing?.metadata,
-            'lastDelta': diff,
-          },
-        ),
-      );
-    }
-
-    if (method == 'item/agentMessage/delta' ||
-        lowerMethod.contains('agentmessage') && lowerMethod.contains('delta')) {
-      final delta = _firstString(<Object?>[
-        params['delta'],
-        params['text'],
-        legacyMessage['delta'],
-        legacyMessage['text'],
-        legacyMessage['message'],
-      ]);
-      if (delta.isEmpty || turnId.isEmpty) return cells;
-      final id = itemId.isEmpty ? 'assistant-$turnId' : 'item-$itemId';
-      final existing = _find(cells, id);
-      final phase = _firstString(<Object?>[
-        item['phase'],
-        params['phase'],
-        existing?.metadata['streamPhase'],
-      ]);
-      final finalAnswer =
-          phase.isEmpty || phase == 'final_answer' || phase == 'final';
-      final current = existing?.markdownText ?? '';
-      final existingKind = existing?.kind;
-      final metadata = <String, Object?>{
-        ...?existing?.metadata,
-        'streamPhase': finalAnswer ? 'final_answer' : 'commentary',
-        'lastDelta': delta,
-      };
-      if (existing != null && existing.metadata['lastDelta'] == delta) {
-        return cells;
-      }
-      return _upsert(
-        cells,
-        _newCell(
-          id: id,
-          itemId: itemId.isEmpty ? null : itemId,
-          turnId: turnId,
-          kind:
-              finalAnswer || existingKind == CodexTimelineKind.assistantMessage
-              ? CodexTimelineKind.assistantMessage
-              : CodexTimelineKind.progressText,
-          status: CodexTimelineStatus.inProgress,
-          timestamp: timestamp,
-          markdownText: '$current$delta',
-          isStreaming: true,
-          metadata: metadata,
-        ),
-      );
-    }
-
-    if (method == 'item/reasoning/summaryTextDelta' ||
-        method == 'item/reasoning/textDelta' ||
-        lowerMethod.contains('reasoning') && lowerMethod.contains('delta')) {
-      final delta = _firstString(<Object?>[
-        params['delta'],
-        params['text'],
-        legacyMessage['delta'],
-        legacyMessage['text'],
-      ]);
-      if (delta.isEmpty || turnId.isEmpty) return cells;
-      final id = itemId.isEmpty ? 'reasoning-$turnId' : 'item-$itemId';
-      final existing = _find(cells, id);
-      if (existing != null && existing.metadata['lastDelta'] == delta) {
-        return cells;
-      }
-      return _upsert(
-        cells,
-        _newCell(
-          id: id,
-          itemId: itemId.isEmpty ? null : itemId,
-          turnId: turnId,
-          kind: CodexTimelineKind.reasoning,
-          status: CodexTimelineStatus.inProgress,
-          timestamp: timestamp,
-          title: 'Reasoning',
-          markdownText: '${existing?.markdownText ?? ''}$delta',
-          isStreaming: true,
-          metadata: <String, Object?>{
-            ...?existing?.metadata,
-            'lastDelta': delta,
-          },
-        ),
-      );
-    }
-
-    if (method == 'item/commandExecution/outputDelta' ||
-        method == 'item/fileChange/outputDelta' ||
-        method == 'item/mcpToolCall/outputDelta' ||
-        method == 'item/webSearch/outputDelta' ||
-        method == 'item/plan/delta' ||
-        method == 'item/commandExecution/terminalInteraction' ||
-        method == 'item/mcpToolCall/progress' ||
-        lowerMethod.contains('outputdelta')) {
-      final delta = _firstString(<Object?>[
-        params['delta'],
-        params['text'],
-        params['output'],
-        params['interaction'],
-        legacyMessage['delta'],
-        legacyMessage['text'],
-      ]);
-      if (delta.isEmpty || turnId.isEmpty) return cells;
-      final provisionalKind = _kindFor(type, lowerMethod);
-      final id = itemId.isEmpty
-          ? '${provisionalKind.name}-$turnId'
-          : 'item-$itemId';
-      final existing = _find(cells, id);
-      final kind = existing?.kind ?? provisionalKind;
-      if (existing?.metadata['lastDelta'] == delta) return cells;
-      final resolvedId = itemId.isEmpty
-          ? '${kind.name}-$turnId'
-          : 'item-$itemId';
-      final details = existing?.detailsText ?? existing?.markdownText ?? '';
-      return _upsert(
-        cells,
-        _newCell(
-          id: resolvedId,
-          itemId: itemId.isEmpty ? null : itemId,
-          turnId: turnId,
-          kind: kind,
-          status: CodexTimelineStatus.inProgress,
-          timestamp: timestamp,
-          title: _titleFor(type, lowerMethod),
-          detailsText: '$details$delta',
-          isStreaming: true,
-          metadata: <String, Object?>{
-            ...?existing?.metadata,
-            'lastDelta': delta,
-          },
-        ),
-      );
-    }
-
-    if ((lowerMethod.contains('subagent') || lowerMethod.contains('collab')) &&
-        turnId.isNotEmpty) {
-      final delta = _firstString(<Object?>[
-        params['delta'],
-        params['text'],
-        params['summary'],
-        params['message'],
-        legacyMessage['summary'],
-        legacyMessage['message'],
-      ]);
-      final id = itemId.isEmpty ? 'subAgent-$turnId' : 'item-$itemId';
-      final existing = _find(cells, id);
-      if (existing?.metadata['lastDelta'] == delta) return cells;
-      return _upsert(
-        cells,
-        _newCell(
-          id: id,
-          itemId: itemId.isEmpty ? null : itemId,
-          turnId: turnId,
-          kind: CodexTimelineKind.subAgent,
-          status:
-              lowerMethod.contains('completed') || lowerMethod.contains('end')
-              ? CodexTimelineStatus.completed
-              : CodexTimelineStatus.inProgress,
-          timestamp: timestamp,
-          title: 'Sub-agent',
-          markdownText: delta.isEmpty
-              ? existing?.markdownText
-              : '${existing?.markdownText ?? ''}$delta',
-          isStreaming:
-              !lowerMethod.contains('completed') &&
-              !lowerMethod.contains('end'),
-          metadata: <String, Object?>{
-            ...?existing?.metadata,
-            if (delta.isNotEmpty) 'lastDelta': delta,
-          },
-        ),
-      );
-    }
-
-    if (method == 'item/started' ||
-        method == 'item/completed' ||
-        method == 'item/updated') {
-      if (turnId.isEmpty) return cells;
-      final provisionalId = itemId.isEmpty ? '$type-$turnId' : 'item-$itemId';
-      final existing = _find(cells, provisionalId);
-      final phase = _firstString(<Object?>[
-        item['phase'],
-        params['phase'],
-        existing?.metadata['streamPhase'],
-      ]);
-      final isAgentMessage =
-          type.contains('agentmessage') || type.contains('assistant');
-      final kind = isAgentMessage && phase == 'commentary'
-          ? CodexTimelineKind.progressText
-          : _kindFor(type, lowerMethod);
-      final id = kind == CodexTimelineKind.userMessage
-          ? 'user-$turnId'
-          : itemId.isEmpty
-          ? '${kind.name}-$turnId'
-          : 'item-$itemId';
-      final current = _find(cells, id) ?? existing;
-      final fullText = _itemMarkdown(item);
-      final details = _itemDetails(item);
-      final rawStatus = (item['status'] ?? params['status'] ?? '')
-          .toString()
-          .toLowerCase();
-      final status = rawStatus.contains('fail')
-          ? CodexTimelineStatus.failed
-          : rawStatus.contains('declin')
-          ? CodexTimelineStatus.declined
-          : method == 'item/completed'
-          ? CodexTimelineStatus.completed
-          : CodexTimelineStatus.inProgress;
-      return _upsert(
-        cells,
-        _newCell(
-          id: id,
-          itemId: itemId.isEmpty ? null : itemId,
-          turnId: turnId,
-          kind: kind,
-          status: status,
-          timestamp: timestamp,
-          title: type.contains('contextcompaction')
-              ? _contextCompactionTitle(status)
-              : _titleFor(type, lowerMethod, item: item),
-          subtitle: _firstString(<Object?>[
-            item['command'],
-            item['name'],
-            item['path'],
-            item['cwd'],
-            item['server'],
-          ]),
-          markdownText: fullText.isEmpty ? current?.markdownText : fullText,
-          detailsText: details.isEmpty ? current?.detailsText : details,
-          isStreaming: method != 'item/completed',
-          metadata: <String, Object?>{
-            ...?current?.metadata,
-            ..._itemTimelineMetadata(item),
-            if (isAgentMessage && phase.isNotEmpty) 'streamPhase': phase,
-          },
-        ),
-      );
-    }
-
-    if (method == 'error' ||
-        method == 'stream/error' ||
-        method == 'stream_error') {
-      final text = _firstString(<Object?>[
-        params['message'],
-        params['error'],
-        message['error'],
-      ]);
-      if (text.isEmpty) return cells;
-      return <CodexTimelineCell>[
-        ...cells,
-        _newCell(
-          id: 'error-${timestamp.microsecondsSinceEpoch}',
-          turnId: turnId.isEmpty ? null : turnId,
-          kind: CodexTimelineKind.systemNotice,
-          status: CodexTimelineStatus.failed,
-          timestamp: timestamp,
-          title: 'Codex error',
-          markdownText: text,
-        ),
-      ];
-    }
-
-    if (method.contains('review') && turnId.isNotEmpty) {
-      final title = method.contains('enter')
-          ? 'Entered review mode'
-          : 'Exited review mode';
-      final review = _firstString(<Object?>[
-        params['review'],
-        item['review'],
-        params['text'],
-      ]);
-      final id = itemId.isEmpty ? 'review-$turnId' : 'item-$itemId';
-      final result = _upsert(
-        cells,
-        _newCell(
-          id: id,
-          itemId: itemId.isEmpty ? null : itemId,
-          turnId: turnId,
-          kind: CodexTimelineKind.toolCall,
-          status: CodexTimelineStatus.completed,
-          timestamp: timestamp,
-          title: title,
-          detailsText: review.isEmpty ? null : review,
-          metadata: <String, Object?>{
-            'itemType': method.contains('enter')
-                ? 'enteredReviewMode'
-                : 'exitedReviewMode',
-          },
-        ),
-      );
-      if (review.isEmpty) return result;
-      return <CodexTimelineCell>[
-        ...result,
-        _newCell(
-          id: 'review-body-$turnId',
-          turnId: turnId,
-          kind: CodexTimelineKind.progressText,
-          status: CodexTimelineStatus.completed,
-          timestamp: timestamp,
-          markdownText: review,
-          metadata: <String, Object?>{
-            CodexTimelineMetadata.uiPlacement:
-                CodexTimelineMetadata.outsideWorked,
-          },
-        ),
-      ];
-    }
-
-    return cells;
+    final event = (
+      cells: cells,
+      message: message,
+      rawMethod: rawMethod,
+      method: method,
+      params: params,
+      legacyMessage: legacyMessage,
+      item: item,
+      turnId: turnId,
+      itemId: itemId,
+      lowerMethod: lowerMethod,
+      type: type,
+      timestamp: timestamp,
+    );
+    return _reduceLegacyTaskCompletion(event) ??
+        _reduceTurnLifecycle(event) ??
+        _reduceTurnDiff(event) ??
+        _reduceAssistantDelta(event) ??
+        _reduceReasoningDelta(event) ??
+        _reduceItemOutputDelta(event) ??
+        _reduceSubAgentEvent(event) ??
+        _reduceItemLifecycle(event) ??
+        _reduceError(event) ??
+        _reduceReview(event) ??
+        cells;
   }
+}
+
+typedef _CodexTimelineEvent = ({
+  List<CodexTimelineCell> cells,
+  Map<String, Object?> message,
+  String rawMethod,
+  String method,
+  Map<String, Object?> params,
+  Map<String, Object?> legacyMessage,
+  Map<String, Object?> item,
+  String turnId,
+  String itemId,
+  String lowerMethod,
+  String type,
+  DateTime timestamp,
+});
+
+List<CodexTimelineCell>? _reduceLegacyTaskCompletion(
+  _CodexTimelineEvent event,
+) {
+  if (event.rawMethod != 'codex/event/task_complete') return null;
+  final text = _firstString(<Object?>[
+    event.legacyMessage['last_agent_message'],
+    event.legacyMessage['lastAgentMessage'],
+  ]);
+  var next = event.cells;
+  if (text.isNotEmpty && event.turnId.isNotEmpty) {
+    final existing = _find(next, 'assistant-${event.turnId}');
+    next = _upsert(
+      next,
+      _newCell(
+        id: 'assistant-${event.turnId}',
+        turnId: event.turnId,
+        kind: CodexTimelineKind.assistantMessage,
+        status: CodexTimelineStatus.completed,
+        timestamp: event.timestamp,
+        title: 'Codex',
+        markdownText: text,
+        isStreaming: false,
+        metadata: existing?.metadata ?? const <String, Object?>{},
+      ),
+    );
+  }
+  final completed = <CodexTimelineCell>[
+    for (final cell in next)
+      if (cell.turnId == event.turnId && cell.isStreaming)
+        cell.copyWith(
+          status: CodexTimelineStatus.completed,
+          isStreaming: false,
+          updatedAt: event.timestamp,
+        )
+      else
+        cell,
+  ];
+  return _updateTurnSeparator(
+    completed,
+    event.turnId,
+    event.params,
+    event.timestamp,
+  );
+}
+
+List<CodexTimelineCell>? _reduceTurnDiff(_CodexTimelineEvent event) {
+  if (event.method != 'turn/diff/updated') return null;
+  final diff = _firstString(<Object?>[
+    event.params['diff'],
+    event.params['delta'],
+    event.params['text'],
+  ]);
+  final hasSnapshot =
+      event.params.containsKey('diff') ||
+      event.params.containsKey('delta') ||
+      event.params.containsKey('text');
+  if (event.turnId.isEmpty || !hasSnapshot) return event.cells;
+  final id = 'diff-${event.turnId}';
+  final existing = _find(event.cells, id);
+  if (existing?.metadata['lastDelta'] == diff) return event.cells;
+  return _upsert(
+    event.cells,
+    _newCell(
+      id: id,
+      turnId: event.turnId,
+      kind: CodexTimelineKind.diff,
+      status: CodexTimelineStatus.inProgress,
+      timestamp: event.timestamp,
+      title: 'File changes',
+      detailsText: diff,
+      isStreaming: true,
+      metadata: <String, Object?>{...?existing?.metadata, 'lastDelta': diff},
+    ),
+  );
+}
+
+List<CodexTimelineCell>? _reduceAssistantDelta(_CodexTimelineEvent event) {
+  if (event.method != 'item/agentMessage/delta' &&
+      !(event.lowerMethod.contains('agentmessage') &&
+          event.lowerMethod.contains('delta'))) {
+    return null;
+  }
+  final delta = _firstString(<Object?>[
+    event.params['delta'],
+    event.params['text'],
+    event.legacyMessage['delta'],
+    event.legacyMessage['text'],
+    event.legacyMessage['message'],
+  ]);
+  if (delta.isEmpty || event.turnId.isEmpty) return event.cells;
+  final id = event.itemId.isEmpty
+      ? 'assistant-${event.turnId}'
+      : 'item-${event.itemId}';
+  final existing = _find(event.cells, id);
+  final phase = _firstString(<Object?>[
+    event.item['phase'],
+    event.params['phase'],
+    existing?.metadata['streamPhase'],
+  ]);
+  final finalAnswer =
+      phase.isEmpty || phase == 'final_answer' || phase == 'final';
+  final current = existing?.markdownText ?? '';
+  final existingKind = existing?.kind;
+  final metadata = <String, Object?>{
+    ...?existing?.metadata,
+    'streamPhase': finalAnswer ? 'final_answer' : 'commentary',
+    'lastDelta': delta,
+  };
+  if (existing != null && existing.metadata['lastDelta'] == delta) {
+    return event.cells;
+  }
+  return _upsert(
+    event.cells,
+    _newCell(
+      id: id,
+      itemId: event.itemId.isEmpty ? null : event.itemId,
+      turnId: event.turnId,
+      kind: finalAnswer || existingKind == CodexTimelineKind.assistantMessage
+          ? CodexTimelineKind.assistantMessage
+          : CodexTimelineKind.progressText,
+      status: CodexTimelineStatus.inProgress,
+      timestamp: event.timestamp,
+      markdownText: '$current$delta',
+      isStreaming: true,
+      metadata: metadata,
+    ),
+  );
+}
+
+List<CodexTimelineCell>? _reduceReasoningDelta(_CodexTimelineEvent event) {
+  if (event.method != 'item/reasoning/summaryTextDelta' &&
+      event.method != 'item/reasoning/textDelta' &&
+      !(event.lowerMethod.contains('reasoning') &&
+          event.lowerMethod.contains('delta'))) {
+    return null;
+  }
+  final delta = _firstString(<Object?>[
+    event.params['delta'],
+    event.params['text'],
+    event.legacyMessage['delta'],
+    event.legacyMessage['text'],
+  ]);
+  if (delta.isEmpty || event.turnId.isEmpty) return event.cells;
+  final id = event.itemId.isEmpty
+      ? 'reasoning-${event.turnId}'
+      : 'item-${event.itemId}';
+  final existing = _find(event.cells, id);
+  if (existing != null && existing.metadata['lastDelta'] == delta) {
+    return event.cells;
+  }
+  return _upsert(
+    event.cells,
+    _newCell(
+      id: id,
+      itemId: event.itemId.isEmpty ? null : event.itemId,
+      turnId: event.turnId,
+      kind: CodexTimelineKind.reasoning,
+      status: CodexTimelineStatus.inProgress,
+      timestamp: event.timestamp,
+      title: 'Reasoning',
+      markdownText: '${existing?.markdownText ?? ''}$delta',
+      isStreaming: true,
+      metadata: <String, Object?>{...?existing?.metadata, 'lastDelta': delta},
+    ),
+  );
+}
+
+List<CodexTimelineCell>? _reduceItemOutputDelta(_CodexTimelineEvent event) {
+  if (event.method != 'item/commandExecution/outputDelta' &&
+      event.method != 'item/fileChange/outputDelta' &&
+      event.method != 'item/mcpToolCall/outputDelta' &&
+      event.method != 'item/webSearch/outputDelta' &&
+      event.method != 'item/plan/delta' &&
+      event.method != 'item/commandExecution/terminalInteraction' &&
+      event.method != 'item/mcpToolCall/progress' &&
+      !event.lowerMethod.contains('outputdelta')) {
+    return null;
+  }
+  final delta = _firstString(<Object?>[
+    event.params['delta'],
+    event.params['text'],
+    event.params['output'],
+    event.params['interaction'],
+    event.legacyMessage['delta'],
+    event.legacyMessage['text'],
+  ]);
+  if (delta.isEmpty || event.turnId.isEmpty) return event.cells;
+  final provisionalKind = _kindFor(event.type, event.lowerMethod);
+  final id = event.itemId.isEmpty
+      ? '${provisionalKind.name}-${event.turnId}'
+      : 'item-${event.itemId}';
+  final existing = _find(event.cells, id);
+  final kind = existing?.kind ?? provisionalKind;
+  if (existing?.metadata['lastDelta'] == delta) return event.cells;
+  final resolvedId = event.itemId.isEmpty
+      ? '${kind.name}-${event.turnId}'
+      : 'item-${event.itemId}';
+  final details = existing?.detailsText ?? existing?.markdownText ?? '';
+  return _upsert(
+    event.cells,
+    _newCell(
+      id: resolvedId,
+      itemId: event.itemId.isEmpty ? null : event.itemId,
+      turnId: event.turnId,
+      kind: kind,
+      status: CodexTimelineStatus.inProgress,
+      timestamp: event.timestamp,
+      title: _titleFor(event.type, event.lowerMethod),
+      detailsText: '$details$delta',
+      isStreaming: true,
+      metadata: <String, Object?>{...?existing?.metadata, 'lastDelta': delta},
+    ),
+  );
+}
+
+List<CodexTimelineCell>? _reduceSubAgentEvent(_CodexTimelineEvent event) {
+  if ((!event.lowerMethod.contains('subagent') &&
+          !event.lowerMethod.contains('collab')) ||
+      event.turnId.isEmpty) {
+    return null;
+  }
+  final delta = _firstString(<Object?>[
+    event.params['delta'],
+    event.params['text'],
+    event.params['summary'],
+    event.params['message'],
+    event.legacyMessage['summary'],
+    event.legacyMessage['message'],
+  ]);
+  final id = event.itemId.isEmpty
+      ? 'subAgent-${event.turnId}'
+      : 'item-${event.itemId}';
+  final existing = _find(event.cells, id);
+  if (existing?.metadata['lastDelta'] == delta) return event.cells;
+  return _upsert(
+    event.cells,
+    _newCell(
+      id: id,
+      itemId: event.itemId.isEmpty ? null : event.itemId,
+      turnId: event.turnId,
+      kind: CodexTimelineKind.subAgent,
+      status:
+          event.lowerMethod.contains('completed') ||
+              event.lowerMethod.contains('end')
+          ? CodexTimelineStatus.completed
+          : CodexTimelineStatus.inProgress,
+      timestamp: event.timestamp,
+      title: 'Sub-agent',
+      markdownText: delta.isEmpty
+          ? existing?.markdownText
+          : '${existing?.markdownText ?? ''}$delta',
+      isStreaming:
+          !event.lowerMethod.contains('completed') &&
+          !event.lowerMethod.contains('end'),
+      metadata: <String, Object?>{
+        ...?existing?.metadata,
+        if (delta.isNotEmpty) 'lastDelta': delta,
+      },
+    ),
+  );
+}
+
+List<CodexTimelineCell>? _reduceError(_CodexTimelineEvent event) {
+  if (event.method != 'error' &&
+      event.method != 'stream/error' &&
+      event.method != 'stream_error') {
+    return null;
+  }
+  final text = _firstString(<Object?>[
+    event.params['message'],
+    event.params['error'],
+    event.message['error'],
+  ]);
+  if (text.isEmpty) return event.cells;
+  return <CodexTimelineCell>[
+    ...event.cells,
+    _newCell(
+      id: 'error-${event.timestamp.microsecondsSinceEpoch}',
+      turnId: event.turnId.isEmpty ? null : event.turnId,
+      kind: CodexTimelineKind.systemNotice,
+      status: CodexTimelineStatus.failed,
+      timestamp: event.timestamp,
+      title: 'Codex error',
+      markdownText: text,
+    ),
+  ];
+}
+
+List<CodexTimelineCell>? _reduceReview(_CodexTimelineEvent event) {
+  if (!event.method.contains('review') || event.turnId.isEmpty) return null;
+  final title = event.method.contains('enter')
+      ? 'Entered review mode'
+      : 'Exited review mode';
+  final review = _firstString(<Object?>[
+    event.params['review'],
+    event.item['review'],
+    event.params['text'],
+  ]);
+  final id = event.itemId.isEmpty
+      ? 'review-${event.turnId}'
+      : 'item-${event.itemId}';
+  final result = _upsert(
+    event.cells,
+    _newCell(
+      id: id,
+      itemId: event.itemId.isEmpty ? null : event.itemId,
+      turnId: event.turnId,
+      kind: CodexTimelineKind.toolCall,
+      status: CodexTimelineStatus.completed,
+      timestamp: event.timestamp,
+      title: title,
+      detailsText: review.isEmpty ? null : review,
+      metadata: <String, Object?>{
+        'itemType': event.method.contains('enter')
+            ? 'enteredReviewMode'
+            : 'exitedReviewMode',
+      },
+    ),
+  );
+  if (review.isEmpty) return result;
+  return <CodexTimelineCell>[
+    ...result,
+    _newCell(
+      id: 'review-body-${event.turnId}',
+      turnId: event.turnId,
+      kind: CodexTimelineKind.progressText,
+      status: CodexTimelineStatus.completed,
+      timestamp: event.timestamp,
+      markdownText: review,
+      metadata: <String, Object?>{
+        CodexTimelineMetadata.uiPlacement: CodexTimelineMetadata.outsideWorked,
+      },
+    ),
+  ];
 }

--- a/lib/src/features/codex_chat/domain/codex_timeline_lifecycle.dart
+++ b/lib/src/features/codex_chat/domain/codex_timeline_lifecycle.dart
@@ -1,0 +1,127 @@
+part of 'codex_timeline.dart';
+
+List<CodexTimelineCell>? _reduceTurnLifecycle(_CodexTimelineEvent event) {
+  if (event.method == 'turn/started' || event.method == 'turn/created') {
+    if (event.turnId.isEmpty) return event.cells;
+    final turn = _map(event.params['turn']);
+    return _upsert(
+      event.cells,
+      _newCell(
+        id: 'turn-${event.turnId}',
+        turnId: event.turnId,
+        kind: CodexTimelineKind.turnSeparator,
+        status: CodexTimelineStatus.info,
+        timestamp: event.timestamp,
+        title: 'Turn started',
+        metadata: <String, Object?>{
+          'startedAt': turn['startedAt'],
+          'completedAt': turn['completedAt'],
+          'computedDurationMs': turn['durationMs'],
+        },
+      ),
+    );
+  }
+
+  if (event.method != 'turn/completed' &&
+      event.method != 'turn/failed' &&
+      event.method != 'turn/aborted' &&
+      event.method != 'turn/interrupted') {
+    return null;
+  }
+  final turnError = _map(event.params['turn'])['error'];
+  final failed =
+      event.method == 'turn/failed' ||
+      (turnError is String && turnError.trim().isNotEmpty) ||
+      (turnError is Map && turnError.isNotEmpty);
+  final completed = <CodexTimelineCell>[
+    for (final cell in event.cells)
+      if (event.turnId.isNotEmpty &&
+          cell.turnId == event.turnId &&
+          cell.isStreaming)
+        cell.copyWith(
+          status: failed
+              ? CodexTimelineStatus.failed
+              : CodexTimelineStatus.completed,
+          isStreaming: false,
+          updatedAt: event.timestamp,
+        )
+      else
+        cell,
+  ];
+  return _updateTurnSeparator(
+    completed,
+    event.turnId,
+    event.params,
+    event.timestamp,
+  );
+}
+
+List<CodexTimelineCell>? _reduceItemLifecycle(_CodexTimelineEvent event) {
+  if (event.method != 'item/started' &&
+      event.method != 'item/completed' &&
+      event.method != 'item/updated') {
+    return null;
+  }
+  if (event.turnId.isEmpty) return event.cells;
+  final provisionalId = event.itemId.isEmpty
+      ? '${event.type}-${event.turnId}'
+      : 'item-${event.itemId}';
+  final existing = _find(event.cells, provisionalId);
+  final phase = _firstString(<Object?>[
+    event.item['phase'],
+    event.params['phase'],
+    existing?.metadata['streamPhase'],
+  ]);
+  final isAgentMessage =
+      event.type.contains('agentmessage') || event.type.contains('assistant');
+  final kind = isAgentMessage && phase == 'commentary'
+      ? CodexTimelineKind.progressText
+      : _kindFor(event.type, event.lowerMethod);
+  final id = kind == CodexTimelineKind.userMessage
+      ? 'user-${event.turnId}'
+      : event.itemId.isEmpty
+      ? '${kind.name}-${event.turnId}'
+      : 'item-${event.itemId}';
+  final current = _find(event.cells, id) ?? existing;
+  final fullText = _itemMarkdown(event.item);
+  final details = _itemDetails(event.item);
+  final rawStatus = (event.item['status'] ?? event.params['status'] ?? '')
+      .toString()
+      .toLowerCase();
+  final status = rawStatus.contains('fail')
+      ? CodexTimelineStatus.failed
+      : rawStatus.contains('declin')
+      ? CodexTimelineStatus.declined
+      : event.method == 'item/completed'
+      ? CodexTimelineStatus.completed
+      : CodexTimelineStatus.inProgress;
+  return _upsert(
+    event.cells,
+    _newCell(
+      id: id,
+      itemId: event.itemId.isEmpty ? null : event.itemId,
+      turnId: event.turnId,
+      kind: kind,
+      status: status,
+      timestamp: event.timestamp,
+      title: event.type.contains('contextcompaction')
+          ? _contextCompactionTitle(status)
+          : _titleFor(event.type, event.lowerMethod, item: event.item),
+      subtitle: _firstString(<Object?>[
+        event.item['command'],
+        event.item['name'],
+        event.item['path'],
+        event.item['cwd'],
+        event.item['server'],
+      ]),
+      markdownText: fullText.isEmpty ? current?.markdownText : fullText,
+      detailsText: details.isEmpty ? current?.detailsText : details,
+      isStreaming: event.method != 'item/completed',
+      metadata: <String, Object?>{
+        ...?current?.metadata,
+        ..._itemTimelineMetadata(event.item),
+        if (isAgentMessage && phase.isNotEmpty) 'streamPhase': phase,
+      },
+    ),
+  );
+}

--- a/test/unit/codex_timeline_coverage_test.dart
+++ b/test/unit/codex_timeline_coverage_test.dart
@@ -157,6 +157,32 @@ void main() {
     expect(cells.any((cell) => cell.kind == CodexTimelineKind.plan), isTrue);
   });
 
+  test('reducer accepts compatibility delta method variants', () {
+    var cells = CodexTimelineReducer.reduce(
+      const <CodexTimelineCell>[],
+      _event('legacy/agentMessage/contentDelta', <String, Object?>{
+        'turnId': 'turn-1',
+        'delta': 'answer',
+      }),
+      now: now,
+    );
+    cells = CodexTimelineReducer.reduce(
+      cells,
+      _event('legacy/reasoning/contentDelta', <String, Object?>{
+        'turnId': 'turn-1',
+        'delta': 'thought',
+      }),
+      now: now,
+    );
+
+    expect(cells.map((cell) => cell.kind), <CodexTimelineKind>[
+      CodexTimelineKind.assistantMessage,
+      CodexTimelineKind.reasoning,
+    ]);
+    expect(cells.first.markdownText, 'answer');
+    expect(cells.last.markdownText, 'thought');
+  });
+
   test('reducer coalesces subagent progress and completion', () {
     var cells = CodexTimelineReducer.reduce(
       <CodexTimelineCell>[],


### PR DESCRIPTION
## Summary
- normalize each Codex notification once and dispatch timeline reduction by event family
- extract turn and item lifecycle handling into a private timeline part
- preserve legacy/current protocol ordering, IDs, equality, timestamps, metadata, and streaming semantics
- reduce `CodexTimelineReducer.reduce` from 469 to 72 lines and keep both touched domain files below the 500-line ratchet
- characterize generic assistant and reasoning delta method fallbacks revealed by the coverage gate

## Validation
- `dart format --output=none --set-exit-if-changed lib/src/features/codex_chat/domain/codex_timeline.dart lib/src/features/codex_chat/domain/codex_timeline_lifecycle.dart test/unit/codex_timeline_coverage_test.dart`
- `dart tool/quality/check_max_lines.dart`
- `flutter analyze lib/src/features/codex_chat/domain/codex_timeline.dart lib/src/features/codex_chat/domain/codex_timeline_lifecycle.dart`
- 50 focused timeline and domain contract tests passed
- focused LCOV confirms both previously uncovered compatibility branches execute
- full local `flutter test` executed 3,221 tests under Flutter 3.47.1, with six unrelated failures including four golden diffs; PR CI uses the repository-pinned Flutter 3.44.8 and is the merge gate

## Risks
- behavior-preserving refactor with no public API changes
- the added characterization test covers compatibility fallbacks already supported by the reducer