### PR TITLE
refactor: simplify typed codex session commands

### DIFF
--- a/lib/src/features/codex_chat/presentation/codex_chat_surface.dart
+++ b/lib/src/features/codex_chat/presentation/codex_chat_surface.dart
@@ -67,6 +67,7 @@ part 'codex_chat_surface_dialogs.dart';
 part 'codex_chat_surface_goal.dart';
 part 'codex_chat_review_dialog.dart';
 part 'codex_chat_surface_draft_actions.dart';
+part 'codex_chat_surface_typed_session_commands.dart';
 part 'codex_chat_surface_link_handling.dart';
 part 'codex_chat_surface_plan_actions.dart';
 part 'codex_chat_surface_session_actions.dart';

--- a/lib/src/features/codex_chat/presentation/codex_chat_surface_draft_actions.dart
+++ b/lib/src/features/codex_chat/presentation/codex_chat_surface_draft_actions.dart
@@ -260,88 +260,14 @@ extension _CodexDraftActions on _CodexChatSurfaceState {
     CodexChatState state,
   ) async {
     if (_attachments.isNotEmpty || _draftItems.isNotEmpty) return false;
-    final match = RegExp(
-      r'^/(goal|rename|new|clear|resume)(?:\s+(.+))?$',
-      caseSensitive: false,
-    ).firstMatch(_composer.text.trim());
-    if (match == null) return false;
-    final command = match.group(1)!.toLowerCase();
-    final argument = match.group(2)?.trim();
-    if (_savedPrompts.any((prompt) => prompt.name.toLowerCase() == command)) {
+    final command = _TypedSessionCommand.parse(_composer.text);
+    if (command == null) return false;
+    if (_savedPrompts.any(
+      (prompt) => prompt.name.toLowerCase() == command.kind.token,
+    )) {
       return false;
     }
-    if (command == 'goal') {
-      if (!state.supportsGoals) return true;
-      final normalizedArgument = argument?.toLowerCase();
-      _composer.clear();
-      switch (normalizedArgument) {
-        case 'pause':
-          await controller.updateGoalStatus(CodexThreadGoalStatus.paused);
-        case 'resume':
-          await controller.updateGoalStatus(CodexThreadGoalStatus.active);
-        case 'clear':
-          await controller.clearGoal();
-        case 'edit':
-          final goal = state.snapshot.goal;
-          if (goal != null) {
-            final edited = await _showCodexGoalEditor(
-              context,
-              initialObjective: goal.objective,
-            );
-            if (edited != null) await controller.editGoal(edited);
-          }
-        default:
-          if (argument == null || argument.isEmpty) {
-            final edited = await _showCodexGoalEditor(
-              context,
-              initialObjective: state.snapshot.goal?.objective ?? '',
-            );
-            if (edited != null) {
-              if (state.snapshot.goal == null) {
-                await controller.setGoal(edited, recordUserMessage: true);
-              } else {
-                await controller.editGoal(edited);
-              }
-            }
-          } else {
-            await controller.replaceGoal(argument, recordUserMessage: true);
-          }
-      }
-      return true;
-    }
-    if (!state.supportsSessions) {
-      if (command == 'resume') return false;
-      if (command == 'new' || command == 'clear') {
-        _composer.clear();
-        await _openLegacyCodexTab();
-        return true;
-      }
-    }
-    if (command == 'resume' && argument != null && argument.isNotEmpty) {
-      return false;
-    }
-    _composer.clear();
-    switch (command) {
-      case 'rename':
-        if (argument == null || argument.isEmpty) {
-          await _rename(context, controller);
-        } else {
-          await controller.rename(argument);
-        }
-      case 'new':
-        final succeeded = await controller.newThread();
-        if (succeeded && argument != null && argument.isNotEmpty) {
-          await controller.rename(argument);
-        }
-      case 'clear':
-        final succeeded = await controller.clearThread();
-        if (succeeded && argument != null && argument.isNotEmpty) {
-          await controller.rename(argument);
-        }
-      case 'resume':
-        await _resumeThread(context, controller, state);
-    }
-    return true;
+    return _dispatchTypedSessionCommand(controller, state, command);
   }
 
   void _editQueued(

--- a/lib/src/features/codex_chat/presentation/codex_chat_surface_typed_session_commands.dart
+++ b/lib/src/features/codex_chat/presentation/codex_chat_surface_typed_session_commands.dart
@@ -1,0 +1,185 @@
+part of 'codex_chat_surface.dart';
+
+enum _TypedSessionCommandKind {
+  goal('goal'),
+  rename('rename'),
+  newThread('new'),
+  clear('clear'),
+  resume('resume');
+
+  const _TypedSessionCommandKind(this.token);
+
+  final String token;
+}
+
+final class _TypedSessionCommand {
+  const _TypedSessionCommand({required this.kind, required this.argument});
+
+  static final RegExp _pattern = RegExp(
+    r'^/(goal|rename|new|clear|resume)(?:\s+(.+))?$',
+    caseSensitive: false,
+  );
+
+  final _TypedSessionCommandKind kind;
+  final String? argument;
+
+  bool get hasArgument => argument != null && argument!.isNotEmpty;
+
+  static _TypedSessionCommand? parse(String text) {
+    final match = _pattern.firstMatch(text.trim());
+    if (match == null) return null;
+    final token = match.group(1)!.toLowerCase();
+    return _TypedSessionCommand(
+      kind: _TypedSessionCommandKind.values.firstWhere(
+        (kind) => kind.token == token,
+      ),
+      argument: match.group(2)?.trim(),
+    );
+  }
+}
+
+extension _CodexTypedSessionCommands on _CodexChatSurfaceState {
+  Future<bool> _dispatchTypedSessionCommand(
+    CodexChatController controller,
+    CodexChatState state,
+    _TypedSessionCommand command,
+  ) => switch (command.kind) {
+    _TypedSessionCommandKind.goal => _runTypedGoalCommand(
+      controller,
+      state,
+      command,
+    ),
+    _TypedSessionCommandKind.rename => _runTypedRenameCommand(
+      controller,
+      command,
+    ),
+    _TypedSessionCommandKind.newThread => _runTypedThreadResetCommand(
+      controller,
+      state,
+      command,
+      controller.newThread,
+    ),
+    _TypedSessionCommandKind.clear => _runTypedThreadResetCommand(
+      controller,
+      state,
+      command,
+      controller.clearThread,
+    ),
+    _TypedSessionCommandKind.resume => _runTypedResumeCommand(
+      controller,
+      state,
+      command,
+    ),
+  };
+
+  Future<bool> _runTypedGoalCommand(
+    CodexChatController controller,
+    CodexChatState state,
+    _TypedSessionCommand command,
+  ) async {
+    if (!state.supportsGoals) return true;
+    _composer.clear();
+    await _executeTypedGoalCommand(controller, state, command);
+    return true;
+  }
+
+  Future<void> _executeTypedGoalCommand(
+    CodexChatController controller,
+    CodexChatState state,
+    _TypedSessionCommand command,
+  ) async {
+    switch (command.argument?.toLowerCase()) {
+      case 'pause':
+        await controller.updateGoalStatus(CodexThreadGoalStatus.paused);
+      case 'resume':
+        await controller.updateGoalStatus(CodexThreadGoalStatus.active);
+      case 'clear':
+        await controller.clearGoal();
+      case 'edit':
+        final goal = state.snapshot.goal;
+        if (goal != null) {
+          final edited = await _showCodexGoalEditor(
+            context,
+            initialObjective: goal.objective,
+          );
+          if (edited != null) await controller.editGoal(edited);
+        }
+      default:
+        await _setGoalFromTypedCommand(controller, state, command.argument);
+    }
+  }
+
+  Future<void> _setGoalFromTypedCommand(
+    CodexChatController controller,
+    CodexChatState state,
+    String? argument,
+  ) async {
+    if (argument != null && argument.isNotEmpty) {
+      await controller.replaceGoal(argument, recordUserMessage: true);
+      return;
+    }
+    final edited = await _showCodexGoalEditor(
+      context,
+      initialObjective: state.snapshot.goal?.objective ?? '',
+    );
+    if (edited == null) return;
+    if (state.snapshot.goal == null) {
+      await controller.setGoal(edited, recordUserMessage: true);
+    } else {
+      await controller.editGoal(edited);
+    }
+  }
+
+  Future<bool> _runTypedRenameCommand(
+    CodexChatController controller,
+    _TypedSessionCommand command,
+  ) async {
+    _composer.clear();
+    if (command.hasArgument) {
+      await controller.rename(command.argument!);
+    } else {
+      await _rename(context, controller);
+    }
+    return true;
+  }
+
+  Future<bool> _runTypedThreadResetCommand(
+    CodexChatController controller,
+    CodexChatState state,
+    _TypedSessionCommand command,
+    Future<bool> Function() reset,
+  ) async {
+    _composer.clear();
+    if (!state.supportsSessions) {
+      await _openLegacyCodexTab();
+      return true;
+    }
+    final succeeded = await reset();
+    final result = _handleTypedThreadResetResult(
+      controller,
+      command,
+      succeeded,
+    );
+    if (result != null) await result;
+    return true;
+  }
+
+  Future<void>? _handleTypedThreadResetResult(
+    CodexChatController controller,
+    _TypedSessionCommand command,
+    bool succeeded,
+  ) => succeeded && command.hasArgument
+      ? controller.rename(command.argument!)
+      : null;
+
+  Future<bool> _runTypedResumeCommand(
+    CodexChatController controller,
+    CodexChatState state,
+    _TypedSessionCommand command,
+  ) async {
+    if (!state.supportsSessions || command.hasArgument) return false;
+    _composer.clear();
+    await _resumeThread(context, controller, state);
+    return true;
+  }
+}

--- a/test/widget/codex_chat_surface_session_test_cases.dart
+++ b/test/widget/codex_chat_surface_session_test_cases.dart
@@ -71,6 +71,87 @@ void registerCodexChatSurfaceSessionTests() {
     );
   });
 
