### PR TITLE
fix: retry version pull request after a failed publish

### DIFF
--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -235,31 +235,44 @@ jobs:
           existing_head="$(git ls-remote --heads origin "refs/heads/$VERSION_BRANCH" | awk '{print $1}')"
           if [[ -n "$existing_head" ]]; then
             git fetch origin "refs/heads/$VERSION_BRANCH:refs/remotes/origin/$VERSION_BRANCH" --quiet
-            git show "origin/$VERSION_BRANCH:tool/release/prepared_release.json" >"$RUNNER_TEMP/existing-prepared-release.json"
-            dart tool/release/prepared_release.dart compare \
-              --file "$RUNNER_TEMP/existing-prepared-release.json" \
-              --source-sha "$SOURCE_SHA" \
-              --channel "$CHANNEL" \
-              --desktop-tag "$DESKTOP_TAG" \
-              --mobile-tag "$MOBILE_TAG" \
-              --treeish "origin/$VERSION_BRANCH" \
-              --github-output "$RUNNER_TEMP/existing-prepared-output.txt"
-            version_head="$existing_head"
+            if git show "origin/$VERSION_BRANCH:tool/release/prepared_release.json" >"$RUNNER_TEMP/existing-prepared-release.json" &&
+              dart tool/release/prepared_release.dart compare \
+                --file "$RUNNER_TEMP/existing-prepared-release.json" \
+                --source-sha "$SOURCE_SHA" \
+                --channel "$CHANNEL" \
+                --desktop-tag "$DESKTOP_TAG" \
+                --mobile-tag "$MOBILE_TAG" \
+                --treeish "origin/$VERSION_BRANCH" \
+                --github-output "$RUNNER_TEMP/existing-prepared-output.txt"; then
+              version_head="$existing_head"
+            else
+              git push --force-with-lease="refs/heads/$VERSION_BRANCH:$existing_head" \
+                origin "HEAD:refs/heads/$VERSION_BRANCH"
+            fi
           else
             git push origin "HEAD:refs/heads/$VERSION_BRANCH"
           fi
 
-          mapfile -t pulls < <(gh pr list \
+          mapfile -t open_pulls < <(gh pr list \
             --repo "$GITHUB_REPOSITORY" \
             --head "$VERSION_BRANCH" \
-            --state all \
+            --state open \
             --json number,state,mergedAt,headRefOid \
             --jq '.[] | @base64')
-          if ((${#pulls[@]} > 1)); then
-            echo "::error::Multiple pull requests use $VERSION_BRANCH."
+          if ((${#open_pulls[@]} > 1)); then
+            echo "::error::Multiple open pull requests use $VERSION_BRANCH."
             exit 1
           fi
-          if ((${#pulls[@]} == 0)); then
+          if ((${#open_pulls[@]} == 1)); then
+            pull_json="$(printf '%s' "${open_pulls[0]}" | base64 --decode)"
+            remote_head="$(jq -r .headRefOid <<<"$pull_json")"
+            if [[ "$remote_head" != "$version_head" ]]; then
+              echo "::error::The existing version pull request has an unexpected head."
+              exit 1
+            fi
+            number="$(jq -r .number <<<"$pull_json")"
+            pr_url="https://github.com/$GITHUB_REPOSITORY/pull/$number"
+          else
             body_file="$RUNNER_TEMP/version-pr-body.md"
             {
               echo "Automated version update for the Cut Release workflow."
@@ -278,17 +291,6 @@ jobs:
               --head "$VERSION_BRANCH" \
               --title "$VERSION_TITLE" \
               --body-file "$body_file")"
-          else
-            pull_json="$(printf '%s' "${pulls[0]}" | base64 --decode)"
-            state="$(jq -r .state <<<"$pull_json")"
-            merged_at="$(jq -r '.mergedAt // empty' <<<"$pull_json")"
-            remote_head="$(jq -r .headRefOid <<<"$pull_json")"
-            if [[ "$state" != "OPEN" || -n "$merged_at" || "$remote_head" != "$version_head" ]]; then
-              echo "::error::The existing version pull request is closed, merged, or has an unexpected head."
-              exit 1
-            fi
-            number="$(jq -r .number <<<"$pull_json")"
-            pr_url="https://github.com/$GITHUB_REPOSITORY/pull/$number"
           fi
 
           check_dispatches="$(gh run list \

--- a/test/unit/release_workflow_config_test.dart
+++ b/test/unit/release_workflow_config_test.dart
@@ -353,6 +353,12 @@ void main() {
       expect(workflow, contains('prepare_version_pr:'));
       expect(workflow, contains('prepared_release.dart write'));
       expect(workflow, contains('prepared_release.dart inspect'));
+      expect(workflow, contains('--state open'));
+      expect(workflow, contains('--force-with-lease='));
+      expect(
+        workflow,
+        isNot(contains('closed, merged, or has an unexpected head')),
+      );
       expect(workflow, contains("ready_to_publish == 'true'"));
       expect(workflow, contains('gh workflow run pr.yml'));
       expect(workflow, contains('gh workflow run landing.yml'));


### PR DESCRIPTION
## Summary

Cut Release can plan a retry after a version PR already merged, but it then refuses to open another PR because `gh pr list --state all` still finds the merged branch.

This happened on run 32680567771 after #520: the bot pushed `release/version-v0.66.0-and-v0.31.0-mobile` with build 141, then exited with `The existing version pull request is closed, merged, or has an unexpected head.`

The prepare job now only reuses an open PR, and force-with-leases a stale version branch when the prepared plan no longer matches.

## Screenshots

- No visual change

## Testing

- [x] `flutter test test/unit/release_workflow_config_test.dart`
- [ ] Remaining PR Checks will run on GitHub

## AI Review Report

Checked the failed prepare-version-PR job against the merged #520 branch reuse path. Cross-platform release behavior is unchanged; this only affects the version-PR retry on GitHub.

## Security Audit

The force push is `--force-with-lease` against the observed remote head of the bot-owned version branch only. It does not touch `main`, tags, or signing secrets.

## Notes

After this merges, Cut Release needs another dispatch. Tags `v0.66.0` and `v0.31.0-mobile` still do not exist.

Refs #489