### PR TITLE
refactor: deduplicate settings search entries

### DIFF
--- a/lib/src/features/settings/presentation/ai_dictation_search_entries.dart
+++ b/lib/src/features/settings/presentation/ai_dictation_search_entries.dart
@@ -1,32 +1,32 @@
+import 'package:alera/src/features/settings/presentation/settings_search_entry_catalog.dart';
 import 'package:alera/src/features/settings/presentation/settings_sections.dart';
 
-const List<SettingsSearchEntry> aiDictationSearchEntries =
-    <SettingsSearchEntry>[
-      SettingsSearchEntry(
-        title: 'AI Dictation',
-        description: 'Transcribe microphone recordings locally with Whisper.',
-        keywords: <String>[
-          'ai',
-          'dictation',
-          'voice',
-          'speech',
-          'whisper',
-          'microphone',
-        ],
-        groupId: 'transcription',
-      ),
-      SettingsSearchEntry(
-        title: 'Whisper Model',
-        description:
-            'Download, resume, select, or remove local Whisper models.',
-        keywords: <String>['offline', 'model', 'download', 'resume', 'privacy'],
-        groupId: 'models',
-      ),
-      SettingsSearchEntry(
-        title: 'Speech Processing',
-        description:
-            'Clean up or summarize transcripts with an agent subscription.',
-        keywords: <String>['agent', 'model', 'summary', 'cleanup', 'speech'],
-        groupId: 'processing',
-      ),
-    ];
+final List<SettingsSearchEntry>
+aiDictationSearchEntries = buildSettingsSearchEntryCatalog(const {
+  'transcription': {
+    'AI Dictation': SettingsSearchEntryDetails(
+      description: 'Transcribe microphone recordings locally with Whisper.',
+      keywords: <String>[
+        'ai',
+        'dictation',
+        'voice',
+        'speech',
+        'whisper',
+        'microphone',
+      ],
+    ),
+  },
+  'models': {
+    'Whisper Model': SettingsSearchEntryDetails(
+      description: 'Download, resume, select, or remove local Whisper models.',
+      keywords: <String>['offline', 'model', 'download', 'resume', 'privacy'],
+    ),
+  },
+  'processing': {
+    'Speech Processing': SettingsSearchEntryDetails(
+      description:
+          'Clean up or summarize transcripts with an agent subscription.',
+      keywords: <String>['agent', 'model', 'summary', 'cleanup', 'speech'],
+    ),
+  },
+});

--- a/lib/src/features/settings/presentation/settings_search_entries.dart
+++ b/lib/src/features/settings/presentation/settings_search_entries.dart
@@ -1,278 +1,238 @@
 import 'package:alera/src/features/settings/presentation/settings_sections.dart';
+import 'package:alera/src/features/settings/presentation/settings_search_entry_catalog.dart';
 import 'package:alera/src/features/settings/presentation/settings_search_entries_reading_diff.dart';
 
