### PR TITLE
feat: add desktop tray icon and pending-review dock badge

### DIFF
--- a/.agents/setup
+++ b/.agents/setup
@@ -23,6 +23,7 @@ sudo -n apt-get install -y --no-install-recommends \
   curl \
   git \
   libgtk-3-dev \
+  libayatana-appindicator3-dev \
   liblzma-dev \
   ninja-build \
   pkg-config \

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -36,6 +36,7 @@ sudo apt-get install -y \
   ninja-build \
   pkg-config \
   libgtk-3-dev \
+  libayatana-appindicator3-dev \
   libwebkit2gtk-4.1-dev \
   libjson-glib-dev \
   libsecret-1-dev \

--- a/.github/actions/setup-flutter-workspace/action.yml
+++ b/.github/actions/setup-flutter-workspace/action.yml
@@ -72,7 +72,7 @@ runs:
       shell: bash
       run: |
         set -euo pipefail
-        packages="clang libclang-dev cmake ninja-build pkg-config libgtk-3-dev libwebkit2gtk-4.1-dev libjson-glib-dev libsecret-1-dev libsqlite3-dev libssl-dev libepoxy-dev libmpv-dev libvulkan-dev glslc"
+        packages="clang libclang-dev cmake ninja-build pkg-config libgtk-3-dev libwebkit2gtk-4.1-dev libjson-glib-dev libsecret-1-dev libsqlite3-dev libssl-dev libepoxy-dev libmpv-dev libvulkan-dev glslc libayatana-appindicator3-dev"
         if [ "${{ inputs.xvfb }}" = "true" ]; then
           packages="${packages} xvfb"
         fi

--- a/lib/src/app/app.dart
+++ b/lib/src/app/app.dart
@@ -7,6 +7,7 @@ import 'package:alera/src/features/diagnostics/presentation/diagnostics_settings
 import 'package:alera/src/features/shell/presentation/alera_shell_page.dart';
 import 'package:alera/src/features/text_actions/presentation/text_actions_scope.dart';
 import 'package:alera/src/features/updater/presentation/update_availability_watch.dart';
+import 'package:alera/src/features/desktop_presence/presentation/desktop_presence_scope.dart';
 import 'package:alera/src/features/runtime_host/presentation/runtime_host_quit_gate_scope.dart';
 import 'package:flutter/material.dart';
 
