### PR TITLE
fix: reject loopback lookalike hosts in cloud base url

### DIFF
--- a/cloud/src/google_oidc.rs
+++ b/cloud/src/google_oidc.rs
@@ -273,49 +273,54 @@ mod tests {
             Err(error) => panic!("create verifier: {error}"),
         };
 
+        let nonce = uuid::Uuid::new_v4().to_string();
+        let other_nonce = uuid::Uuid::new_v4().to_string();
         let valid = token(
-            claims("https://accounts.google.com", "alera-client", 3600, "nonce"),
+            claims("https://accounts.google.com", "alera-client", 3600, &nonce),
             &key.encoding,
         );
-        assert!(verifier.verify(&valid, Some("nonce")).await.is_ok());
-        assert!(verifier.verify(&valid, Some("nonce")).await.is_ok());
+        assert!(verifier.verify(&valid, Some(nonce.as_str())).await.is_ok());
+        assert!(verifier.verify(&valid, Some(nonce.as_str())).await.is_ok());
         assert_eq!(hits.load(Ordering::SeqCst), 1);
 
         assert!(verifier
-            .verify(&tamper_signature(&valid), Some("nonce"))
+            .verify(&tamper_signature(&valid), Some(nonce.as_str()))
             .await
             .is_err());
         assert!(verifier
             .verify(
                 &token(
-                    claims("https://attacker.example", "alera-client", 3600, "nonce",),
+                    claims("https://attacker.example", "alera-client", 3600, &nonce),
                     &key.encoding,
                 ),
-                Some("nonce"),
+                Some(nonce.as_str()),
             )
             .await
             .is_err());
         assert!(verifier
             .verify(
                 &token(
-                    claims("https://accounts.google.com", "other-client", 3600, "nonce",),
+                    claims("https://accounts.google.com", "other-client", 3600, &nonce),
                     &key.encoding,
                 ),
-                Some("nonce"),
+                Some(nonce.as_str()),
             )
             .await
             .is_err());
         assert!(verifier
             .verify(
                 &token(
-                    claims("https://accounts.google.com", "alera-client", -120, "nonce",),
+                    claims("https://accounts.google.com", "alera-client", -120, &nonce),
                     &key.encoding,
                 ),
-                Some("nonce"),
+                Some(nonce.as_str()),
             )
             .await
             .is_err());