+  testWidgets('typed session commands preserve parsing and result order', (
+    tester,
+  ) async {
+    final client = _SurfaceRuntimeClient(
+      supportsSessions: true,
+      pendingRequests: const <Object?>[],
+    );
+    addTearDown(client.dispose);
+    await _pumpSessionSurface(tester, client);
+    final composer = find.byKey(
+      const ValueKey<String>('codex-composer-text-field'),
+    );
+
+    Future<void> submit(String command) async {
+      await tester.enterText(composer, command);
+      await tester.pump();
+      await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+      await tester.pumpAndSettle();
+    }
+
+    await submit('  /NeW   Feature  Thread  ');
+    await submit('/clear Reset Thread');
+    await submit('/ReNaMe Final Thread');
+
+    final requests = client.requests
+        .where(
+          (request) =>
+              request.type == 'codex.thread.new' ||
+              request.type == 'codex.thread.clear' ||
+              request.type == 'codex.thread.rename',
+        )
+        .toList();
+    expect(requests.map((request) => request.type), <String>[
+      'codex.thread.new',
+      'codex.thread.rename',
+      'codex.thread.clear',
+      'codex.thread.rename',
+      'codex.thread.rename',
+    ]);
+    expect(
+      requests
+          .where((request) => request.type == 'codex.thread.rename')
+          .map((request) => request.payload['name']),
+      <String>['Feature  Thread', 'Reset Thread', 'Final Thread'],
+    );
+    expect(tester.widget<TextField>(composer).controller?.text, isEmpty);
+    expect(tester.widget<TextField>(composer).focusNode?.hasFocus, isTrue);
+  });
+
+  testWidgets('failed typed reset reports the error without renaming', (
+    tester,
+  ) async {
+    final client = _SurfaceRuntimeClient(
+      supportsSessions: true,
+      pendingRequests: const <Object?>[],
+      sessionCommandFailures: const <String>{'codex.thread.new'},
+    );
+    addTearDown(client.dispose);
+    await _pumpSessionSurface(tester, client);
+    final composer = find.byKey(
+      const ValueKey<String>('codex-composer-text-field'),
+    );
+
+    await tester.enterText(composer, '/new Must Not Rename');
+    await tester.pump();
+    await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+    await tester.pumpAndSettle();
+
+    final container = ProviderScope.containerOf(
+      tester.element(find.byType(CodexChatSurface)),
+    );
+    expect(client.requestTypes, contains('codex.thread.new'));
+    expect(client.requestTypes, isNot(contains('codex.thread.rename')));
+    expect(
+      container.read(codexChatControllerProvider('codex-tab')).error,
+      contains('codex.thread.new failed'),
+    );
+    expect(tester.widget<TextField>(composer).controller?.text, isEmpty);
+    expect(tester.widget<TextField>(composer).focusNode?.hasFocus, isTrue);
+  });
+
   testWidgets('legacy hosts keep new and clear commands available', (
     tester,
   ) async {
@@ -136,6 +217,35 @@ void registerCodexChatSurfaceSessionTests() {
     expect(input.whereType<Map>().single['text'], '/resume old');
   });
 
+  testWidgets('invalid typed commands fall through as prompts', (tester) async {
+    final client = _SurfaceRuntimeClient(
+      supportsSessions: true,
+      pendingRequests: const <Object?>[],
+    );
+    addTearDown(client.dispose);
+    await _pumpSessionSurface(tester, client);
+    final composer = find.byKey(
+      const ValueKey<String>('codex-composer-text-field'),
+    );
+
+    for (final prompt in <String>['/resume old', '/newish thread']) {
+      await tester.enterText(composer, prompt);
+      await tester.pump();
+      await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+      await tester.pumpAndSettle();
+    }
+
+    expect(client.requestTypes, isNot(contains('codex.thread.resume')));
+    expect(client.requestTypes, isNot(contains('codex.thread.new')));
+    expect(
+      client.startTurnPayloads.map((payload) {
+        final input = payload['input']! as List<Object?>;
+        return input.whereType<Map>().single['text'];
+      }),
+      <String>['/resume old', '/newish thread'],
+    );
+  });
+
   testWidgets('resume and earlier history are reachable from the surface', (
     tester,
   ) async {
@@ -197,7 +307,7 @@ void registerCodexChatSurfaceSessionTests() {
     expect(find.text('Current history'), findsOneWidget);
 
     final composer = find.byType(TextField).last;
-    await _selectSlashCommand(tester, composer, '/resume');
+    await _selectSlashCommand(tester, composer, ' /ReSuMe ');
     await tester.pumpAndSettle();
     expect(find.text('Old Thread'), findsOneWidget);
     await tester.tap(find.text('Old Thread'));

--- a/test/widget/codex_chat_surface_test_support.dart
+++ b/test/widget/codex_chat_surface_test_support.dart
@@ -75,6 +75,7 @@ final class _SurfaceRuntimeClient implements RuntimeHostClient {
     this.goalGetFailureMessage = 'temporary goal read failure',
     this.goalSetFailures = 0,
     this.goalSetFailureMessage = 'temporary goal set failure',
+    this.sessionCommandFailures = const <String>{},
     this.historyNextCursor,
     this.historyTimelineCells = const <Object?>[],
     this.historyGate,
@@ -103,6 +104,7 @@ final class _SurfaceRuntimeClient implements RuntimeHostClient {
   final String goalGetFailureMessage;
   int goalSetFailures;
   final String goalSetFailureMessage;
+  final Set<String> sessionCommandFailures;
   final String? historyNextCursor;
   final List<Object?> historyTimelineCells;
   final Completer<void>? historyGate;
@@ -116,6 +118,8 @@ final class _SurfaceRuntimeClient implements RuntimeHostClient {
   final Map<String, Object?> skills;
   final List<Map<String, Object?>> collaborationModes;
   final List<String> requestTypes = <String>[];
+  final List<({String type, Map<String, Object?> payload})> requests =
+      <({String type, Map<String, Object?> payload})>[];
   final List<Map<String, Object?>> startTurnPayloads = <Map<String, Object?>>[];
   final List<Map<String, Object?>> responsePayloads = <Map<String, Object?>>[];
   final List<Map<String, Object?>> reviewPayloads = <Map<String, Object?>>[];
@@ -134,6 +138,10 @@ final class _SurfaceRuntimeClient implements RuntimeHostClient {
     Duration? timeout,
   ]) async {
     requestTypes.add(type);
+    requests.add((type: type, payload: Map.unmodifiable(payload)));
+    if (sessionCommandFailures.contains(type)) {
+      throw StateError('$type failed');
+    }
     if (type == 'status.get') {
       return <String, Object?>{
         'runtimeCapabilities': <String>[


### PR DESCRIPTION
## Summary
- split typed Codex command parsing, dispatch, and result handling into focused responsibilities
- preserve draft clearing, focus, legacy fallbacks, saved prompt precedence, and controller error reporting
- characterize valid, invalid, and failed typed session commands

## Validation
- dart format on the five affected files
- focused flutter analyze on the five affected files
- 9 focused Codex surface widget tests

## Risk
- internal refactor only; no ProcessRunner, PTY, deferred-enter, snapshot, or timeline behavior changed