### PR TITLE
Add mobile quota host visibility controls

### DIFF
--- a/docs/agent-quotas.md
+++ b/docs/agent-quotas.md
@@ -20,6 +20,8 @@ The quota host follows the active workspace. Local desktop and mobile requests g
 
 Mobile exposes a dedicated **Quotas** screen with the same provider ordering, Claude Default and CCS profile configuration, environment variable names, manual refresh, and remaining/reset details as desktop. When a Claude profile is not `ok` and the runtime advertises `agentQuotaClaudeTuiV1`, the card also offers **Try With TUI**. Codex reset credits and their next expiry appear when the runtime advertises `codexResetCreditsV1`. It refreshes when opened and every 15 minutes while visible. Disabling every provider is supported and produces an empty snapshot rather than falling back to defaults.
 
+Mobile Home shows quotas from all available hosts by default. Use **Settings > Quota Hosts** or **Choose Hosts** beside the Home quota heading to hide hosts that share the same accounts. Each switch applies to all quotas from that host in the Home summary, and hidden hosts are not polled for quotas by that summary. The selection is saved only on this phone by runtime ID, survives host renaming and reconnection, and includes newly added hosts by default. All hosts may be hidden; **Choose Hosts** remains available to restore them. Individual host Quotas screens, provider settings, and desktop behavior are unchanged.
+
 ## Codex Reset Credits
 
 For the default Codex account, desktop hover cards, the desktop quota overview, and the mobile Quotas card show how many earned rate-limit resets are available and when the next available credit expires. Alera always asks for confirmation before spending one.

--- a/mobile/lib/src/features/quotas/application/quota_host_visibility_controller.dart
+++ b/mobile/lib/src/features/quotas/application/quota_host_visibility_controller.dart
@@ -1,0 +1,54 @@
+import 'package:logging/logging.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+part 'quota_host_visibility_controller.g.dart';
+
+const quotaHiddenRuntimeIdsKey = 'quotas.hiddenRuntimeIds';
+
+@Riverpod(keepAlive: true)
+class QuotaHostVisibilityController extends _$QuotaHostVisibilityController {
+  final _logger = Logger('QuotaHostVisibilityController');
+  Future<void> _pendingWrite = Future<void>.value();
+
+  @override
+  Future<Set<String>> build() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      return Set<String>.unmodifiable(
+        prefs.getStringList(quotaHiddenRuntimeIdsKey) ?? const <String>[],
+      );
+    } on Object catch (error, stackTrace) {
+      _logger.warning('could not load quota hosts', error, stackTrace);
+      rethrow;
+    }
+  }
+
+  Future<void> setHostVisible(String runtimeId, bool visible) {
+    // Serialize read-modify-write so quick changes to different hosts survive.
+    final operation = _pendingWrite.then((_) async {
+      try {
+        final current = await future;
+        final hidden = <String>{...current};
+        if (visible) {
+          hidden.remove(runtimeId);
+        } else {
+          hidden.add(runtimeId);
+        }
+        final prefs = await SharedPreferences.getInstance();
+        final saved = await prefs.setStringList(
+          quotaHiddenRuntimeIdsKey,
+          hidden.toList()..sort(),
+        );
+        if (!saved) throw StateError('Could not save quota hosts.');
+        if (ref.mounted) state = AsyncData(Set<String>.unmodifiable(hidden));
+      } on Object catch (error, stackTrace) {
+        _logger.warning('could not save quota hosts', error, stackTrace);
+        rethrow;
+      }
+    });
+    // A failed write must not block later edits; the caller receives the error.
+    _pendingWrite = operation.then<void>((_) {}, onError: (Object _) {});
+    return operation;
+  }
+}

