### PR TITLE
feat: add grok build usage history

### DIFF
--- a/docs/agent-quotas.md
+++ b/docs/agent-quotas.md
@@ -16,6 +16,20 @@ The left-to-right provider order is configurable in **Settings → Quotas → Pr
 - Z.ai.
 - OpenCode Go and OpenCode Zen.
 
+## Historical Usage
+
+The desktop **Usage** panel reads Claude Code, Codex, and Grok Build session history from the active host. It shows processed tokens, costs, cache savings, daily activity, and profile, provider, and model breakdowns. These historical costs are separate from subscription quotas and billing.
+
+Grok Build history comes from `$GROK_HOME/sessions/**/updates.jsonl`, falling back to `~/.grok/sessions`. Only persisted `turn_completed` updates with usage are counted; interactive turns without such a record do not appear. Alera reads no Grok credentials and makes no Grok API calls for this history. Scanning runs off the runtime's async executor, streams files line by line, and caches parsed records by file size and modification time. Other Grok logs are excluded.
+
+Grok's per-model usage takes precedence over aggregate tokens so totals are not counted twice. Cache tokens are separated from input, reasoning remains a subset of output, and repeated session/prompt/model records are deduplicated. Provider-reported costs use `10^10` ticks per USD. When only the turn total is available, the cost remaining after explicit model costs is distributed by token share among models without costs; that per-model allocation is an estimate. Without reported cost, Alera uses available model rates or marks the records unpriced.
+
+The Grok transcript format and cost interpretation were verified against [T3 Code's usage parser](https://github.com/pingdotgg/t3code/blob/1f8ed54add4133ac39effceded8fc1fff12d8e03/apps/server/src/usage/usageTranscripts.ts) and [source discovery](https://github.com/pingdotgg/t3code/blob/1f8ed54add4133ac39effceded8fc1fff12d8e03/apps/server/src/usage/UsageService.ts). T3 Code is a reference only, not a runtime dependency.
+
+Grok-aware clients send `includeGrok: true` on both local and SSH usage requests. Requests that omit it retain the Claude/Codex-only response, so older clients sharing an updated runtime do not misclassify Grok. This is additive and does not change the terminal-host protocol version. Persisted desktop Usage snapshots use a new cache version that older apps reject; previous caches are refreshed from the host.
+
+## Quota Hosts
+
 The quota host follows the active workspace. Local desktop and mobile requests go through the runtime-host quota service, which keeps a 15-minute in-memory cache and returns the last successful snapshot as stale data when a provider refresh fails. Automatic reads reuse that cache; the explicit refresh button bypasses it. For the local desktop host, Alera resolves configured variables missing from the GUI process through the user's login shell and sends their values directly to the runtime host in memory. Values are never persisted or returned in quota responses. Alera must be restarted after changing those shell exports because the resolver caches them for the app lifetime. SSH workspaces run `alera runtime-proxy` through the Alera runtime installed on that remote host, so credentials stay on the machine where the agent runs.
 
 Mobile exposes a dedicated **Quotas** screen with the same provider ordering, Claude Default and CCS profile configuration, environment variable names, manual refresh, and remaining/reset details as desktop. When a Claude profile is not `ok` and the runtime advertises `agentQuotaClaudeTuiV1`, the card also offers **Try With TUI**. Codex reset credits and their next expiry appear when the runtime advertises `codexResetCreditsV1`. It refreshes when opened and every 15 minutes while visible. Disabling every provider is supported and produces an empty snapshot rather than falling back to defaults.

--- a/lib/src/features/agent_usage/domain/agent_usage.dart
+++ b/lib/src/features/agent_usage/domain/agent_usage.dart
@@ -1,4 +1,4 @@
-enum AgentUsageProvider { claude, codex }
+enum AgentUsageProvider { claude, codex, grok }
 
 enum AgentUsageCostSource { providerReported, modelPriced, unpriced }
 
@@ -267,6 +267,7 @@ class AgentUsageSnapshot {
               label: switch (bucket.provider) {
                 AgentUsageProvider.claude => 'Claude Code',
                 AgentUsageProvider.codex => 'Codex',
+                AgentUsageProvider.grok => 'Grok Build',
               },
             ),
           )
@@ -331,6 +332,7 @@ String _usageAccountLabel(AgentUsageBucket bucket) {
   return switch ((bucket.provider, bucket.accountId)) {
     (AgentUsageProvider.claude, 'default') => 'Claude Code Default',
     (AgentUsageProvider.codex, 'default') => 'Codex',
+    (AgentUsageProvider.grok, 'default') => 'Grok Build',
     _ => bucket.displayName,
   };
 }
@@ -358,6 +360,7 @@ class AgentUsageDay {
     required this.day,
     required this.claudeTokens,
     required this.codexTokens,
+    this.grokTokens = 0,
     required this.costUsd,
   });
 
