### PR TITLE
fix: repair linux runner build

### DIFF
--- a/linux/runner/desktop_presence.cc
+++ b/linux/runner/desktop_presence.cc
@@ -45,8 +45,8 @@ static void emit_launcher_update(DesktopPresence* self) {
                         g_variant_new_int64(self->badge_count));
   g_variant_builder_add(&builder, "{sv}", "count-visible",
                         g_variant_new_boolean(visible));
-  g_autoptr(gchar) app_uri = launcher_app_uri();
-  g_autoptr(gchar) object_path = launcher_object_path();
+  g_autofree gchar* app_uri = launcher_app_uri();
+  g_autofree gchar* object_path = launcher_object_path();
   g_dbus_connection_emit_signal(
       bus, nullptr, object_path, kLauncherInterface, "Update",
       g_variant_new("(s@a{sv})", app_uri, g_variant_builder_end(&builder)),
@@ -69,7 +69,7 @@ static void launcher_query(GDBusConnection*,
                         g_variant_new_int64(self->badge_count));
   g_variant_builder_add(&builder, "{sv}", "count-visible",
                         g_variant_new_boolean(visible));
-  g_autoptr(gchar) app_uri = launcher_app_uri();
+  g_autofree gchar* app_uri = launcher_app_uri();
   g_dbus_method_invocation_return_value(
       invocation,
       g_variant_new("(s@a{sv})", app_uri, g_variant_builder_end(&builder)));
@@ -119,7 +119,7 @@ static void ensure_launcher_object(DesktopPresence* self) {
   if (info == nullptr) {
     return;
   }
-  g_autoptr(gchar) object_path = launcher_object_path();
+  g_autofree gchar* object_path = launcher_object_path();
   self->launcher_registration = g_dbus_connection_register_object(
       bus, object_path, info->interfaces[0], &kLauncherVtable, self, nullptr,
       nullptr);
@@ -165,8 +165,14 @@ static void set_tray(DesktopPresence* self, bool visible,
   }
   if (self->indicator == nullptr) {
     self->menu = build_menu(self);
+    // libayatana-appindicator 0.5.94 deprecates both constructors without
+    // naming a replacement, and the runner builds with -Werror. Ubuntu 24.04
+    // ships an older header, so this only bites on newer distros.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     self->indicator = app_indicator_new(APPLICATION_ID, "alera",
                                         APP_INDICATOR_CATEGORY_APPLICATION_STATUS);
+#pragma GCC diagnostic pop
     app_indicator_set_menu(self->indicator, GTK_MENU(self->menu));
     // Primary click opens the AppIndicator menu. Middle-click / secondary
     // activate runs Show, which is the protocol the indicator actually

--- a/linux/runner/my_application.cc
+++ b/linux/runner/my_application.cc
@@ -408,5 +408,10 @@ MyApplication* my_application_new() {
 
   return MY_APPLICATION(g_object_new(my_application_get_type(),
                                      "application-id", APPLICATION_ID, "flags",
-                                     G_APPLICATION_FLAGS_NONE, nullptr));
+#if GLIB_CHECK_VERSION(2, 74, 0)
+                                     G_APPLICATION_DEFAULT_FLAGS,
+#else
+                                     G_APPLICATION_FLAGS_NONE,
+#endif
+                                     nullptr));
 }


### PR DESCRIPTION
The Linux runner stopped compiling on main after #563, so `Warm CI caches` fails on the `warm linux` job. `pr.yml` never builds the native Linux runner (only `merge-queue.yml` and `warm-cache.yml` do), so a direct squash merge never compiled these files.

Three `-Werror` failures:

- `desktop_presence.cc`: `g_autoptr(gchar)` does not exist, GLib defines no cleanup for `gchar`. Switched the four launcher string locals to `g_autofree gchar*`.
- `my_application.cc`: `G_APPLICATION_FLAGS_NONE` is deprecated since GLib 2.74. Uses `G_APPLICATION_DEFAULT_FLAGS` behind a `GLIB_CHECK_VERSION` guard so older distros still build. Both constants are zero, so the single-instance behavior #563 introduced is unchanged.
- `desktop_presence.cc`: libayatana-appindicator 0.5.94 deprecates both `AppIndicator` constructors without naming a replacement. Ubuntu 24.04 ships an older header so this did not break CI, but it broke local builds on newer distros. Silenced with a pragma scoped to that one call.

## Validation

`flutter build linux --debug` passes locally (`Built build/linux/x64/debug/bundle/alera-dev`). Before the change it failed with the exact errors from the failing `warm linux` run.

No documentation changes needed: this restores the behavior #563 intended, nothing user-visible or contributor-facing changes.