### PR TITLE
fix: allow already-current landing pins on version inspect

### DIFF
--- a/test/unit/prepared_release_test.dart
+++ b/test/unit/prepared_release_test.dart
@@ -35,10 +35,18 @@ void main() {
       expect(decoded.title, 'release: v1.2.0 v0.8.1-mobile');
       expect(decoded.branchName, 'release/version-v1.2.0-and-v0.8.1-mobile');
       expect(decoded.tags, ['v1.2.0', 'v0.8.1-mobile']);
+      expect(decoded.requiredChangedPaths, {
+        preparedReleasePath,
+        'pubspec.yaml',
+        'mobile/pubspec.yaml',
+      });
       expect(decoded.expectedChangedPaths, {
         preparedReleasePath,
         'pubspec.yaml',
         'mobile/pubspec.yaml',
+        'landing/src/data/releases.json',
+      });
+      expect(decoded.optionalUnchangedPaths, {
         'landing/src/data/releases.json',
       });
     });

--- a/tool/release/prepared_release.dart
+++ b/tool/release/prepared_release.dart
@@ -87,10 +87,18 @@ final class PreparedRelease {
 
   String get branchName => 'release/version-${tags.join('-and-')}';
 
-  Set<String> get expectedChangedPaths => {
+  Set<String> get requiredChangedPaths => {
     preparedReleasePath,
     if (desktop.shouldRelease) 'pubspec.yaml',
     if (mobile.shouldRelease) 'mobile/pubspec.yaml',
+  };
+
+  Set<String> get expectedChangedPaths => {
+    ...requiredChangedPaths,
+    if (channel == ReleaseChannel.stable) 'landing/src/data/releases.json',
+  };
+
+  Set<String> get optionalUnchangedPaths => {
     if (channel == ReleaseChannel.stable) 'landing/src/data/releases.json',
   };
 
@@ -324,8 +332,14 @@ Future<void> _inspectMergedRelease(Map<String, String> values) async {
         await _run('git', ['diff', '--name-only', '$targetSha^', targetSha]),
       )
       .toSet();
-  if (!_setEquals(changedPaths, release.expectedChangedPaths)) {
-    throw StateError('Merged version commit changed unexpected paths.');
+  final unexpected = changedPaths.difference(release.expectedChangedPaths);
+  final missing = release.requiredChangedPaths.difference(changedPaths);
+  if (unexpected.isNotEmpty || missing.isNotEmpty) {
+    throw StateError(
+      'Merged version commit changed unexpected paths: '
+      'missing=${missing.toList()..sort()} '
+      'unexpected=${unexpected.toList()..sort()}.',
+    );
   }
   release.validateVersionFiles();
 


### PR DESCRIPTION
## Summary

Publish of #523 failed in `plan` with `Merged version commit changed unexpected paths.` The squash only touched `pubspec.yaml`, `mobile/pubspec.yaml`, and `prepared_release.json` because #520 had already written the same `v0.66.0` / `v0.31.0-mobile` landing pins.

Inspect now requires the prepared-release and pubspec files, and treats an unchanged landing pin as valid on a stable retry.

## Screenshots

- No visual change

## Testing

- [x] `flutter test test/unit/prepared_release_test.dart`
- [ ] Remaining PR Checks will run on GitHub

## AI Review Report

Checked merge commit `a8c80452` against `prepared_release.dart inspect`. Landing content already matched the planned tags, so rewriting it would have been a no-op.

## Security Audit

No secrets, signing, or updater trust path changed. Unexpected extra files in the version commit still fail inspect.

## Notes

After this merges, Cut Release needs another dispatch. Tags `v0.66.0` and `v0.31.0-mobile` still do not exist. The next version PR should reuse those tags and increment the build number.

Refs #489