### PR TITLE
fix: serialize terminal attachment recovery

### DIFF
--- a/lib/src/features/workbench/infra/terminal_host/terminal_host_pty_session.dart
+++ b/lib/src/features/workbench/infra/terminal_host/terminal_host_pty_session.dart
@@ -86,7 +86,9 @@ final class TerminalHostPtySession
   bool _startedNewProcess = false;
   bool _outputPaused = false;
   Future<void>? _startFuture;
-  Future<void> _resizeOperations = Future<void>.value();
+  // Resize and output resync can both observe a lost attachment. Keep their
+  // retries in one lane so no request races the createOrAttach response.
+  Future<void> _attachmentOperations = Future<void>.value();
   Future<void> Function()? _onProcessCreated;
 
   @override
@@ -236,7 +238,11 @@ final class TerminalHostPtySession
     if (!_started) {
       return;
     }
-    unawaited(_enqueueResize(() => _resize(cols: cols, rows: rows)));
+    unawaited(
+      _enqueueAttachmentOperation(
+        () => _resize(cols: cols, rows: rows),
+      ).catchError(_emitHostError),
+    );
   }
 
   @override
@@ -252,85 +258,82 @@ final class TerminalHostPtySession
     _cols = cols;
     _rows = rows;
     final pulseCols = cols > 1 ? cols - 1 : cols + 1;
-    return _enqueueResize(() async {
+    return _enqueueAttachmentOperation<void>(() async {
       try {
         await _resize(cols: pulseCols, rows: rows);
       } finally {
         await _resize(cols: cols, rows: rows);
       }
-    });
+    }).catchError(_emitHostError);
   }
 
