### PR TITLE
feat(landing): link agent cards to official sites in new tab

### DIFF
--- a/landing/src/components/Agents.astro
+++ b/landing/src/components/Agents.astro
@@ -1,15 +1,27 @@
 ---
 const agents = [
-  { name: 'Claude Code', src: '/agents/claude.svg' },
-  { name: 'Codex', src: '/agents/codex.svg' },
-  { name: 'Amp', src: '/agents/amp.png' },
-  { name: 'Antigravity', src: '/agents/agy.png' },
-  { name: 'OpenCode', src: '/agents/opencode.svg' },
-  { name: 'Cursor', src: '/agents/cursor.png' },
-  { name: 'Copilot', src: '/agents/copilot.svg' },
-  { name: 'Pi', src: '/agents/pi.svg' },
-  { name: 'Grok Build', src: '/agents/grok.svg' },
-  { name: 'fx', src: '/agents/fx.svg' },
+  {
+    name: 'Claude Code',
+    src: '/agents/claude.svg',
+    href: 'https://docs.anthropic.com/claude/docs/claude-code',
+  },
+  { name: 'Codex', src: '/agents/codex.svg', href: 'https://github.com/openai/codex' },
+  { name: 'Amp', src: '/agents/amp.png', href: 'https://ampcode.com/manual#install' },
+  {
+    name: 'Antigravity',
+    src: '/agents/agy.png',
+    href: 'https://antigravity.google/docs/cli-overview',
+  },
+  { name: 'OpenCode', src: '/agents/opencode.svg', href: 'https://opencode.ai/docs/cli/' },
+  { name: 'Cursor', src: '/agents/cursor.png', href: 'https://cursor.com/cli' },
+  {
+    name: 'Copilot',
+    src: '/agents/copilot.svg',
+    href: 'https://docs.github.com/en/copilot/how-tos/set-up/install-copilot-cli',
+  },
+  { name: 'Pi', src: '/agents/pi.svg', href: 'https://pi.dev' },
+  { name: 'Grok Build', src: '/agents/grok.svg', href: 'https://x.ai/cli' },
+  { name: 'fx', src: '/agents/fx.svg', href: 'https://fx.sh' },
 ];
 ---
 
@@ -24,21 +36,26 @@ const agents = [
 
     <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-x-8 gap-y-8 md:gap-x-12">
       {agents.map((agent, i) => (
-        <div
-          class="flex flex-col items-center gap-3 group opacity-0-initial animate-fade-in-up min-w-0"
+        <a
+          href={agent.href}
+          target="_blank"
+          rel="noopener noreferrer"
+          class="flex flex-col items-center gap-3 group opacity-0-initial animate-fade-in-up min-w-0 rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
           style={`animation-delay: ${200 + i * 60}ms`}
+          aria-label={`Open ${agent.name} official site in a new tab`}
         >
           <div class="w-14 h-14 rounded-xl bg-surface border border-border flex items-center justify-center transition-all duration-mid group-hover:border-foreground-faint group-hover:bg-surface-variant group-hover:scale-105">
             <img
               src={agent.src}
-              alt={agent.name}
+              alt=""
+              aria-hidden="true"
               class="w-7 h-7 opacity-80 group-hover:opacity-100 transition-opacity duration-mid"
             />
           </div>
-          <span class="text-label-md text-foreground-faint tracking-wider font-mono">
+          <span class="text-label-md text-foreground-faint tracking-wider font-mono transition-colors duration-mid group-hover:text-foreground-muted">
             {agent.name}
           </span>
-        </div>
+        </a>
       ))}
     </div>
   </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Each agent card in the landing page agents section now links to that agent's official documentation or product page. Links open in a new tab with `rel="noopener noreferrer"`, matching the existing Stack section pattern.

Official URLs are aligned with the repository README:

- Claude Code → Anthropic docs
- Codex → OpenAI GitHub repo
- Amp → ampcode.com manual
- Antigravity → Google Antigravity CLI docs
- OpenCode → opencode.ai CLI docs
- Cursor → cursor.com/cli
- Copilot → GitHub Copilot CLI install docs
- Pi → pi.dev
- Grok Build → x.ai/cli
- fx → fx.sh

## Validation

- `bun run build` in `landing/`
- Manual preview at `/#agents`: clicked Cursor and Pi cards; both opened the correct official sites in new tabs while keeping the landing page open

[Agents section with clickable cards](https://cursor.com/agents/bc-f7d1f54f-76a7-41da-87bc-00398c46df9c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fagents_section_with_links.webp)

[agent_links_open_new_tab_demo.mp4](https://cursor.com/agents/bc-f7d1f54f-76a7-41da-87bc-00398c46df9c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fagent_links_open_new_tab_demo.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f7d1f54f-76a7-41da-87bc-00398c46df9c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f7d1f54f-76a7-41da-87bc-00398c46df9c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

