### PR TITLE
fix: suppress expected runtime owner sentry events

### DIFF
--- a/rust/alera-cli/src/runtime_host_command.rs
+++ b/rust/alera-cli/src/runtime_host_command.rs
@@ -7,6 +7,8 @@ use crate::terminal_host::protocol::TerminalHostConfig;
 use crate::terminal_host::server::{run_terminal_host_server, TerminalHostExit};
 
 const USAGE_EXIT_CODE: i32 = 64;
+const EXPECTED_OWNER_CONFLICT_PREFIX: &str =
+    "runtime directory is already owned by live runtime host process ";
 
 pub(crate) async fn run(args: TerminalHostArgs) -> i32 {
     let runtime_dir = args.runtime_dir.trim().to_string();
@@ -72,10 +74,35 @@ pub(crate) async fn run(args: TerminalHostArgs) -> i32 {
             }
         }
         Err(error) => {
-            tracing::error!(target: "alera.host", "runtime host exited with an error: {error}");
+            log_runtime_host_error(&error);
             eprintln!("{error}");
             1
         }
+    }
+}
+
+fn is_expected_owner_conflict(error: &anyhow::Error) -> bool {
+    error.chain().any(|cause| {
+        cause
+            .to_string()
+            .strip_prefix(EXPECTED_OWNER_CONFLICT_PREFIX)
+            .is_some_and(|pid| !pid.is_empty() && pid.bytes().all(|byte| byte.is_ascii_digit()))
+    })
+}
+
+fn log_runtime_host_error(error: &anyhow::Error) {
+    if is_expected_owner_conflict(error) {
+        // The ownership rejection is an expected coordination result while a
+        // live host is recovering its control metadata. Keep it as an ERROR
+        // in the local log, but do not turn each client retry into a Sentry
+        // event.
+        tracing::error!(
+            target: "alera.host",
+            sentry_report = false,
+            "runtime host exited with an error: {error}"
+        );
+    } else {
+        tracing::error!(target: "alera.host", "runtime host exited with an error: {error}");
     }
 }
 
@@ -130,5 +157,41 @@ fn required_option_error(value: &str, name: &str) -> bool {
         true
     } else {
         false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn only_the_live_owner_conflict_is_expected() {
+        let error = anyhow::anyhow!(
+            "runtime directory is already owned by live runtime host process 2197858"
+        );
+        assert!(is_expected_owner_conflict(&error));
+    }
+
+    #[test]
+    fn an_unexpected_runtime_error_is_still_reportable() {
+        let error = anyhow::anyhow!("failed binding runtime host socket");
+        assert!(!is_expected_owner_conflict(&error));
+    }
+
+    #[test]
+    fn an_owner_conflict_in_an_error_chain_is_expected() {
+        let error = anyhow::anyhow!(
+            "runtime directory is already owned by live runtime host process 2197858"
+        )
+        .context("runtime host startup failed");
+        assert!(is_expected_owner_conflict(&error));
+    }
+
+    #[test]
+    fn a_malformed_owner_conflict_is_not_suppressed() {
+        let error = anyhow::anyhow!(
+            "runtime directory is already owned by live runtime host process unknown"
+        );
+        assert!(!is_expected_owner_conflict(&error));
     }
 }

--- a/rust/alera-cli/src/terminal_host/diagnostics/sentry_error_layer.rs
+++ b/rust/alera-cli/src/terminal_host/diagnostics/sentry_error_layer.rs
@@ -10,12 +10,14 @@ use super::sentry_reporting;
 use sentry::protocol::{Event as SentryEvent, Level as SentryLevel};
 use std::borrow::Cow;
 use std::sync::Arc;
+use tracing::field::{Field, Visit};
 use tracing::{Event, Level, Subscriber};
 use tracing_subscriber::layer::Context;
 use tracing_subscriber::Layer;
 
 const PANIC_TARGET: &str = "alera.panic";
 const FALLBACK_LOGGER: &str = "alera.runtime";
+const SENTRY_REPORT_FIELD: &str = "sentry_report";
 
 trait EventCapture: Send + Sync {
     fn capture(&self, event: SentryEvent<'static>);
@@ -79,11 +81,33 @@ fn mapped_event(target: &str) -> SentryEvent<'static> {
     }
 }
 
+#[derive(Default)]
+struct ReportingVisitor {
+    report: Option<bool>,
+}
+
+impl Visit for ReportingVisitor {
+    fn record_bool(&mut self, field: &Field, value: bool) {
+        if field.name() == SENTRY_REPORT_FIELD {
+            self.report = Some(value);
+        }
+    }
+
+    fn record_debug(&mut self, _field: &Field, _value: &dyn std::fmt::Debug) {}
+}
+
+fn should_report(event: &Event<'_>) -> bool {
+    let mut visitor = ReportingVisitor::default();
+    event.record(&mut visitor);
+    visitor.report.unwrap_or(true)
+}
+
 impl<S: Subscriber> Layer<S> for SentryErrorLayer {
     fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
         let metadata = event.metadata();
         if metadata.level() != &Level::ERROR
             || metadata.target() == PANIC_TARGET
+            || !should_report(event)
             || !sentry_reporting::is_enabled()
         {
             return;
@@ -178,6 +202,19 @@ mod tests {
         emit(layer, || {
             tracing::info!("ordinary runtime status");
             tracing::warn!("recoverable runtime warning");
+        });
+        assert!(transport.take_events().is_empty());
+    }
+
+    #[test]
+    fn explicitly_suppressed_error_is_not_sent() {
+        let _guard = sentry_reporting::test_serial_guard();
+        let (layer, transport, _) = test_layer(true);
+        emit(layer, || {
+            tracing::error!(
+                sentry_report = false,
+                "runtime directory is already owned by live runtime host process 2197858"
+            );
         });
         assert!(transport.take_events().is_empty());
     }


### PR DESCRIPTION
## Summary
- recognize the exact live-runtime ownership rejection
- retain the local error while excluding expected retries from Sentry
- keep unexpected runtime host failures reportable

Closes Sentry ALERA-RUNTIME-2.

## Validation
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `make rust-test` (1,289 tests plus integration suites)