### PR TITLE
refactor(mobile): simplify workspace file viewer

### DIFF
--- a/mobile/lib/src/features/codex_chat/presentation/mobile_codex_chat_file_preview.dart
+++ b/mobile/lib/src/features/codex_chat/presentation/mobile_codex_chat_file_preview.dart
@@ -173,3 +173,197 @@ class _MobileRemoteLoadMore extends StatelessWidget {
     ),
   );
 }
+
+class _MobileWorkspaceFileViewerView extends StatelessWidget {
+  const _MobileWorkspaceFileViewerView({
+    required this.displayName,
+    required this.range,
+    required this.loading,
+    required this.sharing,
+    required this.onShare,
+    required this.body,
+  });
+
+  final String displayName;
+  final MobileWorkspaceFileRange? range;
+  final bool loading;
+  final bool sharing;
+  final Future<void> Function(BuildContext context) onShare;
+  final Widget body;
+
+  @override
+  Widget build(BuildContext context) => Scaffold(
+    appBar: AppBar(
+      title: Text(displayName),
+      actions: <Widget>[
+        if (range != null && mobileWorkspaceFileCanShare(range!.totalBytes))
+          Builder(
+            builder: (shareContext) => IconButton(
+              tooltip: 'Share File',
+              onPressed: loading || sharing
+                  ? null
+                  : () => unawaited(onShare(shareContext)),
+              icon: sharing
+                  ? const SizedBox.square(
+                      dimension: AleraTokens.iconSm,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : const Icon(Icons.ios_share_outlined),
+            ),
+          ),
+      ],
+    ),
+    body: body,
+  );
+}
+
+class _MobileWorkspaceFileViewerBody extends StatelessWidget {
+  const _MobileWorkspaceFileViewerBody({
+    required this.range,
+    required this.error,
+    required this.rasterFile,
+    required this.lines,
+    required this.targetLine,
+    required this.loadedPreviewBytes,
+    required this.loading,
+    required this.sharing,
+    required this.scrollController,
+    required this.targetLineKey,
+    required this.onLoadMore,
+  });
+
+  final MobileWorkspaceFileRange? range;
+  final Object? error;
+  final File? rasterFile;
+  final List<String> lines;
+  final int? targetLine;
+  final int loadedPreviewBytes;
+  final bool loading;
+  final bool sharing;
+  final ScrollController scrollController;
+  final GlobalKey targetLineKey;
+  final Future<void> Function() onLoadMore;
+
+  @override
+  Widget build(BuildContext context) {
+    if (error != null) {
+      return _MobileError(message: error.toString(), onRetry: onLoadMore);
+    }
+    final range = this.range;
+    if (range == null) {
+      return const Center(child: CircularProgressIndicator());
+    }
+    final canLoadMore =
+        range.totalBytes <= maxMobileWorkspacePreviewBytes &&
+        loadedPreviewBytes < maxMobileWorkspacePreviewBytes;
+    final busy = loading || sharing;
+    if (mobileCodexCanRasterPreviewMime(range.mimeType)) {
+      return _MobileRemoteImagePreview(
+        file: rasterFile,
+        complete: range.nextOffset >= range.totalBytes,
+        canLoadMore: canLoadMore,
+        loading: busy,
+        onLoadMore: onLoadMore,
+      );
+    }
+    if (range.isText) {
+      return _MobileWorkspaceTextPreview(
+        lines: lines,
+        targetLine: targetLine,
+        hasMore: range.nextOffset < range.totalBytes,
+        previewLimitReached:
+            loadedPreviewBytes >= maxMobileWorkspacePreviewBytes,
+        loading: loading,
+        sharing: sharing,
+        scrollController: scrollController,
+        targetLineKey: targetLineKey,
+        onLoadMore: onLoadMore,
+      );
+    }
+    return _MobileUnsupportedFilePreview(
+      complete: range.nextOffset >= range.totalBytes,
+      shareable: mobileWorkspaceFileCanShare(range.totalBytes),
+      canLoadMore: canLoadMore,
+      loading: busy,
+      onLoadMore: onLoadMore,
+    );
+  }
+}
+
+class _MobileWorkspaceTextPreview extends StatelessWidget {
+  const _MobileWorkspaceTextPreview({
+    required this.lines,
+    required this.targetLine,
+    required this.hasMore,
+    required this.previewLimitReached,
+    required this.loading,
+    required this.sharing,
+    required this.scrollController,
+    required this.targetLineKey,
+    required this.onLoadMore,
+  });
+
+  final List<String> lines;
+  final int? targetLine;
+  final bool hasMore;
+  final bool previewLimitReached;
+  final bool loading;
+  final bool sharing;
+  final ScrollController scrollController;
+  final GlobalKey targetLineKey;
+  final Future<void> Function() onLoadMore;
+
+  @override
+  Widget build(BuildContext context) => ListView.builder(
+    controller: scrollController,
+    itemCount: lines.length + (hasMore ? 1 : 0),
+    itemBuilder: (context, index) {
+      if (index == lines.length) {
+        return Padding(
+          padding: AleraTokens.contentPadding,
+          child: FilledButton(
+            onPressed: loading || sharing || previewLimitReached
+                ? null
+                : () => unawaited(onLoadMore()),
+            child: Text(
+              loading
+                  ? 'Loading...'
+                  : previewLimitReached
+                  ? 'Preview Limit Reached'
+                  : 'Load More',
+            ),
+          ),
+        );
+      }
+      final number = index + 1;
+      final highlighted = number == targetLine;
+      return Container(
+        key: highlighted ? targetLineKey : null,
+        color: highlighted ? AleraTokens.accentSubtle : null,
+        padding: const EdgeInsets.symmetric(
+          horizontal: AleraTokens.space12,
+          vertical: AleraTokens.space2,
+        ),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            SizedBox(
+              width: AleraTokens.space48,
+              child: Text('$number', style: AleraTokens.monoStyle),
+            ),
+            Expanded(
+              child: SelectableText(
+                lines[index],
+                style: AleraTokens.monoStyle.copyWith(
+                  color: highlighted
+                      ? AleraTokens.foreground
+                      : AleraTokens.foregroundMuted,
+                ),
+              ),
+            ),
+          ],
+        ),
+      );
+    },
+  );
+}

