### PR TITLE
fix: release terminal memory on cleanup

### DIFF
--- a/lib/src/features/workbench/infra/terminal_host/terminal_host_pty_session.dart
+++ b/lib/src/features/workbench/infra/terminal_host/terminal_host_pty_session.dart
@@ -415,6 +415,7 @@ final class TerminalHostPtySession
     unawaited(_hostSub?.cancel());
     _hostSub = null;
     if (_lease?.release() ?? true) {
+      _client.releaseSession(_sessionId);
       unawaited(_client.detach(_sessionId).catchError((_) {}));
     }
     unawaited(_events.close());

--- a/test/unit/terminal_host_pty_session_lease_cases.dart
+++ b/test/unit/terminal_host_pty_session_lease_cases.dart
@@ -62,6 +62,7 @@ void _registerTerminalHostPtySessionLeaseTests() {
     await _flushAsync();
 
     expect(client.detached, isEmpty);
+    expect(client.released, isEmpty);
     expect(replacement.writeBytes(<int>[7]), isTrue);
     await _flushAsync();
     expect(client.writes, <List<int>>[
@@ -71,5 +72,6 @@ void _registerTerminalHostPtySessionLeaseTests() {
     replacement.dispose();
     await _flushAsync();
     expect(client.detached, <String>['session-1']);
+    expect(client.released, <String>['session-1']);
   });
 }

--- a/test/unit/terminal_host_test_fakes.dart
+++ b/test/unit/terminal_host_test_fakes.dart
@@ -45,6 +45,7 @@ final class FakeTerminalHostClient
   final List<(String, int, int)> resizes = <(String, int, int)>[];
   final List<(String, bool)> outputPaused = <(String, bool)>[];
   final List<String> detached = <String>[];
+  final List<String> released = <String>[];
   final List<String> terminated = <String>[];
   final List<String> restarted = <String>[];
   final List<String> reclaimed = <String>[];
@@ -86,7 +87,9 @@ final class FakeTerminalHostClient
   }
 
   @override
-  void releaseSession(String sessionId) {}
+  void releaseSession(String sessionId) {
+    released.add(sessionId);
+  }
 
   @override
   Future<void> configure(TerminalHostConfig config) async {}


### PR DESCRIPTION
$## Summary\n- release trimmed xterm buffer rows so dropped scrollback cells are no longer retained\n- release the terminal-host per-session event stream when the final PTY lease detaches\n- update the xterm submodule to ebfab96 (`fix: release trimmed terminal buffer rows`)\n\n## Validation\n- `flutter analyze`\n- `flutter test` (3341 passed, 1 skipped)\n- `flutter build linux --debug`\n- xterm circular buffer tests (22 passed)\n\nRebased onto `main` at `4a733ec6` (v0.75.1) with no conflicts.