--- a/mobile/lib/src/features/quotas/application/quota_host_visibility_controller.g.dart
+++ b/mobile/lib/src/features/quotas/application/quota_host_visibility_controller.g.dart
@@ -1,0 +1,57 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'quota_host_visibility_controller.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(QuotaHostVisibilityController)
+final quotaHostVisibilityControllerProvider =
+    QuotaHostVisibilityControllerProvider._();
+
+final class QuotaHostVisibilityControllerProvider
+    extends $AsyncNotifierProvider<QuotaHostVisibilityController, Set<String>> {
+  QuotaHostVisibilityControllerProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'quotaHostVisibilityControllerProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$quotaHostVisibilityControllerHash();
+
+  @$internal
+  @override
+  QuotaHostVisibilityController create() => QuotaHostVisibilityController();
+}
+
+String _$quotaHostVisibilityControllerHash() =>
+    r'33addd4591b33f6337a74b4d1457e367af9b7359';
+
+abstract class _$QuotaHostVisibilityController
+    extends $AsyncNotifier<Set<String>> {
+  FutureOr<Set<String>> build();
+  @$mustCallSuper
+  @override
+  WhenComplete runBuild() {
+    final ref = this.ref as $Ref<AsyncValue<Set<String>>, Set<String>>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<AsyncValue<Set<String>>, Set<String>>,
+              AsyncValue<Set<String>>,
+              Object?,
+              Object?
+            >;
+    return element.handleCreate(ref, build);
+  }
+}

--- a/mobile/lib/src/features/quotas/presentation/home_quotas_section.dart
+++ b/mobile/lib/src/features/quotas/presentation/home_quotas_section.dart
@@ -1,13 +1,16 @@
 import 'package:alera_mobile/src/app/theme/alera_tokens.dart';
 import 'package:alera_mobile/src/design_system/layout/alera_section_header.dart';
+import 'package:alera_mobile/src/design_system/feedback/alera_empty_state.dart';
 import 'package:alera_mobile/src/features/hosts/domain/paired_host_profile.dart';
 import 'package:alera_mobile/src/features/quotas/application/agent_quota_controller.dart';
+import 'package:alera_mobile/src/features/quotas/application/quota_host_visibility_controller.dart';
 import 'package:alera_mobile/src/features/quotas/domain/quota_settings.dart';
 import 'package:alera_mobile/src/features/quotas/domain/quota_snapshot.dart';
 import 'package:alera_mobile/src/features/quotas/presentation/agent_quota_provider_icon.dart';
 import 'package:alera_mobile/src/features/quotas/presentation/agent_quotas_screen.dart';
 import 'package:alera_mobile/src/features/quotas/presentation/quota_display_labels.dart';
 import 'package:alera_mobile/src/features/quotas/presentation/quota_ordering.dart';
+import 'package:alera_mobile/src/features/quotas/presentation/quota_hosts_settings_screen.dart';
 import 'package:alera_mobile/src/features/quotas/presentation/quota_status_pill.dart';
 import 'package:alera_mobile/src/features/settings/application/host_settings_controller.dart';
 import 'package:flutter/material.dart';
@@ -21,10 +24,16 @@ class HomeQuotasSection extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final visibility = ref.watch(quotaHostVisibilityControllerProvider);
+    final hidden = visibility.value;
+    // Wait for the local selection before subscribing to any host's quotas.
+    final visibleHosts = hidden == null
+        ? const <PairedHostProfile>[]
+        : hosts.where((host) => !hidden.contains(host.runtimeId)).toList();
     final groupByHost = hosts.length > 1;
     final children = <Widget>[];
 