@@ -367,9 +370,10 @@ class AgentUsageDay {
   final String day;
   final int claudeTokens;
   final int codexTokens;
+  final int grokTokens;
   final double costUsd;
 
-  int get tokens => claudeTokens + codexTokens;
+  int get tokens => claudeTokens + codexTokens + grokTokens;
 
   AgentUsageDay add(AgentUsageBucket bucket) {
     return AgentUsageDay(
@@ -382,6 +386,11 @@ class AgentUsageDay {
       codexTokens:
           codexTokens +
           (bucket.provider == AgentUsageProvider.codex
+              ? bucket.totals.totalTokens
+              : 0),
+      grokTokens:
+          grokTokens +
+          (bucket.provider == AgentUsageProvider.grok
               ? bucket.totals.totalTokens
               : 0),
       costUsd: costUsd + bucket.costUsd,

--- a/lib/src/features/agent_usage/infra/file_agent_usage_snapshot_cache.dart
+++ b/lib/src/features/agent_usage/infra/file_agent_usage_snapshot_cache.dart
@@ -15,7 +15,8 @@ class FileAgentUsageSnapshotCache implements AgentUsageSnapshotCache {
   }) : _applicationSupportDirectory =
            applicationSupportDirectory ?? getApplicationSupportDirectory;
 
-  static const int _schemaVersion = 1;
+  // Older apps map unknown providers to Codex; they must reject Grok snapshots.
+  static const int _schemaVersion = 2;
 
   final AgentUsageSupportDirectoryResolver _applicationSupportDirectory;
   final Map<String, Map<String, Object?>> _memory =

--- a/lib/src/features/agent_usage/infra/runtime_agent_usage_loader.dart
+++ b/lib/src/features/agent_usage/infra/runtime_agent_usage_loader.dart
@@ -13,6 +13,7 @@ class RuntimeAgentUsageLoader implements AgentUsageLoader {
     final payload = <String, Object?>{
       'sinceDay': request.sinceDay,
       'untilDay': request.untilDay,
+      'includeGrok': true,
     };
     if (request.hostId == 'local') {
       return _mapValue(

--- a/lib/src/features/agent_usage/presentation/agent_usage_daily_chart.dart
+++ b/lib/src/features/agent_usage/presentation/agent_usage_daily_chart.dart
@@ -23,7 +23,8 @@ class AgentUsageDailyChart extends StatelessWidget {
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: <Widget>[
         Semantics(
-          label: 'Daily Claude Code and Codex token usage. $semanticLabel',
+          label:
+              'Daily Claude Code, Codex, and Grok Build token usage. $semanticLabel',
           image: true,
           child: SizedBox(
             height: AleraTokens.usageChartHeight,
@@ -46,6 +47,11 @@ class AgentUsageDailyChart extends StatelessWidget {
             const _UsageChartLegend(
               color: AleraTokens.foregroundFaint,
               label: 'Codex',
+            ),
+            const SizedBox(width: AleraTokens.space12),
+            const _UsageChartLegend(
+              color: AleraTokens.foregroundMuted,
+              label: 'Grok Build',
             ),
             const Spacer(),
             Text(
@@ -99,11 +105,11 @@ class _UsageBarChart extends StatelessWidget {
     return LayoutBuilder(
       builder: (context, constraints) {
         final slotWidth = constraints.maxWidth / days.length;
-        final pairWidth = (slotWidth - AleraTokens.space2).clamp(
+        final groupWidth = (slotWidth - AleraTokens.space2).clamp(
           AleraTokens.space2,
-          AleraTokens.space20,
+          AleraTokens.space24,
         );
-        final barWidth = (pairWidth - AleraTokens.space2) / 2;
+        final barWidth = groupWidth / 5;
         return BarChart(
           BarChartData(
             minY: 0,
@@ -113,7 +119,7 @@ class _UsageBarChart extends StatelessWidget {
               for (var index = 0; index < days.length; index++)
                 BarChartGroupData(
                   x: index,
-                  barsSpace: AleraTokens.space2,
+                  barsSpace: barWidth,
                   barRods: <BarChartRodData>[
                     _usageBar(
                       days[index].claudeTokens,
@@ -124,6 +130,11 @@ class _UsageBarChart extends StatelessWidget {
                       days[index].codexTokens,
                       barWidth,
                       AleraTokens.foregroundFaint,
+                    ),
+                    _usageBar(
+                      days[index].grokTokens,
+                      barWidth,
+                      AleraTokens.foregroundMuted,
                     ),
                   ],
                 ),
@@ -147,7 +158,9 @@ class _UsageBarChart extends StatelessWidget {
                 ),
                 tooltipPadding: const EdgeInsets.all(AleraTokens.space8),
                 getTooltipItem: (group, groupIndex, rod, rodIndex) {
-                  final provider = rodIndex == 0 ? 'Claude Code' : 'Codex';
+                  final provider = _usageProviderLabel(
+                    AgentUsageProvider.values[rodIndex],
+                  );
                   return BarTooltipItem(
                     '${_formatUsageDay(days[groupIndex].day)}\n$provider: ${_formatUsageTokens(rod.toY.round())}',
                     AleraTokens.monoCompactStyle.copyWith(

--- a/lib/src/features/agent_usage/presentation/agent_usage_dialog_content.dart
+++ b/lib/src/features/agent_usage/presentation/agent_usage_dialog_content.dart
@@ -84,7 +84,7 @@ class _AgentUsageContentState extends State<_AgentUsageContent> {
           Text('Daily Activity', style: Theme.of(context).textTheme.titleSmall),
           const SizedBox(height: AleraTokens.space4),
           Text(
-            'Tokens read from Claude Code and Codex transcripts on this host.',
+            'Tokens read from Claude Code, Codex, and Grok Build transcripts on this host.',
             style: Theme.of(
               context,
             ).textTheme.bodySmall?.copyWith(color: AleraTokens.foregroundMuted),
@@ -142,7 +142,8 @@ class _UsageBreakdownTable extends StatelessWidget {
     if (values.isEmpty) {
       return const AleraEmptyState(
         title: 'No Activity',
-        message: 'No Claude Code or Codex usage was found in this range.',
+        message:
+            'No Claude Code, Codex, or Grok Build usage was found in this range.',
       );
     }
     return AleraPanel(
@@ -192,9 +193,11 @@ class _UsageBreakdownRow extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final quotaProvider = value.provider == AgentUsageProvider.claude
-        ? AgentQuotaProviderId.claude
-        : AgentQuotaProviderId.codex;
+    final quotaProvider = switch (value.provider) {
+      AgentUsageProvider.claude => AgentQuotaProviderId.claude,
+      AgentUsageProvider.codex => AgentQuotaProviderId.codex,
+      AgentUsageProvider.grok => AgentQuotaProviderId.grok,
+    };
     return Padding(
       padding: const EdgeInsets.symmetric(
         horizontal: AleraTokens.space12,

--- a/lib/src/features/agent_usage/presentation/agent_usage_format.dart
+++ b/lib/src/features/agent_usage/presentation/agent_usage_format.dart
@@ -56,6 +56,7 @@ String _formatUsageDay(String value) {
 String _usageProviderLabel(AgentUsageProvider provider) => switch (provider) {
   AgentUsageProvider.claude => 'Claude Code',
   AgentUsageProvider.codex => 'Codex',
+  AgentUsageProvider.grok => 'Grok Build',
 };
 
 String _usagePricingDetail(AgentUsageSnapshot snapshot) {
@@ -64,6 +65,12 @@ String _usagePricingDetail(AgentUsageSnapshot snapshot) {
     (sum, bucket) => sum + bucket.unpricedRecords,
   );
   if (unpriced > 0) return '$unpriced unpriced responses';
+  if (snapshot.buckets.isNotEmpty &&
+      snapshot.buckets.every(
+        (bucket) => bucket.costSource == AgentUsageCostSource.providerReported,
+      )) {
+    return 'Provider-reported costs';
+  }
   return switch (snapshot.pricing.status) {
     AgentUsagePricingStatus.fresh => 'Current model rates',
     AgentUsagePricingStatus.cached => 'Cached model rates',

--- a/rust/alera-cli/src/agent_quota/usage.rs
+++ b/rust/alera-cli/src/agent_quota/usage.rs
@@ -1,7 +1,10 @@
 mod aggregation;
+mod grok_transcripts;
 mod pricing;
 mod transcripts;
 
+#[cfg(test)]
+mod grok_tests;
 #[cfg(test)]
 mod tests;
 
@@ -18,6 +21,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
 use self::aggregation::UsageAggregator;
+use self::grok_transcripts::{grok_usage_source, parse_grok_line};
 use self::pricing::{load_rates, PricingState, RateTable};
 use self::transcripts::{
     might_carry_usage, parse_claude_line, parse_codex_line, CodexScanState, UsageRecord,
@@ -32,6 +36,7 @@ const MTIME_SLACK_MILLIS: i64 = 36 * 60 * 60 * 1000;
 enum UsageProvider {
     Claude,
     Codex,
+    Grok,
 }
 
 impl UsageProvider {
@@ -39,6 +44,7 @@ impl UsageProvider {
         match self {
             Self::Claude => "claude",
             Self::Codex => "codex",
+            Self::Grok => "grok",
         }
     }
 }
@@ -100,6 +106,8 @@ struct UsageBucket {
 struct UsageRequest {
     since_day: String,
     until_day: String,
+    #[serde(default)]
+    include_grok: bool,
     #[serde(default = "usage_default_true")]
     claude_default_enabled: bool,
     #[serde(default)]
@@ -208,6 +216,8 @@ async fn resolve_sources(request: &UsageRequest) -> Result<Vec<UsageSourceConfig
         display_name: "Default".to_string(),
         directory: codex_home.join("sessions"),
     });
+    let grok_home = shell_environment_value("GROK_HOME").await;
+    sources.extend(grok_usage_source(request, &home, grok_home.as_deref()));
     Ok(sources)
 }
 
@@ -261,7 +271,8 @@ fn scan_source(
     if !source.directory.is_dir() {
         return source_result(source, "missing", 0, 0, 0, Some("No transcript directory."));
     }
-    let (files, walk_failed) = list_transcript_files(&source.directory, since_millis);
+    let (files, walk_failed) =
+        list_transcript_files(&source.directory, since_millis, source.provider);
     let mut scanned_files = 0;
     let mut skipped_files = 0;
     let mut sessions = HashSet::new();
@@ -318,7 +329,11 @@ fn source_result(
     }
 }
 
-fn list_transcript_files(root: &Path, since_millis: i64) -> (Vec<PathBuf>, bool) {
+fn list_transcript_files(
+    root: &Path,
+    since_millis: i64,
+    provider: UsageProvider,
+) -> (Vec<PathBuf>, bool) {
     let mut pending = vec![root.to_path_buf()];
     let mut files = Vec::new();
     let mut failed = false;
@@ -342,6 +357,9 @@ fn list_transcript_files(root: &Path, since_millis: i64) -> (Vec<PathBuf>, bool)
             }
             if !file_type.is_file()
                 || path.extension().and_then(|value| value.to_str()) != Some("jsonl")
+                // Grok's chat_history and events logs do not carry turn usage.
+                || (provider == UsageProvider::Grok
+                    && path.file_name().and_then(|value| value.to_str()) != Some("updates.jsonl"))
             {
                 continue;
             }
@@ -385,12 +403,10 @@ fn read_file_records(path: &Path, provider: UsageProvider) -> Option<Vec<UsageRe
         if !might_carry_usage(&line, provider) {
             continue;
         }
-        let record = match provider {
-            UsageProvider::Claude => parse_claude_line(&line),
-            UsageProvider::Codex => parse_codex_line(&line, &mut codex_state),
-        };
-        if let Some(record) = record {
-            records.push(record);
+        match provider {
+            UsageProvider::Claude => records.extend(parse_claude_line(&line)),
+            UsageProvider::Codex => records.extend(parse_codex_line(&line, &mut codex_state)),
+            UsageProvider::Grok => records.extend(parse_grok_line(&line)),
         }
     }
     if let Ok(mut cache) = scan_cache().lock() {

--- a/rust/alera-cli/src/agent_quota/usage/grok_tests.rs
+++ b/rust/alera-cli/src/agent_quota/usage/grok_tests.rs
@@ -1,0 +1,367 @@
+use super::grok_transcripts::grok_sessions_directory;
+use super::*;
+use chrono::Local;
+
+fn turn(usage: Value) -> Value {
+    json!({
+        "timestamp": 1_786_372_566,
+        "method": "_x.ai/session/update",
+        "params": {
+            "sessionId": "session-1",
+            "_meta": {"agentTimestampMs": 1_786_372_566_485_i64},
+            "update": {
+                "sessionUpdate": "turn_completed",
+                "prompt_id": "prompt-1",
+                "usage": usage
+            }
+        }
+    })
+}
+
+#[test]
+fn grok_separates_cache_and_reasoning_without_counting_aggregate_twice() {
+    let records = parse_grok_line(
+        &turn(json!({
+            "inputTokens": 20_272, "outputTokens": 272, "costUsdTicks": 230_272_000,
+            "modelUsage": {"grok-4.5-build": {
+                "inputTokens": 20_272, "outputTokens": 272,
+                "cachedReadTokens": 11_264, "cacheCreationTokens": 8,
+                "reasoningTokens": 180, "costUsdTicks": 230_272_000
+            }}
+        }))
+        .to_string(),
+    );
+    assert_eq!(records.len(), 1);
+    let record = &records[0];
+    assert_eq!(record.provider, UsageProvider::Grok);
+    assert_eq!(record.timestamp_ms, 1_786_372_566_485);
+    assert_eq!(record.session_id, "session-1");
+    assert_eq!(record.model, "grok-4.5-build");
+    assert_eq!(record.totals.uncached_input_tokens, 9_000);
+    assert_eq!(record.totals.cached_input_tokens, 11_264);
+    assert_eq!(record.totals.cache_creation_tokens, 8);
+    assert_eq!(record.totals.reasoning_tokens, 180);
+    assert_eq!(record.totals.total(), 20_544);
+    assert!((record.reported_cost_usd.unwrap() - 0.0230272).abs() < 1e-12);
+}
+
+#[test]
+fn grok_preserves_model_costs_and_allocates_only_the_remaining_cost() {
+    for (explicit_cost, expected_a, expected_b) in [
+        (Value::Null, 0.75, 0.25),
+        (json!(4_000_000_000_u64), 0.4, 0.6),
+        (json!(12_000_000_000_u64), 1.2, 0.0),
+        (json!(0), 0.0, 1.0),
+        (json!(-1), 0.75, 0.25),
+    ] {
+        let records = parse_grok_line(
+            &turn(json!({
+                "costUsdTicks": 10_000_000_000_u64,
+                "modelUsage": {
+                    "a": {"inputTokens": 300, "costUsdTicks": explicit_cost},
+                    "b": {"inputTokens": 100},
+                    "empty": {"inputTokens": 0, "costUsdTicks": 10_000_000_000_u64}
+                }
+            }))
+            .to_string(),
+        );
+        assert_eq!(records.len(), 2);
+        assert_eq!(records[0].model, "a");
+        assert!((records[0].reported_cost_usd.unwrap() - expected_a).abs() < 1e-12);
+        assert!((records[1].reported_cost_usd.unwrap() - expected_b).abs() < 1e-12);
+    }
+}
+
+#[test]
+fn grok_uses_aggregate_when_models_are_missing_and_preserves_zero_cost() {
+    for model_usage in [Value::Null, json!({}), json!({"": {}, "invalid": 12})] {
+        let records = parse_grok_line(
+            &turn(json!({
+                "inputTokens": 10, "outputTokens": 2,
+                "modelUsage": model_usage, "costUsdTicks": 0
+            }))
+            .to_string(),
+        );
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].model, "grok");
+        assert_eq!(records[0].totals.total(), 12);
+        assert_eq!(records[0].reported_cost_usd, Some(0.0));
+    }
+    let records = parse_grok_line(
+        &turn(json!({
+            "inputTokens": 10, "costUsdTicks": -1
+        }))
+        .to_string(),
+    );
+    assert_eq!(records[0].reported_cost_usd, None);
+}
+
+#[test]
+fn grok_missing_cost_uses_model_rates_or_remains_unpriced() {
+    let rates = pricing::parse_rate_table(&json!({
+        "xai/grok-known": {
+            "input_cost_per_token": 0.01,
+            "output_cost_per_token": 0.02,
+            "cache_read_input_token_cost": 0.001
+        }
+    }));
+    let mut aggregator = UsageAggregator::new("2026-08-01", "2026-08-31", &rates);
+    for record in parse_grok_line(
+        &turn(json!({"modelUsage": {
+            "grok-known": {"inputTokens": 20, "cachedReadTokens": 10, "outputTokens": 5},
+            "grok-unknown": {"inputTokens": 10}
+        }}))
+        .to_string(),
+    ) {
+        assert!(aggregator.add("default", "Default", record));
+    }
+    let buckets = aggregator.finish();
+    assert!((buckets[0].cost_usd - 0.21).abs() < 1e-12);
+    assert!((buckets[0].cache_savings_usd - 0.09).abs() < 1e-12);
+    assert!(matches!(
+        buckets[0].cost_source,
+        UsageCostSource::ModelPriced
+    ));
+    assert_eq!(buckets[1].unpriced_records, 1);
+    assert!(matches!(buckets[1].cost_source, UsageCostSource::Unpriced));
+}
+
+#[test]
+fn grok_falls_back_to_seconds_or_milliseconds_and_rejects_invalid_dates() {
+    let mut event = turn(json!({"inputTokens": 1}));
+    event["params"]["_meta"] = Value::Null;
+    for timestamp in [json!(1_786_372_566), json!(1_786_372_566_000_i64)] {
+        event["timestamp"] = timestamp;
+        assert_eq!(
+            parse_grok_line(&event.to_string())[0].timestamp_ms,
+            1_786_372_566_000
+        );
+    }
+    for timestamp in [Value::Null, json!("invalid"), json!(-1), json!(1e30)] {
+        event["timestamp"] = timestamp;
+        assert!(parse_grok_line(&event.to_string()).is_empty());
+    }
+}
+
+#[test]
+fn grok_skips_incomplete_updates_and_clamps_inconsistent_token_subsets() {
+    for line in [
+        "{",
+        "null",
+        "[]",
+        "{}",
+        "{\"params\":{\"update\":{\"sessionUpdate\":\"turn_started\"}}}",
+    ] {
+        assert!(parse_grok_line(line).is_empty());
+    }
+    assert!(parse_grok_line(&turn(json!({"inputTokens": 0})).to_string()).is_empty());
+    let records = parse_grok_line(
+        &turn(json!({
+            "inputTokens": -5, "cachedReadTokens": 10, "cacheCreationTokens": 2,
+            "outputTokens": 3, "reasoningTokens": 100
+        }))
+        .to_string(),
+    );
+    assert_eq!(records[0].totals.uncached_input_tokens, 0);
+    assert_eq!(records[0].totals.reasoning_tokens, 3);
+    assert_eq!(records[0].totals.total(), 15);
+}
+
+#[test]
+fn grok_deduplicates_turn_models_but_retains_turns_without_identity() {
+    let rates = RateTable::new();
+    let mut aggregator = UsageAggregator::new("2026-08-01", "2026-08-31", &rates);
+    let event = turn(json!({"modelUsage": {
+        "a": {"inputTokens": 10}, "b": {"inputTokens": 20}
+    }}));
+    let records = parse_grok_line(&event.to_string());
+    for record in &records {
+        assert!(aggregator.add("default", "Default", record.clone()));
+        assert!(!aggregator.add("default", "Default", record.clone()));
+    }
+    for identity in ["prompt_id", "sessionId"] {
+        let mut incomplete_identity = event.clone();
+        if identity == "sessionId" {
+            incomplete_identity["params"][identity] = Value::Null;
+        } else {
+            incomplete_identity["params"]["update"][identity] = Value::Null;
+        }
+        for record in parse_grok_line(&incomplete_identity.to_string()) {
+            assert!(record.dedupe_key.is_none());
+            assert!(aggregator.add("default", "Default", record.clone()));
+            assert!(aggregator.add("default", "Default", record));
+        }
+    }
+    assert_eq!(
+        aggregator
+            .finish()
+            .iter()
+            .map(|row| row.records)
+            .sum::<u64>(),
+        10
+    );
+}
+
+#[test]
+fn grok_home_defaults_and_overrides_stay_under_sessions() {
+    let home = Path::new("user-home");
+    for configured in [None, Some(""), Some("   ")] {
+        assert_eq!(
+            grok_sessions_directory(home, configured),
+            home.join(".grok/sessions")
+        );
+    }
+    assert_eq!(
+        grok_sessions_directory(home, Some("~/custom")),
+        home.join("custom/sessions")
+    );
+    assert_eq!(
+        grok_sessions_directory(home, Some("~\\custom")),
+        home.join("custom/sessions")
+    );
+    assert_eq!(
+        grok_sessions_directory(home, Some("~")),
+        home.join("sessions")
+    );
+    assert_eq!(
+        grok_sessions_directory(home, Some("  custom  ")),
+        Path::new("custom").join("sessions")
+    );
+}
+
+#[test]
+fn grok_opt_in_preserves_legacy_buckets_and_sources_after_cached_scans() {
+    let root = tempfile::tempdir().unwrap();
+    let grok_dir = root.path().join(".grok/sessions/session-1");
+    let codex_dir = root.path().join("codex");
+    std::fs::create_dir_all(&grok_dir).unwrap();
+    std::fs::create_dir_all(&codex_dir).unwrap();
+    std::fs::write(
+        grok_dir.join("updates.jsonl"),
+        turn(json!({"inputTokens": 100})).to_string(),
+    )
+    .unwrap();
+    let timestamp = chrono::DateTime::from_timestamp_millis(1_786_372_566_485).unwrap();
+    let codex_lines = [
+        json!({"type": "session_meta", "payload": {"id": "codex-session"}}),
+        json!({"type": "turn_context", "payload": {"model": "gpt-5.6-codex"}}),
+        json!({"type": "event_msg", "timestamp": timestamp.to_rfc3339(),
+            "payload": {"type": "token_count", "info": {
+                "last_token_usage": {"input_tokens": 10}
+            }}
+        }),
+    ]
+    .map(|line| line.to_string())
+    .join("\n");
+    std::fs::write(codex_dir.join("rollout.jsonl"), codex_lines).unwrap();
+    let day = timestamp.with_timezone(&Local).date_naive();
+    for include_grok in [Some(true), None, Some(false), Some(true)] {
+        let mut payload = json!({"sinceDay": day.to_string(), "untilDay": day.to_string()});
+        if let Some(enabled) = include_grok {
+            payload["includeGrok"] = json!(enabled);
+        }
+        let request: UsageRequest = serde_json::from_value(payload).unwrap();
+        let mut sources = vec![UsageSourceConfig {
+            provider: UsageProvider::Codex,
+            account_id: "default".to_string(),
+            display_name: "Default".to_string(),
+            directory: codex_dir.clone(),
+        }];
+        sources.extend(grok_usage_source(&request, root.path(), None));
+        let snapshot = scan_sources(
+            &request.since_day,
+            &request.until_day,
+            day,
+            sources,
+            &RateTable::new(),
+            PricingState {
+                status: "unavailable",
+                source: "test",
+                known_models: 0,
+            },
+        )
+        .unwrap();
+        let expected_count = if include_grok == Some(true) { 2 } else { 1 };
+        assert_eq!(snapshot.sources.len(), expected_count);
+        assert_eq!(snapshot.buckets.len(), expected_count);
+        assert_eq!(snapshot.sources[0].provider, UsageProvider::Codex);
+        assert_eq!(snapshot.sources[0].distinct_sessions, 1);
+        assert_eq!(snapshot.buckets[0].provider, UsageProvider::Codex);
+        assert_eq!(snapshot.buckets[0].totals.total(), 10);
+        if include_grok == Some(true) {
+            assert_eq!(snapshot.buckets[1].provider, UsageProvider::Grok);
+            assert_eq!(snapshot.buckets[1].totals.total(), 100);
+        }
+    }
+}
+
+#[test]
+fn grok_scan_filters_logs_deduplicates_copies_and_refreshes_changed_files() {
+    let root = tempfile::tempdir().unwrap();
+    let session = root.path().join("session-1");
+    let copy = root.path().join("copy");
+    std::fs::create_dir_all(&session).unwrap();
+    std::fs::create_dir_all(&copy).unwrap();
+    let event = turn(json!({
+        "inputTokens": 10, "costUsdTicks": 10_000_000_000_u64
+    }));
+    let line = event.to_string();
+    let path = session.join("updates.jsonl");
+    std::fs::write(&path, format!("{line}\n{{\n")).unwrap();
+    std::fs::write(copy.join("updates.jsonl"), &line).unwrap();
+    let mut other = event.clone();
+    other["params"]["update"]["prompt_id"] = json!("excluded");
+    for name in ["events.jsonl", "chat_history.jsonl"] {
+        std::fs::write(session.join(name), other.to_string()).unwrap();
+    }
+    let day = Local
+        .timestamp_millis_opt(1_786_372_566_485)
+        .single()
+        .unwrap()
+        .date_naive();
+    let day_label = day.to_string();
+    let scan = || {
+        scan_sources(
+            &day_label,
+            &day_label,
+            day,
+            vec![UsageSourceConfig {
+                provider: UsageProvider::Grok,
+                account_id: "default".to_string(),
+                display_name: "Default".to_string(),
+                directory: root.path().to_path_buf(),
+            }],
+            &RateTable::new(),
+            PricingState {
+                status: "unavailable",
+                source: "test",
+                known_models: 0,
+            },
+        )
+        .unwrap()
+    };
+    for _ in 0..2 {
+        let snapshot = scan();
+        assert_eq!(snapshot.sources[0].scanned_files, 2);
+        assert_eq!(snapshot.sources[0].distinct_sessions, 1);
+        assert_eq!(snapshot.buckets[0].records, 1);
+        assert_eq!(snapshot.buckets[0].cost_usd, 1.0);
+        assert!(matches!(
+            snapshot.buckets[0].cost_source,
+            UsageCostSource::ProviderReported
+        ));
+        assert_eq!(
+            serde_json::to_value(&snapshot).unwrap()["buckets"][0]["provider"],
+            "grok"
+        );
+    }
+    other["params"]["update"]["prompt_id"] = json!("prompt-2");
+    std::fs::write(&path, format!("{line}\n{other}\n")).unwrap();
+    let snapshot = scan();
+    assert_eq!(snapshot.buckets[0].records, 2);
+    assert_eq!(snapshot.buckets[0].totals.total(), 20);
+    assert_eq!(snapshot.buckets[0].cost_usd, 2.0);
+    let rates = RateTable::new();
+    let mut outside_window = UsageAggregator::new("2020-01-01", "2020-01-01", &rates);
+    assert!(!outside_window.add("default", "Default", parse_grok_line(&line).remove(0)));
+}

--- a/rust/alera-cli/src/agent_quota/usage/grok_transcripts.rs
+++ b/rust/alera-cli/src/agent_quota/usage/grok_transcripts.rs
@@ -1,0 +1,148 @@
+use std::path::{Path, PathBuf};
+
+use serde_json::Value;
+
+use super::transcripts::{positive_int, UsageRecord};
+use super::{UsageProvider, UsageRequest, UsageSourceConfig, UsageTokenTotals};
+
+pub(super) fn grok_usage_source(
+    request: &UsageRequest,
+    home: &Path,
+    configured: Option<&str>,
+) -> Option<UsageSourceConfig> {
+    // Older clients classify unknown providers as Codex, so Grok requires opt-in.
+    request.include_grok.then(|| UsageSourceConfig {
+        provider: UsageProvider::Grok,
+        account_id: "default".to_string(),
+        display_name: "Default".to_string(),
+        directory: grok_sessions_directory(home, configured),
+    })
+}
+
+pub(super) fn grok_sessions_directory(home: &Path, configured: Option<&str>) -> PathBuf {
+    let root = match configured.map(str::trim).filter(|value| !value.is_empty()) {
+        None => home.join(".grok"),
+        Some("~") => home.to_path_buf(),
+        Some(value) => value
+            .strip_prefix("~/")
+            .or_else(|| value.strip_prefix("~\\"))
+            .map(|suffix| home.join(suffix))
+            .unwrap_or_else(|| PathBuf::from(value)),
+    };
+    root.join("sessions")
+}
+
+pub(super) fn parse_grok_line(line: &str) -> Vec<UsageRecord> {
+    serde_json::from_str(line)
+        .ok()
+        .and_then(|record| parse_turn(&record))
+        .unwrap_or_default()
+}
+
+fn parse_turn(record: &Value) -> Option<Vec<UsageRecord>> {
+    let params = record.get("params")?;
+    let update = params.get("update")?;
+    if update.get("sessionUpdate")?.as_str()? != "turn_completed" {
+        return None;
+    }
+    let usage = update.get("usage")?.as_object()?;
+    let timestamp_ms = params
+        .pointer("/_meta/agentTimestampMs")
+        .and_then(|value| timestamp_millis(value, false))
+        .or_else(|| timestamp_millis(record.get("timestamp")?, true))?;
+    let session_id = params
+        .get("sessionId")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    let prompt_id = update
+        .get("prompt_id")
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty());
+    let mut models: Vec<(&str, &Value)> = usage
+        .get("modelUsage")
+        .and_then(Value::as_object)
+        .into_iter()
+        .flatten()
+        .filter(|(model, value)| !model.trim().is_empty() && value.is_object())
+        .map(|(model, value)| (model.as_str(), value))
+        .collect();
+    if models.is_empty() {
+        models.push(("grok", update.get("usage")?));
+    }
+    let mut records: Vec<UsageRecord> = models
+        .into_iter()
+        .filter_map(|(model, value)| {
+            let totals = token_totals(value);
+            if totals.total() == 0 {
+                return None;
+            }
+            Some(UsageRecord {
+                provider: UsageProvider::Grok,
+                timestamp_ms,
+                model: model.to_string(),
+                session_id: session_id.to_string(),
+                totals,
+                reported_cost_usd: cost_usd(value.get("costUsdTicks")),
+                // Missing identity must not merge unrelated same-second turns.
+                dedupe_key: prompt_id.filter(|_| !session_id.is_empty()).map(|prompt| {
+                    serde_json::to_string(&(session_id, prompt, model))
+                        .expect("string tuple serializes")
+                }),
+            })
+        })
+        .collect();
+
+    if let Some(total_cost) = cost_usd(usage.get("costUsdTicks")) {
+        let assigned_cost: f64 = records.iter().filter_map(|row| row.reported_cost_usd).sum();
+        let unpriced_tokens: f64 = records
+            .iter()
+            .filter(|row| row.reported_cost_usd.is_none())
+            .map(|row| row.totals.total() as f64)
+            .sum();
+        // Preserve model costs and distribute only the remaining turn cost.
+        // Zero-token models must not consume any of that remainder.
+        let remainder = (total_cost - assigned_cost).max(0.0);
+        if unpriced_tokens > 0.0 {
+            for row in &mut records {
+                if row.reported_cost_usd.is_none() {
+                    row.reported_cost_usd =
+                        Some(remainder * (row.totals.total() as f64 / unpriced_tokens));
+                }
+            }
+        }
+    }
+    Some(records)
+}
+
+fn token_totals(value: &Value) -> UsageTokenTotals {
+    let input = positive_int(value.get("inputTokens"));
+    let cached = positive_int(value.get("cachedReadTokens"));
+    let created = positive_int(value.get("cacheCreationTokens"));
+    let output = positive_int(value.get("outputTokens"));
+    UsageTokenTotals {
+        // Input includes cache reads/writes; reasoning is part of output.
+        uncached_input_tokens: input.saturating_sub(cached.saturating_add(created)),
+        cached_input_tokens: cached,
+        cache_creation_tokens: created,
+        output_tokens: output,
+        reasoning_tokens: positive_int(value.get("reasoningTokens")).min(output),
+    }
+}
+
+fn cost_usd(value: Option<&Value>) -> Option<f64> {
+    value
+        .and_then(Value::as_f64)
+        .filter(|ticks| ticks.is_finite() && *ticks >= 0.0)
+        // Grok stores cost in ticks, with 10^10 ticks per USD.
+        .map(|ticks| ticks / 10_000_000_000.0)
+}
+
+fn timestamp_millis(value: &Value, allow_seconds: bool) -> Option<i64> {
+    let raw = value.as_f64()?;
+    let millis = if allow_seconds && raw <= 1e12 {
+        raw * 1000.0
+    } else {
+        raw
+    };
+    (millis.is_finite() && (0.0..i64::MAX as f64).contains(&millis)).then_some(millis as i64)
+}

--- a/rust/alera-cli/src/agent_quota/usage/transcripts.rs
+++ b/rust/alera-cli/src/agent_quota/usage/transcripts.rs
@@ -16,6 +16,7 @@ pub(super) struct UsageRecord {
 pub(super) fn might_carry_usage(line: &str, provider: UsageProvider) -> bool {
     match provider {
         UsageProvider::Claude => line.contains("\"usage\""),
+        UsageProvider::Grok => line.contains("\"turn_completed\""),
         UsageProvider::Codex => {
             line.contains("\"token_count\"")
                 || line.contains("\"turn_context\"")
@@ -173,7 +174,7 @@ fn parse_timestamp(value: &Value) -> Option<i64> {
         .map(|date| date.timestamp_millis())
 }
 
-fn positive_int(value: Option<&Value>) -> u64 {
+pub(super) fn positive_int(value: Option<&Value>) -> u64 {
     value
         .and_then(|value| {
             value

--- a/rust/alera-cli/src/terminal_host/server/host_service_agent_quota.rs
+++ b/rust/alera-cli/src/terminal_host/server/host_service_agent_quota.rs
@@ -24,6 +24,7 @@ impl ServerActor {
     ) -> HostResult<()> {
         let since_day = required_non_blank(payload, "sinceDay")?;
         let until_day = required_non_blank(payload, "untilDay")?;
+        let include_grok = payload.get("includeGrok").and_then(Value::as_bool) == Some(true);
         let store = self.runtime_store.clone();
         let inbox = self.inbox.clone();
         tokio::spawn(async move {
@@ -36,6 +37,7 @@ impl ServerActor {
                 fetch_agent_usage(json!({
                     "sinceDay": since_day,
                     "untilDay": until_day,
+                    "includeGrok": include_grok,
                     "claudeDefaultEnabled": settings.claude_default_show_in_usage,
                     "claudeProfiles": claude_profiles,
                 }))

--- a/test/unit/agent_usage_grok_test.dart
+++ b/test/unit/agent_usage_grok_test.dart
@@ -1,0 +1,94 @@
+import 'package:alera/src/features/agent_usage/application/agent_usage_profile_selection.dart';
+import 'package:alera/src/features/agent_usage/domain/agent_usage.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('Grok stays separate from Codex in totals and every breakdown', () {
+    final snapshot = AgentUsageSnapshot.fromJson(<String, Object?>{
+      'sinceDay': '2026-08-09',
+      'untilDay': '2026-08-10',
+      'sources': <Object?>[
+        <String, Object?>{
+          'provider': 'grok',
+          'accountId': 'default',
+          'displayName': 'Default',
+          'status': 'ok',
+          'distinctSessions': 1,
+        },
+        <String, Object?>{
+          'provider': 'codex',
+          'accountId': 'default',
+          'status': 'ok',
+          'distinctSessions': 1,
+        },
+      ],
+      'buckets': <Object?>[
+        _bucket('grok', 'grok-4.5-build', 10, 0.75),
+        _bucket('grok', 'grok-composer', 20, 0.25),
+        _bucket('codex', 'gpt-5.6-codex', 40, 2),
+      ],
+    });
+
+    expect(snapshot.sources.first.provider, AgentUsageProvider.grok);
+    expect(snapshot.buckets.first.provider, AgentUsageProvider.grok);
+    expect(snapshot.costUsd, 3);
+    expect(snapshot.totals.totalTokens, 70);
+    expect(snapshot.sessions, 2);
+    final grok = snapshot.providers.singleWhere(
+      (row) => row.provider == AgentUsageProvider.grok,
+    );
+    expect(grok.label, 'Grok Build');
+    expect(grok.tokens, 30);
+    expect(grok.costUsd, 1);
+    expect(grok.sessions, 1);
+    expect(grok.records, 2);
+    expect(
+      snapshot.accounts.map((row) => row.label),
+      unorderedEquals(<String>['Grok Build', 'Codex']),
+    );
+    expect(
+      snapshot.models.where((row) => row.provider == AgentUsageProvider.grok),
+      hasLength(2),
+    );
+    expect(snapshot.days.first.grokTokens, 0);
+    expect(snapshot.days.last.grokTokens, 30);
+    expect(snapshot.days.last.codexTokens, 40);
+    expect(snapshot.days.last.claudeTokens, 0);
+    expect(snapshot.days.last.tokens, 70);
+    expect(snapshot.days.last.costUsd, 3);
+
+    final filtered = snapshot.withClaudeProfileSelection(
+      defaultEnabled: false,
+      profileLabels: const <String, String>{},
+    );
+    expect(filtered.totals.totalTokens, 70);
+    expect(filtered.sources.first.provider, AgentUsageProvider.grok);
+  });
+
+  test('snapshots from older hosts keep working without Grok data', () {
+    final snapshot = AgentUsageSnapshot.fromJson(<String, Object?>{
+      'sinceDay': '2026-08-10',
+      'untilDay': '2026-08-10',
+      'buckets': <Object?>[_bucket('codex', 'gpt-5.6-codex', 40, 2)],
+    });
+    expect(snapshot.days.single.grokTokens, 0);
+    expect(snapshot.days.single.tokens, 40);
+    expect(snapshot.providers.single.provider, AgentUsageProvider.codex);
+  });
+}
+
+Map<String, Object?> _bucket(
+  String provider,
+  String model,
+  int tokens,
+  double cost,
+) => <String, Object?>{
+  'provider': provider,
+  'model': model,
+  'day': '2026-08-10',
+  'totals': <String, Object?>{'uncachedInputTokens': tokens},
+  'costUsd': cost,
+  'costSource': 'providerReported',
+  'records': 1,
+  'sessions': 1,
+};

--- a/test/unit/file_agent_usage_snapshot_cache_test.dart
+++ b/test/unit/file_agent_usage_snapshot_cache_test.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:alera/src/features/agent_usage/infra/file_agent_usage_snapshot_cache.dart';
@@ -56,6 +57,25 @@ void main() {
     expect(files, hasLength(1));
     await files.single.writeAsString('{not json');
 
+    expect(await createCache().read(hostId: 'local', days: 90), isNull);
+  });
+
+  test('Grok snapshots are incompatible with legacy cache readers', () async {
+    final snapshot = _snapshot(readAt: 90);
+    snapshot['buckets'] = <Object?>[
+      <String, Object?>{'provider': 'grok'},
+    ];
+    await createCache().write(hostId: 'local', days: 90, snapshot: snapshot);
+    final file = await Directory(
+      '${supportDirectory.path}${Platform.pathSeparator}agent_usage',
+    ).list().where((entry) => entry is File).cast<File>().single;
+    final envelope =
+        jsonDecode(await file.readAsString()) as Map<String, dynamic>;
+    // Version 1 readers reject any other version before parsing provider names.
+    expect(envelope['version'], isNot(1));
+    expect(await createCache().read(hostId: 'local', days: 90), snapshot);
+    envelope['version'] = 1;
+    await file.writeAsString(jsonEncode(envelope));
     expect(await createCache().read(hostId: 'local', days: 90), isNull);
   });
 }

--- a/test/unit/runtime_agent_usage_loader_test.dart
+++ b/test/unit/runtime_agent_usage_loader_test.dart
@@ -7,11 +7,37 @@ import 'package:alera/src/features/workbench/infra/terminal_host/terminal_host_p
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  test('local usage opts in to Grok history', () async {
+    final runtime = _RecordingRuntimeHostClient();
+    final loader = RuntimeAgentUsageLoader(
+      runtime,
+      _RecordingRuntimeProxyClient(),
+    );
+    await loader.fetch(
+      const AgentUsageRequest(
+        hostId: 'local',
+        target: null,
+        settings: AgentQuotaHostSettings(),
+        sinceDay: '2026-08-04',
+        untilDay: '2026-08-10',
+      ),
+    );
+    expect(runtime.type, 'agentUsage.snapshot');
+    expect(runtime.payload, <String, Object?>{
+      'sinceDay': '2026-08-04',
+      'untilDay': '2026-08-10',
+      'includeGrok': true,
+    });
+  });
+
   test(
     'remote usage sends only selected CCS profiles with Usage names',
     () async {
       final proxy = _RecordingRuntimeProxyClient();
-      final loader = RuntimeAgentUsageLoader(_UnusedRuntimeHostClient(), proxy);
+      final loader = RuntimeAgentUsageLoader(
+        _RecordingRuntimeHostClient(),
+        proxy,
+      );
 
       await loader.fetch(
         AgentUsageRequest(
@@ -39,6 +65,7 @@ void main() {
       );
 
       expect(proxy.type, 'agentUsage.fetch');
+      expect(proxy.payload['includeGrok'], isTrue);
       expect(proxy.payload['claudeDefaultEnabled'], isFalse);
       expect(proxy.payload['claudeProfiles'], <Object?>[
         <String, String>{'alias': 'Engineering', 'profile': 'dev'},
@@ -47,7 +74,10 @@ void main() {
   );
 }
 
-class _UnusedRuntimeHostClient implements RuntimeHostClient {
+class _RecordingRuntimeHostClient implements RuntimeHostClient {
+  String? type;
+  Map<String, Object?> payload = const <String, Object?>{};
+
   @override
   Stream<RuntimeHostEvent> get runtimeEvents => const Stream.empty();
 
@@ -56,8 +86,10 @@ class _UnusedRuntimeHostClient implements RuntimeHostClient {
     String type, [
     Map<String, Object?> payload = const <String, Object?>{},
     Duration? timeout,
-  ]) {
-    throw UnsupportedError('Local runtime is not used by this test.');
+  ]) async {
+    this.type = type;
+    this.payload = payload;
+    return <String, Object?>{};
   }
 }
 

--- a/test/widget/agent_usage_dialog_test.dart
+++ b/test/widget/agent_usage_dialog_test.dart
@@ -1,12 +1,62 @@
 import 'package:alera/src/app/theme/alera_dark_theme.dart';
 import 'package:alera/src/design_system/surfaces/alera_panel.dart';
+import 'package:alera/src/features/agent_quota/presentation/agent_quota_provider_icon.dart';
 import 'package:alera/src/features/agent_usage/domain/agent_usage.dart';
 import 'package:alera/src/features/agent_usage/presentation/agent_usage_dialog.dart';
+import 'package:alera/src/features/settings/domain/alera_settings.dart';
 import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  testWidgets('shows Grok in metrics, chart, tooltip, and model breakdown', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(1280, 900));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    await tester.pumpWidget(
+      _wrap(
+        AgentUsageDialogView(
+          hostId: 'local',
+          days: 30,
+          snapshot: _snapshot(includeGrok: true),
+          loading: false,
+          error: null,
+          onDaysChanged: (_) {},
+          onRefresh: () {},
+          onClose: () {},
+        ),
+      ),
+    );
+    expect(find.text('149'), findsOneWidget);
+    expect(find.text(r'$2.75'), findsOneWidget);
+    expect(find.text('Grok Build'), findsWidgets);
+    expect(
+      tester
+          .widgetList<AgentQuotaProviderIcon>(
+            find.byType(AgentQuotaProviderIcon),
+          )
+          .where((icon) => icon.provider == AgentQuotaProviderId.grok),
+      hasLength(1),
+    );
+    final chart = tester.widget<BarChart>(find.byType(BarChart));
+    final group = chart.data.barGroups.last;
+    expect(group.barRods, hasLength(3));
+    expect(group.barRods[2].toY, 100);
+    expect(chart.data.barGroups.first.barRods[2].color, Colors.transparent);
+    final tooltip = chart.data.barTouchData.touchTooltipData.getTooltipItem(
+      group,
+      chart.data.barGroups.length - 1,
+      group.barRods[2],
+      2,
+    );
+    expect(tooltip?.text, contains('Grok Build: 100'));
+    expect(tester.takeException(), isNull);
+    await tester.tap(find.text('Models'));
+    await tester.pumpAndSettle();
+    expect(find.text('grok-4.5-build'), findsOneWidget);
+  });
+
   testWidgets('renders usage metrics and CCS account breakdown', (
     tester,
   ) async {
@@ -237,7 +287,7 @@ Widget _wrap(Widget child) {
   );
 }
 
-AgentUsageSnapshot _snapshot() {
+AgentUsageSnapshot _snapshot({bool includeGrok = false}) {
   return AgentUsageSnapshot.fromJson(<String, Object?>{
     'readAt': 1_800_000_000_000,
     'sinceDay': '2026-08-01',
@@ -249,6 +299,15 @@ AgentUsageSnapshot _snapshot() {
       'knownModels': 10,
     },
     'sources': <Object?>[
+      if (includeGrok)
+        <String, Object?>{
+          'provider': 'grok',
+          'accountId': 'default',
+          'displayName': 'Default',
+          'status': 'ok',
+          'scannedFiles': 1,
+          'distinctSessions': 1,
+        },
       <String, Object?>{
         'provider': 'claude',
         'accountId': 'dev',
@@ -267,6 +326,16 @@ AgentUsageSnapshot _snapshot() {
       },
     ],
     'buckets': <Object?>[
+      if (includeGrok)
+        _bucket(
+          provider: 'grok',
+          accountId: 'default',
+          displayName: 'Default',
+          model: 'grok-4.5-build',
+          day: '2026-08-10',
+          tokens: 100,
+          cost: 1,
+        ),
       _bucket(
         provider: 'claude',
         accountId: 'dev',


### PR DESCRIPTION
## Summary

- Add Grok Build historical usage alongside Claude Code and Codex.
- Parse persisted `turn_completed` records from Grok `updates.jsonl` files with deduplication, pricing, cache handling, and provider-reported costs.
- Opt local and SSH usage requests into Grok data while preserving backward-compatible protocol behavior.
- Display Grok metrics, charts, tooltips, model breakdowns, and provider icons.
- Invalidate legacy usage snapshots through a cache schema version bump.
- Document Grok history discovery, pricing, and compatibility behavior.

## Testing

- Added Rust unit tests for Grok transcript parsing and aggregation.
- Added Dart unit tests for cache compatibility and usage request payloads.
- Added Flutter widget tests covering Grok metrics, charts, tooltips, and model breakdowns.