### PR TITLE
feat: move the terminal toolbar between tab corners

### DIFF
--- a/lib/src/design_system/buttons/alera_icon_button.dart
+++ b/lib/src/design_system/buttons/alera_icon_button.dart
@@ -10,14 +10,17 @@ class AleraIconButton extends StatelessWidget {
     this.tooltip,
     required this.onPressed,
     required this.icon,
-    this.iconSize = 16,
-    this.minSize = 30,
+    this.iconSize = defaultIconSize,
+    this.minSize = defaultMinSize,
     this.iconColor = AleraTokens.foregroundMuted,
     this.backgroundColor,
     this.hoverColor,
     this.borderColor,
     this.borderRadius = AleraTokens.radiusMd,
   });
+
+  static const double defaultIconSize = 16;
+  static const double defaultMinSize = 30;
 
   final String? tooltip;
   final VoidCallback? onPressed;

--- a/lib/src/features/settings/domain/alera_settings.dart
+++ b/lib/src/features/settings/domain/alera_settings.dart
@@ -14,6 +14,21 @@ part 'alera_settings.mapper.dart';
 @MappableEnum()
 enum TerminalCursorShape { block, bar, underline }
 
+@MappableEnum()
+enum TerminalToolbarCorner {
+  topLeft,
+  topRight,
+  bottomLeft,
+  bottomRight;
+
+  String get label => switch (this) {
+    topLeft => 'Top Left',
+    topRight => 'Top Right',
+    bottomLeft => 'Bottom Left',
+    bottomRight => 'Bottom Right',
+  };
+}
+
 final _hexColorPattern = RegExp(r'^#?[0-9a-fA-F]{6}$');
 
 String? normalizeTerminalHexColor(Object? value) {
@@ -73,6 +88,7 @@ class TerminalSettings with TerminalSettingsMappable {
     this.clipboardOnSelect = false,
     this.allowOsc52Clipboard = false,
     this.showComposerByDefault = false,
+    this.toolbarCorner = TerminalToolbarCorner.topRight,
     this.hostEmptyShutdownDelaySeconds = 30,
     this.hostDetachedSessionShutdownDelaySeconds = 60 * 60,
     this.hostScrollbackBytes = 10 * 1000 * 1000,
@@ -101,6 +117,9 @@ class TerminalSettings with TerminalSettingsMappable {
 
   /// Whether new terminal sessions open the prompt composer immediately.
   final bool showComposerByDefault;
+
+  /// Where the terminal action-button cluster sits inside the tab.
+  final TerminalToolbarCorner toolbarCorner;
   final int hostEmptyShutdownDelaySeconds;
   final int hostDetachedSessionShutdownDelaySeconds;
   final int hostScrollbackBytes;
@@ -143,6 +162,7 @@ class TerminalSettings with TerminalSettingsMappable {
     clipboardOnSelect: false,
     allowOsc52Clipboard: false,
     showComposerByDefault: false,
+    toolbarCorner: TerminalToolbarCorner.topRight,
     hostEmptyShutdownDelaySeconds: 30,
     hostDetachedSessionShutdownDelaySeconds: 60 * 60,
     hostScrollbackBytes: 10 * 1000 * 1000,

--- a/lib/src/features/settings/domain/alera_settings.mapper.dart
+++ b/lib/src/features/settings/domain/alera_settings.mapper.dart
@@ -58,6 +58,61 @@ extension TerminalCursorShapeMapperExtension on TerminalCursorShape {
   }
 }
 
+class TerminalToolbarCornerMapper extends EnumMapper<TerminalToolbarCorner> {
+  TerminalToolbarCornerMapper._();
+
+  static TerminalToolbarCornerMapper? _instance;
+  static TerminalToolbarCornerMapper ensureInitialized() {
+    if (_instance == null) {
+      MapperContainer.globals.use(_instance = TerminalToolbarCornerMapper._());
+    }
+    return _instance!;
+  }
+
+  static TerminalToolbarCorner fromValue(dynamic value) {
+    ensureInitialized();
+    return MapperContainer.globals.fromValue(value);
+  }
+
+  @override
+  TerminalToolbarCorner decode(dynamic value) {
+    switch (value) {
+      case r'topLeft':
+        return TerminalToolbarCorner.topLeft;
+      case r'topRight':
+        return TerminalToolbarCorner.topRight;
+      case r'bottomLeft':
+        return TerminalToolbarCorner.bottomLeft;
+      case r'bottomRight':
+        return TerminalToolbarCorner.bottomRight;
+      default:
+        throw MapperException.unknownEnumValue(value);
+    }
+  }
+
+  @override
+  dynamic encode(TerminalToolbarCorner self) {
+    switch (self) {
+      case TerminalToolbarCorner.topLeft:
+        return r'topLeft';
+      case TerminalToolbarCorner.topRight:
+        return r'topRight';
+      case TerminalToolbarCorner.bottomLeft:
+        return r'bottomLeft';
+      case TerminalToolbarCorner.bottomRight:
+        return r'bottomRight';
+    }
+  }
+}
+
+extension TerminalToolbarCornerMapperExtension on TerminalToolbarCorner {
+  String toValue() {
+    TerminalToolbarCornerMapper.ensureInitialized();
+    return MapperContainer.globals.toValue<TerminalToolbarCorner>(this)
+        as String;
+  }
+}
+
 class DiagnosticsLogLevelMapper extends EnumMapper<DiagnosticsLogLevel> {
   DiagnosticsLogLevelMapper._();
 
@@ -371,6 +426,7 @@ class TerminalSettingsMapper extends ClassMapperBase<TerminalSettings> {
       MapperContainer.globals.use(_instance = TerminalSettingsMapper._());
       TerminalCursorShapeMapper.ensureInitialized();
       TerminalColorOverridesMapper.ensureInitialized();
+      TerminalToolbarCornerMapper.ensureInitialized();
     }
     return _instance!;
   }
@@ -496,6 +552,15 @@ class TerminalSettingsMapper extends ClassMapperBase<TerminalSettings> {
     opt: true,
     def: false,
   );
+  static TerminalToolbarCorner _$toolbarCorner(TerminalSettings v) =>
+      v.toolbarCorner;
+  static const Field<TerminalSettings, TerminalToolbarCorner> _f$toolbarCorner =
+      Field(
+        'toolbarCorner',
+        _$toolbarCorner,
+        opt: true,
+        def: TerminalToolbarCorner.topRight,
+      );
   static int _$hostEmptyShutdownDelaySeconds(TerminalSettings v) =>
       v.hostEmptyShutdownDelaySeconds;
   static const Field<TerminalSettings, int> _f$hostEmptyShutdownDelaySeconds =
@@ -565,6 +630,7 @@ class TerminalSettingsMapper extends ClassMapperBase<TerminalSettings> {
     #clipboardOnSelect: _f$clipboardOnSelect,
     #allowOsc52Clipboard: _f$allowOsc52Clipboard,
     #showComposerByDefault: _f$showComposerByDefault,
+    #toolbarCorner: _f$toolbarCorner,
     #hostEmptyShutdownDelaySeconds: _f$hostEmptyShutdownDelaySeconds,
     #hostDetachedSessionShutdownDelaySeconds:
         _f$hostDetachedSessionShutdownDelaySeconds,
@@ -596,6 +662,7 @@ class TerminalSettingsMapper extends ClassMapperBase<TerminalSettings> {
       clipboardOnSelect: data.dec(_f$clipboardOnSelect),
       allowOsc52Clipboard: data.dec(_f$allowOsc52Clipboard),
       showComposerByDefault: data.dec(_f$showComposerByDefault),
+      toolbarCorner: data.dec(_f$toolbarCorner),
       hostEmptyShutdownDelaySeconds: data.dec(_f$hostEmptyShutdownDelaySeconds),
       hostDetachedSessionShutdownDelaySeconds: data.dec(
         _f$hostDetachedSessionShutdownDelaySeconds,
@@ -694,6 +761,7 @@ abstract class TerminalSettingsCopyWith<$R, $In extends TerminalSettings, $Out>
     bool? clipboardOnSelect,
     bool? allowOsc52Clipboard,
     bool? showComposerByDefault,
+    TerminalToolbarCorner? toolbarCorner,
     int? hostEmptyShutdownDelaySeconds,
     int? hostDetachedSessionShutdownDelaySeconds,
     int? hostScrollbackBytes,
@@ -742,6 +810,7 @@ class _TerminalSettingsCopyWithImpl<$R, $Out>
     bool? clipboardOnSelect,
     bool? allowOsc52Clipboard,
     bool? showComposerByDefault,
+    TerminalToolbarCorner? toolbarCorner,
     int? hostEmptyShutdownDelaySeconds,
     int? hostDetachedSessionShutdownDelaySeconds,
     int? hostScrollbackBytes,
@@ -771,6 +840,7 @@ class _TerminalSettingsCopyWithImpl<$R, $Out>
         #allowOsc52Clipboard: allowOsc52Clipboard,
       if (showComposerByDefault != null)
         #showComposerByDefault: showComposerByDefault,
+      if (toolbarCorner != null) #toolbarCorner: toolbarCorner,
       if (hostEmptyShutdownDelaySeconds != null)
         #hostEmptyShutdownDelaySeconds: hostEmptyShutdownDelaySeconds,
       if (hostDetachedSessionShutdownDelaySeconds != null)
@@ -820,6 +890,7 @@ class _TerminalSettingsCopyWithImpl<$R, $Out>
       #showComposerByDefault,
       or: $value.showComposerByDefault,
     ),
+    toolbarCorner: data.get(#toolbarCorner, or: $value.toolbarCorner),
     hostEmptyShutdownDelaySeconds: data.get(
       #hostEmptyShutdownDelaySeconds,
       or: $value.hostEmptyShutdownDelaySeconds,

--- a/lib/src/features/settings/presentation/panes/terminal_pane.dart
+++ b/lib/src/features/settings/presentation/panes/terminal_pane.dart
@@ -156,6 +156,11 @@ class TerminalSettingsPane extends StatelessWidget {
                 onChanged: (value) =>
                     onChanged(settings.copyWith(paddingY: value)),
               ),
+              ToolbarCornerRow(
+                value: settings.toolbarCorner,
+                onChanged: (value) =>
+                    onChanged(settings.copyWith(toolbarCorner: value)),
+              ),
               HexColorSettingRow(
                 title: 'Foreground Color',
                 description: 'Override the terminal text color.',

--- a/lib/src/features/settings/presentation/panes/terminal_theme_controls.dart
+++ b/lib/src/features/settings/presentation/panes/terminal_theme_controls.dart
@@ -1,6 +1,7 @@
 import 'package:alera/src/app/theme/alera_tokens.dart';
 import 'package:alera/src/design_system/buttons/alera_segmented_button.dart';
 import 'package:alera/src/design_system/feedback/alera_color_swatch.dart';
+import 'package:alera/src/design_system/forms/alera_dropdown_field.dart';
 import 'package:alera/src/design_system/forms/alera_setting_row.dart';
 import 'package:alera/src/design_system/forms/alera_text_field.dart';
 import 'package:alera/src/features/settings/domain/alera_settings.dart';
@@ -196,6 +197,38 @@ class _CursorGlyph extends StatelessWidget {
               : EdgeInsets.zero,
           child: glyph,
         ),
+      ),
+    );
+  }
+}
+
+class ToolbarCornerRow extends StatelessWidget {
+  const ToolbarCornerRow({
+    super.key,
+    required this.value,
+    required this.onChanged,
+  });
+
+  final TerminalToolbarCorner value;
+  final ValueChanged<TerminalToolbarCorner> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return AleraSettingRow(
+      title: 'Toolbar Corner',
+      description:
+          'Where the pulse, composer, and refresh buttons sit on the terminal tab.',
+      child: AleraDropdownField<TerminalToolbarCorner>(
+        key: ValueKey<String>('terminal-toolbar-corner-${value.name}'),
+        value: value,
+        entries: <AleraDropdownFieldEntry<TerminalToolbarCorner>>[
+          for (final corner in TerminalToolbarCorner.values)
+            AleraDropdownFieldEntry<TerminalToolbarCorner>(
+              value: corner,
+              label: corner.label,
+            ),
+        ],
+        onChanged: onChanged,
       ),
     );
   }

--- a/lib/src/features/settings/presentation/settings_search_entries_terminal.dart
+++ b/lib/src/features/settings/presentation/settings_search_entries_terminal.dart
@@ -54,6 +54,13 @@ const List<SettingsSearchEntry> terminalSearchEntries = <SettingsSearchEntry>[
     groupId: 'appearance',
   ),
   SettingsSearchEntry(
+    title: 'Toolbar Corner',
+    description:
+        'Where the pulse, composer, and refresh buttons sit on the terminal tab.',
+    keywords: <String>['buttons', 'overlay', 'position', 'corner', 'move'],
+    groupId: 'appearance',
+  ),
+  SettingsSearchEntry(
     title: 'Cursor Shape',
     description: 'Cursor style for new terminal sessions.',
     keywords: <String>['caret', 'block', 'bar', 'underline'],

--- a/lib/src/features/workbench/domain/terminal_toolbar_placement.dart
+++ b/lib/src/features/workbench/domain/terminal_toolbar_placement.dart
@@ -1,0 +1,154 @@
+import 'package:alera/src/app/theme/alera_tokens.dart';
+import 'package:alera/src/features/settings/domain/alera_settings.dart';
+
+extension TerminalToolbarCornerLayout on TerminalToolbarCorner {
+  bool get isTop =>
+      this == TerminalToolbarCorner.topLeft ||
+      this == TerminalToolbarCorner.topRight;
+
+  bool get isLeft =>
+      this == TerminalToolbarCorner.topLeft ||
+      this == TerminalToolbarCorner.bottomLeft;
+
+  bool get isBottom => !isTop;
+
+  bool get isRight => !isLeft;
+}
+
+class TerminalToolbarAnchor {
+  const TerminalToolbarAnchor({this.top, this.left, this.right, this.bottom});
+
+  final double? top;
+  final double? left;
+  final double? right;
+  final double? bottom;
+
+  @override
+  bool operator ==(Object other) {
+    return other is TerminalToolbarAnchor &&
+        other.top == top &&
+        other.left == left &&
+        other.right == right &&
+        other.bottom == bottom;
+  }
+
+  @override
+  int get hashCode => Object.hash(top, left, right, bottom);
+
+  static TerminalToolbarAnchor forCorner(
+    TerminalToolbarCorner corner, {
+    double inset = AleraTokens.space4,
+  }) {
+    return TerminalToolbarAnchor(
+      top: corner.isTop ? inset : null,
+      bottom: corner.isBottom ? inset : null,
+      left: corner.isLeft ? inset : null,
+      right: corner.isRight ? inset : null,
+    );
+  }
+}
+
+({double left, double top}) terminalToolbarOffset({
+  required TerminalToolbarCorner corner,
+  required double viewportWidth,
+  required double viewportHeight,
+  required double toolbarWidth,
+  required double toolbarHeight,
+  double inset = AleraTokens.space4,
+}) {
+  return (
+    left: corner.isLeft ? inset : viewportWidth - toolbarWidth - inset,
+    top: corner.isTop ? inset : viewportHeight - toolbarHeight - inset,
+  );
+}
+
+double clampTerminalToolbarLeft({
+  required double left,
+  required double viewportWidth,
+  required double toolbarWidth,
+  double inset = AleraTokens.space4,
+}) {
+  final maxLeft = viewportWidth - toolbarWidth - inset;
+  if (maxLeft <= inset) {
+    return inset;
+  }
+  return left.clamp(inset, maxLeft);
+}
+
+double clampTerminalToolbarTop({
+  required double top,
+  required double viewportHeight,
+  required double toolbarHeight,
+  double inset = AleraTokens.space4,
+}) {
+  final maxTop = viewportHeight - toolbarHeight - inset;
+  if (maxTop <= inset) {
+    return inset;
+  }
+  return top.clamp(inset, maxTop);
+}
+
+TerminalToolbarCorner nearestTerminalToolbarCorner({
+  required double centerX,
+  required double centerY,
+  required double viewportWidth,
+  required double viewportHeight,
+}) {
+  final left = centerX <= viewportWidth / 2;
+  final top = centerY <= viewportHeight / 2;
+  if (top) {
+    return left
+        ? TerminalToolbarCorner.topLeft
+        : TerminalToolbarCorner.topRight;
+  }
+  return left
+      ? TerminalToolbarCorner.bottomLeft
+      : TerminalToolbarCorner.bottomRight;
+}
+
+class TerminalSearchOverlayLayout {
+  const TerminalSearchOverlayLayout({
+    required this.left,
+    required this.right,
+    required this.alignLeft,
+  });
+
+  final double left;
+  final double right;
+  final bool alignLeft;
+}
+
+TerminalSearchOverlayLayout terminalSearchOverlayLayout({
+  required TerminalToolbarCorner toolbarCorner,
+  required int toolbarButtonCount,
+}) {
+  final toolbarInset =
+      AleraTokens.space48 * toolbarButtonCount + AleraTokens.space4;
+  if (toolbarCorner == TerminalToolbarCorner.topLeft) {
+    return TerminalSearchOverlayLayout(
+      left: toolbarInset,
+      right: AleraTokens.space16,
+      alignLeft: true,
+    );
+  }
+  if (toolbarCorner == TerminalToolbarCorner.topRight) {
+    return TerminalSearchOverlayLayout(
+      left: AleraTokens.space16,
+      right: toolbarInset,
+      alignLeft: false,
+    );
+  }
+  return const TerminalSearchOverlayLayout(
+    left: AleraTokens.space16,
+    right: AleraTokens.space16,
+    alignLeft: false,
+  );
+}
+
+int terminalToolbarButtonCount({
+  required bool supportsPulse,
+  required bool hasCanvas,
+}) {
+  // Move handle, composer, and refresh are always present.
+  return 3 + (supportsPulse ? 1 : 0) + (hasCanvas ? 1 : 0);
+}

--- a/lib/src/features/workbench/presentation/terminal_surface.dart
+++ b/lib/src/features/workbench/presentation/terminal_surface.dart
@@ -2,8 +2,6 @@ import 'dart:async';
 
 import 'package:alera/src/app/providers.dart';
 import 'package:alera/src/app/theme/alera_tokens.dart';
-import 'package:alera/src/design_system/buttons/alera_icon_button.dart';
-import 'package:alera/src/design_system/icons/alera_icons.dart';
 import 'package:alera/src/features/agent_canvas/application/agent_canvas_providers.dart';
 import 'package:alera/src/features/keyboard/application/keybinding_resolver.dart';
 import 'package:alera/src/features/keyboard/application/keyboard_command_dispatcher.dart';
@@ -11,13 +9,14 @@ import 'package:alera/src/features/keyboard/domain/key_chord.dart';
 import 'package:alera/src/features/keyboard/domain/keyboard_action.dart';
 import 'package:alera/src/features/workbench/presentation/terminal_composer_drop_target.dart';
 import 'package:alera/src/features/workbench/presentation/terminal_composer_workspace_file_opener.dart';
-import 'package:alera/src/features/workbench/infra/terminal_host/terminal_host_client_models.dart';
 import 'package:alera/src/features/workbench/presentation/terminal_path_drop.dart';
-import 'package:alera/src/features/workbench/presentation/terminal_pulse_dialog.dart';
+import 'package:alera/src/features/workbench/domain/terminal_toolbar_placement.dart';
 import 'package:alera/src/features/workbench/presentation/terminal_runtime.dart';
 import 'package:alera/src/features/workbench/presentation/terminal_search_controller.dart';
 import 'package:alera/src/features/workbench/presentation/terminal_search_overlay.dart';
+import 'package:alera/src/features/workbench/presentation/terminal_surface_toolbar.dart';
 import 'package:alera/src/features/workbench/domain/workbench_view_prefs.dart';
+import 'package:alera/src/features/settings/domain/alera_settings.dart';
 import 'package:desktop_drop/desktop_drop.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -156,8 +155,8 @@ class _TerminalSurfaceState extends ConsumerState<TerminalSurface> {
   @override
   Widget build(BuildContext context) {
     // Keep the surface usable in isolated previews and test harnesses that do
-    // not mount the application ProviderScope. The toolbar is unavailable
-    // there, while the normal app still watches the runtime-owned catalog.
+    // not mount the application ProviderScope. The canvas catalog is
+    // unavailable there, while the normal app still watches it.
     final hasProviderScope = _hasProviderScope(context);
     final hasCanvas =
         hasProviderScope &&
@@ -167,16 +166,33 @@ class _TerminalSurfaceState extends ConsumerState<TerminalSurface> {
                 ?.value
                 .isNotEmpty ==
             true;
+    final toolbarCorner = hasProviderScope
+        ? ref.watch(
+            settingsControllerProvider.select(
+              (settings) => settings.terminal.toolbarCorner,
+            ),
+          )
+        : TerminalToolbarCorner.topRight;
     return AnimatedBuilder(
       animation: Listenable.merge(<Listenable>[
         widget.session,
         widget.session.composerController,
       ]),
-      builder: (context, _) => _buildSurface(context, hasCanvas: hasCanvas),
+      builder: (context, _) => _buildSurface(
+        context,
+        hasCanvas: hasCanvas,
+        toolbarCorner: toolbarCorner,
+        canPersistToolbarCorner: hasProviderScope,
+      ),
     );
   }
 
-  Widget _buildSurface(BuildContext context, {required bool hasCanvas}) {
+  Widget _buildSurface(
+    BuildContext context, {
+    required bool hasCanvas,
+    required TerminalToolbarCorner toolbarCorner,
+    required bool canPersistToolbarCorner,
+  }) {
     final error = switch (widget.session.errorMessage) {
       final String message when message.trim().isNotEmpty => message,
       _ => null,
@@ -206,6 +222,8 @@ class _TerminalSurfaceState extends ConsumerState<TerminalSurface> {
           operation: operation,
           searchController: searchController,
           hasCanvas: hasCanvas,
+          toolbarCorner: toolbarCorner,
+          canPersistToolbarCorner: canPersistToolbarCorner,
         ),
       ),
     );
@@ -217,6 +235,8 @@ class _TerminalSurfaceState extends ConsumerState<TerminalSurface> {
     required TerminalSessionOperation? operation,
     required TerminalSearchController? searchController,
     required bool hasCanvas,
+    required TerminalToolbarCorner toolbarCorner,
+    required bool canPersistToolbarCorner,
   }) {
     return Column(
       children: <Widget>[
@@ -227,6 +247,8 @@ class _TerminalSurfaceState extends ConsumerState<TerminalSurface> {
             operation: operation,
             searchController: searchController,
             hasCanvas: hasCanvas,
+            toolbarCorner: toolbarCorner,
+            canPersistToolbarCorner: canPersistToolbarCorner,
           ),
         ),
         if (widget.session.composerController.visible)
@@ -241,21 +263,44 @@ class _TerminalSurfaceState extends ConsumerState<TerminalSurface> {
     required TerminalSessionOperation? operation,
     required TerminalSearchController? searchController,
     required bool hasCanvas,
+    required TerminalToolbarCorner toolbarCorner,
+    required bool canPersistToolbarCorner,
   }) {
-    final toolbarButtonCount =
-        2 +
-        (widget.session.supportsTerminalPulse ? 1 : 0) +
-        (hasCanvas ? 1 : 0);
-    return Stack(
-      children: <Widget>[
-        Positioned.fill(child: _buildTerminalContent(context, error)),
-        if (operation != null)
-          Positioned.fill(child: _TerminalOperationState(operation: operation)),
-        if (error == null) _buildRestoreOverlay(),
-        _buildToolbar(context, hasCanvas: hasCanvas),
-        if (searchController?.isOpen == true)
-          _buildSearchOverlay(searchController!, toolbarButtonCount),
-      ],
+    final toolbarButtonCount = terminalToolbarButtonCount(
+      supportsPulse: widget.session.supportsTerminalPulse,
+      hasCanvas: hasCanvas,
+    );
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        return Stack(
+          children: <Widget>[
+            Positioned.fill(child: _buildTerminalContent(context, error)),
+            if (operation != null)
+              Positioned.fill(
+                child: _TerminalOperationState(operation: operation),
+              ),
+            if (error == null) _buildRestoreOverlay(),
+            TerminalSurfaceToolbar(
+              session: widget.session,
+              viewportSize: constraints.biggest,
+              corner: toolbarCorner,
+              hasCanvas: hasCanvas,
+              refreshing: _refreshing,
+              onRefresh: () => unawaited(_refreshTerminal()),
+              onShowAgentCanvas: _showAgentCanvas,
+              onCornerChanged: canPersistToolbarCorner
+                  ? _persistToolbarCorner
+                  : null,
+            ),
+            if (searchController?.isOpen == true)
+              _buildSearchOverlay(
+                searchController!,
+                toolbarCorner,
+                toolbarButtonCount,
+              ),
+          ],
+        );
+      },
     );
   }
 
@@ -294,86 +339,21 @@ class _TerminalSurfaceState extends ConsumerState<TerminalSurface> {
     );
   }
 
-  Widget _buildToolbar(BuildContext context, {required bool hasCanvas}) {
-    return Positioned(
-      top: AleraTokens.space4,
-      right: AleraTokens.space4,
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        spacing: AleraTokens.space2,
-        children: <Widget>[
-          if (widget.session.supportsTerminalPulse)
-            _buildTerminalPulseControl(context),
-          AleraIconButton(
-            tooltip: widget.session.composerController.visible
-                ? 'Hide Terminal Composer'
-                : 'Show Terminal Composer',
-            icon: AleraIcons.composer,
-            iconColor: widget.session.composerController.visible
-                ? AleraTokens.foreground
-                : AleraTokens.foregroundMuted,
-            backgroundColor: widget.session.composerController.visible
-                ? AleraTokens.accentSubtle
-                : AleraTokens.surfaceElevated,
-            borderColor: AleraTokens.borderSubtle,
-            onPressed: widget.session.composerController.toggle,
-          ),
-          AleraIconButton(
-            tooltip: _refreshing ? 'Refreshing Terminal' : 'Refresh Terminal',
-            icon: _refreshing ? AleraIcons.loading : AleraIcons.refresh,
-            backgroundColor: AleraTokens.surfaceElevated,
-            borderColor: AleraTokens.borderSubtle,
-            onPressed: _refreshing ? null : () => unawaited(_refreshTerminal()),
-          ),
-          if (hasCanvas)
-            AleraIconButton(
-              tooltip: 'Agent Canvas',
-              icon: AleraIcons.agent,
-              backgroundColor: AleraTokens.surfaceElevated,
-              borderColor: AleraTokens.borderSubtle,
-              onPressed: _showAgentCanvas,
-            ),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildTerminalPulseControl(BuildContext context) {
-    return ValueListenableBuilder<TerminalPulseState>(
-      valueListenable: widget.session.terminalPulseState,
-      builder: (context, state, _) {
-        return AleraIconButton(
-          tooltip: !state.statusKnown
-              ? 'Configure Terminal Pulse - Status Unavailable'
-              : state.armed
-              ? 'Configure Terminal Pulse - Armed'
-              : 'Configure Terminal Pulse',
-          icon: AleraIcons.pulse,
-          iconColor: state.statusKnown && state.armed
-              ? AleraTokens.foreground
-              : AleraTokens.foregroundMuted,
-          backgroundColor: state.statusKnown && state.armed
-              ? AleraTokens.accentSubtle
-              : AleraTokens.surfaceElevated,
-          borderColor: AleraTokens.borderSubtle,
-          onPressed: () =>
-              unawaited(showTerminalPulseDialog(context, widget.session)),
-        );
-      },
-    );
-  }
-
   Widget _buildSearchOverlay(
     TerminalSearchController searchController,
+    TerminalToolbarCorner toolbarCorner,
     int toolbarButtonCount,
   ) {
+    final layout = terminalSearchOverlayLayout(
+      toolbarCorner: toolbarCorner,
+      toolbarButtonCount: toolbarButtonCount,
+    );
     return Positioned(
       top: AleraTokens.space4,
-      left: AleraTokens.space16,
-      // Keep search clear of every visible terminal toolbar action.
-      right: AleraTokens.space48 * toolbarButtonCount + AleraTokens.space4,
+      left: layout.left,
+      right: layout.right,
       child: Align(
-        alignment: Alignment.topRight,
+        alignment: layout.alignLeft ? Alignment.topLeft : Alignment.topRight,
         child: ConstrainedBox(
           constraints: const BoxConstraints(
             maxWidth: AleraTokens.dialogWideWidth,
@@ -384,6 +364,18 @@ class _TerminalSurfaceState extends ConsumerState<TerminalSurface> {
           ),
         ),
       ),
+    );
+  }
+
+  void _persistToolbarCorner(TerminalToolbarCorner corner) {
+    final terminal = ref.read(settingsControllerProvider).terminal;
+    if (terminal.toolbarCorner == corner) {
+      return;
+    }
+    unawaited(
+      ref
+          .read(settingsControllerProvider.notifier)
+          .updateTerminal(terminal.copyWith(toolbarCorner: corner)),
     );
   }
 

--- a/lib/src/features/workbench/presentation/terminal_surface_toolbar.dart
+++ b/lib/src/features/workbench/presentation/terminal_surface_toolbar.dart
@@ -9,7 +9,6 @@ import 'package:alera/src/features/workbench/domain/terminal_toolbar_placement.d
 import 'package:alera/src/features/workbench/infra/terminal_host/terminal_host_client_models.dart';
 import 'package:alera/src/features/workbench/presentation/terminal_pulse_dialog.dart';
 import 'package:alera/src/features/workbench/presentation/terminal_runtime.dart';
-import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 
 class TerminalSurfaceToolbar extends StatefulWidget {
@@ -198,12 +197,9 @@ class _TerminalSurfaceToolbarState extends State<TerminalSurfaceToolbar> {
           onPressed: widget.onShowAgentCanvas,
         ),
     ];
-    return Listener(
-      onPointerDown: (event) {
-        if (event.kind == PointerDeviceKind.mouse &&
-            event.buttons == kSecondaryMouseButton) {
-          unawaited(_showCornerMenu(event.position));
-        }
+    return GestureDetector(
+      onSecondaryTapDown: (details) {
+        unawaited(_showCornerMenu(details.globalPosition));
       },
       child: Row(
         key: _toolbarKey,
@@ -257,30 +253,18 @@ class _MoveToolbarHandle extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Tooltip(
-      message: 'Move Toolbar',
-      child: MouseRegion(
-        cursor: SystemMouseCursors.move,
-        child: GestureDetector(
-          onPanStart: onPanStart,
-          onPanUpdate: onPanUpdate,
-          onPanEnd: onPanEnd,
-          child: DecoratedBox(
-            decoration: BoxDecoration(
-              color: AleraTokens.surfaceElevated,
-              borderRadius: BorderRadius.circular(AleraTokens.radiusMd),
-              border: Border.all(color: AleraTokens.borderSubtle),
-            ),
-            child: const SizedBox(
-              width: AleraIconButton.defaultMinSize,
-              height: AleraIconButton.defaultMinSize,
-              child: Icon(
-                AleraIcons.dragHandle,
-                size: AleraIconButton.defaultIconSize,
-                color: AleraTokens.foregroundMuted,
-              ),
-            ),
-          ),
+    return MouseRegion(
+      cursor: SystemMouseCursors.move,
+      child: GestureDetector(
+        onPanStart: onPanStart,
+        onPanUpdate: onPanUpdate,
+        onPanEnd: onPanEnd,
+        child: AleraIconButton(
+          tooltip: 'Move Toolbar',
+          icon: AleraIcons.dragHandle,
+          backgroundColor: AleraTokens.surfaceElevated,
+          borderColor: AleraTokens.borderSubtle,
+          onPressed: () {},
         ),
       ),
     );

--- a/lib/src/features/workbench/presentation/terminal_surface_toolbar.dart
+++ b/lib/src/features/workbench/presentation/terminal_surface_toolbar.dart
@@ -1,0 +1,288 @@
+import 'dart:async';
+
+import 'package:alera/src/app/theme/alera_tokens.dart';
+import 'package:alera/src/design_system/buttons/alera_icon_button.dart';
+import 'package:alera/src/design_system/menus/alera_dropdown_entry.dart';
+import 'package:alera/src/design_system/icons/alera_icons.dart';
+import 'package:alera/src/features/settings/domain/alera_settings.dart';
+import 'package:alera/src/features/workbench/domain/terminal_toolbar_placement.dart';
+import 'package:alera/src/features/workbench/infra/terminal_host/terminal_host_client_models.dart';
+import 'package:alera/src/features/workbench/presentation/terminal_pulse_dialog.dart';
+import 'package:alera/src/features/workbench/presentation/terminal_runtime.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+
+class TerminalSurfaceToolbar extends StatefulWidget {
+  const TerminalSurfaceToolbar({
+    super.key,
+    required this.session,
+    required this.viewportSize,
+    required this.corner,
+    required this.hasCanvas,
+    required this.refreshing,
+    required this.onRefresh,
+    required this.onShowAgentCanvas,
+    this.onCornerChanged,
+  });
+
+  final TerminalSessionHandle session;
+  final Size viewportSize;
+  final TerminalToolbarCorner corner;
+  final bool hasCanvas;
+  final bool refreshing;
+  final VoidCallback onRefresh;
+  final VoidCallback onShowAgentCanvas;
+  final ValueChanged<TerminalToolbarCorner>? onCornerChanged;
+
+  @override
+  State<TerminalSurfaceToolbar> createState() => _TerminalSurfaceToolbarState();
+}
+
+class _TerminalSurfaceToolbarState extends State<TerminalSurfaceToolbar> {
+  final GlobalKey _toolbarKey = GlobalKey();
+  TerminalToolbarCorner? _localCorner;
+  Offset? _dragOrigin;
+
+  TerminalToolbarCorner get _corner => _localCorner ?? widget.corner;
+
+  @override
+  void didUpdateWidget(TerminalSurfaceToolbar oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.corner != widget.corner && _dragOrigin == null) {
+      _localCorner = null;
+    }
+  }
+
+  void _setCorner(TerminalToolbarCorner corner) {
+    if (corner == _corner) {
+      return;
+    }
+    setState(() {
+      _localCorner = corner;
+      _dragOrigin = null;
+    });
+    widget.onCornerChanged?.call(corner);
+  }
+
+  Future<void> _showCornerMenu(Offset globalPosition) async {
+    final overlay =
+        Overlay.of(context).context.findRenderObject()! as RenderBox;
+    final selected = await showMenu<TerminalToolbarCorner>(
+      context: context,
+      position: RelativeRect.fromRect(
+        Rect.fromPoints(globalPosition, globalPosition),
+        Offset.zero & overlay.size,
+      ),
+      items: <PopupMenuEntry<TerminalToolbarCorner>>[
+        for (final corner in TerminalToolbarCorner.values)
+          AleraDropdownEntry<TerminalToolbarCorner>(
+            value: corner,
+            label: corner.label,
+            selected: corner == _corner,
+          ),
+      ],
+    );
+    if (!mounted || selected == null) {
+      return;
+    }
+    _setCorner(selected);
+  }
+
+  void _onPanStart(DragStartDetails details) {
+    final toolbarSize = _toolbarKey.currentContext?.size;
+    if (toolbarSize == null) {
+      return;
+    }
+    final origin = terminalToolbarOffset(
+      corner: _corner,
+      viewportWidth: widget.viewportSize.width,
+      viewportHeight: widget.viewportSize.height,
+      toolbarWidth: toolbarSize.width,
+      toolbarHeight: toolbarSize.height,
+    );
+    setState(() => _dragOrigin = Offset(origin.left, origin.top));
+  }
+
+  void _onPanUpdate(DragUpdateDetails details) {
+    final origin = _dragOrigin;
+    final toolbarSize = _toolbarKey.currentContext?.size;
+    if (origin == null || toolbarSize == null) {
+      return;
+    }
+    setState(() {
+      _dragOrigin = Offset(
+        clampTerminalToolbarLeft(
+          left: origin.dx + details.delta.dx,
+          viewportWidth: widget.viewportSize.width,
+          toolbarWidth: toolbarSize.width,
+        ),
+        clampTerminalToolbarTop(
+          top: origin.dy + details.delta.dy,
+          viewportHeight: widget.viewportSize.height,
+          toolbarHeight: toolbarSize.height,
+        ),
+      );
+    });
+  }
+
+  void _onPanEnd(DragEndDetails details) {
+    final origin = _dragOrigin;
+    final toolbarSize = _toolbarKey.currentContext?.size;
+    if (origin == null || toolbarSize == null) {
+      return;
+    }
+    final next = nearestTerminalToolbarCorner(
+      centerX: origin.dx + toolbarSize.width / 2,
+      centerY: origin.dy + toolbarSize.height / 2,
+      viewportWidth: widget.viewportSize.width,
+      viewportHeight: widget.viewportSize.height,
+    );
+    _setCorner(next);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final dragOrigin = _dragOrigin;
+    if (dragOrigin != null) {
+      return Positioned(
+        left: dragOrigin.dx,
+        top: dragOrigin.dy,
+        child: _buildCluster(),
+      );
+    }
+    final anchor = TerminalToolbarAnchor.forCorner(_corner);
+    return Positioned(
+      top: anchor.top,
+      left: anchor.left,
+      right: anchor.right,
+      bottom: anchor.bottom,
+      child: _buildCluster(),
+    );
+  }
+
+  Widget _buildCluster() {
+    final handle = _MoveToolbarHandle(
+      onPanStart: _onPanStart,
+      onPanUpdate: _onPanUpdate,
+      onPanEnd: _onPanEnd,
+    );
+    final actions = <Widget>[
+      if (widget.session.supportsTerminalPulse) _buildTerminalPulseControl(),
+      AleraIconButton(
+        tooltip: widget.session.composerController.visible
+            ? 'Hide Terminal Composer'
+            : 'Show Terminal Composer',
+        icon: AleraIcons.composer,
+        iconColor: widget.session.composerController.visible
+            ? AleraTokens.foreground
+            : AleraTokens.foregroundMuted,
+        backgroundColor: widget.session.composerController.visible
+            ? AleraTokens.accentSubtle
+            : AleraTokens.surfaceElevated,
+        borderColor: AleraTokens.borderSubtle,
+        onPressed: widget.session.composerController.toggle,
+      ),
+      AleraIconButton(
+        tooltip: widget.refreshing ? 'Refreshing Terminal' : 'Refresh Terminal',
+        icon: widget.refreshing ? AleraIcons.loading : AleraIcons.refresh,
+        backgroundColor: AleraTokens.surfaceElevated,
+        borderColor: AleraTokens.borderSubtle,
+        onPressed: widget.refreshing ? null : widget.onRefresh,
+      ),
+      if (widget.hasCanvas)
+        AleraIconButton(
+          tooltip: 'Agent Canvas',
+          icon: AleraIcons.agent,
+          backgroundColor: AleraTokens.surfaceElevated,
+          borderColor: AleraTokens.borderSubtle,
+          onPressed: widget.onShowAgentCanvas,
+        ),
+    ];
+    return Listener(
+      onPointerDown: (event) {
+        if (event.kind == PointerDeviceKind.mouse &&
+            event.buttons == kSecondaryMouseButton) {
+          unawaited(_showCornerMenu(event.position));
+        }
+      },
+      child: Row(
+        key: _toolbarKey,
+        mainAxisSize: MainAxisSize.min,
+        spacing: AleraTokens.space2,
+        children: <Widget>[
+          if (_corner.isRight) handle,
+          ...actions,
+          if (_corner.isLeft) handle,
+        ],
+      ),
+    );
+  }
+
+  Widget _buildTerminalPulseControl() {
+    return ValueListenableBuilder<TerminalPulseState>(
+      valueListenable: widget.session.terminalPulseState,
+      builder: (context, state, _) {
+        return AleraIconButton(
+          tooltip: !state.statusKnown
+              ? 'Configure Terminal Pulse - Status Unavailable'
+              : state.armed
+              ? 'Configure Terminal Pulse - Armed'
+              : 'Configure Terminal Pulse',
+          icon: AleraIcons.pulse,
+          iconColor: state.statusKnown && state.armed
+              ? AleraTokens.foreground
+              : AleraTokens.foregroundMuted,
+          backgroundColor: state.statusKnown && state.armed
+              ? AleraTokens.accentSubtle
+              : AleraTokens.surfaceElevated,
+          borderColor: AleraTokens.borderSubtle,
+          onPressed: () =>
+              unawaited(showTerminalPulseDialog(context, widget.session)),
+        );
+      },
+    );
+  }
+}
+
+class _MoveToolbarHandle extends StatelessWidget {
+  const _MoveToolbarHandle({
+    required this.onPanStart,
+    required this.onPanUpdate,
+    required this.onPanEnd,
+  });
+
+  final GestureDragStartCallback onPanStart;
+  final GestureDragUpdateCallback onPanUpdate;
+  final GestureDragEndCallback onPanEnd;
+
+  @override
+  Widget build(BuildContext context) {
+    return Tooltip(
+      message: 'Move Toolbar',
+      child: MouseRegion(
+        cursor: SystemMouseCursors.move,
+        child: GestureDetector(
+          onPanStart: onPanStart,
+          onPanUpdate: onPanUpdate,
+          onPanEnd: onPanEnd,
+          child: DecoratedBox(
+            decoration: BoxDecoration(
+              color: AleraTokens.surfaceElevated,
+              borderRadius: BorderRadius.circular(AleraTokens.radiusMd),
+              border: Border.all(color: AleraTokens.borderSubtle),
+            ),
+            child: const SizedBox(
+              width: AleraIconButton.defaultMinSize,
+              height: AleraIconButton.defaultMinSize,
+              child: Icon(
+                AleraIcons.dragHandle,
+                size: AleraIconButton.defaultIconSize,
+                color: AleraTokens.foregroundMuted,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/test/unit/alera_settings_json_test.dart
+++ b/test/unit/alera_settings_json_test.dart
@@ -76,6 +76,7 @@ void main() {
           hostEmptyShutdownDelaySeconds: 5,
           hostDetachedSessionShutdownDelaySeconds: 120,
           hostScrollbackBytes: 24 * 1000 * 1000,
+          toolbarCorner: TerminalToolbarCorner.bottomRight,
         ),
         keyboard: KeyboardShortcutSettings(
           overrides: <KeyboardActionId, List<String>>{
@@ -144,6 +145,10 @@ void main() {
       expect(restored.terminal.hostEmptyShutdownDelaySeconds, 5);
       expect(restored.terminal.hostDetachedSessionShutdownDelaySeconds, 120);
       expect(restored.terminal.hostScrollbackBytes, 24 * 1000 * 1000);
+      expect(
+        restored.terminal.toolbarCorner,
+        TerminalToolbarCorner.bottomRight,
+      );
       expect(restored.keyboard.overrides[KeyboardActionId.closeTab], <String>[
         'Mod+Shift+W',
       ]);

--- a/test/unit/alera_settings_test.dart
+++ b/test/unit/alera_settings_test.dart
@@ -29,6 +29,7 @@ void main() {
       expect(terminal.clipboardOnSelect, isFalse);
       expect(terminal.allowOsc52Clipboard, isFalse);
       expect(terminal.showComposerByDefault, isFalse);
+      expect(terminal.toolbarCorner, TerminalToolbarCorner.topRight);
       expect(terminal.hostEmptyShutdownDelaySeconds, 30);
       expect(terminal.hostDetachedSessionShutdownDelaySeconds, 60 * 60);
       expect(terminal.hostScrollbackBytes, 10 * 1000 * 1000);
@@ -240,6 +241,7 @@ void main() {
         'clipboardOnSelect': true,
         'allowOsc52Clipboard': true,
         'showComposerByDefault': true,
+        'toolbarCorner': 'bottomLeft',
         'hostEmptyShutdownDelaySeconds': 45,
         'hostDetachedSessionShutdownDelaySeconds': 600,
         'hostScrollbackBytes': 16 * 1000 * 1000,
@@ -258,6 +260,7 @@ void main() {
       expect(restored.clipboardOnSelect, isTrue);
       expect(restored.allowOsc52Clipboard, isTrue);
       expect(restored.showComposerByDefault, isTrue);
+      expect(restored.toolbarCorner, TerminalToolbarCorner.bottomLeft);
       expect(restored.hostEmptyShutdownDelaySeconds, 45);
       expect(restored.hostDetachedSessionShutdownDelaySeconds, 600);
       expect(restored.hostScrollbackBytes, 16 * 1000 * 1000);
@@ -294,6 +297,7 @@ void main() {
         expect(keptOpen.keepRuntimeOpenOnAppQuit, isTrue);
         expect(stoppedOnQuit.keepRuntimeOpenOnAppQuit, isFalse);
         expect(omittedQuitFlag.keepRuntimeOpenOnAppQuit, isTrue);
+        expect(omittedQuitFlag.toolbarCorner, TerminalToolbarCorner.topRight);
       },
     );
 

--- a/test/unit/settings_search_entries_test.dart
+++ b/test/unit/settings_search_entries_test.dart
@@ -159,6 +159,16 @@ void main() {
     expect(entry.matches('mouse wheel'), isTrue);
     expect(entry.groupId, 'interaction');
   });
+
+  test('terminal toolbar corner is searchable in appearance', () {
+    final entry = terminalSearchEntries.singleWhere(
+      (candidate) => candidate.title == 'Toolbar Corner',
+    );
+
+    expect(entry.matches('overlay'), isTrue);
+    expect(entry.matches('move'), isTrue);
+    expect(entry.groupId, 'appearance');
+  });
 }
 
 String _catalogFingerprint(Map<String, List<SettingsSearchEntry>> catalogs) {

--- a/test/unit/terminal_toolbar_placement_test.dart
+++ b/test/unit/terminal_toolbar_placement_test.dart
@@ -78,6 +78,10 @@ void main() {
       toolbarCorner: TerminalToolbarCorner.bottomLeft,
       toolbarButtonCount: buttonCount,
     );
+    final bottomRight = terminalSearchOverlayLayout(
+      toolbarCorner: TerminalToolbarCorner.bottomRight,
+      toolbarButtonCount: buttonCount,
+    );
 
     expect(
       topRight.right,
@@ -91,6 +95,8 @@ void main() {
     expect(topLeft.alignLeft, isTrue);
     expect(bottomLeft.left, AleraTokens.space16);
     expect(bottomLeft.right, AleraTokens.space16);
+    expect(bottomRight.left, AleraTokens.space16);
+    expect(bottomRight.alignLeft, isFalse);
   });
 
   test('counts the move handle with the other toolbar actions', () {
@@ -98,6 +104,156 @@ void main() {
       terminalToolbarButtonCount(supportsPulse: false, hasCanvas: false),
       3,
     );
+    expect(
+      terminalToolbarButtonCount(supportsPulse: true, hasCanvas: false),
+      4,
+    );
+    expect(
+      terminalToolbarButtonCount(supportsPulse: false, hasCanvas: true),
+      4,
+    );
     expect(terminalToolbarButtonCount(supportsPulse: true, hasCanvas: true), 5);
+  });
+
+  test('places a dragged cluster at the matching corner offset', () {
+    const inset = AleraTokens.space4;
+    const viewportWidth = 400.0;
+    const viewportHeight = 300.0;
+    const toolbarWidth = 120.0;
+    const toolbarHeight = 28.0;
+
+    expect(
+      terminalToolbarOffset(
+        corner: TerminalToolbarCorner.topLeft,
+        viewportWidth: viewportWidth,
+        viewportHeight: viewportHeight,
+        toolbarWidth: toolbarWidth,
+        toolbarHeight: toolbarHeight,
+      ),
+      (left: inset, top: inset),
+    );
+    expect(
+      terminalToolbarOffset(
+        corner: TerminalToolbarCorner.topRight,
+        viewportWidth: viewportWidth,
+        viewportHeight: viewportHeight,
+        toolbarWidth: toolbarWidth,
+        toolbarHeight: toolbarHeight,
+      ),
+      (left: viewportWidth - toolbarWidth - inset, top: inset),
+    );
+    expect(
+      terminalToolbarOffset(
+        corner: TerminalToolbarCorner.bottomLeft,
+        viewportWidth: viewportWidth,
+        viewportHeight: viewportHeight,
+        toolbarWidth: toolbarWidth,
+        toolbarHeight: toolbarHeight,
+      ),
+      (left: inset, top: viewportHeight - toolbarHeight - inset),
+    );
+    expect(
+      terminalToolbarOffset(
+        corner: TerminalToolbarCorner.bottomRight,
+        viewportWidth: viewportWidth,
+        viewportHeight: viewportHeight,
+        toolbarWidth: toolbarWidth,
+        toolbarHeight: toolbarHeight,
+      ),
+      (
+        left: viewportWidth - toolbarWidth - inset,
+        top: viewportHeight - toolbarHeight - inset,
+      ),
+    );
+  });
+
+  test('clamps a dragged cluster inside the viewport', () {
+    const inset = AleraTokens.space4;
+    const viewportWidth = 400.0;
+    const viewportHeight = 300.0;
+    const toolbarWidth = 120.0;
+    const toolbarHeight = 28.0;
+    final maxLeft = viewportWidth - toolbarWidth - inset;
+    final maxTop = viewportHeight - toolbarHeight - inset;
+
+    expect(
+      clampTerminalToolbarLeft(
+        left: -40,
+        viewportWidth: viewportWidth,
+        toolbarWidth: toolbarWidth,
+      ),
+      inset,
+    );
+    expect(
+      clampTerminalToolbarLeft(
+        left: 80,
+        viewportWidth: viewportWidth,
+        toolbarWidth: toolbarWidth,
+      ),
+      80,
+    );
+    expect(
+      clampTerminalToolbarLeft(
+        left: 500,
+        viewportWidth: viewportWidth,
+        toolbarWidth: toolbarWidth,
+      ),
+      maxLeft,
+    );
+    expect(
+      clampTerminalToolbarTop(
+        top: -40,
+        viewportHeight: viewportHeight,
+        toolbarHeight: toolbarHeight,
+      ),
+      inset,
+    );
+    expect(
+      clampTerminalToolbarTop(
+        top: 90,
+        viewportHeight: viewportHeight,
+        toolbarHeight: toolbarHeight,
+      ),
+      90,
+    );
+    expect(
+      clampTerminalToolbarTop(
+        top: 500,
+        viewportHeight: viewportHeight,
+        toolbarHeight: toolbarHeight,
+      ),
+      maxTop,
+    );
+  });
+
+  test(
+    'pins a dragged cluster when the viewport is smaller than the toolbar',
+    () {
+      const inset = AleraTokens.space4;
+
+      expect(
+        clampTerminalToolbarLeft(
+          left: 80,
+          viewportWidth: 40,
+          toolbarWidth: 120,
+        ),
+        inset,
+      );
+      expect(
+        clampTerminalToolbarTop(top: 80, viewportHeight: 20, toolbarHeight: 28),
+        inset,
+      );
+    },
+  );
+
+  test('treats equal toolbar anchors as interchangeable', () {
+    const left = TerminalToolbarAnchor(top: 8, left: 8);
+    const same = TerminalToolbarAnchor(top: 8, left: 8);
+    const other = TerminalToolbarAnchor(top: 8, right: 8);
+
+    expect(left, same);
+    expect(left.hashCode, same.hashCode);
+    expect(left, isNot(other));
+    expect(left, isNot(Object()));
   });
 }

--- a/test/unit/terminal_toolbar_placement_test.dart
+++ b/test/unit/terminal_toolbar_placement_test.dart
@@ -1,0 +1,103 @@
+import 'package:alera/src/app/theme/alera_tokens.dart';
+import 'package:alera/src/features/settings/domain/alera_settings.dart';
+import 'package:alera/src/features/workbench/domain/terminal_toolbar_placement.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('anchors the cluster to each terminal corner', () {
+    const inset = AleraTokens.space4;
+
+    expect(
+      TerminalToolbarAnchor.forCorner(TerminalToolbarCorner.topRight),
+      const TerminalToolbarAnchor(top: inset, right: inset),
+    );
+    expect(
+      TerminalToolbarAnchor.forCorner(TerminalToolbarCorner.topLeft),
+      const TerminalToolbarAnchor(top: inset, left: inset),
+    );
+    expect(
+      TerminalToolbarAnchor.forCorner(TerminalToolbarCorner.bottomLeft),
+      const TerminalToolbarAnchor(bottom: inset, left: inset),
+    );
+    expect(
+      TerminalToolbarAnchor.forCorner(TerminalToolbarCorner.bottomRight),
+      const TerminalToolbarAnchor(bottom: inset, right: inset),
+    );
+  });
+
+  test('snaps the cluster center to the nearest corner', () {
+    expect(
+      nearestTerminalToolbarCorner(
+        centerX: 10,
+        centerY: 10,
+        viewportWidth: 100,
+        viewportHeight: 100,
+      ),
+      TerminalToolbarCorner.topLeft,
+    );
+    expect(
+      nearestTerminalToolbarCorner(
+        centerX: 90,
+        centerY: 10,
+        viewportWidth: 100,
+        viewportHeight: 100,
+      ),
+      TerminalToolbarCorner.topRight,
+    );
+    expect(
+      nearestTerminalToolbarCorner(
+        centerX: 10,
+        centerY: 90,
+        viewportWidth: 100,
+        viewportHeight: 100,
+      ),
+      TerminalToolbarCorner.bottomLeft,
+    );
+    expect(
+      nearestTerminalToolbarCorner(
+        centerX: 90,
+        centerY: 90,
+        viewportWidth: 100,
+        viewportHeight: 100,
+      ),
+      TerminalToolbarCorner.bottomRight,
+    );
+  });
+
+  test('keeps search clear of a top-side toolbar', () {
+    const buttonCount = 3;
+    final topRight = terminalSearchOverlayLayout(
+      toolbarCorner: TerminalToolbarCorner.topRight,
+      toolbarButtonCount: buttonCount,
+    );
+    final topLeft = terminalSearchOverlayLayout(
+      toolbarCorner: TerminalToolbarCorner.topLeft,
+      toolbarButtonCount: buttonCount,
+    );
+    final bottomLeft = terminalSearchOverlayLayout(
+      toolbarCorner: TerminalToolbarCorner.bottomLeft,
+      toolbarButtonCount: buttonCount,
+    );
+
+    expect(
+      topRight.right,
+      AleraTokens.space48 * buttonCount + AleraTokens.space4,
+    );
+    expect(topRight.alignLeft, isFalse);
+    expect(
+      topLeft.left,
+      AleraTokens.space48 * buttonCount + AleraTokens.space4,
+    );
+    expect(topLeft.alignLeft, isTrue);
+    expect(bottomLeft.left, AleraTokens.space16);
+    expect(bottomLeft.right, AleraTokens.space16);
+  });
+
+  test('counts the move handle with the other toolbar actions', () {
+    expect(
+      terminalToolbarButtonCount(supportsPulse: false, hasCanvas: false),
+      3,
+    );
+    expect(terminalToolbarButtonCount(supportsPulse: true, hasCanvas: true), 5);
+  });
+}

--- a/test/widget/terminal_surface_test.dart
+++ b/test/widget/terminal_surface_test.dart
@@ -31,6 +31,7 @@ part 'terminal_surface_composer_test_cases.dart';
 part 'terminal_surface_composer_submit_test_cases.dart';
 part 'terminal_surface_interaction_test_cases.dart';
 part 'terminal_surface_tab_switch_test_cases.dart';
+part 'terminal_surface_toolbar_test_cases.dart';
 part 'terminal_surface_test_harness.dart';
 
 void main() {
@@ -39,4 +40,5 @@ void main() {
   _registerTerminalSurfaceComposerSubmitTests();
   _registerTerminalSurfaceInteractionTests();
   _registerTerminalSurfaceTabSwitchTests();
+  _registerTerminalSurfaceToolbarTests();
 }

--- a/test/widget/terminal_surface_test_harness.dart
+++ b/test/widget/terminal_surface_test_harness.dart
@@ -37,13 +37,14 @@ Future<void> _pumpTerminalOutput(WidgetTester tester) async {
 
 Future<void> _pumpTerminalSurface(
   WidgetTester tester,
-  TerminalSessionHandle session,
-) async {
+  TerminalSessionHandle session, {
+  AleraSettings? settings,
+}) async {
   await tester.pumpWidget(
     ProviderScope(
       overrides: [
         settingsControllerProvider.overrideWith(
-          () => _FakeSettingsController(AleraSettings.defaults),
+          () => _FakeSettingsController(settings ?? AleraSettings.defaults),
         ),
       ],
       child: MaterialApp(
@@ -352,6 +353,12 @@ class _FakeSettingsController extends SettingsController {
 
   @override
   AleraSettings build() => settings;
+
+  @override
+  Future<void> updateTerminal(TerminalSettings next) async {
+    settings = settings.copyWith(terminal: next);
+    state = settings;
+  }
 }
 
 class _ErrorSessionHandle extends TerminalSessionHandle {

--- a/test/widget/terminal_surface_toolbar_test_cases.dart
+++ b/test/widget/terminal_surface_toolbar_test_cases.dart
@@ -1,0 +1,92 @@
+part of 'terminal_surface_test.dart';
+
+void _registerTerminalSurfaceToolbarTests() {
+  testWidgets('toolbar cluster sits in the persisted corner', (tester) async {
+    final session = _ImmediateNotifySessionHandle(tabId: 'tab-1');
+
+    await _pumpTerminalSurface(
+      tester,
+      session,
+      settings: AleraSettings.defaults.copyWith(
+        terminal: TerminalSettings.defaults.copyWith(
+          toolbarCorner: TerminalToolbarCorner.bottomLeft,
+        ),
+      ),
+    );
+
+    final surfaceRect = tester.getRect(find.byType(TerminalSurface));
+    final composerRect = tester.getRect(
+      find.byTooltip('Show Terminal Composer'),
+    );
+    final refreshRect = tester.getRect(find.byTooltip('Refresh Terminal'));
+    final moveRect = tester.getRect(find.byTooltip('Move Toolbar'));
+
+    expect(
+      composerRect.left,
+      closeTo(surfaceRect.left + AleraTokens.space4, 0.01),
+    );
+    expect(
+      composerRect.bottom,
+      closeTo(surfaceRect.bottom - AleraTokens.space4, 0.01),
+    );
+    expect(composerRect.right, lessThan(refreshRect.left));
+    expect(refreshRect.right, lessThan(moveRect.left));
+    expect(moveRect.bottom, composerRect.bottom);
+  });
+
+  testWidgets('right-clicking the cluster moves it to another corner', (
+    tester,
+  ) async {
+    final session = _ImmediateNotifySessionHandle(tabId: 'tab-1');
+
+    await _pumpTerminalSurface(tester, session);
+
+    await tester.tap(
+      find.byTooltip('Refresh Terminal'),
+      buttons: kSecondaryButton,
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Top Left'));
+    await tester.pumpAndSettle();
+
+    final surfaceRect = tester.getRect(find.byType(TerminalSurface));
+    final composerRect = tester.getRect(
+      find.byTooltip('Show Terminal Composer'),
+    );
+    expect(
+      composerRect.left,
+      closeTo(surfaceRect.left + AleraTokens.space4, 0.01),
+    );
+    expect(
+      composerRect.top,
+      closeTo(surfaceRect.top + AleraTokens.space4, 0.01),
+    );
+  });
+
+  testWidgets('dragging the cluster snaps it to the nearest corner', (
+    tester,
+  ) async {
+    final session = _ImmediateNotifySessionHandle(tabId: 'tab-1');
+
+    await _pumpTerminalSurface(tester, session);
+
+    final surfaceRect = tester.getRect(find.byType(TerminalSurface));
+    await tester.drag(
+      find.byTooltip('Move Toolbar'),
+      Offset(-surfaceRect.width * 0.7, surfaceRect.height * 0.7),
+    );
+    await tester.pumpAndSettle();
+
+    final composerRect = tester.getRect(
+      find.byTooltip('Show Terminal Composer'),
+    );
+    expect(
+      composerRect.left,
+      closeTo(surfaceRect.left + AleraTokens.space4, 0.01),
+    );
+    expect(
+      composerRect.bottom,
+      closeTo(surfaceRect.bottom - AleraTokens.space4, 0.01),
+    );
+  });
+}

--- a/test/widget/terminal_surface_toolbar_test_cases.dart
+++ b/test/widget/terminal_surface_toolbar_test_cases.dart
@@ -41,10 +41,7 @@ void _registerTerminalSurfaceToolbarTests() {
 
     await _pumpTerminalSurface(tester, session);
 
-    await tester.tap(
-      find.byTooltip('Refresh Terminal'),
-      buttons: kSecondaryButton,
-    );
+    await tester.tap(find.byTooltip('Move Toolbar'), buttons: kSecondaryButton);
     await tester.pumpAndSettle();
     await tester.tap(find.text('Top Left'));
     await tester.pumpAndSettle();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The pulse, composer, and refresh buttons on a terminal tab can now move as one cluster to any of the four corners.

- Drag the grip to snap the cluster to the nearest corner.
- Right-click the cluster to pick Top Left, Top Right, Bottom Left, or Bottom Right.
- The choice is persisted in Terminal settings (`Toolbar Corner`) and applies to every terminal tab.

## Screenshots

Covered by widget tests for default top-right placement, persisted bottom-left, right-click to top-left, and drag-to-snap.

## Testing

- [x] Focused format of edited Dart files
- [x] `flutter analyze` on edited files
- [x] Focused tests: `flutter test test/unit/terminal_toolbar_placement_test.dart test/unit/alera_settings_test.dart test/unit/alera_settings_json_test.dart test/unit/settings_search_entries_test.dart test/widget/terminal_surface_test.dart` (75 passed)
- [x] Coverage follow-up: `flutter test --coverage test/unit/terminal_toolbar_placement_test.dart` now hits 46/46 lines in `terminal_toolbar_placement.dart` (the previous CI miss was the too-small-viewport clamp branches)
- [ ] `dart format --set-exit-if-changed lib test integration_test tool`
- [ ] `flutter analyze`
- [ ] `flutter test --coverage --exclude-tags golden`
- [ ] `dart run tool/quality/coverage_report.dart --input coverage/lcov.info --min-lines 100 --worst 25`
- [ ] Golden tests, if UI changed: `flutter test --tags golden`
- [ ] Desktop E2E, if app-shell flow changed: `flutter test integration_test -d macos`
- [ ] Relevant desktop build: `flutter build macos`, `flutter build windows`, or `flutter build linux`
- [ ] Landing build, if applicable: `cd landing && bun run build`
- [x] Added or updated tests that would catch regressions, or explained why tests were not needed

## AI Review Report

Checked that the cluster stays one unit, that older settings without `toolbarCorner` keep top-right, and that search overlay insets follow a top-side toolbar. Widget tests initially failed because the grip was 30px (IconButtons are density-compact) and because the menu required a mouse pointer kind; both are fixed.

Coverage CI failed at 99.96% (5503/5505) because `clampTerminalToolbarLeft` / `clampTerminalToolbarTop` never hit the branch that pins the cluster when the viewport is smaller than the toolbar. Unit tests now cover that edge, plus hashCode, drag offsets, and min/max clamping.

Cross-platform: corner layout uses Flutter `Positioned` anchors and does not depend on platform-specific paths, shortcuts, or shells. The same cluster appears on macOS, Linux, and Windows desktop. Mobile keeps its own terminal controls and is unchanged.

## Security Audit

No new command execution, path handling, auth, secrets, or process-spawn paths. The preference is a local settings enum persisted with existing settings storage.

## Notes

The default remains top-right, matching current behavior. AGENTS.md, readme, and docs were not updated because this is existing toolbar chrome with no new contributor workflow or protocol change.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d31f5c4e-bc78-459a-9238-4f98377ac3c3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d31f5c4e-bc78-459a-9238-4f98377ac3c3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