-const List<SettingsSearchEntry>
-applicationSearchEntries = <SettingsSearchEntry>[
-  SettingsSearchEntry(
-    title: 'Workspace Directory',
-    description: 'Where new linked workspaces are created on disk.',
-    keywords: <String>['worktree', 'folder', 'location', 'path'],
-    groupId: 'storage',
-  ),
-  SettingsSearchEntry(
-    title: 'Confirm Project Removal',
-    description: 'Ask before unregistering a project.',
-    keywords: <String>['safety', 'destructive', 'remove', 'delete'],
-    groupId: 'safety',
-  ),
-  SettingsSearchEntry(
-    title: 'Confirm Workspace Removal',
-    description: 'Ask before removing a workspace worktree.',
-    keywords: <String>['safety', 'destructive', 'remove', 'delete'],
-    groupId: 'safety',
-  ),
-  SettingsSearchEntry(
-    title: 'Keep Runtime Open When App Quits',
-    description: 'Leave the app-launched sidecar running after a clean quit.',
-    keywords: <String>[
-      'host',
-      'sidecar',
-      'lifecycle',
-      'quit',
-      'shutdown',
-      'leave',
-    ],
-    groupId: 'runtime',
-  ),
-  SettingsSearchEntry(
-    title: 'Empty Host Shutdown',
-    description:
-        'Stop the terminal host after the app closes with no sessions.',
-    keywords: <String>['host', 'sidecar', 'lifetime', 'timeout'],
-    groupId: 'runtime',
-  ),
-  SettingsSearchEntry(
-    title: 'Detached Session Shutdown',
-    description:
-        'Stop detached running terminal sessions after the app stays closed.',
-    keywords: <String>['host', 'sidecar', 'session', 'timeout'],
-    groupId: 'runtime',
-  ),
-  SettingsSearchEntry(
-    title: 'Open Logs Folder',
-    description: 'Show the folder holding the app log files.',
-    keywords: <String>['log', 'logs', 'diagnostics', 'debug', 'folder'],
-    groupId: 'diagnostics',
-  ),
-  SettingsSearchEntry(
-    title: 'Export Diagnostics',
-    description: 'Save app and runtime logs with version details as a zip.',
-    keywords: <String>[
-      'log',
-      'logs',
-      'diagnostics',
-      'export',
-      'bundle',
-      'report',
-      'zip',
-    ],
-    groupId: 'diagnostics',
-  ),
-  SettingsSearchEntry(
-    title: 'Log Level',
-    description: 'How much detail is written to the log files.',
-    keywords: <String>['log', 'verbose', 'debug', 'diagnostics'],
-    groupId: 'diagnostics',
-  ),
-  SettingsSearchEntry(
-    title: 'Send Crash Reports',
-    description: 'Send crashes to Sentry, an external service.',
-    keywords: <String>['crash', 'sentry', 'telemetry', 'report', 'error'],
-    groupId: 'diagnostics',
-  ),
-  SettingsSearchEntry(
-    title: 'Updates',
-    description: 'Check desktop releases for this platform.',
-    keywords: <String>['release', 'download', 'version'],
-    groupId: 'updates',
-  ),
-  SettingsSearchEntry(
-    title: 'Star Alera on GitHub',
-    description: 'Show your support for the project.',
-    keywords: <String>['support', 'github', 'star'],
-    groupId: 'support',
-  ),
-];
+final List<SettingsSearchEntry>
+applicationSearchEntries = buildSettingsSearchEntryCatalog(const {
+  'storage': {
+    'Workspace Directory': SettingsSearchEntryDetails(
+      description: 'Where new linked workspaces are created on disk.',
+      keywords: <String>['worktree', 'folder', 'location', 'path'],
+    ),
+  },
+  'safety': {
+    'Confirm Project Removal': SettingsSearchEntryDetails(
+      description: 'Ask before unregistering a project.',
+      keywords: <String>['safety', 'destructive', 'remove', 'delete'],
+    ),
+    'Confirm Workspace Removal': SettingsSearchEntryDetails(
+      description: 'Ask before removing a workspace worktree.',
+      keywords: <String>['safety', 'destructive', 'remove', 'delete'],
+    ),
+  },
+  'runtime': {
+    'Keep Runtime Open When App Quits': SettingsSearchEntryDetails(
+      description: 'Leave the app-launched sidecar running after a clean quit.',
+      keywords: <String>[
+        'host',
+        'sidecar',
+        'lifecycle',
+        'quit',
+        'shutdown',
+        'leave',
+      ],
+    ),
+    'Empty Host Shutdown': SettingsSearchEntryDetails(
+      description:
+          'Stop the terminal host after the app closes with no sessions.',
+      keywords: <String>['host', 'sidecar', 'lifetime', 'timeout'],
+    ),
+    'Detached Session Shutdown': SettingsSearchEntryDetails(
+      description:
+          'Stop detached running terminal sessions after the app stays closed.',
+      keywords: <String>['host', 'sidecar', 'session', 'timeout'],
+    ),
+  },
+  'diagnostics': {
+    'Open Logs Folder': SettingsSearchEntryDetails(
+      description: 'Show the folder holding the app log files.',
+      keywords: <String>['log', 'logs', 'diagnostics', 'debug', 'folder'],
+    ),
+    'Export Diagnostics': SettingsSearchEntryDetails(
+      description: 'Save app and runtime logs with version details as a zip.',
+      keywords: <String>[
+        'log',
+        'logs',
+        'diagnostics',
+        'export',
+        'bundle',
+        'report',
+        'zip',
+      ],
+    ),
+    'Log Level': SettingsSearchEntryDetails(
+      description: 'How much detail is written to the log files.',
+      keywords: <String>['log', 'verbose', 'debug', 'diagnostics'],
+    ),
+    'Send Crash Reports': SettingsSearchEntryDetails(
+      description: 'Send crashes to Sentry, an external service.',
+      keywords: <String>['crash', 'sentry', 'telemetry', 'report', 'error'],
+    ),
+  },
+  'updates': {
+    'Updates': SettingsSearchEntryDetails(
+      description: 'Check desktop releases for this platform.',
+      keywords: <String>['release', 'download', 'version'],
+    ),
+  },
+  'support': {
+    'Star Alera on GitHub': SettingsSearchEntryDetails(
+      description: 'Show your support for the project.',
+      keywords: <String>['support', 'github', 'star'],
+    ),
+  },
+});
 
