### PR TITLE
fix: guard riverpod callbacks after disposal

### DIFF
--- a/lib/src/features/agent_quota/application/agent_quota_providers.dart
+++ b/lib/src/features/agent_quota/application/agent_quota_providers.dart
@@ -56,7 +56,11 @@ Future<AgentQuotaState> agentQuotaState(Ref ref) async {
   final target = hostId == 'local'
       ? null
       : targets.where((candidate) => candidate.id == hostId).firstOrNull;
-  final timer = Timer(agentQuotaRefreshInterval, ref.invalidateSelf);
+  final timer = Timer(agentQuotaRefreshInterval, () {
+    if (ref.mounted) {
+      ref.invalidateSelf();
+    }
+  });
   ref.onDispose(timer.cancel);
   final service = ref.watch(agentQuotaServiceProvider);
   return service.fetch(

--- a/lib/src/features/agent_quota/application/agent_quota_providers.g.dart
+++ b/lib/src/features/agent_quota/application/agent_quota_providers.g.dart
@@ -141,4 +141,4 @@ final class AgentQuotaStateProvider
   }
 }
 
-String _$agentQuotaStateHash() => r'b237c82a99cea9e924f8e4c5c692a8f0a84507e1';
+String _$agentQuotaStateHash() => r'aff66547d5431d847288af38a120171ef8257d14';

--- a/mobile/lib/src/features/quotas/application/agent_quota_controller.dart
+++ b/mobile/lib/src/features/quotas/application/agent_quota_controller.dart
@@ -16,7 +16,14 @@ class AgentQuotaController extends _$AgentQuotaController {
     if (!client.supportsAgentQuotas) {
       throw UnsupportedError('Update the runtime to view quotas.');
     }
-    final timer = Timer(mobileQuotaRefreshInterval, ref.invalidateSelf);
+    if (!ref.mounted) {
+      return client.fetchAgentQuotas();
+    }
+    final timer = Timer(mobileQuotaRefreshInterval, () {
+      if (ref.mounted) {
+        ref.invalidateSelf();
+      }
+    });
     ref.onDispose(timer.cancel);
     return client.fetchAgentQuotas();
   }
