### PR TITLE
refactor: deduplicate sidebar action mutations

### DIFF
--- a/lib/src/features/workbench/presentation/project_workbench_sidebar_actions.dart
+++ b/lib/src/features/workbench/presentation/project_workbench_sidebar_actions.dart
@@ -1,5 +1,23 @@
 part of 'project_workbench_sidebar.dart';
 
+enum _WorkbenchSidebarMutation {
+  renameProject('Project renamed'),
+  renameWorkspace('Workspace renamed'),
+  pinWorkspace('Workspace pinned'),
+  unpinWorkspace('Workspace unpinned'),
+  removeWorkspace('Workspace removed'),
+  updateWorkspaceTags('Workspace tags updated'),
+  updateWorkspaceParent('Workspace parent updated'),
+  clearWorkspaceParent('Workspace parent cleared'),
+  removeProject('Project removed');
+
+  const _WorkbenchSidebarMutation(this.successMessage);
+
+  final String successMessage;
+}
+
+enum _WorkbenchSidebarMutationResult { applied, notApplied }
+
 mixin _ProjectWorkbenchSidebarActions
     on ConsumerState<ProjectWorkbenchSidebar>, _WorkspaceSidebarActions {
   Future<void> _createWorkspaceForActiveProject() async {
@@ -49,28 +67,15 @@ mixin _ProjectWorkbenchSidebarActions
     if (name == null || !mounted) {
       return;
     }
-    try {
-      await ref
-          .read(workbenchControllerProvider.notifier)
-          .renameProject(projectId: project.id, name: name);
-      if (!mounted) {
-        return;
-      }
-      AleraToast.show(
-        context,
-        message: 'Project renamed',
-        tone: AleraToastTone.success,
-      );
-    } catch (error) {
-      if (!mounted) {
-        return;
-      }
-      AleraToast.show(
-        context,
-        message: error.toString(),
-        tone: AleraToastTone.error,
-      );
-    }
+    await _runWorkbenchSidebarMutation(
+      mutation: _WorkbenchSidebarMutation.renameProject,
+      execute: () async {
+        await ref
+            .read(workbenchControllerProvider.notifier)
+            .renameProject(projectId: project.id, name: name);
+        return _WorkbenchSidebarMutationResult.applied;
+      },
+    );
   }
 
   Future<void> _renameWorkspace(Workspace workspace) async {
@@ -84,49 +89,29 @@ mixin _ProjectWorkbenchSidebarActions
     if (name == null || !mounted) {
       return;
     }
-    try {
-      await ref
-          .read(workbenchControllerProvider.notifier)
-          .renameWorkspace(workspaceId: workspace.id, name: name);
-      if (!mounted) {
-        return;
-      }
-      AleraToast.show(
-        context,
-        message: 'Workspace renamed',
-        tone: AleraToastTone.success,
-      );
-    } catch (error) {
-      if (!mounted) {
-        return;
-      }
-      AleraToast.show(
-        context,
-        message: error.toString(),
-        tone: AleraToastTone.error,
-      );
-    }
+    await _runWorkbenchSidebarMutation(
+      mutation: _WorkbenchSidebarMutation.renameWorkspace,
+      execute: () async {
+        await ref
+            .read(workbenchControllerProvider.notifier)
+            .renameWorkspace(workspaceId: workspace.id, name: name);
+        return _WorkbenchSidebarMutationResult.applied;
+      },
+    );
   }
 
   Future<void> _setWorkspacePinned(Workspace workspace, bool isPinned) async {
-    try {
-      await ref
-          .read(workbenchControllerProvider.notifier)
-          .setWorkspacePinned(workspaceId: workspace.id, isPinned: isPinned);
-      if (!mounted) return;
-      AleraToast.show(
-        context,
-        message: isPinned ? 'Workspace pinned' : 'Workspace unpinned',
-        tone: AleraToastTone.success,
-      );
-    } catch (error) {
-      if (!mounted) return;
-      AleraToast.show(
-        context,
-        message: error.toString(),
-        tone: AleraToastTone.error,
-      );
-    }
+    await _runWorkbenchSidebarMutation(
+      mutation: isPinned
+          ? _WorkbenchSidebarMutation.pinWorkspace
+          : _WorkbenchSidebarMutation.unpinWorkspace,
+      execute: () async {
+        await ref
+            .read(workbenchControllerProvider.notifier)
+            .setWorkspacePinned(workspaceId: workspace.id, isPinned: isPinned);
+        return _WorkbenchSidebarMutationResult.applied;
+      },
+    );
   }
 
   Future<void> _deleteWorkspace(Project project, Workspace workspace) async {
@@ -202,41 +187,28 @@ mixin _ProjectWorkbenchSidebarActions
     if (confirmed != true || !mounted) {
       return;
     }
-    try {
-      await ref
-          .read(workbenchControllerProvider.notifier)
-          .deleteWorkspace(
-            project: project,
-            workspace: workspace,
-            deleteBranch: deleteBranch,
-            activeWorkspaceId: ref
-                .read(workbenchControllerProvider)
-                .activeWorkspaceId,
-          );
-      await ref
-          .read(browserSessionRegistryProvider)
-          .closeWorkspace(workspace.id);
-      // Only dispose the live terminal sessions once the worktree was actually
-      // removed, so a failed git removal doesn't orphan a still-valid workspace.
-      ref.read(terminalRuntimeProvider).closeWorkspace(workspace.id);
-      if (!mounted) {
-        return;
-      }
-      AleraToast.show(
-        context,
-        message: 'Workspace removed',
-        tone: AleraToastTone.success,
-      );
-    } catch (error) {
-      if (!mounted) {
-        return;
-      }
-      AleraToast.show(
-        context,
-        message: error.toString(),
-        tone: AleraToastTone.error,
-      );
-    }
+    await _runWorkbenchSidebarMutation(
+      mutation: _WorkbenchSidebarMutation.removeWorkspace,
+      execute: () async {
+        await ref
+            .read(workbenchControllerProvider.notifier)
+            .deleteWorkspace(
+              project: project,
+              workspace: workspace,
+              deleteBranch: deleteBranch,
+              activeWorkspaceId: ref
+                  .read(workbenchControllerProvider)
+                  .activeWorkspaceId,
+            );
+        await ref
+            .read(browserSessionRegistryProvider)
+            .closeWorkspace(workspace.id);
+        // Only dispose the live terminal sessions once the worktree was actually
+        // removed, so a failed git removal doesn't orphan a still-valid workspace.
+        ref.read(terminalRuntimeProvider).closeWorkspace(workspace.id);
+        return _WorkbenchSidebarMutationResult.applied;
+      },
+    );
   }
 
   String _workspaceStorageTimestamp(DateTime value) {
@@ -246,110 +218,71 @@ mixin _ProjectWorkbenchSidebarActions
         '${twoDigits(local.hour)}:${twoDigits(local.minute)}';
   }
 
-  Future<void> _manageWorkspaceTags(Workspace workspace) async {
+  Future<void> _manageWorkspaceTags(Workspace workspace) {
     final controller = ref.read(workbenchControllerProvider.notifier);
-    try {
-      final tags = await controller.listWorkspaceTags();
-      if (!mounted) {
-        return;
-      }
-      final selection = await showWorkspaceTagsDialog(
-        context: context,
-        workspace: workspace,
-        tags: tags,
-        onCreateTag: controller.createWorkspaceTag,
-        onDeleteTag: controller.deleteWorkspaceTag,
-      );
-      if (selection == null || !mounted) {
-        return;
-      }
-      await controller.updateWorkspaceTags(
-        workspace: workspace,
-        tagIds: selection.tagIds,
-      );
-      if (!mounted) {
-        return;
-      }
-      AleraToast.show(
-        context,
-        message: 'Workspace tags updated',
-        tone: AleraToastTone.success,
-      );
-    } catch (error) {
-      if (!mounted) {
-        return;
-      }
-      AleraToast.show(
-        context,
-        message: error.toString(),
-        tone: AleraToastTone.error,
-      );
-    }
+    return _runWorkbenchSidebarMutation(
+      mutation: _WorkbenchSidebarMutation.updateWorkspaceTags,
+      execute: () async {
+        final tags = await controller.listWorkspaceTags();
+        if (!mounted) {
+          return _WorkbenchSidebarMutationResult.notApplied;
+        }
+        final selection = await showWorkspaceTagsDialog(
+          context: context,
+          workspace: workspace,
+          tags: tags,
+          onCreateTag: controller.createWorkspaceTag,
+          onDeleteTag: controller.deleteWorkspaceTag,
+        );
+        if (selection == null || !mounted) {
+          return _WorkbenchSidebarMutationResult.notApplied;
+        }
+        await controller.updateWorkspaceTags(
+          workspace: workspace,
+          tagIds: selection.tagIds,
+        );
+        return _WorkbenchSidebarMutationResult.applied;
+      },
+    );
   }
 
-  Future<void> _setWorkspaceParent(Workspace workspace) async {
+  Future<void> _setWorkspaceParent(Workspace workspace) {
     final controller = ref.read(workbenchControllerProvider.notifier);
-    try {
-      final relations = await controller.listWorkspaceRelations();
-      if (!mounted) {
-        return;
-      }
-      final selection = await showWorkspaceParentDialog(
-        context: context,
-        workspace: workspace,
-        options: _workspaceParentOptions(),
-        relations: relations,
-      );
-      if (selection == null || !mounted) {
-        return;
-      }
-      await controller.setWorkspaceParent(
-        workspace: workspace,
-        parentWorkspaceId: selection.parentWorkspaceId,
-      );
-      if (!mounted) {
-        return;
-      }
-      AleraToast.show(
-        context,
-        message: 'Workspace parent updated',
-        tone: AleraToastTone.success,
-      );
-    } catch (error) {
-      if (!mounted) {
-        return;
-      }
-      AleraToast.show(
-        context,
-        message: error.toString(),
-        tone: AleraToastTone.error,
-      );
-    }
+    return _runWorkbenchSidebarMutation(
+      mutation: _WorkbenchSidebarMutation.updateWorkspaceParent,
+      execute: () async {
+        final relations = await controller.listWorkspaceRelations();
+        if (!mounted) {
+          return _WorkbenchSidebarMutationResult.notApplied;
+        }
+        final selection = await showWorkspaceParentDialog(
+          context: context,
+          workspace: workspace,
+          options: _workspaceParentOptions(),
+          relations: relations,
+        );
+        if (selection == null || !mounted) {
+          return _WorkbenchSidebarMutationResult.notApplied;
+        }
+        await controller.setWorkspaceParent(
+          workspace: workspace,
+          parentWorkspaceId: selection.parentWorkspaceId,
+        );
+        return _WorkbenchSidebarMutationResult.applied;
+      },
+    );
   }
 
-  Future<void> _clearWorkspaceParent(Workspace workspace) async {
-    try {
-      await ref
-          .read(workbenchControllerProvider.notifier)
-          .setWorkspaceParent(workspace: workspace);
-      if (!mounted) {
-        return;
-      }
-      AleraToast.show(
-        context,
-        message: 'Workspace parent cleared',
-        tone: AleraToastTone.success,
-      );
-    } catch (error) {
-      if (!mounted) {
-        return;
-      }
-      AleraToast.show(
-        context,
-        message: error.toString(),
-        tone: AleraToastTone.error,
-      );
-    }
+  Future<void> _clearWorkspaceParent(Workspace workspace) {
+    return _runWorkbenchSidebarMutation(
+      mutation: _WorkbenchSidebarMutation.clearWorkspaceParent,
+      execute: () async {
+        await ref
+            .read(workbenchControllerProvider.notifier)
+            .setWorkspaceParent(workspace: workspace);
+        return _WorkbenchSidebarMutationResult.applied;
+      },
+    );
   }
 
   List<WorkspaceParentOption> _workspaceParentOptions() {
@@ -390,21 +323,34 @@ mixin _ProjectWorkbenchSidebarActions
     for (final workspace in workspaces) {
       runtime.closeWorkspace(workspace.id);
     }
-    try {
-      await ref
-          .read(workbenchControllerProvider.notifier)
-          .removeProject(project.id);
-      for (final workspace in workspaces) {
+    await _runWorkbenchSidebarMutation(
+      mutation: _WorkbenchSidebarMutation.removeProject,
+      execute: () async {
         await ref
-            .read(browserSessionRegistryProvider)
-            .closeWorkspace(workspace.id);
-      }
-      if (!mounted) {
+            .read(workbenchControllerProvider.notifier)
+            .removeProject(project.id);
+        for (final workspace in workspaces) {
+          await ref
+              .read(browserSessionRegistryProvider)
+              .closeWorkspace(workspace.id);
+        }
+        return _WorkbenchSidebarMutationResult.applied;
+      },
+    );
+  }
+
+  Future<void> _runWorkbenchSidebarMutation({
+    required _WorkbenchSidebarMutation mutation,
+    required Future<_WorkbenchSidebarMutationResult> Function() execute,
+  }) async {
+    try {
+      final result = await execute();
+      if (result != _WorkbenchSidebarMutationResult.applied || !mounted) {
         return;
       }
       AleraToast.show(
         context,
-        message: 'Project removed',
+        message: mutation.successMessage,
         tone: AleraToastTone.success,
       );
     } catch (error) {

--- a/test/widget/alera_shell_page_sidebar_actions_test_cases.dart
+++ b/test/widget/alera_shell_page_sidebar_actions_test_cases.dart
@@ -53,30 +53,6 @@ void _registerAleraShellSidebarActionTests() {
     expect(tester.takeException(), isNull);
   });
 
-  testWidgets('project context menu renames the project', (tester) async {
-    final harness = await _pumpShell(
-      tester,
-      state: _linkedWorkbenchState(linkedExpanded: true),
-    );
-
-    await tester.tapAt(
-      tester.getCenter(find.text('Alera').last),
-      buttons: kSecondaryMouseButton,
-    );
-    await tester.pumpAndSettle();
-    await tester.tap(find.text('Rename'));
-    await tester.pumpAndSettle();
-    await tester.enterText(
-      find.widgetWithText(TextField, 'Project Name'),
-      '  Renamed Alera  ',
-    );
-    await tester.tap(find.text('Rename'));
-    await tester.pump();
-    await tester.pump(const Duration(milliseconds: 300));
-
-    expect(harness.controller.state.projects.single.name, 'Renamed Alera');
-  });
-
   testWidgets('workspace context menu renames the workspace', (tester) async {
     final harness = await _pumpShell(
       tester,
@@ -137,32 +113,6 @@ void _registerAleraShellSidebarActionTests() {
     await tester.pump(const Duration(milliseconds: 300));
 
     expect(copiedText, '/repo/alera');
-  });
-
-  testWidgets('workspace context menu creates and assigns tags', (
-    tester,
-  ) async {
-    final state = _linkedWorkbenchState(linkedExpanded: true);
-    final controller = _ShellTestWorkbenchController(state);
-    await _pumpShell(tester, state: state, controller: controller);
-
-    await tester.tapAt(
-      tester.getCenter(find.text('Feature login').first),
-      buttons: kSecondaryMouseButton,
-    );
-    await tester.pumpAndSettle();
-    await tester.tap(find.text('Manage Tags'));
-    await tester.pumpAndSettle();
-    await tester.enterText(find.widgetWithText(TextField, 'New Tag'), 'Review');
-    await tester.tap(find.text('Create Tag'));
-    await tester.pumpAndSettle();
-    await tester.tap(find.text('Save'));
-    await tester.pump();
-    await tester.pump(const Duration(milliseconds: 300));
-
-    expect(controller.workspaceTags.single.name, 'Review');
-    expect(controller.tagUpdates.single.workspaceId, 'workspace-2');
-    expect(controller.tagUpdates.single.tagIds, <String>{'tag-1'});
   });
 
   testWidgets('workspace tags dialog deletes a tag after confirmation', (

--- a/test/widget/alera_shell_page_sidebar_mutation_test_cases.dart
+++ b/test/widget/alera_shell_page_sidebar_mutation_test_cases.dart
@@ -1,0 +1,123 @@
+part of 'alera_shell_page_test.dart';
+
+void _registerAleraShellSidebarMutationTests() {
+  testWidgets('project rename applies the mutation and reports success', (
+    tester,
+  ) async {
+    final events = <AleraToastData>[];
+    final subscription = AleraToast.stream.listen(events.add);
+    addTearDown(subscription.cancel);
+    final harness = await _pumpShell(
+      tester,
+      state: _linkedWorkbenchState(linkedExpanded: true),
+    );
+
+    await tester.tapAt(
+      tester.getCenter(find.text('Alera').last),
+      buttons: kSecondaryMouseButton,
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Rename'));
+    await tester.pumpAndSettle();
+    await tester.enterText(
+      find.widgetWithText(TextField, 'Project Name'),
+      '  Renamed Alera  ',
+    );
+    await tester.tap(find.text('Rename'));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 300));
+
+    expect(harness.controller.state.projects.single.name, 'Renamed Alera');
+    expect(events.last.message, 'Project renamed');
+    expect(events.last.tone, AleraToastTone.success);
+  });
+
+  testWidgets('cancelling a workspace rename leaves it unchanged', (
+    tester,
+  ) async {
+    final events = <AleraToastData>[];
+    final subscription = AleraToast.stream.listen(events.add);
+    addTearDown(subscription.cancel);
+    final harness = await _pumpShell(
+      tester,
+      state: _linkedWorkbenchState(linkedExpanded: true),
+    );
+
+    await tester.tapAt(
+      tester.getCenter(find.text('Feature login').first),
+      buttons: kSecondaryMouseButton,
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Rename'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Cancel'));
+    await tester.pumpAndSettle();
+
+    expect(
+      harness.controller.state.workspacesFor('project-1').last.name,
+      'Feature login',
+    );
+    expect(
+      events.where((event) => event.message == 'Workspace renamed'),
+      isEmpty,
+    );
+  });
+
+  testWidgets('workspace tag mutation applies and reports success', (
+    tester,
+  ) async {
+    final events = <AleraToastData>[];
+    final subscription = AleraToast.stream.listen(events.add);
+    addTearDown(subscription.cancel);
+    final state = _linkedWorkbenchState(linkedExpanded: true);
+    final controller = _ShellTestWorkbenchController(state);
+    await _pumpShell(tester, state: state, controller: controller);
+
+    await tester.tapAt(
+      tester.getCenter(find.text('Feature login').first),
+      buttons: kSecondaryMouseButton,
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Manage Tags'));
+    await tester.pumpAndSettle();
+    await tester.enterText(find.widgetWithText(TextField, 'New Tag'), 'Review');
+    await tester.tap(find.text('Create Tag'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Save'));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 300));
+
+    expect(controller.workspaceTags.single.name, 'Review');
+    expect(controller.tagUpdates.single.workspaceId, 'workspace-2');
+    expect(controller.tagUpdates.single.tagIds, <String>{'tag-1'});
+    expect(events.last.message, 'Workspace tags updated');
+    expect(events.last.tone, AleraToastTone.success);
+  });
+
+  testWidgets('cancelling workspace tag management does not apply changes', (
+    tester,
+  ) async {
+    final events = <AleraToastData>[];
+    final subscription = AleraToast.stream.listen(events.add);
+    addTearDown(subscription.cancel);
+    final state = _linkedWorkbenchState(linkedExpanded: true);
+    final controller = _ShellTestWorkbenchController(state);
+    await _pumpShell(tester, state: state, controller: controller);
+
+    await tester.tapAt(
+      tester.getCenter(find.text('Feature login').first),
+      buttons: kSecondaryMouseButton,
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Manage Tags'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Cancel'));
+    await tester.pumpAndSettle();
+
+    expect(controller.tagUpdates, isEmpty);
+    expect(
+      events.where((event) => event.message == 'Workspace tags updated'),
+      isEmpty,
+    );
+  });
+}

--- a/test/widget/alera_shell_page_test.dart
+++ b/test/widget/alera_shell_page_test.dart
@@ -43,6 +43,7 @@ part 'alera_shell_page_runtime_test_harness.dart';
 part 'alera_shell_page_workbench_test_cases.dart';
 part 'alera_shell_page_codex_sidebar_test_cases.dart';
 part 'alera_shell_page_sidebar_actions_test_cases.dart';
+part 'alera_shell_page_sidebar_mutation_test_cases.dart';
 part 'alera_shell_page_sidebar_states_test_cases.dart';
 part 'alera_shell_page_pinning_test_cases.dart';
 part 'alera_shell_page_sidebar_identity_test_cases.dart';
@@ -120,6 +121,7 @@ void main() {
   _registerAleraShellWorkbenchTests();
   _registerAleraShellCodexSidebarTests();
   _registerAleraShellSidebarActionTests();
+  _registerAleraShellSidebarMutationTests();
   _registerAleraShellSidebarStateTests();
   _registerAleraShellPinningTests();
   _registerAleraShellSidebarIdentityTests();


### PR DESCRIPTION
## Summary
- model sidebar mutations with explicit action and applied/not-applied outcomes
- centralize mounted success/error feedback while preserving each action's dialogs, confirmation, loading, and cleanup effects
- add focused success and cancellation coverage without growing the oversized sidebar action test part

## Validation
- `dart format --output=none --set-exit-if-changed` on changed Dart files
- `dart tool/quality/check_max_lines.dart`
- `flutter analyze lib/src/features/workbench/presentation/project_workbench_sidebar_actions.dart test/widget/alera_shell_page_test.dart`
- `flutter test test/widget/alera_shell_page_test.dart test/unit/max_lines_check_test.dart` (78 passed)
- full local Flutter suite reached 3,218 passed / 3 skipped; its two remaining failures require GLIBC 2.39 from an orb-built PTY asset, while required CI builds the compatible asset with the pinned toolchain