--- a/mobile/lib/src/features/codex_chat/presentation/mobile_codex_chat_viewer.dart
+++ b/mobile/lib/src/features/codex_chat/presentation/mobile_codex_chat_viewer.dart
@@ -339,111 +339,24 @@ class _MobileWorkspaceFileViewerState
   }
 
   @override
-  Widget build(BuildContext context) {
-    final range = _range;
-    return Scaffold(
-      appBar: AppBar(
-        title: Text(_displayName),
-        actions: <Widget>[
-          if (range != null && mobileWorkspaceFileCanShare(range.totalBytes))
-            Builder(
-              builder: (shareContext) => IconButton(
-                tooltip: 'Share File',
-                onPressed: _sharing || _loading
-                    ? null
-                    : () => unawaited(_shareFile(shareContext)),
-                icon: _sharing
-                    ? const SizedBox.square(
-                        dimension: AleraTokens.iconSm,
-                        child: CircularProgressIndicator(strokeWidth: 2),
-                      )
-                    : const Icon(Icons.ios_share_outlined),
-              ),
-            ),
-        ],
-      ),
-      body: _error != null
-          ? _MobileError(message: _error.toString(), onRetry: _load)
-          : range == null
-          ? const Center(child: CircularProgressIndicator())
-          : mobileCodexCanRasterPreviewMime(range.mimeType)
-          ? _MobileRemoteImagePreview(
-              file: _rasterFile,
-              complete: range.nextOffset >= range.totalBytes,
-              canLoadMore:
-                  range.totalBytes <= maxMobileWorkspacePreviewBytes &&
-                  _loadedPreviewBytes < maxMobileWorkspacePreviewBytes,
-              loading: _loading || _sharing,
-              onLoadMore: _load,
-            )
-          : range.isText
-          ? ListView.builder(
-              controller: _fileScroll,
-              itemCount:
-                  _lines.length + (range.nextOffset < range.totalBytes ? 1 : 0),
-              itemBuilder: (context, index) {
-                if (index == _lines.length) {
-                  return Padding(
-                    padding: AleraTokens.contentPadding,
-                    child: FilledButton(
-                      onPressed:
-                          _loading ||
-                              _sharing ||
-                              _loadedPreviewBytes >=
-                                  maxMobileWorkspacePreviewBytes
-                          ? null
-                          : () => unawaited(_load()),
-                      child: Text(
-                        _loading
-                            ? 'Loading...'
-                            : _loadedPreviewBytes >=
-                                  maxMobileWorkspacePreviewBytes
-                            ? 'Preview Limit Reached'
-                            : 'Load More',
-                      ),
-                    ),
-                  );
-                }
-                final number = index + 1;
-                final highlighted = number == widget.target.line;
-                return Container(
-                  key: highlighted ? _targetLineKey : null,
-                  color: highlighted ? AleraTokens.accentSubtle : null,
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: AleraTokens.space12,
-                    vertical: AleraTokens.space2,
-                  ),
-                  child: Row(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: <Widget>[
-                      SizedBox(
-                        width: AleraTokens.space48,
-                        child: Text('$number', style: AleraTokens.monoStyle),
-                      ),
-                      Expanded(
-                        child: SelectableText(
-                          _lines[index],
-                          style: AleraTokens.monoStyle.copyWith(
-                            color: highlighted
-                                ? AleraTokens.foreground
-                                : AleraTokens.foregroundMuted,
-                          ),
-                        ),
-                      ),
-                    ],
-                  ),
-                );
-              },
-            )
-          : _MobileUnsupportedFilePreview(
-              complete: range.nextOffset >= range.totalBytes,
-              shareable: mobileWorkspaceFileCanShare(range.totalBytes),
-              canLoadMore:
-                  range.totalBytes <= maxMobileWorkspacePreviewBytes &&
-                  _loadedPreviewBytes < maxMobileWorkspacePreviewBytes,
-              loading: _loading || _sharing,
-              onLoadMore: _load,
-            ),
-    );
-  }
+  Widget build(BuildContext context) => _MobileWorkspaceFileViewerView(
+    displayName: _displayName,
+    range: _range,
+    loading: _loading,
+    sharing: _sharing,
+    onShare: _shareFile,
+    body: _MobileWorkspaceFileViewerBody(
+      range: _range,
+      error: _error,
+      rasterFile: _rasterFile,
+      lines: _lines,
+      targetLine: widget.target.line,
+      loadedPreviewBytes: _loadedPreviewBytes,
+      loading: _loading,
+      sharing: _sharing,
+      scrollController: _fileScroll,
+      targetLineKey: _targetLineKey,
+      onLoadMore: _load,
+    ),
+  );
 }

