### PR TITLE
fix: quiesce terminal host client during app quit

### DIFF
--- a/lib/src/features/runtime_host/presentation/runtime_host_quit_gate_scope.dart
+++ b/lib/src/features/runtime_host/presentation/runtime_host_quit_gate_scope.dart
@@ -25,22 +25,32 @@ class _RuntimeHostQuitGateScopeState
   bool _bound = false;
 
   Future<bool> _closeGate() async {
-    final keepRuntimeOpen = ref
-        .read(settingsControllerProvider)
-        .terminal
-        .keepRuntimeOpenOnAppQuit;
-    final allowed = await ref
-        .read(runtimeHostLifecycleServiceProvider)
-        .prepareAppQuit(
-          keepRuntimeOpen: keepRuntimeOpen,
-          confirmBusyQuit: _confirmBusyQuit,
-        );
-    if (!allowed) {
-      return false;
+    final client = ref.read(runtimeHostClientProvider);
+    client.beginAppQuit();
+    var closeCommitted = false;
+    try {
+      final keepRuntimeOpen = ref
+          .read(settingsControllerProvider)
+          .terminal
+          .keepRuntimeOpenOnAppQuit;
+      final allowed = await ref
+          .read(runtimeHostLifecycleServiceProvider)
+          .prepareAppQuit(
+            keepRuntimeOpen: keepRuntimeOpen,
+            confirmBusyQuit: _confirmBusyQuit,
+          );
+      if (!allowed) {
+        return false;
+      }
+      // Mirror the Linux detach path for all platforms when quitting.
+      client.dispose();
+      closeCommitted = true;
+      return true;
+    } finally {
+      if (!closeCommitted) {
+        client.cancelAppQuit();
+      }
     }
-    // Mirror the Linux detach path for all platforms when quitting.
-    ref.read(runtimeHostClientProvider).dispose();
-    return true;
   }
 
   Future<RuntimeHostQuitDecision> _confirmBusyQuit({

--- a/lib/src/features/workbench/infra/terminal_host/terminal_host_client.dart
+++ b/lib/src/features/workbench/infra/terminal_host/terminal_host_client.dart
@@ -24,6 +24,7 @@ export 'package:alera/src/features/workbench/infra/terminal_host/terminal_host_p
 part 'terminal_host_client_types.dart';
 part 'terminal_host_client_requests.dart';
 part 'terminal_host_client_capabilities.dart';
+part 'terminal_host_client_connections.dart';
 part 'terminal_host_client_guarded_requests.dart';
 part 'terminal_host_client_terminal_requests.dart';
 part 'terminal_host_client_lifecycle.dart';
@@ -93,7 +94,9 @@ final class SocketTerminalHostClient
   _TerminalHostConnection? _runtimeConnection;
   StreamSubscription<Object?>? _runtimeLineSub;
   int _nextRequestId = 1;
+  @override
   bool _disposed = false;
+  bool _appQuitInProgress = false;
   TerminalHostConfig _config;
 
   @override
@@ -110,8 +113,32 @@ final class SocketTerminalHostClient
 
   @override
   Future<void> ensureStarted({required TerminalHostConfig config}) async {
+    if (_disposed) {
+      throw StateError('Terminal host client is disposed.');
+    }
+    _throwIfAppQuitInProgress();
     _config = config;
     await _terminalRequest('configure', config.toJson());
+  }
+
+  /// Stops application traffic while the quit gate probes and shuts down the
+  /// runtime. Requests already in flight cannot be allowed to reach their
+  /// normal timeout: the host may close the socket as part of shutdown, so
+  /// they are completed as an expected connection close instead.
+  void beginAppQuit() {
+    if (_disposed || _appQuitInProgress) {
+      return;
+    }
+    _appQuitInProgress = true;
+    _stopHeartbeat();
+    _failPendingRequests(const TerminalHostConnectionClosedException());
+  }
+
+  /// Reopens application traffic when the user cancels the quit gate.
+  void cancelAppQuit() {
+    if (!_disposed) {
+      _appQuitInProgress = false;
+    }
   }
 
   @override
@@ -119,6 +146,7 @@ final class SocketTerminalHostClient
     if (_disposed) {
       throw StateError('Terminal host client is disposed.');
     }
+    _throwIfAppQuitInProgress();
     _config = config;
     final pendingConnections = <Future<_TerminalHostConnection>>[];
     if (_terminalConnection case final connection?) {
@@ -273,7 +301,9 @@ final class SocketTerminalHostClient
     if (_disposed) {
       throw StateError('Terminal host client is disposed.');
     }
+    _throwIfAppQuitInProgress();
     final connection = await _connectTerminal();
+    _throwIfAppQuitInProgress();
     return _requestOnConnection(connection, type, payload, timeout: timeout);
   }
 
@@ -285,9 +315,11 @@ final class SocketTerminalHostClient
     if (_disposed) {
       throw StateError('Terminal host client is disposed.');
     }
+    _throwIfAppQuitInProgress();
     final connection = await _connectRuntime(
       requireOrchestration: type.startsWith('orchestration.'),
     );
+    _throwIfAppQuitInProgress();
     return _requestOnConnection(connection, type, payload, timeout: timeout);
   }
 
@@ -296,13 +328,23 @@ final class SocketTerminalHostClient
     String type,
     Map<String, Object?> payload, {
     Duration? timeout,
-  }) => _sendTerminalHostRequestWithMutationRetry(
-    this,
-    connection,
-    type,
-    payload,
-    timeout: timeout,
-  );
+    bool allowDuringAppQuit = false,
+  }) {
+    if (_disposed) {
+      throw StateError('Terminal host client is disposed.');
+    }
+    if (_appQuitInProgress && !allowDuringAppQuit) {
+      throw const TerminalHostConnectionClosedException();
+    }
+    return _sendTerminalHostRequestWithMutationRetry(
+      this,
+      connection,
+      type,
+      payload,
+      timeout: timeout,
+      allowDuringAppQuit: allowDuringAppQuit,
+    );
+  }
 
   @override
   Future<Object?> runtimeRequest(
@@ -314,6 +356,9 @@ final class SocketTerminalHostClient
   }
 
   Future<_TerminalHostConnection> _connectTerminal() {
+    if (_disposed) {
+      throw const TerminalHostConnectionClosedException();
+    }
     if (_terminalConnection case final connection?) {
       return Future<_TerminalHostConnection>.value(connection);
     }
@@ -342,6 +387,9 @@ final class SocketTerminalHostClient
     bool requireOrchestration = false,
     bool launchIfMissing = true,
   }) async {
+    if (_disposed) {
+      throw const TerminalHostConnectionClosedException();
+    }
     if (_runtimeConnection case final connection?
         when _supportsRuntime(connection, requireOrchestration)) {
       return Future<_TerminalHostConnection>.value(connection);
@@ -410,6 +458,9 @@ final class SocketTerminalHostClient
     try {
       return await future;
     } catch (_) {
+      if (_disposed) {
+        throw const TerminalHostConnectionClosedException();
+      }
       if (requireOrchestration) {
         rethrow;
       }
@@ -417,243 +468,6 @@ final class SocketTerminalHostClient
       // normal runtime callers should retry without inheriting that error.
       return null;
     }
-  }
-
-  Future<_TerminalHostConnection> _openTerminalConnection() async {
-    final runtime = await _runtimePaths();
-    final control = await _readControl(runtime.controlFile);
-    if (control != null) {
-      try {
-        return await _connectToControl(control, _HostConnectionRole.terminal);
-      } catch (_) {
-        await _deleteControlFile(runtime.controlFile);
-      }
-    }
-    final runtimeControl = await _readControl(runtime.runtimeControlFile);
-    if (runtimeControl?.supportsRuntime == true) {
-      try {
-        return await _connectToControl(
-          runtimeControl!,
-          _HostConnectionRole.terminal,
-        );
-      } catch (_) {
-        await _deleteControlFile(runtime.runtimeControlFile);
-      }
-    }
-    final runtimeFuture = _runtimeConnectionFuture;
-    if (runtimeFuture != null) {
-      try {
-        final connection = await runtimeFuture;
-        if (connection.supportsRuntime) {
-          _terminalConnection = connection;
-          return connection;
-        }
-      } catch (_) {
-        // A failed runtime connection must not prevent the terminal path from
-        // starting its own host connection.
-      }
-    }
-    return _launchAndConnect(
-      runtime,
-      runtime.controlFile,
-      requireOrchestration: false,
-    );
-  }
-
-  Future<_TerminalHostConnection> _openRuntimeConnection({
-    bool requireOrchestration = false,
-    bool launchIfMissing = true,
-  }) async {
-    final runtime = await _runtimePaths();
-    final control = await _readControl(runtime.controlFile);
-    if (_controlSupportsRuntime(control, requireOrchestration)) {
-      try {
-        return await _connectToControl(control!, _HostConnectionRole.runtime);
-      } catch (_) {
-        await _deleteControlFile(runtime.controlFile);
-      }
-    }
-    if (requireOrchestration && control != null) {
-      if (await _controlAcceptsHello(control)) {
-        throw StateError(_orchestrationHostRestartRequiredMessage);
-      }
-      await _deleteControlFile(runtime.controlFile);
-    }
-    final runtimeControl = await _readControl(runtime.runtimeControlFile);
-    if (_controlSupportsRuntime(runtimeControl, requireOrchestration)) {
-      try {
-        return await _connectToControl(
-          runtimeControl!,
-          _HostConnectionRole.runtime,
-        );
-      } catch (_) {
-        await _deleteControlFile(runtime.runtimeControlFile);
-      }
-    }
-    if (requireOrchestration && runtimeControl != null) {
-      if (await _controlAcceptsHello(runtimeControl)) {
-        throw StateError(_orchestrationHostRestartRequiredMessage);
-      }
-      await _deleteControlFile(runtime.runtimeControlFile);
-    }
-    if (!launchIfMissing) {
-      throw StateError('No live Alera runtime host is available.');
-    }
-    return _launchAndConnect(
-      runtime,
-      control == null || requireOrchestration
-          ? runtime.controlFile
-          : runtime.runtimeControlFile,
-      requireOrchestration: requireOrchestration,
-    );
-  }
-
-  Future<_TerminalHostConnection> _launchAndConnect(
-    _TerminalHostPaths runtime,
-    File controlFile, {
-    required bool requireOrchestration,
-  }) async {
-    await _failIfIncompatibleHostHoldsRuntime(runtime);
-    final token = _newToken();
-    // Masked in logs and crash reports from here on: the token grants full
-    // control of the runtime, and a diagnostics bundle is meant to be shared.
-    registerLogSecret(token);
-    await _launcher.start(
-      runtimeDir: runtime.runtimeDir.path,
-      controlFilePath: controlFile.path,
-      token: token,
-      config: _config,
-    );
-    final deadline = DateTime.now().add(_startupTimeout);
-    Object? lastError;
-    while (DateTime.now().isBefore(deadline)) {
-      await Future<void>.delayed(const Duration(milliseconds: 100));
-      final nextControl = await _readControl(controlFile);
-      if (nextControl == null ||
-          nextControl.token != token ||
-          !_controlSupportsRuntime(nextControl, requireOrchestration)) {
-        continue;
-      }
-      try {
-        return await _connectToControl(
-          nextControl,
-          _HostConnectionRole.runtime,
-        );
-      } catch (error) {
-        lastError = error;
-      }
-    }
-    // Keep the public message stable for crash grouping, but preserve the
-    // concrete startup cause in the local diagnostics log.
-    if (lastError case final error?) {
-      AppLogger.recordError(
-        error,
-        StackTrace.current,
-        context: 'SocketTerminalHostClient',
-      );
-    }
-    throw TerminalHostStartupException(lastError);
-  }
-
-  Future<_TerminalHostConnection> _connectToControl(
-    _TerminalHostControl control,
-    _HostConnectionRole role,
-  ) async {
-    final connection = await _openHostConnection(control);
-    unawaited(
-      connection.done.then(
-        (_) => _handleConnectionClosed(connection),
-        onError: (Object error, StackTrace _) {
-          _handleConnectionClosed(connection, error);
-        },
-      ),
-    );
-    // Output frames bypass the JSON path entirely: no line split, no
-    // jsonDecode, no base64. That is the whole point of the binary mode.
-    connection.outputFrames.listen(
-      (frame) => _emitHostEvent(
-        frame.sessionId,
-        TerminalHostOutputEvent(frame.sessionId, frame.data),
-      ),
-      onError: (Object _) {},
-    );
-    connection.decodedOutput.listen(
-      (event) => _emitHostEvent(event.sessionId, event),
-      onError: (Object _) {},
-    );
-    final lineSub = connection.lines.listen(
-      (line) {
-        try {
-          _handleLine(connection, line);
-        } catch (error) {
-          _handleConnectionClosed(connection, error);
-        }
-      },
-      onError: (error) => _handleConnectionClosed(connection, error),
-      onDone: () => _handleConnectionClosed(connection),
-      cancelOnError: true,
-    );
-    try {
-      connection.write(<String, Object?>{
-        'id': 0,
-        'type': 'hello',
-        'payload': <String, Object?>{
-          'protocolVersion': aleraTerminalHostProtocolVersion,
-          'token': control.token,
-          'clientKind': 'app',
-          'supportedTabKinds': const <String>[
-            aleraMobileEmulatorTabKind,
-            aleraCodexTabKind,
-          ],
-          if (control.supportsBinaryFrames) 'binaryFrames': true,
-        },
-      });
-      await connection.authenticated.timeout(
-        _terminalHostConnectTimeout,
-        onTimeout: () => throw TimeoutException(
-          'Terminal host authentication timed out.',
-          _terminalHostConnectTimeout,
-        ),
-      );
-      if (connection.isClosed) {
-        throw StateError(
-          'Terminal host connection closed during authentication.',
-        );
-      }
-      switch (role) {
-        case _HostConnectionRole.terminal:
-          _terminalLineSub = lineSub;
-          _terminalConnection = connection;
-          _terminalConnectionFuture = null;
-          if (connection.supportsRuntime) {
-            _runtimeConnection = connection;
-            _runtimeConnectionFuture = null;
-            _runtimeLineSub = lineSub;
-          }
-        case _HostConnectionRole.runtime:
-          _runtimeLineSub = lineSub;
-          _runtimeConnection = connection;
-          _runtimeConnectionFuture = null;
-          if (_terminalConnection == null && connection.supportsRuntime) {
-            _terminalConnection = connection;
-            _terminalConnectionFuture = null;
-            _terminalLineSub = lineSub;
-          }
-      }
-      if (connection.supportsRuntime && !_runtimeEvents.isClosed) {
-        _runtimeEvents.add(
-          const RuntimeHostEvent(
-            aleraRuntimeHostConnectedEvent,
-            <String, Object?>{},
-          ),
-        );
-      }
-    } catch (_) {
-      await lineSub.cancel();
-      connection.dispose();
-      rethrow;
-    }
-    return connection;
   }
 
   void _handleLine(_TerminalHostConnection connection, Object? line) {
@@ -722,7 +536,7 @@ final class SocketTerminalHostClient
       unawaited(_terminalLineSub?.cancel());
       _terminalLineSub = null;
     }
-    if (wasTerminalConnection && !_disposed) {
+    if (wasTerminalConnection && !_disposed && !_appQuitInProgress) {
       _emitConnectionError(closedError);
     }
     if (identical(_runtimeConnection, connection)) {
@@ -740,8 +554,8 @@ final class SocketTerminalHostClient
     for (final id in pendingIds) {
       final completer = _pending.remove(id)?.completer;
       if (completer != null && !completer.isCompleted) {
-        final pendingError = _disposed
-            ? StateError('Terminal host client is disposed.')
+        final pendingError = _disposed || _appQuitInProgress
+            ? const TerminalHostConnectionClosedException()
             : closedError;
         // Preserve the close site for reporters that receive this error
         // without an await; public callers observe the async wrapper stack.
@@ -775,8 +589,10 @@ final class SocketTerminalHostClient
       return;
     }
     _disposed = true;
+    _appQuitInProgress = true;
     _stopHeartbeat();
     _closeSessionEvents();
+    _failPendingRequests(const TerminalHostConnectionClosedException());
     final connections = <_TerminalHostConnection>{};
     if (_terminalConnection case final connection?) {
       connections.add(connection);
@@ -789,6 +605,23 @@ final class SocketTerminalHostClient
     }
     unawaited(_events.close());
     unawaited(_runtimeEvents.close());
+  }
+
+  void _failPendingRequests(Object error) {
+    final pending = _pending.values.toList(growable: false);
+    _pending.clear();
+    for (final request in pending) {
+      if (!request.completer.isCompleted) {
+        request.completer.completeError(error, StackTrace.current);
+      }
+    }
+  }
+
+  @override
+  void _throwIfAppQuitInProgress() {
+    if (_appQuitInProgress) {
+      throw const TerminalHostConnectionClosedException();
+    }
   }
 
   bool _supportsRuntime(

--- a/lib/src/features/workbench/infra/terminal_host/terminal_host_client_capabilities.dart
+++ b/lib/src/features/workbench/infra/terminal_host/terminal_host_client_capabilities.dart
@@ -2,6 +2,10 @@ part of 'terminal_host_client.dart';
 
 mixin _RuntimeHostCapabilitySupport
     implements TerminalHostClient, RuntimeHostCapabilityClient {
+  bool get _disposed;
+
+  void _throwIfAppQuitInProgress();
+
   _TerminalHostConnection? get _terminalConnection;
   _TerminalHostConnection? get _runtimeConnection;
 
@@ -15,6 +19,10 @@ mixin _RuntimeHostCapabilitySupport
 
   @override
   Future<bool> supportsRuntimeCapability(String capability) async {
+    if (_disposed) {
+      throw StateError('Terminal host client is disposed.');
+    }
+    _throwIfAppQuitInProgress();
     final connection = await _connectRuntime();
     return switch (capability) {
       aleraRuntimeHostRemoteAiDictationCapability =>

--- a/lib/src/features/workbench/infra/terminal_host/terminal_host_client_connections.dart
+++ b/lib/src/features/workbench/infra/terminal_host/terminal_host_client_connections.dart
@@ -1,0 +1,286 @@
+part of 'terminal_host_client.dart';
+
+extension _SocketTerminalHostClientConnections on SocketTerminalHostClient {
+  Future<_TerminalHostConnection> _openTerminalConnection() async {
+    if (_disposed) {
+      throw const TerminalHostConnectionClosedException();
+    }
+    final runtime = await _runtimePaths();
+    final control = await _readControl(runtime.controlFile);
+    if (control != null) {
+      try {
+        return await _connectToControl(control, _HostConnectionRole.terminal);
+      } catch (_) {
+        if (_disposed) {
+          throw const TerminalHostConnectionClosedException();
+        }
+        await _deleteControlFile(runtime.controlFile);
+      }
+    }
+    final runtimeControl = await _readControl(runtime.runtimeControlFile);
+    if (runtimeControl?.supportsRuntime == true) {
+      try {
+        return await _connectToControl(
+          runtimeControl!,
+          _HostConnectionRole.terminal,
+        );
+      } catch (_) {
+        if (_disposed) {
+          throw const TerminalHostConnectionClosedException();
+        }
+        await _deleteControlFile(runtime.runtimeControlFile);
+      }
+    }
+    final runtimeFuture = _runtimeConnectionFuture;
+    if (runtimeFuture != null) {
+      try {
+        final connection = await runtimeFuture;
+        if (connection.supportsRuntime) {
+          _terminalConnection = connection;
+          return connection;
+        }
+      } catch (_) {
+        if (_disposed) {
+          throw const TerminalHostConnectionClosedException();
+        }
+        // A failed runtime connection must not prevent the terminal path from
+        // starting its own host connection.
+      }
+    }
+    if (_disposed) {
+      throw const TerminalHostConnectionClosedException();
+    }
+    return _launchAndConnect(
+      runtime,
+      runtime.controlFile,
+      requireOrchestration: false,
+    );
+  }
+
+  Future<_TerminalHostConnection> _openRuntimeConnection({
+    bool requireOrchestration = false,
+    bool launchIfMissing = true,
+  }) async {
+    if (_disposed) {
+      throw const TerminalHostConnectionClosedException();
+    }
+    final runtime = await _runtimePaths();
+    final control = await _readControl(runtime.controlFile);
+    if (_controlSupportsRuntime(control, requireOrchestration)) {
+      try {
+        return await _connectToControl(control!, _HostConnectionRole.runtime);
+      } catch (_) {
+        if (_disposed) {
+          throw const TerminalHostConnectionClosedException();
+        }
+        await _deleteControlFile(runtime.controlFile);
+      }
+    }
+    if (requireOrchestration && control != null) {
+      if (await _controlAcceptsHello(control)) {
+        throw StateError(_orchestrationHostRestartRequiredMessage);
+      }
+      await _deleteControlFile(runtime.controlFile);
+    }
+    final runtimeControl = await _readControl(runtime.runtimeControlFile);
+    if (_controlSupportsRuntime(runtimeControl, requireOrchestration)) {
+      try {
+        return await _connectToControl(
+          runtimeControl!,
+          _HostConnectionRole.runtime,
+        );
+      } catch (_) {
+        if (_disposed) {
+          throw const TerminalHostConnectionClosedException();
+        }
+        await _deleteControlFile(runtime.runtimeControlFile);
+      }
+    }
+    if (requireOrchestration && runtimeControl != null) {
+      if (await _controlAcceptsHello(runtimeControl)) {
+        throw StateError(_orchestrationHostRestartRequiredMessage);
+      }
+      await _deleteControlFile(runtime.runtimeControlFile);
+    }
+    if (!launchIfMissing) {
+      throw StateError('No live Alera runtime host is available.');
+    }
+    if (_disposed) {
+      throw const TerminalHostConnectionClosedException();
+    }
+    return _launchAndConnect(
+      runtime,
+      control == null || requireOrchestration
+          ? runtime.controlFile
+          : runtime.runtimeControlFile,
+      requireOrchestration: requireOrchestration,
+    );
+  }
+
+  Future<_TerminalHostConnection> _launchAndConnect(
+    _TerminalHostPaths runtime,
+    File controlFile, {
+    required bool requireOrchestration,
+  }) async {
+    if (_disposed || _appQuitInProgress) {
+      throw const TerminalHostConnectionClosedException();
+    }
+    await _failIfIncompatibleHostHoldsRuntime(runtime);
+    if (_disposed || _appQuitInProgress) {
+      throw const TerminalHostConnectionClosedException();
+    }
+    final token = _newToken();
+    // Masked in logs and crash reports from here on: the token grants full
+    // control of the runtime, and a diagnostics bundle is meant to be shared.
+    registerLogSecret(token);
+    await _launcher.start(
+      runtimeDir: runtime.runtimeDir.path,
+      controlFilePath: controlFile.path,
+      token: token,
+      config: _config,
+    );
+    if (_disposed || _appQuitInProgress) {
+      throw const TerminalHostConnectionClosedException();
+    }
+    final deadline = DateTime.now().add(_startupTimeout);
+    Object? lastError;
+    while (DateTime.now().isBefore(deadline)) {
+      if (_disposed || _appQuitInProgress) {
+        throw const TerminalHostConnectionClosedException();
+      }
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+      final nextControl = await _readControl(controlFile);
+      if (nextControl == null ||
+          nextControl.token != token ||
+          !_controlSupportsRuntime(nextControl, requireOrchestration)) {
+        continue;
+      }
+      try {
+        return await _connectToControl(
+          nextControl,
+          _HostConnectionRole.runtime,
+        );
+      } catch (error) {
+        lastError = error;
+      }
+    }
+    // Keep the public message stable for crash grouping, but preserve the
+    // concrete startup cause in the local diagnostics log.
+    if (lastError case final error?) {
+      AppLogger.recordError(
+        error,
+        StackTrace.current,
+        context: 'SocketTerminalHostClient',
+      );
+    }
+    throw TerminalHostStartupException(lastError);
+  }
+
+  Future<_TerminalHostConnection> _connectToControl(
+    _TerminalHostControl control,
+    _HostConnectionRole role,
+  ) async {
+    final connection = await _openHostConnection(control);
+    if (_disposed) {
+      connection.dispose();
+      throw const TerminalHostConnectionClosedException();
+    }
+    unawaited(
+      connection.done.then(
+        (_) => _handleConnectionClosed(connection),
+        onError: (Object error, StackTrace _) {
+          _handleConnectionClosed(connection, error);
+        },
+      ),
+    );
+    // Output frames bypass the JSON path entirely: no line split, no
+    // jsonDecode, no base64. That is the whole point of the binary mode.
+    connection.outputFrames.listen(
+      (frame) => _emitHostEvent(
+        frame.sessionId,
+        TerminalHostOutputEvent(frame.sessionId, frame.data),
+      ),
+      onError: (Object _) {},
+    );
+    connection.decodedOutput.listen(
+      (event) => _emitHostEvent(event.sessionId, event),
+      onError: (Object _) {},
+    );
+    final lineSub = connection.lines.listen(
+      (line) {
+        try {
+          _handleLine(connection, line);
+        } catch (error) {
+          _handleConnectionClosed(connection, error);
+        }
+      },
+      onError: (error) => _handleConnectionClosed(connection, error),
+      onDone: () => _handleConnectionClosed(connection),
+      cancelOnError: true,
+    );
+    try {
+      connection.write(<String, Object?>{
+        'id': 0,
+        'type': 'hello',
+        'payload': <String, Object?>{
+          'protocolVersion': aleraTerminalHostProtocolVersion,
+          'token': control.token,
+          'clientKind': 'app',
+          'supportedTabKinds': const <String>[
+            aleraMobileEmulatorTabKind,
+            aleraCodexTabKind,
+          ],
+          if (control.supportsBinaryFrames) 'binaryFrames': true,
+        },
+      });
+      await connection.authenticated.timeout(
+        _terminalHostConnectTimeout,
+        onTimeout: () => throw TimeoutException(
+          'Terminal host authentication timed out.',
+          _terminalHostConnectTimeout,
+        ),
+      );
+      if (connection.isClosed) {
+        throw StateError(
+          'Terminal host connection closed during authentication.',
+        );
+      }
+      if (_disposed) {
+        throw const TerminalHostConnectionClosedException();
+      }
+      switch (role) {
+        case _HostConnectionRole.terminal:
+          _terminalLineSub = lineSub;
+          _terminalConnection = connection;
+          _terminalConnectionFuture = null;
+          if (connection.supportsRuntime) {
+            _runtimeConnection = connection;
+            _runtimeConnectionFuture = null;
+            _runtimeLineSub = lineSub;
+          }
+        case _HostConnectionRole.runtime:
+          _runtimeLineSub = lineSub;
+          _runtimeConnection = connection;
+          _runtimeConnectionFuture = null;
+          if (_terminalConnection == null && connection.supportsRuntime) {
+            _terminalConnection = connection;
+            _terminalConnectionFuture = null;
+            _terminalLineSub = lineSub;
+          }
+      }
+      if (connection.supportsRuntime && !_runtimeEvents.isClosed) {
+        _runtimeEvents.add(
+          const RuntimeHostEvent(
+            aleraRuntimeHostConnectedEvent,
+            <String, Object?>{},
+          ),
+        );
+      }
+    } catch (_) {
+      await lineSub.cancel();
+      connection.dispose();
+      rethrow;
+    }
+    return connection;
+  }
+}

--- a/lib/src/features/workbench/infra/terminal_host/terminal_host_client_lifecycle.dart
+++ b/lib/src/features/workbench/infra/terminal_host/terminal_host_client_lifecycle.dart
@@ -14,6 +14,7 @@ extension SocketTerminalHostClientLifecycle on SocketTerminalHostClient {
         connection,
         'status.get',
         const <String, Object?>{},
+        allowDuringAppQuit: true,
       );
       final status = asTerminalHostMap(payload, 'runtime status');
       CrashReporting.updateRuntimeContext(status);
@@ -39,6 +40,7 @@ extension SocketTerminalHostClientLifecycle on SocketTerminalHostClient {
         connection,
         'host.shutdown',
         <String, Object?>{'force': force},
+        allowDuringAppQuit: true,
       );
       return RuntimeHostShutdownResult.fromJson(
         asTerminalHostMap(payload, 'runtime shutdown'),

--- a/lib/src/features/workbench/infra/terminal_host/terminal_host_client_requests.dart
+++ b/lib/src/features/workbench/infra/terminal_host/terminal_host_client_requests.dart
@@ -18,12 +18,16 @@ Future<Object?> _sendTerminalHostRequestWithMutationRetry(
   String type,
   Map<String, Object?> payload, {
   Duration? timeout,
+  bool allowDuringAppQuit = false,
 }) async {
   final requestTimeout = timeout ?? _terminalHostRequestTimeout;
   final elapsed = Stopwatch()..start();
   while (true) {
     if (client._disposed) {
       throw StateError('Terminal host client is disposed.');
+    }
+    if (client._appQuitInProgress && !allowDuringAppQuit) {
+      throw const TerminalHostConnectionClosedException();
     }
     final remaining = requestTimeout - elapsed.elapsed;
     if (remaining <= Duration.zero) {
@@ -38,6 +42,7 @@ Future<Object?> _sendTerminalHostRequestWithMutationRetry(
         payload,
         timeout: remaining,
         reportedTimeout: requestTimeout,
+        allowDuringAppQuit: allowDuringAppQuit,
       );
     } on _RuntimeMutationInProgressError {
       final delayRemaining = requestTimeout - elapsed.elapsed;
@@ -58,7 +63,14 @@ Future<Object?> _sendTerminalHostRequest(
   Map<String, Object?> payload, {
   Duration? timeout,
   Duration? reportedTimeout,
+  bool allowDuringAppQuit = false,
 }) {
+  if (client._disposed) {
+    throw StateError('Terminal host client is disposed.');
+  }
+  if (client._appQuitInProgress && !allowDuringAppQuit) {
+    throw const TerminalHostConnectionClosedException();
+  }
   final id = client._nextRequestId++;
   final completer = Completer<Object?>();
   client._pending[id] = _PendingHostRequest(connection, completer);
@@ -95,7 +107,10 @@ Future<Object?> _sendTerminalHostRequest(
     client._pending.remove(id);
     client._handleConnectionClosed(connection, error);
     if (!completer.isCompleted) {
-      completer.completeError(error, stackTrace);
+      final requestError = client._disposed || client._appQuitInProgress
+          ? const TerminalHostConnectionClosedException()
+          : error;
+      completer.completeError(requestError, stackTrace);
     }
   }
   return response;

--- a/test/unit/terminal_host_client_timeout_cases.dart
+++ b/test/unit/terminal_host_client_timeout_cases.dart
@@ -27,6 +27,102 @@ Future<SocketTerminalHostClient> _connectedClient(
 }
 
 void _registerTerminalHostClientTimeoutTests() {
+  test(
+    'quiesces pending tab mutations before an intentional app quit',
+    () async {
+      final releaseMutations = Completer<void>();
+      final server = await _TerminalHostTestServer.start(
+        beforeResponse: (type) async {
+          if (type == 'tab.upsert' || type == 'tab.remove') {
+            await releaseMutations.future;
+          }
+        },
+      );
+      addTearDown(server.dispose);
+      final client = await _connectedClient(server);
+
+      await client.runtimeRequest('project.list');
+      final upsert = client.runtimeRequest(
+        'tab.upsert',
+        const <String, Object?>{'id': 'tab-1'},
+      );
+      final remove = client.runtimeRequest(
+        'tab.remove',
+        const <String, Object?>{'id': 'tab-1'},
+      );
+      await _waitForServerRequestCount(server, 4);
+
+      client.beginAppQuit();
+
+      await expectLater(
+        upsert,
+        throwsA(isA<TerminalHostConnectionClosedException>()),
+      );
+      await expectLater(
+        remove,
+        throwsA(isA<TerminalHostConnectionClosedException>()),
+      );
+
+      // Lifecycle requests remain available to complete the quit gate while
+      // ordinary runtime traffic is rejected as an expected close.
+      final shutdown = client.shutdownRuntime();
+      final shutdownResult = await shutdown;
+      expect(shutdownResult.stopped, isFalse);
+      expect(server.requestTypes, contains('host.shutdown'));
+
+      releaseMutations.complete();
+    },
+  );
+
+  test('reopens runtime traffic when an app quit is cancelled', () async {
+    final server = await _TerminalHostTestServer.start();
+    addTearDown(server.dispose);
+    final client = await _connectedClient(server);
+
+    await client.runtimeRequest('project.list');
+    client.beginAppQuit();
+    await expectLater(
+      client.runtimeRequest('project.list'),
+      throwsA(isA<TerminalHostConnectionClosedException>()),
+    );
+
+    client.cancelAppQuit();
+    await client.runtimeRequest('project.list');
+    expect(server.requestTypes, <String>[
+      'hello',
+      'project.list',
+      'project.list',
+    ]);
+  });
+
+  test('disposal completes pending mutations as an expected close', () async {
+    final releaseMutation = Completer<void>();
+    final server = await _TerminalHostTestServer.start(
+      beforeResponse: (type) async {
+        if (type == 'tab.upsert') {
+          await releaseMutation.future;
+        }
+      },
+    );
+    addTearDown(server.dispose);
+    final client = await _connectedClient(server);
+
+    await client.runtimeRequest('project.list');
+    final mutation = client.runtimeRequest(
+      'tab.upsert',
+      const <String, Object?>{'id': 'tab-1'},
+    );
+    await _waitForServerRequestCount(server, 3);
+
+    client.dispose();
+
+    await expectLater(
+      mutation,
+      throwsA(isA<TerminalHostConnectionClosedException>()),
+    );
+    releaseMutation.complete();
+  });
+
   test('a sibling request still completes while another times out', () async {
     final server = await _TerminalHostTestServer.start(
       beforeResponse: (type) async {


### PR DESCRIPTION
## Summary
- quiesce runtime traffic before the app quit gate shuts down the host
- complete pending tab mutations as typed connection closures
- preserve lifecycle requests needed to finish or cancel quit

Closes Sentry ALERA-DESKTOP-APP-K, ALERA-DESKTOP-APP-M, and ALERA-DESKTOP-APP-N.

## Validation
- `puro -e v3_44_8 flutter test test/unit/terminal_host_client_test.dart` (47 tests)