### PR TITLE
ci: let mergify start a single-pr batch

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -170,7 +170,7 @@ If there is no visual change, say that explicitly in the PR description.
 
 ### Merge Queue
 
-Mergify validates pull requests in batches of two to four. When only one pull request is eligible, the queue waits up to 60 minutes for a second entry before starting the speculative checks. A maintainer can queue another ready pull request to start the batch sooner, but unrelated or unready changes must not be used to bypass the required checks.
+Mergify validates pull requests in batches of one to four. A single ready pull request starts speculative checks immediately. When more than one pull request is eligible, the queue may wait up to 10 minutes to fill a larger batch. Unrelated or unready changes must not be used to bypass the required checks.
 
 ## Release Process
 

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -33,9 +33,9 @@ queue_rules:
   - name: default
     queue_branch_prefix: mergify/merge-queue/
     batch_size:
-      min: 2
+      min: 1
       max: 4
-    batch_max_wait_time: 60 min
+    batch_max_wait_time: 10 min
     max_checks_retries: 0
     merge_method: squash
     queue_conditions:

--- a/test/unit/release_workflow_config_test.dart
+++ b/test/unit/release_workflow_config_test.dart
@@ -385,6 +385,8 @@ void main() {
         expect(mergify, contains('author = github-actions[bot]'));
         expect(mergify, contains('head ~= ^release/version-'));
         expect(mergify, contains('check-success = @github-actions/pr-ready'));
+        expect(mergify, contains('min: 1'));
+        expect(mergify, contains('batch_max_wait_time: 10 min'));
       },
     );
 


### PR DESCRIPTION
## Summary

Mergify is holding the prepared version PR #523 because `batch_size.min` is 2 and the queue is waiting until 03:16 UTC for a second entry.

This lets a single ready pull request start speculative checks immediately, and shortens the optional extra-wait window to 10 minutes when more than one PR is eligible.

## Screenshots

- No visual change

## Testing

- [x] `flutter test test/unit/release_workflow_config_test.dart`
- [ ] Remaining PR Checks will run on GitHub

## AI Review Report

Checked the current Mergify queue status on #523 (`Waiting for batch (1/2)`). This change only affects merge-queue batching; release publish still requires `pr-ready` and `queue-ready`.

## Security Audit

No secrets, signing, or updater trust path changed. Required merge checks stay in place.

## Notes

Queue this PR after `pr-ready` so it can fill the current batch with #523.

Refs #489