--- a/mobile/test/mobile_codex_chat_widget_test.dart
+++ b/mobile/test/mobile_codex_chat_widget_test.dart
@@ -25,6 +25,7 @@ import 'support/fake_mobile_codex_client.dart';
 part 'mobile_codex_chat_widget_foundation_test_cases.dart';
 part 'mobile_codex_chat_widget_catalog_test_cases.dart';
 part 'mobile_codex_chat_widget_model_menu_test_cases.dart';
+part 'mobile_codex_chat_widget_viewer_test_cases.dart';
 part 'mobile_codex_chat_widget_timeline_test_cases.dart';
 part 'mobile_codex_chat_widget_turn_activity_test_cases.dart';
 part 'mobile_codex_chat_widget_file_change_test_cases.dart';
@@ -47,6 +48,7 @@ void main() {
   _registerMobileCodexFoundationTests();
   _registerMobileCodexCatalogTests();
   _registerMobileCodexModelMenuTests();
+  _registerMobileCodexViewerTests();
   _registerMobileCodexTimelineTests();
   _registerMobileCodexTurnActivityTests();
   _registerMobileCodexFileChangeTests();

--- a/mobile/test/mobile_codex_chat_widget_viewer_test_cases.dart
+++ b/mobile/test/mobile_codex_chat_widget_viewer_test_cases.dart
@@ -1,0 +1,106 @@
+part of 'mobile_codex_chat_widget_test.dart';
+
+void _registerMobileCodexViewerTests() {
+  testWidgets('mobile renders empty text file previews without load controls', (
+    tester,
+  ) async {
+    final client = FakeMobileCodexClient(
+      workspaceFiles: const <String>['empty.md'],
+      timelineCells: const <Object?>[
+        <String, Object?>{
+          'id': 'empty-file-link',
+          'kind': 'assistantMessage',
+          'status': 'completed',
+          'markdownText': '[empty.md](empty.md)',
+        },
+      ],
+      workspaceFileReader:
+          (workspaceId, relativePath, cwd, offset, length) async {
+            return const MobileWorkspaceFileRange(
+              relativePath: 'empty.md',
+              offset: 0,
+              nextOffset: 0,
+              totalBytes: 0,
+              mimeType: 'text/markdown',
+              isText: true,
+              bytes: <int>[],
+            );
+          },
+    );
+    addTearDown(client.dispose);
+    await _pumpScreen(tester, client: client, hostId: 'host-empty-preview');
+
+    await tester.tap(find.text('empty.md'));
+    await tester.pump();
+    await tester.runAsync(
+      () => Future<void>.delayed(const Duration(milliseconds: 100)),
+    );
+    await tester.pump(const Duration(milliseconds: 300));
+
+    expect(find.byType(ListView), findsOneWidget);
+    expect(
+      find.byWidgetPredicate(
+        (widget) => widget is SelectableText && widget.data == '',
+      ),
+      findsOneWidget,
+    );
+    expect(find.text('Load More'), findsNothing);
+  });
+
+  testWidgets('mobile scrolls to and highlights a linked text line', (
+    tester,
+  ) async {
+    final contents = List<String>.generate(
+      200,
+      (index) => 'line ${index + 1}',
+    ).join('\n');
+    final bytes = utf8.encode(contents);
+    final client = FakeMobileCodexClient(
+      workspaceFiles: const <String>['long.md'],
+      timelineCells: const <Object?>[
+        <String, Object?>{
+          'id': 'long-file-link',
+          'kind': 'assistantMessage',
+          'status': 'completed',
+          'markdownText': '[long.md](long.md#L150)',
+        },
+      ],
+      workspaceFileReader:
+          (workspaceId, relativePath, cwd, offset, length) async {
+            return MobileWorkspaceFileRange(
+              relativePath: 'long.md',
+              offset: 0,
+              nextOffset: bytes.length,
+              totalBytes: bytes.length,
+              mimeType: 'text/markdown',
+              isText: true,
+              bytes: bytes,
+            );
+          },
+    );
+    addTearDown(client.dispose);
+    await _pumpScreen(tester, client: client, hostId: 'host-target-line');
+
+    await tester.tap(find.text('long.md'));
+    await tester.pump();
+    await tester.runAsync(
+      () => Future<void>.delayed(const Duration(milliseconds: 100)),
+    );
+    for (var index = 0; index < 4; index++) {
+      await tester.pump(const Duration(milliseconds: 100));
+    }
+
+    final targetLine = find.text('line 150');
+    expect(targetLine, findsOneWidget);
+    expect(
+      find.ancestor(
+        of: targetLine,
+        matching: find.byWidgetPredicate(
+          (widget) =>
+              widget is Container && widget.color == AleraTokens.accentSubtle,
+        ),
+      ),
+      findsOneWidget,
+    );
+  });
+}


### PR DESCRIPTION
## Summary

- move workspace file viewer presentation branches into co-located stateless widgets
- keep loading, sharing, lifecycle, async cleanup, and target-line scrolling in the existing state owner
- add viewer regressions for empty text files and distant linked-line highlighting

## Screenshots

No visual change.

## Testing

- [x] Focused `dart format` for changed Dart files
- [x] Focused `flutter analyze` for the viewer, preview widgets, and widget tests
- [x] Six representative viewer widget tests
- [x] `dart --packages=mobile/.dart_tool/package_config.json tool/quality/check_max_lines.dart`
- [x] Added tests for empty previews and target-line scrolling/highlighting

## AI Review Report

Reviewed state/effect ownership, async disposal paths, share/load gating, lazy list construction, target-line `ScrollController`/`GlobalKey` identity, and theme-token usage. The initial extraction exceeded the repository's 500-line ratchet, so the presentation widgets and tests were split into their existing co-located owners; the ratchet now passes. Focused analysis and viewer tests are green.

No cross-platform shortcut, label, path, shell, terminal, release, or updater behavior changed.

## Security Audit

No new input handling, command execution, auth, secret, dependency, updater, or process-execution surface. Existing workspace file reads and native share behavior are unchanged.

## Notes

- no Riverpod provider or mutable state was added
- no timeline or model-menu code changed
- local full mobile analysis and the two general Codex goldens have pre-existing failures reproducible on a clean `origin/main`; required CI is authoritative for this PR