-const List<SettingsSearchEntry> agentsSearchEntries = <SettingsSearchEntry>[
-  SettingsSearchEntry(
-    title: 'All Alera Skills',
-    description: 'Install or update every Alera agent skill.',
-    keywords: <String>[
-      'all',
-      'install',
-      'update',
-      'skills',
-      'computer use',
-      'emulator',
-      'orchestration',
-    ],
-    groupId: 'cliSkill',
-  ),
-  SettingsSearchEntry(
-    title: 'Alera CLI Skill',
-    description: 'Install agent instructions for the Alera CLI.',
-    keywords: <String>['codex', 'skill', 'cli', 'agent', 'workspace'],
-    groupId: 'cliSkill',
-  ),
-  SettingsSearchEntry(
-    title: 'Agent Canvas Skill',
-    description:
-        'Install agent instructions for publishing structured updates in Agent Canvas.',
-    keywords: <String>[
-      'agent canvas',
-      'canvas',
-      'skill',
-      'agent',
-      'publish',
-      'decision',
-    ],
-    groupId: 'cliSkill',
-  ),
-  SettingsSearchEntry(
-    title: 'Alera Orchestration Skill',
-    description: 'Install agent instructions for Alera orchestration.',
-    keywords: <String>[
-      'orchestration',
-      'skill',
-      'agent',
-      'handoff',
-      'task',
-      'dispatch',
-    ],
-    groupId: 'cliSkill',
-  ),
-  SettingsSearchEntry(
-    title: 'Alera Computer Use Skill',
-    description: 'Install agent instructions for desktop computer use.',
-    keywords: <String>[
-      'computer use',
-      'desktop',
-      'accessibility',
-      'skill',
-      'agent',
-      'click',
-      'window',
-    ],
-    groupId: 'cliSkill',
-  ),
-  SettingsSearchEntry(
-    title: 'Codex Hooks',
-    description: 'Use Alera-managed Codex runtime hooks.',
-    keywords: <String>['codex', 'agent', 'status', 'hooks'],
-    groupId: 'hooks',
-  ),
-  SettingsSearchEntry(
-    title: 'Claude Code Hooks',
-    description: 'Use an Alera-managed Claude Code config with status hooks.',
-    keywords: <String>['claude', 'agent', 'status', 'hooks'],
-    groupId: 'hooks',
-  ),
-  SettingsSearchEntry(
-    title: 'GitHub Copilot Hooks',
-    description: 'Use an Alera-managed GitHub Copilot home overlay.',
-    keywords: <String>['copilot', 'github', 'agent', 'status', 'hooks'],
-    groupId: 'hooks',
-  ),
-  SettingsSearchEntry(
-    title: 'Cursor Hooks',
-    description: 'Use an Alera-managed Cursor agent plugin wrapper.',
-    keywords: <String>['cursor', 'agent', 'status', 'hooks', 'cli'],
-    groupId: 'hooks',
-  ),
-  SettingsSearchEntry(
-    title: 'Antigravity Hooks',
-    description: 'Install managed Antigravity hooks for the agy CLI.',
-    keywords: <String>['antigravity', 'agy', 'agent', 'status', 'hooks'],
-    groupId: 'hooks',
-  ),
-  SettingsSearchEntry(
-    title: 'OpenCode Hooks',
-    description: 'Install managed OpenCode status plugin.',
-    keywords: <String>['opencode', 'agent', 'status', 'hooks', 'plugin'],
-    groupId: 'hooks',
-  ),
-  SettingsSearchEntry(
-    title: 'OpenCode 2 Hooks',
-    description: 'Install managed OpenCode 2 status plugin.',
-    keywords: <String>[
-      'opencode',
-      'opencode2',
-      'agent',
-      'status',
-      'hooks',
-      'plugin',
-      'v2',
-    ],
-    groupId: 'hooks',
-  ),
-  SettingsSearchEntry(
-    title: 'Pi Hooks',
-    description: 'Install managed Pi status extension.',
-    keywords: <String>['pi', 'agent', 'status', 'hooks', 'extension'],
-    groupId: 'hooks',
-  ),
-  SettingsSearchEntry(
-    title: 'Amp Hooks',
-    description: 'Use an Alera-managed Amp config overlay.',
-    keywords: <String>['amp', 'agent', 'status', 'hooks', 'plugin'],
-    groupId: 'hooks',
-  ),
-  SettingsSearchEntry(
-    title: 'Grok Build Hooks',
-    description: 'Install managed Grok Build status hooks.',
-    keywords: <String>['grok', 'xai', 'agent', 'status', 'hooks'],
-    groupId: 'hooks',
-  ),
-  SettingsSearchEntry(
-    title: 'Agent Status Notifications',
-    description: 'Show native notifications when agents need attention.',
-    keywords: <String>[
-      'codex',
-      'claude',
-      'copilot',
-      'cursor',
-      'antigravity',
-      'agy',
-      'opencode',
-      'opencode2',
-      'pi',
-      'amp',
-      'grok',
-      'agent',
-      'status',
-      'notification',
-    ],
-    groupId: 'behavior',
-  ),
-  SettingsSearchEntry(
-    title: 'Agent Finished Notifications',
-    description: 'Also notify when an agent finishes a turn.',
-    keywords: <String>[
-      'agent',
-      'status',
-      'notification',
-      'finished',
-      'done',
-      'turn',
-    ],
-    groupId: 'behavior',
-  ),
-  SettingsSearchEntry(
-    title: 'Keep Computer Awake While Agents Are Working',
-    description: 'Keep this computer and display awake during agent work.',
-    keywords: <String>[
-      'awake',
-      'sleep',
-      'power',
-      'agent',
-      'working',
-      'lid',
-      'display',
-    ],
-    groupId: 'behavior',
-  ),
-];
+final List<SettingsSearchEntry>
+agentsSearchEntries = buildSettingsSearchEntryCatalog(const {
+  'cliSkill': {
+    'All Alera Skills': SettingsSearchEntryDetails(
+      description: 'Install or update every Alera agent skill.',
+      keywords: <String>[
+        'all',
+        'install',
+        'update',
+        'skills',
+        'computer use',
+        'emulator',
+        'orchestration',
+      ],
+    ),
+    'Alera CLI Skill': SettingsSearchEntryDetails(
+      description: 'Install agent instructions for the Alera CLI.',
+      keywords: <String>['codex', 'skill', 'cli', 'agent', 'workspace'],
+    ),
+    'Agent Canvas Skill': SettingsSearchEntryDetails(
+      description:
+          'Install agent instructions for publishing structured updates in Agent Canvas.',
+      keywords: <String>[
+        'agent canvas',
+        'canvas',
+        'skill',
+        'agent',
+        'publish',
+        'decision',
+      ],
+    ),
+    'Alera Orchestration Skill': SettingsSearchEntryDetails(
+      description: 'Install agent instructions for Alera orchestration.',
+      keywords: <String>[
+        'orchestration',
+        'skill',
+        'agent',
+        'handoff',
+        'task',
+        'dispatch',
+      ],
+    ),
+    'Alera Computer Use Skill': SettingsSearchEntryDetails(
+      description: 'Install agent instructions for desktop computer use.',
+      keywords: <String>[
+        'computer use',
+        'desktop',
+        'accessibility',
+        'skill',
+        'agent',
+        'click',
+        'window',
+      ],
+    ),
+  },
+  'hooks': {
+    'Codex Hooks': SettingsSearchEntryDetails(
+      description: 'Use Alera-managed Codex runtime hooks.',
+      keywords: <String>['codex', 'agent', 'status', 'hooks'],
+    ),
+    'Claude Code Hooks': SettingsSearchEntryDetails(
+      description: 'Use an Alera-managed Claude Code config with status hooks.',
+      keywords: <String>['claude', 'agent', 'status', 'hooks'],
+    ),
+    'GitHub Copilot Hooks': SettingsSearchEntryDetails(
+      description: 'Use an Alera-managed GitHub Copilot home overlay.',
+      keywords: <String>['copilot', 'github', 'agent', 'status', 'hooks'],
+    ),
+    'Cursor Hooks': SettingsSearchEntryDetails(
+      description: 'Use an Alera-managed Cursor agent plugin wrapper.',
+      keywords: <String>['cursor', 'agent', 'status', 'hooks', 'cli'],
+    ),
+    'Antigravity Hooks': SettingsSearchEntryDetails(
+      description: 'Install managed Antigravity hooks for the agy CLI.',
+      keywords: <String>['antigravity', 'agy', 'agent', 'status', 'hooks'],
+    ),
+    'OpenCode Hooks': SettingsSearchEntryDetails(
+      description: 'Install managed OpenCode status plugin.',
+      keywords: <String>['opencode', 'agent', 'status', 'hooks', 'plugin'],
+    ),
+    'OpenCode 2 Hooks': SettingsSearchEntryDetails(
+      description: 'Install managed OpenCode 2 status plugin.',
+      keywords: <String>[
+        'opencode',
+        'opencode2',
+        'agent',
+        'status',
+        'hooks',
+        'plugin',
+        'v2',
+      ],
+    ),
+    'Pi Hooks': SettingsSearchEntryDetails(
+      description: 'Install managed Pi status extension.',
+      keywords: <String>['pi', 'agent', 'status', 'hooks', 'extension'],
+    ),
+    'Amp Hooks': SettingsSearchEntryDetails(
+      description: 'Use an Alera-managed Amp config overlay.',
+      keywords: <String>['amp', 'agent', 'status', 'hooks', 'plugin'],
+    ),
+    'Grok Build Hooks': SettingsSearchEntryDetails(
+      description: 'Install managed Grok Build status hooks.',
+      keywords: <String>['grok', 'xai', 'agent', 'status', 'hooks'],
+    ),
+  },
+  'behavior': {
+    'Agent Status Notifications': SettingsSearchEntryDetails(
+      description: 'Show native notifications when agents need attention.',
+      keywords: <String>[
+        'codex',
+        'claude',
+        'copilot',
+        'cursor',
+        'antigravity',
+        'agy',
+        'opencode',
+        'opencode2',
+        'pi',
+        'amp',
+        'grok',
+        'agent',
+        'status',
+        'notification',
+      ],
+    ),
+    'Agent Finished Notifications': SettingsSearchEntryDetails(
+      description: 'Also notify when an agent finishes a turn.',
+      keywords: <String>[
+        'agent',
+        'status',
+        'notification',
+        'finished',
+        'done',
+        'turn',
+      ],
+    ),
+    'Keep Computer Awake While Agents Are Working': SettingsSearchEntryDetails(
+      description: 'Keep this computer and display awake during agent work.',
+      keywords: <String>[
+        'awake',
+        'sleep',
+        'power',
+        'agent',
+        'working',
+        'lid',
+        'display',
+      ],
+    ),
+  },
+});
 
 const List<SettingsSearchEntry> keyboardSearchEntries = <SettingsSearchEntry>[
   SettingsSearchEntry(
@@ -289,45 +249,44 @@ const List<SettingsSearchEntry> keyboardSearchEntries = <SettingsSearchEntry>[
   ),
 ];
 
-const List<SettingsSearchEntry> browserSearchEntries = <SettingsSearchEntry>[
-  SettingsSearchEntry(
-    title: 'System Browser Engine',
-    description: 'Check the stable browser capability gate.',
-    keywords: <String>['browser', 'webview', 'webkit', 'webview2', 'engine'],
-    groupId: 'general',
-  ),
-  SettingsSearchEntry(
-    title: 'Browser Search Engine',
-    description: 'Choose the default address bar search provider.',
-    keywords: <String>['google', 'duckduckgo', 'bing', 'kagi', 'search'],
-    groupId: 'general',
-  ),
-  SettingsSearchEntry(
-    title: 'Browser Profiles',
-    description: 'Manage isolated cookies, storage and permissions.',
-    keywords: <String>['browser', 'profile', 'cookies', 'storage', 'import'],
-    groupId: 'profiles',
-  ),
-  SettingsSearchEntry(
-    title: 'Trusted Local Certificates',
-    description: 'Review or remove certificate trust for browser profiles.',
-    keywords: <String>[
-      'browser',
-      'certificate',
-      'tls',
-      'https',
-      'localhost',
-      'self signed',
-    ],
-    groupId: 'certificates',
-  ),
-  SettingsSearchEntry(
-    title: 'Browser History',
-    description: 'Clear history and reopen recently closed tabs.',
-    keywords: <String>['browser', 'history', 'closed', 'tabs'],
-    groupId: 'data',
-  ),
-];
+final List<SettingsSearchEntry>
+browserSearchEntries = buildSettingsSearchEntryCatalog(const {
+  'general': {
+    'System Browser Engine': SettingsSearchEntryDetails(
+      description: 'Check the stable browser capability gate.',
+      keywords: <String>['browser', 'webview', 'webkit', 'webview2', 'engine'],
+    ),
+    'Browser Search Engine': SettingsSearchEntryDetails(
+      description: 'Choose the default address bar search provider.',
+      keywords: <String>['google', 'duckduckgo', 'bing', 'kagi', 'search'],
+    ),
+  },
+  'profiles': {
+    'Browser Profiles': SettingsSearchEntryDetails(
+      description: 'Manage isolated cookies, storage and permissions.',
+      keywords: <String>['browser', 'profile', 'cookies', 'storage', 'import'],
+    ),
+  },
+  'certificates': {
+    'Trusted Local Certificates': SettingsSearchEntryDetails(
+      description: 'Review or remove certificate trust for browser profiles.',
+      keywords: <String>[
+        'browser',
+        'certificate',
+        'tls',
+        'https',
+        'localhost',
+        'self signed',
+      ],
+    ),
+  },
+  'data': {
+    'Browser History': SettingsSearchEntryDetails(
+      description: 'Clear history and reopen recently closed tabs.',
+      keywords: <String>['browser', 'history', 'closed', 'tabs'],
+    ),
+  },
+});
 
 const List<SettingsSearchEntry> editorSearchEntries = <SettingsSearchEntry>[
   SettingsSearchEntry(

--- a/lib/src/features/settings/presentation/settings_search_entries_quota.dart
+++ b/lib/src/features/settings/presentation/settings_search_entries_quota.dart
@@ -1,77 +1,72 @@
+import 'package:alera/src/features/settings/presentation/settings_search_entry_catalog.dart';
 import 'package:alera/src/features/settings/presentation/settings_sections.dart';
 
-const List<SettingsSearchEntry> quotaSearchEntries = <SettingsSearchEntry>[
-  SettingsSearchEntry(
-    title: 'Provider Quotas',
-    description: 'Choose quota providers and their display order.',
-    keywords: <String>[
-      'quota',
-      'usage',
-      'codex',
-      'kimi',
-      'grok',
-      'antigravity',
-      'minimax',
-      'z.ai',
-      'order',
-      'pin',
-      'pinned',
-      'status bar',
-    ],
-    groupId: 'providers',
-  ),
-  SettingsSearchEntry(
-    title: 'Claude Code Quotas',
-    description: 'Enable Claude quotas for default and CCS accounts.',
-    keywords: <String>['claude', 'quota', 'usage'],
-    groupId: 'claude',
-  ),
-  SettingsSearchEntry(
-    title: 'Claude Default Quotas',
-    description: 'Configure the default Claude account independently.',
-    keywords: <String>['claude', 'default', 'account', 'quota'],
-    groupId: 'claude',
-  ),
-  SettingsSearchEntry(
-    title: 'Claude Default in Usage',
-    description: 'Choose whether the default Claude account appears in Usage.',
-    keywords: <String>['claude', 'default', 'account', 'usage', 'visible'],
-    groupId: 'claude',
-  ),
-  SettingsSearchEntry(
-    title: 'Claude CCS Profiles',
-    description: 'Configure CCS alias and profile pairs for Claude quotas.',
-    keywords: <String>[
-      'claude',
-      'ccs',
-      'profile',
-      'alias',
-      'quota',
-      'pin',
-      'pinned',
-      'status bar',
-    ],
-    groupId: 'claude',
-  ),
-  SettingsSearchEntry(
-    title: 'Kimi API Key Variable',
-    description: 'Configure the Kimi API key environment variable name.',
-    keywords: <String>['kimi', 'environment', 'api key', 'KIMI_API_KEY'],
-    groupId: 'credentials',
-  ),
-  SettingsSearchEntry(
-    title: 'Quota Credential Environment',
-    description:
-        'Configure environment variable names for Kimi, Z.ai and MiniMax.',
-    keywords: <String>[
-      'environment',
-      'api key',
-      'kimi',
-      'z.ai',
-      'minimax',
-      'remote',
-      'host',
-    ],
-    groupId: 'credentials',
-  ),
-];
+final List<SettingsSearchEntry>
+quotaSearchEntries = buildSettingsSearchEntryCatalog(const {
+  'providers': {
+    'Provider Quotas': SettingsSearchEntryDetails(
+      description: 'Choose quota providers and their display order.',
+      keywords: <String>[
+        'quota',
+        'usage',
+        'codex',
+        'kimi',
+        'grok',
+        'antigravity',
+        'minimax',
+        'z.ai',
+        'order',
+        'pin',
+        'pinned',
+        'status bar',
+      ],
+    ),
+  },
+  'claude': {
+    'Claude Code Quotas': SettingsSearchEntryDetails(
+      description: 'Enable Claude quotas for default and CCS accounts.',
+      keywords: <String>['claude', 'quota', 'usage'],
+    ),
+    'Claude Default Quotas': SettingsSearchEntryDetails(
+      description: 'Configure the default Claude account independently.',
+      keywords: <String>['claude', 'default', 'account', 'quota'],
+    ),
+    'Claude Default in Usage': SettingsSearchEntryDetails(
+      description:
+          'Choose whether the default Claude account appears in Usage.',
+      keywords: <String>['claude', 'default', 'account', 'usage', 'visible'],
+    ),
+    'Claude CCS Profiles': SettingsSearchEntryDetails(
+      description: 'Configure CCS alias and profile pairs for Claude quotas.',
+      keywords: <String>[
+        'claude',
+        'ccs',
+        'profile',
+        'alias',
+        'quota',
+        'pin',
+        'pinned',
+        'status bar',
+      ],
+    ),
+  },
+  'credentials': {
+    'Kimi API Key Variable': SettingsSearchEntryDetails(
+      description: 'Configure the Kimi API key environment variable name.',
+      keywords: <String>['kimi', 'environment', 'api key', 'KIMI_API_KEY'],
+    ),
+    'Quota Credential Environment': SettingsSearchEntryDetails(
+      description:
+          'Configure environment variable names for Kimi, Z.ai and MiniMax.',
+      keywords: <String>[
+        'environment',
+        'api key',
+        'kimi',
+        'z.ai',
+        'minimax',
+        'remote',
+        'host',
+      ],
+    ),
+  },
+});

--- a/lib/src/features/settings/presentation/settings_search_entry_catalog.dart
+++ b/lib/src/features/settings/presentation/settings_search_entry_catalog.dart
@@ -1,0 +1,26 @@
+import 'package:alera/src/features/settings/presentation/settings_sections.dart';
+
+final class SettingsSearchEntryDetails {
+  const SettingsSearchEntryDetails({
+    this.description,
+    this.keywords = const <String>[],
+  });
+
+  final String? description;
+  final List<String> keywords;
+}
+
+List<SettingsSearchEntry> buildSettingsSearchEntryCatalog(
+  Map<String, Map<String, SettingsSearchEntryDetails>> groups,
+) {
+  return List<SettingsSearchEntry>.unmodifiable(<SettingsSearchEntry>[
+    for (final group in groups.entries)
+      for (final entry in group.value.entries)
+        SettingsSearchEntry(
+          title: entry.key,
+          description: entry.value.description,
+          keywords: entry.value.keywords,
+          groupId: group.key,
+        ),
+  ]);
+}

--- a/lib/src/features/settings/presentation/text_actions_search_entries.dart
+++ b/lib/src/features/settings/presentation/text_actions_search_entries.dart
@@ -1,48 +1,39 @@
+import 'package:alera/src/features/settings/presentation/settings_search_entry_catalog.dart';
 import 'package:alera/src/features/settings/presentation/settings_sections.dart';
 
-const List<SettingsSearchEntry> textActionsSearchEntries =
-    <SettingsSearchEntry>[
-      SettingsSearchEntry(
-        title: 'Text Actions',
-        description: 'Create reusable replacements for selected text.',
-        keywords: <String>[
-          'text',
-          'action',
-          'replace',
-          'selection',
-          'ai',
-          'prompt',
-        ],
-        groupId: 'actions',
-      ),
-      SettingsSearchEntry(
-        title: 'New Action',
-        description: 'Create a reusable text replacement action.',
-        keywords: <String>['create', 'add'],
-        groupId: 'actions',
-      ),
-      SettingsSearchEntry(
-        title: 'Enabled',
-        description: 'Show an action in the Text Actions menu.',
-        keywords: <String>['enable', 'disable'],
-        groupId: 'actions',
-      ),
-      SettingsSearchEntry(
-        title: 'Agent And Model',
-        description: 'Choose the CLI and model for an action.',
-        keywords: <String>['agent', 'model', 'reasoning'],
-        groupId: 'actions',
-      ),
-      SettingsSearchEntry(
-        title: 'Duplicate And Reorder',
-        description: 'Copy actions and arrange their menu order.',
-        keywords: <String>['copy', 'drag', 'sort', 'order'],
-        groupId: 'actions',
-      ),
-      SettingsSearchEntry(
-        title: 'Delete',
-        description: 'Remove a text action after confirmation.',
-        keywords: <String>['remove', 'destructive'],
-        groupId: 'actions',
-      ),
-    ];
+final List<SettingsSearchEntry> textActionsSearchEntries =
+    buildSettingsSearchEntryCatalog(const {
+      'actions': {
+        'Text Actions': SettingsSearchEntryDetails(
+          description: 'Create reusable replacements for selected text.',
+          keywords: <String>[
+            'text',
+            'action',
+            'replace',
+            'selection',
+            'ai',
+            'prompt',
+          ],
+        ),
+        'New Action': SettingsSearchEntryDetails(
+          description: 'Create a reusable text replacement action.',
+          keywords: <String>['create', 'add'],
+        ),
+        'Enabled': SettingsSearchEntryDetails(
+          description: 'Show an action in the Text Actions menu.',
+          keywords: <String>['enable', 'disable'],
+        ),
+        'Agent And Model': SettingsSearchEntryDetails(
+          description: 'Choose the CLI and model for an action.',
+          keywords: <String>['agent', 'model', 'reasoning'],
+        ),
+        'Duplicate And Reorder': SettingsSearchEntryDetails(
+          description: 'Copy actions and arrange their menu order.',
+          keywords: <String>['copy', 'drag', 'sort', 'order'],
+        ),
+        'Delete': SettingsSearchEntryDetails(
+          description: 'Remove a text action after confirmation.',
+          keywords: <String>['remove', 'destructive'],
+        ),
+      },
+    });

--- a/test/unit/settings_search_entries_test.dart
+++ b/test/unit/settings_search_entries_test.dart
@@ -1,9 +1,100 @@
+import 'dart:convert';
+
+import 'package:alera/src/features/settings/presentation/ai_dictation_search_entries.dart';
 import 'package:alera/src/features/settings/presentation/settings_search_entries.dart';
 import 'package:alera/src/features/settings/presentation/settings_search_entries_quota.dart';
 import 'package:alera/src/features/settings/presentation/settings_search_entries_terminal.dart';
+import 'package:alera/src/features/settings/presentation/settings_sections.dart';
+import 'package:alera/src/features/settings/presentation/text_actions_search_entries.dart';
+import 'package:crypto/crypto.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+typedef _SearchCase = ({
+  List<SettingsSearchEntry> entries,
+  String query,
+  List<(String, String?)> expected,
+});
+
 void main() {
+  test('search catalogs preserve exact metadata and order', () {
+    final catalogs = <String, List<SettingsSearchEntry>>{
+      'application': applicationSearchEntries,
+      'agents': agentsSearchEntries,
+      'keyboard': keyboardSearchEntries,
+      'browser': browserSearchEntries,
+      'editor': editorSearchEntries,
+      'aiText': aiTextSearchEntries,
+      'aiDictation': aiDictationSearchEntries,
+      'textActions': textActionsSearchEntries,
+      'quota': quotaSearchEntries,
+    };
+
+    expect(
+      _catalogFingerprint(catalogs),
+      '89a3a912bfe315f784b7da051f870063716d25d72c6d78f03412d30dc525923a',
+    );
+  });
+
+  test('built search catalogs remain immutable', () {
+    expect(
+      () => textActionsSearchEntries.add(
+        const SettingsSearchEntry(title: 'Unexpected Entry'),
+      ),
+      throwsUnsupportedError,
+    );
+  });
+
+  test('search results retain their section order and navigation groups', () {
+    final cases = <_SearchCase>[
+      (
+        entries: applicationSearchEntries,
+        query: 'sidecar',
+        expected: <(String, String?)>[
+          ('Keep Runtime Open When App Quits', 'runtime'),
+          ('Empty Host Shutdown', 'runtime'),
+          ('Detached Session Shutdown', 'runtime'),
+        ],
+      ),
+      (
+        entries: agentsSearchEntries,
+        query: 'xai',
+        expected: <(String, String?)>[('Grok Build Hooks', 'hooks')],
+      ),
+      (
+        entries: browserSearchEntries,
+        query: 'self signed',
+        expected: <(String, String?)>[
+          ('Trusted Local Certificates', 'certificates'),
+        ],
+      ),
+      (
+        entries: aiDictationSearchEntries,
+        query: 'privacy',
+        expected: <(String, String?)>[('Whisper Model', 'models')],
+      ),
+      (
+        entries: textActionsSearchEntries,
+        query: 'destructive',
+        expected: <(String, String?)>[('Delete', 'actions')],
+      ),
+      (
+        entries: quotaSearchEntries,
+        query: 'visible',
+        expected: <(String, String?)>[('Claude Default in Usage', 'claude')],
+      ),
+    ];
+
+    for (final testCase in cases) {
+      expect(
+        testCase.entries
+            .where((entry) => entry.matches(testCase.query))
+            .map((entry) => (entry.title, entry.groupId)),
+        testCase.expected,
+        reason: testCase.query,
+      );
+    }
+  });
+
   test('orchestration skill is searchable in the agents skill group', () {
     final entry = agentsSearchEntries.singleWhere(
       (candidate) => candidate.title == 'Alera Orchestration Skill',
@@ -63,4 +154,21 @@ void main() {
     expect(entry.matches('mouse wheel'), isTrue);
     expect(entry.groupId, 'interaction');
   });
+}
+
+String _catalogFingerprint(Map<String, List<SettingsSearchEntry>> catalogs) {
+  final data = <String, Object?>{
+    for (final catalog in catalogs.entries)
+      catalog.key: <Map<String, Object?>>[
+        for (final entry in catalog.value)
+          <String, Object?>{
+            'title': entry.title,
+            'description': entry.description,
+            'keywords': entry.keywords,
+            'groupId': entry.groupId,
+          },
+      ],
+  };
+  final snapshot = '${const JsonEncoder.withIndent('  ').convert(data)}\n';
+  return sha256.convert(utf8.encode(snapshot)).toString();
 }


### PR DESCRIPTION
## Summary

- Define homogeneous settings search catalogs as navigation-grouped domain data and construct immutable `SettingsSearchEntry` lists through a search-specific catalog factory.
- Keep heterogeneous catalogs explicit where they do not share that contract.
- Preserve every title, description, keyword, group id, catalog order, search result, and navigation target with an exhaustive fingerprint regression test.
- Reduce the four requested catalogs from 587 to 532 lines (−55, 9.4%); including the 26-line catalog module, production code is 29 lines smaller (4.9%). Direct entry constructors fall from 62 to 11.

## Screenshots

No visual change.

## Testing

- [x] `dart format --output=none --set-exit-if-changed lib test integration_test tool`
- [x] `flutter analyze`
- [x] `flutter test test/unit/settings_search_entries_test.dart` (9/9; before/after metadata fingerprint `89a3a912bfe315f784b7da051f870063716d25d72c6d78f03412d30dc525923a`)
- [x] `flutter test --coverage --exclude-tags golden` (3,221 passed, 3 skipped; the 2 native PTY adapter tests fail because the orb's glibc is older than the downloaded `libportable_pty_rs.so`, identically reproduced on clean `origin/main`)
- [x] `dart run tool/quality/coverage_report.dart --input coverage/lcov.info --min-lines 100 --worst 25` (100.00%, 5,403/5,403 domain lines)
- [ ] Golden tests: not applicable; no UI output changed.
- [ ] Desktop E2E/build: not applicable; no app-shell or platform behavior changed.
- [x] Added regression coverage for exact catalog metadata/order, immutability, representative results, and navigation groups.

## AI Review Report

Reviewed the entry model, all catalog consumers, filtering and first-match navigation before extracting the common contract. Confirmed that entries contain no callbacks/routes, consumers do not rely on const identity or a concrete list implementation, and only catalogs with repeated group semantics use the factory. Map insertion order is behaviorally significant and is locked by the exhaustive SHA-256 snapshot plus representative result-order assertions.

No cross-platform behavior changes: this refactor only changes construction of platform-neutral search metadata.

## Security Audit

No input handling, commands, paths, authentication, secrets, dependencies, release, updater, or process behavior changed.

## Notes

The built catalogs remain immutable. Search/navigation behavior depends on declared group and entry order; the fingerprint test is intended to catch accidental drift.