### PR TITLE
feat: add source control tree context actions

### DIFF
--- a/lib/src/features/shell/presentation/alera_shell_page_body.dart
+++ b/lib/src/features/shell/presentation/alera_shell_page_body.dart
@@ -158,6 +158,12 @@ class _AleraShellPageBodyState extends ConsumerState<_AleraShellPageBody> {
                                 ),
                               );
                             },
+                            onRevealInExplorer: (relativePath) {
+                              controller.revealInExplorer(
+                                workspace: workspace,
+                                relativePath: relativePath,
+                              );
+                            },
                             onOpenGitDiff:
                                 ({
                                   relativePath,

--- a/lib/src/features/workbench/application/workbench_controller.dart
+++ b/lib/src/features/workbench/application/workbench_controller.dart
@@ -10,6 +10,7 @@ import 'package:alera/src/features/projects/application/project_providers.dart';
 import 'package:alera/src/app/theme/alera_tokens.dart';
 import 'package:alera/src/features/projects/application/projects_service.dart';
 import 'package:alera/src/features/projects/domain/project.dart';
+import 'package:alera/src/features/workbench/application/workspace_explorer_reveal.dart';
 import 'package:alera/src/features/workbench/application/workspace_tab_service.dart';
 import 'package:alera/src/features/workbench/application/workspace_browser_tab_service.dart';
 import 'package:alera/src/features/workbench/application/workbench_repository.dart';

--- a/lib/src/features/workbench/application/workbench_controller.g.dart
+++ b/lib/src/features/workbench/application/workbench_controller.g.dart
@@ -42,7 +42,7 @@ final class WorkbenchControllerProvider
 }
 
 String _$workbenchControllerHash() =>
-    r'9376113f40e69aa16b3b8e07e6eb3829ad44e2d1';
+    r'b843f0598ce7f8401b64e3c80d7c8d8884c66caf';
 
 abstract class _$WorkbenchController extends $Notifier<WorkbenchState> {
   WorkbenchState build();

--- a/lib/src/features/workbench/application/workbench_controller_view_prefs.dart
+++ b/lib/src/features/workbench/application/workbench_controller_view_prefs.dart
@@ -252,6 +252,21 @@ mixin _WorkbenchControllerViewPrefs
     _updateViewPrefs(state.viewPrefs.copyWith(activeContextPanelTab: tab));
   }
 
+  void revealInExplorer({
+    required Workspace workspace,
+    required String relativePath,
+  }) {
+    final normalized = normalizeWorkspaceRelativePath(relativePath);
+    if (normalized == null) {
+      return;
+    }
+    ref
+        .read(workspaceExplorerRevealControllerProvider.notifier)
+        .reveal(workspaceId: workspace.id, relativePath: normalized);
+    setRightSidebarVisible(true);
+    setContextPanelTab(WorkbenchContextPanelTab.explorer);
+  }
+
   void setExplorerMode(WorkspaceExplorerMode mode) {
     if (state.viewPrefs.explorerMode == mode) {
       return;

--- a/lib/src/features/workbench/application/workspace_explorer_reveal.dart
+++ b/lib/src/features/workbench/application/workspace_explorer_reveal.dart
@@ -1,0 +1,43 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'workspace_explorer_reveal.g.dart';
+
+/// One-shot request to reveal a workspace-relative path in Explorer.
+///
+/// Source Control queues this, switches to the Explorer tab, and Explorer
+/// consumes it after the tree is ready. The request is not persisted.
+class WorkspaceExplorerRevealRequest {
+  const WorkspaceExplorerRevealRequest({
+    required this.workspaceId,
+    required this.relativePath,
+    required this.generation,
+  });
+
+  final String workspaceId;
+  final String relativePath;
+  final int generation;
+}
+
+@Riverpod(keepAlive: true)
+class WorkspaceExplorerRevealController
+    extends _$WorkspaceExplorerRevealController {
+  int _generation = 0;
+
+  @override
+  WorkspaceExplorerRevealRequest? build() => null;
+
+  void reveal({required String workspaceId, required String relativePath}) {
+    _generation += 1;
+    state = WorkspaceExplorerRevealRequest(
+      workspaceId: workspaceId,
+      relativePath: relativePath,
+      generation: _generation,
+    );
+  }
+
+  void consume(WorkspaceExplorerRevealRequest request) {
+    if (state?.generation == request.generation) {
+      state = null;
+    }
+  }
+}

--- a/lib/src/features/workbench/application/workspace_explorer_reveal.g.dart
+++ b/lib/src/features/workbench/application/workspace_explorer_reveal.g.dart
@@ -1,0 +1,81 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'workspace_explorer_reveal.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(WorkspaceExplorerRevealController)
+final workspaceExplorerRevealControllerProvider =
+    WorkspaceExplorerRevealControllerProvider._();
+
+final class WorkspaceExplorerRevealControllerProvider
+    extends
+        $NotifierProvider<
+          WorkspaceExplorerRevealController,
+          WorkspaceExplorerRevealRequest?
+        > {
+  WorkspaceExplorerRevealControllerProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'workspaceExplorerRevealControllerProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() =>
+      _$workspaceExplorerRevealControllerHash();
+
+  @$internal
+  @override
+  WorkspaceExplorerRevealController create() =>
+      WorkspaceExplorerRevealController();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(WorkspaceExplorerRevealRequest? value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<WorkspaceExplorerRevealRequest?>(
+        value,
+      ),
+    );
+  }
+}
+
+String _$workspaceExplorerRevealControllerHash() =>
+    r'd4f06706cfb7bbbdcd32e1f7dc53f9dd2241e1da';
+
+abstract class _$WorkspaceExplorerRevealController
+    extends $Notifier<WorkspaceExplorerRevealRequest?> {
+  WorkspaceExplorerRevealRequest? build();
+  @$mustCallSuper
+  @override
+  WhenComplete runBuild() {
+    final ref =
+        this.ref
+            as $Ref<
+              WorkspaceExplorerRevealRequest?,
+              WorkspaceExplorerRevealRequest?
+            >;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<
+                WorkspaceExplorerRevealRequest?,
+                WorkspaceExplorerRevealRequest?
+              >,
+              WorkspaceExplorerRevealRequest?,
+              Object?,
+              Object?
+            >;
+    return element.handleCreate(ref, build);
+  }
+}

--- a/lib/src/features/workbench/application/workspace_folder_opener.dart
+++ b/lib/src/features/workbench/application/workspace_folder_opener.dart
@@ -111,7 +111,9 @@ class WorkspaceFolderOpener {
         ];
       case WorkspaceFolderPlatform.windows:
         return <_WorkspaceFolderOpenCommand>[
-          _WorkspaceFolderOpenCommand('explorer.exe', <String>[path]),
+          _WorkspaceFolderOpenCommand('explorer.exe', <String>[
+            _windowsExplorerPath(path),
+          ]),
         ];
       case WorkspaceFolderPlatform.linux:
         return <_WorkspaceFolderOpenCommand>[
@@ -132,9 +134,13 @@ class WorkspaceFolderOpener {
           _WorkspaceFolderOpenCommand('open', <String>['-R', path]),
         ];
       case WorkspaceFolderPlatform.windows:
+        // Explorer treats `/select,C:/foo` as one token and opens Documents
+        // when the path uses `/` or contains spaces. Keep `/select,` as its
+        // own argument and pass a backslash path separately.
         return <_WorkspaceFolderOpenCommand>[
           _WorkspaceFolderOpenCommand('explorer.exe', <String>[
-            '/select,$path',
+            '/select,',
+            _windowsExplorerPath(path),
           ]),
         ];
       case WorkspaceFolderPlatform.linux:
@@ -157,6 +163,10 @@ class WorkspaceFolderOpener {
         ? path
         : File(path).parent.path;
   }
+}
+
+String _windowsExplorerPath(String path) {
+  return path.replaceAll('/', r'\');
 }
 
 /// FreeDesktop FileManager1.ShowItems selects the path in the session file

--- a/lib/src/features/workbench/presentation/workspace_context_sidebar.dart
+++ b/lib/src/features/workbench/presentation/workspace_context_sidebar.dart
@@ -30,6 +30,7 @@ class WorkspaceContextSidebar extends StatelessWidget {
     this.onClearSourceControlRoot,
     required this.onOpenFile,
     this.onOpenFilePermanently,
+    this.onRevealInExplorer,
     required this.onOpenGitDiff,
     required this.onOpenGitCommitDiff,
     required this.onOpenSearchMatch,
@@ -54,6 +55,7 @@ class WorkspaceContextSidebar extends StatelessWidget {
   final VoidCallback? onClearSourceControlRoot;
   final ValueChanged<String> onOpenFile;
   final ValueChanged<String>? onOpenFilePermanently;
+  final ValueChanged<String>? onRevealInExplorer;
   final OpenGitDiffTabCallback onOpenGitDiff;
   final OpenGitCommitDiffTabCallback onOpenGitCommitDiff;
   final ValueChanged<WorkspaceSearchMatchTarget> onOpenSearchMatch;
@@ -121,6 +123,8 @@ class WorkspaceContextSidebar extends StatelessWidget {
                                 onGroupModeChanged: onSetGitDiffGroupMode,
                                 onOpenGitDiff: onOpenGitDiff,
                                 onOpenGitCommitDiff: onOpenGitCommitDiff,
+                                onOpenFile: onOpenFilePermanently ?? onOpenFile,
+                                onRevealInExplorer: onRevealInExplorer,
                                 onClearSourceControlRoot:
                                     sourceControlScope.isWorkspaceRoot
                                     ? null

--- a/lib/src/features/workbench/presentation/workspace_explorer.dart
+++ b/lib/src/features/workbench/presentation/workspace_explorer.dart
@@ -131,15 +131,7 @@ class _WorkspaceExplorerState extends ConsumerState<WorkspaceExplorer> {
 
   @override
   Widget build(BuildContext context) {
-    ref.listen<WorkspaceExplorerRevealRequest?>(
-      workspaceExplorerRevealControllerProvider,
-      (previous, next) {
-        if (next == null || next.workspaceId != widget.workspace.id) {
-          return;
-        }
-        unawaited(_revealPendingPath(relativePath: next.relativePath));
-      },
-    );
+    _listenForRevealRequest();
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: <Widget>[

--- a/lib/src/features/workbench/presentation/workspace_explorer.dart
+++ b/lib/src/features/workbench/presentation/workspace_explorer.dart
@@ -9,10 +9,12 @@ import 'package:alera/src/design_system/icons/alera_file_icon.dart';
 import 'package:alera/src/design_system/icons/alera_icons.dart';
 import 'package:alera/src/design_system/layout/alera_confirm_dialog.dart';
 import 'package:alera/src/design_system/menus/alera_dropdown_entry.dart';
+import 'package:alera/src/features/workbench/application/workspace_explorer_reveal.dart';
 import 'package:alera/src/features/workbench/application/workspace_file_service.dart';
 import 'package:alera/src/features/workbench/application/workspace_folder_opener.dart';
 import 'package:alera/src/features/workbench/domain/workbench_view_prefs.dart';
 import 'package:alera/src/features/workbench/domain/workspace.dart';
+import 'package:alera/src/features/workbench/domain/workspace_source_control_scope.dart';
 import 'package:alera/src/features/workbench/presentation/terminal_path_drop.dart';
 import 'package:alera/src/rust/api/workspace_files.dart' as native;
 import 'package:alera/src/shared/infra/git/git_backend.dart';
@@ -129,6 +131,15 @@ class _WorkspaceExplorerState extends ConsumerState<WorkspaceExplorer> {
 
   @override
   Widget build(BuildContext context) {
+    ref.listen<WorkspaceExplorerRevealRequest?>(
+      workspaceExplorerRevealControllerProvider,
+      (previous, next) {
+        if (next == null || next.workspaceId != widget.workspace.id) {
+          return;
+        }
+        unawaited(_revealPendingPath(relativePath: next.relativePath));
+      },
+    );
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: <Widget>[

--- a/lib/src/features/workbench/presentation/workspace_explorer_actions.dart
+++ b/lib/src/features/workbench/presentation/workspace_explorer_actions.dart
@@ -195,6 +195,58 @@ extension _WorkspaceExplorerActions on _WorkspaceExplorerState {
     }
   }
 
+  Future<void> _revealPendingPath({String? relativePath}) async {
+    final request = ref.read(workspaceExplorerRevealControllerProvider);
+    final targetPath = normalizeWorkspaceRelativePath(
+      relativePath ??
+          (request?.workspaceId == widget.workspace.id
+              ? request?.relativePath
+              : null),
+    );
+    if (targetPath == null) {
+      return;
+    }
+    await _ensureAncestorsLoaded(targetPath);
+    if (!mounted) {
+      return;
+    }
+    _rebuildTree();
+    final nodeId = _nodeIdForRelativePath(targetPath);
+    await _controller.reveal(nodeId: nodeId, select: true);
+    if (request != null &&
+        request.workspaceId == widget.workspace.id &&
+        request.relativePath == targetPath) {
+      ref
+          .read(workspaceExplorerRevealControllerProvider.notifier)
+          .consume(request);
+    }
+  }
+
+  Future<void> _ensureAncestorsLoaded(String relativePath) async {
+    var ancestor = '';
+    for (final part in relativePath.split('/')) {
+      if (part.isEmpty) {
+        continue;
+      }
+      if (!_childrenByDirectory.containsKey(ancestor)) {
+        await _loadDirectory(ancestor);
+        if (!mounted) {
+          return;
+        }
+      }
+      ancestor = ancestor.isEmpty ? part : '$ancestor/$part';
+    }
+  }
+
+  String? _nodeIdForRelativePath(String relativePath) {
+    for (final binding in _entryByNodeId.entries) {
+      if (binding.value.relativePath == relativePath) {
+        return binding.key;
+      }
+    }
+    return 'path:$relativePath';
+  }
+
   Future<void> _reveal(native.WorkspaceFileEntry entry) async {
     final result = await _folderOpener.reveal(
       _absolutePath(entry.relativePath),

--- a/lib/src/features/workbench/presentation/workspace_explorer_refresh.dart
+++ b/lib/src/features/workbench/presentation/workspace_explorer_refresh.dart
@@ -1,6 +1,18 @@
 part of 'workspace_explorer.dart';
 
 extension _WorkspaceExplorerRefresh on _WorkspaceExplorerState {
+  void _listenForRevealRequest() {
+    ref.listen<WorkspaceExplorerRevealRequest?>(
+      workspaceExplorerRevealControllerProvider,
+      (previous, next) {
+        if (next == null || next.workspaceId != widget.workspace.id) {
+          return;
+        }
+        unawaited(_revealPendingPath(relativePath: next.relativePath));
+      },
+    );
+  }
+
   Future<void> _bootstrapExplorer() async {
     await _startNativeWatcher();
     if (!mounted) {

--- a/lib/src/features/workbench/presentation/workspace_explorer_refresh.dart
+++ b/lib/src/features/workbench/presentation/workspace_explorer_refresh.dart
@@ -7,6 +7,10 @@ extension _WorkspaceExplorerRefresh on _WorkspaceExplorerState {
       return;
     }
     await _reloadRoot();
+    if (!mounted) {
+      return;
+    }
+    await _revealPendingPath();
   }
 
   Future<void> _restartExplorer() async {

--- a/lib/src/features/workbench/presentation/workspace_git_diff_panel.dart
+++ b/lib/src/features/workbench/presentation/workspace_git_diff_panel.dart
@@ -16,6 +16,7 @@ import 'package:alera/src/features/ai_assist/application/ai_assist_providers.dar
 import 'package:alera/src/features/ai_assist/application/ai_assist_service.dart';
 import 'package:alera/src/features/ai_assist/domain/ai_assist_settings.dart';
 import 'package:alera/src/features/settings/application/settings_controller.dart';
+import 'package:alera/src/features/workbench/application/workspace_explorer_reveal.dart';
 import 'package:alera/src/features/workbench/application/workspace_source_control_controller.dart';
 import 'package:alera/src/features/workbench/application/workspace_submodule_status_provider.dart';
 import 'package:alera/src/features/workbench/domain/workbench_view_prefs.dart';
@@ -46,6 +47,9 @@ part 'workspace_git_history_panel_graph.dart';
 part 'workspace_git_history_panel_row.dart';
 part 'workspace_git_history_panel_files.dart';
 part 'workspace_git_diff_panel_preview_opening.dart';
+part 'workspace_git_diff_panel_context_menu.dart';
+part 'workspace_git_diff_panel_inline_actions.dart';
+part 'workspace_git_diff_panel_navigation.dart';
 
 class WorkspaceGitDiffPanel extends ConsumerStatefulWidget {
   const WorkspaceGitDiffPanel({
@@ -58,6 +62,8 @@ class WorkspaceGitDiffPanel extends ConsumerStatefulWidget {
     required this.onGroupModeChanged,
     required this.onOpenGitDiff,
     required this.onOpenGitCommitDiff,
+    this.onOpenFile,
+    this.onRevealInExplorer,
     this.onClearSourceControlRoot,
   });
 
@@ -69,6 +75,8 @@ class WorkspaceGitDiffPanel extends ConsumerStatefulWidget {
   final ValueChanged<GitDiffGroupMode> onGroupModeChanged;
   final OpenGitDiffTabCallback onOpenGitDiff;
   final OpenGitCommitDiffTabCallback onOpenGitCommitDiff;
+  final ValueChanged<String>? onOpenFile;
+  final ValueChanged<String>? onRevealInExplorer;
   final VoidCallback? onClearSourceControlRoot;
 
   @override
@@ -229,6 +237,10 @@ class _WorkspaceGitDiffPanelState extends ConsumerState<WorkspaceGitDiffPanel> {
                       onToggleTreeNode: _toggleTreeNodeCollapsed,
                       onToggleSubmodule: _toggleSubmodule,
                       onOpenGitDiff: _openGitDiff,
+                      onOpenFile: widget.onOpenFile == null
+                          ? null
+                          : _openWorkspaceFile,
+                      onRevealInExplorer: _revealInExplorer,
                       onStage: _stageEntry,
                       onUnstage: _unstageEntry,
                       onDiscard: _discardEntry,

--- a/lib/src/features/workbench/presentation/workspace_git_diff_panel_context_menu.dart
+++ b/lib/src/features/workbench/presentation/workspace_git_diff_panel_context_menu.dart
@@ -1,0 +1,85 @@
+part of 'workspace_git_diff_panel.dart';
+
+enum _GitChangeContextAction {
+  openFile,
+  revealInExplorer,
+  stage,
+  unstage,
+  discard,
+}
+
+Future<void> _showGitChangeContextMenu(
+  BuildContext context,
+  Offset position, {
+  required bool canOpenFile,
+  required bool canStage,
+  required bool canUnstage,
+  required bool canDiscard,
+  required bool busy,
+  required VoidCallback? onOpenFile,
+  required VoidCallback onRevealInExplorer,
+  required VoidCallback onStage,
+  required VoidCallback onUnstage,
+  required VoidCallback onDiscard,
+}) async {
+  final selected = await showMenu<_GitChangeContextAction>(
+    context: context,
+    position: RelativeRect.fromLTRB(
+      position.dx,
+      position.dy,
+      position.dx,
+      position.dy,
+    ),
+    items: <PopupMenuEntry<_GitChangeContextAction>>[
+      if (canOpenFile)
+        const AleraDropdownEntry<_GitChangeContextAction>(
+          value: _GitChangeContextAction.openFile,
+          label: 'Open File',
+          leading: Icon(AleraIcons.file, size: 16),
+        ),
+      const AleraDropdownEntry<_GitChangeContextAction>(
+        value: _GitChangeContextAction.revealInExplorer,
+        label: 'Reveal in Explorer',
+        leading: Icon(AleraIcons.copyFiles, size: 16),
+      ),
+      if (canStage || canUnstage || canDiscard)
+        const PopupMenuDivider(height: AleraTokens.space8),
+      if (canUnstage)
+        AleraDropdownEntry<_GitChangeContextAction>(
+          value: _GitChangeContextAction.unstage,
+          label: 'Unstage',
+          leading: const Icon(AleraIcons.gitUnstage, size: 16),
+          enabled: !busy,
+        ),
+      if (canStage)
+        AleraDropdownEntry<_GitChangeContextAction>(
+          value: _GitChangeContextAction.stage,
+          label: 'Stage',
+          leading: const Icon(AleraIcons.gitStage, size: 16),
+          enabled: !busy,
+        ),
+      if (canDiscard)
+        AleraDropdownEntry<_GitChangeContextAction>(
+          value: _GitChangeContextAction.discard,
+          label: 'Discard',
+          leading: const Icon(AleraIcons.gitDiscard, size: 16),
+          enabled: !busy,
+        ),
+    ],
+  );
+  if (selected == null || !context.mounted) {
+    return;
+  }
+  switch (selected) {
+    case _GitChangeContextAction.openFile:
+      onOpenFile?.call();
+    case _GitChangeContextAction.revealInExplorer:
+      onRevealInExplorer();
+    case _GitChangeContextAction.stage:
+      onStage();
+    case _GitChangeContextAction.unstage:
+      onUnstage();
+    case _GitChangeContextAction.discard:
+      onDiscard();
+  }
+}

--- a/lib/src/features/workbench/presentation/workspace_git_diff_panel_groups.dart
+++ b/lib/src/features/workbench/presentation/workspace_git_diff_panel_groups.dart
@@ -13,6 +13,8 @@ class _GitDiffGroups extends StatelessWidget {
     required this.onToggleTreeNode,
     required this.onToggleSubmodule,
     required this.onOpenGitDiff,
+    this.onOpenFile,
+    required this.onRevealInExplorer,
     required this.onStage,
     required this.onUnstage,
     required this.onDiscard,
@@ -35,6 +37,8 @@ class _GitDiffGroups extends StatelessWidget {
   final ValueChanged<String> onToggleTreeNode;
   final ValueChanged<GitChangeEntry> onToggleSubmodule;
   final OpenGitDiffTabCallback onOpenGitDiff;
+  final ValueChanged<String>? onOpenFile;
+  final ValueChanged<String> onRevealInExplorer;
   final ValueChanged<GitChangeEntry> onStage;
   final ValueChanged<GitChangeEntry> onUnstage;
   final ValueChanged<GitChangeEntry> onDiscard;
@@ -63,6 +67,8 @@ class _GitDiffGroups extends StatelessWidget {
             onToggleTreeNode: onToggleTreeNode,
             onToggleSubmodule: onToggleSubmodule,
             onOpenGitDiff: onOpenGitDiff,
+            onOpenFile: onOpenFile,
+            onRevealInExplorer: onRevealInExplorer,
             onStage: onStage,
             onUnstage: onUnstage,
             onDiscard: onDiscard,
@@ -91,6 +97,8 @@ class _GitDiffGroup extends StatelessWidget {
     required this.onToggleTreeNode,
     required this.onToggleSubmodule,
     required this.onOpenGitDiff,
+    this.onOpenFile,
+    required this.onRevealInExplorer,
     required this.onStage,
     required this.onUnstage,
     required this.onDiscard,
@@ -113,6 +121,8 @@ class _GitDiffGroup extends StatelessWidget {
   final ValueChanged<String> onToggleTreeNode;
   final ValueChanged<GitChangeEntry> onToggleSubmodule;
   final OpenGitDiffTabCallback onOpenGitDiff;
+  final ValueChanged<String>? onOpenFile;
+  final ValueChanged<String> onRevealInExplorer;
   final ValueChanged<GitChangeEntry> onStage;
   final ValueChanged<GitChangeEntry> onUnstage;
   final ValueChanged<GitChangeEntry> onDiscard;
@@ -169,6 +179,10 @@ class _GitDiffGroup extends StatelessWidget {
                   showRelativePath: true,
                   showAreaMarker: group.unified,
                   busy: busy,
+                  onOpenFile: onOpenFile == null
+                      ? null
+                      : () => onOpenFile!(entry.path),
+                  onRevealInExplorer: () => onRevealInExplorer(entry.path),
                   onStage: onStage,
                   onUnstage: onUnstage,
                   onDiscard: onDiscard,
@@ -193,6 +207,8 @@ class _GitDiffGroup extends StatelessWidget {
                     depth: 1,
                     busy: busy,
                     onOpenGitDiff: onOpenGitDiff,
+                    onOpenFile: onOpenFile,
+                    onRevealInExplorer: onRevealInExplorer,
                   ),
               ]
             else
@@ -206,6 +222,8 @@ class _GitDiffGroup extends StatelessWidget {
                 onToggleTreeNode: onToggleTreeNode,
                 onToggleSubmodule: onToggleSubmodule,
                 onOpenGitDiff: onOpenGitDiff,
+                onOpenFile: onOpenFile,
+                onRevealInExplorer: onRevealInExplorer,
                 onStage: onStage,
                 onUnstage: onUnstage,
                 onDiscard: onDiscard,

--- a/lib/src/features/workbench/presentation/workspace_git_diff_panel_inline_actions.dart
+++ b/lib/src/features/workbench/presentation/workspace_git_diff_panel_inline_actions.dart
@@ -1,0 +1,97 @@
+part of 'workspace_git_diff_panel.dart';
+
+class _GitFileActions extends StatelessWidget {
+  const _GitFileActions({
+    required this.entry,
+    required this.busy,
+    required this.onStage,
+    required this.onUnstage,
+    required this.onDiscard,
+  });
+
+  final GitChangeEntry entry;
+  final bool busy;
+  final ValueChanged<GitChangeEntry> onStage;
+  final ValueChanged<GitChangeEntry> onUnstage;
+  final ValueChanged<GitChangeEntry> onDiscard;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: 58,
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.end,
+        children: <Widget>[
+          if (entry.canUnstageFromParent)
+            AleraIconButton(
+              tooltip: 'Unstage',
+              icon: AleraIcons.gitUnstage,
+              onPressed: busy ? null : () => onUnstage(entry),
+            )
+          else if (entry.canStageFromParent)
+            AleraIconButton(
+              tooltip: 'Stage',
+              icon: AleraIcons.gitStage,
+              onPressed: busy ? null : () => onStage(entry),
+            ),
+          if (entry.canDiscardFromParent)
+            AleraIconButton(
+              tooltip: 'Discard',
+              icon: AleraIcons.gitDiscard,
+              onPressed: busy ? null : () => onDiscard(entry),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _AreaActions extends StatelessWidget {
+  const _AreaActions({
+    required this.busy,
+    required this.onStage,
+    required this.onUnstage,
+    required this.onDiscard,
+    required this.canStage,
+    required this.canUnstage,
+    required this.canDiscard,
+  });
+
+  final bool busy;
+  final VoidCallback onStage;
+  final VoidCallback onUnstage;
+  final VoidCallback onDiscard;
+  final bool canStage;
+  final bool canUnstage;
+  final bool canDiscard;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: 58,
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.end,
+        children: <Widget>[
+          if (canUnstage)
+            AleraIconButton(
+              tooltip: 'Unstage',
+              icon: AleraIcons.gitUnstage,
+              onPressed: busy ? null : onUnstage,
+            )
+          else if (canStage)
+            AleraIconButton(
+              tooltip: 'Stage',
+              icon: AleraIcons.gitStage,
+              onPressed: busy ? null : onStage,
+            ),
+          if (canDiscard)
+            AleraIconButton(
+              tooltip: 'Discard',
+              icon: AleraIcons.gitDiscard,
+              onPressed: busy ? null : onDiscard,
+            ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/src/features/workbench/presentation/workspace_git_diff_panel_navigation.dart
+++ b/lib/src/features/workbench/presentation/workspace_git_diff_panel_navigation.dart
@@ -1,0 +1,31 @@
+part of 'workspace_git_diff_panel.dart';
+
+extension _WorkspaceGitDiffPanelNavigation on _WorkspaceGitDiffPanelState {
+  void _openWorkspaceFile(String sourceRelativePath) {
+    final workspaceRelativePath = widget.sourceControlScope
+        .toWorkspaceRelativePath(sourceRelativePath);
+    if (workspaceRelativePath == null) {
+      return;
+    }
+    widget.onOpenFile?.call(workspaceRelativePath);
+  }
+
+  void _revealInExplorer(String sourceRelativePath) {
+    final workspaceRelativePath = widget.sourceControlScope
+        .toWorkspaceRelativePath(sourceRelativePath);
+    if (workspaceRelativePath == null) {
+      return;
+    }
+    final onRevealInExplorer = widget.onRevealInExplorer;
+    if (onRevealInExplorer != null) {
+      onRevealInExplorer(workspaceRelativePath);
+      return;
+    }
+    ref
+        .read(workspaceExplorerRevealControllerProvider.notifier)
+        .reveal(
+          workspaceId: widget.workspace.id,
+          relativePath: workspaceRelativePath,
+        );
+  }
+}

--- a/lib/src/features/workbench/presentation/workspace_git_diff_panel_rows.dart
+++ b/lib/src/features/workbench/presentation/workspace_git_diff_panel_rows.dart
@@ -92,11 +92,15 @@ class _GitDiffBaseRow extends StatelessWidget {
     required this.depth,
     required this.child,
     required this.onTap,
+    this.onSecondaryTapDown,
+    this.onLongPressStart,
   });
 
   final int depth;
   final Widget child;
   final VoidCallback onTap;
+  final GestureTapDownCallback? onSecondaryTapDown;
+  final GestureLongPressStartCallback? onLongPressStart;
 
   @override
   Widget build(BuildContext context) {
@@ -105,6 +109,8 @@ class _GitDiffBaseRow extends StatelessWidget {
       child: GestureDetector(
         behavior: HitTestBehavior.translucent,
         onTap: onTap,
+        onSecondaryTapDown: onSecondaryTapDown,
+        onLongPressStart: onLongPressStart,
         child: Padding(
           padding: EdgeInsets.only(
             left: AleraTokens.space8 + (depth * AleraTokens.space12),

--- a/lib/src/features/workbench/presentation/workspace_git_diff_panel_submodules.dart
+++ b/lib/src/features/workbench/presentation/workspace_git_diff_panel_submodules.dart
@@ -7,6 +7,8 @@ class _SubmoduleChanges extends ConsumerWidget {
     required this.depth,
     required this.busy,
     required this.onOpenGitDiff,
+    this.onOpenFile,
+    required this.onRevealInExplorer,
   });
 
   final String workspacePath;
@@ -14,6 +16,8 @@ class _SubmoduleChanges extends ConsumerWidget {
   final int depth;
   final bool busy;
   final OpenGitDiffTabCallback onOpenGitDiff;
+  final ValueChanged<String>? onOpenFile;
+  final ValueChanged<String> onRevealInExplorer;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -54,6 +58,10 @@ class _SubmoduleChanges extends ConsumerWidget {
                 depth: depth,
                 showRelativePath: true,
                 busy: busy,
+                onOpenFile: onOpenFile == null
+                    ? null
+                    : () => onOpenFile!(child.path),
+                onRevealInExplorer: () => onRevealInExplorer(child.path),
                 onStage: (_) {},
                 onUnstage: (_) {},
                 onDiscard: (_) {},

--- a/lib/src/features/workbench/presentation/workspace_git_diff_panel_tree.dart
+++ b/lib/src/features/workbench/presentation/workspace_git_diff_panel_tree.dart
@@ -11,6 +11,8 @@ class _GitDiffTree extends StatefulWidget {
     required this.onToggleTreeNode,
     required this.onToggleSubmodule,
     required this.onOpenGitDiff,
+    this.onOpenFile,
+    required this.onRevealInExplorer,
     required this.onStage,
     required this.onUnstage,
     required this.onDiscard,
@@ -33,6 +35,8 @@ class _GitDiffTree extends StatefulWidget {
   final ValueChanged<String> onToggleTreeNode;
   final ValueChanged<GitChangeEntry> onToggleSubmodule;
   final OpenGitDiffTabCallback onOpenGitDiff;
+  final ValueChanged<String>? onOpenFile;
+  final ValueChanged<String> onRevealInExplorer;
   final ValueChanged<GitChangeEntry> onStage;
   final ValueChanged<GitChangeEntry> onUnstage;
   final ValueChanged<GitChangeEntry> onDiscard;
@@ -122,6 +126,10 @@ class _GitDiffTreeState extends State<_GitDiffTree> {
           ),
           depth: row.depth,
           busy: widget.busy,
+          onOpenFile: widget.onOpenFile == null
+              ? null
+              : () => widget.onOpenFile!(entry.path),
+          onRevealInExplorer: () => widget.onRevealInExplorer(entry.path),
           onStage: widget.onStage,
           onUnstage: widget.onUnstage,
           onDiscard: widget.onDiscard,
@@ -146,6 +154,8 @@ class _GitDiffTreeState extends State<_GitDiffTree> {
             depth: row.depth + 1,
             busy: widget.busy,
             onOpenGitDiff: widget.onOpenGitDiff,
+            onOpenFile: widget.onOpenFile,
+            onRevealInExplorer: widget.onRevealInExplorer,
           ),
       ];
     }
@@ -163,6 +173,8 @@ class _GitDiffTreeState extends State<_GitDiffTree> {
         canUnstage: capabilities?.canUnstage ?? false,
         canDiscard: capabilities?.canDiscard ?? false,
         onTap: () => widget.onToggleTreeNode(_treeNodeKey(row.path)),
+        onOpenFile: null,
+        onRevealInExplorer: () => widget.onRevealInExplorer(row.path),
         onStage: () {
           if (widget.unified) {
             widget.onStagePath?.call(row.path);
@@ -220,6 +232,8 @@ class _GitDiffDirectoryRow extends StatelessWidget {
     required this.canUnstage,
     required this.canDiscard,
     required this.onTap,
+    this.onOpenFile,
+    required this.onRevealInExplorer,
     required this.onStage,
     required this.onUnstage,
     required this.onDiscard,
@@ -233,6 +247,8 @@ class _GitDiffDirectoryRow extends StatelessWidget {
   final bool canUnstage;
   final bool canDiscard;
   final VoidCallback onTap;
+  final VoidCallback? onOpenFile;
+  final VoidCallback onRevealInExplorer;
   final VoidCallback onStage;
   final VoidCallback onUnstage;
   final VoidCallback onDiscard;
@@ -242,6 +258,10 @@ class _GitDiffDirectoryRow extends StatelessWidget {
     return _GitDiffBaseRow(
       depth: row.depth,
       onTap: onTap,
+      onSecondaryTapDown: (details) =>
+          unawaited(_openMenu(context, details.globalPosition)),
+      onLongPressStart: (details) =>
+          unawaited(_openMenu(context, details.globalPosition)),
       child: Row(
         children: <Widget>[
           Icon(
@@ -298,6 +318,23 @@ class _GitDiffDirectoryRow extends StatelessWidget {
       ),
     );
   }
+
+  Future<void> _openMenu(BuildContext context, Offset position) {
+    return _showGitChangeContextMenu(
+      context,
+      position,
+      canOpenFile: onOpenFile != null,
+      canStage: canStage,
+      canUnstage: canUnstage,
+      canDiscard: canDiscard,
+      busy: busy,
+      onOpenFile: onOpenFile,
+      onRevealInExplorer: onRevealInExplorer,
+      onStage: onStage,
+      onUnstage: onUnstage,
+      onDiscard: onDiscard,
+    );
+  }
 }
 
 class _GitDiffFileRow extends StatelessWidget {
@@ -307,6 +344,8 @@ class _GitDiffFileRow extends StatelessWidget {
     required this.depth,
     required this.onTap,
     required this.busy,
+    this.onOpenFile,
+    required this.onRevealInExplorer,
     required this.onStage,
     required this.onUnstage,
     required this.onDiscard,
@@ -321,6 +360,8 @@ class _GitDiffFileRow extends StatelessWidget {
   final int depth;
   final VoidCallback onTap;
   final bool busy;
+  final VoidCallback? onOpenFile;
+  final VoidCallback onRevealInExplorer;
   final ValueChanged<GitChangeEntry> onStage;
   final ValueChanged<GitChangeEntry> onUnstage;
   final ValueChanged<GitChangeEntry> onDiscard;
@@ -334,6 +375,10 @@ class _GitDiffFileRow extends StatelessWidget {
     return _GitDiffBaseRow(
       depth: depth,
       onTap: onTap,
+      onSecondaryTapDown: (details) =>
+          unawaited(_openMenu(context, details.globalPosition)),
+      onLongPressStart: (details) =>
+          unawaited(_openMenu(context, details.globalPosition)),
       child: Row(
         children: <Widget>[
           if (entry.isExpandableSubmodule)
@@ -413,100 +458,22 @@ class _GitDiffFileRow extends StatelessWidget {
       ),
     );
   }
-}
 
-class _GitFileActions extends StatelessWidget {
-  const _GitFileActions({
-    required this.entry,
-    required this.busy,
-    required this.onStage,
-    required this.onUnstage,
-    required this.onDiscard,
-  });
-
-  final GitChangeEntry entry;
-  final bool busy;
-  final ValueChanged<GitChangeEntry> onStage;
-  final ValueChanged<GitChangeEntry> onUnstage;
-  final ValueChanged<GitChangeEntry> onDiscard;
-
-  @override
-  Widget build(BuildContext context) {
-    return SizedBox(
-      width: 58,
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.end,
-        children: <Widget>[
-          if (entry.canUnstageFromParent)
-            AleraIconButton(
-              tooltip: 'Unstage',
-              icon: AleraIcons.gitUnstage,
-              onPressed: busy ? null : () => onUnstage(entry),
-            )
-          else if (entry.canStageFromParent)
-            AleraIconButton(
-              tooltip: 'Stage',
-              icon: AleraIcons.gitStage,
-              onPressed: busy ? null : () => onStage(entry),
-            ),
-          if (entry.canDiscardFromParent)
-            AleraIconButton(
-              tooltip: 'Discard',
-              icon: AleraIcons.gitDiscard,
-              onPressed: busy ? null : () => onDiscard(entry),
-            ),
-        ],
-      ),
-    );
-  }
-}
-
-class _AreaActions extends StatelessWidget {
-  const _AreaActions({
-    required this.busy,
-    required this.onStage,
-    required this.onUnstage,
-    required this.onDiscard,
-    required this.canStage,
-    required this.canUnstage,
-    required this.canDiscard,
-  });
-
-  final bool busy;
-  final VoidCallback onStage;
-  final VoidCallback onUnstage;
-  final VoidCallback onDiscard;
-  final bool canStage;
-  final bool canUnstage;
-  final bool canDiscard;
-
-  @override
-  Widget build(BuildContext context) {
-    return SizedBox(
-      width: 58,
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.end,
-        children: <Widget>[
-          if (canUnstage)
-            AleraIconButton(
-              tooltip: 'Unstage',
-              icon: AleraIcons.gitUnstage,
-              onPressed: busy ? null : onUnstage,
-            )
-          else if (canStage)
-            AleraIconButton(
-              tooltip: 'Stage',
-              icon: AleraIcons.gitStage,
-              onPressed: busy ? null : onStage,
-            ),
-          if (canDiscard)
-            AleraIconButton(
-              tooltip: 'Discard',
-              icon: AleraIcons.gitDiscard,
-              onPressed: busy ? null : onDiscard,
-            ),
-        ],
-      ),
+  Future<void> _openMenu(BuildContext context, Offset position) {
+    return _showGitChangeContextMenu(
+      context,
+      position,
+      canOpenFile:
+          onOpenFile != null && entry.status != GitChangeStatus.deleted,
+      canStage: entry.canStageFromParent,
+      canUnstage: entry.canUnstageFromParent,
+      canDiscard: entry.canDiscardFromParent,
+      busy: busy,
+      onOpenFile: onOpenFile,
+      onRevealInExplorer: onRevealInExplorer,
+      onStage: () => onStage(entry),
+      onUnstage: () => onUnstage(entry),
+      onDiscard: () => onDiscard(entry),
     );
   }
 }

--- a/test/unit/workbench_controller_explorer_reveal_test_cases.dart
+++ b/test/unit/workbench_controller_explorer_reveal_test_cases.dart
@@ -1,0 +1,27 @@
+part of 'workbench_controller_test.dart';
+
+void _registerWorkbenchControllerExplorerRevealTests() {
+  test('revealInExplorer switches to explorer and queues the path', () async {
+    await _controller.bootstrap();
+    final workspace = await _selectMainWorkspace(_controller, _harness);
+    _controller.setContextPanelTab(WorkbenchContextPanelTab.gitDiff);
+    await _flush();
+
+    _controller.revealInExplorer(
+      workspace: workspace,
+      relativePath: 'lib/src/dirty.dart',
+    );
+    await _flush();
+
+    expect(
+      _controller.state.viewPrefs.activeContextPanelTab,
+      WorkbenchContextPanelTab.explorer,
+    );
+    expect(_controller.state.viewPrefs.rightSidebarVisible, isTrue);
+    final request = _harness.container.read(
+      workspaceExplorerRevealControllerProvider,
+    );
+    expect(request?.workspaceId, workspace.id);
+    expect(request?.relativePath, 'lib/src/dirty.dart');
+  });
+}

--- a/test/unit/workbench_controller_test.dart
+++ b/test/unit/workbench_controller_test.dart
@@ -49,6 +49,7 @@ part 'workbench_controller_sleep_test_cases.dart';
 part 'workbench_controller_layout_persistence_test_cases.dart';
 part 'workbench_controller_mobile_emulator_test_cases.dart';
 part 'workbench_controller_view_prefs_test_cases.dart';
+part 'workbench_controller_explorer_reveal_test_cases.dart';
 part 'workbench_controller_active_filter_test_cases.dart';
 part 'workbench_controller_failure_test_cases.dart';
 part 'workbench_controller_create_workspace_test_cases.dart';
@@ -81,6 +82,7 @@ void main() {
     _registerWorkbenchControllerLayoutPersistenceTests();
     _registerWorkbenchControllerMobileEmulatorTests();
     _registerWorkbenchControllerViewPrefsTests();
+    _registerWorkbenchControllerExplorerRevealTests();
     _registerWorkbenchControllerActiveFilterTests();
     _registerWorkbenchControllerFailureTests();
     _registerWorkbenchControllerCreateWorkspaceTests();

--- a/test/unit/workbench_controller_test.dart
+++ b/test/unit/workbench_controller_test.dart
@@ -19,6 +19,7 @@ import 'package:alera/src/features/settings/domain/alera_settings.dart';
 import 'package:alera/src/features/workbench/application/workbench_providers.dart';
 import 'package:alera/src/features/workbench/application/workspace_tab_service.dart';
 import 'package:alera/src/features/workbench/application/workbench_controller.dart';
+import 'package:alera/src/features/workbench/application/workspace_explorer_reveal.dart';
 import 'package:alera/src/features/workbench/application/workbench_repository.dart';
 import 'package:alera/src/features/workbench/application/workbench_view_prefs_repository.dart';
 import 'package:alera/src/features/workbench/application/workspace_graph_repository.dart';

--- a/test/unit/workbench_controller_view_prefs_test_cases.dart
+++ b/test/unit/workbench_controller_view_prefs_test_cases.dart
@@ -259,30 +259,6 @@ void _registerWorkbenchControllerViewPrefsTests() {
     },
   );
 
-  test('revealInExplorer switches to explorer and queues the path', () async {
-    await _controller.bootstrap();
-    final workspace = await _selectMainWorkspace(_controller, _harness);
-    _controller.setContextPanelTab(WorkbenchContextPanelTab.gitDiff);
-    await _flush();
-
-    _controller.revealInExplorer(
-      workspace: workspace,
-      relativePath: 'lib/src/dirty.dart',
-    );
-    await _flush();
-
-    expect(
-      _controller.state.viewPrefs.activeContextPanelTab,
-      WorkbenchContextPanelTab.explorer,
-    );
-    expect(_controller.state.viewPrefs.rightSidebarVisible, isTrue);
-    final request = _harness.container.read(
-      workspaceExplorerRevealControllerProvider,
-    );
-    expect(request?.workspaceId, workspace.id);
-    expect(request?.relativePath, 'lib/src/dirty.dart');
-  });
-
   test('selecting a git workspace keeps source control active', () async {
     await _controller.bootstrap();
     _controller.setContextPanelTab(WorkbenchContextPanelTab.gitDiff);

--- a/test/unit/workbench_controller_view_prefs_test_cases.dart
+++ b/test/unit/workbench_controller_view_prefs_test_cases.dart
@@ -259,6 +259,30 @@ void _registerWorkbenchControllerViewPrefsTests() {
     },
   );
 
+  test('revealInExplorer switches to explorer and queues the path', () async {
+    await _controller.bootstrap();
+    final workspace = await _selectMainWorkspace(_controller, _harness);
+    _controller.setContextPanelTab(WorkbenchContextPanelTab.gitDiff);
+    await _flush();
+
+    _controller.revealInExplorer(
+      workspace: workspace,
+      relativePath: 'lib/src/dirty.dart',
+    );
+    await _flush();
+
+    expect(
+      _controller.state.viewPrefs.activeContextPanelTab,
+      WorkbenchContextPanelTab.explorer,
+    );
+    expect(_controller.state.viewPrefs.rightSidebarVisible, isTrue);
+    final request = _harness.container.read(
+      workspaceExplorerRevealControllerProvider,
+    );
+    expect(request?.workspaceId, workspace.id);
+    expect(request?.relativePath, 'lib/src/dirty.dart');
+  });
+
   test('selecting a git workspace keeps source control active', () async {
     await _controller.bootstrap();
     _controller.setContextPanelTab(WorkbenchContextPanelTab.gitDiff);

--- a/test/unit/workspace_folder_opener_test.dart
+++ b/test/unit/workspace_folder_opener_test.dart
@@ -62,6 +62,24 @@ void main() {
     expect(opener.fileManagerLabel, 'Explorer');
   });
 
+  test('normalizes Windows open paths that use forward slashes', () async {
+    final processRunner = _FakeProcessRunner();
+    final opener = WorkspaceFolderOpener(
+      processRunner: processRunner,
+      platform: WorkspaceFolderPlatform.windows,
+      directoryExists: (_) async => true,
+    );
+
+    final result = await opener.open('C:/Users/me/My Documents/repo');
+
+    expect(result.ok, isTrue);
+    expect(processRunner.calls, <_ProcessCall>[
+      const _ProcessCall('explorer.exe', <String>[
+        r'C:\Users\me\My Documents\repo',
+      ]),
+    ]);
+  });
+
   test('reveals an item in Finder on macOS', () async {
     final processRunner = _FakeProcessRunner();
     final directory = await Directory.systemTemp.createTemp(
@@ -108,7 +126,38 @@ void main() {
 
     expect(result.ok, isTrue);
     expect(processRunner.calls, <_ProcessCall>[
-      _ProcessCall('explorer.exe', <String>['/select,${file.path}']),
+      _ProcessCall('explorer.exe', <String>[
+        '/select,',
+        file.path.replaceAll('/', r'\'),
+      ]),
+    ]);
+  });
+
+  test('normalizes Windows reveal paths that use forward slashes', () async {
+    final processRunner = _FakeProcessRunner();
+    final directory = await Directory.systemTemp.createTemp(
+      'alera-reveal-item-',
+    );
+    final file = File('${directory.path}/note.txt');
+    await file.writeAsString('note');
+    addTearDown(() async {
+      if (await directory.exists()) {
+        await directory.delete(recursive: true);
+      }
+    });
+    final opener = WorkspaceFolderOpener(
+      processRunner: processRunner,
+      platform: WorkspaceFolderPlatform.windows,
+    );
+
+    final result = await opener.reveal(file.path.replaceAll(r'\', '/'));
+
+    expect(result.ok, isTrue);
+    expect(processRunner.calls, <_ProcessCall>[
+      _ProcessCall('explorer.exe', <String>[
+        '/select,',
+        file.path.replaceAll('/', r'\'),
+      ]),
     ]);
   });
 

--- a/test/widget/workspace_explorer_reveal_cases.dart
+++ b/test/widget/workspace_explorer_reveal_cases.dart
@@ -1,0 +1,51 @@
+part of 'workspace_explorer_test.dart';
+
+void _registerWorkspaceExplorerRevealTests() {
+  testWidgets('queued reveal expands ancestors and selects the file', (
+    tester,
+  ) async {
+    final service = _FakeWorkspaceFileService()
+      ..childrenByDirectory[''] = <native.WorkspaceFileEntry>[
+        _directory('src', hasChildrenHint: true),
+      ]
+      ..childrenByDirectory['src'] = <native.WorkspaceFileEntry>[
+        _file('src/main.dart'),
+      ];
+    late ProviderContainer container;
+    await tester.pumpWidget(
+      _withWorkspaceFiles(
+        service,
+        child: MaterialApp(
+          home: Scaffold(
+            body: SizedBox(
+              width: 320,
+              height: 480,
+              child: Consumer(
+                builder: (context, ref, _) {
+                  container = ProviderScope.containerOf(context);
+                  return WorkspaceExplorer(
+                    workspace: _workspace(),
+                    mode: WorkspaceExplorerMode.hideIgnored,
+                    onModeChanged: (_) {},
+                    onOpenFile: (_) {},
+                    onPathMoved: (_, _) async {},
+                  );
+                },
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(find.text('main.dart'), findsNothing);
+
+    container
+        .read(workspaceExplorerRevealControllerProvider.notifier)
+        .reveal(workspaceId: 'workspace-1', relativePath: 'src/main.dart');
+    await tester.pumpAndSettle();
+
+    expect(find.text('main.dart'), findsOneWidget);
+    expect(container.read(workspaceExplorerRevealControllerProvider), isNull);
+  });
+}

--- a/test/widget/workspace_explorer_test.dart
+++ b/test/widget/workspace_explorer_test.dart
@@ -28,10 +28,12 @@ import '../unit/fake_git_backend.dart';
 part 'workspace_explorer_cursor_cases.dart';
 part 'workspace_explorer_context_sidebar_cases.dart';
 part 'workspace_explorer_git_snapshot_cases.dart';
+part 'workspace_explorer_reveal_cases.dart';
 
 void main() {
   _registerWorkspaceExplorerContextSidebarTests();
   _registerWorkspaceExplorerGitSnapshotTests();
+  _registerWorkspaceExplorerRevealTests();
   _registerWorkspaceExplorerCursorTests();
 
   testWidgets('single click toggles folders and rows expose click cursors', (
@@ -419,54 +421,6 @@ void main() {
 
     expect(service.writtenFiles, <String, String>{'note.txt': 'changed'});
     expect(registry.isDirty('tab-1'), isFalse);
-  });
-
-  testWidgets('queued reveal expands ancestors and selects the file', (
-    tester,
-  ) async {
-    final service = _FakeWorkspaceFileService()
-      ..childrenByDirectory[''] = <native.WorkspaceFileEntry>[
-        _directory('src', hasChildrenHint: true),
-      ]
-      ..childrenByDirectory['src'] = <native.WorkspaceFileEntry>[
-        _file('src/main.dart'),
-      ];
-    late ProviderContainer container;
-    await tester.pumpWidget(
-      _withWorkspaceFiles(
-        service,
-        child: MaterialApp(
-          home: Scaffold(
-            body: SizedBox(
-              width: 320,
-              height: 480,
-              child: Consumer(
-                builder: (context, ref, _) {
-                  container = ProviderScope.containerOf(context);
-                  return WorkspaceExplorer(
-                    workspace: _workspace(),
-                    mode: WorkspaceExplorerMode.hideIgnored,
-                    onModeChanged: (_) {},
-                    onOpenFile: (_) {},
-                    onPathMoved: (_, _) async {},
-                  );
-                },
-              ),
-            ),
-          ),
-        ),
-      ),
-    );
-    await tester.pumpAndSettle();
-    expect(find.text('main.dart'), findsNothing);
-
-    container
-        .read(workspaceExplorerRevealControllerProvider.notifier)
-        .reveal(workspaceId: 'workspace-1', relativePath: 'src/main.dart');
-    await tester.pumpAndSettle();
-
-    expect(find.text('main.dart'), findsOneWidget);
-    expect(container.read(workspaceExplorerRevealControllerProvider), isNull);
   });
 
   testWidgets('background context menu creates items at workspace root', (

--- a/test/widget/workspace_explorer_test.dart
+++ b/test/widget/workspace_explorer_test.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:alera/src/design_system/icons/alera_icons.dart';
 import 'package:alera/src/features/projects/application/project_providers.dart';
 import 'package:alera/src/features/workbench/application/workbench_providers.dart';
+import 'package:alera/src/features/workbench/application/workspace_explorer_reveal.dart';
 import 'package:alera/src/features/workbench/application/workspace_file_service.dart';
 import 'package:alera/src/features/workbench/application/workspace_folder_opener.dart';
 import 'package:alera/src/features/workbench/domain/workspace.dart';
@@ -418,6 +419,54 @@ void main() {
 
     expect(service.writtenFiles, <String, String>{'note.txt': 'changed'});
     expect(registry.isDirty('tab-1'), isFalse);
+  });
+
+  testWidgets('queued reveal expands ancestors and selects the file', (
+    tester,
+  ) async {
+    final service = _FakeWorkspaceFileService()
+      ..childrenByDirectory[''] = <native.WorkspaceFileEntry>[
+        _directory('src', hasChildrenHint: true),
+      ]
+      ..childrenByDirectory['src'] = <native.WorkspaceFileEntry>[
+        _file('src/main.dart'),
+      ];
+    late ProviderContainer container;
+    await tester.pumpWidget(
+      _withWorkspaceFiles(
+        service,
+        child: MaterialApp(
+          home: Scaffold(
+            body: SizedBox(
+              width: 320,
+              height: 480,
+              child: Consumer(
+                builder: (context, ref, _) {
+                  container = ProviderScope.containerOf(context);
+                  return WorkspaceExplorer(
+                    workspace: _workspace(),
+                    mode: WorkspaceExplorerMode.hideIgnored,
+                    onModeChanged: (_) {},
+                    onOpenFile: (_) {},
+                    onPathMoved: (_, _) async {},
+                  );
+                },
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(find.text('main.dart'), findsNothing);
+
+    container
+        .read(workspaceExplorerRevealControllerProvider.notifier)
+        .reveal(workspaceId: 'workspace-1', relativePath: 'src/main.dart');
+    await tester.pumpAndSettle();
+
+    expect(find.text('main.dart'), findsOneWidget);
+    expect(container.read(workspaceExplorerRevealControllerProvider), isNull);
   });
 
   testWidgets('background context menu creates items at workspace root', (

--- a/test/widget/workspace_git_diff_panel_context_menu_test_cases.dart
+++ b/test/widget/workspace_git_diff_panel_context_menu_test_cases.dart
@@ -1,0 +1,111 @@
+part of 'workspace_git_diff_panel_test.dart';
+
+void _registerWorkspaceGitDiffPanelContextMenuTests() {
+  testWidgets('tree file context menu opens the file instead of the diff', (
+    tester,
+  ) async {
+    final backend = FakeGitBackend()
+      ..gitStatusResult = const GitStatusResult(
+        entries: <GitChangeEntry>[
+          GitChangeEntry(
+            path: 'lib/src/dirty.dart',
+            area: GitChangeArea.unstaged,
+            status: GitChangeStatus.modified,
+          ),
+        ],
+      );
+    final opened = <String>[];
+
+    await _pumpPanel(
+      tester,
+      backend: backend,
+      viewMode: GitDiffViewMode.tree,
+      onOpenFile: opened.add,
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('dirty.dart'), buttons: kSecondaryMouseButton);
+    await tester.pumpAndSettle();
+    expect(find.text('Open File'), findsOneWidget);
+    expect(find.text('Reveal in Explorer'), findsOneWidget);
+    expect(find.text('Stage'), findsWidgets);
+    expect(find.text('Discard'), findsWidgets);
+
+    await tester.tap(find.text('Open File'));
+    await tester.pumpAndSettle();
+
+    expect(opened, <String>['lib/src/dirty.dart']);
+  });
+
+  testWidgets('tree folder context menu stages the folder path', (
+    tester,
+  ) async {
+    final backend = FakeGitBackend()
+      ..gitStatusResult = const GitStatusResult(
+        entries: <GitChangeEntry>[
+          GitChangeEntry(
+            path: 'lib/src/dirty.dart',
+            area: GitChangeArea.unstaged,
+            status: GitChangeStatus.modified,
+          ),
+        ],
+      );
+
+    await _pumpPanel(tester, backend: backend, viewMode: GitDiffViewMode.tree);
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('src'), buttons: kSecondaryMouseButton);
+    await tester.pumpAndSettle();
+    expect(find.text('Open File'), findsNothing);
+    expect(find.text('Reveal in Explorer'), findsOneWidget);
+
+    await tester.tap(find.text('Stage').last);
+    await tester.pumpAndSettle();
+
+    expect(
+      backend.calls.where((call) => call.method == 'stageArea').single.args,
+      <String, Object?>{
+        'path': '/tmp/project',
+        'area': GitChangeArea.unstaged,
+        'filePath': 'lib/src',
+      },
+    );
+  });
+
+  testWidgets('tree file context menu reveals the workspace-relative path', (
+    tester,
+  ) async {
+    final backend = FakeGitBackend()
+      ..gitStatusResult = const GitStatusResult(
+        entries: <GitChangeEntry>[
+          GitChangeEntry(
+            path: 'lib/src/dirty.dart',
+            area: GitChangeArea.unstaged,
+            status: GitChangeStatus.modified,
+          ),
+        ],
+      );
+    final revealed = <String>[];
+
+    await _pumpPanel(
+      tester,
+      backend: backend,
+      viewMode: GitDiffViewMode.tree,
+      sourceControlScope: const WorkspaceSourceControlScope(
+        workspaceId: 'workspace-1',
+        workspacePath: '/tmp/project',
+        path: '/tmp/project/packages/app',
+        relativeRoot: 'packages/app',
+      ),
+      onRevealInExplorer: revealed.add,
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('dirty.dart'), buttons: kSecondaryMouseButton);
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Reveal in Explorer'));
+    await tester.pumpAndSettle();
+
+    expect(revealed, <String>['packages/app/lib/src/dirty.dart']);
+  });
+}

--- a/test/widget/workspace_git_diff_panel_test.dart
+++ b/test/widget/workspace_git_diff_panel_test.dart
@@ -27,9 +27,11 @@ import '../unit/fake_git_backend.dart';
 import '../unit/fake_source_control_watcher.dart';
 
 part 'workspace_git_diff_panel_preview_test_cases.dart';
+part 'workspace_git_diff_panel_context_menu_test_cases.dart';
 
 void main() {
   _registerWorkspaceGitDiffPanelPreviewTests();
+  _registerWorkspaceGitDiffPanelContextMenuTests();
   testWidgets('git diff panel hides zero-valued line counts', (tester) async {
     final backend = FakeGitBackend()
       ..gitStatusResult = const GitStatusResult(
@@ -1440,6 +1442,8 @@ Future<void> _pumpPanel(
   AleraSettings settings = AleraSettings.defaults,
   OpenGitDiffTabCallback? onOpenGitDiff,
   OpenGitCommitDiffTabCallback? onOpenGitCommitDiff,
+  ValueChanged<String>? onOpenFile,
+  ValueChanged<String>? onRevealInExplorer,
   VoidCallback? onClearSourceControlRoot,
 }) {
   final resolvedWorkspace = workspace ?? _workspace();
@@ -1491,6 +1495,8 @@ Future<void> _pumpPanel(
                     message,
                     bool preview = false,
                   }) async {},
+              onOpenFile: onOpenFile,
+              onRevealInExplorer: onRevealInExplorer,
               onClearSourceControlRoot: onClearSourceControlRoot,
             ),
           ),


### PR DESCRIPTION
## Summary

Adds a right-click menu on Source Control tree files and folders with Stage, Unstage, Discard, Open File (instead of the diff), and Reveal in Explorer. Also fixes Windows Reveal in Explorer so `explorer.exe /select` uses a backslash path as a separate argument instead of falling back to Documents.

## Screenshots

- Source Control tree file and folder context menu with git actions, Open File, and Reveal in Explorer.
- No new visual chrome besides the existing dropdown menu style.

## Testing

- [x] `dart format` on the touched files
- [x] `flutter analyze` on the touched files
- [ ] `flutter test --coverage --exclude-tags golden`
- [ ] `dart run tool/quality/coverage_report.dart --input coverage/lcov.info --min-lines 100 --worst 25`
- [ ] Golden tests, if UI changed: `flutter test --tags golden`
- [ ] Desktop E2E, if app-shell flow changed: `flutter test integration_test -d macos`
- [ ] Relevant desktop build: `flutter build macos`, `flutter build windows`, or `flutter build linux`
- [ ] Landing build, if applicable: `cd landing && bun run build`
- [x] Added or updated tests that would catch regressions, or explained why tests were not needed

Local Flutter tests could not run in this orb because the Ghostty native-asset hook requires Zig 0.16 and network access. Added widget and unit coverage for the tree context menu, Explorer reveal request, and Windows explorer path quoting.

## AI Review Report

Checked path conversion from Source Control roots to workspace-relative Explorer paths, menu availability for files vs folders vs deleted files, and Windows Explorer `/select` argument parsing. Cross-platform path handling was reviewed for macOS (`open -R`), Linux (`FileManager1.ShowItems`), and Windows (`explorer.exe /select,` plus a separate backslash path).

## Security Audit

No new command construction beyond the existing folder opener. Windows reveal now normalizes `/` to `\` and keeps `/select,` as its own argument so Explorer cannot misparse a path as an invalid switch. Paths still come from workspace-relative git entries already shown in the UI.

## Notes

Reveal in Explorer queues a one-shot in-memory request, switches to the Explorer tab, and selects the item after ancestors load. It is not persisted.