### PR TITLE
fix: use Homebrew symbol form for macOS cask dependency

### DIFF
--- a/packaging/homebrew/alera.rb.tmpl
+++ b/packaging/homebrew/alera.rb.tmpl
@@ -15,8 +15,10 @@ cask "alera" do
 
   # CI builds the macOS app on an Apple Silicon runner only, and the app targets
   # macOS 14. Claiming more would install a bundle that cannot run.
+  # Homebrew treats a symbol as "this version or newer"; the string comparison
+  # form (`">= :sonoma"`) is deprecated and warns on every brew command.
   depends_on arch: :arm64
-  depends_on macos: ">= :sonoma"
+  depends_on macos: :sonoma
 
   app "Alera.app"
 

--- a/test/unit/package_manifest_render_test.dart
+++ b/test/unit/package_manifest_render_test.dart
@@ -160,6 +160,14 @@ void main() {
         rendered['homebrew/Casks/alera.rb'],
         contains('depends_on arch: :arm64'),
       );
+      expect(
+        rendered['homebrew/Casks/alera.rb'],
+        contains('depends_on macos: :sonoma'),
+      );
+      expect(
+        rendered['homebrew/Casks/alera.rb'],
+        isNot(contains('depends_on macos: ">=')),
+      );
       final scoop =
           jsonDecode(rendered['scoop/bucket/alera.json']!)
               as Map<String, dynamic>;


### PR DESCRIPTION
## Summary

Homebrew warns on every brew command because the Alera cask still uses the deprecated string comparison:

```ruby
depends_on macos: ">= :sonoma"
```

The cask template now uses the symbol form Homebrew wants:

```ruby
depends_on macos: :sonoma
```

That still means macOS 14 (Sonoma) or newer. The package-manifest render test locks the new syntax so a later release cannot ship the old comparison again.

The published tap (`leynier/homebrew-tap`) will pick this up on the next stable desktop release.

## Screenshots

No visual change

## Testing

- [x] `flutter test test/unit/package_manifest_render_test.dart`
- [x] `flutter test --coverage --exclude-tags golden` (2 PTY adapter tests fail on this orb with `GLIBC_2.39` missing; same failures on `origin/main`)
- [ ] Golden tests, if UI changed: not applicable
- [ ] Desktop E2E, if app-shell flow changed: not applicable
- [ ] Relevant desktop build: not applicable
- [ ] Landing build, if applicable: not applicable
- [x] Added or updated tests that would catch regressions, or explained why tests were not needed

`dart format --set-exit-if-changed lib test integration_test tool` reports unrelated pre-existing drift on `origin/main`; this PR does not reformat those files. `flutter analyze` reports the same existing `alera_preview.dart` / unawaited-future issues on `origin/main`.

## AI Review Report

Checked that Homebrew's cask DSL treats `depends_on macos: :sonoma` as Sonoma or newer, matching the previous `">= :sonoma"` comparison. Confirmed the change is template-only and does not alter install, update, or signing paths.

Cross-platform: this only affects the macOS Homebrew cask. Linux and Windows package manifests are unchanged.

## Security Audit

No input handling, command execution, path handling, auth, secrets, signing, updater, or process-execution changes. The cask still requires arm64 and macOS 14+.

## Notes

Users already seeing the warning will keep seeing it until the next stable release publishes the regenerated cask. A local workaround is editing `/opt/homebrew/Library/Taps/leynier/homebrew-tap/Casks/alera.rb` line 19 to `depends_on macos: :sonoma`.