@@ -25,10 +32,16 @@ class AgentQuotaController extends _$AgentQuotaController {
     final client = await ref.read(
       hostConnectionControllerProvider(hostId).future,
     );
+    if (!ref.mounted) {
+      return;
+    }
     state = const AsyncLoading<QuotaSnapshotState>();
-    state = await AsyncValue.guard(
+    final nextState = await AsyncValue.guard(
       () => client.fetchAgentQuotas(forceRefresh: true),
     );
+    if (ref.mounted) {
+      state = nextState;
+    }
   }
 
   Future<void> tryClaudeWithTui(QuotaSnapshot snapshot) async {
@@ -42,6 +55,9 @@ class AgentQuotaController extends _$AgentQuotaController {
       accountId: snapshot.accountId,
       displayName: snapshot.displayName,
     );
+    if (!ref.mounted) {
+      return;
+    }
     final previous = state.value;
     if (previous == null) {
       ref.invalidateSelf();
@@ -85,6 +101,9 @@ class AgentQuotaController extends _$AgentQuotaController {
       throw UnsupportedError('Update the runtime to use Codex resets.');
     }
     final result = await client.consumeCodexResetCredit(credits.offerRevision);
+    if (!ref.mounted) {
+      return result;
+    }
     final previous = state.value;
     if (previous == null) {
       ref.invalidateSelf();

--- a/mobile/lib/src/features/quotas/application/agent_quota_controller.g.dart
+++ b/mobile/lib/src/features/quotas/application/agent_quota_controller.g.dart
@@ -51,7 +51,7 @@ final class AgentQuotaControllerProvider
 }
 
 String _$agentQuotaControllerHash() =>
-    r'67f0fee8a2d9173dfd4e29deb52118fe6d6c3a3d';
+    r'10774784fda8b5142cb3d81023ee3c8693e03124';
 
 final class AgentQuotaControllerFamily extends $Family
     with

--- a/mobile/lib/src/features/workbench/application/workspace_list_controller.dart
+++ b/mobile/lib/src/features/workbench/application/workspace_list_controller.dart
@@ -77,12 +77,14 @@ class WorkspaceListController extends _$WorkspaceListController {
         'Update Alera on this host to use mobile workspaces.',
       );
     }
-    final subscription = client.events.listen((event) {
-      if (_refreshEvents.contains(event.name)) {
-        ref.invalidateSelf();
-      }
-    });
-    ref.onDispose(subscription.cancel);
+    if (ref.mounted) {
+      final subscription = client.events.listen((event) {
+        if (ref.mounted && _refreshEvents.contains(event.name)) {
+          ref.invalidateSelf();
+        }
+      });
+      ref.onDispose(subscription.cancel);
+    }
     final snapshot = await client.workspaceSidebarSnapshot();
     return WorkspaceListData(
       workspaces: snapshot.workspaces,
@@ -110,7 +112,7 @@ class WorkspaceListController extends _$WorkspaceListController {
   Future<void> setPinned(String workspaceId, bool isPinned) async {
     final client = await ref.read(workspaceClientProvider(hostId).future);
     await client.setWorkspacePinned(workspaceId, isPinned);
-    ref.invalidateSelf();
+    _invalidateIfMounted();
   }
 
   Future<void> linkParent({
@@ -122,7 +124,7 @@ class WorkspaceListController extends _$WorkspaceListController {
       parentWorkspaceId: parentWorkspaceId,
       childWorkspaceId: childWorkspaceId,
     );
-    ref.invalidateSelf();
+    _invalidateIfMounted();
   }
 
   Future<void> unlinkParent(WorkspaceSummary workspace) async {
@@ -135,7 +137,7 @@ class WorkspaceListController extends _$WorkspaceListController {
       parentWorkspaceId: parentId,
       childWorkspaceId: workspace.id,
     );
-    ref.invalidateSelf();
+    _invalidateIfMounted();
   }
 
   Future<WorkspaceCreationResult> createWorkspace({
@@ -174,7 +176,7 @@ class WorkspaceListController extends _$WorkspaceListController {
           result = result.withParentLinkError(error);
         }
       }
-      ref.invalidateSelf();
+      _invalidateIfMounted();
       return result;
     } finally {
       keepAlive.close();
@@ -187,7 +189,7 @@ class WorkspaceListController extends _$WorkspaceListController {
       workspaceId,
       deleteBranch: deleteBranch,
     );
-    ref.invalidateSelf();
+    _invalidateIfMounted();
   }
 
   Future<List<String>> cascadePreview(String workspaceId) async {
@@ -198,13 +200,13 @@ class WorkspaceListController extends _$WorkspaceListController {
   Future<void> renameWorkspace(String workspaceId, String name) async {
     final client = await ref.read(workspaceClientProvider(hostId).future);
     await client.renameWorkspace(workspaceId, name);
-    ref.invalidateSelf();
+    _invalidateIfMounted();
   }
 
   Future<void> sleepWorkspace(String workspaceId) async {
     final client = await ref.read(workspaceClientProvider(hostId).future);
     await client.sleepWorkspace(workspaceId);
-    ref.invalidateSelf();
+    _invalidateIfMounted();
   }
 
   Future<String?> repositoryRemoteUrl(String workspaceId) async {
@@ -215,19 +217,25 @@ class WorkspaceListController extends _$WorkspaceListController {
   Future<WorkspaceTagSummary> createTag(String name, {String? color}) async {
     final client = await ref.read(workspaceClientProvider(hostId).future);
     final tag = await client.createWorkspaceTag(name, color: color);
-    ref.invalidateSelf();
+    _invalidateIfMounted();
     return tag;
   }
 
   Future<void> removeTag(String tagId) async {
     final client = await ref.read(workspaceClientProvider(hostId).future);
     await client.removeWorkspaceTag(tagId);
-    ref.invalidateSelf();
+    _invalidateIfMounted();
   }
 
   Future<void> setTags(String workspaceId, List<String> tagIds) async {
     final client = await ref.read(workspaceClientProvider(hostId).future);
     await client.setWorkspaceTags(workspaceId, tagIds);
-    ref.invalidateSelf();
+    _invalidateIfMounted();
+  }
+
+  void _invalidateIfMounted() {
+    if (ref.mounted) {
+      ref.invalidateSelf();
+    }
   }
 }

--- a/mobile/lib/src/features/workbench/application/workspace_list_controller.g.dart
+++ b/mobile/lib/src/features/workbench/application/workspace_list_controller.g.dart
@@ -52,7 +52,7 @@ final class WorkspaceListControllerProvider
 }
 
 String _$workspaceListControllerHash() =>
-    r'bdc178e91960b856eced7a89814752b23eb24901';
+    r'a41107b638b4faf1f1872fba53137fce4e6a26ad';
 
 final class WorkspaceListControllerFamily extends $Family
     with

--- a/mobile/test/agent_quota_controller_test.dart
+++ b/mobile/test/agent_quota_controller_test.dart
@@ -1,0 +1,156 @@
+import 'dart:async';
+
+import 'package:alera_mobile/src/features/quotas/application/agent_quota_controller.dart';
+import 'package:alera_mobile/src/features/quotas/domain/quota_snapshot.dart';
+import 'package:alera_mobile/src/features/runtime/application/host_connection_controller.dart';
+import 'package:alera_mobile/src/features/runtime/infra/mobile_runtime_client.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+void main() {
+  testWidgets(
+    'does not register a refresh timer after the controller is disposed',
+    (tester) async {
+      final client = _FakeMobileRuntimeClient();
+      final clientReady = Completer<MobileRuntimeClient>();
+      final container = ProviderContainer(
+        overrides: [
+          hostConnectionControllerProvider.overrideWith2(
+            (_) => _FakeHostConnection(clientReady.future),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+      addTearDown(client.dispose);
+      final provider = agentQuotaControllerProvider('host-disposed-build');
+      final subscription = container.listen(
+        provider,
+        (_, _) {},
+        fireImmediately: true,
+      );
+      final result = container.read(provider.future);
+      subscription.close();
+      container.dispose();
+
+      clientReady.complete(client);
+      await result;
+      await tester.pump(mobileQuotaRefreshInterval);
+    },
+  );
+
+  testWidgets('does not invalidate the quota controller after disposal', (
+    tester,
+  ) async {
+    final client = _FakeMobileRuntimeClient();
+    final container = ProviderContainer(
+      overrides: [
+        hostConnectionControllerProvider.overrideWith2(
+          (_) => _FakeHostConnection(Future<MobileRuntimeClient>.value(client)),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+    addTearDown(client.dispose);
+    final hostSubscription = container.listen(
+      hostConnectionControllerProvider('host-1'),
+      (_, _) {},
+      fireImmediately: true,
+    );
+    final quotaSubscription = container.listen(
+      agentQuotaControllerProvider('host-1'),
+      (_, _) {},
+      fireImmediately: true,
+    );
+    addTearDown(hostSubscription.close);
+    addTearDown(quotaSubscription.close);
+    await tester.pump();
+    expect(
+      container.read(agentQuotaControllerProvider('host-1')).hasValue,
+      isTrue,
+    );
+
+    quotaSubscription.close();
+    hostSubscription.close();
+    container.dispose();
+    await tester.pump(mobileQuotaRefreshInterval);
+  });
+}
+
+final class _FakeHostConnection extends HostConnectionController {
+  _FakeHostConnection(this.client);
+
+  final Future<MobileRuntimeClient> client;
+
+  @override
+  Future<MobileRuntimeClient> build(String hostId) => client;
+}
+
+final class _FakeMobileRuntimeClient extends MobileRuntimeClient {
+  _FakeMobileRuntimeClient() : super.forTesting(_PassiveWebSocketChannel());
+
+  @override
+  bool get supportsAgentQuotas => true;
+
+  @override
+  Future<QuotaSnapshotState> fetchAgentQuotas({bool forceRefresh = false}) {
+    return Future<QuotaSnapshotState>.value(
+      QuotaSnapshotState(
+        snapshots: const <QuotaSnapshot>[],
+        environment: const <String, bool>{},
+        fetchedAt: DateTime.now().toUtc(),
+      ),
+    );
+  }
+}
+
+final class _PassiveWebSocketChannel implements WebSocketChannel {
+  final StreamController<Object?> _incoming =
+      StreamController<Object?>.broadcast(sync: true);
+  final StreamController<Object?> _outgoing =
+      StreamController<Object?>.broadcast(sync: true);
+
+  @override
+  int? get closeCode => null;
+
+  @override
+  String? get closeReason => null;
+
+  @override
+  String? get protocol => null;
+
+  @override
+  Future<void> get ready => Future<void>.value();
+
+  @override
+  Stream<Object?> get stream => _incoming.stream;
+
+  @override
+  late final WebSocketSink sink = _PassiveWebSocketSink(_outgoing.sink);
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+final class _PassiveWebSocketSink implements WebSocketSink {
+  _PassiveWebSocketSink(this._sink);
+
+  final StreamSink<Object?> _sink;
+
+  @override
+  Future<void> get done => _sink.done;
+
+  @override
+  void add(Object? data) => _sink.add(data);
+
+  @override
+  void addError(Object error, [StackTrace? stackTrace]) {
+    _sink.addError(error, stackTrace);
+  }
+
+  @override
+  Future<void> addStream(Stream<Object?> stream) => _sink.addStream(stream);
+
+  @override
+  Future<void> close([int? closeCode, String? closeReason]) => _sink.close();
+}

--- a/mobile/test/workspace_list_controller_test.dart
+++ b/mobile/test/workspace_list_controller_test.dart
@@ -35,6 +35,65 @@ void main() {
     expect(refreshed.workspaces, hasLength(2));
   });
 
+  test('ignores a runtime event delivered after controller disposal', () async {
+    final client = _FakeWorkspaceClient();
+    final container = _container(client);
+
+    await container.read(workspaceListControllerProvider('host-1').future);
+    container.dispose();
+    client.emitAfterDispose('workspacesChanged');
+  });
+
+  test(
+    'does not subscribe when the client resolves after controller disposal',
+    () async {
+      final client = _FakeWorkspaceClient();
+      final clientReady = Completer<MobileWorkspaceClient>();
+      final container = ProviderContainer(
+        overrides: [
+          workspaceClientProvider(
+            'host-disposed-build',
+          ).overrideWith((ref) => clientReady.future),
+        ],
+      );
+      final provider = workspaceListControllerProvider('host-disposed-build');
+      final subscription = container.listen(
+        provider,
+        (_, _) {},
+        fireImmediately: true,
+      );
+      final result = container.read(provider.future);
+      subscription.close();
+      container.dispose();
+
+      clientReady.complete(client);
+      await result;
+      expect(client.eventSubscriptionCount, 0);
+      await client.dispose();
+    },
+  );
+
+  test(
+    'does not invalidate after a mutation completes after disposal',
+    () async {
+      final client = _FakeWorkspaceClient();
+      final container = _container(client);
+      final notifier = container.read(
+        workspaceListControllerProvider('host-1').notifier,
+      );
+      await container.read(workspaceListControllerProvider('host-1').future);
+
+      final completion = Completer<void>();
+      client.pinCompletion = completion;
+      final operation = notifier.setPinned('a', true);
+      await Future<void>.delayed(Duration.zero);
+      container.dispose();
+
+      completion.complete();
+      await operation;
+    },
+  );
+
   test('Mutations call the runtime and refresh the list', () async {
     final client = _FakeWorkspaceClient();
     final container = _container(client);
@@ -108,10 +167,20 @@ WorkspaceSummary _workspace(String id, {String? parent}) {
 }
 
 class _FakeWorkspaceClient implements MobileWorkspaceClient {
-  final StreamController<MobileRuntimeEvent> _events =
-      StreamController<MobileRuntimeEvent>.broadcast();
+  _FakeWorkspaceClient() {
+    _events = StreamController<MobileRuntimeEvent>.broadcast(
+      onListen: () => eventSubscriptionCount += 1,
+      onCancel: () => eventSubscriptionCount -= 1,
+    );
+  }
+
+  late final StreamController<MobileRuntimeEvent> _events;
   final List<String> calls = <String>[];
+  final List<void Function(MobileRuntimeEvent)> _eventListeners =
+      <void Function(MobileRuntimeEvent)>[];
   Object? linkError;
+  Completer<void>? pinCompletion;
+  int eventSubscriptionCount = 0;
   List<WorkspaceSummary> workspaces = <WorkspaceSummary>[_workspace('a')];
   List<String> cascadeIds = <String>['a'];
 
@@ -119,10 +188,20 @@ class _FakeWorkspaceClient implements MobileWorkspaceClient {
     _events.add(MobileRuntimeEvent(name, const <String, Object?>{}));
   }
 
+  void emitAfterDispose(String name) {
+    final event = MobileRuntimeEvent(name, const <String, Object?>{});
+    for (final listener in List<void Function(MobileRuntimeEvent)>.of(
+      _eventListeners,
+    )) {
+      listener(event);
+    }
+  }
+
   Future<void> dispose() => _events.close();
 
   @override
-  Stream<MobileRuntimeEvent> get events => _events.stream;
+  Stream<MobileRuntimeEvent> get events =>
+      _CapturingEventStream(_events.stream, _eventListeners.add);
 
   @override
   bool get supportsWorkspaceMutations => true;
@@ -237,6 +316,7 @@ class _FakeWorkspaceClient implements MobileWorkspaceClient {
   @override
   Future<void> setWorkspacePinned(String workspaceId, bool isPinned) async {
     calls.add('setPinned $workspaceId $isPinned');
+    await pinCompletion?.future;
   }
 
   @override
@@ -339,4 +419,32 @@ class _FakeWorkspaceClient implements MobileWorkspaceClient {
     String workspaceId,
     List<String> tagIds,
   ) async => _workspace(workspaceId);
+}
+
+final class _CapturingEventStream extends Stream<MobileRuntimeEvent> {
+  _CapturingEventStream(this._source, this._capture);
+
+  final Stream<MobileRuntimeEvent> _source;
+  final void Function(void Function(MobileRuntimeEvent)) _capture;
+
+  @override
+  bool get isBroadcast => _source.isBroadcast;
+
+  @override
+  StreamSubscription<MobileRuntimeEvent> listen(
+    void Function(MobileRuntimeEvent)? onData, {
+    Function? onError,
+    void Function()? onDone,
+    bool? cancelOnError,
+  }) {
+    if (onData != null) {
+      _capture(onData);
+    }
+    return _source.listen(
+      onData,
+      onError: onError,
+      onDone: onDone,
+      cancelOnError: cancelOnError,
+    );
+  }
 }

--- a/test/unit/agent_quota_test.dart
+++ b/test/unit/agent_quota_test.dart
@@ -3,8 +3,15 @@ import 'dart:async';
 import 'package:alera/src/features/agent_quota/application/agent_quota_providers.dart';
 import 'package:alera/src/features/agent_quota/domain/agent_quota.dart';
 import 'package:alera/src/features/agent_quota/infra/runtime_proxy_client.dart';
+import 'package:alera/src/features/remote_hosts/application/ssh_target_providers.dart';
+import 'package:alera/src/features/remote_hosts/domain/ssh_target.dart';
+import 'package:alera/src/features/settings/application/settings_controller.dart';
 import 'package:alera/src/features/settings/domain/alera_settings.dart';
+import 'package:alera/src/features/workbench/application/workbench_controller.dart';
+import 'package:alera/src/features/workbench/application/workbench_state.dart';
 import 'package:alera/src/features/workbench/infra/terminal_host/terminal_host_protocol.dart';
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'fake_recording_process_runner.dart';
@@ -33,6 +40,45 @@ void main() {
     );
 
     expect(agentQuotaRequestKey(first), agentQuotaRequestKey(reordered));
+  });
+
+  test('does not invalidate the quota provider after disposal', () {
+    fakeAsync((async) {
+      final container = ProviderContainer(
+        overrides: [
+          workbenchControllerProvider.overrideWithValue(const WorkbenchState()),
+          settingsControllerProvider.overrideWithValue(AleraSettings.defaults),
+          sshTargetsProvider.overrideWith(
+            (ref) => Stream<List<SshTarget>>.value(const <SshTarget>[]),
+          ),
+          agentQuotaServiceProvider.overrideWithValue(
+            AgentQuotaService(
+              RuntimeProxyClient(
+                processRunner: FakeRecordingProcessRunner(<Object>[]),
+              ),
+              _FixedQuotaRuntimeHostClient(<String, Object?>{
+                'snapshots': const <Object?>[],
+                'environment': const <String, bool>{},
+              }),
+            ),
+          ),
+        ],
+      );
+      final providerSubscription = container.listen(
+        agentQuotaStateProvider,
+        (_, _) {},
+        fireImmediately: true,
+      );
+      async.flushMicrotasks();
+      async.elapse(Duration.zero);
+      async.flushMicrotasks();
+      expect(container.read(agentQuotaStateProvider).hasValue, isTrue);
+
+      providerSubscription.close();
+      container.dispose();
+      async.elapse(agentQuotaRefreshInterval);
+      async.flushMicrotasks();
+    });
   });
 
   test('parses quota windows and reports the lowest remaining percentage', () {


### PR DESCRIPTION
## Summary
- guard quota timers and async controller updates with `ref.mounted`
- stop workspace event callbacks from invalidating disposed providers
- regenerate Riverpod output and add disposal regressions

Closes Sentry ALERA-MOBILE-APP-D and ALERA-MOBILE-APP-E.

## Validation
- desktop and mobile `flutter analyze --no-pub`
- focused desktop/mobile controller tests