-  Future<void> _enqueueResize(Future<void> Function() operation) {
-    final next = _resizeOperations
-        .then((_) => _disposed ? null : operation())
-        .catchError(_emitHostError);
-    _resizeOperations = next;
-    return next;
+  @override
+  Future<T> _enqueueAttachmentOperation<T>(Future<T> Function() operation) {
+    final previous = _attachmentOperations;
+    final gate = Completer<void>();
+    _attachmentOperations = gate.future;
+    return previous.then((_) async {
+      try {
+        return await operation();
+      } finally {
+        gate.complete();
+      }
+    });
   }
 
   Future<void> _writeBytes(
     List<int> bytes, {
     bool deferredEnter = false,
   }) async {
-    try {
-      await _client.write(
+    await _withReattach(
+      () => _client.write(
         sessionId: _sessionId,
         bytes: bytes,
         deferredEnter: deferredEnter,
-      );
-    } catch (error) {
-      if (!_isDefinitivelyNotAttached(error)) {
-        rethrow;
-      }
-      await _reattach();
-      await _client.write(
-        sessionId: _sessionId,
-        bytes: bytes,
-        deferredEnter: deferredEnter,
-      );
-    }
+      ),
+      shouldRecover: _isDefinitivelyNotAttached,
+    );
   }
 
   Future<void> _resize({required int cols, required int rows}) async {
-    try {
-      await _client.resize(sessionId: _sessionId, cols: cols, rows: rows);
-    } catch (error) {
-      if (!_shouldRecoverFromHostError(error)) {
-        rethrow;
-      }
-      await _reattach();
-      await _client.resize(sessionId: _sessionId, cols: cols, rows: rows);
-    }
+    await _withReattach(
+      () => _client.resize(sessionId: _sessionId, cols: cols, rows: rows),
+      shouldRecover: _shouldRecoverFromHostError,
+    );
   }
 
   @override
-  Future<void> setOutputPaused(bool paused) async {
+  Future<void> setOutputPaused(bool paused) {
     if (_disposed || !_started) {
-      return;
+      return Future<void>.value();
     }
     _outputPaused = paused;
-    try {
-      final resume = await _client.setOutputPaused(
-        sessionId: _sessionId,
-        paused: paused,
-      );
-      _emitResume(paused: paused, resume: resume);
-    } catch (error) {
-      if (!_shouldRecoverFromHostError(error)) {
-        _emitHostError(error);
-        return;
-      }
+    return _enqueueAttachmentOperation<void>(() async {
       try {
-        await _reattach();
-        final resume = await _client.setOutputPaused(
-          sessionId: _sessionId,
-          paused: paused,
+        final resume = await _withReattach(
+          () => _client.setOutputPaused(sessionId: _sessionId, paused: paused),
+          shouldRecover: _shouldRecoverFromHostError,
         );
         _emitResume(paused: paused, resume: resume);
-      } catch (retryError) {
-        _emitHostError(retryError);
+      } catch (error) {
+        _emitHostError(error);
       }
+    });
+  }
+
+  @override
+  Future<T> _withReattach<T>(
+    Future<T> Function() operation, {
+    required bool Function(Object error) shouldRecover,
+  }) async {
+    try {
+      return await operation();
+    } catch (error) {
+      if (!shouldRecover(error)) {
+        rethrow;
+      }
+      await _reattach();
+      return operation();
     }
   }
 
@@ -349,9 +352,8 @@ final class TerminalHostPtySession
   }
 
   @override
-  Future<void> reconnect() async {
-    await _reattach();
-  }
+  Future<void> reconnect() =>
+      _enqueueAttachmentOperation<void>(() => _reattach().then((_) {}));
 
   @override
   Future<void> restartProcess() async {

--- a/lib/src/features/workbench/infra/terminal_host/terminal_host_pty_session_errors.dart
+++ b/lib/src/features/workbench/infra/terminal_host/terminal_host_pty_session_errors.dart
@@ -1,23 +1,27 @@
 part of 'terminal_host_pty_session.dart';
 
+bool _shouldRecoverFromTerminalHostError(Object error) {
+  final message = _terminalHostErrorMessage(error);
+  return message.contains('Terminal session is not attached') ||
+      message.contains('Terminal host connection closed');
+}
+
+String _terminalHostErrorMessage(Object error) {
+  if (error is StateError) {
+    return error.message;
+  }
+  return error.toString();
+}
+
 extension _TerminalHostPtySessionErrors on TerminalHostPtySession {
   bool _shouldRecoverFromHostError(Object error) {
-    final message = _hostErrorMessage(error);
-    return message.contains('Terminal session is not attached') ||
-        message.contains('Terminal host connection closed');
+    return _shouldRecoverFromTerminalHostError(error);
   }
 
   bool _isDefinitivelyNotAttached(Object error) {
-    return _hostErrorMessage(
+    return _terminalHostErrorMessage(
       error,
     ).contains('Terminal session is not attached');
-  }
-
-  String _hostErrorMessage(Object error) {
-    if (error is StateError) {
-      return error.message;
-    }
-    return error.toString();
   }
 
   void _emitHostError(Object error) {
@@ -27,6 +31,8 @@ extension _TerminalHostPtySessionErrors on TerminalHostPtySession {
   }
 
   bool _isInputBackpressure(Object error) {
-    return _hostErrorMessage(error).contains('terminal_input_backpressure');
+    return _terminalHostErrorMessage(
+      error,
+    ).contains('terminal_input_backpressure');
   }
 }

--- a/lib/src/features/workbench/infra/terminal_host/terminal_host_pty_session_pulse.dart
+++ b/lib/src/features/workbench/infra/terminal_host/terminal_host_pty_session_pulse.dart
@@ -5,6 +5,13 @@ mixin _TerminalPulsePtySessionSupport implements TerminalPulsePtySession {
 
   String get _sessionId;
 
+  Future<T> _enqueueAttachmentOperation<T>(Future<T> Function() operation);
+
+  Future<T> _withReattach<T>(
+    Future<T> Function() operation, {
+    required bool Function(Object error) shouldRecover,
+  });
+
   @override
   bool get supportsTerminalPulse =>
       _client is TerminalPulseHostClient &&
@@ -20,7 +27,12 @@ mixin _TerminalPulsePtySessionSupport implements TerminalPulsePtySession {
         'The running terminal host does not support Terminal Pulse.',
       );
     }
-    return client.terminalPulseStatus(_sessionId);
+    return _enqueueAttachmentOperation(
+      () => _withReattach(
+        () => client.terminalPulseStatus(_sessionId),
+        shouldRecover: _shouldRecoverFromTerminalHostError,
+      ),
+    );
   }
 
   @override
@@ -36,10 +48,15 @@ mixin _TerminalPulsePtySessionSupport implements TerminalPulsePtySession {
         'The running terminal host does not support Terminal Pulse.',
       );
     }
-    return client.configureTerminalPulse(
-      sessionId: _sessionId,
-      configuration: configuration,
-      armed: armed,
+    return _enqueueAttachmentOperation(
+      () => _withReattach(
+        () => client.configureTerminalPulse(
+          sessionId: _sessionId,
+          configuration: configuration,
+          armed: armed,
+        ),
+        shouldRecover: _shouldRecoverFromTerminalHostError,
+      ),
     );
   }
 }

--- a/test/unit/terminal_host_pty_output_resync_cases.dart
+++ b/test/unit/terminal_host_pty_output_resync_cases.dart
@@ -36,6 +36,65 @@ void _registerTerminalHostPtyOutputResyncTests() {
     expect(events.whereType<TerminalPtySnapshotEvent>(), hasLength(1));
   });
 
+  test('serializes output resync behind a resize reattach', () async {
+    final client = FakeTerminalHostClient(
+      attachment: TerminalHostAttachment(
+        sessionId: 'session-1',
+        created: true,
+        running: true,
+        snapshot: Uint8List(0),
+      ),
+      attachments: <TerminalHostAttachment>[
+        TerminalHostAttachment(
+          sessionId: 'session-1',
+          created: true,
+          running: true,
+          snapshot: Uint8List(0),
+        ),
+        TerminalHostAttachment(
+          sessionId: 'session-1',
+          created: false,
+          running: true,
+          snapshot: Uint8List(0),
+        ),
+      ],
+    );
+    client.reattachCompleter = Completer<void>();
+    client.resizeErrors.add(
+      StateError('Terminal session is not attached: session-1'),
+    );
+    final session = TerminalHostPtySession(
+      client: client,
+      sessionId: 'session-1',
+      workspaceId: 'workspace-1',
+      tabId: 'tab-1',
+    );
+    addTearDown(session.dispose);
+    final events = <TerminalPtySessionEvent>[];
+    final sub = session.events.listen(events.add);
+    addTearDown(sub.cancel);
+
+    await session.start(
+      launch: _launch(),
+      workingDirectory: '/repo',
+      cols: 80,
+      rows: 24,
+    );
+    session.resize(120, 40, 8, 16);
+    client.emit(const TerminalHostOutputResyncRequiredEvent('session-1'));
+    await _flushAsync();
+
+    expect(client.attachCalls, hasLength(2));
+    expect(client.outputPaused, isEmpty);
+
+    client.reattachCompleter!.complete();
+    await _flushAsync();
+
+    expect(client.resizes, <(String, int, int)>[('session-1', 120, 40)]);
+    expect(client.outputPaused, <(String, bool)>[('session-1', false)]);
+    expect(events.whereType<TerminalPtyErrorEvent>(), isEmpty);
+  });
+
   test(
     'hidden host PTY defers output resync until it becomes visible',
     () async {

--- a/test/unit/terminal_host_pty_pulse_cases.dart
+++ b/test/unit/terminal_host_pty_pulse_cases.dart
@@ -37,4 +37,49 @@ void _registerTerminalHostPtyPulseTests() {
 
     expect((await pulseEvent).state.error, 'watcher stopped');
   });
+
+  test('host PTY session reattaches before Terminal Pulse requests', () async {
+    final initial = TerminalHostAttachment(
+      sessionId: 'session-1',
+      created: true,
+      running: true,
+      snapshot: Uint8List(0),
+    );
+    final client = FakeTerminalHostClient(
+      attachment: initial,
+      attachments: <TerminalHostAttachment>[
+        initial,
+        TerminalHostAttachment(
+          sessionId: 'session-1',
+          created: false,
+          running: true,
+          snapshot: Uint8List(0),
+        ),
+      ],
+      pulseEnabled: true,
+    );
+    client.pulseStatusErrors.add(
+      StateError('Terminal session is not attached: session-1'),
+    );
+    final session = TerminalHostPtySession(
+      client: client,
+      sessionId: 'session-1',
+      workspaceId: 'workspace-1',
+      tabId: 'tab-1',
+    );
+    addTearDown(session.dispose);
+
+    await session.start(
+      launch: _launch(),
+      workingDirectory: '/repo',
+      cols: 80,
+      rows: 24,
+    );
+
+    final state = await session.terminalPulseStatus();
+
+    expect(state.armed, isFalse);
+    expect(client.attachCalls, hasLength(2));
+    expect(client.pulseStatusErrors, isEmpty);
+  });
 }

--- a/test/unit/terminal_host_test_fakes.dart
+++ b/test/unit/terminal_host_test_fakes.dart
@@ -1,15 +1,18 @@
 import 'dart:async';
 import 'dart:typed_data';
 
+import 'package:alera/src/features/workbench/domain/workspace_tab_record.dart';
 import 'package:alera/src/features/workbench/infra/terminal_host/terminal_host_client.dart';
 import 'package:alera/src/features/workbench/infra/terminal_host/terminal_host_protocol.dart';
 import 'package:ghostty_vte_flutter/ghostty_vte_flutter.dart';
 
-final class FakeTerminalHostClient implements TerminalHostClient {
+final class FakeTerminalHostClient
+    implements TerminalHostClient, TerminalPulseHostClient {
   FakeTerminalHostClient({
     required TerminalHostAttachment attachment,
     List<TerminalHostAttachment>? attachments,
     this.attachCompleter,
+    this.pulseEnabled = false,
   }) : _attachments = attachments ?? <TerminalHostAttachment>[attachment];
 
   final List<TerminalHostAttachment> _attachments;
@@ -49,8 +52,19 @@ final class FakeTerminalHostClient implements TerminalHostClient {
       <String, TerminalSessionDriver>{};
   final List<Object> writeErrors = <Object>[];
   final List<Object> resizeErrors = <Object>[];
+  final List<Object> outputPausedErrors = <Object>[];
+  final List<Object> pulseStatusErrors = <Object>[];
+  final List<Object> pulseConfigurationErrors = <Object>[];
+  final List<TerminalPulseConfiguration> pulseConfigurations =
+      <TerminalPulseConfiguration>[];
   String? attachedWorkingDirectory;
   Object? writeError;
+  final bool pulseEnabled;
+  Completer<void>? reattachCompleter;
+  TerminalPulseState pulseState = const TerminalPulseState(
+    configuration: TerminalPulseConfiguration(),
+    armed: false,
+  );
 
   /// What `setOutputPaused(false)` answers with. A host that can still place
   /// the client in the output stream answers with a delta and pushes the
@@ -99,7 +113,8 @@ final class FakeTerminalHostClient implements TerminalHostClient {
       rows: rows,
     ));
     attachedWorkingDirectory = workingDirectory;
-    if (attachCompleter case final completer?) {
+    final gate = attachCalls.length == 1 ? attachCompleter : reattachCompleter;
+    if (gate case final completer?) {
       await completer.future;
     }
     final index = attachCalls.length - 1;
@@ -155,8 +170,36 @@ final class FakeTerminalHostClient implements TerminalHostClient {
     required String sessionId,
     required bool paused,
   }) async {
+    if (outputPausedErrors.isNotEmpty) {
+      throw outputPausedErrors.removeAt(0);
+    }
     outputPaused.add((sessionId, paused));
     return resume ?? TerminalHostResume(isDelta: true, snapshot: Uint8List(0));
+  }
+
+  @override
+  bool get supportsTerminalPulse => pulseEnabled;
+
+  @override
+  Future<TerminalPulseState> terminalPulseStatus(String sessionId) async {
+    if (pulseStatusErrors.isNotEmpty) {
+      throw pulseStatusErrors.removeAt(0);
+    }
+    return pulseState;
+  }
+
+  @override
+  Future<TerminalPulseState> configureTerminalPulse({
+    required String sessionId,
+    required TerminalPulseConfiguration configuration,
+    required bool armed,
+  }) async {
+    if (pulseConfigurationErrors.isNotEmpty) {
+      throw pulseConfigurationErrors.removeAt(0);
+    }
+    pulseConfigurations.add(configuration);
+    pulseState = TerminalPulseState(configuration: configuration, armed: armed);
+    return pulseState;
   }
 
   @override


### PR DESCRIPTION
## Summary
- serialize attachment-sensitive PTY operations per session
- share bounded reattach recovery across resync and Terminal Pulse
- prevent transient not-attached errors from escaping concurrent recovery

Closes Sentry ALERA-DESKTOP-APP-8.

## Validation
- `puro -e v3_44_8 dart analyze` on changed files
- `puro -e v3_44_8 flutter test test/unit/terminal_host_pty_session_test.dart` (21 tests)