### PR TITLE
refactor: simplify create workspace dialog

### DIFF
--- a/lib/src/features/workbench/presentation/create_workspace_dialog.dart
+++ b/lib/src/features/workbench/presentation/create_workspace_dialog.dart
@@ -19,7 +19,11 @@ import 'package:alera/src/features/workbench/domain/workspace_parent_selection_o
 import 'package:flutter/material.dart';
 
 part 'create_workspace_dialog_pickers.dart';
+part 'create_workspace_dialog_frame.dart';
+part 'create_workspace_dialog_interactions.dart';
 part 'create_workspace_dialog_selection_order.dart';
+part 'create_workspace_dialog_selection_step.dart';
+part 'create_workspace_dialog_settings_step.dart';
 part 'create_workspace_dialog_submission.dart';
 
 class CreateWorkspaceDialog extends StatefulWidget {
@@ -186,25 +190,6 @@ class _CreateWorkspaceDialogState extends State<CreateWorkspaceDialog> {
 
   List<String> _branchesForMode(bool reuseExistingBranch) {
     return reuseExistingBranch ? _localBranches : _branches;
-  }
-
-  String _parentLabel(WorkspaceParentCandidate candidate) {
-    final branch = candidate.workspace.branch;
-    final suffix = branch == null || branch.isEmpty ? '' : ' - $branch';
-    return '${candidate.project.name} / ${candidate.workspace.name}$suffix';
-  }
-
-  String? _selectedParentLabel() {
-    final selectedId = _selectedParentWorkspaceId;
-    if (selectedId == null) {
-      return null;
-    }
-    for (final candidate in _parentCandidates) {
-      if (candidate.workspace.id == selectedId) {
-        return _parentLabel(candidate);
-      }
-    }
-    return null;
   }
 
   String? _pickBranchForMode(bool reuseExistingBranch) {
@@ -425,728 +410,79 @@ class _CreateWorkspaceDialogState extends State<CreateWorkspaceDialog> {
         : 'New branch name is required';
   }
 
-  String _branchPickerLabel() {
-    return _reuseExistingBranch ? 'Existing Branch' : 'Source Branch';
-  }
-
-  String _branchSearchHint() {
-    return _reuseExistingBranch
-        ? 'Search existing branches'
-        : 'Search source branches';
-  }
-
-  String _emptyBranchesMessage() {
-    return _reuseExistingBranch
-        ? 'No existing branches match "$_branchQuery"'
-        : 'No source branches match "$_branchQuery"';
-  }
-
-  String _slugify(String input) {
-    return input
-        .trim()
-        .toLowerCase()
-        .replaceAll(RegExp(r'[\s_/]+'), '-')
-        .replaceAll(RegExp(r'[^a-z0-9-]'), '-')
-        .replaceAll(RegExp(r'-+'), '-')
-        .replaceAll(RegExp(r'^-|-$'), '');
-  }
-
-  String _getPreviewWorkspacePath() {
-    final project = _selectedProject;
-    if (project == null) return '';
-    final projectSlug = _slugify(project.name);
-    final displayName = _nameController.text.trim().isNotEmpty
-        ? _nameController.text.trim()
-        : _newBranchController.text.trim();
-    final workspaceSlug = displayName.isNotEmpty
-        ? _slugify(displayName)
-        : 'workspace';
-    return '~/.alera/workspaces/$projectSlug-${project.id}/$workspaceSlug';
-  }
-
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
     final selectedProject = _selectedProject;
-    final visibleBranches = _branchesForMode(_reuseExistingBranch);
-    final loadingBranchChoices =
-        _loadingBranches || (_reuseExistingBranch && _loadingLocalBranches);
-
     if (widget.projects.isEmpty) {
-      return AleraDialog(
-        maxWidth: 440,
-        child: Padding(
-          padding: const EdgeInsets.all(AleraTokens.space24),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              AleraEmptyState(
-                icon: AleraIcons.folderOff,
-                title: 'No Git projects yet',
-                message:
-                    'Linked workspaces require a Git project. Add one to get started.',
-                action: widget.onAddProject != null
-                    ? FilledButton.icon(
-                        onPressed: widget.onAddProject,
-                        icon: const Icon(AleraIcons.add, size: 16),
-                        label: const Text('Add Git Project'),
-                      )
-                    : null,
-              ),
-              const SizedBox(height: AleraTokens.space8),
-              TextButton(
-                onPressed: () => Navigator.of(context).pop(),
-                child: const Text('Cancel'),
-              ),
-            ],
-          ),
-        ),
+      return _EmptyProjectsDialog(
+        onAddProject: widget.onAddProject,
+        onCancel: () => Navigator.of(context).pop(),
       );
     }
 
-    final isStep1 = _currentStep == 1;
+    final isSelectionStep = _currentStep == 1;
+    final sourceBranch = _selectedSourceBranch ?? _sourceBranchController.text;
+    final step = isSelectionStep
+        ? _CreateWorkspaceSelectionStep(
+            projects: _orderedProjects,
+            selectedProject: selectedProject,
+            projectQuery: _projectQuery,
+            projectSearchController: _projectSearchController,
+            onProjectQueryChanged: _setProjectQuery,
+            onSelectProject: _selectProject,
+            getProjectActiveBranch: widget.getProjectActiveBranch,
+            reuseExistingBranch: _reuseExistingBranch,
+            onReuseExistingBranchChanged: _setReuseExistingBranch,
+            loadingBranches:
+                _loadingBranches ||
+                (_reuseExistingBranch && _loadingLocalBranches),
+            branches: _branchesForMode(_reuseExistingBranch),
+            selectedBranch: _selectedSourceBranch,
+            branchQuery: _branchQuery,
+            branchSearchController: _branchSearchController,
+            onBranchQueryChanged: _setBranchQuery,
+            onSelectBranch: _selectSourceBranch,
+            branchesError: _branchesError,
+            onRetryBranches: _retryBranches,
+            sourceBranchController: _sourceBranchController,
+            sourceBranchError: _sourceBranchError,
+            onManualSourceBranchChanged: _onManualSourceBranchChanged,
+          )
+        : _CreateWorkspaceSettingsStep(
+            project: selectedProject,
+            sourceBranch: sourceBranch,
+            reuseExistingBranch: _reuseExistingBranch,
+            newBranchController: _newBranchController,
+            newBranchError: _newBranchError,
+            branchValidationError: _branchValidationError,
+            isValidatingBranch: _isValidatingBranch,
+            onNewBranchChanged: _onNewBranchChanged,
+            nameController: _nameController,
+            nameTouched: _nameTouched,
+            onNameChanged: _onNameChanged,
+            parentCandidates: _parentCandidates,
+            selectedParentWorkspaceId: _selectedParentWorkspaceId,
+            onParentWorkspaceChanged: _setParentWorkspace,
+            creating: _creating,
+            onSubmit: _submit,
+          );
 
-    return AleraDialog(
-      maxWidth: isStep1 ? 680 : 560,
-      maxHeight: 740,
-      child: Padding(
-        padding: const EdgeInsets.all(AleraTokens.space20),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: <Widget>[
-            Row(
-              children: <Widget>[
-                if (!isStep1 && !_creating) ...[
-                  IconButton(
-                    icon: const Icon(AleraIcons.back, size: 20),
-                    color: AleraTokens.foregroundMuted,
-                    padding: EdgeInsets.zero,
-                    constraints: const BoxConstraints(),
-                    onPressed: () {
-                      setState(() {
-                        _currentStep = 1;
-                        _creationError = null;
-                      });
-                    },
-                  ),
-                  const SizedBox(width: AleraTokens.space12),
-                ],
-                const Icon(AleraIcons.gitFork, color: AleraTokens.accent),
-                const SizedBox(width: AleraTokens.space8),
-                Expanded(
-                  child: Text(
-                    isStep1
-                        ? 'New Workspace - Selection'
-                        : 'New Workspace - Settings',
-                    overflow: TextOverflow.ellipsis,
-                    maxLines: 1,
-                    style: theme.textTheme.titleMedium?.copyWith(
-                      fontWeight: FontWeight.bold,
-                    ),
-                  ),
-                ),
-                const SizedBox(width: AleraTokens.space12),
-                if (_creating)
-                  const SizedBox(
-                    width: 14,
-                    height: 14,
-                    child: CircularProgressIndicator(strokeWidth: 2),
-                  )
-                else
-                  Text(
-                    isStep1 ? 'Step 1 of 2' : 'Step 2 of 2',
-                    style: theme.textTheme.bodySmall?.copyWith(
-                      color: AleraTokens.foregroundFaint,
-                    ),
-                  ),
-              ],
-            ),
-            const SizedBox(height: AleraTokens.space16),
-            if (_creationError != null) ...[
-              Container(
-                width: double.infinity,
-                padding: const EdgeInsets.all(AleraTokens.space12),
-                decoration: BoxDecoration(
-                  color: AleraTokens.error.withValues(alpha: 0.1),
-                  borderRadius: BorderRadius.circular(AleraTokens.radiusMd),
-                  border: Border.all(
-                    color: AleraTokens.error.withValues(alpha: 0.3),
-                  ),
-                ),
-                child: Row(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    const Icon(
-                      AleraIcons.error,
-                      color: AleraTokens.error,
-                      size: 16,
-                    ),
-                    const SizedBox(width: AleraTokens.space8),
-                    Expanded(
-                      child: Text(
-                        _creationError!,
-                        style: theme.textTheme.bodySmall?.copyWith(
-                          color: AleraTokens.error,
-                        ),
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-              const SizedBox(height: AleraTokens.space12),
-            ],
-            Flexible(
-              child: AnimatedSwitcher(
-                duration: AleraTokens.durationMid,
-                transitionBuilder: (Widget child, Animation<double> animation) {
-                  return FadeTransition(
-                    opacity: animation,
-                    child: SlideTransition(
-                      position: Tween<Offset>(
-                        begin: const Offset(0.05, 0.0),
-                        end: Offset.zero,
-                      ).animate(animation),
-                      child: child,
-                    ),
-                  );
-                },
-                child: isStep1
-                    ? KeyedSubtree(
-                        key: const ValueKey('step1'),
-                        child: SingleChildScrollView(
-                          child: Column(
-                            mainAxisSize: MainAxisSize.min,
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            children: <Widget>[
-                              _ProjectPicker(
-                                projects: _orderedProjects,
-                                selectedProject: selectedProject,
-                                query: _projectQuery,
-                                controller: _projectSearchController,
-                                onQueryChanged: (value) {
-                                  setState(() => _projectQuery = value);
-                                },
-                                onSelectProject: _selectProject,
-                                getProjectActiveBranch:
-                                    widget.getProjectActiveBranch,
-                              ),
-                              const SizedBox(height: AleraTokens.space16),
-                              AleraSegmentedButton<bool>(
-                                segments: const <ButtonSegment<bool>>[
-                                  ButtonSegment<bool>(
-                                    value: false,
-                                    label: Text('New Branch'),
-                                  ),
-                                  ButtonSegment<bool>(
-                                    value: true,
-                                    label: Text('Existing Branch'),
-                                  ),
-                                ],
-                                selected: _reuseExistingBranch,
-                                onSelectionChanged: _setReuseExistingBranch,
-                              ),
-                              const SizedBox(height: AleraTokens.space16),
-                              if (loadingBranchChoices)
-                                const _LoadingBranches()
-                              else if (visibleBranches.isNotEmpty)
-                                _SourceBranchPicker(
-                                  label: _branchPickerLabel(),
-                                  searchHint: _branchSearchHint(),
-                                  emptyMessage: _emptyBranchesMessage(),
-                                  branches: visibleBranches,
-                                  selectedBranch: _selectedSourceBranch,
-                                  query: _branchQuery,
-                                  controller: _branchSearchController,
-                                  onQueryChanged: (value) {
-                                    setState(() => _branchQuery = value);
-                                  },
-                                  onSelectBranch: _selectSourceBranch,
-                                )
-                              else ...<Widget>[
-                                if (_branchesError != null) ...[
-                                  Row(
-                                    children: [
-                                      Expanded(
-                                        child: Text(
-                                          _branchesError!,
-                                          style: theme.textTheme.bodySmall
-                                              ?.copyWith(
-                                                color: AleraTokens.error,
-                                              ),
-                                        ),
-                                      ),
-                                      const SizedBox(width: AleraTokens.space8),
-                                      IconButton(
-                                        icon: const Icon(
-                                          AleraIcons.refresh,
-                                          size: 16,
-                                        ),
-                                        onPressed: () {
-                                          if (selectedProject != null) {
-                                            _loadBranches(selectedProject);
-                                          }
-                                        },
-                                      ),
-                                    ],
-                                  ),
-                                  const SizedBox(height: AleraTokens.space8),
-                                ],
-                                AleraTextField(
-                                  controller: _sourceBranchController,
-                                  autofocus: true,
-                                  labelText: _branchPickerLabel(),
-                                  hintText: 'e.g. main',
-                                  errorText: _sourceBranchError,
-                                  onChanged: (_) {
-                                    setState(() {
-                                      _sourceBranchError = null;
-                                      if (_reuseExistingBranch) {
-                                        final branch = _sourceBranchController
-                                            .text
-                                            .trim();
-                                        _newBranchController.text = branch;
-                                        if (!_nameTouched) {
-                                          _nameController.text = branch;
-                                        }
-                                      }
-                                    });
-                                  },
-                                ),
-                              ],
-                            ],
-                          ),
-                        ),
-                      )
-                    : KeyedSubtree(
-                        key: const ValueKey('step2'),
-                        child: SingleChildScrollView(
-                          child: Column(
-                            mainAxisSize: MainAxisSize.min,
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            children: <Widget>[
-                              Container(
-                                width: double.infinity,
-                                padding: const EdgeInsets.symmetric(
-                                  horizontal: AleraTokens.space12,
-                                  vertical: AleraTokens.space8,
-                                ),
-                                decoration: BoxDecoration(
-                                  color: AleraTokens.surfaceVariant,
-                                  borderRadius: BorderRadius.circular(
-                                    AleraTokens.radiusMd,
-                                  ),
-                                  border: Border.all(
-                                    color: AleraTokens.borderSubtle,
-                                  ),
-                                ),
-                                child: Table(
-                                  columnWidths: const {
-                                    0: IntrinsicColumnWidth(),
-                                    1: FlexColumnWidth(),
-                                  },
-                                  children: [
-                                    TableRow(
-                                      children: [
-                                        Padding(
-                                          padding: const EdgeInsets.only(
-                                            right: AleraTokens.space12,
-                                            bottom: AleraTokens.space4,
-                                          ),
-                                          child: Text(
-                                            'Project:',
-                                            style: theme.textTheme.labelMedium
-                                                ?.copyWith(
-                                                  color: AleraTokens
-                                                      .foregroundMuted,
-                                                ),
-                                          ),
-                                        ),
-                                        Text(
-                                          selectedProject?.name ?? '',
-                                          style: theme.textTheme.bodySmall
-                                              ?.copyWith(
-                                                color: AleraTokens.foreground,
-                                                fontWeight: FontWeight.w500,
-                                              ),
-                                        ),
-                                      ],
-                                    ),
-                                    TableRow(
-                                      children: [
-                                        Padding(
-                                          padding: const EdgeInsets.only(
-                                            right: AleraTokens.space12,
-                                          ),
-                                          child: Text(
-                                            _reuseExistingBranch
-                                                ? 'Existing Branch:'
-                                                : 'Source Branch:',
-                                            style: theme.textTheme.labelMedium
-                                                ?.copyWith(
-                                                  color: AleraTokens
-                                                      .foregroundMuted,
-                                                ),
-                                          ),
-                                        ),
-                                        Text(
-                                          _selectedSourceBranch ??
-                                              _sourceBranchController.text,
-                                          style: theme.textTheme.bodySmall
-                                              ?.copyWith(
-                                                color: AleraTokens.foreground,
-                                                fontWeight: FontWeight.w500,
-                                              ),
-                                        ),
-                                      ],
-                                    ),
-                                  ],
-                                ),
-                              ),
-                              const SizedBox(height: AleraTokens.space16),
-                              if (_reuseExistingBranch)
-                                AleraTextField(
-                                  controller: _newBranchController,
-                                  enabled: false,
-                                  labelText: 'Existing Branch *',
-                                  errorText: _newBranchError,
-                                )
-                              else
-                                AleraTextField(
-                                  controller: _newBranchController,
-                                  autofocus: true,
-                                  enabled: !_creating,
-                                  labelText: 'New Branch Name *',
-                                  hintText: 'e.g. feature/terminal-tabs',
-                                  errorText:
-                                      _newBranchError ?? _branchValidationError,
-                                  suffix: _isValidatingBranch
-                                      ? const SizedBox(
-                                          width: 12,
-                                          height: 12,
-                                          child: CircularProgressIndicator(
-                                            strokeWidth: 1.5,
-                                          ),
-                                        )
-                                      : null,
-                                  onChanged: _onNewBranchChanged,
-                                  onSubmitted: (_) => _submit(),
-                                ),
-                              const SizedBox(height: AleraTokens.space12),
-                              Row(
-                                crossAxisAlignment: CrossAxisAlignment.center,
-                                children: [
-                                  Expanded(
-                                    child: AleraTextField(
-                                      controller: _nameController,
-                                      enabled: !_creating,
-                                      labelText: 'Workspace Name (Optional)',
-                                      onChanged: (value) {
-                                        setState(() {
-                                          _nameTouched = value.isNotEmpty;
-                                        });
-                                      },
-                                      onSubmitted: (_) => _submit(),
-                                    ),
-                                  ),
-                                  if (!_nameTouched &&
-                                      _newBranchController.text.isNotEmpty) ...[
-                                    const SizedBox(width: AleraTokens.space8),
-                                    Padding(
-                                      padding: const EdgeInsets.only(
-                                        top: AleraTokens.space16,
-                                      ),
-                                      child: Container(
-                                        padding: const EdgeInsets.symmetric(
-                                          horizontal: AleraTokens.space6,
-                                          vertical: AleraTokens.space2,
-                                        ),
-                                        decoration: BoxDecoration(
-                                          color: AleraTokens.accentSubtle,
-                                          borderRadius: BorderRadius.circular(
-                                            AleraTokens.radiusSm,
-                                          ),
-                                          border: Border.all(
-                                            color: AleraTokens.accent
-                                                .withValues(alpha: 0.2),
-                                          ),
-                                        ),
-                                        child: Row(
-                                          mainAxisSize: MainAxisSize.min,
-                                          children: [
-                                            Icon(
-                                              AleraIcons.link,
-                                              size: 10,
-                                              color: AleraTokens.accent
-                                                  .withValues(alpha: 0.7),
-                                            ),
-                                            const SizedBox(
-                                              width: AleraTokens.space4,
-                                            ),
-                                            Text(
-                                              'Sync',
-                                              style: theme.textTheme.labelSmall
-                                                  ?.copyWith(
-                                                    color: AleraTokens.accent,
-                                                    fontWeight: FontWeight.w500,
-                                                  ),
-                                            ),
-                                          ],
-                                        ),
-                                      ),
-                                    ),
-                                  ],
-                                ],
-                              ),
-                              const SizedBox(height: AleraTokens.space16),
-                              AleraDropdownField<String?>(
-                                value: _selectedParentWorkspaceId,
-                                labelText: 'Parent Workspace',
-                                enabled: !_creating,
-                                filterable: true,
-                                filterHintText: 'Search Workspaces',
-                                entries: <AleraDropdownFieldEntry<String?>>[
-                                  const AleraDropdownFieldEntry<String?>(
-                                    value: null,
-                                    label: 'No Parent',
-                                  ),
-                                  for (final candidate in _parentCandidates)
-                                    AleraDropdownFieldEntry<String?>(
-                                      value: candidate.workspace.id,
-                                      label: _parentLabel(candidate),
-                                    ),
-                                ],
-                                onChanged: (value) => setState(
-                                  () => _selectedParentWorkspaceId = value,
-                                ),
-                              ),
-                              const SizedBox(height: AleraTokens.space16),
-                              Text(
-                                'Preview',
-                                style: theme.textTheme.labelMedium?.copyWith(
-                                  color: AleraTokens.foregroundMuted,
-                                ),
-                              ),
-                              const SizedBox(height: AleraTokens.space6),
-                              Container(
-                                width: double.infinity,
-                                padding: const EdgeInsets.all(
-                                  AleraTokens.space12,
-                                ),
-                                decoration: BoxDecoration(
-                                  color: AleraTokens.surface,
-                                  borderRadius: BorderRadius.circular(
-                                    AleraTokens.radiusMd,
-                                  ),
-                                  border: Border.all(
-                                    color: AleraTokens.borderSubtle,
-                                  ),
-                                ),
-                                child: Column(
-                                  crossAxisAlignment: CrossAxisAlignment.start,
-                                  children: [
-                                    Row(
-                                      children: [
-                                        Icon(
-                                          AleraIcons.folder,
-                                          size: 14,
-                                          color: AleraTokens.foregroundMuted
-                                              .withValues(alpha: 0.7),
-                                        ),
-                                        const SizedBox(
-                                          width: AleraTokens.space6,
-                                        ),
-                                        Expanded(
-                                          child: Text(
-                                            _getPreviewWorkspacePath(),
-                                            overflow: TextOverflow.ellipsis,
-                                            style: AleraTokens.monoStyle
-                                                .copyWith(
-                                                  color: AleraTokens
-                                                      .foregroundMuted,
-                                                ),
-                                          ),
-                                        ),
-                                      ],
-                                    ),
-                                    const SizedBox(height: AleraTokens.space6),
-                                    Row(
-                                      children: [
-                                        Icon(
-                                          AleraIcons.gitFork,
-                                          size: 14,
-                                          color: AleraTokens.foregroundMuted
-                                              .withValues(alpha: 0.7),
-                                        ),
-                                        const SizedBox(
-                                          width: AleraTokens.space6,
-                                        ),
-                                        Expanded(
-                                          child: Text(
-                                            _reuseExistingBranch
-                                                ? 'Branch: ${(_selectedSourceBranch ?? _sourceBranchController.text).isEmpty ? "<existing-branch>" : (_selectedSourceBranch ?? _sourceBranchController.text)}'
-                                                : 'Branch: ${_newBranchController.text.isEmpty ? "<new-branch>" : _newBranchController.text} ← from ${(_selectedSourceBranch ?? _sourceBranchController.text).isEmpty ? "<source>" : (_selectedSourceBranch ?? _sourceBranchController.text)}',
-                                            overflow: TextOverflow.ellipsis,
-                                            style: AleraTokens.monoStyle
-                                                .copyWith(
-                                                  color: AleraTokens
-                                                      .foregroundMuted,
-                                                ),
-                                          ),
-                                        ),
-                                      ],
-                                    ),
-                                    if (_selectedParentLabel()
-                                        case final parentLabel?) ...[
-                                      const SizedBox(
-                                        height: AleraTokens.space6,
-                                      ),
-                                      Row(
-                                        children: [
-                                          Icon(
-                                            AleraIcons.link,
-                                            size: 14,
-                                            color: AleraTokens.foregroundMuted
-                                                .withValues(alpha: 0.7),
-                                          ),
-                                          const SizedBox(
-                                            width: AleraTokens.space6,
-                                          ),
-                                          Expanded(
-                                            child: Text(
-                                              'Parent: $parentLabel',
-                                              overflow: TextOverflow.ellipsis,
-                                              style: theme.textTheme.labelSmall
-                                                  ?.copyWith(
-                                                    color: AleraTokens
-                                                        .foregroundMuted,
-                                                  ),
-                                            ),
-                                          ),
-                                        ],
-                                      ),
-                                    ],
-                                    const SizedBox(height: AleraTokens.space6),
-                                    Row(
-                                      children: [
-                                        Icon(
-                                          AleraIcons.terminal,
-                                          size: 14,
-                                          color: AleraTokens.foregroundMuted
-                                              .withValues(alpha: 0.7),
-                                        ),
-                                        const SizedBox(
-                                          width: AleraTokens.space6,
-                                        ),
-                                        Expanded(
-                                          child: Text(
-                                            'Initial terminal tab will be opened',
-                                            style: theme.textTheme.labelSmall
-                                                ?.copyWith(
-                                                  color: AleraTokens
-                                                      .foregroundMuted,
-                                                ),
-                                          ),
-                                        ),
-                                      ],
-                                    ),
-                                  ],
-                                ),
-                              ),
-                            ],
-                          ),
-                        ),
-                      ),
-              ),
-            ),
-            const SizedBox(height: AleraTokens.space16),
-            if (!isStep1) ...<Widget>[
-              Align(
-                alignment: Alignment.centerLeft,
-                child: AleraCheckbox(
-                  value: _createAnother,
-                  enabled: !_creating,
-                  onChanged: (value) {
-                    setState(() => _createAnother = value);
-                  },
-                  label: 'Create Another',
-                ),
-              ),
-              const SizedBox(height: AleraTokens.space8),
-            ],
-            Row(
-              mainAxisAlignment: MainAxisAlignment.end,
-              children: <Widget>[
-                if (isStep1)
-                  TextButton(
-                    onPressed: () => Navigator.of(context).pop(),
-                    child: const Text('Cancel'),
-                  )
-                else
-                  TextButton(
-                    onPressed: _creating
-                        ? null
-                        : () {
-                            setState(() {
-                              _currentStep = 1;
-                              _creationError = null;
-                            });
-                          },
-                    child: const Text('Back'),
-                  ),
-                const SizedBox(width: AleraTokens.space8),
-                if (isStep1)
-                  FilledButton(
-                    onPressed: selectedProject == null || _loadingBranches
-                        ? null
-                        : () {
-                            final sourceBranch =
-                                (_selectedSourceBranch ??
-                                        _sourceBranchController.text)
-                                    .trim();
-                            if (sourceBranch.isEmpty) {
-                              setState(() {
-                                _sourceBranchError =
-                                    _sourceBranchRequiredError();
-                              });
-                              return;
-                            }
-                            setState(() {
-                              _currentStep = 2;
-                            });
-                          },
-                    child: const Text('Continue'),
-                  )
-                else
-                  FilledButton(
-                    onPressed:
-                        selectedProject == null ||
-                            _creating ||
-                            _branchValidationError != null
-                        ? null
-                        : () {
-                            final sourceBranch =
-                                (_selectedSourceBranch ??
-                                        _sourceBranchController.text)
-                                    .trim();
-                            final targetBranch = _targetBranchName(
-                              sourceBranch,
-                            );
-                            if (targetBranch.isEmpty) {
-                              setState(() {
-                                _newBranchError = _targetBranchRequiredError();
-                              });
-                              return;
-                            }
-                            _submit();
-                          },
-                    child: Text(_creating ? 'Creating…' : 'Create Workspace'),
-                  ),
-              ],
-            ),
-          ],
-        ),
-      ),
+    return _CreateWorkspaceDialogFrame(
+      isSelectionStep: isSelectionStep,
+      creating: _creating,
+      creationError: _creationError,
+      step: step,
+      createAnother: _createAnother,
+      onCreateAnotherChanged: _setCreateAnother,
+      onCancel: () => Navigator.of(context).pop(),
+      onBack: _showSelectionStep,
+      onContinue: selectedProject == null || _loadingBranches
+          ? null
+          : _continueToSettings,
+      onCreate:
+          selectedProject == null || _creating || _branchValidationError != null
+          ? null
+          : _submitFromButton,
     );
   }
 }

--- a/lib/src/features/workbench/presentation/create_workspace_dialog_frame.dart
+++ b/lib/src/features/workbench/presentation/create_workspace_dialog_frame.dart
@@ -1,0 +1,270 @@
+part of 'create_workspace_dialog.dart';
+
+class _EmptyProjectsDialog extends StatelessWidget {
+  const _EmptyProjectsDialog({
+    required this.onAddProject,
+    required this.onCancel,
+  });
+
+  final VoidCallback? onAddProject;
+  final VoidCallback onCancel;
+
+  @override
+  Widget build(BuildContext context) {
+    return AleraDialog(
+      maxWidth: 440,
+      child: Padding(
+        padding: const EdgeInsets.all(AleraTokens.space24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            AleraEmptyState(
+              icon: AleraIcons.folderOff,
+              title: 'No Git projects yet',
+              message:
+                  'Linked workspaces require a Git project. Add one to get started.',
+              action: onAddProject != null
+                  ? FilledButton.icon(
+                      onPressed: onAddProject,
+                      icon: const Icon(AleraIcons.add, size: 16),
+                      label: const Text('Add Git Project'),
+                    )
+                  : null,
+            ),
+            const SizedBox(height: AleraTokens.space8),
+            TextButton(onPressed: onCancel, child: const Text('Cancel')),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _CreateWorkspaceDialogFrame extends StatelessWidget {
+  const _CreateWorkspaceDialogFrame({
+    required this.isSelectionStep,
+    required this.creating,
+    required this.creationError,
+    required this.step,
+    required this.createAnother,
+    required this.onCreateAnotherChanged,
+    required this.onCancel,
+    required this.onBack,
+    required this.onContinue,
+    required this.onCreate,
+  });
+
+  final bool isSelectionStep;
+  final bool creating;
+  final String? creationError;
+  final Widget step;
+  final bool createAnother;
+  final ValueChanged<bool> onCreateAnotherChanged;
+  final VoidCallback onCancel;
+  final VoidCallback onBack;
+  final VoidCallback? onContinue;
+  final VoidCallback? onCreate;
+
+  @override
+  Widget build(BuildContext context) {
+    return AleraDialog(
+      maxWidth: isSelectionStep ? 680 : 560,
+      maxHeight: 740,
+      child: Padding(
+        padding: const EdgeInsets.all(AleraTokens.space20),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            _CreateWorkspaceDialogHeader(
+              isSelectionStep: isSelectionStep,
+              creating: creating,
+              onBack: onBack,
+            ),
+            const SizedBox(height: AleraTokens.space16),
+            if (creationError case final error?) ...[
+              _CreateWorkspaceError(message: error),
+              const SizedBox(height: AleraTokens.space12),
+            ],
+            Flexible(
+              child: AnimatedSwitcher(
+                duration: AleraTokens.durationMid,
+                transitionBuilder: (child, animation) {
+                  return FadeTransition(
+                    opacity: animation,
+                    child: SlideTransition(
+                      position: Tween<Offset>(
+                        begin: const Offset(0.05, 0.0),
+                        end: Offset.zero,
+                      ).animate(animation),
+                      child: child,
+                    ),
+                  );
+                },
+                child: KeyedSubtree(
+                  key: ValueKey(isSelectionStep ? 'step1' : 'step2'),
+                  child: SingleChildScrollView(child: step),
+                ),
+              ),
+            ),
+            const SizedBox(height: AleraTokens.space16),
+            if (!isSelectionStep) ...<Widget>[
+              Align(
+                alignment: Alignment.centerLeft,
+                child: AleraCheckbox(
+                  value: createAnother,
+                  enabled: !creating,
+                  onChanged: onCreateAnotherChanged,
+                  label: 'Create Another',
+                ),
+              ),
+              const SizedBox(height: AleraTokens.space8),
+            ],
+            _CreateWorkspaceDialogActions(
+              isSelectionStep: isSelectionStep,
+              creating: creating,
+              onCancel: onCancel,
+              onBack: onBack,
+              onContinue: onContinue,
+              onCreate: onCreate,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _CreateWorkspaceDialogHeader extends StatelessWidget {
+  const _CreateWorkspaceDialogHeader({
+    required this.isSelectionStep,
+    required this.creating,
+    required this.onBack,
+  });
+
+  final bool isSelectionStep;
+  final bool creating;
+  final VoidCallback onBack;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Row(
+      children: <Widget>[
+        if (!isSelectionStep && !creating) ...[
+          IconButton(
+            icon: const Icon(AleraIcons.back, size: 20),
+            color: AleraTokens.foregroundMuted,
+            padding: EdgeInsets.zero,
+            constraints: const BoxConstraints(),
+            onPressed: onBack,
+          ),
+          const SizedBox(width: AleraTokens.space12),
+        ],
+        const Icon(AleraIcons.gitFork, color: AleraTokens.accent),
+        const SizedBox(width: AleraTokens.space8),
+        Expanded(
+          child: Text(
+            isSelectionStep
+                ? 'New Workspace - Selection'
+                : 'New Workspace - Settings',
+            overflow: TextOverflow.ellipsis,
+            maxLines: 1,
+            style: theme.textTheme.titleMedium?.copyWith(
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+        ),
+        const SizedBox(width: AleraTokens.space12),
+        if (creating)
+          const SizedBox(
+            width: 14,
+            height: 14,
+            child: CircularProgressIndicator(strokeWidth: 2),
+          )
+        else
+          Text(
+            isSelectionStep ? 'Step 1 of 2' : 'Step 2 of 2',
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: AleraTokens.foregroundFaint,
+            ),
+          ),
+      ],
+    );
+  }
+}
+
+class _CreateWorkspaceError extends StatelessWidget {
+  const _CreateWorkspaceError({required this.message});
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(AleraTokens.space12),
+      decoration: BoxDecoration(
+        color: AleraTokens.error.withValues(alpha: 0.1),
+        borderRadius: BorderRadius.circular(AleraTokens.radiusMd),
+        border: Border.all(color: AleraTokens.error.withValues(alpha: 0.3)),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Icon(AleraIcons.error, color: AleraTokens.error, size: 16),
+          const SizedBox(width: AleraTokens.space8),
+          Expanded(
+            child: Text(
+              message,
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: AleraTokens.error,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _CreateWorkspaceDialogActions extends StatelessWidget {
+  const _CreateWorkspaceDialogActions({
+    required this.isSelectionStep,
+    required this.creating,
+    required this.onCancel,
+    required this.onBack,
+    required this.onContinue,
+    required this.onCreate,
+  });
+
+  final bool isSelectionStep;
+  final bool creating;
+  final VoidCallback onCancel;
+  final VoidCallback onBack;
+  final VoidCallback? onContinue;
+  final VoidCallback? onCreate;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.end,
+      children: <Widget>[
+        TextButton(
+          onPressed: isSelectionStep ? onCancel : (creating ? null : onBack),
+          child: Text(isSelectionStep ? 'Cancel' : 'Back'),
+        ),
+        const SizedBox(width: AleraTokens.space8),
+        FilledButton(
+          onPressed: isSelectionStep ? onContinue : onCreate,
+          child: Text(
+            isSelectionStep
+                ? 'Continue'
+                : (creating ? 'Creating…' : 'Create Workspace'),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/src/features/workbench/presentation/create_workspace_dialog_interactions.dart
+++ b/lib/src/features/workbench/presentation/create_workspace_dialog_interactions.dart
@@ -1,0 +1,79 @@
+part of 'create_workspace_dialog.dart';
+
+extension _CreateWorkspaceDialogInteractions on _CreateWorkspaceDialogState {
+  void _setProjectQuery(String value) {
+    _update(() => _projectQuery = value);
+  }
+
+  void _setBranchQuery(String value) {
+    _update(() => _branchQuery = value);
+  }
+
+  void _onManualSourceBranchChanged(String _) {
+    _update(() {
+      _sourceBranchError = null;
+      if (_reuseExistingBranch) {
+        final branch = _sourceBranchController.text.trim();
+        _newBranchController.text = branch;
+        if (!_nameTouched) {
+          _nameController.text = branch;
+        }
+      }
+    });
+  }
+
+  void _onNameChanged(String value) {
+    _update(() {
+      _nameTouched = value.isNotEmpty;
+    });
+  }
+
+  void _setParentWorkspace(String? value) {
+    _update(() => _selectedParentWorkspaceId = value);
+  }
+
+  void _setCreateAnother(bool value) {
+    _update(() => _createAnother = value);
+  }
+
+  void _showSelectionStep() {
+    _update(() {
+      _currentStep = 1;
+      _creationError = null;
+    });
+  }
+
+  void _continueToSettings() {
+    final sourceBranch = (_selectedSourceBranch ?? _sourceBranchController.text)
+        .trim();
+    if (sourceBranch.isEmpty) {
+      _update(() {
+        _sourceBranchError = _sourceBranchRequiredError();
+      });
+      return;
+    }
+    _update(() {
+      _currentStep = 2;
+    });
+  }
+
+  void _submitFromButton() {
+    final sourceBranch = (_selectedSourceBranch ?? _sourceBranchController.text)
+        .trim();
+    final targetBranch = _targetBranchName(sourceBranch);
+    if (targetBranch.isEmpty) {
+      _update(() {
+        _newBranchError = _targetBranchRequiredError();
+      });
+      return;
+    }
+    _submit();
+  }
+
+  void _retryBranches() {
+    final project = _selectedProject;
+    if (project != null) {
+      _loadBranches(project);
+    }
+  }
+}

--- a/lib/src/features/workbench/presentation/create_workspace_dialog_selection_step.dart
+++ b/lib/src/features/workbench/presentation/create_workspace_dialog_selection_step.dart
@@ -1,0 +1,168 @@
+part of 'create_workspace_dialog.dart';
+
+class _CreateWorkspaceSelectionStep extends StatelessWidget {
+  const _CreateWorkspaceSelectionStep({
+    required this.projects,
+    required this.selectedProject,
+    required this.projectQuery,
+    required this.projectSearchController,
+    required this.onProjectQueryChanged,
+    required this.onSelectProject,
+    required this.getProjectActiveBranch,
+    required this.reuseExistingBranch,
+    required this.onReuseExistingBranchChanged,
+    required this.loadingBranches,
+    required this.branches,
+    required this.selectedBranch,
+    required this.branchQuery,
+    required this.branchSearchController,
+    required this.onBranchQueryChanged,
+    required this.onSelectBranch,
+    required this.branchesError,
+    required this.onRetryBranches,
+    required this.sourceBranchController,
+    required this.sourceBranchError,
+    required this.onManualSourceBranchChanged,
+  });
+
+  final List<Project> projects;
+  final Project? selectedProject;
+  final String projectQuery;
+  final TextEditingController projectSearchController;
+  final ValueChanged<String> onProjectQueryChanged;
+  final ValueChanged<Project> onSelectProject;
+  final String? Function(Project project) getProjectActiveBranch;
+  final bool reuseExistingBranch;
+  final ValueChanged<bool> onReuseExistingBranchChanged;
+  final bool loadingBranches;
+  final List<String> branches;
+  final String? selectedBranch;
+  final String branchQuery;
+  final TextEditingController branchSearchController;
+  final ValueChanged<String> onBranchQueryChanged;
+  final ValueChanged<String> onSelectBranch;
+  final String? branchesError;
+  final VoidCallback onRetryBranches;
+  final TextEditingController sourceBranchController;
+  final String? sourceBranchError;
+  final ValueChanged<String> onManualSourceBranchChanged;
+
+  String get _branchLabel =>
+      reuseExistingBranch ? 'Existing Branch' : 'Source Branch';
+
+  String get _branchSearchHint => reuseExistingBranch
+      ? 'Search existing branches'
+      : 'Search source branches';
+
+  String get _emptyBranchesMessage => reuseExistingBranch
+      ? 'No existing branches match "$branchQuery"'
+      : 'No source branches match "$branchQuery"';
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        _ProjectPicker(
+          projects: projects,
+          selectedProject: selectedProject,
+          query: projectQuery,
+          controller: projectSearchController,
+          onQueryChanged: onProjectQueryChanged,
+          onSelectProject: onSelectProject,
+          getProjectActiveBranch: getProjectActiveBranch,
+        ),
+        const SizedBox(height: AleraTokens.space16),
+        AleraSegmentedButton<bool>(
+          segments: const <ButtonSegment<bool>>[
+            ButtonSegment<bool>(value: false, label: Text('New Branch')),
+            ButtonSegment<bool>(value: true, label: Text('Existing Branch')),
+          ],
+          selected: reuseExistingBranch,
+          onSelectionChanged: onReuseExistingBranchChanged,
+        ),
+        const SizedBox(height: AleraTokens.space16),
+        if (loadingBranches)
+          const _LoadingBranches()
+        else if (branches.isNotEmpty)
+          _SourceBranchPicker(
+            label: _branchLabel,
+            searchHint: _branchSearchHint,
+            emptyMessage: _emptyBranchesMessage,
+            branches: branches,
+            selectedBranch: selectedBranch,
+            query: branchQuery,
+            controller: branchSearchController,
+            onQueryChanged: onBranchQueryChanged,
+            onSelectBranch: onSelectBranch,
+          )
+        else
+          _ManualSourceBranchField(
+            label: _branchLabel,
+            controller: sourceBranchController,
+            errorText: sourceBranchError,
+            loadError: branchesError,
+            onRetry: onRetryBranches,
+            onChanged: onManualSourceBranchChanged,
+          ),
+      ],
+    );
+  }
+}
+
+class _ManualSourceBranchField extends StatelessWidget {
+  const _ManualSourceBranchField({
+    required this.label,
+    required this.controller,
+    required this.errorText,
+    required this.loadError,
+    required this.onRetry,
+    required this.onChanged,
+  });
+
+  final String label;
+  final TextEditingController controller;
+  final String? errorText;
+  final String? loadError;
+  final VoidCallback onRetry;
+  final ValueChanged<String> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: <Widget>[
+        if (loadError case final message?) ...[
+          Row(
+            children: [
+              Expanded(
+                child: Text(
+                  message,
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: AleraTokens.error,
+                  ),
+                ),
+              ),
+              const SizedBox(width: AleraTokens.space8),
+              IconButton(
+                icon: const Icon(AleraIcons.refresh, size: 16),
+                onPressed: onRetry,
+              ),
+            ],
+          ),
+          const SizedBox(height: AleraTokens.space8),
+        ],
+        AleraTextField(
+          controller: controller,
+          autofocus: true,
+          labelText: label,
+          hintText: 'e.g. main',
+          errorText: errorText,
+          onChanged: onChanged,
+        ),
+      ],
+    );
+  }
+}

--- a/lib/src/features/workbench/presentation/create_workspace_dialog_settings_step.dart
+++ b/lib/src/features/workbench/presentation/create_workspace_dialog_settings_step.dart
@@ -1,0 +1,458 @@
+part of 'create_workspace_dialog.dart';
+
+class _CreateWorkspaceSettingsStep extends StatelessWidget {
+  const _CreateWorkspaceSettingsStep({
+    required this.project,
+    required this.sourceBranch,
+    required this.reuseExistingBranch,
+    required this.newBranchController,
+    required this.newBranchError,
+    required this.branchValidationError,
+    required this.isValidatingBranch,
+    required this.onNewBranchChanged,
+    required this.nameController,
+    required this.nameTouched,
+    required this.onNameChanged,
+    required this.parentCandidates,
+    required this.selectedParentWorkspaceId,
+    required this.onParentWorkspaceChanged,
+    required this.creating,
+    required this.onSubmit,
+  });
+
+  final Project? project;
+  final String sourceBranch;
+  final bool reuseExistingBranch;
+  final TextEditingController newBranchController;
+  final String? newBranchError;
+  final String? branchValidationError;
+  final bool isValidatingBranch;
+  final ValueChanged<String> onNewBranchChanged;
+  final TextEditingController nameController;
+  final bool nameTouched;
+  final ValueChanged<String> onNameChanged;
+  final List<WorkspaceParentCandidate> parentCandidates;
+  final String? selectedParentWorkspaceId;
+  final ValueChanged<String?> onParentWorkspaceChanged;
+  final bool creating;
+  final VoidCallback onSubmit;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        _WorkspaceSelectionSummary(
+          projectName: project?.name ?? '',
+          sourceBranch: sourceBranch,
+          reuseExistingBranch: reuseExistingBranch,
+        ),
+        const SizedBox(height: AleraTokens.space16),
+        if (reuseExistingBranch)
+          AleraTextField(
+            controller: newBranchController,
+            enabled: false,
+            labelText: 'Existing Branch *',
+            errorText: newBranchError,
+          )
+        else
+          AleraTextField(
+            controller: newBranchController,
+            autofocus: true,
+            enabled: !creating,
+            labelText: 'New Branch Name *',
+            hintText: 'e.g. feature/terminal-tabs',
+            errorText: newBranchError ?? branchValidationError,
+            suffix: isValidatingBranch
+                ? const SizedBox(
+                    width: 12,
+                    height: 12,
+                    child: CircularProgressIndicator(strokeWidth: 1.5),
+                  )
+                : null,
+            onChanged: onNewBranchChanged,
+            onSubmitted: (_) => onSubmit(),
+          ),
+        const SizedBox(height: AleraTokens.space12),
+        _WorkspaceNameField(
+          controller: nameController,
+          enabled: !creating,
+          showSync: !nameTouched && newBranchController.text.isNotEmpty,
+          onChanged: onNameChanged,
+          onSubmitted: onSubmit,
+        ),
+        const SizedBox(height: AleraTokens.space16),
+        AleraDropdownField<String?>(
+          value: selectedParentWorkspaceId,
+          labelText: 'Parent Workspace',
+          enabled: !creating,
+          filterable: true,
+          filterHintText: 'Search Workspaces',
+          entries: <AleraDropdownFieldEntry<String?>>[
+            const AleraDropdownFieldEntry<String?>(
+              value: null,
+              label: 'No Parent',
+            ),
+            for (final candidate in parentCandidates)
+              AleraDropdownFieldEntry<String?>(
+                value: candidate.workspace.id,
+                label: _workspaceParentLabel(candidate),
+              ),
+          ],
+          onChanged: onParentWorkspaceChanged,
+        ),
+        const SizedBox(height: AleraTokens.space16),
+        _WorkspaceCreationPreview(
+          project: project,
+          sourceBranch: sourceBranch,
+          newBranchName: newBranchController.text,
+          workspaceName: nameController.text,
+          reuseExistingBranch: reuseExistingBranch,
+          parentLabel: _selectedWorkspaceParentLabel(
+            parentCandidates,
+            selectedParentWorkspaceId,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _WorkspaceSelectionSummary extends StatelessWidget {
+  const _WorkspaceSelectionSummary({
+    required this.projectName,
+    required this.sourceBranch,
+    required this.reuseExistingBranch,
+  });
+
+  final String projectName;
+  final String sourceBranch;
+  final bool reuseExistingBranch;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.symmetric(
+        horizontal: AleraTokens.space12,
+        vertical: AleraTokens.space8,
+      ),
+      decoration: BoxDecoration(
+        color: AleraTokens.surfaceVariant,
+        borderRadius: BorderRadius.circular(AleraTokens.radiusMd),
+        border: Border.all(color: AleraTokens.borderSubtle),
+      ),
+      child: Table(
+        columnWidths: const {0: IntrinsicColumnWidth(), 1: FlexColumnWidth()},
+        children: [
+          TableRow(
+            children: [
+              Padding(
+                padding: const EdgeInsets.only(
+                  right: AleraTokens.space12,
+                  bottom: AleraTokens.space4,
+                ),
+                child: Text(
+                  'Project:',
+                  style: theme.textTheme.labelMedium?.copyWith(
+                    color: AleraTokens.foregroundMuted,
+                  ),
+                ),
+              ),
+              Text(
+                projectName,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: AleraTokens.foreground,
+                  fontWeight: FontWeight.w500,
+                ),
+              ),
+            ],
+          ),
+          TableRow(
+            children: [
+              Padding(
+                padding: const EdgeInsets.only(right: AleraTokens.space12),
+                child: Text(
+                  reuseExistingBranch ? 'Existing Branch:' : 'Source Branch:',
+                  style: theme.textTheme.labelMedium?.copyWith(
+                    color: AleraTokens.foregroundMuted,
+                  ),
+                ),
+              ),
+              Text(
+                sourceBranch,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: AleraTokens.foreground,
+                  fontWeight: FontWeight.w500,
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _WorkspaceNameField extends StatelessWidget {
+  const _WorkspaceNameField({
+    required this.controller,
+    required this.enabled,
+    required this.showSync,
+    required this.onChanged,
+    required this.onSubmitted,
+  });
+
+  final TextEditingController controller;
+  final bool enabled;
+  final bool showSync;
+  final ValueChanged<String> onChanged;
+  final VoidCallback onSubmitted;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [
+        Expanded(
+          child: AleraTextField(
+            controller: controller,
+            enabled: enabled,
+            labelText: 'Workspace Name (Optional)',
+            onChanged: onChanged,
+            onSubmitted: (_) => onSubmitted(),
+          ),
+        ),
+        if (showSync) ...[
+          const SizedBox(width: AleraTokens.space8),
+          const Padding(
+            padding: EdgeInsets.only(top: AleraTokens.space16),
+            child: _WorkspaceNameSyncBadge(),
+          ),
+        ],
+      ],
+    );
+  }
+}
+
+class _WorkspaceNameSyncBadge extends StatelessWidget {
+  const _WorkspaceNameSyncBadge();
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      padding: const EdgeInsets.symmetric(
+        horizontal: AleraTokens.space6,
+        vertical: AleraTokens.space2,
+      ),
+      decoration: BoxDecoration(
+        color: AleraTokens.accentSubtle,
+        borderRadius: BorderRadius.circular(AleraTokens.radiusSm),
+        border: Border.all(color: AleraTokens.accent.withValues(alpha: 0.2)),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(
+            AleraIcons.link,
+            size: 10,
+            color: AleraTokens.accent.withValues(alpha: 0.7),
+          ),
+          const SizedBox(width: AleraTokens.space4),
+          Text(
+            'Sync',
+            style: theme.textTheme.labelSmall?.copyWith(
+              color: AleraTokens.accent,
+              fontWeight: FontWeight.w500,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _WorkspaceCreationPreview extends StatelessWidget {
+  const _WorkspaceCreationPreview({
+    required this.project,
+    required this.sourceBranch,
+    required this.newBranchName,
+    required this.workspaceName,
+    required this.reuseExistingBranch,
+    required this.parentLabel,
+  });
+
+  final Project? project;
+  final String sourceBranch;
+  final String newBranchName;
+  final String workspaceName;
+  final bool reuseExistingBranch;
+  final String? parentLabel;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          'Preview',
+          style: theme.textTheme.labelMedium?.copyWith(
+            color: AleraTokens.foregroundMuted,
+          ),
+        ),
+        const SizedBox(height: AleraTokens.space6),
+        Container(
+          width: double.infinity,
+          padding: const EdgeInsets.all(AleraTokens.space12),
+          decoration: BoxDecoration(
+            color: AleraTokens.surface,
+            borderRadius: BorderRadius.circular(AleraTokens.radiusMd),
+            border: Border.all(color: AleraTokens.borderSubtle),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              _PreviewRow(
+                icon: AleraIcons.folder,
+                text: _previewWorkspacePath(
+                  project,
+                  workspaceName,
+                  newBranchName,
+                ),
+              ),
+              const SizedBox(height: AleraTokens.space6),
+              _PreviewRow(
+                icon: AleraIcons.gitFork,
+                text: _previewBranch(
+                  sourceBranch,
+                  newBranchName,
+                  reuseExistingBranch,
+                ),
+              ),
+              if (parentLabel case final label?) ...[
+                const SizedBox(height: AleraTokens.space6),
+                _PreviewRow(
+                  icon: AleraIcons.link,
+                  text: 'Parent: $label',
+                  useMonoStyle: false,
+                ),
+              ],
+              const SizedBox(height: AleraTokens.space6),
+              const _PreviewRow(
+                icon: AleraIcons.terminal,
+                text: 'Initial terminal tab will be opened',
+                useMonoStyle: false,
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _PreviewRow extends StatelessWidget {
+  const _PreviewRow({
+    required this.icon,
+    required this.text,
+    this.useMonoStyle = true,
+  });
+
+  final IconData icon;
+  final String text;
+  final bool useMonoStyle;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Row(
+      children: [
+        Icon(
+          icon,
+          size: 14,
+          color: AleraTokens.foregroundMuted.withValues(alpha: 0.7),
+        ),
+        const SizedBox(width: AleraTokens.space6),
+        Expanded(
+          child: Text(
+            text,
+            overflow: TextOverflow.ellipsis,
+            style: useMonoStyle
+                ? AleraTokens.monoStyle.copyWith(
+                    color: AleraTokens.foregroundMuted,
+                  )
+                : theme.textTheme.labelSmall?.copyWith(
+                    color: AleraTokens.foregroundMuted,
+                  ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+String _workspaceParentLabel(WorkspaceParentCandidate candidate) {
+  final branch = candidate.workspace.branch;
+  final suffix = branch == null || branch.isEmpty ? '' : ' - $branch';
+  return '${candidate.project.name} / ${candidate.workspace.name}$suffix';
+}
+
+String? _selectedWorkspaceParentLabel(
+  List<WorkspaceParentCandidate> candidates,
+  String? selectedId,
+) {
+  if (selectedId == null) {
+    return null;
+  }
+  for (final candidate in candidates) {
+    if (candidate.workspace.id == selectedId) {
+      return _workspaceParentLabel(candidate);
+    }
+  }
+  return null;
+}
+
+String _previewWorkspacePath(
+  Project? project,
+  String workspaceName,
+  String newBranchName,
+) {
+  if (project == null) {
+    return '';
+  }
+  final displayName = workspaceName.trim().isNotEmpty
+      ? workspaceName.trim()
+      : newBranchName.trim();
+  final workspaceSlug = displayName.isNotEmpty
+      ? _slugifyWorkspaceName(displayName)
+      : 'workspace';
+  return '~/.alera/workspaces/${_slugifyWorkspaceName(project.name)}-${project.id}/$workspaceSlug';
+}
+
+String _previewBranch(
+  String sourceBranch,
+  String newBranchName,
+  bool reuseExistingBranch,
+) {
+  if (reuseExistingBranch) {
+    final branch = sourceBranch.isEmpty ? '<existing-branch>' : sourceBranch;
+    return 'Branch: $branch';
+  }
+  final target = newBranchName.isEmpty ? '<new-branch>' : newBranchName;
+  final source = sourceBranch.isEmpty ? '<source>' : sourceBranch;
+  return 'Branch: $target ← from $source';
+}
+
+String _slugifyWorkspaceName(String input) {
+  return input
+      .trim()
+      .toLowerCase()
+      .replaceAll(RegExp(r'[\s_/]+'), '-')
+      .replaceAll(RegExp(r'[^a-z0-9-]'), '-')
+      .replaceAll(RegExp(r'-+'), '-')
+      .replaceAll(RegExp(r'^-|-$'), '');
+}


### PR DESCRIPTION
## Summary

- reduce `_CreateWorkspaceDialogState.build` from roughly 684 lines to 74 lines
- extract the dialog frame, interaction callbacks, selection step, and settings/preview step into private typed presentation components
- preserve the existing project/branch/parent selection, validation, loading/error, submit, focus, create-another, and close behavior without moving domain state out of the dialog state

## Screenshots

No visual change.

## Testing

- [x] `dart format --output=none --set-exit-if-changed` for the five changed files
- [x] `dart run tool/quality/check_max_lines.dart`
- [x] focused `flutter analyze --no-pub` for the dialog components and dialog widget tests
- [x] `flutter test --no-pub test/widget/create_workspace_dialog_test.dart test/widget/create_workspace_dialog_create_another_test.dart` (13 passed)
- [ ] Broad coverage and platform checks are delegated to PR CI

Existing interaction tests already cover default selection, required-field validation, branch-load errors and cancellation, existing/new branch submission, field submission, and Create Another reset behavior, so this behavior-preserving extraction does not add test-only assertions.

## AI Review Report

Reviewed the extraction against the previous inline build, with particular attention to callback enablement, validation messages, controller ownership, autofocus, async branch loading, submit/loading/error state, Create Another, back/cancel behavior, and parent preview labels. The review found no intended behavior or copy/theme changes; focused analysis and interaction tests remained green after the final rebase.

## Security Audit

No command execution, path handling, auth, secret, dependency, or process behavior changed. Existing preview-path formatting moved unchanged into presentation-only functions.

## Notes

All new files remain under workbench presentation and are under the 500-line ratchet. Terminal surface and workspace listing code are untouched.