@@ -17,7 +18,9 @@ class AleraApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       title: kAleraAppName,
-      home: const RuntimeHostQuitGateScope(child: AleraShellPage()),
+      home: const RuntimeHostQuitGateScope(
+        child: DesktopPresenceScope(child: AleraShellPage()),
+      ),
       debugShowCheckedModeBanner: false,
       builder: (context, child) {
         return AiDictationDownloadBootstrap(

--- a/lib/src/features/agent_status/infra/window_manager_agent_window_activator.dart
+++ b/lib/src/features/agent_status/infra/window_manager_agent_window_activator.dart
@@ -9,7 +9,9 @@ class WindowManagerAgentWindowActivator
 
   @override
   Future<void> showAndFocus() async {
-    await windowManager.show();
+    if (!await windowManager.isVisible()) {
+      await windowManager.show();
+    }
     if (await windowManager.isMinimized()) {
       await windowManager.restore();
     }

--- a/lib/src/features/app_menu/presentation/app_menu_actions.dart
+++ b/lib/src/features/app_menu/presentation/app_menu_actions.dart
@@ -64,9 +64,12 @@ Future<void> showAppMenuAbout(
   );
 }
 
-/// Closes through the app-window lifecycle (flush state, then destroy).
+/// Quits through the app-window lifecycle (flush state, then destroy).
+///
+/// This must not go through [AppWindowController.close]: with the tray
+/// enabled, close only hides the window.
 Future<void> exitAppFromMenu(WidgetRef ref) {
-  return ref.read(appWindowControllerProvider).close();
+  return ref.read(appWindowLifecycleCoordinatorProvider).requestQuit();
 }
 
 /// Invokes a text-editing intent on the primary focus, if any action handles it.

--- a/lib/src/features/app_window/application/app_window_controller.dart
+++ b/lib/src/features/app_window/application/app_window_controller.dart
@@ -196,6 +196,14 @@ class AppWindowLifecycleCoordinator extends AppWindowEventListener {
   /// swallow a tray or app-menu Quit.
   bool get isQuitting => _quitting;
 
+  /// Completes when an in-flight hide-on-close finishes, or immediately.
+  Future<void> waitForPendingHide() async {
+    final hide = _hideFuture;
+    if (hide != null) {
+      await hide;
+    }
+  }
+
   Future<void> start() async {
     if (_started || _closed) {
       return;

--- a/lib/src/features/app_window/application/app_window_controller.dart
+++ b/lib/src/features/app_window/application/app_window_controller.dart
@@ -177,6 +177,7 @@ class AppWindowLifecycleCoordinator extends AppWindowEventListener {
   bool _closeCommitted = false;
   bool _closed = false;
   bool _quitting = false;
+  Future<void>? _hideFuture;
 
   /// Optional gate invoked before the window is destroyed. Return `false` to
   /// cancel the close (for example when the user declines force-stopping the
@@ -233,7 +234,7 @@ class AppWindowLifecycleCoordinator extends AppWindowEventListener {
       return;
     }
     if (!_quitting && (_hideOnClose?.call() ?? false)) {
-      unawaited(_hideInsteadOfDestroy());
+      _hideFuture ??= _hideInsteadOfDestroy();
       return;
     }
     _closing = true;
@@ -242,29 +243,47 @@ class AppWindowLifecycleCoordinator extends AppWindowEventListener {
 
   /// Commits a real process exit even when hide-on-close is enabled.
   Future<void> requestQuit() async {
-    if (_closing || _closed) {
+    if (_closing || _closed || _quitting) {
       return;
     }
     _quitting = true;
     _closing = true;
+    final hide = _hideFuture;
+    if (hide != null) {
+      await hide;
+    }
+    if (_closed) {
+      return;
+    }
     await _flushAndDestroy();
   }
 
   Future<void> _hideInsteadOfDestroy() async {
     try {
       await flush();
+      if (_quitting || _closing) {
+        return;
+      }
+      try {
+        await _window.hide();
+      } catch (error, stackTrace) {
+        _logWarningIfActive('failed to hide app window', error, stackTrace);
+      }
     } catch (error, stackTrace) {
       _logWarningIfActive(
         'failed to flush app window state on hide',
         error,
         stackTrace,
       );
+    } finally {
+      _hideFuture = null;
     }
-    try {
-      await _window.hide();
-    } catch (error, stackTrace) {
-      _logWarningIfActive('failed to hide app window', error, stackTrace);
-    }
+  }
+
+  void _resetQuitAttempt() {
+    _closing = false;
+    _quitting = false;
+    _hideFuture = null;
   }
 
   @override
@@ -318,15 +337,13 @@ class AppWindowLifecycleCoordinator extends AppWindowEventListener {
       if (gate != null) {
         final allowClose = await gate();
         if (!allowClose) {
-          _closing = false;
-          _quitting = false;
+          _resetQuitAttempt();
           return;
         }
       }
     } catch (error, stackTrace) {
       // Logging listeners are synchronous and may request another close.
-      _closing = false;
-      _quitting = false;
+      _resetQuitAttempt();
       _logWarningIfActive('app window close gate failed', error, stackTrace);
       return;
     }

--- a/lib/src/features/app_window/application/app_window_controller.dart
+++ b/lib/src/features/app_window/application/app_window_controller.dart
@@ -50,6 +50,16 @@ abstract interface class AppWindowController {
 
   Future<bool> isMinimized();
 
+  Future<void> hide();
+
+  Future<void> show();
+
+  Future<void> restore();
+
+  Future<void> focus();
+
+  Future<bool> isVisible();
+
   Future<void> setPreventClose(bool value);
 
   /// Requests a user-initiated window close (system close path).
@@ -129,6 +139,7 @@ class AppWindowLifecycleCoordinator extends AppWindowEventListener {
         const DestroyAppWindowCloseStrategy(),
     Duration saveDebounce = const Duration(milliseconds: 350),
     Future<bool> Function()? closeGate,
+    bool Function()? hideOnClose,
     Logger? logger,
   }) : this._(
          repository: repository,
@@ -136,6 +147,7 @@ class AppWindowLifecycleCoordinator extends AppWindowEventListener {
          closeStrategy: closeStrategy,
          saveDebounce: saveDebounce,
          closeGate: closeGate,
+         hideOnClose: hideOnClose,
          logger: logger ?? Logger('AppWindowLifecycleCoordinator'),
        );
 
@@ -145,6 +157,7 @@ class AppWindowLifecycleCoordinator extends AppWindowEventListener {
     required this._closeStrategy,
     required this._saveDebounce,
     required this._closeGate,
+    required this._hideOnClose,
     required this._logger,
   });
 
@@ -153,6 +166,7 @@ class AppWindowLifecycleCoordinator extends AppWindowEventListener {
   final AppWindowCloseStrategy _closeStrategy;
   final Duration _saveDebounce;
   Future<bool> Function()? _closeGate;
+  bool Function()? _hideOnClose;
   final Logger _logger;
 
   AppWindowState? _lastState;
@@ -162,6 +176,7 @@ class AppWindowLifecycleCoordinator extends AppWindowEventListener {
   bool _closing = false;
   bool _closeCommitted = false;
   bool _closed = false;
+  bool _quitting = false;
 
   /// Optional gate invoked before the window is destroyed. Return `false` to
   /// cancel the close (for example when the user declines force-stopping the
@@ -169,6 +184,16 @@ class AppWindowLifecycleCoordinator extends AppWindowEventListener {
   void bindCloseGate(Future<bool> Function()? closeGate) {
     _closeGate = closeGate;
   }
+
+  /// When this returns true, a user close hides the window instead of
+  /// destroying the process. Quit still goes through [requestQuit].
+  void bindHideOnClose(bool Function()? hideOnClose) {
+    _hideOnClose = hideOnClose;
+  }
+
+  /// True while a committed quit is in progress, so hide-on-close cannot
+  /// swallow a tray or app-menu Quit.
+  bool get isQuitting => _quitting;
 
   Future<void> start() async {
     if (_started || _closed) {
@@ -207,8 +232,39 @@ class AppWindowLifecycleCoordinator extends AppWindowEventListener {
     if (_closing || _closed) {
       return;
     }
+    if (!_quitting && (_hideOnClose?.call() ?? false)) {
+      unawaited(_hideInsteadOfDestroy());
+      return;
+    }
     _closing = true;
     unawaited(_flushAndDestroy());
+  }
+
+  /// Commits a real process exit even when hide-on-close is enabled.
+  Future<void> requestQuit() async {
+    if (_closing || _closed) {
+      return;
+    }
+    _quitting = true;
+    _closing = true;
+    await _flushAndDestroy();
+  }
+
+  Future<void> _hideInsteadOfDestroy() async {
+    try {
+      await flush();
+    } catch (error, stackTrace) {
+      _logWarningIfActive(
+        'failed to flush app window state on hide',
+        error,
+        stackTrace,
+      );
+    }
+    try {
+      await _window.hide();
+    } catch (error, stackTrace) {
+      _logWarningIfActive('failed to hide app window', error, stackTrace);
+    }
   }
 
   @override
@@ -263,12 +319,14 @@ class AppWindowLifecycleCoordinator extends AppWindowEventListener {
         final allowClose = await gate();
         if (!allowClose) {
           _closing = false;
+          _quitting = false;
           return;
         }
       }
     } catch (error, stackTrace) {
       // Logging listeners are synchronous and may request another close.
       _closing = false;
+      _quitting = false;
       _logWarningIfActive('app window close gate failed', error, stackTrace);
       return;
     }

--- a/lib/src/features/app_window/infra/window_manager_app_window_controller.dart
+++ b/lib/src/features/app_window/infra/window_manager_app_window_controller.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:ui';
 
 import 'package:alera/src/features/app_window/application/app_window_controller.dart';
@@ -43,17 +44,24 @@ class WindowManagerAppWindowController implements AppWindowController {
     await _manager.hide();
     // window_manager 0.5.2 dispatches macOS orderOut asynchronously, so the
     // method channel can return while isVisible is still true.
-    await _waitUntilHidden();
+    if (await _becameHidden()) {
+      return;
+    }
+    try {
+      await _manager.show();
+    } catch (_) {}
+    throw StateError('window hide did not complete');
   }
 
-  Future<void> _waitUntilHidden() async {
+  Future<bool> _becameHidden() async {
     final deadline = DateTime.now().add(const Duration(milliseconds: 500));
     while (await _manager.isVisible()) {
       if (DateTime.now().isAfter(deadline)) {
-        return;
+        return false;
       }
       await Future<void>.delayed(const Duration(milliseconds: 16));
     }
+    return true;
   }
 
   @override

--- a/lib/src/features/app_window/infra/window_manager_app_window_controller.dart
+++ b/lib/src/features/app_window/infra/window_manager_app_window_controller.dart
@@ -39,6 +39,21 @@ class WindowManagerAppWindowController implements AppWindowController {
   Future<bool> isMinimized() => _manager.isMinimized();
 
   @override
+  Future<void> hide() => _manager.hide();
+
+  @override
+  Future<void> show() => _manager.show();
+
+  @override
+  Future<void> restore() => _manager.restore();
+
+  @override
+  Future<void> focus() => _manager.focus();
+
+  @override
+  Future<bool> isVisible() => _manager.isVisible();
+
+  @override
   Future<void> maximize() => _manager.maximize();
 
   @override

--- a/lib/src/features/app_window/infra/window_manager_app_window_controller.dart
+++ b/lib/src/features/app_window/infra/window_manager_app_window_controller.dart
@@ -39,7 +39,22 @@ class WindowManagerAppWindowController implements AppWindowController {
   Future<bool> isMinimized() => _manager.isMinimized();
 
   @override
-  Future<void> hide() => _manager.hide();
+  Future<void> hide() async {
+    await _manager.hide();
+    // window_manager 0.5.2 dispatches macOS orderOut asynchronously, so the
+    // method channel can return while isVisible is still true.
+    await _waitUntilHidden();
+  }
+
+  Future<void> _waitUntilHidden() async {
+    final deadline = DateTime.now().add(const Duration(milliseconds: 500));
+    while (await _manager.isVisible()) {
+      if (DateTime.now().isAfter(deadline)) {
+        return;
+      }
+      await Future<void>.delayed(const Duration(milliseconds: 16));
+    }
+  }
 
   @override
   Future<void> show() => _manager.show();

--- a/lib/src/features/desktop_presence/application/desktop_presence.dart
+++ b/lib/src/features/desktop_presence/application/desktop_presence.dart
@@ -1,0 +1,40 @@
+import 'package:alera/src/core/build_flavor.dart';
+import 'package:alera/src/features/agent_status/domain/agent_status.dart';
+import 'package:alera/src/features/desktop_presence/infra/desktop_presence_channel.dart';
+import 'package:alera/src/features/workbench/application/workspace_agent_status_projection.dart';
+import 'package:alera/src/features/workbench/domain/workspace_tab_record.dart';
+
+String linuxLauncherDesktopId({String bundleId = kAleraBundleId}) {
+  return '$bundleId.desktop';
+}
+
+String pendingReviewTooltip(int count) {
+  if (count <= 0) {
+    return kAleraAppName;
+  }
+  if (count == 1) {
+    return '1 agent needs attention';
+  }
+  return '$count agents need attention';
+}
+
+int pendingReviewCountForTabs({
+  required Iterable<WorkspaceTabRecord> tabs,
+  required Map<String, AgentStatusEntry> agentStatuses,
+}) {
+  return pendingReviewAgentCount(
+    visibleWorkspaceAgentRuns(tabs: tabs, agentStatuses: agentStatuses),
+  );
+}
+
+DesktopPresenceSnapshot desktopPresenceSnapshot({
+  required bool showTrayIcon,
+  required bool showDockBadge,
+  required int pendingReviewCount,
+}) {
+  return DesktopPresenceSnapshot(
+    trayVisible: showTrayIcon,
+    tooltip: pendingReviewTooltip(pendingReviewCount),
+    badgeCount: showDockBadge ? pendingReviewCount : 0,
+  );
+}

--- a/lib/src/features/desktop_presence/application/desktop_presence_coordinator.dart
+++ b/lib/src/features/desktop_presence/application/desktop_presence_coordinator.dart
@@ -21,6 +21,9 @@ class DesktopPresenceCoordinator {
   bool _started = false;
   Future<void> _applyQueue = Future<void>.value();
 
+  /// Hide-on-close follows a tray that was actually applied, not the setting.
+  bool get trayInstalled => _last?.trayVisible ?? false;
+
   void start() {
     if (_started) {
       return;
@@ -42,6 +45,7 @@ class DesktopPresenceCoordinator {
       return;
     }
     if ((_last?.trayVisible ?? false) && !snapshot.trayVisible) {
+      await lifecycle.waitForPendingHide();
       final hidden = !await window.isVisible();
       final minimized = await window.isMinimized();
       if ((hidden || minimized) && !await _showAndFocus()) {

--- a/lib/src/features/desktop_presence/application/desktop_presence_coordinator.dart
+++ b/lib/src/features/desktop_presence/application/desktop_presence_coordinator.dart
@@ -19,6 +19,7 @@ class DesktopPresenceCoordinator {
 
   DesktopPresenceSnapshot? _last;
   bool _started = false;
+  Future<void> _applyQueue = Future<void>.value();
 
   void start() {
     if (_started) {
@@ -28,16 +29,32 @@ class DesktopPresenceCoordinator {
     backend.listen(onShow: _showWindow, onQuit: _quit);
   }
 
-  Future<void> apply(DesktopPresenceSnapshot snapshot) async {
+  Future<void> apply(DesktopPresenceSnapshot snapshot) {
+    final pending = _applyQueue.then((_) => _applyNow(snapshot));
+    _applyQueue = pending.catchError((Object error, StackTrace stackTrace) {
+      _logger.warning('failed to apply desktop presence', error, stackTrace);
+    });
+    return _applyQueue;
+  }
+
+  Future<void> _applyNow(DesktopPresenceSnapshot snapshot) async {
     if (_last == snapshot) {
       return;
     }
-    _last = snapshot;
+    if ((_last?.trayVisible ?? false) && !snapshot.trayVisible) {
+      final hidden = !await window.isVisible();
+      final minimized = await window.isMinimized();
+      if ((hidden || minimized) && !await _showAndFocus()) {
+        return;
+      }
+    }
     try {
       await backend.apply(snapshot);
     } catch (error, stackTrace) {
       _logger.warning('failed to apply desktop presence', error, stackTrace);
+      return;
     }
+    _last = snapshot;
   }
 
   Future<void> destroy() async {
@@ -53,17 +70,22 @@ class DesktopPresenceCoordinator {
     unawaited(_showAndFocus());
   }
 
-  Future<void> _showAndFocus() async {
+  Future<bool> _showAndFocus() async {
     try {
       if (!await window.isVisible()) {
         await window.show();
+        if (!await window.isVisible()) {
+          return false;
+        }
       }
       if (await window.isMinimized()) {
         await window.restore();
       }
       await window.focus();
+      return true;
     } catch (error, stackTrace) {
       _logger.warning('failed to show app window from tray', error, stackTrace);
+      return false;
     }
   }
 

--- a/lib/src/features/desktop_presence/application/desktop_presence_coordinator.dart
+++ b/lib/src/features/desktop_presence/application/desktop_presence_coordinator.dart
@@ -1,0 +1,73 @@
+import 'dart:async';
+
+import 'package:alera/src/features/app_window/application/app_window_controller.dart';
+import 'package:alera/src/features/desktop_presence/infra/desktop_presence_channel.dart';
+import 'package:logging/logging.dart';
+
+class DesktopPresenceCoordinator {
+  DesktopPresenceCoordinator({
+    required this.backend,
+    required this.window,
+    required this.lifecycle,
+    Logger? logger,
+  }) : _logger = logger ?? Logger('DesktopPresenceCoordinator');
+
+  final DesktopPresenceBackend backend;
+  final AppWindowController window;
+  final AppWindowLifecycleCoordinator lifecycle;
+  final Logger _logger;
+
+  DesktopPresenceSnapshot? _last;
+  bool _started = false;
+
+  void start() {
+    if (_started) {
+      return;
+    }
+    _started = true;
+    backend.listen(onShow: _showWindow, onQuit: _quit);
+  }
+
+  Future<void> apply(DesktopPresenceSnapshot snapshot) async {
+    if (_last == snapshot) {
+      return;
+    }
+    _last = snapshot;
+    try {
+      await backend.apply(snapshot);
+    } catch (error, stackTrace) {
+      _logger.warning('failed to apply desktop presence', error, stackTrace);
+    }
+  }
+
+  Future<void> destroy() async {
+    _last = null;
+    try {
+      await backend.destroy();
+    } catch (error, stackTrace) {
+      _logger.warning('failed to destroy desktop presence', error, stackTrace);
+    }
+  }
+
+  void _showWindow() {
+    unawaited(_showAndFocus());
+  }
+
+  Future<void> _showAndFocus() async {
+    try {
+      if (!await window.isVisible()) {
+        await window.show();
+      }
+      if (await window.isMinimized()) {
+        await window.restore();
+      }
+      await window.focus();
+    } catch (error, stackTrace) {
+      _logger.warning('failed to show app window from tray', error, stackTrace);
+    }
+  }
+
+  void _quit() {
+    unawaited(lifecycle.requestQuit());
+  }
+}

--- a/lib/src/features/desktop_presence/application/desktop_presence_coordinator.dart
+++ b/lib/src/features/desktop_presence/application/desktop_presence_coordinator.dart
@@ -19,17 +19,23 @@ class DesktopPresenceCoordinator {
 
   DesktopPresenceSnapshot? _last;
   bool _started = false;
+  bool _trayInstalled = false;
+  bool _removingTray = false;
   Future<void> _applyQueue = Future<void>.value();
 
-  /// Hide-on-close follows a tray that was actually applied, not the setting.
-  bool get trayInstalled => _last?.trayVisible ?? false;
+  /// Hide-on-close follows a tray that is installed and not being removed.
+  bool get trayInstalled => _trayInstalled && !_removingTray;
 
   void start() {
     if (_started) {
       return;
     }
     _started = true;
-    backend.listen(onShow: _showWindow, onQuit: _quit);
+    backend.listen(
+      onShow: _showWindow,
+      onQuit: _quit,
+      onInstallationChanged: _onInstallationChanged,
+    );
   }
 
   Future<void> apply(DesktopPresenceSnapshot snapshot) {
@@ -41,28 +47,57 @@ class DesktopPresenceCoordinator {
   }
 
   Future<void> _applyNow(DesktopPresenceSnapshot snapshot) async {
-    if (_last == snapshot) {
+    if (_last == snapshot && _trayInstalled == snapshot.trayVisible) {
       return;
     }
-    if ((_last?.trayVisible ?? false) && !snapshot.trayVisible) {
-      await lifecycle.waitForPendingHide();
-      final hidden = !await window.isVisible();
-      final minimized = await window.isMinimized();
-      if ((hidden || minimized) && !await _showAndFocus()) {
-        return;
-      }
+    final removing = (_last?.trayVisible ?? false) && !snapshot.trayVisible;
+    if (removing) {
+      _removingTray = true;
     }
     try {
-      await backend.apply(snapshot);
-    } catch (error, stackTrace) {
-      _logger.warning('failed to apply desktop presence', error, stackTrace);
+      if (removing) {
+        await lifecycle.waitForPendingHide();
+        final hidden = !await window.isVisible();
+        final minimized = await window.isMinimized();
+        if ((hidden || minimized) && !await _showAndFocus()) {
+          return;
+        }
+      }
+      try {
+        await backend.apply(snapshot);
+      } catch (error, stackTrace) {
+        _logger.warning('failed to apply desktop presence', error, stackTrace);
+        return;
+      }
+      _last = snapshot;
+      _trayInstalled = snapshot.trayVisible;
+    } finally {
+      if (removing) {
+        _removingTray = false;
+      }
+    }
+  }
+
+  void _onInstallationChanged(bool installed) {
+    _trayInstalled = installed;
+    if (!installed) {
+      // TaskbarCreated reports unavailable before retrying. Wait a turn so a
+      // successful reinstall does not flash a hidden window.
+      unawaited(_recoverIfStillUninstalled());
+    }
+  }
+
+  Future<void> _recoverIfStillUninstalled() async {
+    await Future<void>.delayed(Duration.zero);
+    if (_trayInstalled) {
       return;
     }
-    _last = snapshot;
+    await _showAndFocus();
   }
 
   Future<void> destroy() async {
     _last = null;
+    _trayInstalled = false;
     try {
       await backend.destroy();
     } catch (error, stackTrace) {

--- a/lib/src/features/desktop_presence/application/desktop_presence_providers.dart
+++ b/lib/src/features/desktop_presence/application/desktop_presence_providers.dart
@@ -1,0 +1,99 @@
+import 'dart:async';
+
+import 'package:alera/src/features/agent_status/application/agent_status_controller.dart';
+import 'package:alera/src/features/agent_status/domain/agent_status.dart';
+import 'package:alera/src/features/app_window/application/app_window_platform.dart';
+import 'package:alera/src/features/app_window/application/app_window_providers.dart';
+import 'package:alera/src/features/desktop_presence/application/desktop_presence.dart';
+import 'package:alera/src/features/desktop_presence/application/desktop_presence_coordinator.dart';
+import 'package:alera/src/features/desktop_presence/infra/desktop_presence_channel.dart';
+import 'package:alera/src/features/settings/application/settings_controller.dart';
+import 'package:alera/src/features/workbench/application/workbench_controller.dart';
+import 'package:alera/src/features/workbench/domain/workspace_tab_record.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'desktop_presence_providers.g.dart';
+
+@Riverpod(keepAlive: true)
+DesktopPresenceBackend desktopPresenceBackend(Ref ref) {
+  return MethodChannelDesktopPresenceBackend();
+}
+
+@Riverpod(keepAlive: true)
+DesktopPresenceCoordinator desktopPresenceCoordinator(Ref ref) {
+  final coordinator = DesktopPresenceCoordinator(
+    backend: ref.watch(desktopPresenceBackendProvider),
+    window: ref.watch(appWindowControllerProvider),
+    lifecycle: ref.watch(appWindowLifecycleCoordinatorProvider),
+  );
+  ref.onDispose(() {
+    unawaited(coordinator.destroy());
+  });
+  return coordinator;
+}
+
+int pendingReviewAgentCountFromWorkbench({
+  required Map<String, List<WorkspaceTabRecord>> tabsByWorkspace,
+  required Map<String, AgentStatusEntry> agentStatuses,
+}) {
+  return pendingReviewCountForTabs(
+    tabs: tabsByWorkspace.values.expand((tabs) => tabs),
+    agentStatuses: agentStatuses,
+  );
+}
+
+/// Pushes tray visibility and the dock/taskbar badge whenever agent status or
+/// the related settings change. No-op off desktop.
+@Riverpod(keepAlive: true)
+void desktopPresenceSync(Ref ref) {
+  if (!supportsDesktopAppWindowState) {
+    return;
+  }
+  final coordinator = ref.watch(desktopPresenceCoordinatorProvider);
+  coordinator.start();
+  final lifecycle = ref.watch(appWindowLifecycleCoordinatorProvider);
+  lifecycle.bindHideOnClose(
+    () => ref.read(settingsControllerProvider).general.showTrayIcon,
+  );
+
+  void push() {
+    final settings = ref.read(settingsControllerProvider).general;
+    final count = pendingReviewAgentCountFromWorkbench(
+      tabsByWorkspace: ref.read(workbenchControllerProvider).tabsByWorkspace,
+      agentStatuses: ref.read(agentStatusControllerProvider),
+    );
+    unawaited(
+      coordinator.apply(
+        desktopPresenceSnapshot(
+          showTrayIcon: settings.showTrayIcon,
+          showDockBadge: settings.showDockBadge,
+          pendingReviewCount: count,
+        ),
+      ),
+    );
+  }
+
+  ref.listen(settingsControllerProvider.select((s) => s.general.showTrayIcon), (
+    _,
+    _,
+  ) {
+    push();
+  });
+  ref.listen(
+    settingsControllerProvider.select((s) => s.general.showDockBadge),
+    (_, _) {
+      push();
+    },
+  );
+  ref.listen(agentStatusControllerProvider, (_, _) {
+    push();
+  });
+  ref.listen(
+    workbenchControllerProvider.select((state) => state.tabsByWorkspace),
+    (_, _) {
+      push();
+    },
+  );
+  push();
+}

--- a/lib/src/features/desktop_presence/application/desktop_presence_providers.dart
+++ b/lib/src/features/desktop_presence/application/desktop_presence_providers.dart
@@ -53,9 +53,7 @@ void desktopPresenceSync(Ref ref) {
   final coordinator = ref.watch(desktopPresenceCoordinatorProvider);
   coordinator.start();
   final lifecycle = ref.watch(appWindowLifecycleCoordinatorProvider);
-  lifecycle.bindHideOnClose(
-    () => ref.read(settingsControllerProvider).general.showTrayIcon,
-  );
+  lifecycle.bindHideOnClose(() => coordinator.trayInstalled);
 
   void push() {
     final settings = ref.read(settingsControllerProvider).general;

--- a/lib/src/features/desktop_presence/application/desktop_presence_providers.g.dart
+++ b/lib/src/features/desktop_presence/application/desktop_presence_providers.g.dart
@@ -154,4 +154,4 @@ final class DesktopPresenceSyncProvider
 }
 
 String _$desktopPresenceSyncHash() =>
-    r'730e29a45a932e394d6eef87f1d1f22b3df8109f';
+    r'3df098f757656c21041cbe9df010cc12a532b8f9';

--- a/lib/src/features/desktop_presence/application/desktop_presence_providers.g.dart
+++ b/lib/src/features/desktop_presence/application/desktop_presence_providers.g.dart
@@ -1,0 +1,157 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'desktop_presence_providers.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(desktopPresenceBackend)
+final desktopPresenceBackendProvider = DesktopPresenceBackendProvider._();
+
+final class DesktopPresenceBackendProvider
+    extends
+        $FunctionalProvider<
+          DesktopPresenceBackend,
+          DesktopPresenceBackend,
+          DesktopPresenceBackend
+        >
+    with $Provider<DesktopPresenceBackend> {
+  DesktopPresenceBackendProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'desktopPresenceBackendProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$desktopPresenceBackendHash();
+
+  @$internal
+  @override
+  $ProviderElement<DesktopPresenceBackend> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  DesktopPresenceBackend create(Ref ref) {
+    return desktopPresenceBackend(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(DesktopPresenceBackend value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<DesktopPresenceBackend>(value),
+    );
+  }
+}
+
+String _$desktopPresenceBackendHash() =>
+    r'56fc4858ec39de0c53ad175a0724bb3ecbb5332b';
+
+@ProviderFor(desktopPresenceCoordinator)
+final desktopPresenceCoordinatorProvider =
+    DesktopPresenceCoordinatorProvider._();
+
+final class DesktopPresenceCoordinatorProvider
+    extends
+        $FunctionalProvider<
+          DesktopPresenceCoordinator,
+          DesktopPresenceCoordinator,
+          DesktopPresenceCoordinator
+        >
+    with $Provider<DesktopPresenceCoordinator> {
+  DesktopPresenceCoordinatorProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'desktopPresenceCoordinatorProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$desktopPresenceCoordinatorHash();
+
+  @$internal
+  @override
+  $ProviderElement<DesktopPresenceCoordinator> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  DesktopPresenceCoordinator create(Ref ref) {
+    return desktopPresenceCoordinator(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(DesktopPresenceCoordinator value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<DesktopPresenceCoordinator>(value),
+    );
+  }
+}
+
+String _$desktopPresenceCoordinatorHash() =>
+    r'a32b4658226e232de8d8273c2d216012775efdfb';
+
+/// Pushes tray visibility and the dock/taskbar badge whenever agent status or
+/// the related settings change. No-op off desktop.
+
+@ProviderFor(desktopPresenceSync)
+final desktopPresenceSyncProvider = DesktopPresenceSyncProvider._();
+
+/// Pushes tray visibility and the dock/taskbar badge whenever agent status or
+/// the related settings change. No-op off desktop.
+
+final class DesktopPresenceSyncProvider
+    extends $FunctionalProvider<void, void, void>
+    with $Provider<void> {
+  /// Pushes tray visibility and the dock/taskbar badge whenever agent status or
+  /// the related settings change. No-op off desktop.
+  DesktopPresenceSyncProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'desktopPresenceSyncProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$desktopPresenceSyncHash();
+
+  @$internal
+  @override
+  $ProviderElement<void> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  void create(Ref ref) {
+    return desktopPresenceSync(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(void value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<void>(value),
+    );
+  }
+}
+
+String _$desktopPresenceSyncHash() =>
+    r'730e29a45a932e394d6eef87f1d1f22b3df8109f';

--- a/lib/src/features/desktop_presence/infra/desktop_presence_channel.dart
+++ b/lib/src/features/desktop_presence/infra/desktop_presence_channel.dart
@@ -1,0 +1,92 @@
+import 'dart:async';
+
+import 'package:flutter/services.dart';
+
+const String desktopPresenceChannelName = 'dev.leynier.alera/desktop_presence';
+
+abstract final class DesktopPresenceMethod {
+  static const String setTray = 'setTray';
+  static const String setBadgeCount = 'setBadgeCount';
+  static const String destroy = 'destroy';
+}
+
+abstract final class DesktopPresenceEvent {
+  static const String trayShow = 'trayShow';
+  static const String trayQuit = 'trayQuit';
+}
+
+class DesktopPresenceSnapshot {
+  const DesktopPresenceSnapshot({
+    required this.trayVisible,
+    required this.tooltip,
+    required this.badgeCount,
+  });
+
+  final bool trayVisible;
+  final String tooltip;
+  final int badgeCount;
+
+  @override
+  bool operator ==(Object other) {
+    return other is DesktopPresenceSnapshot &&
+        other.trayVisible == trayVisible &&
+        other.tooltip == tooltip &&
+        other.badgeCount == badgeCount;
+  }
+
+  @override
+  int get hashCode => Object.hash(trayVisible, tooltip, badgeCount);
+}
+
+abstract interface class DesktopPresenceBackend {
+  void listen({required VoidCallback onShow, required VoidCallback onQuit});
+
+  Future<void> apply(DesktopPresenceSnapshot snapshot);
+
+  Future<void> destroy();
+}
+
+class MethodChannelDesktopPresenceBackend implements DesktopPresenceBackend {
+  MethodChannelDesktopPresenceBackend({MethodChannel? channel})
+    : _channel = channel ?? const MethodChannel(desktopPresenceChannelName);
+
+  final MethodChannel _channel;
+  bool _listening = false;
+
+  @override
+  void listen({required VoidCallback onShow, required VoidCallback onQuit}) {
+    if (_listening) {
+      return;
+    }
+    _listening = true;
+    _channel.setMethodCallHandler((call) async {
+      switch (call.method) {
+        case DesktopPresenceEvent.trayShow:
+          onShow();
+        case DesktopPresenceEvent.trayQuit:
+          onQuit();
+      }
+      return null;
+    });
+  }
+
+  @override
+  Future<void> apply(DesktopPresenceSnapshot snapshot) async {
+    await _channel.invokeMethod<void>(
+      DesktopPresenceMethod.setTray,
+      <String, Object?>{
+        'visible': snapshot.trayVisible,
+        'tooltip': snapshot.tooltip,
+      },
+    );
+    await _channel.invokeMethod<void>(
+      DesktopPresenceMethod.setBadgeCount,
+      <String, Object?>{'count': snapshot.badgeCount},
+    );
+  }
+
+  @override
+  Future<void> destroy() {
+    return _channel.invokeMethod<void>(DesktopPresenceMethod.destroy);
+  }
+}

--- a/lib/src/features/desktop_presence/infra/desktop_presence_channel.dart
+++ b/lib/src/features/desktop_presence/infra/desktop_presence_channel.dart
@@ -72,13 +72,16 @@ class MethodChannelDesktopPresenceBackend implements DesktopPresenceBackend {
 
   @override
   Future<void> apply(DesktopPresenceSnapshot snapshot) async {
-    await _channel.invokeMethod<void>(
+    final installed = await _channel.invokeMethod<Object?>(
       DesktopPresenceMethod.setTray,
       <String, Object?>{
         'visible': snapshot.trayVisible,
         'tooltip': snapshot.tooltip,
       },
     );
+    if (snapshot.trayVisible && installed == false) {
+      throw StateError('desktop tray was not installed');
+    }
     await _channel.invokeMethod<void>(
       DesktopPresenceMethod.setBadgeCount,
       <String, Object?>{'count': snapshot.badgeCount},

--- a/lib/src/features/desktop_presence/infra/desktop_presence_channel.dart
+++ b/lib/src/features/desktop_presence/infra/desktop_presence_channel.dart
@@ -13,6 +13,7 @@ abstract final class DesktopPresenceMethod {
 abstract final class DesktopPresenceEvent {
   static const String trayShow = 'trayShow';
   static const String trayQuit = 'trayQuit';
+  static const String trayInstallationChanged = 'trayInstallationChanged';
 }
 
 class DesktopPresenceSnapshot {
@@ -39,7 +40,11 @@ class DesktopPresenceSnapshot {
 }
 
 abstract interface class DesktopPresenceBackend {
-  void listen({required VoidCallback onShow, required VoidCallback onQuit});
+  void listen({
+    required VoidCallback onShow,
+    required VoidCallback onQuit,
+    void Function(bool installed)? onInstallationChanged,
+  });
 
   Future<void> apply(DesktopPresenceSnapshot snapshot);
 
@@ -54,7 +59,11 @@ class MethodChannelDesktopPresenceBackend implements DesktopPresenceBackend {
   bool _listening = false;
 
   @override
-  void listen({required VoidCallback onShow, required VoidCallback onQuit}) {
+  void listen({
+    required VoidCallback onShow,
+    required VoidCallback onQuit,
+    void Function(bool installed)? onInstallationChanged,
+  }) {
     if (_listening) {
       return;
     }
@@ -65,6 +74,8 @@ class MethodChannelDesktopPresenceBackend implements DesktopPresenceBackend {
           onShow();
         case DesktopPresenceEvent.trayQuit:
           onQuit();
+        case DesktopPresenceEvent.trayInstallationChanged:
+          onInstallationChanged?.call(call.arguments == true);
       }
       return null;
     });

--- a/lib/src/features/desktop_presence/presentation/desktop_presence_scope.dart
+++ b/lib/src/features/desktop_presence/presentation/desktop_presence_scope.dart
@@ -1,0 +1,20 @@
+import 'package:alera/src/features/app_window/application/app_window_platform.dart';
+import 'package:alera/src/features/desktop_presence/application/desktop_presence_providers.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Watches agent status and desktop settings so the tray icon and dock badge
+/// stay in sync. Mounted once at the app root.
+class DesktopPresenceScope extends ConsumerWidget {
+  const DesktopPresenceScope({super.key, required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    if (supportsDesktopAppWindowState) {
+      ref.watch(desktopPresenceSyncProvider);
+    }
+    return child;
+  }
+}

--- a/lib/src/features/runtime_host/presentation/runtime_host_quit_gate_scope.dart
+++ b/lib/src/features/runtime_host/presentation/runtime_host_quit_gate_scope.dart
@@ -60,6 +60,12 @@ class _RuntimeHostQuitGateScopeState
     if (!mounted) {
       return RuntimeHostQuitDecision.cancel;
     }
+    // Tray Quit can fire while the window is hidden. The confirmation dialog
+    // is in-window, so the window has to be visible first.
+    await _showWindowForQuitConfirmation();
+    if (!mounted) {
+      return RuntimeHostQuitDecision.cancel;
+    }
     final decision = await showDialog<RuntimeHostQuitDecision>(
       context: context,
       builder: (_) => AleraChoiceDialog<RuntimeHostQuitDecision>(
@@ -73,6 +79,22 @@ class _RuntimeHostQuitGateScopeState
       ),
     );
     return decision ?? RuntimeHostQuitDecision.cancel;
+  }
+
+  Future<void> _showWindowForQuitConfirmation() async {
+    final window = ref.read(appWindowControllerProvider);
+    try {
+      if (!await window.isVisible()) {
+        await window.show();
+      }
+      if (await window.isMinimized()) {
+        await window.restore();
+      }
+      await window.focus();
+    } catch (_) {
+      // The dialog still tries to open; a hidden window is worse than a
+      // failed restore.
+    }
   }
 
   @override

--- a/lib/src/features/settings/application/settings_controller.dart
+++ b/lib/src/features/settings/application/settings_controller.dart
@@ -152,6 +152,24 @@ class SettingsController extends _$SettingsController {
     );
   }
 
+  Future<void> setShowTrayIcon(bool value) async {
+    if (state.general.showTrayIcon == value) {
+      return;
+    }
+    await _save(
+      state.copyWith(general: state.general.copyWith(showTrayIcon: value)),
+    );
+  }
+
+  Future<void> setShowDockBadge(bool value) async {
+    if (state.general.showDockBadge == value) {
+      return;
+    }
+    await _save(
+      state.copyWith(general: state.general.copyWith(showDockBadge: value)),
+    );
+  }
+
   Future<void> setAgentStatusHookEnabled(
     AgentType agentType,
     bool value,

--- a/lib/src/features/settings/application/settings_controller.g.dart
+++ b/lib/src/features/settings/application/settings_controller.g.dart
@@ -42,7 +42,7 @@ final class SettingsControllerProvider
 }
 
 String _$settingsControllerHash() =>
-    r'8f1ada0ea26dd8aba97db18aaeff1f8a95f5244c';
+    r'fcc6fc5a417916b776800a1c18748262fbefdd64';
 
 abstract class _$SettingsController extends $Notifier<AleraSettings> {
   AleraSettings build();

--- a/lib/src/features/settings/domain/alera_settings.dart
+++ b/lib/src/features/settings/domain/alera_settings.dart
@@ -299,6 +299,8 @@ class GeneralSettings with GeneralSettingsMappable {
     this.confirmProjectRemoval = true,
     this.confirmWorkspaceRemoval = true,
     this.keepAliveEnabled = false,
+    this.showTrayIcon = true,
+    this.showDockBadge = true,
   });
 
   /// User-configured root directory where new linked workspaces are created.
@@ -320,6 +322,17 @@ class GeneralSettings with GeneralSettingsMappable {
   ///
   /// Lid-close and explicit sleep still follow the device power policy.
   final bool keepAliveEnabled;
+
+  /// Keep a tray / menu-extra / AppIndicator icon while the desktop app runs.
+  ///
+  /// When this is on, closing the window hides it; Quit from the tray or the
+  /// app menu still exits. Missing from older settings blobs, so those decode
+  /// as on.
+  final bool showTrayIcon;
+
+  /// Show how many agents are waiting for review on the Dock, taskbar, or
+  /// Ubuntu Dock. Missing from older settings blobs, so those decode as on.
+  final bool showDockBadge;
 
   static const GeneralSettings defaults = GeneralSettings();
 

--- a/lib/src/features/settings/domain/alera_settings.dart
+++ b/lib/src/features/settings/domain/alera_settings.dart
@@ -307,9 +307,7 @@ class GeneralSettings with GeneralSettingsMappable {
   /// `null` falls back to the platform default (`~/.alera/workspaces`).
   final String? workspaceDirectory;
 
-  /// Local flag set after the user has interacted with the GitHub star flow.
-  /// Used to mute the in-app nag; the Settings row state is still driven by
-  /// the live `gh` check.
+  /// Local flag after the GitHub star flow; Settings still uses the live `gh` check.
   final bool starClicked;
 
   /// Ask before unregistering a project and deleting its workspace metadata.
@@ -318,22 +316,14 @@ class GeneralSettings with GeneralSettingsMappable {
   /// Ask before removing a linked workspace and its Git worktree.
   final bool confirmWorkspaceRemoval;
 
-  /// Prevent idle sleep and display sleep while Alera is running.
-  ///
-  /// Lid-close and explicit sleep still follow the device power policy.
+  /// Prevent idle and display sleep while Alera is running.
   final bool keepAliveEnabled;
 
-  /// Keep a tray / menu-extra / AppIndicator icon while the desktop app runs.
-  ///
-  /// When this is on, closing the window hides it; Quit from the tray or the
-  /// app menu still exits. Missing from older settings blobs, so those decode
-  /// as on.
+  /// Tray icon. Close hides; Quit still exits.
   final bool showTrayIcon;
 
-  /// Show how many agents are waiting for review on the Dock, taskbar, or
-  /// Ubuntu Dock. Missing from older settings blobs, so those decode as on.
+  /// Pending-review Dock / taskbar badge.
   final bool showDockBadge;
-
   static const GeneralSettings defaults = GeneralSettings();
 
   factory GeneralSettings.fromJson(Map<String, Object?> json) =>

--- a/lib/src/features/settings/domain/alera_settings.mapper.dart
+++ b/lib/src/features/settings/domain/alera_settings.mapper.dart
@@ -1416,6 +1416,20 @@ class GeneralSettingsMapper extends ClassMapperBase<GeneralSettings> {
     opt: true,
     def: false,
   );
+  static bool _$showTrayIcon(GeneralSettings v) => v.showTrayIcon;
+  static const Field<GeneralSettings, bool> _f$showTrayIcon = Field(
+    'showTrayIcon',
+    _$showTrayIcon,
+    opt: true,
+    def: true,
+  );
+  static bool _$showDockBadge(GeneralSettings v) => v.showDockBadge;
+  static const Field<GeneralSettings, bool> _f$showDockBadge = Field(
+    'showDockBadge',
+    _$showDockBadge,
+    opt: true,
+    def: true,
+  );
 
   @override
   final MappableFields<GeneralSettings> fields = const {
@@ -1424,6 +1438,8 @@ class GeneralSettingsMapper extends ClassMapperBase<GeneralSettings> {
     #confirmProjectRemoval: _f$confirmProjectRemoval,
     #confirmWorkspaceRemoval: _f$confirmWorkspaceRemoval,
     #keepAliveEnabled: _f$keepAliveEnabled,
+    #showTrayIcon: _f$showTrayIcon,
+    #showDockBadge: _f$showDockBadge,
   };
 
   static GeneralSettings _instantiate(DecodingData data) {
@@ -1433,6 +1449,8 @@ class GeneralSettingsMapper extends ClassMapperBase<GeneralSettings> {
       confirmProjectRemoval: data.dec(_f$confirmProjectRemoval),
       confirmWorkspaceRemoval: data.dec(_f$confirmWorkspaceRemoval),
       keepAliveEnabled: data.dec(_f$keepAliveEnabled),
+      showTrayIcon: data.dec(_f$showTrayIcon),
+      showDockBadge: data.dec(_f$showDockBadge),
     );
   }
 
@@ -1504,6 +1522,8 @@ abstract class GeneralSettingsCopyWith<$R, $In extends GeneralSettings, $Out>
     bool? confirmProjectRemoval,
     bool? confirmWorkspaceRemoval,
     bool? keepAliveEnabled,
+    bool? showTrayIcon,
+    bool? showDockBadge,
   });
   GeneralSettingsCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(
     Then<$Out2, $R2> t,
@@ -1525,6 +1545,8 @@ class _GeneralSettingsCopyWithImpl<$R, $Out>
     bool? confirmProjectRemoval,
     bool? confirmWorkspaceRemoval,
     bool? keepAliveEnabled,
+    bool? showTrayIcon,
+    bool? showDockBadge,
   }) => $apply(
     FieldCopyWithData({
       if (workspaceDirectory != $none) #workspaceDirectory: workspaceDirectory,
@@ -1534,6 +1556,8 @@ class _GeneralSettingsCopyWithImpl<$R, $Out>
       if (confirmWorkspaceRemoval != null)
         #confirmWorkspaceRemoval: confirmWorkspaceRemoval,
       if (keepAliveEnabled != null) #keepAliveEnabled: keepAliveEnabled,
+      if (showTrayIcon != null) #showTrayIcon: showTrayIcon,
+      if (showDockBadge != null) #showDockBadge: showDockBadge,
     }),
   );
   @override
@@ -1552,6 +1576,8 @@ class _GeneralSettingsCopyWithImpl<$R, $Out>
       or: $value.confirmWorkspaceRemoval,
     ),
     keepAliveEnabled: data.get(#keepAliveEnabled, or: $value.keepAliveEnabled),
+    showTrayIcon: data.get(#showTrayIcon, or: $value.showTrayIcon),
+    showDockBadge: data.get(#showDockBadge, or: $value.showDockBadge),
   );
 
   @override

--- a/lib/src/features/settings/presentation/panes/application_pane.dart
+++ b/lib/src/features/settings/presentation/panes/application_pane.dart
@@ -75,6 +75,31 @@ class ApplicationSettingsPane extends ConsumerWidget {
         ),
         const SizedBox(height: AleraTokens.space16),
         KeyedSubtree(
+          key: groupKeys['desktop'],
+          child: AleraSettingsGroup(
+            title: 'Desktop',
+            description:
+                'Tray icon and dock or taskbar badge while Alera is running.',
+            children: <Widget>[
+              SettingsSwitchRow(
+                title: 'Show Tray Icon',
+                description:
+                    'Keep Alera in the menu extra (macOS), notification area (Windows), or status bar (Ubuntu). Closing the window hides it; Quit from the tray or the app menu exits.',
+                value: general.showTrayIcon,
+                onChanged: (value) => controller.setShowTrayIcon(value),
+              ),
+              SettingsSwitchRow(
+                title: 'Show Dock Badge',
+                description:
+                    'Show how many agents are waiting for review on the Dock, taskbar, or Ubuntu Dock.',
+                value: general.showDockBadge,
+                onChanged: (value) => controller.setShowDockBadge(value),
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(height: AleraTokens.space16),
+        KeyedSubtree(
           key: groupKeys['runtime'],
           child: AleraSettingsGroup(
             title: 'Runtime',

--- a/lib/src/features/settings/presentation/settings_dialog.dart
+++ b/lib/src/features/settings/presentation/settings_dialog.dart
@@ -159,6 +159,7 @@ class _SettingsDialogState extends ConsumerState<SettingsDialog> {
     const applicationGroups = <SettingsGroupSpec>[
       SettingsGroupSpec(id: 'storage', title: 'Storage'),
       SettingsGroupSpec(id: 'safety', title: 'Safety'),
+      SettingsGroupSpec(id: 'desktop', title: 'Desktop'),
       SettingsGroupSpec(id: 'runtime', title: 'Runtime'),
       SettingsGroupSpec(id: 'diagnostics', title: 'Diagnostics'),
       SettingsGroupSpec(id: 'updates', title: 'Updates'),

--- a/lib/src/features/settings/presentation/settings_search_entries.dart
+++ b/lib/src/features/settings/presentation/settings_search_entries.dart
@@ -20,6 +20,34 @@ applicationSearchEntries = buildSettingsSearchEntryCatalog(const {
       keywords: <String>['safety', 'destructive', 'remove', 'delete'],
     ),
   },
+  'desktop': {
+    'Show Tray Icon': SettingsSearchEntryDetails(
+      description:
+          'Keep Alera in the menu extra, notification area, or Ubuntu status bar.',
+      keywords: <String>[
+        'tray',
+        'status bar',
+        'menu extra',
+        'notification area',
+        'appindicator',
+        'hide',
+        'close',
+      ],
+    ),
+    'Show Dock Badge': SettingsSearchEntryDetails(
+      description:
+          'Show how many agents are waiting for review on the Dock or taskbar.',
+      keywords: <String>[
+        'dock',
+        'taskbar',
+        'badge',
+        'count',
+        'attention',
+        'review',
+        'ubuntu',
+      ],
+    ),
+  },
   'runtime': {
     'Keep Computer Awake': SettingsSearchEntryDetails(
       description:

--- a/lib/src/features/workbench/application/workbench_agent_activity_sort.dart
+++ b/lib/src/features/workbench/application/workbench_agent_activity_sort.dart
@@ -62,14 +62,14 @@ WorkspaceAttention workspaceAttention({
 }
 
 AgentAttentionClass _classify(AgentStatusEntry status) {
-  if (status.interrupted ?? false) {
+  if (agentStatusNeedsYou(status)) {
     return AgentAttentionClass.needsYou;
   }
   return switch (status.state) {
-    AgentStatusState.waiting ||
-    AgentStatusState.blocked => AgentAttentionClass.needsYou,
     AgentStatusState.done => AgentAttentionClass.done,
     AgentStatusState.working => AgentAttentionClass.working,
+    AgentStatusState.waiting ||
+    AgentStatusState.blocked => AgentAttentionClass.needsYou,
   };
 }
 

--- a/lib/src/features/workbench/application/workspace_agent_status_projection.dart
+++ b/lib/src/features/workbench/application/workspace_agent_status_projection.dart
@@ -103,6 +103,28 @@ int _compareAgentRuns(WorkspaceAgentRun a, WorkspaceAgentRun b) {
   return a.tab.createdAt.compareTo(b.tab.createdAt);
 }
 
+/// Agents that currently need the user: waiting, blocked, or interrupted.
+int pendingReviewAgentCount(Iterable<WorkspaceAgentRun> runs) {
+  var count = 0;
+  for (final run in runs) {
+    if (agentStatusNeedsYou(run.status)) {
+      count += 1;
+    }
+  }
+  return count;
+}
+
+/// Shared with Agent Activity: interruption and waiting/blocked need the user.
+bool agentStatusNeedsYou(AgentStatusEntry status) {
+  if (status.interrupted ?? false) {
+    return true;
+  }
+  return switch (status.state) {
+    AgentStatusState.waiting || AgentStatusState.blocked => true,
+    AgentStatusState.working || AgentStatusState.done => false,
+  };
+}
+
 // Compact tray and Agent Activity treat interruption as attention, not as
 // a finished run. Ranking it above working/done keeps the glyph from
 // turning green (or spinning) over a leftover interrupted tab.

--- a/linux/runner/CMakeLists.txt
+++ b/linux/runner/CMakeLists.txt
@@ -9,6 +9,7 @@ project(runner LANGUAGES CXX)
 add_executable(${BINARY_NAME}
   "main.cc"
   "my_application.cc"
+  "desktop_presence.cc"
   "${FLUTTER_MANAGED_DIR}/generated_plugin_registrant.cc"
 )
 
@@ -23,5 +24,7 @@ target_compile_definitions(${BINARY_NAME} PRIVATE ALERA_APP_NAME="${ALERA_APP_NA
 # Add dependency libraries. Add any application-specific dependencies here.
 target_link_libraries(${BINARY_NAME} PRIVATE flutter)
 target_link_libraries(${BINARY_NAME} PRIVATE PkgConfig::GTK)
+pkg_check_modules(AYATANA REQUIRED IMPORTED_TARGET ayatana-appindicator3-0.1)
+target_link_libraries(${BINARY_NAME} PRIVATE PkgConfig::AYATANA)
 
 target_include_directories(${BINARY_NAME} PRIVATE "${CMAKE_SOURCE_DIR}")

--- a/linux/runner/desktop_presence.cc
+++ b/linux/runner/desktop_presence.cc
@@ -1,0 +1,267 @@
+#include "desktop_presence.h"
+
+#include <gtk/gtk.h>
+
+#include <libayatana-appindicator/app-indicator.h>
+
+namespace {
+
+constexpr char kChannelName[] = "dev.leynier.alera/desktop_presence";
+constexpr char kLauncherInterface[] = "com.canonical.Unity.LauncherEntry";
+
+static gchar* launcher_object_path() {
+  guint32 hash = g_str_hash(APPLICATION_ID);
+  return g_strdup_printf("/com/canonical/unity/launcherentry/%u", hash);
+}
+
+}  // namespace
+
+struct _DesktopPresence {
+  FlMethodChannel* channel;
+  AppIndicator* indicator;
+  GtkWidget* menu;
+  GtkWidget* show_item;
+  guint launcher_owner_watch;
+  guint launcher_registration;
+  GDBusConnection* bus;
+  int badge_count;
+};
+
+static gchar* launcher_app_uri() {
+  return g_strdup_printf("application://%s.desktop", APPLICATION_ID);
+}
+
+static void ensure_launcher_object(DesktopPresence* self);
+
+static void emit_launcher_update(DesktopPresence* self) {
+  GDBusConnection* bus = self->bus;
+  if (bus == nullptr) {
+    return;
+  }
+  GVariantBuilder builder;
+  g_variant_builder_init(&builder, G_VARIANT_TYPE("a{sv}"));
+  const gboolean visible = self->badge_count > 0;
+  g_variant_builder_add(&builder, "{sv}", "count",
+                        g_variant_new_int64(self->badge_count));
+  g_variant_builder_add(&builder, "{sv}", "count-visible",
+                        g_variant_new_boolean(visible));
+  g_autoptr(gchar) app_uri = launcher_app_uri();
+  g_autoptr(gchar) object_path = launcher_object_path();
+  g_dbus_connection_emit_signal(
+      bus, nullptr, object_path, kLauncherInterface, "Update",
+      g_variant_new("(s@a{sv})", app_uri, g_variant_builder_end(&builder)),
+      nullptr);
+}
+
+static void launcher_query(GDBusConnection*,
+                           const gchar*,
+                           const gchar*,
+                           const gchar*,
+                           const gchar*,
+                           GVariant*,
+                           GDBusMethodInvocation* invocation,
+                           gpointer user_data) {
+  auto* self = static_cast<DesktopPresence*>(user_data);
+  GVariantBuilder builder;
+  g_variant_builder_init(&builder, G_VARIANT_TYPE("a{sv}"));
+  const gboolean visible = self->badge_count > 0;
+  g_variant_builder_add(&builder, "{sv}", "count",
+                        g_variant_new_int64(self->badge_count));
+  g_variant_builder_add(&builder, "{sv}", "count-visible",
+                        g_variant_new_boolean(visible));
+  g_autoptr(gchar) app_uri = launcher_app_uri();
+  g_dbus_method_invocation_return_value(
+      invocation,
+      g_variant_new("(s@a{sv})", app_uri, g_variant_builder_end(&builder)));
+}
+
+static void on_unity_appeared(GDBusConnection*,
+                              const gchar*,
+                              const gchar*,
+                              gpointer user_data) {
+  auto* self = static_cast<DesktopPresence*>(user_data);
+  ensure_launcher_object(self);
+  emit_launcher_update(self);
+}
+
+static const GDBusInterfaceVTable kLauncherVtable = {
+    launcher_query,
+    nullptr,
+    nullptr,
+    {},
+};
+
+static void ensure_launcher_object(DesktopPresence* self) {
+  if (self->launcher_registration != 0) {
+    return;
+  }
+  if (self->bus == nullptr) {
+    self->bus = g_bus_get_sync(G_BUS_TYPE_SESSION, nullptr, nullptr);
+  }
+  GDBusConnection* bus = self->bus;
+  if (bus == nullptr) {
+    return;
+  }
+  g_autoptr(GDBusNodeInfo) info = g_dbus_node_info_new_for_xml(
+      "<node>"
+      "  <interface name='com.canonical.Unity.LauncherEntry'>"
+      "    <method name='Query'>"
+      "      <arg type='s' name='app_uri' direction='out'/>"
+      "      <arg type='a{sv}' name='properties' direction='out'/>"
+      "    </method>"
+      "    <signal name='Update'>"
+      "      <arg type='s' name='app_uri'/>"
+      "      <arg type='a{sv}' name='properties'/>"
+      "    </signal>"
+      "  </interface>"
+      "</node>",
+      nullptr);
+  if (info == nullptr) {
+    return;
+  }
+  g_autoptr(gchar) object_path = launcher_object_path();
+  self->launcher_registration = g_dbus_connection_register_object(
+      bus, object_path, info->interfaces[0], &kLauncherVtable, self, nullptr,
+      nullptr);
+}
+
+static void invoke_event(DesktopPresence* self, const char* method) {
+  if (self->channel == nullptr) {
+    return;
+  }
+  fl_method_channel_invoke_method(self->channel, method, nullptr, nullptr,
+                                  nullptr, nullptr);
+}
+
+static void on_show_activate(GtkMenuItem*, gpointer user_data) {
+  invoke_event(static_cast<DesktopPresence*>(user_data), "trayShow");
+}
+
+static void on_quit_activate(GtkMenuItem*, gpointer user_data) {
+  invoke_event(static_cast<DesktopPresence*>(user_data), "trayQuit");
+}
+
+static GtkWidget* build_menu(DesktopPresence* self) {
+  GtkWidget* menu = gtk_menu_new();
+  GtkWidget* show_item = gtk_menu_item_new_with_label("Show " ALERA_APP_NAME);
+  GtkWidget* quit_item = gtk_menu_item_new_with_label("Quit");
+  gtk_menu_shell_append(GTK_MENU_SHELL(menu), show_item);
+  gtk_menu_shell_append(GTK_MENU_SHELL(menu), gtk_separator_menu_item_new());
+  gtk_menu_shell_append(GTK_MENU_SHELL(menu), quit_item);
+  g_signal_connect(show_item, "activate", G_CALLBACK(on_show_activate), self);
+  g_signal_connect(quit_item, "activate", G_CALLBACK(on_quit_activate), self);
+  gtk_widget_show_all(menu);
+  self->show_item = show_item;
+  return menu;
+}
+
+static void set_tray(DesktopPresence* self, bool visible,
+                     const gchar* tooltip) {
+  if (!visible) {
+    if (self->indicator != nullptr) {
+      app_indicator_set_status(self->indicator, APP_INDICATOR_STATUS_PASSIVE);
+    }
+    return;
+  }
+  if (self->indicator == nullptr) {
+    self->menu = build_menu(self);
+    self->indicator = app_indicator_new(APPLICATION_ID, "alera",
+                                        APP_INDICATOR_CATEGORY_APPLICATION_STATUS);
+    app_indicator_set_menu(self->indicator, GTK_MENU(self->menu));
+    // Primary click opens the AppIndicator menu. Middle-click / secondary
+    // activate runs Show, which is the protocol the indicator actually
+    // exposes for a direct show action.
+    app_indicator_set_secondary_activate_target(self->indicator,
+                                                self->show_item);
+  }
+  (void)tooltip;
+  app_indicator_set_status(self->indicator, APP_INDICATOR_STATUS_ACTIVE);
+}
+
+static void method_call_cb(FlMethodChannel*,
+                           FlMethodCall* method_call,
+                           gpointer user_data) {
+  auto* self = static_cast<DesktopPresence*>(user_data);
+  const gchar* method = fl_method_call_get_name(method_call);
+  FlValue* args = fl_method_call_get_args(method_call);
+  if (g_strcmp0(method, "setTray") == 0) {
+    bool visible = false;
+    const gchar* tooltip = "";
+    if (fl_value_get_type(args) == FL_VALUE_TYPE_MAP) {
+      FlValue* visible_value = fl_value_lookup_string(args, "visible");
+      if (visible_value != nullptr &&
+          fl_value_get_type(visible_value) == FL_VALUE_TYPE_BOOL) {
+        visible = fl_value_get_bool(visible_value);
+      }
+      FlValue* tooltip_value = fl_value_lookup_string(args, "tooltip");
+      if (tooltip_value != nullptr &&
+          fl_value_get_type(tooltip_value) == FL_VALUE_TYPE_STRING) {
+        tooltip = fl_value_get_string(tooltip_value);
+      }
+    }
+    set_tray(self, visible, tooltip);
+    fl_method_call_respond_success(method_call, nullptr, nullptr);
+    return;
+  }
+  if (g_strcmp0(method, "setBadgeCount") == 0) {
+    int count = 0;
+    if (fl_value_get_type(args) == FL_VALUE_TYPE_MAP) {
+      FlValue* count_value = fl_value_lookup_string(args, "count");
+      if (count_value != nullptr) {
+        switch (fl_value_get_type(count_value)) {
+          case FL_VALUE_TYPE_INT:
+            count = static_cast<int>(fl_value_get_int(count_value));
+            break;
+          default:
+            break;
+        }
+      }
+    }
+    self->badge_count = count < 0 ? 0 : count;
+    ensure_launcher_object(self);
+    emit_launcher_update(self);
+    fl_method_call_respond_success(method_call, nullptr, nullptr);
+    return;
+  }
+  if (g_strcmp0(method, "destroy") == 0) {
+    set_tray(self, false, "");
+    self->badge_count = 0;
+    emit_launcher_update(self);
+    fl_method_call_respond_success(method_call, nullptr, nullptr);
+    return;
+  }
+  fl_method_call_respond_not_implemented(method_call, nullptr);
+}
+
+DesktopPresence* desktop_presence_new(FlEngine* engine) {
+  auto* self = g_new0(DesktopPresence, 1);
+  g_autoptr(FlStandardMethodCodec) codec = fl_standard_method_codec_new();
+  self->channel = fl_method_channel_new(fl_engine_get_binary_messenger(engine),
+                                        kChannelName, FL_METHOD_CODEC(codec));
+  fl_method_channel_set_method_call_handler(self->channel, method_call_cb, self,
+                                            nullptr);
+  self->launcher_owner_watch = g_bus_watch_name(
+      G_BUS_TYPE_SESSION, "com.canonical.Unity", G_BUS_NAME_WATCHER_FLAGS_NONE,
+      on_unity_appeared, nullptr, self, nullptr);
+  return self;
+}
+
+void desktop_presence_free(DesktopPresence* presence) {
+  if (presence == nullptr) {
+    return;
+  }
+  if (presence->launcher_owner_watch != 0) {
+    g_bus_unwatch_name(presence->launcher_owner_watch);
+  }
+  if (presence->bus != nullptr && presence->launcher_registration != 0) {
+    g_dbus_connection_unregister_object(presence->bus,
+                                        presence->launcher_registration);
+  }
+  g_clear_object(&presence->bus);
+  if (presence->indicator != nullptr) {
+    app_indicator_set_status(presence->indicator, APP_INDICATOR_STATUS_PASSIVE);
+    g_clear_object(&presence->indicator);
+  }
+  g_clear_object(&presence->channel);
+  g_free(presence);
+}

--- a/linux/runner/desktop_presence.cc
+++ b/linux/runner/desktop_presence.cc
@@ -200,7 +200,8 @@ static void method_call_cb(FlMethodChannel*,
       }
     }
     set_tray(self, visible, tooltip);
-    fl_method_call_respond_success(method_call, nullptr, nullptr);
+    g_autoptr(FlValue) installed = fl_value_new_bool(TRUE);
+    fl_method_call_respond_success(method_call, installed, nullptr);
     return;
   }
   if (g_strcmp0(method, "setBadgeCount") == 0) {

--- a/linux/runner/desktop_presence.h
+++ b/linux/runner/desktop_presence.h
@@ -1,0 +1,12 @@
+#ifndef FLUTTER_DESKTOP_PRESENCE_H_
+#define FLUTTER_DESKTOP_PRESENCE_H_
+
+#include <flutter_linux/flutter_linux.h>
+
+typedef struct _DesktopPresence DesktopPresence;
+
+DesktopPresence* desktop_presence_new(FlEngine* engine);
+
+void desktop_presence_free(DesktopPresence* presence);
+
+#endif  // FLUTTER_DESKTOP_PRESENCE_H_

--- a/linux/runner/my_application.cc
+++ b/linux/runner/my_application.cc
@@ -1,5 +1,7 @@
 #include "my_application.h"
 
+#include "desktop_presence.h"
+
 #include <flutter_linux/flutter_linux.h>
 #include <gio/gio.h>
 #include <glib/gstdio.h>
@@ -15,6 +17,8 @@ struct _MyApplication {
   char** dart_entrypoint_arguments;
   FlMethodChannel* clipboard_channel;
   FlMethodChannel* app_menu_channel;
+  DesktopPresence* desktop_presence;
+  GtkWindow* window;
 };
 
 G_DEFINE_TYPE(MyApplication, my_application, GTK_TYPE_APPLICATION)
@@ -221,11 +225,22 @@ static void first_frame_cb(MyApplication* self, FlView* view) {
   gtk_widget_show(gtk_widget_get_toplevel(GTK_WIDGET(view)));
 }
 
+static void on_window_destroy(GtkWidget*, gpointer user_data) {
+  auto* self = MY_APPLICATION(user_data);
+  self->window = nullptr;
+}
+
 // Implements GApplication::activate.
 static void my_application_activate(GApplication* application) {
   MyApplication* self = MY_APPLICATION(application);
+  if (self->window != nullptr) {
+    gtk_window_present(self->window);
+    return;
+  }
   GtkWindow* window =
       GTK_WINDOW(gtk_application_window_new(GTK_APPLICATION(application)));
+  self->window = window;
+  g_signal_connect(window, "destroy", G_CALLBACK(on_window_destroy), self);
 
   // Use a header bar when running in GNOME as this is the common style used
   // by applications and is the setup most users will be using (e.g. Ubuntu
@@ -311,6 +326,8 @@ static void my_application_activate(GApplication* application) {
       fl_engine_get_binary_messenger(engine), kAppMenuChannel,
       FL_METHOD_CODEC(app_menu_codec));
 
+  self->desktop_presence = desktop_presence_new(engine);
+
   fl_register_plugins(FL_PLUGIN_REGISTRY(view));
 
   gtk_widget_grab_focus(GTK_WIDGET(view));
@@ -331,6 +348,8 @@ static gboolean my_application_local_command_line(GApplication* application,
     return TRUE;
   }
 
+  // Unique apps: a second launch registers against the primary instance.
+  // Activate presents the existing window instead of constructing another.
   g_application_activate(application);
   *exit_status = 0;
 
@@ -361,6 +380,8 @@ static void my_application_dispose(GObject* object) {
   g_clear_pointer(&self->dart_entrypoint_arguments, g_strfreev);
   g_clear_object(&self->clipboard_channel);
   g_clear_object(&self->app_menu_channel);
+  desktop_presence_free(self->desktop_presence);
+  self->desktop_presence = nullptr;
   G_OBJECT_CLASS(my_application_parent_class)->dispose(object);
 }
 
@@ -380,9 +401,12 @@ MyApplication* my_application_new() {
   // like GTK and desktop environments map this running application to its
   // corresponding .desktop file. This ensures better integration by allowing
   // the application to be recognized beyond its binary name.
+  // Unique so a Dock/launcher activation presents the existing hidden window
+  // instead of starting a second process. Dev and release still coexist via
+  // distinct APPLICATION_IDs.
   g_set_prgname(APPLICATION_ID);
 
   return MY_APPLICATION(g_object_new(my_application_get_type(),
                                      "application-id", APPLICATION_ID, "flags",
-                                     G_APPLICATION_NON_UNIQUE, nullptr));
+                                     G_APPLICATION_FLAGS_NONE, nullptr));
 }

--- a/macos/Runner.xcodeproj/project.pbxproj
+++ b/macos/Runner.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		33CC10F32044A3C60003C045 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 33CC10F22044A3C60003C045 /* Assets.xcassets */; };
 		33CC10F62044A3C60003C045 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 33CC10F42044A3C60003C045 /* MainMenu.xib */; };
 		33CC11132044BFA00003C045 /* MainFlutterWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33CC11122044BFA00003C045 /* MainFlutterWindow.swift */; };
+		A1D15C0DE570000000000002 /* DesktopPresence.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1D15C0DE570000000000001 /* DesktopPresence.swift */; };
 		78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */ = {isa = PBXBuildFile; productRef = 78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */; };
 		DECF42638C0B8536C880E44E /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E2C97C1B267E0A4263A34FDE /* Pods_RunnerTests.framework */; };
 		FFBF0B72A49B835FF17EB6B6 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 96BAEBB7029E92ABB3CEFEF0 /* Pods_Runner.framework */; };
@@ -74,6 +75,7 @@
 		33CC10F52044A3C60003C045 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/MainMenu.xib; sourceTree = "<group>"; };
 		33CC10F72044A3C60003C045 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = Info.plist; path = Runner/Info.plist; sourceTree = "<group>"; };
 		33CC11122044BFA00003C045 /* MainFlutterWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainFlutterWindow.swift; sourceTree = "<group>"; };
+		A1D15C0DE570000000000001 /* DesktopPresence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesktopPresence.swift; sourceTree = "<group>"; };
 		33CEB47222A05771004F2AC0 /* Flutter-Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Flutter-Debug.xcconfig"; sourceTree = "<group>"; };
 		33CEB47422A05771004F2AC0 /* Flutter-Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Flutter-Release.xcconfig"; sourceTree = "<group>"; };
 		33CEB47722A0578A004F2AC0 /* Flutter-Generated.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = "Flutter-Generated.xcconfig"; path = "ephemeral/Flutter-Generated.xcconfig"; sourceTree = "<group>"; };
@@ -181,6 +183,7 @@
 			children = (
 				33CC10F02044A3C60003C045 /* AppDelegate.swift */,
 				33CC11122044BFA00003C045 /* MainFlutterWindow.swift */,
+				A1D15C0DE570000000000001 /* DesktopPresence.swift */,
 				33E51913231747F40026EE4D /* DebugProfile.entitlements */,
 				33E51914231749380026EE4D /* Release.entitlements */,
 				33CC11242044D66E0003C045 /* Resources */,
@@ -468,6 +471,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				33CC11132044BFA00003C045 /* MainFlutterWindow.swift in Sources */,
+				A1D15C0DE570000000000002 /* DesktopPresence.swift in Sources */,
 				33CC10F12044A3C60003C045 /* AppDelegate.swift in Sources */,
 				335BBD1B22A9A15E00E9071D /* GeneratedPluginRegistrant.swift in Sources */,
 			);

--- a/macos/Runner/AppDelegate.swift
+++ b/macos/Runner/AppDelegate.swift
@@ -4,6 +4,8 @@ import Speech
 
 @main
 class AppDelegate: FlutterAppDelegate {
+  private var desktopPresence: DesktopPresence?
+
   override func applicationDidFinishLaunching(_ notification: Notification) {
     super.applicationDidFinishLaunching(notification)
     guard let controller = mainFlutterWindow?.contentViewController as? FlutterViewController else {
@@ -23,9 +25,22 @@ class AppDelegate: FlutterAppDelegate {
       let locale = localeId.map { Locale(identifier: $0) } ?? Locale.current
       result(SFSpeechRecognizer(locale: locale)?.supportsOnDeviceRecognition == true)
     }
+    desktopPresence = DesktopPresence(messenger: controller.engine.binaryMessenger)
+  }
+
+  override func applicationShouldHandleReopen(
+    _ sender: NSApplication,
+    hasVisibleWindows flag: Bool
+  ) -> Bool {
+    if !flag {
+      desktopPresence?.requestShow()
+    }
+    return true
   }
 
   override func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
+    // Hide-on-close uses NSWindow.orderOut, so the window still exists.
+    // Destroying it (Quit) is what should terminate the process.
     return true
   }
 

--- a/macos/Runner/DesktopPresence.swift
+++ b/macos/Runner/DesktopPresence.swift
@@ -1,0 +1,129 @@
+import Cocoa
+import FlutterMacOS
+
+/// Tray icon (NSStatusItem) and Dock badge for pending agent review.
+final class DesktopPresence: NSObject {
+  private let channel: FlutterMethodChannel
+  private var statusItem: NSStatusItem?
+
+  init(messenger: FlutterBinaryMessenger) {
+    channel = FlutterMethodChannel(
+      name: "dev.leynier.alera/desktop_presence",
+      binaryMessenger: messenger
+    )
+    super.init()
+    channel.setMethodCallHandler { [weak self] call, result in
+      self?.handle(call, result: result)
+    }
+  }
+
+  private func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+    switch call.method {
+    case "setTray":
+      let args = call.arguments as? [String: Any]
+      let visible = args?["visible"] as? Bool ?? false
+      let tooltip = args?["tooltip"] as? String ?? ""
+      setTray(visible: visible, tooltip: tooltip)
+      result(nil)
+    case "setBadgeCount":
+      let args = call.arguments as? [String: Any]
+      let count = args?["count"] as? Int ?? 0
+      setBadgeCount(count)
+      result(nil)
+    case "destroy":
+      destroy()
+      result(nil)
+    default:
+      result(FlutterMethodNotImplemented)
+    }
+  }
+
+  private func setTray(visible: Bool, tooltip: String) {
+    NSApp.setActivationPolicy(.regular)
+    if visible {
+      if statusItem == nil {
+        let item = NSStatusBar.system.statusItem(withLength: NSStatusItem.squareLength)
+        item.button?.image = NSApp.applicationIconImage
+        item.button?.image?.isTemplate = false
+        item.button?.imageScaling = .scaleProportionallyDown
+        item.button?.target = self
+        item.button?.action = #selector(statusItemClicked(_:))
+        item.button?.sendAction(on: [.leftMouseUp, .rightMouseUp])
+        statusItem = item
+      }
+      statusItem?.button?.toolTip = tooltip
+    } else {
+      removeStatusItem()
+    }
+  }
+
+  private func setBadgeCount(_ count: Int) {
+    if count <= 0 {
+      NSApp.dockTile.badgeLabel = nil
+    } else {
+      NSApp.dockTile.badgeLabel = "\(count)"
+    }
+    NSApp.dockTile.display()
+  }
+
+  private func destroy() {
+    removeStatusItem()
+    NSApp.dockTile.badgeLabel = nil
+    NSApp.dockTile.display()
+  }
+
+  private func removeStatusItem() {
+    if let item = statusItem {
+      NSStatusBar.system.removeStatusItem(item)
+      statusItem = nil
+    }
+  }
+
+  private func buildMenu() -> NSMenu {
+    let menu = NSMenu()
+    let show = NSMenuItem(
+      title: "Show \(Bundle.main.object(forInfoDictionaryKey: "CFBundleName") as? String ?? "Alera")",
+      action: #selector(showWindow),
+      keyEquivalent: ""
+    )
+    show.target = self
+    menu.addItem(show)
+    menu.addItem(.separator())
+    let quit = NSMenuItem(
+      title: "Quit",
+      action: #selector(quitApp),
+      keyEquivalent: ""
+    )
+    quit.target = self
+    menu.addItem(quit)
+    return menu
+  }
+
+  @objc
+  private func statusItemClicked(_ sender: Any?) {
+    let event = NSApp.currentEvent
+    if event?.type == .rightMouseUp, let button = statusItem?.button {
+      buildMenu().popUp(
+        positioning: nil,
+        at: NSPoint(x: 0, y: button.bounds.height),
+        in: button
+      )
+      return
+    }
+    showWindow()
+  }
+
+  func requestShow() {
+    showWindow()
+  }
+
+  @objc
+  private func showWindow() {
+    channel.invokeMethod("trayShow", arguments: nil)
+  }
+
+  @objc
+  private func quitApp() {
+    channel.invokeMethod("trayQuit", arguments: nil)
+  }
+}

--- a/macos/Runner/DesktopPresence.swift
+++ b/macos/Runner/DesktopPresence.swift
@@ -24,7 +24,7 @@ final class DesktopPresence: NSObject {
       let visible = args?["visible"] as? Bool ?? false
       let tooltip = args?["tooltip"] as? String ?? ""
       setTray(visible: visible, tooltip: tooltip)
-      result(nil)
+      result(true)
     case "setBadgeCount":
       let args = call.arguments as? [String: Any]
       let count = args?["count"] as? Int ?? 0

--- a/roadmap.md
+++ b/roadmap.md
@@ -154,7 +154,7 @@ Comprehensive feature roadmap for Alera. Each feature is scored on two axes:
 | Feature | Difficulty | Utility | Status | Notes |
 |---|:---:|:---:|:---:|---|
 | Activity feed | 3 | 5 | Partial | Agent activity sort, sidebar agent runs, and status projection ship; no unified chronological activity feed yet |
-| Notification system | 3 | 4 | Partial | Native desktop notifications plus opt-in FCM mobile push for attention, done, orchestration, and terminal-exit events with tap routing; no unread model or OS dock badge yet |
+| Notification system | 3 | 4 | Partial | Native desktop notifications plus opt-in FCM mobile push for attention, done, orchestration, and terminal-exit events with tap routing; desktop tray icon and dock/taskbar badge for pending-review agents ship |
 | Agent auto-acknowledge | 1 | 3 | Shipped | Viewing a completed agent tab acknowledges that completion epoch and clears attention until the next run |
 
 ---

--- a/test/unit/alera_settings_json_test.dart
+++ b/test/unit/alera_settings_json_test.dart
@@ -14,6 +14,8 @@ void main() {
           confirmProjectRemoval: false,
           confirmWorkspaceRemoval: false,
           keepAliveEnabled: true,
+          showTrayIcon: false,
+          showDockBadge: false,
         ),
         agents: AgentSettings(
           agentStatusHooks: AgentStatusHookSettings(
@@ -95,6 +97,8 @@ void main() {
       expect(restored.general.confirmProjectRemoval, isFalse);
       expect(restored.general.confirmWorkspaceRemoval, isFalse);
       expect(restored.general.keepAliveEnabled, isTrue);
+      expect(restored.general.showTrayIcon, isFalse);
+      expect(restored.general.showDockBadge, isFalse);
       expect(restored.agents.agentStatusHooks.codex, isTrue);
       expect(restored.agents.agentStatusHooks.claude, isTrue);
       expect(restored.agents.agentStatusHooks.copilot, isFalse);

--- a/test/unit/alera_settings_test.dart
+++ b/test/unit/alera_settings_test.dart
@@ -42,6 +42,8 @@ void main() {
       expect(general.confirmProjectRemoval, isTrue);
       expect(general.confirmWorkspaceRemoval, isTrue);
       expect(general.keepAliveEnabled, isFalse);
+      expect(general.showTrayIcon, isTrue);
+      expect(general.showDockBadge, isTrue);
     });
 
     test('agent defaults are conservative', () {
@@ -151,6 +153,8 @@ void main() {
       expect(overrides.selection, '#123456');
       expect(general.workspaceDirectory, '/tmp/workspaces');
       expect(general.starClicked, isTrue);
+      expect(general.showTrayIcon, isTrue);
+      expect(general.showDockBadge, isTrue);
       expect(agents.agentStatusHooks.codex, isTrue);
       expect(agents.agentStatusHooks.claude, isFalse);
       expect(agents.agentStatusHooks.copilot, isTrue);

--- a/test/unit/app_window_lifecycle_coordinator_test.dart
+++ b/test/unit/app_window_lifecycle_coordinator_test.dart
@@ -105,6 +105,44 @@ void main() {
       await _waitFor(() => gateCalls == 2);
     });
 
+    test('hides the window when hide-on-close is bound', () async {
+      final repository = _RecordingStateRepository();
+      final window = _RecordingWindowController();
+      final coordinator = AppWindowLifecycleCoordinator(
+        repository: repository,
+        window: window,
+        saveDebounce: Duration.zero,
+        hideOnClose: () => true,
+      );
+      await coordinator.start();
+
+      window.emit((listener) => listener.onWindowClose());
+      await _waitFor(() => window.hideCalls == 1);
+
+      expect(window.destroyCalls, 0);
+      expect(window.hideCalls, 1);
+      expect(window.preventCloseValues, <bool>[true]);
+    });
+
+    test('requestQuit destroys even when hide-on-close is bound', () async {
+      final repository = _RecordingStateRepository();
+      final window = _RecordingWindowController();
+      final coordinator = AppWindowLifecycleCoordinator(
+        repository: repository,
+        window: window,
+        saveDebounce: Duration.zero,
+        hideOnClose: () => true,
+      );
+      await coordinator.start();
+
+      await coordinator.requestQuit();
+      await _waitFor(() => window.destroyCalls == 1);
+
+      expect(window.hideCalls, 0);
+      expect(window.destroyCalls, 1);
+      expect(window.preventCloseValues, <bool>[true, false]);
+    });
+
     test('closes once and ignores post-close state work', () async {
       final repository = _RecordingStateRepository();
       final window = _RecordingWindowController();
@@ -173,6 +211,12 @@ class _RecordingWindowController implements AppWindowController {
   final List<bool> preventCloseValues = <bool>[];
   Rect bounds = const Rect.fromLTWH(20, 30, 800, 500);
   int destroyCalls = 0;
+  int hideCalls = 0;
+  int showCalls = 0;
+  int focusCalls = 0;
+  int restoreCalls = 0;
+  bool visible = true;
+  bool minimized = false;
 
   void emit(void Function(AppWindowEventListener listener) notify) {
     for (final listener in List<AppWindowEventListener>.from(listeners)) {
@@ -196,6 +240,32 @@ class _RecordingWindowController implements AppWindowController {
   }
 
   @override
+  Future<void> hide() async {
+    hideCalls += 1;
+    visible = false;
+  }
+
+  @override
+  Future<void> show() async {
+    showCalls += 1;
+    visible = true;
+  }
+
+  @override
+  Future<void> restore() async {
+    restoreCalls += 1;
+    minimized = false;
+  }
+
+  @override
+  Future<void> focus() async {
+    focusCalls += 1;
+  }
+
+  @override
+  Future<bool> isVisible() async => visible;
+
+  @override
   Future<Rect> getBounds() async => bounds;
 
   @override
@@ -205,7 +275,7 @@ class _RecordingWindowController implements AppWindowController {
   Future<bool> isMaximized() async => false;
 
   @override
-  Future<bool> isMinimized() async => false;
+  Future<bool> isMinimized() async => minimized;
 
   @override
   Future<void> maximize() async {}

--- a/test/unit/app_window_lifecycle_coordinator_test.dart
+++ b/test/unit/app_window_lifecycle_coordinator_test.dart
@@ -143,6 +143,94 @@ void main() {
       expect(window.preventCloseValues, <bool>[true, false]);
     });
 
+    test(
+      'requestQuit waits for an in-flight hide before the close gate',
+      () async {
+        final saveStarted = Completer<void>();
+        final finishSave = Completer<void>();
+        final gate = Completer<bool>();
+        final repository = _RecordingStateRepository()
+          ..saveStarted = saveStarted
+          ..saveBarrier = finishSave.future;
+        final window = _RecordingWindowController();
+        var gateCalls = 0;
+        final coordinator = AppWindowLifecycleCoordinator(
+          repository: repository,
+          window: window,
+          saveDebounce: Duration.zero,
+          hideOnClose: () => true,
+          closeGate: () {
+            gateCalls += 1;
+            return gate.future;
+          },
+        );
+        await coordinator.start();
+
+        window.emit((listener) => listener.onWindowClose());
+        window.emit((listener) => listener.onWindowClose());
+        await saveStarted.future;
+        expect(window.hideCalls, 0);
+        expect(gateCalls, 0);
+
+        final quit = coordinator.requestQuit();
+        await Future<void>.delayed(Duration.zero);
+        expect(gateCalls, 0);
+        expect(window.hideCalls, 0);
+        expect(window.destroyCalls, 0);
+
+        finishSave.complete();
+        await _waitFor(() => gateCalls == 1);
+        expect(window.hideCalls, 0);
+
+        gate.complete(false);
+        await quit;
+        expect(window.destroyCalls, 0);
+
+        window.emit((listener) => listener.onWindowClose());
+        await _waitFor(() => window.hideCalls == 1);
+        expect(window.destroyCalls, 0);
+      },
+    );
+
+    test('requestQuit finishes hide before opening the close gate', () async {
+      final hideStarted = Completer<void>();
+      final finishHide = Completer<void>();
+      final gate = Completer<bool>();
+      final window = _RecordingWindowController()
+        ..hideStarted = hideStarted
+        ..hideBarrier = finishHide.future;
+      var gateCalls = 0;
+      final coordinator = AppWindowLifecycleCoordinator(
+        repository: _RecordingStateRepository(),
+        window: window,
+        saveDebounce: Duration.zero,
+        hideOnClose: () => true,
+        closeGate: () {
+          gateCalls += 1;
+          return gate.future;
+        },
+      );
+      await coordinator.start();
+
+      window.emit((listener) => listener.onWindowClose());
+      await hideStarted.future;
+      expect(gateCalls, 0);
+
+      final quit = coordinator.requestQuit();
+      await Future<void>.delayed(Duration.zero);
+      expect(gateCalls, 0);
+      expect(window.destroyCalls, 0);
+
+      finishHide.complete();
+      await _waitFor(() => gateCalls == 1);
+      expect(window.hideCalls, 1);
+      expect(window.visible, isFalse);
+
+      gate.complete(false);
+      await quit;
+      expect(window.destroyCalls, 0);
+    });
+
     test('closes once and ignores post-close state work', () async {
       final repository = _RecordingStateRepository();
       final window = _RecordingWindowController();
@@ -217,6 +305,8 @@ class _RecordingWindowController implements AppWindowController {
   int restoreCalls = 0;
   bool visible = true;
   bool minimized = false;
+  Completer<void>? hideStarted;
+  Future<void>? hideBarrier;
 
   void emit(void Function(AppWindowEventListener listener) notify) {
     for (final listener in List<AppWindowEventListener>.from(listeners)) {
@@ -241,6 +331,8 @@ class _RecordingWindowController implements AppWindowController {
 
   @override
   Future<void> hide() async {
+    hideStarted?.complete();
+    await hideBarrier;
     hideCalls += 1;
     visible = false;
   }

--- a/test/unit/app_window_state_test.dart
+++ b/test/unit/app_window_state_test.dart
@@ -332,6 +332,8 @@ class _FakeAppWindowController implements AppWindowController {
   bool minimized = false;
   bool destroyed = false;
   int maximizeCalls = 0;
+  int hideCalls = 0;
+  bool visible = true;
 
   void emit(void Function(AppWindowEventListener listener) notify) {
     for (final listener in List<AppWindowEventListener>.from(listeners)) {
@@ -348,6 +350,28 @@ class _FakeAppWindowController implements AppWindowController {
   Future<void> destroy() async {
     destroyed = true;
   }
+
+  @override
+  Future<void> hide() async {
+    hideCalls += 1;
+    visible = false;
+  }
+
+  @override
+  Future<void> show() async {
+    visible = true;
+  }
+
+  @override
+  Future<void> restore() async {
+    minimized = false;
+  }
+
+  @override
+  Future<void> focus() async {}
+
+  @override
+  Future<bool> isVisible() async => visible;
 
   @override
   Future<Rect> getBounds() async => bounds;

--- a/test/unit/desktop_presence_test.dart
+++ b/test/unit/desktop_presence_test.dart
@@ -228,23 +228,148 @@ void main() {
       expect(backend.applied.last.trayVisible, isFalse);
       expect(coordinator.trayInstalled, isFalse);
     });
+
+    test('does not hide while tray removal is in progress', () async {
+      final applyStarted = Completer<void>();
+      final finishApply = Completer<void>();
+      final backend = _RecordingPresenceBackend();
+      final window = _RecordingWindow();
+      final lifecycle = AppWindowLifecycleCoordinator(
+        repository: _MemoryWindowStateRepository(),
+        window: window,
+        saveDebounce: Duration.zero,
+      );
+      await lifecycle.start();
+      final coordinator = DesktopPresenceCoordinator(
+        backend: backend,
+        window: window,
+        lifecycle: lifecycle,
+      );
+      coordinator.start();
+      lifecycle.bindHideOnClose(() => coordinator.trayInstalled);
+
+      await coordinator.apply(
+        const DesktopPresenceSnapshot(
+          trayVisible: true,
+          tooltip: 'Alera',
+          badgeCount: 0,
+        ),
+      );
+      expect(coordinator.trayInstalled, isTrue);
+      backend.applyStarted = applyStarted;
+      backend.applyBarrier = finishApply.future;
+
+      final removeTray = coordinator.apply(
+        const DesktopPresenceSnapshot(
+          trayVisible: false,
+          tooltip: 'Alera',
+          badgeCount: 0,
+        ),
+      );
+      await applyStarted.future;
+      expect(coordinator.trayInstalled, isFalse);
+
+      window.emitClose();
+      await Future<void>.delayed(Duration.zero);
+      expect(window.hideCalls, 0);
+
+      finishApply.complete();
+      await removeTray;
+      expect(window.hideCalls, 0);
+      expect(coordinator.trayInstalled, isFalse);
+    });
+
+    test('shows a hidden window when tray installation is lost', () async {
+      final backend = _RecordingPresenceBackend();
+      final window = _RecordingWindow();
+      final lifecycle = AppWindowLifecycleCoordinator(
+        repository: _MemoryWindowStateRepository(),
+        window: window,
+        saveDebounce: Duration.zero,
+      );
+      await lifecycle.start();
+      final coordinator = DesktopPresenceCoordinator(
+        backend: backend,
+        window: window,
+        lifecycle: lifecycle,
+      );
+      coordinator.start();
+
+      await coordinator.apply(
+        const DesktopPresenceSnapshot(
+          trayVisible: true,
+          tooltip: 'Alera',
+          badgeCount: 0,
+        ),
+      );
+      window.visible = false;
+      backend.onInstallationChanged?.call(false);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(coordinator.trayInstalled, isFalse);
+      expect(window.showCalls, 1);
+      expect(window.visible, isTrue);
+    });
+
+    test('does not show when tray reinstall succeeds immediately', () async {
+      final backend = _RecordingPresenceBackend();
+      final window = _RecordingWindow();
+      final lifecycle = AppWindowLifecycleCoordinator(
+        repository: _MemoryWindowStateRepository(),
+        window: window,
+        saveDebounce: Duration.zero,
+      );
+      await lifecycle.start();
+      final coordinator = DesktopPresenceCoordinator(
+        backend: backend,
+        window: window,
+        lifecycle: lifecycle,
+      );
+      coordinator.start();
+
+      await coordinator.apply(
+        const DesktopPresenceSnapshot(
+          trayVisible: true,
+          tooltip: 'Alera',
+          badgeCount: 0,
+        ),
+      );
+      window.visible = false;
+      backend.onInstallationChanged?.call(false);
+      backend.onInstallationChanged?.call(true);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(coordinator.trayInstalled, isTrue);
+      expect(window.showCalls, 0);
+      expect(window.visible, isFalse);
+    });
   });
 }
 
 class _RecordingPresenceBackend implements DesktopPresenceBackend {
   VoidCallback? onShow;
   VoidCallback? onQuit;
+  void Function(bool installed)? onInstallationChanged;
   final List<DesktopPresenceSnapshot> applied = <DesktopPresenceSnapshot>[];
   int destroyCalls = 0;
+  Completer<void>? applyStarted;
+  Future<void>? applyBarrier;
 
   @override
-  void listen({required VoidCallback onShow, required VoidCallback onQuit}) {
+  void listen({
+    required VoidCallback onShow,
+    required VoidCallback onQuit,
+    void Function(bool installed)? onInstallationChanged,
+  }) {
     this.onShow = onShow;
     this.onQuit = onQuit;
+    this.onInstallationChanged = onInstallationChanged;
   }
 
   @override
   Future<void> apply(DesktopPresenceSnapshot snapshot) async {
+    applyStarted?.complete();
+    await applyBarrier;
     applied.add(snapshot);
   }
 

--- a/test/unit/desktop_presence_test.dart
+++ b/test/unit/desktop_presence_test.dart
@@ -1,0 +1,208 @@
+import 'package:alera/src/core/build_flavor.dart';
+import 'package:alera/src/features/desktop_presence/application/desktop_presence.dart';
+import 'package:alera/src/features/desktop_presence/application/desktop_presence_coordinator.dart';
+import 'package:alera/src/features/desktop_presence/infra/desktop_presence_channel.dart';
+import 'package:alera/src/features/app_window/application/app_window_controller.dart';
+import 'package:alera/src/features/app_window/application/app_window_state_repository.dart';
+import 'package:alera/src/features/app_window/domain/app_window_state.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('desktop presence snapshot', () {
+    test('clears the badge when the dock setting is off', () {
+      final snapshot = desktopPresenceSnapshot(
+        showTrayIcon: true,
+        showDockBadge: false,
+        pendingReviewCount: 4,
+      );
+      expect(snapshot.trayVisible, isTrue);
+      expect(snapshot.badgeCount, 0);
+      expect(snapshot.tooltip, '4 agents need attention');
+    });
+
+    test('hides the tray independently of the badge', () {
+      final snapshot = desktopPresenceSnapshot(
+        showTrayIcon: false,
+        showDockBadge: true,
+        pendingReviewCount: 1,
+      );
+      expect(snapshot.trayVisible, isFalse);
+      expect(snapshot.badgeCount, 1);
+      expect(snapshot.tooltip, '1 agent needs attention');
+    });
+
+    test('uses the flavor desktop id for Unity launcher entries', () {
+      expect(
+        linuxLauncherDesktopId(bundleId: kAleraReleaseBundleId),
+        'dev.leynier.alera.desktop',
+      );
+      expect(
+        linuxLauncherDesktopId(bundleId: kAleraDevBundleId),
+        'dev.leynier.alera.dev.desktop',
+      );
+    });
+  });
+
+  group('DesktopPresenceCoordinator', () {
+    test('applies snapshots and shows the window from the tray', () async {
+      final backend = _RecordingPresenceBackend();
+      final window = _RecordingWindow();
+      final lifecycle = AppWindowLifecycleCoordinator(
+        repository: _MemoryWindowStateRepository(),
+        window: window,
+        saveDebounce: Duration.zero,
+      );
+      await lifecycle.start();
+      final coordinator = DesktopPresenceCoordinator(
+        backend: backend,
+        window: window,
+        lifecycle: lifecycle,
+      );
+      coordinator.start();
+
+      await coordinator.apply(
+        const DesktopPresenceSnapshot(
+          trayVisible: true,
+          tooltip: 'Alera',
+          badgeCount: 2,
+        ),
+      );
+      expect(backend.applied.single.badgeCount, 2);
+
+      window.visible = false;
+      backend.onShow?.call();
+      await Future<void>.delayed(Duration.zero);
+      expect(window.showCalls, 1);
+      expect(window.focusCalls, 1);
+
+      backend.onQuit?.call();
+      await Future<void>.delayed(Duration.zero);
+      expect(window.destroyCalls, 1);
+    });
+  });
+}
+
+class _RecordingPresenceBackend implements DesktopPresenceBackend {
+  VoidCallback? onShow;
+  VoidCallback? onQuit;
+  final List<DesktopPresenceSnapshot> applied = <DesktopPresenceSnapshot>[];
+  int destroyCalls = 0;
+
+  @override
+  void listen({required VoidCallback onShow, required VoidCallback onQuit}) {
+    this.onShow = onShow;
+    this.onQuit = onQuit;
+  }
+
+  @override
+  Future<void> apply(DesktopPresenceSnapshot snapshot) async {
+    applied.add(snapshot);
+  }
+
+  @override
+  Future<void> destroy() async {
+    destroyCalls += 1;
+  }
+}
+
+class _MemoryWindowStateRepository implements AppWindowStateRepository {
+  AppWindowState? state;
+
+  @override
+  Future<void> clear() async {
+    state = null;
+  }
+
+  @override
+  Future<AppWindowState?> load() async => state;
+
+  @override
+  Future<void> save(AppWindowState state) async {
+    this.state = state;
+  }
+}
+
+class _RecordingWindow implements AppWindowController {
+  final List<AppWindowEventListener> listeners = <AppWindowEventListener>[];
+  int destroyCalls = 0;
+  int showCalls = 0;
+  int focusCalls = 0;
+  int hideCalls = 0;
+  bool visible = true;
+  bool minimized = false;
+
+  @override
+  void addListener(AppWindowEventListener listener) {
+    listeners.add(listener);
+  }
+
+  @override
+  void removeListener(AppWindowEventListener listener) {
+    listeners.remove(listener);
+  }
+
+  @override
+  Future<void> close() async {
+    for (final listener in List<AppWindowEventListener>.from(listeners)) {
+      listener.onWindowClose();
+    }
+  }
+
+  @override
+  Future<void> destroy() async {
+    destroyCalls += 1;
+  }
+
+  @override
+  Future<Rect> getBounds() async => const Rect.fromLTWH(0, 0, 800, 600);
+
+  @override
+  Future<void> hide() async {
+    hideCalls += 1;
+    visible = false;
+  }
+
+  @override
+  Future<bool> isFullScreen() async => false;
+
+  @override
+  Future<bool> isMaximized() async => false;
+
+  @override
+  Future<bool> isMinimized() async => minimized;
+
+  @override
+  Future<bool> isVisible() async => visible;
+
+  @override
+  Future<void> maximize() async {}
+
+  @override
+  Future<void> restore() async {
+    minimized = false;
+  }
+
+  @override
+  Future<void> setBounds(Rect bounds) async {}
+
+  @override
+  Future<void> setFullScreen(bool value) async {}
+
+  @override
+  Future<void> setPreventClose(bool value) async {}
+
+  @override
+  Future<void> setTitle(String title) async {}
+
+  @override
+  Future<void> show() async {
+    showCalls += 1;
+    visible = true;
+  }
+
+  @override
+  Future<void> focus() async {
+    focusCalls += 1;
+  }
+}

--- a/test/unit/desktop_presence_test.dart
+++ b/test/unit/desktop_presence_test.dart
@@ -80,6 +80,95 @@ void main() {
       await Future<void>.delayed(Duration.zero);
       expect(window.destroyCalls, 1);
     });
+
+    test('shows a hidden window before removing the tray', () async {
+      final backend = _RecordingPresenceBackend();
+      final window = _RecordingWindow();
+      final lifecycle = AppWindowLifecycleCoordinator(
+        repository: _MemoryWindowStateRepository(),
+        window: window,
+        saveDebounce: Duration.zero,
+      );
+      await lifecycle.start();
+      final coordinator = DesktopPresenceCoordinator(
+        backend: backend,
+        window: window,
+        lifecycle: lifecycle,
+      );
+      coordinator.start();
+
+      await coordinator.apply(
+        const DesktopPresenceSnapshot(
+          trayVisible: true,
+          tooltip: 'Alera',
+          badgeCount: 0,
+        ),
+      );
+      window.visible = false;
+
+      await coordinator.apply(
+        const DesktopPresenceSnapshot(
+          trayVisible: false,
+          tooltip: 'Alera',
+          badgeCount: 0,
+        ),
+      );
+
+      expect(window.showCalls, 1);
+      expect(window.focusCalls, 1);
+      expect(window.visible, isTrue);
+      expect(backend.applied, hasLength(2));
+      expect(backend.applied.last.trayVisible, isFalse);
+    });
+
+    test('keeps the tray when showing a hidden window fails', () async {
+      final backend = _RecordingPresenceBackend();
+      final window = _RecordingWindow()..showFails = true;
+      final lifecycle = AppWindowLifecycleCoordinator(
+        repository: _MemoryWindowStateRepository(),
+        window: window,
+        saveDebounce: Duration.zero,
+      );
+      await lifecycle.start();
+      final coordinator = DesktopPresenceCoordinator(
+        backend: backend,
+        window: window,
+        lifecycle: lifecycle,
+      );
+      coordinator.start();
+
+      await coordinator.apply(
+        const DesktopPresenceSnapshot(
+          trayVisible: true,
+          tooltip: 'Alera',
+          badgeCount: 1,
+        ),
+      );
+      window.visible = false;
+
+      await coordinator.apply(
+        const DesktopPresenceSnapshot(
+          trayVisible: false,
+          tooltip: 'Alera',
+          badgeCount: 1,
+        ),
+      );
+      expect(backend.applied, hasLength(1));
+      expect(backend.applied.single.trayVisible, isTrue);
+      expect(window.visible, isFalse);
+
+      window.showFails = false;
+      await coordinator.apply(
+        const DesktopPresenceSnapshot(
+          trayVisible: false,
+          tooltip: 'Alera',
+          badgeCount: 1,
+        ),
+      );
+      expect(window.visible, isTrue);
+      expect(backend.applied, hasLength(2));
+      expect(backend.applied.last.trayVisible, isFalse);
+    });
   });
 }
 
@@ -131,6 +220,7 @@ class _RecordingWindow implements AppWindowController {
   int hideCalls = 0;
   bool visible = true;
   bool minimized = false;
+  bool showFails = false;
 
   @override
   void addListener(AppWindowEventListener listener) {
@@ -198,6 +288,9 @@ class _RecordingWindow implements AppWindowController {
   @override
   Future<void> show() async {
     showCalls += 1;
+    if (showFails) {
+      throw StateError('show failed');
+    }
     visible = true;
   }
 

--- a/test/unit/desktop_presence_test.dart
+++ b/test/unit/desktop_presence_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:alera/src/core/build_flavor.dart';
 import 'package:alera/src/features/desktop_presence/application/desktop_presence.dart';
 import 'package:alera/src/features/desktop_presence/application/desktop_presence_coordinator.dart';
@@ -169,6 +171,63 @@ void main() {
       expect(backend.applied, hasLength(2));
       expect(backend.applied.last.trayVisible, isFalse);
     });
+
+    test('waits for an in-flight hide before removing the tray', () async {
+      final saveStarted = Completer<void>();
+      final finishSave = Completer<void>();
+      final backend = _RecordingPresenceBackend();
+      final window = _RecordingWindow();
+      final lifecycle = AppWindowLifecycleCoordinator(
+        repository: _MemoryWindowStateRepository()
+          ..saveStarted = saveStarted
+          ..saveBarrier = finishSave.future,
+        window: window,
+        saveDebounce: Duration.zero,
+        hideOnClose: () => true,
+      );
+      await lifecycle.start();
+      final coordinator = DesktopPresenceCoordinator(
+        backend: backend,
+        window: window,
+        lifecycle: lifecycle,
+      );
+      coordinator.start();
+
+      await coordinator.apply(
+        const DesktopPresenceSnapshot(
+          trayVisible: true,
+          tooltip: 'Alera',
+          badgeCount: 0,
+        ),
+      );
+      expect(coordinator.trayInstalled, isTrue);
+
+      window.emitClose();
+      await saveStarted.future;
+      expect(window.hideCalls, 0);
+      expect(window.visible, isTrue);
+
+      final removeTray = coordinator.apply(
+        const DesktopPresenceSnapshot(
+          trayVisible: false,
+          tooltip: 'Alera',
+          badgeCount: 0,
+        ),
+      );
+      await Future<void>.delayed(Duration.zero);
+      expect(backend.applied, hasLength(1));
+      expect(window.showCalls, 0);
+
+      finishSave.complete();
+      await removeTray;
+
+      expect(window.hideCalls, 1);
+      expect(window.showCalls, 1);
+      expect(window.visible, isTrue);
+      expect(backend.applied, hasLength(2));
+      expect(backend.applied.last.trayVisible, isFalse);
+      expect(coordinator.trayInstalled, isFalse);
+    });
   });
 }
 
@@ -197,6 +256,8 @@ class _RecordingPresenceBackend implements DesktopPresenceBackend {
 
 class _MemoryWindowStateRepository implements AppWindowStateRepository {
   AppWindowState? state;
+  Completer<void>? saveStarted;
+  Future<void>? saveBarrier;
 
   @override
   Future<void> clear() async {
@@ -208,6 +269,8 @@ class _MemoryWindowStateRepository implements AppWindowStateRepository {
 
   @override
   Future<void> save(AppWindowState state) async {
+    saveStarted?.complete();
+    await saveBarrier;
     this.state = state;
   }
 }
@@ -221,6 +284,12 @@ class _RecordingWindow implements AppWindowController {
   bool visible = true;
   bool minimized = false;
   bool showFails = false;
+
+  void emitClose() {
+    for (final listener in List<AppWindowEventListener>.from(listeners)) {
+      listener.onWindowClose();
+    }
+  }
 
   @override
   void addListener(AppWindowEventListener listener) {

--- a/test/unit/settings_controller_test.dart
+++ b/test/unit/settings_controller_test.dart
@@ -246,6 +246,8 @@ void main() {
         await controller.setAgentStatusNotificationsEnabled(true);
         await controller.setKeepComputerAwakeWhileAgentsWork(true);
         await controller.setKeepAliveEnabled(true);
+        await controller.setShowTrayIcon(false);
+        await controller.setShowDockBadge(false);
 
         final restored = await repository.load();
         expect(
@@ -277,6 +279,8 @@ void main() {
         expect(restored.agents.agentStatusNotificationsEnabled, isTrue);
         expect(restored.agents.keepComputerAwakeWhileAgentsWork, isTrue);
         expect(restored.general.keepAliveEnabled, isTrue);
+        expect(restored.general.showTrayIcon, isFalse);
+        expect(restored.general.showDockBadge, isFalse);
       },
     );
 

--- a/test/unit/settings_search_entries_test.dart
+++ b/test/unit/settings_search_entries_test.dart
@@ -31,7 +31,7 @@ void main() {
 
     expect(
       _catalogFingerprint(catalogs),
-      '5fc8943def91f434123ca47ec60687752b17d7eed86ce39bdd5a7597f21b79bf',
+      'baa5ae1b5ed44dbf8a290c929d94a92fbb77a514812d9031392e37e89bf78779',
     );
   });
 
@@ -59,6 +59,16 @@ void main() {
         entries: applicationSearchEntries,
         query: 'keep-alive',
         expected: <(String, String?)>[('Keep Computer Awake', 'runtime')],
+      ),
+      (
+        entries: applicationSearchEntries,
+        query: 'tray',
+        expected: <(String, String?)>[('Show Tray Icon', 'desktop')],
+      ),
+      (
+        entries: applicationSearchEntries,
+        query: 'taskbar',
+        expected: <(String, String?)>[('Show Dock Badge', 'desktop')],
       ),
       (
         entries: agentsSearchEntries,

--- a/test/unit/workspace_agent_status_projection_test.dart
+++ b/test/unit/workspace_agent_status_projection_test.dart
@@ -169,6 +169,39 @@ void main() {
       );
     });
 
+    test('counts waiting, blocked, and interrupted runs as pending review', () {
+      final waiting = _tab('tab-waiting');
+      final blocked = _tab('tab-blocked');
+      final interrupted = _tab('tab-interrupted');
+      final working = _tab('tab-working');
+      final done = _tab('tab-done');
+      final unmatched = _tab('tab-unmatched');
+
+      final runs = visibleWorkspaceAgentRuns(
+        tabs: <WorkspaceTabRecord>[
+          waiting,
+          blocked,
+          interrupted,
+          working,
+          done,
+          unmatched,
+        ],
+        agentStatuses: <String, AgentStatusEntry>{
+          waiting.terminalSessionId: _entry(waiting, AgentStatusState.waiting),
+          blocked.terminalSessionId: _entry(blocked, AgentStatusState.blocked),
+          interrupted.terminalSessionId: _entry(
+            interrupted,
+            AgentStatusState.done,
+            interrupted: true,
+          ),
+          working.terminalSessionId: _entry(working, AgentStatusState.working),
+          done.terminalSessionId: _entry(done, AgentStatusState.done),
+        },
+      );
+
+      expect(pendingReviewAgentCount(runs), 3);
+    });
+
     test('matches Codex tabs through their synthetic presence handle', () {
       final tab = _tab('codex-tab', kind: WorkspaceTabKind.codex);
       final handle = 'codex:${tab.id}';

--- a/test/widget/app_menu_test.dart
+++ b/test/widget/app_menu_test.dart
@@ -155,7 +155,7 @@ void main() {
       expect(toastMessages, <String>['Alera is up to date.']);
     });
 
-    testWidgets('exitAppFromMenu closes the app window', (tester) async {
+    testWidgets('exitAppFromMenu quits the app window', (tester) async {
       final window = FakeAppWindowController();
       await pumpActionHarness(
         tester,
@@ -165,8 +165,9 @@ void main() {
 
       await tester.tap(find.text('Run'));
       await tester.pump();
+      await tester.pump();
 
-      expect(window.closeCalls, 1);
+      expect(window.destroyCalls, 1);
     });
   });
 
@@ -242,15 +243,16 @@ void main() {
           });
         });
 
-        testWidgets('native channel closes the app window', (tester) async {
+        testWidgets('native channel quits the app window', (tester) async {
           await withPlatform(platform, () async {
             final window = FakeAppWindowController();
             await pumpMenuScope(tester, window: window);
 
             await invokeNativeMenuMethod(tester, NativeAppMenuMethod.exitApp);
             await tester.pump();
+            await tester.pump();
 
-            expect(window.closeCalls, 1);
+            expect(window.destroyCalls, 1);
           });
         });
 

--- a/test/widget/app_menu_test_support.dart
+++ b/test/widget/app_menu_test_support.dart
@@ -8,6 +8,8 @@ import 'package:alera/src/features/app_menu/infra/native_app_menu_channel.dart';
 import 'package:alera/src/features/app_menu/presentation/alera_app_menu_scope.dart';
 import 'package:alera/src/features/app_window/application/app_window_controller.dart';
 import 'package:alera/src/features/app_window/application/app_window_providers.dart';
+import 'package:alera/src/features/app_window/application/app_window_state_repository.dart';
+import 'package:alera/src/features/app_window/domain/app_window_state.dart';
 import 'package:alera/src/features/settings/domain/alera_settings.dart';
 import 'package:alera/src/features/updater/domain/alera_update.dart';
 import 'package:flutter/foundation.dart';
@@ -36,6 +38,13 @@ Future<void> pumpActionHarness(
   FakeUpdateController? updateController,
   FakeAppWindowController? window,
 }) async {
+  final resolvedWindow = window ?? FakeAppWindowController();
+  final lifecycle = AppWindowLifecycleCoordinator(
+    repository: MemoryAppWindowStateRepository(),
+    window: resolvedWindow,
+    saveDebounce: Duration.zero,
+  );
+  await lifecycle.start();
   await tester.pumpWidget(
     ProviderScope(
       overrides: [
@@ -49,9 +58,8 @@ Future<void> pumpActionHarness(
                 ),
               ),
         ),
-        appWindowControllerProvider.overrideWithValue(
-          window ?? FakeAppWindowController(),
-        ),
+        appWindowControllerProvider.overrideWithValue(resolvedWindow),
+        appWindowLifecycleCoordinatorProvider.overrideWithValue(lifecycle),
         settingsControllerProvider.overrideWith(
           () => FakeSettingsController(AleraSettings.defaults),
         ),
@@ -80,6 +88,13 @@ Future<void> pumpMenuScope(
   FakeAppWindowController? window,
   Widget? child,
 }) async {
+  final resolvedWindow = window ?? FakeAppWindowController();
+  final lifecycle = AppWindowLifecycleCoordinator(
+    repository: MemoryAppWindowStateRepository(),
+    window: resolvedWindow,
+    saveDebounce: Duration.zero,
+  );
+  await lifecycle.start();
   await tester.pumpWidget(
     ProviderScope(
       overrides: [
@@ -93,9 +108,8 @@ Future<void> pumpMenuScope(
                 ),
               ),
         ),
-        appWindowControllerProvider.overrideWithValue(
-          window ?? FakeAppWindowController(),
-        ),
+        appWindowControllerProvider.overrideWithValue(resolvedWindow),
+        appWindowLifecycleCoordinatorProvider.overrideWithValue(lifecycle),
         settingsControllerProvider.overrideWith(
           () => FakeSettingsController(AleraSettings.defaults),
         ),
@@ -199,22 +213,57 @@ class FakeUpdateController extends AleraUpdateController {
   }
 }
 
-class FakeAppWindowController implements AppWindowController {
-  int closeCalls = 0;
+class MemoryAppWindowStateRepository implements AppWindowStateRepository {
+  AppWindowState? state;
 
   @override
-  void addListener(AppWindowEventListener listener) {}
+  Future<void> clear() async {
+    state = null;
+  }
+
+  @override
+  Future<AppWindowState?> load() async => state;
+
+  @override
+  Future<void> save(AppWindowState state) async {
+    this.state = state;
+  }
+}
+
+class FakeAppWindowController implements AppWindowController {
+  int closeCalls = 0;
+  int destroyCalls = 0;
+  final List<AppWindowEventListener> listeners = <AppWindowEventListener>[];
+  bool preventClose = false;
+
+  @override
+  void addListener(AppWindowEventListener listener) {
+    listeners.add(listener);
+  }
+
+  @override
+  void removeListener(AppWindowEventListener listener) {
+    listeners.remove(listener);
+  }
 
   @override
   Future<void> close() async {
     closeCalls += 1;
+    for (final listener in List<AppWindowEventListener>.from(listeners)) {
+      listener.onWindowClose();
+    }
   }
 
   @override
-  Future<void> destroy() async {}
+  Future<void> destroy() async {
+    destroyCalls += 1;
+  }
 
   @override
   Future<Rect> getBounds() async => const Rect.fromLTWH(0, 0, 1280, 720);
+
+  @override
+  Future<void> hide() async {}
 
   @override
   Future<bool> isFullScreen() async => false;
@@ -226,10 +275,13 @@ class FakeAppWindowController implements AppWindowController {
   Future<bool> isMinimized() async => false;
 
   @override
+  Future<bool> isVisible() async => true;
+
+  @override
   Future<void> maximize() async {}
 
   @override
-  void removeListener(AppWindowEventListener listener) {}
+  Future<void> restore() async {}
 
   @override
   Future<void> setBounds(Rect bounds) async {}
@@ -238,8 +290,16 @@ class FakeAppWindowController implements AppWindowController {
   Future<void> setFullScreen(bool value) async {}
 
   @override
-  Future<void> setPreventClose(bool value) async {}
+  Future<void> setPreventClose(bool value) async {
+    preventClose = value;
+  }
 
   @override
   Future<void> setTitle(String title) async {}
+
+  @override
+  Future<void> show() async {}
+
+  @override
+  Future<void> focus() async {}
 }

--- a/tool/release/package_linux.sh
+++ b/tool/release/package_linux.sh
@@ -44,6 +44,7 @@ Name=Alera
 Comment=Alera desktop agentic development environment
 Exec=/opt/alera/alera
 Icon=alera
+StartupWMClass=dev.leynier.alera
 Terminal=false
 Categories=Development;
 DESKTOP
@@ -54,9 +55,8 @@ install_payload "$deb_root"
 mkdir -p "$deb_root/DEBIAN"
 installed_size="$(du -sk "$deb_root/opt/alera" | awk '{print $1}')"
 # The dependency lists below are hand written, so they can only stay honest if
-# every entry is one `ldd` over the bundle resolves. An extra name makes users
-# install a library Alera never loads: `libayatana-appindicator3` was listed
-# here for a tray that no binary in the bundle links or dlopens.
+# every entry is one `ldd` over the bundle resolves. The tray/AppIndicator
+# path links `libayatana-appindicator3`, so that runtime package belongs here.
 #
 # These stay declared rather than copied into the payload, which is not the
 # same tradeoff for each of them:
@@ -84,7 +84,7 @@ Priority: optional
 Architecture: ${arch_deb}
 Maintainer: ${maintainer}
 Installed-Size: ${installed_size}
-Depends: libgtk-3-0, libwebkit2gtk-4.1-0, libjson-glib-1.0-0, libsecret-1-0, libsqlite3-0, libssl3, libmpv2, libvulkan1
+Depends: libgtk-3-0, libwebkit2gtk-4.1-0, libjson-glib-1.0-0, libsecret-1-0, libsqlite3-0, libssl3, libmpv2, libvulkan1, libayatana-appindicator3-1
 Description: ${description}
 DEB
 dpkg-deb --build "$deb_root" "$output_dir/alera-${release_version}-linux.deb"
@@ -116,6 +116,7 @@ Requires: sqlite
 Requires: openssl-libs
 Requires: mpv-libs
 Requires: vulkan-loader
+Requires: libayatana-appindicator-gtk3
 
 %description
 ${description}

--- a/windows/runner/CMakeLists.txt
+++ b/windows/runner/CMakeLists.txt
@@ -12,6 +12,7 @@ add_executable(${BINARY_NAME} WIN32
   "utils.cpp"
   "win32_app_menu.cpp"
   "win32_dark_mode.cpp"
+  "win32_desktop_presence.cpp"
   "win32_window.cpp"
   "${FLUTTER_MANAGED_DIR}/generated_plugin_registrant.cc"
   "Runner.rc"
@@ -38,7 +39,7 @@ target_compile_definitions(${BINARY_NAME} PRIVATE ALERA_APP_NAME=L"${ALERA_APP_N
 # Add dependency libraries and include directories. Add any application-specific
 # dependencies here.
 target_link_libraries(${BINARY_NAME} PRIVATE flutter flutter_wrapper_app)
-target_link_libraries(${BINARY_NAME} PRIVATE "dwmapi.lib")
+target_link_libraries(${BINARY_NAME} PRIVATE "dwmapi.lib" "shell32.lib" "gdi32.lib" "ole32.lib")
 target_include_directories(${BINARY_NAME} PRIVATE "${CMAKE_SOURCE_DIR}")
 
 # Run the Flutter tool portions of the build. This must not be removed.

--- a/windows/runner/flutter_window.cpp
+++ b/windows/runner/flutter_window.cpp
@@ -37,6 +37,19 @@ bool FlutterWindow::OnCreate() {
           "dev.leynier.alera/app_menu",
           &flutter::StandardMethodCodec::GetInstance());
 
+  desktop_presence_channel_ =
+      std::make_unique<flutter::MethodChannel<flutter::EncodableValue>>(
+          flutter_controller_->engine()->messenger(),
+          "dev.leynier.alera/desktop_presence",
+          &flutter::StandardMethodCodec::GetInstance());
+  desktop_presence_.Attach(GetHandle(), desktop_presence_channel_.get());
+  desktop_presence_channel_->SetMethodCallHandler(
+      [this](const flutter::MethodCall<flutter::EncodableValue>& call,
+             std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>>
+                 result) {
+        desktop_presence_.HandleMethodCall(call, std::move(result));
+      });
+
   flutter_controller_->engine()->SetNextFrameCallback([&]() {
     this->Show();
   });
@@ -50,6 +63,7 @@ bool FlutterWindow::OnCreate() {
 }
 
 void FlutterWindow::OnDestroy() {
+  desktop_presence_.Destroy();
   if (flutter_controller_) {
     flutter_controller_ = nullptr;
   }
@@ -97,6 +111,10 @@ FlutterWindow::MessageHandler(HWND hwnd, UINT const message,
     case WM_FONTCHANGE:
       flutter_controller_->engine()->ReloadSystemFonts();
       break;
+  }
+
+  if (desktop_presence_.HandleMessage(hwnd, message, wparam, lparam)) {
+    return 0;
   }
 
   return Win32Window::MessageHandler(hwnd, message, wparam, lparam);

--- a/windows/runner/flutter_window.h
+++ b/windows/runner/flutter_window.h
@@ -8,6 +8,7 @@
 
 #include <memory>
 
+#include "win32_desktop_presence.h"
 #include "win32_window.h"
 
 // A window that does nothing but host a Flutter view.
@@ -34,6 +35,10 @@ class FlutterWindow : public Win32Window {
   // Channel used to forward native app-menu activation into Dart.
   std::unique_ptr<flutter::MethodChannel<flutter::EncodableValue>>
       app_menu_channel_;
+
+  std::unique_ptr<flutter::MethodChannel<flutter::EncodableValue>>
+      desktop_presence_channel_;
+  Win32DesktopPresence desktop_presence_;
 };
 
 #endif  // RUNNER_FLUTTER_WINDOW_H_

--- a/windows/runner/win32_desktop_presence.cpp
+++ b/windows/runner/win32_desktop_presence.cpp
@@ -1,0 +1,327 @@
+#include "win32_desktop_presence.h"
+
+#include <shellapi.h>
+#include <shobjidl.h>
+
+#include <string>
+
+#include "resource.h"
+
+namespace {
+
+constexpr UINT kTrayIconId = 1;
+constexpr UINT kTrayCallback = WM_APP + 40;
+constexpr UINT kTrayShowId = 1;
+constexpr UINT kTrayQuitId = 2;
+
+std::wstring Utf8ToWide(const std::string& value) {
+  if (value.empty()) {
+    return std::wstring();
+  }
+  const int size =
+      ::MultiByteToWideChar(CP_UTF8, 0, value.c_str(), -1, nullptr, 0);
+  if (size <= 0) {
+    return std::wstring();
+  }
+  std::wstring wide(static_cast<size_t>(size), L'\0');
+  ::MultiByteToWideChar(CP_UTF8, 0, value.c_str(), -1, wide.data(), size);
+  if (!wide.empty() && wide.back() == L'\0') {
+    wide.pop_back();
+  }
+  return wide;
+}
+
+std::wstring BadgeLabel(int count) {
+  if (count <= 0) {
+    return L"";
+  }
+  if (count > 9) {
+    return L"9+";
+  }
+  return std::to_wstring(count);
+}
+
+const flutter::EncodableMap* AsMap(const flutter::EncodableValue* value) {
+  return std::get_if<flutter::EncodableMap>(value);
+}
+
+bool MapBool(const flutter::EncodableMap& map, const char* key, bool fallback) {
+  const auto it = map.find(flutter::EncodableValue(key));
+  if (it == map.end()) {
+    return fallback;
+  }
+  if (const auto* flag = std::get_if<bool>(&it->second)) {
+    return *flag;
+  }
+  return fallback;
+}
+
+int MapInt(const flutter::EncodableMap& map, const char* key, int fallback) {
+  const auto it = map.find(flutter::EncodableValue(key));
+  if (it == map.end()) {
+    return fallback;
+  }
+  if (const auto* value = std::get_if<int32_t>(&it->second)) {
+    return *value;
+  }
+  if (const auto* value = std::get_if<int64_t>(&it->second)) {
+    return static_cast<int>(*value);
+  }
+  return fallback;
+}
+
+std::string MapString(const flutter::EncodableMap& map, const char* key) {
+  const auto it = map.find(flutter::EncodableValue(key));
+  if (it == map.end()) {
+    return std::string();
+  }
+  if (const auto* value = std::get_if<std::string>(&it->second)) {
+    return *value;
+  }
+  return std::string();
+}
+
+}  // namespace
+
+Win32DesktopPresence::Win32DesktopPresence() {
+  taskbar_button_created_message_ =
+      ::RegisterWindowMessageW(L"TaskbarButtonCreated");
+  taskbar_created_message_ = ::RegisterWindowMessageW(L"TaskbarCreated");
+}
+
+Win32DesktopPresence::~Win32DesktopPresence() {
+  Destroy();
+}
+
+void Win32DesktopPresence::Attach(
+    HWND hwnd,
+    flutter::MethodChannel<flutter::EncodableValue>* channel) {
+  hwnd_ = hwnd;
+  channel_ = channel;
+}
+
+void Win32DesktopPresence::HandleMethodCall(
+    const flutter::MethodCall<flutter::EncodableValue>& call,
+    std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result) {
+  const auto* args = AsMap(call.arguments());
+  if (call.method_name() == "setTray") {
+    const bool visible = args ? MapBool(*args, "visible", false) : false;
+    const std::wstring tooltip =
+        Utf8ToWide(args ? MapString(*args, "tooltip") : std::string());
+    SetTray(visible, tooltip);
+    result->Success();
+    return;
+  }
+  if (call.method_name() == "setBadgeCount") {
+    SetBadgeCount(args ? MapInt(*args, "count", 0) : 0);
+    result->Success();
+    return;
+  }
+  if (call.method_name() == "destroy") {
+    Destroy();
+    result->Success();
+    return;
+  }
+  result->NotImplemented();
+}
+
+bool Win32DesktopPresence::HandleMessage(HWND hwnd,
+                                         UINT message,
+                                         WPARAM wparam,
+                                         LPARAM lparam) {
+  if (message == kTrayCallback) {
+    if (lparam == WM_LBUTTONUP || lparam == NIN_SELECT) {
+      ShowFromTray();
+      return true;
+    }
+    if (lparam == WM_RBUTTONUP || lparam == WM_CONTEXTMENU) {
+      POINT cursor{};
+      ::GetCursorPos(&cursor);
+      HMENU menu = ::CreatePopupMenu();
+      ::AppendMenuW(menu, MF_STRING, kTrayShowId, L"Show Alera");
+      ::AppendMenuW(menu, MF_SEPARATOR, 0, nullptr);
+      ::AppendMenuW(menu, MF_STRING, kTrayQuitId, L"Quit");
+      ::SetForegroundWindow(hwnd);
+      const UINT command = ::TrackPopupMenu(
+          menu, TPM_RETURNCMD | TPM_RIGHTBUTTON, cursor.x, cursor.y, 0, hwnd,
+          nullptr);
+      ::DestroyMenu(menu);
+      if (command == kTrayShowId) {
+        ShowFromTray();
+      } else if (command == kTrayQuitId) {
+        QuitFromTray();
+      }
+      return true;
+    }
+    return true;
+  }
+  if (taskbar_created_message_ != 0 && message == taskbar_created_message_) {
+    if (tray_visible_) {
+      tray_visible_ = false;
+      SetTray(true, nid_.szTip);
+    }
+    return true;
+  }
+  if (taskbar_button_created_message_ != 0 &&
+      message == taskbar_button_created_message_) {
+    UpdateOverlay();
+    return true;
+  }
+  return false;
+}
+
+void Win32DesktopPresence::Destroy() {
+  if (tray_visible_ && hwnd_) {
+    ::Shell_NotifyIconW(NIM_DELETE, &nid_);
+    tray_visible_ = false;
+  }
+  if (overlay_icon_) {
+    ::DestroyIcon(overlay_icon_);
+    overlay_icon_ = nullptr;
+  }
+  badge_count_ = 0;
+  if (hwnd_) {
+    ITaskbarList3* taskbar = nullptr;
+    if (SUCCEEDED(::CoCreateInstance(CLSID_TaskbarList, nullptr, CLSCTX_INPROC_SERVER,
+                                     IID_PPV_ARGS(&taskbar)))) {
+      taskbar->HrInit();
+      taskbar->SetOverlayIcon(hwnd_, nullptr, L"");
+      taskbar->Release();
+    }
+  }
+}
+
+void Win32DesktopPresence::SetTray(bool visible, const std::wstring& tooltip) {
+  if (!hwnd_) {
+    return;
+  }
+  if (!visible) {
+    if (tray_visible_) {
+      ::Shell_NotifyIconW(NIM_DELETE, &nid_);
+      tray_visible_ = false;
+    }
+    return;
+  }
+  if (tray_icon_ == nullptr) {
+    tray_icon_ = static_cast<HICON>(::LoadImageW(
+        ::GetModuleHandleW(nullptr), MAKEINTRESOURCEW(IDI_APP_ICON), IMAGE_ICON,
+        0, 0, LR_DEFAULTSIZE | LR_SHARED));
+  }
+  ZeroMemory(&nid_, sizeof(nid_));
+  nid_.cbSize = sizeof(nid_);
+  nid_.hWnd = hwnd_;
+  nid_.uID = kTrayIconId;
+  nid_.uFlags = NIF_MESSAGE | NIF_ICON | NIF_TIP;
+  nid_.uCallbackMessage = kTrayCallback;
+  nid_.hIcon = tray_icon_;
+  wcsncpy_s(nid_.szTip, tooltip.c_str(), _TRUNCATE);
+  if (tray_visible_) {
+    ::Shell_NotifyIconW(NIM_MODIFY, &nid_);
+    return;
+  }
+  if (::Shell_NotifyIconW(NIM_ADD, &nid_)) {
+    nid_.uVersion = NOTIFYICON_VERSION_4;
+    ::Shell_NotifyIconW(NIM_SETVERSION, &nid_);
+    tray_visible_ = true;
+  }
+}
+
+void Win32DesktopPresence::SetBadgeCount(int count) {
+  badge_count_ = count < 0 ? 0 : count;
+  UpdateOverlay();
+}
+
+void Win32DesktopPresence::ShowFromTray() {
+  if (channel_) {
+    channel_->InvokeMethod("trayShow", nullptr);
+  }
+}
+
+void Win32DesktopPresence::QuitFromTray() {
+  if (channel_) {
+    channel_->InvokeMethod("trayQuit", nullptr);
+  }
+}
+
+HICON Win32DesktopPresence::CreateBadgeIcon(int count) {
+  const int size = ::GetSystemMetrics(SM_CXSMICON);
+  const int dim = size > 0 ? size : 16;
+  HDC screen = ::GetDC(nullptr);
+  HDC dc = ::CreateCompatibleDC(screen);
+  BITMAPINFO info{};
+  info.bmiHeader.biSize = sizeof(BITMAPINFOHEADER);
+  info.bmiHeader.biWidth = dim;
+  info.bmiHeader.biHeight = -dim;
+  info.bmiHeader.biPlanes = 1;
+  info.bmiHeader.biBitCount = 32;
+  info.bmiHeader.biCompression = BI_RGB;
+  void* bits = nullptr;
+  HBITMAP color = ::CreateDIBSection(dc, &info, DIB_RGB_COLORS, &bits, nullptr, 0);
+  HGDIOBJ old = ::SelectObject(dc, color);
+  RECT rect{0, 0, dim, dim};
+  HBRUSH brush = ::CreateSolidBrush(RGB(0xC0, 0x28, 0x2C));
+  ::FillRect(dc, &rect, brush);
+  ::DeleteObject(brush);
+  ::SetBkMode(dc, TRANSPARENT);
+  ::SetTextColor(dc, RGB(255, 255, 255));
+  const std::wstring label = BadgeLabel(count);
+  LOGFONTW font{};
+  font.lfHeight = -((dim * 3) / 4);
+  font.lfWeight = FW_BOLD;
+  font.lfQuality = ANTIALIASED_QUALITY;
+  wcscpy_s(font.lfFaceName, L"Segoe UI");
+  HFONT hfont = ::CreateFontIndirectW(&font);
+  HGDIOBJ old_font = ::SelectObject(dc, hfont);
+  ::DrawTextW(dc, label.c_str(), -1, &rect,
+              DT_CENTER | DT_VCENTER | DT_SINGLELINE);
+  ::SelectObject(dc, old_font);
+  ::DeleteObject(hfont);
+  if (bits != nullptr) {
+    auto* pixels = static_cast<DWORD*>(bits);
+    const int pixel_count = dim * dim;
+    for (int i = 0; i < pixel_count; i += 1) {
+      pixels[i] |= 0xFF000000;
+    }
+  }
+  HBITMAP mask = ::CreateBitmap(dim, dim, 1, 1, nullptr);
+  HDC mask_dc = ::CreateCompatibleDC(screen);
+  HGDIOBJ old_mask = ::SelectObject(mask_dc, mask);
+  ::PatBlt(mask_dc, 0, 0, dim, dim, BLACKNESS);
+  ::SelectObject(mask_dc, old_mask);
+  ::DeleteDC(mask_dc);
+  ICONINFO icon_info{};
+  icon_info.fIcon = TRUE;
+  icon_info.hbmMask = mask;
+  icon_info.hbmColor = color;
+  HICON icon = ::CreateIconIndirect(&icon_info);
+  ::SelectObject(dc, old);
+  ::DeleteObject(color);
+  ::DeleteObject(mask);
+  ::DeleteDC(dc);
+  ::ReleaseDC(nullptr, screen);
+  return icon;
+}
+
+void Win32DesktopPresence::UpdateOverlay() {
+  if (!hwnd_) {
+    return;
+  }
+  ITaskbarList3* taskbar = nullptr;
+  if (FAILED(::CoCreateInstance(CLSID_TaskbarList, nullptr, CLSCTX_INPROC_SERVER,
+                                IID_PPV_ARGS(&taskbar)))) {
+    return;
+  }
+  taskbar->HrInit();
+  if (overlay_icon_) {
+    ::DestroyIcon(overlay_icon_);
+    overlay_icon_ = nullptr;
+  }
+  if (badge_count_ > 0) {
+    overlay_icon_ = CreateBadgeIcon(badge_count_);
+    const std::wstring label = BadgeLabel(badge_count_);
+    taskbar->SetOverlayIcon(hwnd_, overlay_icon_, label.c_str());
+  } else {
+    taskbar->SetOverlayIcon(hwnd_, nullptr, L"");
+  }
+  taskbar->Release();
+}

--- a/windows/runner/win32_desktop_presence.cpp
+++ b/windows/runner/win32_desktop_presence.cpp
@@ -3,6 +3,7 @@
 #include <shellapi.h>
 #include <shobjidl.h>
 
+#include <memory>
 #include <string>
 
 #include "resource.h"
@@ -167,7 +168,9 @@ bool Win32DesktopPresence::HandleMessage(HWND hwnd,
   if (taskbar_created_message_ != 0 && message == taskbar_created_message_) {
     if (tray_desired_) {
       tray_visible_ = false;
-      SetTray(true, tooltip_);
+      NotifyInstallation(false);
+      const bool installed = SetTray(true, tooltip_);
+      NotifyInstallation(installed);
     }
     return true;
   }
@@ -242,6 +245,14 @@ bool Win32DesktopPresence::SetTray(bool visible, const std::wstring& tooltip) {
 void Win32DesktopPresence::SetBadgeCount(int count) {
   badge_count_ = count < 0 ? 0 : count;
   UpdateOverlay();
+}
+
+void Win32DesktopPresence::NotifyInstallation(bool installed) {
+  if (channel_) {
+    channel_->InvokeMethod(
+        "trayInstallationChanged",
+        std::make_unique<flutter::EncodableValue>(installed));
+  }
 }
 
 void Win32DesktopPresence::ShowFromTray() {

--- a/windows/runner/win32_desktop_presence.cpp
+++ b/windows/runner/win32_desktop_presence.cpp
@@ -108,8 +108,8 @@ void Win32DesktopPresence::HandleMethodCall(
     const bool visible = args ? MapBool(*args, "visible", false) : false;
     const std::wstring tooltip =
         Utf8ToWide(args ? MapString(*args, "tooltip") : std::string());
-    SetTray(visible, tooltip);
-    result->Success();
+    const bool installed = SetTray(visible, tooltip);
+    result->Success(flutter::EncodableValue(installed));
     return;
   }
   if (call.method_name() == "setBadgeCount") {
@@ -165,9 +165,9 @@ bool Win32DesktopPresence::HandleMessage(HWND hwnd,
     return true;
   }
   if (taskbar_created_message_ != 0 && message == taskbar_created_message_) {
-    if (tray_visible_) {
+    if (tray_desired_) {
       tray_visible_ = false;
-      SetTray(true, nid_.szTip);
+      SetTray(true, tooltip_);
     }
     return true;
   }
@@ -180,6 +180,7 @@ bool Win32DesktopPresence::HandleMessage(HWND hwnd,
 }
 
 void Win32DesktopPresence::Destroy() {
+  tray_desired_ = false;
   if (tray_visible_ && hwnd_) {
     ::Shell_NotifyIconW(NIM_DELETE, &nid_);
     tray_visible_ = false;
@@ -200,16 +201,18 @@ void Win32DesktopPresence::Destroy() {
   }
 }
 
-void Win32DesktopPresence::SetTray(bool visible, const std::wstring& tooltip) {
+bool Win32DesktopPresence::SetTray(bool visible, const std::wstring& tooltip) {
+  tray_desired_ = visible;
+  tooltip_ = tooltip;
   if (!hwnd_) {
-    return;
+    return !visible;
   }
   if (!visible) {
     if (tray_visible_) {
       ::Shell_NotifyIconW(NIM_DELETE, &nid_);
       tray_visible_ = false;
     }
-    return;
+    return true;
   }
   if (tray_icon_ == nullptr) {
     tray_icon_ = static_cast<HICON>(::LoadImageW(
@@ -226,13 +229,14 @@ void Win32DesktopPresence::SetTray(bool visible, const std::wstring& tooltip) {
   wcsncpy_s(nid_.szTip, tooltip.c_str(), _TRUNCATE);
   if (tray_visible_) {
     ::Shell_NotifyIconW(NIM_MODIFY, &nid_);
-    return;
+    return true;
   }
   if (::Shell_NotifyIconW(NIM_ADD, &nid_)) {
     nid_.uVersion = NOTIFYICON_VERSION_4;
     ::Shell_NotifyIconW(NIM_SETVERSION, &nid_);
     tray_visible_ = true;
   }
+  return tray_visible_;
 }
 
 void Win32DesktopPresence::SetBadgeCount(int count) {

--- a/windows/runner/win32_desktop_presence.cpp
+++ b/windows/runner/win32_desktop_presence.cpp
@@ -130,11 +130,20 @@ bool Win32DesktopPresence::HandleMessage(HWND hwnd,
                                          WPARAM wparam,
                                          LPARAM lparam) {
   if (message == kTrayCallback) {
-    if (lparam == WM_LBUTTONUP || lparam == NIN_SELECT) {
+    // NOTIFYICON_VERSION_4 packs the event in LOWORD(lParam) and the icon
+    // id in HIWORD. Pre-v4 notifications put the event in the full lParam
+    // (HIWORD 0), so accept either shape.
+    const UINT event = LOWORD(lparam);
+    const UINT icon_id = HIWORD(lparam);
+    if (icon_id != 0 && icon_id != kTrayIconId) {
+      return false;
+    }
+    if (event == WM_LBUTTONUP || event == NIN_SELECT ||
+        event == NIN_KEYSELECT) {
       ShowFromTray();
       return true;
     }
-    if (lparam == WM_RBUTTONUP || lparam == WM_CONTEXTMENU) {
+    if (event == WM_RBUTTONUP || event == WM_CONTEXTMENU) {
       POINT cursor{};
       ::GetCursorPos(&cursor);
       HMENU menu = ::CreatePopupMenu();
@@ -211,7 +220,7 @@ void Win32DesktopPresence::SetTray(bool visible, const std::wstring& tooltip) {
   nid_.cbSize = sizeof(nid_);
   nid_.hWnd = hwnd_;
   nid_.uID = kTrayIconId;
-  nid_.uFlags = NIF_MESSAGE | NIF_ICON | NIF_TIP;
+  nid_.uFlags = NIF_MESSAGE | NIF_ICON | NIF_TIP | NIF_SHOWTIP;
   nid_.uCallbackMessage = kTrayCallback;
   nid_.hIcon = tray_icon_;
   wcsncpy_s(nid_.szTip, tooltip.c_str(), _TRUNCATE);

--- a/windows/runner/win32_desktop_presence.h
+++ b/windows/runner/win32_desktop_presence.h
@@ -27,6 +27,7 @@ class Win32DesktopPresence {
   void SetBadgeCount(int count);
   void ShowFromTray();
   void QuitFromTray();
+  void NotifyInstallation(bool installed);
   HICON CreateBadgeIcon(int count);
   void UpdateOverlay();
 

--- a/windows/runner/win32_desktop_presence.h
+++ b/windows/runner/win32_desktop_presence.h
@@ -1,0 +1,44 @@
+#ifndef RUNNER_WIN32_DESKTOP_PRESENCE_H_
+#define RUNNER_WIN32_DESKTOP_PRESENCE_H_
+
+#include <flutter/encodable_value.h>
+#include <flutter/method_channel.h>
+#include <windows.h>
+
+#include <memory>
+#include <string>
+
+class Win32DesktopPresence {
+ public:
+  Win32DesktopPresence();
+  ~Win32DesktopPresence();
+
+  void Attach(
+      HWND hwnd,
+      flutter::MethodChannel<flutter::EncodableValue>* channel);
+  void HandleMethodCall(
+      const flutter::MethodCall<flutter::EncodableValue>& call,
+      std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result);
+  bool HandleMessage(HWND hwnd, UINT message, WPARAM wparam, LPARAM lparam);
+  void Destroy();
+
+ private:
+  void SetTray(bool visible, const std::wstring& tooltip);
+  void SetBadgeCount(int count);
+  void ShowFromTray();
+  void QuitFromTray();
+  HICON CreateBadgeIcon(int count);
+  void UpdateOverlay();
+
+  HWND hwnd_ = nullptr;
+  flutter::MethodChannel<flutter::EncodableValue>* channel_ = nullptr;
+  NOTIFYICONDATA nid_{};
+  bool tray_visible_ = false;
+  int badge_count_ = 0;
+  HICON overlay_icon_ = nullptr;
+  HICON tray_icon_ = nullptr;
+  UINT taskbar_button_created_message_ = 0;
+  UINT taskbar_created_message_ = 0;
+};
+
+#endif  // RUNNER_WIN32_DESKTOP_PRESENCE_H_

--- a/windows/runner/win32_desktop_presence.h
+++ b/windows/runner/win32_desktop_presence.h
@@ -23,7 +23,7 @@ class Win32DesktopPresence {
   void Destroy();
 
  private:
-  void SetTray(bool visible, const std::wstring& tooltip);
+  bool SetTray(bool visible, const std::wstring& tooltip);
   void SetBadgeCount(int count);
   void ShowFromTray();
   void QuitFromTray();
@@ -33,7 +33,9 @@ class Win32DesktopPresence {
   HWND hwnd_ = nullptr;
   flutter::MethodChannel<flutter::EncodableValue>* channel_ = nullptr;
   NOTIFYICONDATA nid_{};
+  bool tray_desired_ = false;
   bool tray_visible_ = false;
+  std::wstring tooltip_;
   int badge_count_ = 0;
   HICON overlay_icon_ = nullptr;
   HICON tray_icon_ = nullptr;


### PR DESCRIPTION
## Summary

Keep Alera visible from the system tray or menu extra, and show how many agents are waiting for review on the Dock, taskbar, and Ubuntu Dock.

Closing the window hides it when the tray is enabled. Quit from the app menu or tray still exits. Settings live under Application → Desktop (Show Tray Icon, Show Dock Badge), default on.

## Screenshots

- No screenshots in this environment. Visual change: tray/menu-extra icon plus a numeric Dock/taskbar/Ubuntu Dock badge.

## Testing

- [x] Dart format on changed Dart files
- [ ] `flutter analyze` (Flutter rewrites `analysis_options.yaml` locally; CI analyze is authoritative)
- [x] Targeted `flutter test` for settings, desktop presence, window lifecycle, and app menu
- [ ] Full `flutter test --coverage --exclude-tags golden` (orb PTY native tests fail on GLIBC_2.39; golden tests skipped as in CI)
- [ ] Coverage report
- [ ] Golden tests
- [ ] Desktop E2E
- [ ] Desktop builds
- [x] Added unit tests for hide-on-close, pending-review count, settings persistence, and presence snapshots
- [x] Linux packaging tests still pass (`test/unit/linux_release_packaging_test.dart`)

## AI Review Report

Oracle review of the uncommitted work found: tray Quit could open a runtime confirmation dialog while the window was hidden; Windows tooltip conversion overflowed, leaked icons, and used a bad overlay mask; Linux `G_APPLICATION_NON_UNIQUE` could spawn a second process from the Dock; badge/activity classification was duplicated. Those were fixed before this PR.

Cross-platform behavior was checked in code for macOS (`NSStatusItem` + Dock badge), Windows (`NotifyIcon` + taskbar overlay), and Linux (Ayatana AppIndicator + Unity LauncherEntry). Ubuntu GNOME needs the AppIndicator extension (shipped on Ubuntu Desktop); Unity uses the same two APIs.

## Security Audit

No new command execution, auth, secrets, or updater paths. Tray/badge are local OS chrome. Linux now links and declares `libayatana-appindicator3`. D-Bus LauncherEntry emits only count/count-visible for the app's desktop id.

## Notes

- AppIndicator primary click opens the menu; Show is a menu item (middle-click / secondary activate also Shows).
- Linux GtkApplication is unique so Dock activation presents the existing hidden window. Dev and release still coexist via distinct application ids.
- Windows overlay is a drawn 16px badge (`1`–`9`, `9+`); small taskbar icons ignore overlays (OS limitation).