-    for (final host in hosts) {
+    for (final host in visibleHosts) {
       final async = ref.watch(agentQuotaControllerProvider(host.id));
       final settings = ref
           .watch(hostSettingsControllerProvider(host.id))
@@ -41,7 +50,7 @@ class HomeQuotasSection extends ConsumerWidget {
       children.addAll(hostChildren);
     }
 
-    if (children.isEmpty) {
+    if (hosts.isEmpty) {
       return const SizedBox.shrink();
     }
 
@@ -49,15 +58,37 @@ class HomeQuotasSection extends ConsumerWidget {
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: <Widget>[
         const SizedBox(height: AleraTokens.spaceLg),
-        const AleraSectionHeader(
+        AleraSectionHeader(
           label: 'Quotas',
-          padding: EdgeInsets.only(
+          trailing: TextButton(
+            onPressed: () => Navigator.of(context).push<void>(
+              MaterialPageRoute<void>(
+                builder: (_) => const QuotaHostsSettingsScreen(),
+              ),
+            ),
+            child: const Text('Choose Hosts'),
+          ),
+          padding: const EdgeInsets.only(
             left: AleraTokens.space4,
             right: AleraTokens.space8,
             top: AleraTokens.space8,
             bottom: AleraTokens.space4,
           ),
         ),
+        if (visibility.hasError)
+          AleraEmptyState(
+            message: 'Could not load quota hosts.',
+            action: TextButton(
+              onPressed: () =>
+                  ref.invalidate(quotaHostVisibilityControllerProvider),
+              child: const Text('Retry'),
+            ),
+          )
+        else if (hidden != null && visibleHosts.isEmpty)
+          const AleraEmptyState(
+            message:
+                'No hosts selected. Choose hosts to show their quotas here.',
+          ),
         ...children,
       ],
     );

--- a/mobile/lib/src/features/quotas/presentation/quota_hosts_settings_screen.dart
+++ b/mobile/lib/src/features/quotas/presentation/quota_hosts_settings_screen.dart
@@ -1,0 +1,92 @@
+import 'package:alera_mobile/src/app/theme/alera_tokens.dart';
+import 'package:alera_mobile/src/design_system/feedback/alera_empty_state.dart';
+import 'package:alera_mobile/src/features/hosts/application/paired_hosts_controller.dart';
+import 'package:alera_mobile/src/features/quotas/application/quota_host_visibility_controller.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class QuotaHostsSettingsScreen extends ConsumerWidget {
+  const QuotaHostsSettingsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final hosts = ref.watch(availableHostsProvider);
+    final visibility = ref.watch(quotaHostVisibilityControllerProvider);
+    final hostList = hosts.value;
+    final hidden = visibility.value;
+    return Scaffold(
+      appBar: AppBar(title: const Text('Quota Hosts')),
+      body: SafeArea(
+        child: hosts.hasError || visibility.hasError
+            ? AleraEmptyState(
+                message: 'Could not load quota hosts.',
+                action: TextButton(
+                  onPressed: () {
+                    ref.invalidate(availableHostsProvider);
+                    ref.invalidate(quotaHostVisibilityControllerProvider);
+                  },
+                  child: const Text('Retry'),
+                ),
+              )
+            : hostList == null || hidden == null
+            ? const Center(child: CircularProgressIndicator())
+            : ListView(
+                padding: AleraTokens.pagePadding,
+                children: <Widget>[
+                  Text(
+                    'Choose which hosts show quotas on Home. If hosts share '
+                    'the same accounts, select just one to avoid duplicates.',
+                    style: Theme.of(context).textTheme.bodyMedium,
+                  ),
+                  const SizedBox(height: AleraTokens.spaceSm),
+                  Text(
+                    'Saved on this phone. Individual host quotas and desktop '
+                    'settings are unchanged. New hosts are shown by default.',
+                    style: Theme.of(context).textTheme.bodySmall,
+                  ),
+                  const SizedBox(height: AleraTokens.spaceLg),
+                  if (hostList.isEmpty)
+                    const AleraEmptyState(
+                      message: 'Pair a host or sign in to choose quota hosts.',
+                    ),
+                  for (final host in hostList) ...<Widget>[
+                    Card(
+                      child: SwitchListTile(
+                        title: Text(host.effectiveName),
+                        subtitle: Text(host.endpoint),
+                        value: !hidden.contains(host.runtimeId),
+                        onChanged: (visible) => _setHostVisible(
+                          context,
+                          ref,
+                          host.runtimeId,
+                          visible,
+                        ),
+                      ),
+                    ),
+                    const SizedBox(height: AleraTokens.spaceSm),
+                  ],
+                ],
+              ),
+      ),
+    );
+  }
+
+  Future<void> _setHostVisible(
+    BuildContext context,
+    WidgetRef ref,
+    String runtimeId,
+    bool visible,
+  ) async {
+    final messenger = ScaffoldMessenger.of(context);
+    try {
+      await ref
+          .read(quotaHostVisibilityControllerProvider.notifier)
+          .setHostVisible(runtimeId, visible);
+    } on Object {
+      if (!messenger.mounted) return;
+      messenger.showSnackBar(
+        const SnackBar(content: Text('Could not save quota hosts. Try again.')),
+      );
+    }
+  }
+}

--- a/mobile/lib/src/features/settings/presentation/app_settings_screen.dart
+++ b/mobile/lib/src/features/settings/presentation/app_settings_screen.dart
@@ -3,6 +3,7 @@ import 'package:alera_mobile/src/design_system/icons/alera_icons.dart';
 import 'package:alera_mobile/src/features/accounts/presentation/accounts_screen.dart';
 import 'package:alera_mobile/src/features/diagnostics/presentation/diagnostics_screen.dart';
 import 'package:alera_mobile/src/features/ai_dictation/presentation/mobile_ai_dictation_settings_screen.dart';
+import 'package:alera_mobile/src/features/quotas/presentation/quota_hosts_settings_screen.dart';
 import 'package:alera_mobile/src/features/terminal/presentation/terminal_keys_settings_screen.dart';
 import 'package:flutter/material.dart';
 
@@ -52,6 +53,23 @@ class AppSettingsScreen extends StatelessWidget {
             ),
             const SizedBox(height: AleraTokens.spaceXl),
             Text('AI', style: Theme.of(context).textTheme.titleMedium),
+            const SizedBox(height: AleraTokens.spaceSm),
+            Card(
+              child: ListTile(
+                leading: const Icon(Icons.data_usage),
+                title: const Text('Quota Hosts'),
+                subtitle: const Text('Choose which hosts show quotas on Home'),
+                trailing: const Icon(
+                  AleraIcons.chevronRight,
+                  size: AleraTokens.space16,
+                ),
+                onTap: () => Navigator.of(context).push<void>(
+                  MaterialPageRoute<void>(
+                    builder: (_) => const QuotaHostsSettingsScreen(),
+                  ),
+                ),
+              ),
+            ),
             const SizedBox(height: AleraTokens.spaceSm),
             Card(
               child: ListTile(

--- a/mobile/test/quota_host_visibility_controller_test.dart
+++ b/mobile/test/quota_host_visibility_controller_test.dart
@@ -1,0 +1,88 @@
+import 'package:alera_mobile/src/features/quotas/application/quota_host_visibility_controller.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() => SharedPreferences.setMockInitialValues(<String, Object>{}));
+
+  test('existing installs hide no hosts by default', () async {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    expect(
+      await container.read(quotaHostVisibilityControllerProvider.future),
+      isEmpty,
+    );
+  });
+
+  test(
+    'hidden runtimes survive controller recreation and can be restored',
+    () async {
+      final first = ProviderContainer();
+      await first.read(quotaHostVisibilityControllerProvider.future);
+      await first
+          .read(quotaHostVisibilityControllerProvider.notifier)
+          .setHostVisible('runtime-1', false);
+      first.dispose();
+
+      final second = ProviderContainer();
+      addTearDown(second.dispose);
+      expect(await second.read(quotaHostVisibilityControllerProvider.future), {
+        'runtime-1',
+      });
+      await second
+          .read(quotaHostVisibilityControllerProvider.notifier)
+          .setHostVisible('runtime-1', true);
+
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getStringList(quotaHiddenRuntimeIdsKey), isEmpty);
+    },
+  );
+
+  test('quick edits preserve all hosts and the latest choice', () async {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final controller = container.read(
+      quotaHostVisibilityControllerProvider.notifier,
+    );
+
+    await Future.wait([
+      controller.setHostVisible('runtime-1', false),
+      controller.setHostVisible('runtime-2', false),
+      controller.setHostVisible('runtime-1', true),
+      controller.setHostVisible('runtime-3', false),
+    ]);
+
+    expect(container.read(quotaHostVisibilityControllerProvider).requireValue, {
+      'runtime-2',
+      'runtime-3',
+    });
+    final prefs = await SharedPreferences.getInstance();
+    expect(prefs.getStringList(quotaHiddenRuntimeIdsKey), [
+      'runtime-2',
+      'runtime-3',
+    ]);
+  });
+
+  test(
+    'edits preserve preferences for temporarily unavailable runtimes',
+    () async {
+      SharedPreferences.setMockInitialValues(<String, Object>{
+        quotaHiddenRuntimeIdsKey: ['offline-runtime'],
+      });
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      await container
+          .read(quotaHostVisibilityControllerProvider.notifier)
+          .setHostVisible('runtime-1', false);
+
+      expect(
+        container.read(quotaHostVisibilityControllerProvider).requireValue,
+        {'offline-runtime', 'runtime-1'},
+      );
+    },
+  );
+}

--- a/mobile/test/quota_hosts_settings_screen_test.dart
+++ b/mobile/test/quota_hosts_settings_screen_test.dart
@@ -1,0 +1,310 @@
+import 'dart:async';
+
+import 'package:alera_mobile/src/app/theme/alera_theme.dart';
+import 'package:alera_mobile/src/features/hosts/application/paired_hosts_controller.dart';
+import 'package:alera_mobile/src/features/hosts/domain/paired_host_profile.dart';
+import 'package:alera_mobile/src/features/quotas/application/agent_quota_controller.dart';
+import 'package:alera_mobile/src/features/quotas/application/quota_host_visibility_controller.dart';
+import 'package:alera_mobile/src/features/quotas/domain/quota_snapshot.dart';
+import 'package:alera_mobile/src/features/quotas/presentation/agent_quotas_screen.dart';
+import 'package:alera_mobile/src/features/quotas/presentation/home_quotas_section.dart';
+import 'package:alera_mobile/src/features/quotas/presentation/quota_hosts_settings_screen.dart';
+import 'package:alera_mobile/src/features/runtime/application/host_connection_controller.dart';
+import 'package:alera_mobile/src/features/runtime/infra/mobile_runtime_client.dart';
+import 'package:alera_mobile/src/features/settings/application/host_settings_controller.dart';
+import 'package:alera_mobile/src/features/settings/domain/portable_host_settings.dart';
+import 'package:alera_mobile/src/features/settings/presentation/app_settings_screen.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  setUp(() => SharedPreferences.setMockInitialValues(<String, Object>{}));
+
+  testWidgets('settings select local and cloud hosts without connecting', (
+    tester,
+  ) async {
+    final container = ProviderContainer(
+      overrides: [availableHostsProvider.overrideWith((ref) async => _hosts)],
+    );
+    addTearDown(container.dispose);
+    await _pump(tester, container, const AppSettingsScreen());
+    await tester.tap(find.text('Quota Hosts'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Work Laptop'), findsOneWidget);
+    expect(find.text('Cloud Desktop'), findsOneWidget);
+    expect(tester.widget<SwitchListTile>(_switch('Work Laptop')).value, isTrue);
+    await tester.tap(_switch('Work Laptop'));
+    await tester.pumpAndSettle();
+    expect(
+      tester.widget<SwitchListTile>(_switch('Work Laptop')).value,
+      isFalse,
+    );
+    await tester.tap(_switch('Cloud Desktop'));
+    await tester.pumpAndSettle();
+    expect(container.read(quotaHostVisibilityControllerProvider).requireValue, {
+      'runtime-local',
+      'runtime-cloud',
+    });
+  });
+
+  testWidgets('home filters before subscribing and restores hidden quotas', (
+    tester,
+  ) async {
+    SharedPreferences.setMockInitialValues(<String, Object>{
+      quotaHiddenRuntimeIdsKey: ['runtime-local'],
+    });
+    final quotaReads = <String>[];
+    final settingsReads = <String>[];
+    final container = _quotaContainer(quotaReads, settingsReads);
+    addTearDown(container.dispose);
+    await _pump(tester, container, _home(_hosts));
+
+    expect(find.text('Work Laptop'), findsNothing);
+    expect(find.text('Cloud Desktop'), findsOneWidget);
+    expect(quotaReads, ['cloud-profile']);
+    expect(settingsReads, ['cloud-profile']);
+
+    await tester.tap(find.text('Choose Hosts'));
+    await tester.pumpAndSettle();
+    await tester.tap(_switch('Work Laptop'));
+    await tester.pumpAndSettle();
+    await tester.pageBack();
+    await tester.pumpAndSettle();
+    expect(find.text('Work Laptop'), findsOneWidget);
+    expect(quotaReads, contains('local-profile'));
+
+    // Explicit per-host quota screens are independent of Home visibility.
+    await container
+        .read(quotaHostVisibilityControllerProvider.notifier)
+        .setHostVisible('runtime-local', false);
+    await _pump(tester, container, AgentQuotasScreen(host: _hosts.first));
+    expect(find.text('Codex'), findsOneWidget);
+  });
+
+  testWidgets(
+    'all hidden keeps the selector and newly added hosts are visible',
+    (tester) async {
+      SharedPreferences.setMockInitialValues(<String, Object>{
+        quotaHiddenRuntimeIdsKey: ['runtime-local', 'runtime-cloud'],
+      });
+      final quotaReads = <String>[];
+      final settingsReads = <String>[];
+      final container = _quotaContainer(quotaReads, settingsReads);
+      addTearDown(container.dispose);
+      await _pump(tester, container, _home(_hosts));
+
+      expect(find.text('Choose Hosts'), findsOneWidget);
+      expect(find.textContaining('No hosts selected.'), findsOneWidget);
+      expect(quotaReads, isEmpty);
+      expect(settingsReads, isEmpty);
+
+      await _pump(
+        tester,
+        container,
+        _home([
+          _hosts.first.withAlias('Renamed Laptop'),
+          _hosts.last,
+          _host('new-profile', 'runtime-new', 'New Host'),
+        ]),
+      );
+      expect(find.text('Renamed Laptop'), findsNothing);
+      expect(find.text('New Host'), findsOneWidget);
+      expect(quotaReads, ['new-profile']);
+    },
+  );
+
+  testWidgets('does not poll quotas while the saved selection loads', (
+    tester,
+  ) async {
+    final selection = Completer<Set<String>>();
+    final quotaReads = <String>[];
+    final container = ProviderContainer(
+      overrides: [
+        quotaHostVisibilityControllerProvider.overrideWith(
+          () => _DelayedVisibility(selection.future),
+        ),
+        agentQuotaControllerProvider.overrideWith2((_) => _Quotas(quotaReads)),
+        hostSettingsControllerProvider.overrideWith2((_) => _Settings([])),
+      ],
+    );
+    addTearDown(container.dispose);
+    await _pump(tester, container, _home(_hosts));
+    expect(quotaReads, isEmpty);
+
+    selection.complete({'runtime-local'});
+    await tester.pumpAndSettle();
+    expect(quotaReads, ['cloud-profile']);
+  });
+
+  testWidgets(
+    'selection read failure does not poll all hosts and offers retry',
+    (tester) async {
+      SharedPreferences.setMockInitialValues(<String, Object>{
+        quotaHiddenRuntimeIdsKey: 42,
+      });
+      final quotaReads = <String>[];
+      final container = _quotaContainer(quotaReads, []);
+      addTearDown(container.dispose);
+      await _pump(tester, container, _home(_hosts));
+      expect(quotaReads, isEmpty);
+      expect(find.text('Could not load quota hosts.'), findsOneWidget);
+
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setStringList(quotaHiddenRuntimeIdsKey, ['runtime-local']);
+      await tester.tap(find.text('Retry'));
+      await tester.pumpAndSettle();
+      expect(quotaReads, ['cloud-profile']);
+    },
+  );
+
+  testWidgets('empty host list explains how to add a source', (tester) async {
+    final container = ProviderContainer(
+      overrides: [availableHostsProvider.overrideWith((ref) async => [])],
+    );
+    addTearDown(container.dispose);
+    await _pump(tester, container, const QuotaHostsSettingsScreen());
+    expect(
+      find.text('Pair a host or sign in to choose quota hosts.'),
+      findsOneWidget,
+    );
+    expect(find.byType(SwitchListTile), findsNothing);
+  });
+
+  testWidgets('failed save keeps the selected host and shows an error', (
+    tester,
+  ) async {
+    final container = ProviderContainer(
+      overrides: [
+        availableHostsProvider.overrideWith((ref) async => _hosts),
+        quotaHostVisibilityControllerProvider.overrideWith(
+          _FailedSaveVisibility.new,
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+    await _pump(tester, container, const QuotaHostsSettingsScreen());
+    await tester.tap(_switch('Work Laptop'));
+    await tester.pumpAndSettle();
+
+    expect(tester.widget<SwitchListTile>(_switch('Work Laptop')).value, isTrue);
+    expect(find.text('Could not save quota hosts. Try again.'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+}
+
+Finder _switch(String name) => find.widgetWithText(SwitchListTile, name);
+
+Widget _home(List<PairedHostProfile> hosts) => Scaffold(
+  body: SingleChildScrollView(child: HomeQuotasSection(hosts: hosts)),
+);
+
+Future<void> _pump(
+  WidgetTester tester,
+  ProviderContainer container,
+  Widget home,
+) async {
+  tester.view.physicalSize = const Size(390, 844);
+  tester.view.devicePixelRatio = 1;
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(tester.view.resetDevicePixelRatio);
+  await tester.pumpWidget(
+    UncontrolledProviderScope(
+      container: container,
+      child: MaterialApp(theme: buildAleraMobileDarkTheme(), home: home),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+ProviderContainer _quotaContainer(
+  List<String> quotaReads,
+  List<String> settingsReads,
+) {
+  return ProviderContainer(
+    overrides: [
+      availableHostsProvider.overrideWith((ref) async => _hosts),
+      agentQuotaControllerProvider.overrideWith2((_) => _Quotas(quotaReads)),
+      hostConnectionControllerProvider.overrideWith2(
+        (_) => _PendingConnection(),
+      ),
+      hostSettingsControllerProvider.overrideWith2(
+        (_) => _Settings(settingsReads),
+      ),
+    ],
+  );
+}
+
+final _hosts = [
+  _host('local-profile', 'runtime-local', 'Laptop').withAlias('Work Laptop'),
+  _host('cloud-profile', 'runtime-cloud', 'Cloud Desktop', remote: true),
+];
+
+PairedHostProfile _host(
+  String id,
+  String runtimeId,
+  String name, {
+  bool remote = false,
+}) {
+  return PairedHostProfile(
+    id: id,
+    runtimeId: runtimeId,
+    displayName: name,
+    endpoint: remote ? 'relay://$runtimeId' : 'ws://127.0.0.1:6768',
+    deviceId: 'device-1',
+    pairedAt: DateTime.utc(2026),
+    isRemote: remote,
+  );
+}
+
+class _Quotas extends AgentQuotaController {
+  _Quotas(this.reads);
+  final List<String> reads;
+
+  @override
+  Future<QuotaSnapshotState> build(String hostId) async {
+    reads.add(hostId);
+    return QuotaSnapshotState.fromJson({
+      'snapshots': [
+        {'provider': 'codex', 'status': 'ok'},
+      ],
+    });
+  }
+}
+
+class _Settings extends HostSettingsController {
+  _Settings(this.reads);
+  final List<String> reads;
+
+  @override
+  Future<PortableHostSettings> build(String hostId) async {
+    reads.add(hostId);
+    return PortableHostSettings.fromJson({});
+  }
+}
+
+class _DelayedVisibility extends QuotaHostVisibilityController {
+  _DelayedVisibility(this.selection);
+  final Future<Set<String>> selection;
+
+  @override
+  Future<Set<String>> build() => selection;
+}
+
+class _FailedSaveVisibility extends QuotaHostVisibilityController {
+  @override
+  Future<Set<String>> build() async => {};
+
+  @override
+  Future<void> setHostVisible(String runtimeId, bool visible) async {
+    throw StateError('Storage unavailable');
+  }
+}
+
+class _PendingConnection extends HostConnectionController {
+  @override
+  Future<MobileRuntimeClient> build(String hostId) =>
+      Completer<MobileRuntimeClient>().future;
+}


### PR DESCRIPTION
## Summary

- Add mobile Home quota host selection with persisted runtime-ID visibility preferences.
- Add Quota Hosts settings and Home controls for hiding duplicate quota sources.
- Prevent polling hidden or unavailable hosts while preserving individual host quota screens.
- Document the mobile quota host behavior.

## Testing

- Added controller unit tests for persistence, restoration, concurrent edits, and unavailable runtimes.
- Added widget tests for settings navigation, filtering, retry/error states, empty selections, new hosts, and failed saves.