-        assert!(verifier.verify(&valid, Some("wrong-nonce")).await.is_err());
+        assert!(verifier
+            .verify(&valid, Some(other_nonce.as_str()))
+            .await
+            .is_err());
     }
 
     fn claims(issuer: &str, audience: &str, expires_in: i64, nonce: &str) -> VerifiedGoogleClaims {

--- a/docs/marketing/flutter-community-and-linkedin-outreach-2026.md
+++ b/docs/marketing/flutter-community-and-linkedin-outreach-2026.md
@@ -1,0 +1,265 @@
+# Alera Flutter Community And LinkedIn Outreach
+
+## Objective
+
+Use Alera's Flutter implementation to earn technical support, feedback, open-source contributions, and trusted community amplification without treating Flutter spaces as advertising inventory.
+
+## Strategic Angle
+
+Alera should not enter Flutter communities with the message "please try my AI product." It should enter with a useful technical claim:
+
+> We built a native, cross-platform agentic development environment with Flutter, Rust, and Ghostty. Here is what worked, what did not, and where the community can help.
+
+This story is valuable to Flutter developers because Alera exercises parts of the ecosystem that receive less attention than mobile applications:
+
+- A demanding desktop interface on macOS, Windows, and Linux
+- A Rust runtime and process boundary through flutter_rust_bridge
+- Real PTYs, persistent child processes, and terminal rendering
+- Ghostty VTE parsing integrated with Flutter rendering
+- Platform-specific menus, shortcuts, packaging, signing, and updates
+- Riverpod code generation and a reusable previewable design system
+- Measured performance work for terminal output and Linux frame production
+- A full open-source application that contributors can run and inspect
+
+The marketing outcome remains awareness and GitHub growth. The community-facing outcome is different: invite technical review and concrete contributions.
+
+## Audience Segments
+
+### Flutter Desktop Engineers
+
+Interested in windowing, native platform behavior, keyboard input, menus, rendering, packaging, and cross-platform edge cases.
+
+### Flutter Performance Engineers
+
+Interested in frame pacing, rebuilds, terminal streaming, isolate boundaries, memory, and measurement.
+
+### Flutter And Rust Engineers
+
+Interested in flutter_rust_bridge, process ownership, native APIs, sidecars, and safe cross-platform boundaries.
+
+### Flutter DevRel And Community Organizers
+
+Interested in credible production examples, technical talks, open-source case studies, and practical AI-assisted development workflows.
+
+### AI-Assisted Flutter Developers
+
+Interested in coordinating Codex, Claude Code, Cursor, or other agents while keeping tasks and worktrees isolated.
+
+## Verified Channel Map
+
+The statuses below were verified on 23 August 2026. Private community rules remain visible only after joining and must be rechecked before posting.
+
+| Channel | Access | Evidence Of Activity | Best Use For Alera | Required Approach |
+| --- | --- | --- | --- | --- |
+| Flutter Community Slack | Membership workspace linked by Flutter's official community directory | The official directory still links it; a current public directory snapshot lists roughly 19,800 members and active technical channels | Architecture article, technical questions, contributor conversations | Join, complete the profile, read workspace rules, participate first, and ask a moderator where project case studies belong |
+| Flutter Dev Discord | Invite-based membership linked by Flutter's official community directory | Discord reports more than 73,000 members and several thousand online | Fast technical feedback, desktop and tooling discussions, contributor discovery | Read the in-server rules before any post; use a showcase or tooling channel only if it currently permits project sharing |
+| Flutter Forum | Public Discourse account | Active in August 2026 with dedicated Products & Self-Promotion and New Releases categories | The safest direct launch post for the Flutter audience | Use Products & Self-Promotion, keep the post informative, avoid overpromising, disclose authorship, and ask for specific technical feedback |
+| Flutter Study Group | Private Slack application with manual acceptance | The current application page is live and says applicants receive an invitation after acceptance | Smaller, higher-context peer feedback | Apply once, participate as a member, and do not treat acceptance as permission to advertise |
+| Flutter Community AI Circle | Reviewed speaker proposal through Sessionize | Current call welcomes Flutter and AI demos, strategy, workshops, and show-and-tell sessions | Talk, live demo, architecture discussion, and durable community credibility | Submit a focused proposal and let the organizers schedule it; do not frame it as a launch announcement |
+| Flutter Community LinkedIn page | Public follow and editorial relationship | The community page is active and publishes Flutter plus AI programming | Repost, editorial pitch, event collaboration, and community reach | Publish the technical asset first, then send a concise pitch showing why it benefits Flutter developers |
+| Flutter-focused LinkedIn groups | Membership, with public or private visibility depending on the group | A large independent Flutter Community page links to group 10408911; group contents and current moderation are not publicly verifiable | Secondary distribution and discussion | Join, read rules, avoid duplicated posts, and contact the owner when self-promotion guidance is absent |
+| Local GDGs And Flutter Meetups | Registration or organizer approval | Flutter's official directory points to GDGs and local Meetup groups | Technical talk, demo night, and contributor relationships | Pitch a practical engineering session, not a product launch presentation |
+
+## Channels Not To Use As Marketing Surfaces
+
+### Flutter Contributors Discord
+
+Use this only when contributing to Flutter itself or seeking guidance for an upstream contribution. Alera being built with Flutter does not make product promotion relevant there.
+
+### Flutteristas
+
+The official community directory defines Flutteristas for people who identify as women or non-binary. Use it only if the participating founder or contributor belongs to that community and follows its own rules.
+
+### Unverified Invitation Links
+
+Do not use old Slack, Discord, Telegram, or WhatsApp invitations found in historical posts. Start from the current Flutter community directory or an organizer's current page.
+
+## Participation Protocol
+
+### Before Sharing
+
+1. Join with a complete profile that identifies the founder and Alera relationship.
+2. Read pinned rules, channel descriptions, and recent examples of accepted project posts.
+3. Contribute useful replies to existing discussions before opening a new topic.
+4. Ask a moderator privately when the correct channel or self-promotion policy is unclear.
+5. Prepare a technical asset that stands on its own without requiring a click.
+
+### When Sharing
+
+1. Disclose: "I am the maintainer of Alera."
+2. Lead with the Flutter engineering lesson or question.
+3. Include implementation details, tradeoffs, and source links.
+4. Ask for specific feedback, such as Linux frame pacing, Windows process behavior, desktop accessibility, or flutter_rust_bridge structure.
+5. Use one post in one correct channel. Do not duplicate it across multiple channels or groups.
+
+### After Sharing
+
+1. Answer every substantive question.
+2. Turn repeated criticism into a public issue or documentation improvement.
+3. Credit contributors and ask permission before quoting private feedback.
+4. Report what changed because of the discussion.
+5. Do not follow up with private promotional messages unless a member explicitly invites them.
+
+## Community Value Assets
+
+### Technical Article
+
+Working title:
+
+> Building A Native Multi-Agent Workbench With Flutter, Rust, And Ghostty
+
+Recommended sections:
+
+1. Why Flutter for a desktop developer tool
+2. Why the UI does not own the agent processes
+3. Flutter and Rust boundary through flutter_rust_bridge
+4. Integrating PTYs and Ghostty VTE
+5. Cross-platform process and window behavior
+6. What terminal streaming taught us about Flutter performance
+7. What remains difficult
+8. How to run the project and contribute
+
+The article should contain architecture diagrams, measured behavior, source links, and at least one limitation. It should not read like a rewritten landing page.
+
+### LinkedIn Architecture Document
+
+Eight recommended pages:
+
+1. We Built An Agentic Development Environment With Flutter
+2. The UI Runs On macOS, Windows, And Linux
+3. Rust Owns Processes, PTYs, And Persistent Runtime State
+4. Ghostty VTE Parses Real Terminal Output
+5. Each Agent Works In An Isolated Git Worktree
+6. Flutter Coordinates The Human Control Surface
+7. The Entire Application Is Open Source
+8. Help Us Test The Hard Parts Of Flutter Desktop
+
+Export the document as a flattened PDF with a consistent page size. LinkedIn supports document posts from profiles, Pages, and Groups and makes the uploaded document downloadable as a PDF.
+
+### Native LinkedIn Video
+
+Use a 35 to 50-second crop of the main demo with large burned-in captions. Keep important UI and text away from every edge because LinkedIn overlays interface controls. Upload it natively, enable captions, review them before publication, and use a custom thumbnail showing the four active agents.
+
+### Contribution Brief
+
+Create one short GitHub issue or contributor document titled "Where Flutter Contributors Can Help." List bounded areas such as:
+
+- Desktop accessibility review
+- Linux frame pacing and GTK performance measurements
+- Windows keyboard, menu, and process behavior
+- macOS packaging and native interaction polish
+- High-volume terminal rendering benchmarks
+- Widget preview and design-system coverage
+
+Every request must explain setup, expected evidence, relevant files, and how completion will be validated.
+
+## LinkedIn Roles
+
+### Founder Profile
+
+The founder profile carries the point of view and engineering narrative. Recommended topics:
+
+- Why Flutter was chosen for a developer tool
+- What had to move into Rust and why
+- What building Alera revealed about Flutter desktop
+- How multi-agent development changes the human role
+- Honest performance findings and tradeoffs
+
+### Alera Page
+
+The Alera page carries canonical proof:
+
+- Captioned product demonstrations
+- Architecture document posts
+- Release outcomes
+- Contributor acknowledgements
+- Technical articles and talk recordings
+
+### Flutter Community Pages And Groups
+
+Do not paste the founder or brand post into a group. Write a unique version around the group's current interests. LinkedIn explicitly warns that duplicate conversations across groups may be treated as spam and recommends explaining relevance, encouraging discussion, and contacting owners when rules are unclear.
+
+## Publishing Cadence
+
+The Flutter and LinkedIn route must reuse the core campaign assets so it remains inside the founder's five-to-eight-hour weekly capacity.
+
+### Week 1
+
+- Join and observe the official Flutter Slack, Discord, and Forum.
+- Apply once to Flutter Study Group.
+- Connect with five relevant Flutter desktop, performance, DevRel, or community people on LinkedIn with personal context.
+- Draft the technical article and architecture document from existing documentation.
+- Prepare the Flutter Community AI Circle proposal.
+
+### Week 2
+
+- Publish the founder LinkedIn engineering story.
+- Publish the architecture document from the Alera page.
+- Submit the Flutter Community AI Circle proposal.
+- Ask moderators for the correct location to share the technical article.
+- Request feedback from five Flutter engineers on one specific implementation area.
+
+### Launch Week
+
+- Publish the captioned native video from the Alera page.
+- Publish the founder launch post with the Flutter engineering story.
+- Post the informative Flutter Forum topic in Products & Self-Promotion.
+- Share the article in approved Slack or Discord channels only.
+- Send a concise editorial note to Flutter Community after the public technical article is available.
+
+### Post-Launch
+
+- Publish what changed because of Flutter community feedback.
+- Thank and credit contributors.
+- Convert the strongest technical question into a follow-up article or benchmark.
+- If the AI Circle proposal is accepted, adapt the campaign demo into a technical session rather than replaying the launch pitch.
+
+## Success Metrics
+
+Review these separately from the campaign's GitHub-star KPI:
+
+- Five substantive conversations with experienced Flutter developers
+- Three external technical feedback artifacts, such as issues, reviews, or pull requests
+- One merged external contribution or documented improvement attributable to community feedback
+- One submitted Flutter Community AI Circle proposal
+- One accepted talk, editorial feature, or community collaboration within 60 days
+- Flutter and LinkedIn referral traffic, GitHub stars, and downloads recorded with channel-specific campaign parameters
+
+Raw Slack members, Discord members, LinkedIn impressions, and reactions are reach diagnostics, not proof of support.
+
+## Risks And Guardrails
+
+### Marketing Spam
+
+Joining several communities and immediately dropping the same link would damage trust. Participation and moderator permission are required before promotion in private or moderated spaces.
+
+### Weak Flutter Relevance
+
+"Alera happens to use Flutter" is not enough. Every community asset must teach something about Flutter desktop, performance, architecture, Rust integration, or AI-assisted Flutter development.
+
+### False Affiliation
+
+Never describe an independent page, group, Slack, forum, or event as Google-operated unless the current source explicitly says so. The official Flutter directory linking to a community does not make every moderator or group an official Flutter team representative.
+
+### Asking For Stars
+
+In Flutter communities, ask for technical feedback and contributions. The GitHub star action should remain available on the repository but should not be the direct community request.
+
+### Private Feedback
+
+Do not publish names, quotes, screenshots, or details from private communities without explicit permission.
+
+## Sources
+
+- Flutter community directory: https://flutter.dev/community
+- Flutter contribution overview: https://docs.flutter.dev/contribute
+- Flutter Forum: https://forum.itsallwidgets.com/
+- Flutter Forum Products & Self-Promotion guidance: https://forum.itsallwidgets.com/t/about-the-products-self-promotion-category/618
+- Flutter Study Group private Slack application: https://flutterstudygroup.com/
+- Flutter Community AI Circle call for speakers: https://sessionize.com/fcaic/
+- LinkedIn Flutter Community page: https://www.linkedin.com/company/flutter-community
+- LinkedIn document posts: https://www.linkedin.com/help/linkedin/answer/a518909
+- LinkedIn native video: https://www.linkedin.com/help/linkedin/answer/a7174587
+- LinkedIn captions: https://www.linkedin.com/help/linkedin/answer/a1327025
+- LinkedIn group self-promotion: https://www.linkedin.com/help/linkedin/answer/a569220
+- LinkedIn duplicate group posts: https://www.linkedin.com/help/linkedin/answer/a542929

--- a/docs/marketing/public-launch-campaign-2026.md
+++ b/docs/marketing/public-launch-campaign-2026.md
@@ -1,0 +1,491 @@
+# Alera Public Launch Campaign
+
+## Spec
+
+### Objective
+
+Launch Alera publicly to advanced AI developers, grow the GitHub repository from its 23 August 2026 baseline of 17 stars, and establish Alera as the open-source workbench for coordinating CLI coding agents in parallel without losing human control.
+
+### Audience
+
+The primary audience is an experienced developer who already uses two or more CLI coding agents, such as Codex, Claude Code, Cursor, Amp, or OpenCode. They understand Git, terminals, branches, and worktrees. Their problem is no longer access to an agent. Their problem is coordinating several agents without losing track of files, sessions, status, decisions, or results.
+
+The secondary audience is technical founders and small AI-native engineering teams. They should benefit from the same story, but campaign copy should not dilute the initial message to accommodate them.
+
+### Offer
+
+- Free at launch
+- Open source under the MIT license
+- Public beta with working downloads
+- Desktop support for macOS, Windows, and Linux
+- Android companion available, with iOS coming later
+- No account required for the core local workflow
+
+### Constraints
+
+- Global campaign in English
+- Primarily organic distribution
+- Two personal and brand X accounts used together
+- Personal and brand LinkedIn publishing used for the Flutter engineering story
+- Moderated Flutter communities approached through contribution-first participation
+- No voice or face required in demonstrations
+- Five to eight hours of founder time per week
+- Two to four weeks of preparation
+- Product, landing, onboarding, and measurement may be improved as part of the campaign
+
+### Non-Goals
+
+- Do not market Alera to every developer persona at once.
+- Do not lead with a long feature inventory.
+- Do not position Alera as an AI model, another AI IDE, or a replacement for the CLI agents users already trust.
+- Do not spend on broad paid acquisition before an organic message produces qualified installs and feedback.
+- Do not ask friends or communities for coordinated votes or artificial engagement.
+
+## Strategic Thesis
+
+The category already uses phrases such as parallel agents, mission control, workspaces, and Git worktrees. Alera should not expect those phrases alone to differentiate it. The campaign must show a higher-order outcome:
+
+> Alera helps you run a team of CLI coding agents in parallel without losing control.
+
+The visual proof is a real task split across isolated worktrees, multiple agents working at once, live state visible in one place, a human decision handled at the correct moment, and results returning to a coherent review flow.
+
+Alera should be presented as the coordination layer around the agents, not as one more agent competing with them.
+
+## Positioning
+
+### Category
+
+Open-source native workbench for CLI coding agents.
+
+### One-Line Positioning
+
+Alera helps you run a team of CLI coding agents in parallel without losing control.
+
+### Expanded Positioning
+
+Alera gives every CLI coding agent its own Git worktree, persistent terminals, visible activity, and a durable way to coordinate tasks, decisions, and results. It works with the agents developers already use and runs natively on macOS, Windows, and Linux.
+
+### Message Hierarchy
+
+1. Outcome: run several coding agents without becoming the coordination bottleneck.
+2. Proof: isolated worktrees, durable task ownership, live state, decision gates, and structured results.
+3. Compatibility: use Codex, Claude Code, Cursor, Amp, OpenCode, or any agent that runs in a terminal.
+4. Trust: local-first, open source, free, and cross-platform.
+5. Engineering credibility: Flutter, Rust, Ghostty VTE, persistent runtime, and no Electron shell.
+
+### Recommended Hero Copy
+
+Headline:
+
+> Run A Team Of Coding Agents Without Losing Control
+
+Supporting copy:
+
+> Give every CLI coding agent its own Git worktree, keep every session visible, and coordinate tasks, decisions, and results from one native workbench.
+
+Primary action:
+
+> Watch The 60-Second Demo
+
+Secondary actions:
+
+> Star On GitHub
+
+> Download Alera
+
+The current promise, "Run Every CLI Coding Agent In Parallel," should remain available as compatibility proof, but it should no longer carry the full positioning burden by itself.
+
+## Campaign Concept
+
+### Name
+
+Four Agents. One Repo. Full Control.
+
+### Core Demonstration
+
+A single real repository receives one meaningful feature request. A coordinator divides the request into implementation, tests, documentation, and review. Four agents work simultaneously in separate worktrees. Alera shows live states, surfaces one human decision, and brings the completed work back into a reviewable outcome.
+
+This demonstration becomes the source material for the landing hero, X posts, LinkedIn posts, Flutter communities, Show HN, Reddit, Product Hunt, YouTube, the project README, and short follow-up clips.
+
+### Visual Language
+
+- Dark Alera interface with legible, high-contrast captions
+- Real product UI, not an abstract animation
+- One action per shot
+- Cursor movement only when it communicates intent
+- Captions of five to nine words
+- No rapid cuts, tiny terminal text, or decorative code that cannot be read
+- Product state labels such as Working, Waiting, Decision Needed, and Done used as narrative beats
+
+## Hero Demo Storyboard
+
+Target duration: 50 to 60 seconds. Produce a 16:9 master at 1440p, then derive a square or 4:5 cut and short clips.
+
+| Time | Product Action | On-Screen Copy |
+| --- | --- | --- |
+| 0-4s | Show one repository and a substantial feature request | Four agents. One repo. Full control. |
+| 4-10s | Create or reveal isolated workspaces for implementation, tests, docs, and review | One worktree per task. |
+| 10-20s | Dispatch work and show different CLI agents starting | Use the agents you already trust. |
+| 20-30s | Show live agent states and terminal activity together | See who is working and who needs you. |
+| 30-38s | Surface and resolve a decision gate | Human decisions stay human. |
+| 38-48s | Show structured completion, diffs, checks, or pull request state | Results return ready to review. |
+| 48-55s | Pull back to the full workbench with all work visible | Parallel work without coordination chaos. |
+| 55-60s | Alera logo, platforms, and GitHub URL | Free. Open source. macOS, Windows, Linux. |
+
+The Android companion should receive a separate follow-up clip. Adding it to the primary demo would weaken the central orchestration story.
+
+## Account Roles
+
+### Personal X Account
+
+Purpose: founder point of view, product story, technical judgment, conversations, and replies.
+
+Recommended voice:
+
+- "I built this because..."
+- Lessons from running several agents
+- Honest tradeoffs and engineering decisions
+- Direct questions to people with the same workflow problem
+- Replies that help before they promote
+
+### Alera X Account
+
+Purpose: canonical product proof, releases, clips, documentation, and support.
+
+Recommended voice:
+
+- Concise product demonstrations
+- Feature-specific clips
+- Release notes with one visible outcome
+- Installation and compatibility guidance
+- Reposts of substantive founder explanations and user examples
+
+### Cross-Posting Rule
+
+The two accounts should not publish identical copy at the same time. The personal account introduces the problem and why it matters. The brand account supplies the polished proof and permanent link. Each can quote the other when the second post adds a different layer.
+
+## Channel Strategy
+
+### Tier 1
+
+#### X
+
+Use X for repeated narrative testing, short clips, direct conversations, and launch-day distribution. Publish two substantial personal posts and two brand posts per week, plus lightweight replies. Favor native video over external-link-only posts. Put the link in the post or first reply according to the result of a small pre-launch test, not a fixed assumption.
+
+#### LinkedIn
+
+Use the founder profile for the engineering story and the Alera page for durable product proof. Publish one founder post and one brand video or document post per week by adapting the same assets created for X. The primary LinkedIn angle is not generic AI productivity. It is that Alera uses Flutter, Rust, and Ghostty to deliver a demanding native desktop developer tool across three operating systems. Native video should remain captioned, and document posts should turn the architecture into a downloadable visual walkthrough.
+
+#### Flutter Community Spaces
+
+Use the Flutter Community Slack, Flutter Dev Discord, Flutter Forum, Flutter Study Group, and Flutter Community AI Circle as contribution and feedback channels. Join first, read each space's current rules, participate in existing technical discussions, disclose authorship, and ask moderators before posting when no self-promotion area is explicit. The Flutter Forum has a dedicated Products & Self-Promotion category and is the safest direct publication surface. The full channel map and participation protocol live in [flutter-community-and-linkedin-outreach-2026.md](flutter-community-and-linkedin-outreach-2026.md).
+
+#### GitHub
+
+GitHub is the campaign destination and the primary success surface. The repository should answer the same three questions as the demo within the first screen: what Alera is, why it differs, and how to try it. Add the new hero demo near the top, preserve immediate install paths, and provide one obvious feedback route. Release notes should describe user outcomes and include one image or clip when the release supports the launch story.
+
+#### Show HN
+
+Show HN is a strong fit because Alera is substantial, personally built, open source, and immediately usable without signup. The submission should link to the GitHub repository or an immediately useful product page, explain why Alera exists, and remain available for technical discussion. Do not request coordinated votes or comments.
+
+#### Reddit
+
+Use two or three relevant technical communities only after checking each community's current self-promotion rules. Every post should be native to the community and useful without clicking. Lead with the workflow problem, show the architecture or demonstration, disclose that the author built Alera, and ask a specific technical question. Do not paste the same launch copy across communities.
+
+### Tier 2
+
+#### Product Hunt
+
+Use Product Hunt as a second launch wave, not the primary validation mechanism. Prepare a personal maker account early, a silent YouTube demonstration, at least three gallery assets, a concise first comment, and a direct product URL. Alera is already live and free, which fits the platform better than a waitlist launch.
+
+#### YouTube
+
+YouTube hosts the captioned master demonstration for Product Hunt and long-tail discovery. The video can remain silent if captions and pacing make every step understandable. Use a descriptive title and chapters only if the final cut exceeds one minute.
+
+#### Alera Blog
+
+Publish one technical launch article that explains the coordination problem and uses the demo as evidence. Existing technical posts should be linked as depth for readers interested in worktrees, persistent terminals, local-first architecture, quotas, and orchestration.
+
+### Deferred Channels
+
+- Broad paid ads: defer until one message and one audience produce qualified installs organically.
+- Discord or Slack community creation: defer until recurring users need a shared place beyond GitHub Discussions or Issues.
+- Influencer sponsorships: defer until Alera has user proof and a repeatable demonstration.
+
+## Three-Week Calendar
+
+Recommended public launch window: 15 to 22 September 2026. The exact dates may move, but the sequence should remain intact.
+
+### Week 1: Proof And Conversion
+
+Goal: make the product understandable in 60 seconds and make every campaign visit land on a coherent story.
+
+- Record the 16:9 silent master demo and three derivative clips.
+- Update landing hero copy, primary actions, and social preview.
+- Update the first screen of the GitHub README with the same promise and demo.
+- Add campaign parameters and outbound click events for X, HN, Reddit, Product Hunt, and YouTube.
+- Create a single feedback destination and label it clearly.
+- Create the Product Hunt personal account or confirm it can post, then create a draft.
+- Prepare the LinkedIn founder post, architecture document, and native video crop.
+- Join the official Flutter community surfaces, read their rules, apply to the private Flutter Study Group, and identify the correct channels or moderators before sharing Alera.
+- Capture baseline GitHub stars, forks, visitors, clones, referrers, release downloads, landing visitors, and download clicks.
+
+### Week 2: Seed And Learn
+
+Goal: test the message with real developers before spending the launch moment.
+
+- Send 20 highly targeted personal messages to developers who visibly use multiple coding agents. Ask for product feedback, not promotion.
+- Publish the first founder post about the coordination problem.
+- Publish a brand clip showing isolated worktrees.
+- Publish a second founder post explaining why Alera coordinates existing agents instead of replacing them.
+- Publish a brand clip showing live state and a decision gate.
+- Publish the LinkedIn architecture story and document carousel.
+- Submit the Flutter Community AI Circle session proposal.
+- Ask for technical feedback in approved Flutter channels without requesting stars or launch amplification.
+- Hold five short asynchronous feedback conversations and record the exact language users use.
+- Adjust the headline, demo captions, README, and FAQ when the same confusion appears twice.
+- Finalize Show HN, Reddit, and Product Hunt drafts.
+
+### Week 3: Launch Wave
+
+Goal: create one coherent public moment, then adapt the discussion to each community.
+
+#### Tuesday, 15 September
+
+- Publish the founder X launch thread.
+- Publish the Alera canonical demo post.
+- Publish the founder LinkedIn launch story and the captioned native video from the Alera page.
+- Submit Show HN and remain available to answer for at least three focused hours.
+- Pin the launch post on both X accounts.
+- Record every repeated question or objection.
+
+#### Thursday, 17 September
+
+- Publish one Reddit post in the best-fitting community with a native technical explanation.
+- Publish a second Reddit post only if it has a genuinely different angle and follows that community's rules.
+- Publish the informative Flutter Forum post in Products & Self-Promotion.
+- Share the Flutter engineering article only in Slack or Discord channels where moderators or current rules permit it.
+- Ship FAQ or installation fixes discovered during the first wave.
+
+#### Tuesday, 22 September
+
+- Launch on Product Hunt as a second wave.
+- Publish the maker first comment immediately.
+- Share the launch from the personal account and let the brand account supply the demo.
+- Reply to every substantive comment without asking for votes.
+
+#### Remainder Of Launch Week
+
+- Publish a transparent result post: what people understood, what confused them, what changed, and what Alera will build next.
+- Turn the three best questions into short product clips or blog posts.
+- Thank early users individually and ask permission before quoting their feedback.
+
+## Content System
+
+### Pillar 1: The Coordination Problem
+
+- Running one agent is easy. Running four changes the job.
+- Worktrees isolate files, but they do not coordinate ownership, decisions, or results.
+- The human should make product decisions, not babysit terminal windows.
+
+### Pillar 2: Product Proof
+
+- One task, four worktrees, four agents
+- Working, waiting, blocked, and done at a glance
+- Durable dispatch, decision gates, and structured completion
+- Persistent terminals that survive the window
+
+### Pillar 3: Engineering Trust
+
+- Local-first core workflow
+- Open source and free
+- Native Flutter and Rust architecture
+- Ghostty VTE terminal parsing
+- Cross-platform desktop support
+
+### Pillar 4: Builder Story
+
+- Why existing terminals and AI IDEs did not fit the workflow
+- What broke while making sessions persistent
+- Why agents keep their own CLIs and credentials
+- What changed after using Alera to build Alera
+
+### Weekly Output At Five To Eight Hours
+
+- Two substantial personal posts
+- Two polished brand clips or screenshots
+- One LinkedIn founder post and one LinkedIn brand asset adapted from the same weekly material
+- Ten to fifteen useful replies across relevant conversations
+- Five targeted feedback messages
+- One hour for metrics and message review
+
+## Copy Kit
+
+The initial founder thread, brand post, Show HN submission, Product Hunt copy, and targeted feedback message live in [public-launch-copy-kit-2026.md](public-launch-copy-kit-2026.md).
+
+## KPI Framework
+
+### Primary KPI
+
+Net new GitHub stars during the 30 days beginning with the first public launch wave.
+
+Formula:
+
+`GitHub stars at day 30 - 17 baseline stars`
+
+Why it is primary: the founder selected GitHub stars as the clearest initial signal, and stars improve repository credibility and future organic discovery.
+
+Limitation: a star is an intent signal, not proof of installation, activation, retention, or product value. It must be reviewed with the driver and guardrail metrics below.
+
+### Provisional Targets
+
+These are bottom-up directional targets, not external category benchmarks. Confidence is low until the first week of message testing provides real conversion rates.
+
+| Level | Total Stars | Net New Stars | Interpretation |
+| --- | ---: | ---: | --- |
+| Minimum viable result | 75 | 58 | The campaign created a real base but no channel broke out. |
+| Target | 150 | 133 | At least one community or content angle produced meaningful distribution. |
+| Stretch | 300 | 283 | The demonstration and positioning broke beyond the founder's immediate reach. |
+
+### Driver Metrics
+
+1. Qualified landing and repository visitors by channel. Use UTM-tagged campaign links, Vercel Analytics, and GitHub Traffic referrers. Review daily during launch and weekly afterwards.
+2. GitHub intent rate. Calculate `net new stars / unique GitHub repository visitors` for the available period. Use it to compare message quality across waves, while recognizing that GitHub only retains a rolling traffic window and users may arrive through untracked paths.
+3. Flutter community contribution intent. Record substantive architecture feedback, external issues, pull requests, and accepted talk or editorial proposals separately from raw reach.
+
+### Guardrails
+
+1. Product-use evidence: at least 75 cumulative desktop release or package-install signals and ten substantive user feedback conversations during the 30-day window. Download counts are directional because package managers and repeated downloads do not map cleanly to unique users.
+2. Launch quality: no launch-blocking installation issue remains without a public response for more than 24 hours, and no confirmed critical data-loss or security issue is used to continue promotion before mitigation.
+
+### Diagnostic Metrics
+
+- Demo views and completion rate where the channel provides it
+- Landing to GitHub click-through rate
+- Landing to download click-through rate
+- GitHub unique visitors, clones, and top referrers
+- Release asset downloads by platform
+- Product Hunt page visits and comments
+- LinkedIn profile and page impressions, document views, native video views, and qualified comments
+- Flutter community referrals, technical feedback conversations, external issues, and pull requests
+- Substantive replies, questions, and user-created issues
+- Stars by launch wave, using timestamped star data
+
+## Measurement Plan
+
+### Before Launch
+
+- Record the dated baseline for stars, forks, watchers, visitors, clones, referrers, release downloads, landing visitors, and download clicks.
+- Add campaign-specific UTM parameters to every external post.
+- Track clicks for Watch Demo, Star On GitHub, Download Alera, and each platform install path.
+- Create a lightweight daily snapshot because GitHub repository traffic exposes a rolling 14-day view.
+- Define a simple feedback log with source, persona, first confusion, requested outcome, install status, and permission to quote.
+
+### Daily During Launch
+
+- Capture stars and star timestamps.
+- Capture landing traffic and outbound events by source.
+- Capture GitHub visitors, referrers, clones, and release asset downloads.
+- Record substantive questions and installation failures.
+- Note the exact message and visual used by each wave.
+
+### Weekly Decision Rules
+
+- If a post receives qualified replies but few GitHub visits, improve the call to action and link placement.
+- If it generates visits but few stars, revise the repository first screen and proof, not distribution volume.
+- If it generates stars but few downloads or feedback conversations, treat the result as awareness and investigate product friction before scaling.
+- If two communities repeat the same objection, address it in the landing, README, demo, or onboarding before the next wave.
+- If one clip produces at least twice the GitHub intent rate of the others, use its problem framing as the next week's main message.
+
+## Experiments
+
+### Experiment 1: Outcome Versus Feature Headline
+
+- A: Run A Team Of Coding Agents Without Losing Control
+- B: Run Every CLI Coding Agent In Parallel
+- Success: higher Watch Demo and GitHub click-through rates from comparable X posts or landing intervals
+
+### Experiment 2: Orchestration Versus Worktree Proof
+
+- A: task dispatch, live status, decision gate, and result
+- B: four agents in four isolated worktrees
+- Success: higher demo completion, qualified replies, and GitHub intent rate
+
+### Experiment 3: Founder Story Versus Product-Only Post
+
+- A: personal explanation of the coordination problem
+- B: polished brand demonstration
+- Success: qualified profile visits, GitHub visits, and substantive replies per thousand impressions
+
+Only one element should change within each comparison. Results from different platforms should not be treated as a clean A/B test.
+
+## Budget
+
+The campaign can remain almost entirely organic.
+
+Recommended optional spend ceiling: USD 250.
+
+- Up to USD 100 for captioning, format conversion, or a small editing tool if the native workflow is insufficient
+- Up to USD 100 for visual asset support when the Product Hunt gallery or social crops need more polish
+- Up to USD 50 for an unexpected launch utility or domain-related need
+
+Do not buy followers, votes, generic newsletter placements, or broad social ads. Do not promote a Reddit post before its organic message has proven useful inside the community.
+
+## Launch Readiness Checklist
+
+### Product
+
+- The demonstrated multi-agent path completes from a clean installation.
+- The first-run path reaches the demonstrated outcome without undocumented setup.
+- macOS, Windows, and Linux install instructions are current.
+- A rollback or rapid patch path is available for launch-blocking problems.
+- Feedback has one obvious destination.
+
+### Landing And Repository
+
+- Hero promise matches the campaign.
+- The silent demo appears above the first long feature inventory.
+- Social preview uses the new outcome-oriented promise.
+- GitHub README repeats the promise, demo, supported platforms, and quickest install path.
+- Campaign links carry source-specific parameters.
+- Outbound actions generate measurable events.
+
+### Distribution
+
+- Personal and Alera X profiles have current bio, link, banner, and pinned post.
+- Personal LinkedIn profile and Alera page have aligned descriptions, links, visuals, and launch assets.
+- Flutter community memberships, rules, moderator contacts, and approved publication locations are recorded.
+- Show HN title and opening comment are ready.
+- Each Reddit community's current rules and moderator guidance have been reviewed.
+- Product Hunt personal maker account can post and the launch draft is complete.
+- YouTube demo is public or unlisted as required by the launch draft, not private.
+- The founder has protected response time during each launch wave.
+
+### Measurement
+
+- Baseline snapshot is stored.
+- Daily snapshot process works.
+- Vercel and GitHub data sources are accessible.
+- Feedback log is ready.
+- Day 1, day 7, and day 30 reviews are scheduled.
+
+## Assumptions And Open Decisions
+
+- The campaign assumes the current public beta is stable enough for a concentrated traffic increase.
+- The 15 to 22 September window is recommended, not yet confirmed.
+- The exact personal and brand X handles still need to be inserted into profiles, tracking links, and launch assets.
+- The exact personal profile and Alera page URLs on LinkedIn still need to be inserted into tracking links and community pitches.
+- The primary CTA order should be validated after the hero demo exists.
+- Privacy-preserving product activation telemetry is optional. It should be designed explicitly rather than added implicitly because Alera's local-first trust is part of the product promise.
+
+## Evidence Reviewed
+
+- Alera repository, landing page, download paths, release process, architecture, product features, and public beta state as of 23 August 2026
+- Current positioning from adjacent tools including cmux, Conductor, and Agent Deck
+- Show HN guidelines: https://news.ycombinator.com/showhn.html
+- Product Hunt posting and featuring guidance: https://help.producthunt.com/en/articles/479557-how-to-post-a-product and https://help.producthunt.com/en/articles/9883485-product-hunt-featuring-guidelines
+- GitHub repository traffic documentation: https://docs.github.com/en/repositories/viewing-activity-and-data-for-your-repository/viewing-traffic-to-a-repository
+- Official Flutter community directory: https://flutter.dev/community
+- Flutter Forum Products & Self-Promotion guidance: https://forum.itsallwidgets.com/t/about-the-products-self-promotion-category/618
+- Flutter Community AI Circle call for speakers: https://sessionize.com/fcaic/
+- LinkedIn document, video, captions, group, and self-promotion guidance: https://www.linkedin.com/help/linkedin/answer/a518909, https://www.linkedin.com/help/linkedin/answer/a7174587, https://www.linkedin.com/help/linkedin/answer/a1327025, and https://www.linkedin.com/help/linkedin/answer/a569220

--- a/docs/marketing/public-launch-copy-kit-2026.md
+++ b/docs/marketing/public-launch-copy-kit-2026.md
@@ -1,0 +1,174 @@
+# Alera Public Launch Copy Kit
+
+## Founder Launch Thread
+
+Post 1:
+
+> Running one coding agent is easy. Running four turns you into a full-time traffic controller.
+>
+> I built Alera to coordinate CLI coding agents in parallel without losing control.
+>
+> Free, open source, and native on macOS, Windows, and Linux.
+>
+> [demo]
+
+Post 2:
+
+> Every task gets its own Git worktree, terminals, branch, and agent context. Codex, Claude Code, Cursor, Amp, OpenCode, or anything else that runs in a terminal.
+
+Post 3:
+
+> The important part is not opening more terminals. It is knowing who owns each task, who is working, who needs a decision, and what result came back.
+
+Post 4:
+
+> Alera keeps that state durable: task dispatch, agent status, decision gates, structured results, persistent sessions, pull requests, and checks in one workbench.
+
+Post 5:
+
+> I am launching it as a public beta because I want feedback from people already pushing multi-agent workflows past the comfortable limit.
+>
+> GitHub: https://github.com/leynier/alera
+> Download: https://alera.build/download
+
+## Brand Launch Post
+
+> Four agents. One repo. Full control.
+>
+> Alera gives every CLI coding agent its own Git worktree and coordinates tasks, decisions, and results in one native workbench.
+>
+> Free and open source on macOS, Windows, and Linux.
+>
+> https://github.com/leynier/alera
+
+## Show HN Title
+
+> Show HN: Alera - coordinate CLI coding agents across isolated Git worktrees
+
+## Show HN Opening Comment
+
+> I built Alera after my coding workflow became a pile of terminal windows, worktrees, and agent sessions that I was afraid to close. The agents were capable, but I had become the coordination layer.
+>
+> Alera is a native, open-source workbench that keeps each CLI agent in its own Git worktree and makes task ownership, live status, decisions, and structured results visible in one place. It works with the agents already installed on your machine rather than replacing them with another model or chat backend.
+>
+> The core workflow is available now on macOS, Windows, and Linux. I would especially value feedback from people already running several agents at once: where does your coordination workflow break first?
+
+## Product Hunt
+
+Tagline:
+
+> Run CLI Coding Agents In Parallel Without Losing Control
+
+Description:
+
+> Alera is a free, open-source native workbench for coordinating CLI coding agents across isolated Git worktrees, persistent terminals, tasks, decisions, and results. Available on macOS, Windows, and Linux.
+
+First comment:
+
+> I built Alera because the difficult part of using several coding agents was no longer prompting them. It was keeping their branches, terminals, status, decisions, and results coherent. Alera keeps the agents you already use and adds the coordination layer around them. I would love to learn where your own multi-agent workflow becomes difficult to manage.
+
+## Targeted Feedback Message
+
+> Hi [name]. I have seen that you use [agents or workflow] in parallel. I am building an open-source workbench called Alera that gives each CLI agent an isolated Git worktree and coordinates their tasks, status, decisions, and results. I am not asking you to promote it. Would you be willing to watch a 60-second silent demo and tell me the first thing that feels unclear or unconvincing?
+
+## LinkedIn Founder Post
+
+> Most people still associate Flutter with mobile apps.
+>
+> I used it to build a native development environment for coordinating AI coding agents on macOS, Windows, and Linux.
+>
+> Alera's interface is Flutter. Rust owns the PTYs, persistent processes, Git operations, and runtime state. Ghostty's VTE parses the terminal output. Each agent works inside an isolated Git worktree.
+>
+> The interesting part was not making the UI look like a terminal. It was keeping Flutter responsive while real agents streamed output, processes survived the window, and platform behavior remained correct across three desktops.
+>
+> Alera is now free and open source. I am especially interested in feedback from Flutter desktop and performance engineers: which part of this architecture would you inspect first?
+>
+> [architecture document or native video]
+
+## LinkedIn Alera Page Post
+
+> Alera is a native, open-source agentic development environment built with Flutter, Rust, and Ghostty.
+>
+> Flutter provides one cross-platform workbench for macOS, Windows, and Linux. Rust owns the process, PTY, Git, and persistent runtime boundaries. Ghostty VTE handles terminal parsing.
+>
+> This architecture lets developers coordinate CLI coding agents across isolated Git worktrees without replacing the agents they already use.
+>
+> Explore the architecture and help us test the hard parts of Flutter desktop.
+>
+> https://github.com/leynier/alera
+
+## LinkedIn Architecture Document
+
+Page 1:
+
+> We Built An Agentic Development Environment With Flutter
+
+Page 2:
+
+> One UI Across macOS, Windows, And Linux
+
+Page 3:
+
+> Rust Owns Processes, PTYs, Git, And Persistent Runtime State
+
+Page 4:
+
+> Ghostty VTE Parses Real Terminal Output
+
+Page 5:
+
+> Every Agent Gets An Isolated Git Worktree
+
+Page 6:
+
+> Flutter Keeps The Human Control Surface Coherent
+
+Page 7:
+
+> Free, MIT-Licensed, And Built In The Open
+
+Page 8:
+
+> Help Us Test The Hard Parts Of Flutter Desktop
+
+## Flutter Forum Post
+
+Title:
+
+> Alera: A Native Multi-Agent Development Environment Built With Flutter And Rust
+
+Body:
+
+> I am the maintainer of Alera, an open-source desktop workbench for coordinating CLI coding agents across isolated Git worktrees.
+>
+> The desktop UI and design system are implemented in Flutter for macOS, Windows, and Linux. Rust owns PTYs, persistent child processes, Git operations, and runtime state through flutter_rust_bridge, while Ghostty's VTE handles terminal parsing.
+>
+> Building it has forced us to work through Flutter desktop concerns that do not appear in a typical mobile app: high-volume terminal output, Linux frame pacing, Windows process and keyboard behavior, native menus, persistent sidecars, packaging, and cross-platform performance measurement.
+>
+> The repository is available at https://github.com/leynier/alera. I would value technical feedback more than promotion. If you were reviewing this as a Flutter desktop application, which architectural or performance area would you inspect first?
+
+## Flutter Slack Or Discord Moderator Request
+
+> Hi. I maintain Alera, an open-source desktop development environment built with Flutter, Rust, and Ghostty. I have written a technical case study about Flutter desktop performance, PTYs, persistent processes, and flutter_rust_bridge. I would like to ask the community for architecture feedback, not advertise a paid product. Which channel, if any, would be appropriate for sharing it? I will follow the workspace rules and keep it to one informative post.
+
+## Approved Flutter Community Post
+
+> I maintain Alera, an open-source agentic development environment whose desktop UI runs on Flutter across macOS, Windows, and Linux.
+>
+> I documented why Rust owns the PTYs and persistent processes, how Ghostty VTE feeds the terminal surface, and what we learned about Flutter frame production under streaming output.
+>
+> I would appreciate feedback on [one specific technical area]. The article and source are here: [link]. I am happy to answer implementation questions in this thread.
+
+## Flutter Community AI Circle Proposal
+
+Title:
+
+> Building A Multi-Agent Coding Workbench With Flutter, Rust, And Ghostty
+
+Abstract:
+
+> Alera is a native, open-source environment for coordinating Codex, Claude Code, Cursor, and other CLI coding agents across isolated Git worktrees. Its Flutter interface runs on macOS, Windows, and Linux, while a Rust runtime owns PTYs, persistent processes, Git operations, and durable orchestration state. This session will demonstrate the real product, explain the Flutter and Rust boundary, show what high-volume terminal streaming taught us about desktop performance, and discuss how Flutter can serve as the human control surface for agentic development. The session will include architecture diagrams, measured tradeoffs, source links, and the failures that shaped the design.
+
+Format:
+
+> 25-minute technical walkthrough and live demonstration, followed by open Q&A.

--- a/rust/alera-cli/src/alera_account/cloud_base_url.rs
+++ b/rust/alera-cli/src/alera_account/cloud_base_url.rs
@@ -1,0 +1,59 @@
+use anyhow::{anyhow, Result};
+use url::{Host, Url};
+
+/// Cleartext HTTP is accepted only for a literal loopback origin. A prefix match is
+/// not enough: `http://localhost.example.com` starts with `http://localhost` while
+/// resolving to a remote host, which would put bearer tokens on the wire in the clear.
+pub(crate) fn validate_cloud_base_url(base_url: &str) -> Result<()> {
+    let parsed =
+        Url::parse(base_url).map_err(|_| anyhow!("ALERA_CLOUD_URL must be an absolute URL"))?;
+    let loopback = match parsed.host() {
+        Some(Host::Domain(domain)) => domain.eq_ignore_ascii_case("localhost"),
+        Some(Host::Ipv4(address)) => address.is_loopback(),
+        Some(Host::Ipv6(address)) => address.is_loopback(),
+        None => false,
+    };
+    match parsed.scheme() {
+        "https" => Ok(()),
+        "http" if loopback => Ok(()),
+        _ => Err(anyhow!(
+            "ALERA_CLOUD_URL must use HTTPS or a loopback HTTP origin"
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_cloud_base_url;
+
+    #[test]
+    fn loopback_lookalike_hosts_are_rejected() {
+        for base_url in [
+            "http://localhost.example.com",
+            "http://127.0.0.1.example.com",
+            "http://api.alera.build",
+            "ftp://localhost",
+            "not a url",
+        ] {
+            assert!(
+                validate_cloud_base_url(base_url).is_err(),
+                "{base_url} must be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn https_and_real_loopback_origins_are_accepted() {
+        for base_url in [
+            "https://api.alera.build",
+            "http://localhost:8787",
+            "http://127.0.0.1:8787",
+            "http://[::1]:8787",
+        ] {
+            assert!(
+                validate_cloud_base_url(base_url).is_ok(),
+                "{base_url} must be accepted"
+            );
+        }
+    }
+}

--- a/rust/alera-cli/src/alera_account/cloud_client.rs
+++ b/rust/alera-cli/src/alera_account/cloud_client.rs
@@ -1,10 +1,11 @@
-use anyhow::{anyhow, Context as _, Result};
+use anyhow::{Context as _, Result};
 use chrono::{DateTime, Utc};
 use reqwest::{Client, Method, StatusCode};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_json::Value;
 use thiserror::Error;
-use url::{Host, Url};
+
+use crate::terminal_host::alera_account::cloud_base_url::validate_cloud_base_url;
 
 pub(crate) const DEFAULT_CLOUD_BASE_URL: &str = "https://api.alera.build";
 
@@ -394,27 +395,6 @@ impl CloudAccountClient {
     }
 }
 
-/// Cleartext HTTP is accepted only for a literal loopback origin. A prefix match is
-/// not enough: `http://localhost.example.com` starts with `http://localhost` while
-/// resolving to a remote host, which would put bearer tokens on the wire in the clear.
-pub(crate) fn validate_cloud_base_url(base_url: &str) -> Result<()> {
-    let parsed =
-        Url::parse(base_url).map_err(|_| anyhow!("ALERA_CLOUD_URL must be an absolute URL"))?;
-    let loopback = match parsed.host() {
-        Some(Host::Domain(domain)) => domain.eq_ignore_ascii_case("localhost"),
-        Some(Host::Ipv4(address)) => address.is_loopback(),
-        Some(Host::Ipv6(address)) => address.is_loopback(),
-        None => false,
-    };
-    match parsed.scheme() {
-        "https" => Ok(()),
-        "http" if loopback => Ok(()),
-        _ => Err(anyhow!(
-            "ALERA_CLOUD_URL must use HTTPS or a loopback HTTP origin"
-        )),
-    }
-}
-
 fn cloud_error(status: StatusCode, body: &str, path: &str) -> anyhow::Error {
     let parsed = serde_json::from_str::<Value>(body).ok();
     let error = parsed.as_ref().and_then(|value| value.get("error"));
@@ -441,38 +421,7 @@ fn cloud_error(status: StatusCode, body: &str, path: &str) -> anyhow::Error {
 mod tests {
     use reqwest::StatusCode;
 
-    use super::{cloud_error, validate_cloud_base_url, CloudRequestError};
-
-    #[test]
-    fn loopback_lookalike_hosts_are_rejected() {
-        for base_url in [
-            "http://localhost.example.com",
-            "http://127.0.0.1.example.com",
-            "http://api.alera.build",
-            "ftp://localhost",
-            "not a url",
-        ] {
-            assert!(
-                validate_cloud_base_url(base_url).is_err(),
-                "{base_url} must be rejected"
-            );
-        }
-    }
-
-    #[test]
-    fn https_and_real_loopback_origins_are_accepted() {
-        for base_url in [
-            "https://api.alera.build",
-            "http://localhost:8787",
-            "http://127.0.0.1:8787",
-            "http://[::1]:8787",
-        ] {
-            assert!(
-                validate_cloud_base_url(base_url).is_ok(),
-                "{base_url} must be accepted"
-            );
-        }
-    }
+    use super::{cloud_error, CloudRequestError};
 
     #[test]
     fn relay_key_conflicts_remain_machine_readable() {

--- a/rust/alera-cli/src/alera_account/cloud_client.rs
+++ b/rust/alera-cli/src/alera_account/cloud_client.rs
@@ -4,6 +4,7 @@ use reqwest::{Client, Method, StatusCode};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_json::Value;
 use thiserror::Error;
+use url::{Host, Url};
 
 pub(crate) const DEFAULT_CLOUD_BASE_URL: &str = "https://api.alera.build";
 
@@ -140,14 +141,7 @@ pub(crate) struct CloudAccountClient {
 impl CloudAccountClient {
     pub(crate) fn new(base_url: String) -> Result<Self> {
         let base_url = base_url.trim_end_matches('/').to_string();
-        if !base_url.starts_with("https://")
-            && !base_url.starts_with("http://127.0.0.1")
-            && !base_url.starts_with("http://localhost")
-        {
-            return Err(anyhow!(
-                "ALERA_CLOUD_URL must use HTTPS or a loopback HTTP origin"
-            ));
-        }
+        validate_cloud_base_url(&base_url)?;
         Ok(Self {
             base_url,
             http: Client::builder()
@@ -400,6 +394,27 @@ impl CloudAccountClient {
     }
 }
 
+/// Cleartext HTTP is accepted only for a literal loopback origin. A prefix match is
+/// not enough: `http://localhost.example.com` starts with `http://localhost` while
+/// resolving to a remote host, which would put bearer tokens on the wire in the clear.
+pub(crate) fn validate_cloud_base_url(base_url: &str) -> Result<()> {
+    let parsed =
+        Url::parse(base_url).map_err(|_| anyhow!("ALERA_CLOUD_URL must be an absolute URL"))?;
+    let loopback = match parsed.host() {
+        Some(Host::Domain(domain)) => domain.eq_ignore_ascii_case("localhost"),
+        Some(Host::Ipv4(address)) => address.is_loopback(),
+        Some(Host::Ipv6(address)) => address.is_loopback(),
+        None => false,
+    };
+    match parsed.scheme() {
+        "https" => Ok(()),
+        "http" if loopback => Ok(()),
+        _ => Err(anyhow!(
+            "ALERA_CLOUD_URL must use HTTPS or a loopback HTTP origin"
+        )),
+    }
+}
+
 fn cloud_error(status: StatusCode, body: &str, path: &str) -> anyhow::Error {
     let parsed = serde_json::from_str::<Value>(body).ok();
     let error = parsed.as_ref().and_then(|value| value.get("error"));
@@ -426,7 +441,38 @@ fn cloud_error(status: StatusCode, body: &str, path: &str) -> anyhow::Error {
 mod tests {
     use reqwest::StatusCode;
 
-    use super::{cloud_error, CloudRequestError};
+    use super::{cloud_error, validate_cloud_base_url, CloudRequestError};
+
+    #[test]
+    fn loopback_lookalike_hosts_are_rejected() {
+        for base_url in [
+            "http://localhost.example.com",
+            "http://127.0.0.1.example.com",
+            "http://api.alera.build",
+            "ftp://localhost",
+            "not a url",
+        ] {
+            assert!(
+                validate_cloud_base_url(base_url).is_err(),
+                "{base_url} must be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn https_and_real_loopback_origins_are_accepted() {
+        for base_url in [
+            "https://api.alera.build",
+            "http://localhost:8787",
+            "http://127.0.0.1:8787",
+            "http://[::1]:8787",
+        ] {
+            assert!(
+                validate_cloud_base_url(base_url).is_ok(),
+                "{base_url} must be accepted"
+            );
+        }
+    }
 
     #[test]
     fn relay_key_conflicts_remain_machine_readable() {

--- a/rust/alera-cli/src/alera_account/mod.rs
+++ b/rust/alera-cli/src/alera_account/mod.rs
@@ -4,7 +4,9 @@ mod loopback_callback;
 mod pkce;
 mod service;
 
-pub(crate) use cloud_client::{AuthProvider, AuthTransaction, PushEventRequest, RelayGrant};
+pub(crate) use cloud_client::{
+    validate_cloud_base_url, AuthProvider, AuthTransaction, PushEventRequest, RelayGrant,
+};
 pub(crate) use loopback_callback::{bind_callback_listener, wait_for_callback};
 pub(crate) use pkce::Pkce;
 pub(crate) use service::AleraAccountService;

--- a/rust/alera-cli/src/alera_account/mod.rs
+++ b/rust/alera-cli/src/alera_account/mod.rs
@@ -1,12 +1,12 @@
+pub(crate) mod cloud_base_url;
 mod cloud_client;
 mod credential_store;
 mod loopback_callback;
 mod pkce;
 mod service;
 
-pub(crate) use cloud_client::{
-    validate_cloud_base_url, AuthProvider, AuthTransaction, PushEventRequest, RelayGrant,
-};
+pub(crate) use cloud_base_url::validate_cloud_base_url;
+pub(crate) use cloud_client::{AuthProvider, AuthTransaction, PushEventRequest, RelayGrant};
 pub(crate) use loopback_callback::{bind_callback_listener, wait_for_callback};
 pub(crate) use pkce::Pkce;
 pub(crate) use service::AleraAccountService;

--- a/rust/alera-cli/src/terminal_host/relay_runtime_auth.rs
+++ b/rust/alera-cli/src/terminal_host/relay_runtime_auth.rs
@@ -4,6 +4,8 @@ use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
 use ed25519_dalek::{Signature, Verifier, VerifyingKey};
 use serde::Deserialize;
 
+use crate::terminal_host::alera_account::validate_cloud_base_url;
+
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct GrantHeader {
@@ -69,7 +71,9 @@ pub(super) async fn verify_grant(token: &str) -> anyhow::Result<GrantClaims> {
     }
     let cloud_url =
         std::env::var("ALERA_CLOUD_URL").unwrap_or_else(|_| "https://api.alera.build".to_owned());
-    let jwks_url = format!("{}/.well-known/jwks.json", cloud_url.trim_end_matches('/'));
+    let cloud_url = cloud_url.trim_end_matches('/');
+    validate_cloud_base_url(cloud_url)?;
+    let jwks_url = format!("{cloud_url}/.well-known/jwks.json");
     let jwks: JsonWebKeySet = reqwest::Client::builder()
         .timeout(Duration::from_secs(10))
         .build()?


### PR DESCRIPTION
## Summary

Resolves the open CodeQL code-scanning alerts that pointed at real code, and hardens the one that was an actual bug.

- `CloudAccountClient::new` accepted any URL starting with `http://localhost` or `http://127.0.0.1`. `http://localhost.example.com` satisfies that prefix while resolving to a remote host, so an `ALERA_CLOUD_URL` shaped that way would have sent bearer tokens over cleartext HTTP. Validation now parses the URL and allows plain HTTP only for a literal loopback host (`localhost`, an IPv4 loopback, or an IPv6 loopback).
- `relay_runtime_auth::verify_grant` builds the relay JWKS URL from the same `ALERA_CLOUD_URL` and had no scheme check at all, so the keys used to verify relay grant signatures could be fetched over plaintext HTTP from an arbitrary host. It now runs the shared validator before the fetch.
- The Google OIDC verifier tests used the literal `"nonce"` as the token nonce (CodeQL alerts 26-28). They now mint a random per-run nonce.

## Validation

- `cargo test -p alera-cli --bins cloud_client` (4 passed, including the two new cases)
- `cargo test --lib google_oidc` in `cloud/` (1 passed)
- `cargo clippy -p alera-cli --bins` clean, `cargo fmt` applied

## Notes

The remaining code-scanning alerts (`relay_crypto.rs` HKDF domain-separation labels, the `video_server.rs` proxy pinned to `http://[::1]`) are false positives and are dismissed separately with justification.