### PR TITLE
feat: migrate terminal rendering to xterm2 forks

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -15,7 +15,7 @@
 	url = https://github.com/stablyai/orca
 [submodule "third_party/xterm"]
 	path = third_party/xterm
-	url = https://github.com/leynier/xterm.dart.git
+	url = https://github.com/leynier/xterm2.git
 	branch = next
 [submodule "third_party/dart_terminal"]
 	path = third_party/dart_terminal

--- a/docs/terminal-dependency-forks.md
+++ b/docs/terminal-dependency-forks.md
@@ -1,20 +1,25 @@
 # Terminal dependency forks
 
-Alera keeps terminal dependency fixes reproducible through submodules while the fixes are released from maintained forks or reviewed upstream.
+Alera pins terminal dependency fixes through submodules. Each maintained fork has `next` as its default and only permanent remote branch; changes land there after validation, and temporary pull-request branches are deleted after merge.
 
 The `ghostty_vte` package names remain owned and published by the upstream project on pub.dev. Alera consumes the maintained fork only through the path overrides in `pubspec.yaml`; the fork's GitHub releases supply the matching native artifacts.
 
 ## Pattern
 
 - Create a fork under `leynier/*`.
-- Apply the minimal fix on a named branch.
-- Open a pull request from that branch to the upstream repository.
-- Add the fork branch as a submodule under `third_party/`.
+- Apply the minimal fix with a regression test and record its upstream relationship in `ALERA_PATCHES.md`.
+- Keep validated changes on `next`; propose upstream changes separately when appropriate.
+- Add the fork as a submodule under `third_party/`, with `branch = next` and a committed, tested gitlink SHA.
 - Point `dependency_overrides` at the package path inside the submodule.
+- Before consolidating branches, preserve their refs in a verified Git bundle and prove that their changes are integrated. Do not remove tags or releases.
 
 ## Current forks
 
-| Package | Submodule | Fork branch | Upstream PR |
+| Package | Submodule | Fork branch | Notes |
 | --- | --- | --- | --- |
-| `ghostty_vte` | `third_party/dart_terminal` | `master` | <https://github.com/kingwill101/dart_terminal/pull/15> |
-| `xterm` | `third_party/xterm` | `next` | See `third_party/xterm/ALERA_PATCHES.md` |
+| `ghostty_vte` | `third_party/dart_terminal` | `leynier/dart_terminal:next` | Existing SDK, bindings and native artifacts retained; upstream upgrade deferred |
+| `xterm2` | `third_party/xterm` | `leynier/xterm2:next` | Desktop and mobile renderer; see `third_party/xterm/ALERA_PATCHES.md` |
+
+`leynier/xterm.dart:next` retains the complete legacy fork history. It remains available and is not archived, but Alera no longer depends on it. The old upstream proposals [xterm.dart #227](https://github.com/TerminalStudio/xterm.dart/pull/227) and [dart_terminal #15](https://github.com/kingwill101/dart_terminal/pull/15) were closed without merging; their fork fixes are retained locally.
+
+See [the migration validation report](xterm2-migration-validation.md) and [branch preservation manifest](terminal-fork-branches.json) for the audited bases, conservation evidence, validation and recovery details.

--- a/docs/terminal-dependency-forks.md
+++ b/docs/terminal-dependency-forks.md
@@ -1,6 +1,6 @@
 # Terminal dependency forks
 
-Alera pins terminal dependency fixes through submodules. Each maintained fork has `next` as its default and only permanent remote branch; changes land there after validation, and temporary pull-request branches are deleted after merge.
+Alera pins terminal dependency fixes through submodules. Each maintained fork has two permanent remote branches: `next` is the default and holds our validated changes; `master` exactly mirrors the upstream default branch. Temporary pull-request branches are deleted after merge, while both permanent branches are protected against deletion.
 
 The `ghostty_vte` package names remain owned and published by the upstream project on pub.dev. Alera consumes the maintained fork only through the path overrides in `pubspec.yaml`; the fork's GitHub releases supply the matching native artifacts.
 
@@ -9,6 +9,7 @@ The `ghostty_vte` package names remain owned and published by the upstream proje
 - Create a fork under `leynier/*`.
 - Apply the minimal fix with a regression test and record its upstream relationship in `ALERA_PATCHES.md`.
 - Keep validated changes on `next`; propose upstream changes separately when appropriate.
+- Match the upstream default branch name for the mirror (`master` for all three current forks). Select that branch explicitly when using GitHub Sync Fork, or run `gh repo sync leynier/<fork> --branch master`. Never apply fork-specific commits to the mirror. Review upstream integration into `next` separately; syncing the mirror does not update Alera's dependency pin.
 - Add the fork as a submodule under `third_party/`, with `branch = next` and a committed, tested gitlink SHA.
 - Point `dependency_overrides` at the package path inside the submodule.
 - Before consolidating branches, preserve their refs in a verified Git bundle and prove that their changes are integrated. Do not remove tags or releases.
@@ -21,5 +22,7 @@ The `ghostty_vte` package names remain owned and published by the upstream proje
 | `xterm2` | `third_party/xterm` | `leynier/xterm2:next` | Desktop and mobile renderer; see `third_party/xterm/ALERA_PATCHES.md` |
 
 `leynier/xterm.dart:next` retains the complete legacy fork history. It remains available and is not archived, but Alera no longer depends on it. The old upstream proposals [xterm.dart #227](https://github.com/TerminalStudio/xterm.dart/pull/227) and [dart_terminal #15](https://github.com/kingwill101/dart_terminal/pull/15) were closed without merging; their fork fixes are retained locally.
+
+The inherited `autotag.yml` workflow is disabled in both xterm forks so a mirror sync cannot create tags. Fork-owned build and asset-hash updates target `next`. The `dart_terminal:master` mirror can contain a newer SDK than Alera supports; upgrading `next` remains a separate decision.
 
 See [the migration validation report](xterm2-migration-validation.md) and [branch preservation manifest](terminal-fork-branches.json) for the audited bases, conservation evidence, validation and recovery details.

--- a/docs/terminal-fork-branches.json
+++ b/docs/terminal-fork-branches.json
@@ -1,12 +1,11 @@
 {
-  "verifiedAt": "2026-08-30T03:28:52.123Z",
+  "verifiedAt": "2026-08-30T04:17:55.272Z",
   "backupDirectory": "/home/leynier/.codex/artifacts/alera-terminal-forks-20260829-6e04",
   "repositories": [
     {
       "repository": "leynier/xterm.dart",
       "defaultBranch": "next",
-      "onlyBranch": "next",
-      "next": "8e130dd687b0ff036443a5aff318e74275163eee",
+      "next": "dd37dbe3cb0ea5f2de529ba158395af062351e62",
       "deleteBranchOnMerge": true,
       "archived": false,
       "tagsPreserved": 0,
@@ -48,13 +47,23 @@
           "name": "master",
           "sha": "d35ba2cc72d0b89b0fd19af69d57df2c02f26a16"
         }
-      ]
+      ],
+      "permanentBranches": [
+        "master",
+        "next"
+      ],
+      "mirror": {
+        "branch": "master",
+        "upstream": "TerminalStudio/xterm.dart",
+        "sha": "d35ba2cc72d0b89b0fd19af69d57df2c02f26a16"
+      },
+      "deletionProtectionRuleset": 21840088,
+      "autotagState": "disabled_manually"
     },
     {
       "repository": "leynier/dart_terminal",
       "defaultBranch": "next",
-      "onlyBranch": "next",
-      "next": "e7028139cd90a0676c0323b2ec5f4312d14c4932",
+      "next": "7bfb6c57f8da75742891ac27b568cc651f77501a",
       "deleteBranchOnMerge": true,
       "archived": false,
       "tagsPreserved": 20,
@@ -104,13 +113,23 @@
           "name": "master",
           "sha": "cea5f7289c1c9509b2290299b2d9bb2b8192a932"
         }
-      ]
+      ],
+      "permanentBranches": [
+        "master",
+        "next"
+      ],
+      "mirror": {
+        "branch": "master",
+        "upstream": "kingwill101/dart_terminal",
+        "sha": "3146f58d2b675d50383c86b5b5eb5d89e6c1058c"
+      },
+      "deletionProtectionRuleset": 21840090,
+      "autotagState": null
     },
     {
       "repository": "leynier/xterm2",
       "defaultBranch": "next",
-      "onlyBranch": "next",
-      "next": "52fec4dae89c9b8af6e7071096673fe4a5af4ba1",
+      "next": "cd99d34fbcc4b2001418546c94dd7e3533251a12",
       "deleteBranchOnMerge": true,
       "archived": false,
       "tagsPreserved": 0,
@@ -120,7 +139,18 @@
           "name": "master",
           "sha": "2a339558ba103e38a304a4eda7c984b45c47e186"
         }
-      ]
+      ],
+      "permanentBranches": [
+        "master",
+        "next"
+      ],
+      "mirror": {
+        "branch": "master",
+        "upstream": "SoFluffyOS/xterm2",
+        "sha": "2a339558ba103e38a304a4eda7c984b45c47e186"
+      },
+      "deletionProtectionRuleset": 21840089,
+      "autotagState": "disabled_manually"
     }
   ],
   "conservation": [

--- a/docs/terminal-fork-branches.json
+++ b/docs/terminal-fork-branches.json
@@ -1,0 +1,313 @@
+{
+  "verifiedAt": "2026-08-30T03:28:52.123Z",
+  "backupDirectory": "/home/leynier/.codex/artifacts/alera-terminal-forks-20260829-6e04",
+  "repositories": [
+    {
+      "repository": "leynier/xterm.dart",
+      "defaultBranch": "next",
+      "onlyBranch": "next",
+      "next": "8e130dd687b0ff036443a5aff318e74275163eee",
+      "deleteBranchOnMerge": true,
+      "archived": false,
+      "tagsPreserved": 0,
+      "releasesPreserved": 0,
+      "previousBranches": [
+        {
+          "name": "cursor/terminal-buffer-perf-5902",
+          "sha": "14ebe14844b5f35cff20c582f09fd97dd6bedc28"
+        },
+        {
+          "name": "fix/mobile-cursor-restore-buffer-boundary",
+          "sha": "169de2f4112e989f688192357575fc0297e7cf89"
+        },
+        {
+          "name": "fix/reflow-circular-trim",
+          "sha": "4fbb7809ed5fdb894d3fa229d4d0eeb70030a0d2"
+        },
+        {
+          "name": "fix/shift-enter-csi-u",
+          "sha": "eb4e231aa895a8ed1249fc101322614b4e69266d"
+        },
+        {
+          "name": "fix/terminal-erase-range",
+          "sha": "07e28f28706bbcc10a383b6a3aefc73d8cfb68ba"
+        },
+        {
+          "name": "fix/terminal-host-connection-closed",
+          "sha": "83ff280b98430c90ce511dd1af5669722ce15f6d"
+        },
+        {
+          "name": "fix/trim-start-memory-retention",
+          "sha": "ebfab96c67fd1168ff3aa98025e73e6e5dadbfdd"
+        },
+        {
+          "name": "fix/tui-mouse-clipboard-interaction",
+          "sha": "ae511db1ced0d3bcc389a88e84500617253d34f8"
+        },
+        {
+          "name": "master",
+          "sha": "d35ba2cc72d0b89b0fd19af69d57df2c02f26a16"
+        }
+      ]
+    },
+    {
+      "repository": "leynier/dart_terminal",
+      "defaultBranch": "next",
+      "onlyBranch": "next",
+      "next": "e7028139cd90a0676c0323b2ec5f4312d14c4932",
+      "deleteBranchOnMerge": true,
+      "archived": false,
+      "tagsPreserved": 20,
+      "releasesPreserved": 2,
+      "previousBranches": [
+        {
+          "name": "chore/vte-prebuilts-from-fork",
+          "sha": "b6db3a3cf2d4540960085e93d811c1835639a01c"
+        },
+        {
+          "name": "docs/clarify-fork-distribution",
+          "sha": "2960bc7743030cac6def08f82f1261b43fbc1b92"
+        },
+        {
+          "name": "feat/ghostty-2dd79f3",
+          "sha": "132cb6575fb56b247c1c43ede2d0e5681ff48b3a"
+        },
+        {
+          "name": "feat/vte-unicode-and-selection",
+          "sha": "3c2eaab5d6ba7928f2f1539052ff9b3daee298a8"
+        },
+        {
+          "name": "fix/isolate-ghostty-source-patches",
+          "sha": "e00378552ba2fbd9f142f7d7e50682545e6fcf85"
+        },
+        {
+          "name": "fix/patch-crlf-on-windows",
+          "sha": "f1b18bdf05a501d2d6737880230515334cc0a386"
+        },
+        {
+          "name": "fix/repeated-ghostty-build-crash",
+          "sha": "dca082113f7e7a04d465431440a765e71468d3ee"
+        },
+        {
+          "name": "fix/vte-flutter-enum-sentinel",
+          "sha": "15d652c6622a383890ca07dda5c9ffe18d69fa6d"
+        },
+        {
+          "name": "fix/windows-dll-lookup",
+          "sha": "49732c2c2496a90b92f0c8e20e4745b6dac785da"
+        },
+        {
+          "name": "fix/zig-cache-dir-on-windows",
+          "sha": "e74c87c45b56233b7aa185dcbaeb9e62ae4c6b99"
+        },
+        {
+          "name": "master",
+          "sha": "cea5f7289c1c9509b2290299b2d9bb2b8192a932"
+        }
+      ]
+    },
+    {
+      "repository": "leynier/xterm2",
+      "defaultBranch": "next",
+      "onlyBranch": "next",
+      "next": "52fec4dae89c9b8af6e7071096673fe4a5af4ba1",
+      "deleteBranchOnMerge": true,
+      "archived": false,
+      "tagsPreserved": 0,
+      "releasesPreserved": 0,
+      "previousBranches": [
+        {
+          "name": "master",
+          "sha": "2a339558ba103e38a304a4eda7c984b45c47e186"
+        }
+      ]
+    }
+  ],
+  "conservation": [
+    {
+      "repo": "xterm",
+      "branch": "cursor/terminal-buffer-perf-5902",
+      "sha": "14ebe14844b5f35cff20c582f09fd97dd6bedc28",
+      "ancestor": true
+    },
+    {
+      "repo": "xterm",
+      "branch": "fix/mobile-cursor-restore-buffer-boundary",
+      "sha": "169de2f4112e989f688192357575fc0297e7cf89",
+      "ancestor": true
+    },
+    {
+      "repo": "xterm",
+      "branch": "fix/reflow-circular-trim",
+      "sha": "4fbb7809ed5fdb894d3fa229d4d0eeb70030a0d2",
+      "ancestor": true
+    },
+    {
+      "repo": "xterm",
+      "branch": "fix/shift-enter-csi-u",
+      "sha": "eb4e231aa895a8ed1249fc101322614b4e69266d",
+      "ancestor": true
+    },
+    {
+      "repo": "xterm",
+      "branch": "fix/terminal-erase-range",
+      "sha": "07e28f28706bbcc10a383b6a3aefc73d8cfb68ba",
+      "ancestor": true
+    },
+    {
+      "repo": "xterm",
+      "branch": "fix/terminal-host-connection-closed",
+      "sha": "83ff280b98430c90ce511dd1af5669722ce15f6d",
+      "ancestor": true
+    },
+    {
+      "repo": "xterm",
+      "branch": "fix/trim-start-memory-retention",
+      "sha": "ebfab96c67fd1168ff3aa98025e73e6e5dadbfdd",
+      "ancestor": true
+    },
+    {
+      "repo": "xterm",
+      "branch": "fix/tui-mouse-clipboard-interaction",
+      "sha": "ae511db1ced0d3bcc389a88e84500617253d34f8",
+      "ancestor": true
+    },
+    {
+      "repo": "xterm",
+      "branch": "master",
+      "sha": "d35ba2cc72d0b89b0fd19af69d57df2c02f26a16",
+      "ancestor": true
+    },
+    {
+      "repo": "xterm",
+      "branch": "next",
+      "sha": "83ff280b98430c90ce511dd1af5669722ce15f6d",
+      "ancestor": true
+    },
+    {
+      "repo": "dart-terminal",
+      "branch": "chore/vte-prebuilts-from-fork",
+      "sha": "b6db3a3cf2d4540960085e93d811c1835639a01c",
+      "ancestor": false,
+      "squash": "3d8ca353440cb40897f54fb7d12d24c8f0ac9e37",
+      "squashAncestor": true,
+      "branchPatch": "7ee7b6f19edc60b19289aee866a682ba3bb6bd1b",
+      "squashPatch": "7ee7b6f19edc60b19289aee866a682ba3bb6bd1b",
+      "patchEquivalent": true,
+      "binaryBlobs": []
+    },
+    {
+      "repo": "dart-terminal",
+      "branch": "docs/clarify-fork-distribution",
+      "sha": "2960bc7743030cac6def08f82f1261b43fbc1b92",
+      "ancestor": true
+    },
+    {
+      "repo": "dart-terminal",
+      "branch": "feat/ghostty-2dd79f3",
+      "sha": "132cb6575fb56b247c1c43ede2d0e5681ff48b3a",
+      "ancestor": false,
+      "squash": "da96e2ad5167c3abd9fcd3b08ef92e5769fcb4a1",
+      "squashAncestor": true,
+      "branchPatch": "254fff09a7ce25f2ff6975eb563a1dffeec42658",
+      "squashPatch": "254fff09a7ce25f2ff6975eb563a1dffeec42658",
+      "patchEquivalent": true,
+      "binaryBlobs": [
+        {
+          "path": "pkgs/vte/ghostty_vte/lib/ghostty_vte_bindings_generated.dart",
+          "branchBlob": "aac5c81b1fbb1faed5485930df321e79b810b626",
+          "squashBlob": "aac5c81b1fbb1faed5485930df321e79b810b626"
+        },
+        {
+          "path": "pkgs/vte/ghostty_vte_flutter/assets/ghostty-vt.wasm",
+          "branchBlob": "0602476c272b8eb52402c85f16c577dd5db451cc",
+          "squashBlob": "0602476c272b8eb52402c85f16c577dd5db451cc"
+        }
+      ]
+    },
+    {
+      "repo": "dart-terminal",
+      "branch": "feat/vte-unicode-and-selection",
+      "sha": "3c2eaab5d6ba7928f2f1539052ff9b3daee298a8",
+      "ancestor": false,
+      "squash": "2ebef07be16d6d850eefebf072e42af76d416e90",
+      "squashAncestor": true,
+      "branchPatch": "bac0eb5f36743e89631f182d2395ed1bfbeab9e2",
+      "squashPatch": "bac0eb5f36743e89631f182d2395ed1bfbeab9e2",
+      "patchEquivalent": true,
+      "binaryBlobs": []
+    },
+    {
+      "repo": "dart-terminal",
+      "branch": "fix/isolate-ghostty-source-patches",
+      "sha": "e00378552ba2fbd9f142f7d7e50682545e6fcf85",
+      "ancestor": true
+    },
+    {
+      "repo": "dart-terminal",
+      "branch": "fix/patch-crlf-on-windows",
+      "sha": "f1b18bdf05a501d2d6737880230515334cc0a386",
+      "ancestor": false,
+      "squash": "038f33bf93e201dd75c8ae2f32c04b1cf116741c",
+      "squashAncestor": true,
+      "branchPatch": "364cc2b78a1124f58faf5a4faa1a0e299e0e6905",
+      "squashPatch": "364cc2b78a1124f58faf5a4faa1a0e299e0e6905",
+      "patchEquivalent": true,
+      "binaryBlobs": []
+    },
+    {
+      "repo": "dart-terminal",
+      "branch": "fix/repeated-ghostty-build-crash",
+      "sha": "dca082113f7e7a04d465431440a765e71468d3ee",
+      "ancestor": true
+    },
+    {
+      "repo": "dart-terminal",
+      "branch": "fix/vte-flutter-enum-sentinel",
+      "sha": "15d652c6622a383890ca07dda5c9ffe18d69fa6d",
+      "ancestor": false,
+      "squash": "b2eb256a8101de574f338728dcc9a901513df9c4",
+      "squashAncestor": true,
+      "branchPatch": "da738a6e49a1fcab2d0ac9f605538cab2bb55fe0",
+      "squashPatch": "da738a6e49a1fcab2d0ac9f605538cab2bb55fe0",
+      "patchEquivalent": true,
+      "binaryBlobs": []
+    },
+    {
+      "repo": "dart-terminal",
+      "branch": "fix/windows-dll-lookup",
+      "sha": "49732c2c2496a90b92f0c8e20e4745b6dac785da",
+      "ancestor": false,
+      "squash": "83d8b3ef61a0b1f27a421f731d183c4bf5841bb7",
+      "squashAncestor": true,
+      "branchPatch": "3d934f1de8ca7159e309492ed442e89761e4fad7",
+      "squashPatch": "3d934f1de8ca7159e309492ed442e89761e4fad7",
+      "patchEquivalent": true,
+      "binaryBlobs": []
+    },
+    {
+      "repo": "dart-terminal",
+      "branch": "fix/zig-cache-dir-on-windows",
+      "sha": "e74c87c45b56233b7aa185dcbaeb9e62ae4c6b99",
+      "ancestor": false,
+      "squash": "a88fb634841e2e51330621d9f616111b35f92ca8",
+      "squashAncestor": true,
+      "branchPatch": "804bbca055529db7fe47f614d515b0a5c1995130",
+      "squashPatch": "804bbca055529db7fe47f614d515b0a5c1995130",
+      "patchEquivalent": true,
+      "binaryBlobs": []
+    },
+    {
+      "repo": "dart-terminal",
+      "branch": "master",
+      "sha": "cea5f7289c1c9509b2290299b2d9bb2b8192a932",
+      "ancestor": true
+    },
+    {
+      "repo": "dart-terminal",
+      "branch": "next",
+      "sha": "afaa4195335dbd7442c84b5e74db455def5d8118",
+      "ancestor": true
+    }
+  ]
+}

--- a/docs/terminal-fork-branches.json
+++ b/docs/terminal-fork-branches.json
@@ -1,5 +1,5 @@
 {
-  "verifiedAt": "2026-08-30T04:17:55.272Z",
+  "verifiedAt": "2026-08-30T04:49:32.705Z",
   "backupDirectory": "/home/leynier/.codex/artifacts/alera-terminal-forks-20260829-6e04",
   "repositories": [
     {
@@ -129,7 +129,7 @@
     {
       "repository": "leynier/xterm2",
       "defaultBranch": "next",
-      "next": "cd99d34fbcc4b2001418546c94dd7e3533251a12",
+      "next": "45d341383e4d4e137c7e70efad0441babd74c561",
       "deleteBranchOnMerge": true,
       "archived": false,
       "tagsPreserved": 0,

--- a/docs/xterm2-migration-validation.md
+++ b/docs/xterm2-migration-validation.md
@@ -1,0 +1,86 @@
+# xterm2 migration validation
+
+## Scope and pinned sources
+
+Desktop and mobile now use `xterm2` 5.3.0 from the existing `third_party/xterm` path. The fork starts at `SoFluffyOS/xterm2@2a339558ba103e38a304a4eda7c984b45c47e186`. Its Unicode 17/grapheme handling, Kitty keyboard protocol, synchronized updates, native OSC 8 metadata and parser optimizations remain active. Alera keeps its own search and keyboard dispatch; xterm2's additional navigation shortcuts are not installed.
+
+| Fork | Final `next` SHA | Purpose |
+| --- | --- | --- |
+| `leynier/xterm2` | `52fec4dae89c9b8af6e7071096673fe4a5af4ba1` | Upstream base plus focused compatibility, regression tests and renderer cache optimization |
+| `leynier/xterm.dart` | `8e130dd687b0ff036443a5aff318e74275163eee` | Preserves legacy code through `14ebe14844b5f35cff20c582f09fd97dd6bedc28`, plus branch policy and CI documentation |
+| `leynier/dart_terminal` | `e7028139cd90a0676c0323b2ec5f4312d14c4932` | Preserves `dca082113f7e7a04d465431440a765e71468d3ee`, plus branch links and workflow updates |
+
+There is no SDK upgrade, Ghostty renderer migration, pub.dev publication or Alera release. `dart_terminal` is not updated to upstream 0.2.0-beta.2 and does not acquire `native_prebuilt` or a Dart 3.13 requirement. Its nested Ghostty stays at `08f039fbb3dea9c6b1cdb5ff4550666598122346`.
+
+## Compatibility decisions
+
+The [21-change preservation matrix](../third_party/xterm/ALERA_PATCHES.md) identifies every original correction as ported, retained or superseded by upstream and names its regression tests. The old commits were not cherry-picked wholesale.
+
+- Desktop explicitly disables reflow with a hidden cursor to retain the current TUI resize behavior; mobile explicitly enables it while restoring host-sized history to a phone viewport. Saved cursor coordinates, pending wrap, narrow/wide rows, scroll regions, styled erasure and repaired short rows have regression coverage.
+- Scrollback compaction preserves combining marks, wide-cell placeholders, hyperlink IDs and underline metadata. Copying blank columns preserves spaces without inserting spaces after wide glyphs or changing tab expansion.
+- Injected clipboard callbacks, contextual Ctrl+C, Shift selection during mouse reporting, wheel sensitivity, font weight and cursor blink settings remain available. Unnegotiated Shift+Enter retains CSI-u; negotiated Kitty/modifyOtherKeys behavior stays upstream.
+- OSC 8 links use native cell metadata instead of a second anchor tracker. Text URL detection, allowed URI schemes and activation modifiers remain in Alera, with tests for wrapping, overwrite, scrollback eviction and graphemes.
+- Native OSC 52 callbacks use Alera's strict decoder: existing permission gate, explicit selector validation, 128 KiB encoded-payload limit and no clipboard reads. Alera disables iTerm2 clipboard capture and does not attach a clipboard-query callback. Mobile gains no remote clipboard callback.
+- Closing or replacing an emulator calls `Terminal.dispose()` in desktop and mobile, including snapshot rebuilds and reconnects. This cancels xterm2 timers and releases its additional resources.
+- The renderer keeps a bounded 2,048-entry paragraph cache with explicit native paragraph disposal. Linked LRU promotion and a plain ASCII cache hit avoid repeated hash removal/insertion and decoration work; styled/Unicode/selection rendering keeps the general path.
+
+## Test evidence
+
+Local application validation uses isolated Flutter 3.44.8 / Dart 3.12.2 without changing the global Flutter installation. Raw logs and recovery bundles are retained in `/home/leynier/.codex/artifacts/alera-terminal-forks-20260829-6e04/`; local working logs are under ignored `build/terminal-migration/`.
+
+| Check | Result |
+| --- | --- |
+| xterm2 upstream baseline | 742 passed, two skipped, two existing text-scaler golden failures |
+| xterm2 fork | 851 non-golden tests passed, two skipped; static analysis clean |
+| xterm2 CI | [Final commit CI](https://github.com/leynier/xterm2/actions/runs/33290021630) passed on Linux, macOS and Windows using Flutter 3.44.8 |
+| Alera desktop suite | Final complete run: 3,353 passed, one skipped (`flutter test --concurrency 2`) |
+| Alera mobile suite | 575 passed again against the final pin, including lifecycle/reconnect assertions |
+| Static analysis | Complete desktop and mobile analysis clean |
+| Link regressions | 14 passed, including native OSC 8 overwrite/reflow and grapheme URL offsets |
+| dart_terminal build/cache tests | 25 passed from the package directory |
+| dart_terminal CI | Analyze and PTY passed; [VTE build/test matrix](https://github.com/leynier/dart_terminal/actions/runs/33290141457) passed after retrying one transient Zig TLS download failure in Android ARM |
+| Native asset integrity | All 12 extracted native release binaries match the SHA-256 values in `asset_hashes.dart` |
+| Repeated Ghostty source builds | Two successful native hook runs; nested Ghostty checkout remains unchanged |
+| Linux native application | Built successfully and ran all three integration benchmark executables |
+| macOS native input | 10 xterm interaction tests and 145 Alera terminal/input/link/widget tests passed against final sources |
+| Windows native input | 10 xterm interaction tests and 129 Alera terminal/input/widget tests passed; two platform-specific tests skipped |
+| Android build | Debug APK built successfully, including its native Rust library |
+| macOS / iOS builds | Blocked by missing CocoaPods on the Mac; no machine-wide installation was performed |
+
+The two upstream text-scaler golden tests retain their original images and are tagged `platform-golden`. CI gates all other tests and runs those goldens in a separate non-blocking step; unfiltered `flutter test` still reports their failures. They are not presented as passing checks.
+
+An earlier parallel desktop suite run had an isolated failure in `mobile_emulator_playback_monitor_test.dart: reports player errors without treating them as completion` (expected one event, observed zero). All five tests in that file passed on isolated retry, and the final complete run with concurrency two passed all 3,353 tests. No unrelated playback implementation or test was changed. Automated widget/protocol tests do not substitute for interactive IME, clipboard/image, gesture or device smoke testing.
+
+## Performance and memory
+
+The following are Linux debug/Xvfb observations from the existing benchmarks, not release-mode performance guarantees. CPU is percent of one core. Workload, viewport and Alera's production pacing settings are unchanged.
+
+| Render workload | Legacy build / raster median | xterm2 final cache build / raster median | Legacy / xterm2 CPU |
+| --- | --- | --- | --- |
+| No output | 0.40 / 2.07 ms | 0.42 / 2.06 ms | 64.0% / 64.4% |
+| One line per frame | 2.68 / 6.32 ms | 3.29 / 6.07 ms | 125.9% / 119.6% |
+| One screenful per frame | 2.61 / 6.17 ms | 2.36 / 6.33 ms | 127.0% / 123.4% |
+
+Initial xterm2 runs reproducibly increased build medians to approximately 4.7-5.3 ms. The paragraph-cache changes reduce that cost; one-line build time is still about 23% above the recorded legacy median, while raster medians and CPU are comparable. This residual debug result is disclosed rather than treated as proof of performance equivalence. A later final-pin repeat measured build medians 0.42 / 3.54 / 2.58 ms and raster medians 2.27 / 7.43 / 7.51 ms for the three workloads, respectively; that run was on the contended host described below.
+
+The snapshot replay benchmark restored 2,560,000 bytes with a 1 MiB live backlog. A repeat against the final pinned cache implementation also passed all five runs (median 2,510 ms, maximum 2,657 ms, 40 flushes each), despite concurrent compilation/test activity elsewhere on this 16-core host. Legacy median was 3,052 ms (maximum 3,165 ms; two of five runs within the 3,000 ms target). The xterm2 compatibility run measured 2,118 ms (maximum 2,186 ms; all five within target), with 40 flushes in every run and throughput increasing from 0.80 to 1.15 MiB/s. CPU increased from 53.1% to 158.2% while the restore completed sooner; this measurement does not establish an energy reduction. The baseline emitted its measurements but failed teardown because live backlog left a scheduled callback; the benchmark now disposes its runtime before the binding's final checks, and the migrated run passed.
+
+Before the final cache optimization, the cadence benchmark measured 18.7 versus 18.1 flushes/s and CPU 181.2% versus 180.7%, but raster median increased from 7.93 to 13.28 ms. Two later final-cache runs passed functionally but overlapped substantial compilation/test activity in other worktrees (33 then 30 input writes/s versus 74 at baseline, 35.02 then 47.91 ms raster; host load approximately 35 on 16 cores). They are not controlled comparisons and must not be used to attribute a regression to xterm2. Production pacing constants were not changed. Re-run cadence/restoration on an idle machine for a reliable final performance sign-off.
+
+An identical 20,000-line short-output scenario retaining 10,000 rows measured 687,616 bytes in cell backing buffers for both forks, unchanged after resizing 120 to 80 columns. This measures retained typed cell buffers only, not total process heap, native paragraphs or hyperlink-table memory. Compaction tests separately cover hyperlink and grapheme metadata preservation.
+
+## Branch conservation and recovery
+
+The [machine-readable manifest](terminal-fork-branches.json) records every previous branch SHA and its conservation proof. All 10 legacy xterm branches are ancestors of its final `next`. Seven dart_terminal branches are divergent only because they were squash-merged: stable patch IDs match their squash commits, those commits are ancestors of `next`, and the generated binding/WASM blobs checked in the ABI update match exactly.
+
+Before changing refs, full Git bundles and branch manifests were saved and verified. The two old `next` branches were fast-forwarded, default branches changed to `next`, and automatic deletion after merge enabled. Non-`next` branches were removed with atomic pushes and explicit per-ref SHA leases after rechecking refs and open PRs. Tags, releases and repositories were preserved; the legacy fork was not archived.
+
+The external backup directory contains `xterm-original.bundle`, `dart-terminal-original.bundle`, final bundles for all three forks, before-delete manifests, conservation proofs and GitHub inventory snapshots. A fresh recovery repository can import a bundle's refs without contacting GitHub:
+
+```sh
+git init recovered-fork
+git -C recovered-fork fetch /absolute/path/to/fork.bundle '+refs/*:refs/recovery/*'
+git -C recovered-fork branch recovered-change <sha-from-manifest>
+```
+
+Restore remote refs only deliberately, after checking for subsequent changes. Alera pins immutable gitlink commits, so ordinary submodule initialization does not require any deleted branch.

--- a/docs/xterm2-migration-validation.md
+++ b/docs/xterm2-migration-validation.md
@@ -6,11 +6,11 @@ Desktop and mobile now use `xterm2` 5.3.0 from the existing `third_party/xterm` 
 
 | Fork | Final `next` SHA | Purpose |
 | --- | --- | --- |
-| `leynier/xterm2` | `52fec4dae89c9b8af6e7071096673fe4a5af4ba1` | Upstream base plus focused compatibility, regression tests and renderer cache optimization |
-| `leynier/xterm.dart` | `8e130dd687b0ff036443a5aff318e74275163eee` | Preserves legacy code through `14ebe14844b5f35cff20c582f09fd97dd6bedc28`, plus branch policy and CI documentation |
-| `leynier/dart_terminal` | `e7028139cd90a0676c0323b2ec5f4312d14c4932` | Preserves `dca082113f7e7a04d465431440a765e71468d3ee`, plus branch links and workflow updates |
+| `leynier/xterm2` | `cd99d34fbcc4b2001418546c94dd7e3533251a12` | Upstream base plus focused compatibility, regression tests and renderer cache optimization |
+| `leynier/xterm.dart` | `dd37dbe3cb0ea5f2de529ba158395af062351e62` | Preserves legacy code through `14ebe14844b5f35cff20c582f09fd97dd6bedc28`, plus branch policy and CI documentation |
+| `leynier/dart_terminal` | `7bfb6c57f8da75742891ac27b568cc651f77501a` | Preserves `dca082113f7e7a04d465431440a765e71468d3ee`, plus branch links and workflow updates |
 
-There is no SDK upgrade, Ghostty renderer migration, pub.dev publication or Alera release. `dart_terminal` is not updated to upstream 0.2.0-beta.2 and does not acquire `native_prebuilt` or a Dart 3.13 requirement. Its nested Ghostty stays at `08f039fbb3dea9c6b1cdb5ff4550666598122346`.
+There is no SDK upgrade, Ghostty renderer migration, pub.dev publication or Alera release. The consumed `dart_terminal:next` is not updated to upstream 0.2.0-beta.2 and does not acquire `native_prebuilt` or a Dart 3.13 requirement. Its nested Ghostty stays at `08f039fbb3dea9c6b1cdb5ff4550666598122346`. Its separate `master` mirror tracks current upstream without changing this pin.
 
 ## Compatibility decisions
 
@@ -32,7 +32,7 @@ Local application validation uses isolated Flutter 3.44.8 / Dart 3.12.2 without 
 | --- | --- |
 | xterm2 upstream baseline | 742 passed, two skipped, two existing text-scaler golden failures |
 | xterm2 fork | 851 non-golden tests passed, two skipped; static analysis clean |
-| xterm2 CI | [Final commit CI](https://github.com/leynier/xterm2/actions/runs/33290021630) passed on Linux, macOS and Windows using Flutter 3.44.8 |
+| xterm2 CI | [Final pinned commit CI](https://github.com/leynier/xterm2/actions/runs/33292022130) passed on Linux, macOS and Windows using Flutter 3.44.8 |
 | Alera desktop suite | Final complete run: 3,353 passed, one skipped (`flutter test --concurrency 2`) |
 | Alera mobile suite | 575 passed again against the final pin, including lifecycle/reconnect assertions |
 | Static analysis | Complete desktop and mobile analysis clean |
@@ -43,11 +43,25 @@ Local application validation uses isolated Flutter 3.44.8 / Dart 3.12.2 without 
 | Repeated Ghostty source builds | Two successful native hook runs; nested Ghostty checkout remains unchanged |
 | Linux native application | Built successfully and ran all three integration benchmark executables |
 | macOS native input | 10 xterm interaction tests and 145 Alera terminal/input/link/widget tests passed against final sources |
-| Windows native input | 10 xterm interaction tests and 129 Alera terminal/input/widget tests passed; two platform-specific tests skipped |
+| Windows native input | 10 xterm interaction tests and 143 Alera terminal/input/link/widget tests passed against final sources; two platform-specific tests skipped |
+| Windows native application | Full debug build and final-source incremental build passed, including the Rust library and CLI sidecar |
 | Android build | Debug APK built successfully, including its native Rust library |
 | macOS / iOS builds | Blocked by missing CocoaPods on the Mac; no machine-wide installation was performed |
 
 The two upstream text-scaler golden tests retain their original images and are tagged `platform-golden`. CI gates all other tests and runs those goldens in a separate non-blocking step; unfiltered `flutter test` still reports their failures. They are not presented as passing checks.
+
+The final branch-policy commits change documentation and the disabled autotag workflow only. Runtime source and tests are identical to the validated xterm2 `52fec4dae89c9b8af6e7071096673fe4a5af4ba1` and dart_terminal `e7028139cd90a0676c0323b2ec5f4312d14c4932` pins.
+
+For a repeatable local check, activate Flutter 3.44.8 only in the current process environment, initialize submodules, and run these commands from the indicated package directories. Native builds also require the project's platform toolchains; the Mac currently lacks CocoaPods.
+
+| Directory | Commands |
+| --- | --- |
+| Repository root | `flutter pub get`, `flutter analyze --no-pub`, `flutter test --concurrency 2` |
+| `third_party/xterm` | `flutter pub get`, `flutter analyze --fatal-infos`, `flutter test --exclude-tags platform-golden` |
+| `mobile` | `flutter pub get`, `flutter analyze --no-pub`, `flutter test`, `flutter build apk --debug` |
+| `third_party/dart_terminal/pkgs/vte/ghostty_vte` | `flutter pub get`, `flutter test test/hook_build_test.dart test/build_cache_test.dart` |
+
+On Linux, run each benchmark separately with `xvfb-run -a flutter test integration_test/<benchmark>.dart -d linux --reporter expanded`, using `terminal_render_benchmark`, `terminal_flush_cadence_benchmark` and `terminal_restore_benchmark`. Stop this task's other builds first and record host load; do not stop another task's processes to obtain a quieter sample.
 
 An earlier parallel desktop suite run had an isolated failure in `mobile_emulator_playback_monitor_test.dart: reports player errors without treating them as completion` (expected one event, observed zero). All five tests in that file passed on isolated retry, and the final complete run with concurrency two passed all 3,353 tests. No unrelated playback implementation or test was changed. Automated widget/protocol tests do not substitute for interactive IME, clipboard/image, gesture or device smoke testing.
 
@@ -73,7 +87,17 @@ An identical 20,000-line short-output scenario retaining 10,000 rows measured 68
 
 The [machine-readable manifest](terminal-fork-branches.json) records every previous branch SHA and its conservation proof. All 10 legacy xterm branches are ancestors of its final `next`. Seven dart_terminal branches are divergent only because they were squash-merged: stable patch IDs match their squash commits, those commits are ancestors of `next`, and the generated binding/WASM blobs checked in the ABI update match exactly.
 
-Before changing refs, full Git bundles and branch manifests were saved and verified. The two old `next` branches were fast-forwarded, default branches changed to `next`, and automatic deletion after merge enabled. Non-`next` branches were removed with atomic pushes and explicit per-ref SHA leases after rechecking refs and open PRs. Tags, releases and repositories were preserved; the legacy fork was not archived.
+Before changing refs, full Git bundles and branch manifests were saved and verified. The two old `next` branches were fast-forwarded, default branches changed to `next`, and automatic deletion after merge enabled. Initial branch cleanup used atomic pushes and explicit per-ref SHA leases after rechecking refs and open PRs. The final requested policy retains `master` as an upstream mirror alongside `next`; all other branches were removed. Tags, releases and repositories were preserved; the legacy fork was not archived.
+
+Each repository now has exactly `master` and `next`, with `next` as default. Active deletion-only rulesets protect both branches without preventing mirror updates. The inherited autotag workflow is disabled in both xterm forks before restoring their mirrors, preventing sync pushes from generating tags. `dart_terminal` retains its 20 existing tags and two releases; no upstream tags were pushed.
+
+| Fork mirror | Upstream | Verified mirror SHA |
+| --- | --- | --- |
+| `leynier/xterm.dart:master` | `TerminalStudio/xterm.dart:master` | `d35ba2cc72d0b89b0fd19af69d57df2c02f26a16` |
+| `leynier/xterm2:master` | `SoFluffyOS/xterm2:master` | `2a339558ba103e38a304a4eda7c984b45c47e186` |
+| `leynier/dart_terminal:master` | `kingwill101/dart_terminal:master` | `3146f58d2b675d50383c86b5b5eb5d89e6c1058c` |
+
+Select `master` explicitly when syncing a fork. Merging upstream into `next` requires separate review, especially for the deferred dart_terminal SDK upgrade. The backup's `mirror-final-state.json` records live branch SHAs, rulesets, workflow state and preserved tag/release inventories.
 
 The external backup directory contains `xterm-original.bundle`, `dart-terminal-original.bundle`, final bundles for all three forks, before-delete manifests, conservation proofs and GitHub inventory snapshots. A fresh recovery repository can import a bundle's refs without contacting GitHub:
 

--- a/docs/xterm2-migration-validation.md
+++ b/docs/xterm2-migration-validation.md
@@ -6,7 +6,7 @@ Desktop and mobile now use `xterm2` 5.3.0 from the existing `third_party/xterm` 
 
 | Fork | Final `next` SHA | Purpose |
 | --- | --- | --- |
-| `leynier/xterm2` | `cd99d34fbcc4b2001418546c94dd7e3533251a12` | Upstream base plus focused compatibility, regression tests and renderer cache optimization |
+| `leynier/xterm2` | `45d341383e4d4e137c7e70efad0441babd74c561` | Upstream base plus focused compatibility, regression tests and renderer cache optimization |
 | `leynier/xterm.dart` | `dd37dbe3cb0ea5f2de529ba158395af062351e62` | Preserves legacy code through `14ebe14844b5f35cff20c582f09fd97dd6bedc28`, plus branch policy and CI documentation |
 | `leynier/dart_terminal` | `7bfb6c57f8da75742891ac27b568cc651f77501a` | Preserves `dca082113f7e7a04d465431440a765e71468d3ee`, plus branch links and workflow updates |
 
@@ -20,7 +20,7 @@ The [21-change preservation matrix](../third_party/xterm/ALERA_PATCHES.md) ident
 - Scrollback compaction preserves combining marks, wide-cell placeholders, hyperlink IDs and underline metadata. Copying blank columns preserves spaces without inserting spaces after wide glyphs or changing tab expansion.
 - Injected clipboard callbacks, contextual Ctrl+C, Shift selection during mouse reporting, wheel sensitivity, font weight and cursor blink settings remain available. Unnegotiated Shift+Enter retains CSI-u; negotiated Kitty/modifyOtherKeys behavior stays upstream.
 - OSC 8 links use native cell metadata instead of a second anchor tracker. Text URL detection, allowed URI schemes and activation modifiers remain in Alera, with tests for wrapping, overwrite, scrollback eviction and graphemes.
-- Native OSC 52 callbacks use Alera's strict decoder: existing permission gate, explicit selector validation, 128 KiB encoded-payload limit and no clipboard reads. Alera disables iTerm2 clipboard capture and does not attach a clipboard-query callback. Mobile gains no remote clipboard callback.
+- Native OSC 52 callbacks use Alera's strict decoder: existing permission gate, explicit selector validation, 128 KiB encoded-payload limit and no clipboard reads. Alera disables iTerm2 and Kitty clipboard extensions and supplies an explicit deny callback for clipboard queries. Mobile explicitly denies both remote clipboard callbacks, preventing TerminalView from installing system defaults.
 - Closing or replacing an emulator calls `Terminal.dispose()` in desktop and mobile, including snapshot rebuilds and reconnects. This cancels xterm2 timers and releases its additional resources.
 - The renderer keeps a bounded 2,048-entry paragraph cache with explicit native paragraph disposal. Linked LRU promotion and a plain ASCII cache hit avoid repeated hash removal/insertion and decoration work; styled/Unicode/selection rendering keeps the general path.
 
@@ -31,10 +31,10 @@ Local application validation uses isolated Flutter 3.44.8 / Dart 3.12.2 without 
 | Check | Result |
 | --- | --- |
 | xterm2 upstream baseline | 742 passed, two skipped, two existing text-scaler golden failures |
-| xterm2 fork | 851 non-golden tests passed, two skipped; static analysis clean |
-| xterm2 CI | [Final pinned commit CI](https://github.com/leynier/xterm2/actions/runs/33292022130) passed on Linux, macOS and Windows using Flutter 3.44.8 |
-| Alera desktop suite | Final complete run: 3,353 passed, one skipped (`flutter test --concurrency 2`) |
-| Alera mobile suite | 575 passed again against the final pin, including lifecycle/reconnect assertions |
+| xterm2 fork | 863 non-golden tests passed, two skipped; static analysis clean |
+| xterm2 CI | [Final pinned commit CI](https://github.com/leynier/xterm2/actions/runs/33293168080) passed on Linux, macOS and Windows using Flutter 3.44.8 |
+| Alera desktop suite | Final complete run: 3,356 passed, one skipped (`flutter test --concurrency 2`) |
+| Alera mobile suite | 576 passed against the reviewed pin with concurrency two, including focused clipboard denial and lifecycle/reconnect assertions |
 | Static analysis | Complete desktop and mobile analysis clean |
 | Link regressions | 14 passed, including native OSC 8 overwrite/reflow and grapheme URL offsets |
 | dart_terminal build/cache tests | 25 passed from the package directory |
@@ -50,7 +50,7 @@ Local application validation uses isolated Flutter 3.44.8 / Dart 3.12.2 without 
 
 The two upstream text-scaler golden tests retain their original images and are tagged `platform-golden`. CI gates all other tests and runs those goldens in a separate non-blocking step; unfiltered `flutter test` still reports their failures. They are not presented as passing checks.
 
-The final branch-policy commits change documentation and the disabled autotag workflow only. Runtime source and tests are identical to the validated xterm2 `52fec4dae89c9b8af6e7071096673fe4a5af4ba1` and dart_terminal `e7028139cd90a0676c0323b2ec5f4312d14c4932` pins.
+The initial branch-policy commits changed documentation and the disabled autotag workflow only. The platform build/input checks above predate the review corrections below; those application fixes are validated by Linux-hosted Flutter tests. The dart_terminal runtime remains identical to `e7028139cd90a0676c0323b2ec5f4312d14c4932`.
 
 For a repeatable local check, activate Flutter 3.44.8 only in the current process environment, initialize submodules, and run these commands from the indicated package directories. Native builds also require the project's platform toolchains; the Mac currently lacks CocoaPods.
 
@@ -82,6 +82,20 @@ The snapshot replay benchmark restored 2,560,000 bytes with a 1 MiB live backlog
 Before the final cache optimization, the cadence benchmark measured 18.7 versus 18.1 flushes/s and CPU 181.2% versus 180.7%, but raster median increased from 7.93 to 13.28 ms. Two later final-cache runs passed functionally but overlapped substantial compilation/test activity in other worktrees (33 then 30 input writes/s versus 74 at baseline, 35.02 then 47.91 ms raster; host load approximately 35 on 16 cores). They are not controlled comparisons and must not be used to attribute a regression to xterm2. Production pacing constants were not changed. Re-run cadence/restoration on an idle machine for a reliable final performance sign-off.
 
 An identical 20,000-line short-output scenario retaining 10,000 rows measured 687,616 bytes in cell backing buffers for both forks, unchanged after resizing 120 to 80 columns. This measures retained typed cell buffers only, not total process heap, native paragraphs or hyperlink-table memory. Compaction tests separately cover hyperlink and grapheme metadata preservation.
+
+## Review corrections
+
+A Codex review using `gpt-5.6-sol` with high effort against `origin/main` found three reproducible issues that the initial tests missed. The fixes passed 3,356 desktop tests (one skip), 576 mobile tests, and 863 fork tests (two skips, excluding the two inherited goldens), plus static analysis and fork CI on Linux/macOS/Windows. The review fixes preserve the migration policy:
+
+- Focused xterm2 views install system clipboard handlers when callbacks are unset. Desktop now explicitly denies queries while retaining gated writes; mobile explicitly denies both. Mounted, focused-view tests cover desktop permissions and mobile emulator replacement.
+- The generic 8 KiB OSC parser cap prevented larger authorized copies from reaching Alera's decoder. OSC 52 now permits the existing 128 KiB encoded payload after a bounded header, rejects extra fields, and preserves parser recovery across BEL/ST overflow boundaries. Other OSC sequences keep their original cap. A separate switch disables OSC 5522 in Alera, so it cannot bypass the policy limiting supported clipboard protocols.
+- At 4,096 retained native hyperlinks, upstream scanned both buffers for each subsequent allocation. Pruning now waits 256 rejected allocation attempts between scans, including when a scan reclaims only one slot. Storage remains bounded and referenced links remain intact; reclaiming erased links can lag by that bounded number of attempts. Regression tests cover eventual recovery and reset.
+
+The same 7,000-link scenario measured roughly 278-300 ms per 1,000 links after capacity before the fix and 4-25 ms afterward. This is a targeted parser benchmark, not a substitute for the render/cadence measurements above. Reproduce it from the fork with `dart run script/hyperlink_capacity_benchmark.dart`.
+
+An additional mobile full-suite run intermittently failed `A closed socket ends both streams` in `mobile_runtime_terminal_client_test.dart`; all eight cases passed in isolation, and the complete 576-test suite then passed with concurrency two. The socket implementation and its tests were not changed.
+
+The shared Puro Flutter 3.44.8 environment was removed externally during the review's first full desktop run, causing missing `flutter_tester` errors. That interrupted run is not a validation result. Subsequent review commands use a task-owned Flutter 3.44.8 / Dart 3.12.2 checkout under the backup directory's `flutter-sdk/`; this task did not change the global Flutter selection.
 
 ## Branch conservation and recovery
 

--- a/integration_test/terminal_render_benchmark.dart
+++ b/integration_test/terminal_render_benchmark.dart
@@ -24,7 +24,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
-import 'package:xterm/xterm.dart' as xterm;
+import 'package:xterm2/xterm.dart' as xterm;
 
 /// Wall time per scenario. Measuring by time rather than by frame count is what
 /// makes the CPU figure comparable across cadences.

--- a/integration_test/terminal_restore_benchmark.dart
+++ b/integration_test/terminal_restore_benchmark.dart
@@ -51,7 +51,10 @@ void main() {
         ),
       ],
     );
-    addTearDown(runtime.dispose);
+    var runtimeDisposed = false;
+    addTearDown(() {
+      if (!runtimeDisposed) runtime.dispose();
+    });
     final session = runtime.sessionFor(workspace: _workspace(), tab: _tab());
 
     await tester.pumpWidget(
@@ -97,6 +100,12 @@ void main() {
     print(report.format(snapshot));
     expect(samples, hasLength(_measuredRuns));
     expect(samples.every((sample) => sample.frames.isNotEmpty), isTrue);
+    // The measurement deliberately leaves live output queued. Retire its frame
+    // callback before the test binding checks for outstanding animations.
+    await tester.pumpWidget(const SizedBox());
+    runtime.dispose();
+    runtimeDisposed = true;
+    await tester.pump();
   });
 }
 

--- a/lib/src/features/settings/domain/terminal_theme_catalog.dart
+++ b/lib/src/features/settings/domain/terminal_theme_catalog.dart
@@ -1,6 +1,6 @@
 import 'package:alera/src/app/theme/alera_tokens.dart';
 import 'package:flutter/material.dart';
-import 'package:xterm/xterm.dart' as xterm;
+import 'package:xterm2/xterm.dart' as xterm;
 part 'terminal_theme_base_palette.dart';
 part 'terminal_theme_extended_palette.dart';
 

--- a/lib/src/features/workbench/domain/terminal_osc52_clipboard.dart
+++ b/lib/src/features/workbench/domain/terminal_osc52_clipboard.dart
@@ -43,3 +43,8 @@ TerminalOsc52Request parseTerminalOsc52Request(List<String> args) {
     utf8.decode(base64.decode(normalized), allowMalformed: true),
   );
 }
+
+String? decodeTerminalOsc52Payload(String selector, String payload) {
+  final request = parseTerminalOsc52Request([selector, payload]);
+  return request is TerminalOsc52Write ? request.text : null;
+}

--- a/lib/src/features/workbench/presentation/terminal_buffer_budget.dart
+++ b/lib/src/features/workbench/presentation/terminal_buffer_budget.dart
@@ -1,4 +1,4 @@
-import 'package:xterm/xterm.dart' as xterm;
+import 'package:xterm2/xterm.dart' as xterm;
 
 /// Bytes an xterm buffer holds for a given size.
 ///

--- a/lib/src/features/workbench/presentation/terminal_link_resolver.dart
+++ b/lib/src/features/workbench/presentation/terminal_link_resolver.dart
@@ -2,7 +2,7 @@ import 'dart:math' show min;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
-import 'package:xterm/xterm.dart' as xterm;
+import 'package:xterm2/xterm.dart' as xterm;
 
 final class TerminalLinkRange {
   const TerminalLinkRange({
@@ -48,9 +48,8 @@ final class TerminalLinkRange {
 TerminalLinkRange? resolveTerminalLinkAt({
   required xterm.Terminal terminal,
   required xterm.CellOffset offset,
-  Osc8TerminalLinkTracker? osc8Tracker,
 }) {
-  final osc8Link = osc8Tracker?.linkAt(offset);
+  final osc8Link = _resolveNativeHyperlink(terminal, offset);
   if (osc8Link != null) {
     return osc8Link;
   }
@@ -118,124 +117,46 @@ bool isTerminalLinkActivation({
   };
 }
 
-class Osc8TerminalLinkTracker {
-  Osc8TerminalLinkTracker({required this._terminal});
-
-  final xterm.Terminal _terminal;
-  final List<_TrackedOsc8Link> _links = <_TrackedOsc8Link>[];
-  _PendingOsc8Link? _activeLink;
-
-  /// Links are only detached when their anchors scroll out of the buffer, so
-  /// pruning on every close was O(n) per link and quadratic over a session
-  /// with many hyperlinks. Prune on growth instead, which amortizes to O(1).
-  int _nextPruneThreshold = _osc8LinkPruneFloor;
-
-  void handlePrivateOsc(String code, List<String> args) {
-    if (code != '8') {
-      return;
-    }
-    final rawTarget = args.length >= 2 ? args[1].trim() : '';
-    if (rawTarget.isEmpty) {
-      _closeActiveLink();
-      return;
-    }
-    final uri = Uri.tryParse(rawTarget);
-    if (!_supportsWebUri(uri)) {
-      _closeActiveLink();
-      return;
-    }
-    _startLink(uri!);
-  }
-
-  TerminalLinkRange? linkAt(xterm.CellOffset offset) {
-    _pruneDetachedLinks();
-    for (final link in _links.reversed) {
-      final materialized = link.materialize();
-      if (materialized != null && materialized.contains(offset)) {
-        return materialized;
-      }
-    }
-    final activeLink = _activeLink;
-    if (activeLink == null || !activeLink.attached) {
-      return null;
-    }
-    final materialized = activeLink.materialize(_currentCursorOffset());
-    if (materialized != null && materialized.contains(offset)) {
-      return materialized;
-    }
+TerminalLinkRange? _resolveNativeHyperlink(
+  xterm.Terminal terminal,
+  xterm.CellOffset offset,
+) {
+  final buffer = terminal.buffer;
+  if (offset.y < 0 ||
+      offset.y >= buffer.lines.length ||
+      offset.x < 0 ||
+      offset.x >= buffer.viewWidth) {
     return null;
   }
-
-  void dispose() {
-    _activeLink?.dispose();
-    _activeLink = null;
-    for (final link in _links) {
-      link.dispose();
-    }
-    _links.clear();
+  final target = terminal.hyperlinkAt(offset);
+  final uri = target == null ? null : Uri.tryParse(target);
+  if (!_supportsWebUri(uri)) return null;
+  final id = terminal.hyperlinkIdAt(offset);
+  var start = offset;
+  var end = offset;
+  while (true) {
+    final previous = start.x > 0
+        ? xterm.CellOffset(start.x - 1, start.y)
+        : start.y > 0 && buffer.lines[start.y].isWrapped
+        ? xterm.CellOffset(buffer.viewWidth - 1, start.y - 1)
+        : null;
+    if (previous == null || terminal.hyperlinkIdAt(previous) != id) break;
+    start = previous;
   }
-
-  void _startLink(Uri uri) {
-    _closeActiveLink();
-    _activeLink = _PendingOsc8Link(
-      uri: uri,
-      start: _terminal.buffer.createAnchorFromOffset(_currentCursorOffset()),
-    );
+  while (true) {
+    final next = end.x + 1 < buffer.viewWidth
+        ? xterm.CellOffset(end.x + 1, end.y)
+        : end.y + 1 < buffer.lines.length && buffer.lines[end.y + 1].isWrapped
+        ? xterm.CellOffset(0, end.y + 1)
+        : null;
+    if (next == null || terminal.hyperlinkIdAt(next) != id) break;
+    end = next;
   }
-
-  void _closeActiveLink() {
-    final activeLink = _activeLink;
-    if (activeLink == null) {
-      return;
-    }
-    final materialized = activeLink.materialize(_currentCursorOffset());
-    final end = _terminal.buffer.createAnchorFromOffset(_currentCursorOffset());
-    if (materialized != null && !materialized.isEmpty) {
-      _links.add(
-        _TrackedOsc8Link(
-          uri: activeLink.uri,
-          start: activeLink.start,
-          end: end,
-        ),
-      );
-    } else {
-      end.dispose();
-      activeLink.start.dispose();
-    }
-    _activeLink = null;
-    _pruneDetachedLinks();
-  }
-
-  void _pruneDetachedLinks({bool force = false}) {
-    if (!force && _links.length < _nextPruneThreshold) {
-      return;
-    }
-    _links.removeWhere((link) {
-      final keep = link.attached;
-      if (!keep) {
-        link.dispose();
-      }
-      return !keep;
-    });
-    final doubled = _links.length * 2;
-    _nextPruneThreshold = doubled > _osc8LinkPruneFloor
-        ? doubled
-        : _osc8LinkPruneFloor;
-  }
-
-  xterm.CellOffset _currentCursorOffset() {
-    final buffer = _terminal.buffer;
-    final row = buffer.absoluteCursorY;
-    final line = buffer.lines[row];
-    // Why: xterm's public cursorX clamps to the last visible cell, which loses
-    // the exclusive line-end position immediately after writing the last glyph.
-    // Using the current line's trimmed length preserves OSC 8 boundaries at the
-    // true end of the rendered link label.
-    final x = line
-        .getTrimmedLength(buffer.viewWidth)
-        .clamp(0, buffer.viewWidth);
-    return xterm.CellOffset(x, row);
-  }
+  return TerminalLinkRange(
+    uri: uri!,
+    start: start,
+    end: xterm.CellOffset(end.x + 1, end.y),
+  );
 }
 
 final class _LogicalTerminalLine {
@@ -303,6 +224,11 @@ final class _LogicalTerminalLine {
         if (codePoint > 0xffff) {
           spans.add(span);
         }
+        final combining = line.getCombiningCharacters(column);
+        if (combining != null) {
+          text.write(combining);
+          spans.addAll(List.filled(combining.length, span));
+        }
       }
     }
     return _LogicalTerminalLine(text: text.toString(), spans: spans);
@@ -331,58 +257,6 @@ final class _CharacterCellSpan {
 
   bool contains(xterm.CellOffset offset) {
     return offset.y == row && offset.x >= startX && offset.x < endXExclusive;
-  }
-}
-
-final class _PendingOsc8Link {
-  const _PendingOsc8Link({required this.uri, required this.start});
-
-  final Uri uri;
-  final xterm.CellAnchor start;
-
-  bool get attached => start.attached;
-
-  TerminalLinkRange? materialize(xterm.CellOffset end) {
-    if (!attached) {
-      return null;
-    }
-    final range = TerminalLinkRange(uri: uri, start: start.offset, end: end);
-    return range.isEmpty ? null : range;
-  }
-
-  void dispose() {
-    start.dispose();
-  }
-}
-
-final class _TrackedOsc8Link {
-  const _TrackedOsc8Link({
-    required this.uri,
-    required this.start,
-    required this.end,
-  });
-
-  final Uri uri;
-  final xterm.CellAnchor start;
-  final xterm.CellAnchor end;
-
-  bool get attached => start.attached && end.attached;
-
-  TerminalLinkRange? materialize() {
-    if (!attached) {
-      return null;
-    }
-    final range = TerminalLinkRange(
-      uri: uri,
-      start: start.offset,
-      end: end.offset,
-    );
-    return range.isEmpty ? null : range;
-  }
-
-  void dispose() {
-    start.dispose();
-    end.dispose();
   }
 }
 
@@ -450,7 +324,6 @@ final RegExp _visibleHttpUrlPattern = RegExp(
 
 /// Below this many tracked links the O(n) sweep is cheap enough to skip the
 /// growth heuristic entirely.
-const int _osc8LinkPruneFloor = 64;
 
 const Set<String> _alwaysTrimmedTrailingUrlCharacters = <String>{
   '.',

--- a/lib/src/features/workbench/presentation/terminal_runtime.dart
+++ b/lib/src/features/workbench/presentation/terminal_runtime.dart
@@ -29,7 +29,7 @@ import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
 import 'package:ghostty_vte_flutter/ghostty_vte_flutter.dart';
 import 'package:portable_pty/portable_pty.dart';
-import 'package:xterm/xterm.dart' as xterm;
+import 'package:xterm2/xterm.dart' as xterm;
 
 part 'terminal_runtime_posix_adapter.dart';
 part 'terminal_runtime_ghostty_adapter.dart';

--- a/lib/src/features/workbench/presentation/terminal_runtime_clipboard.dart
+++ b/lib/src/features/workbench/presentation/terminal_runtime_clipboard.dart
@@ -97,6 +97,9 @@ xterm.Terminal _createSessionTerminal(_XtermTerminalSessionHandle handle) {
     reflowWithHiddenCursor: false,
     preserveOrphanCombiningMarks: true,
     allowITerm2ClipboardCapture: false,
+    allowKittyClipboard: false,
+    // An unset callback lets TerminalView install its system clipboard reader.
+    onClipboardQuery: (_) => null,
     clipboardDecoder: decodeTerminalOsc52Payload,
     maxLines: handle._settings.scrollbackLines,
     platform: _xtermTargetPlatform,

--- a/lib/src/features/workbench/presentation/terminal_runtime_clipboard.dart
+++ b/lib/src/features/workbench/presentation/terminal_runtime_clipboard.dart
@@ -1,30 +1,19 @@
 part of 'terminal_runtime.dart';
 
-void _handleTerminalPrivateOsc(
-  _XtermTerminalSessionHandle handle,
-  String code,
-  List<String> args,
-) {
-  if (code == '52') {
-    final request = parseTerminalOsc52Request(args);
-    if (request is! TerminalOsc52Write) {
-      return;
-    }
-    if (!handle._settings.allowOsc52Clipboard) {
-      handle._osc52Blocked();
-      return;
-    }
-    unawaited(
-      handle._clipboard.writeText(request.text).catchError((Object error) {
-        handle._notifyInteraction(
-          'Could not copy terminal selection.',
-          error: true,
-        );
-      }),
-    );
+void _storeTerminalClipboard(_XtermTerminalSessionHandle handle, String text) {
+  if (handle._disposed) return;
+  if (!handle._settings.allowOsc52Clipboard) {
+    handle._osc52Blocked();
     return;
   }
-  handle._osc8LinkTracker.handlePrivateOsc(code, args);
+  unawaited(
+    handle._clipboard.writeText(text).catchError((Object error) {
+      handle._notifyInteraction(
+        'Could not copy terminal selection.',
+        error: true,
+      );
+    }),
+  );
 }
 
 void _pasteTerminalText(_XtermTerminalSessionHandle handle, String text) {
@@ -105,6 +94,10 @@ void _publishTerminalInteraction(
 
 xterm.Terminal _createSessionTerminal(_XtermTerminalSessionHandle handle) {
   return xterm.Terminal(
+    reflowWithHiddenCursor: false,
+    preserveOrphanCombiningMarks: true,
+    allowITerm2ClipboardCapture: false,
+    clipboardDecoder: decodeTerminalOsc52Payload,
     maxLines: handle._settings.scrollbackLines,
     platform: _xtermTargetPlatform,
     wordSeparators: _wordSeparatorsFromSettings(
@@ -120,12 +113,13 @@ void _attachSessionTerminal(
   terminal.onTitleChange = handle._handleTitleChanged;
   terminal.onOutput = handle._handleTerminalInput;
   terminal.onResize = handle._handleTerminalResize;
-  terminal.onPrivateOSC = handle._handlePrivateOsc;
+  terminal.onClipboardStore = (_, text) =>
+      _storeTerminalClipboard(handle, text);
 }
 
 void _detachSessionTerminal(xterm.Terminal terminal) {
   terminal.onTitleChange = null;
   terminal.onOutput = null;
   terminal.onResize = null;
-  terminal.onPrivateOSC = null;
+  terminal.onClipboardStore = null;
 }

--- a/lib/src/features/workbench/presentation/terminal_runtime_restore_progress.dart
+++ b/lib/src/features/workbench/presentation/terminal_runtime_restore_progress.dart
@@ -73,13 +73,12 @@ extension _TerminalRestoreProgressTracking on _XtermTerminalSessionHandle {
     final viewWidth = previousTerminal.viewWidth;
     final viewHeight = previousTerminal.viewHeight;
     _detachTerminal(previousTerminal);
-    _osc8LinkTracker.dispose();
 
     final nextTerminal = _createTerminal()..resize(viewWidth, viewHeight);
     _terminal = nextTerminal;
-    _osc8LinkTracker = Osc8TerminalLinkTracker(terminal: nextTerminal);
     _attachTerminal(nextTerminal);
     searchController.attachTerminal(nextTerminal);
+    previousTerminal.dispose();
     // Scrollback can reach the host's 10 MB cap, and parsing all of it in one
     // synchronous write blocked the frame that showed the terminal. Go through
     // the same per-frame batcher as live output instead.

--- a/lib/src/features/workbench/presentation/terminal_runtime_search.dart
+++ b/lib/src/features/workbench/presentation/terminal_runtime_search.dart
@@ -32,8 +32,6 @@ mixin _TerminalSearchSessionSupport on TerminalSessionHandle {
 
   ValueNotifier<TerminalRestoreProgress?> get _restoreProgress;
 
-  Osc8TerminalLinkTracker get _osc8LinkTracker;
-
   Set<Object> get _visibilityLeases;
 
   set _visible(bool value);
@@ -90,11 +88,11 @@ mixin _TerminalSearchSessionSupport on TerminalSessionHandle {
     _appForeground = false;
     _pointerInputResumePending = false;
     _pointerInputCatchUpChars = 0;
-    _osc8LinkTracker.dispose();
     _searchController.dispose();
     _terminalController.removeListener(_handleSelectionChanged);
     _terminalController.dispose();
     _detachTerminal(_terminal);
+    _terminal.dispose();
     _clearPendingTerminalOutput();
     unawaited(
       _stopPtySessionWithMode(suppressExit: true, terminate: terminatePty),

--- a/lib/src/features/workbench/presentation/terminal_runtime_session_handle.dart
+++ b/lib/src/features/workbench/presentation/terminal_runtime_session_handle.dart
@@ -19,7 +19,6 @@ class _XtermTerminalSessionHandle extends TerminalSessionHandle
     this._onVisibilityChanged,
   ) {
     _terminal = _createTerminal();
-    _osc8LinkTracker = Osc8TerminalLinkTracker(terminal: _terminal);
     _attachTerminal(_terminal);
     _terminalController.addListener(_handleSelectionChanged);
     _decodedOutputSub = _ptyOutputController.stream
@@ -47,8 +46,6 @@ class _XtermTerminalSessionHandle extends TerminalSessionHandle
   TerminalSettings _settings;
   @override
   late xterm.Terminal _terminal;
-  @override
-  late Osc8TerminalLinkTracker _osc8LinkTracker;
   @override
   final GlobalKey<xterm.TerminalViewState> _terminalViewKey =
       GlobalKey<xterm.TerminalViewState>();
@@ -237,6 +234,8 @@ class _XtermTerminalSessionHandle extends TerminalSessionHandle
     return xterm.TerminalView(
       _terminal,
       key: _terminalViewKey,
+      shortcuts: xterm.clipboardTerminalShortcuts,
+      shiftOverridesMouseReporting: true,
       controller: _terminalController,
       scrollController: _scrollController,
       focusNode: _focusNode,
@@ -269,11 +268,7 @@ class _XtermTerminalSessionHandle extends TerminalSessionHandle
   }
 
   TerminalLinkRange? _linkAt(xterm.CellOffset offset) {
-    return resolveTerminalLinkAt(
-      terminal: _terminal,
-      offset: offset,
-      osc8Tracker: _osc8LinkTracker,
-    );
+    return resolveTerminalLinkAt(terminal: _terminal, offset: offset);
   }
 
   Future<void> _openLink(Uri uri) {
@@ -541,10 +536,6 @@ class _XtermTerminalSessionHandle extends TerminalSessionHandle
       );
     }
     unawaited(_stopPtySessionWithMode(suppressExit: true, terminate: false));
-  }
-
-  void _handlePrivateOsc(String code, List<String> args) {
-    _handleTerminalPrivateOsc(this, code, args);
   }
 
   Future<void> _pasteFromClipboard() => _pasteTerminalClipboard(this);

--- a/lib/src/features/workbench/presentation/terminal_runtime_testing.dart
+++ b/lib/src/features/workbench/presentation/terminal_runtime_testing.dart
@@ -240,7 +240,9 @@ void handlePrivateOscForTesting(
   String code,
   List<String> args,
 ) {
-  (session as _XtermTerminalSessionHandle)._handlePrivateOsc(code, args);
+  (session as _XtermTerminalSessionHandle)._terminal.write(
+    '\x1b]$code;${args.join(';')}\x07',
+  );
 }
 
 @visibleForTesting

--- a/lib/src/features/workbench/presentation/terminal_search_controller.dart
+++ b/lib/src/features/workbench/presentation/terminal_search_controller.dart
@@ -2,7 +2,7 @@ import 'dart:math' show max;
 
 import 'package:alera/src/features/workbench/domain/terminal_search.dart';
 import 'package:flutter/foundation.dart';
-import 'package:xterm/xterm.dart' as xterm;
+import 'package:xterm2/xterm.dart' as xterm;
 
 typedef TerminalSearchLineScroller = void Function(int lineIndex);
 

--- a/mobile/lib/src/features/terminal/presentation/terminal_tab_view.dart
+++ b/mobile/lib/src/features/terminal/presentation/terminal_tab_view.dart
@@ -25,7 +25,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:alera_mobile/src/features/terminal/domain/terminal_output_batcher.dart';
 import 'package:logging/logging.dart';
-import 'package:xterm/xterm.dart';
+import 'package:xterm2/xterm.dart';
 
 part 'terminal_attachment_actions.dart';
 part 'terminal_tab_state_widgets.dart';
@@ -300,6 +300,7 @@ class _TerminalSurfaceState extends State<_TerminalSurface> {
   void dispose() {
     unawaited(_outputSub?.cancel());
     _batcher?.dispose();
+    _terminal.dispose();
     _restoreProgress.dispose();
     _controller.dispose();
     _scrollController.dispose();
@@ -332,9 +333,13 @@ class _TerminalSurfaceState extends State<_TerminalSurface> {
   /// Builds a fresh emulator rather than writing clear sequences into the old
   /// one, so alt-buffer, mouse reporting, and cursor modes reset too.
   void _replaceEmulator({required bool notify}) {
+    final previous = _batcher == null ? null : _terminal;
     _batcher?.dispose();
+    _controller.clearSelection();
     final next = Terminal(
       maxLines: mobileTerminalScrollbackLines,
+      preserveOrphanCombiningMarks: true,
+      allowITerm2ClipboardCapture: false,
       onOutput: (data) => widget.onInput(data),
       onResize: (width, height, _, _) => _handleViewportResize(width, height),
       // This emulator is filled from restored history, and the program that
@@ -351,6 +356,7 @@ class _TerminalSurfaceState extends State<_TerminalSurface> {
       write: next.write,
       onRestoreProgress: _handleRestoreProgress,
     );
+    previous?.dispose();
     if (notify) {
       setState(() => _terminal = next);
     } else {
@@ -453,6 +459,8 @@ class _TerminalSurfaceState extends State<_TerminalSurface> {
                   : TerminalView(
                       _terminal,
                       key: ValueKey<int>(_viewGeneration),
+                      shortcuts: clipboardTerminalShortcuts,
+                      shiftOverridesMouseReporting: true,
                       controller: _controller,
                       scrollController: _scrollController,
                       focusNode: _focusNode,

--- a/mobile/lib/src/features/terminal/presentation/terminal_tab_view.dart
+++ b/mobile/lib/src/features/terminal/presentation/terminal_tab_view.dart
@@ -340,6 +340,10 @@ class _TerminalSurfaceState extends State<_TerminalSurface> {
       maxLines: mobileTerminalScrollbackLines,
       preserveOrphanCombiningMarks: true,
       allowITerm2ClipboardCapture: false,
+      allowKittyClipboard: false,
+      // Unset callbacks let TerminalView grant remote system clipboard access.
+      onClipboardStore: (_, _) {},
+      onClipboardQuery: (_) => null,
       onOutput: (data) => widget.onInput(data),
       onResize: (width, height, _, _) => _handleViewportResize(width, height),
       // This emulator is filled from restored history, and the program that

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -1668,13 +1668,13 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.6.1"
-  xterm:
+  xterm2:
     dependency: "direct main"
     description:
       path: "../third_party/xterm"
       relative: true
     source: path
-    version: "4.0.0"
+    version: "5.3.0"
   yaml:
     dependency: transitive
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -50,7 +50,7 @@ dependencies:
   package_info_plus: ^10.2.1
   url_launcher: ^6.3.2
   web_socket_channel: ^3.0.3
-  xterm:
+  xterm2:
     path: ../third_party/xterm
   logging: ^1.3.0
   path_provider: ^2.1.6

--- a/mobile/test/terminal_tab_view_clipboard_cases.dart
+++ b/mobile/test/terminal_tab_view_clipboard_cases.dart
@@ -1,0 +1,58 @@
+part of 'terminal_tab_view_test.dart';
+
+void _registerTerminalClipboardSecurityTests() {
+  testWidgets('focused mobile emulators deny remote clipboard access', (
+    tester,
+  ) async {
+    final clipboardCalls = <String>[];
+    tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+      SystemChannels.platform,
+      (call) async {
+        if (call.method == 'Clipboard.getData' ||
+            call.method == 'Clipboard.setData') {
+          clipboardCalls.add(call.method);
+        }
+        if (call.method == 'Clipboard.getData') return {'text': 'private'};
+        return null;
+      },
+    );
+    addTearDown(
+      () => tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        SystemChannels.platform,
+        null,
+      ),
+    );
+    final client = FakeTerminalClient()
+      ..tabs = [fakeTab(id: 'tab-1', title: 'Terminal 1')];
+    await _pumpTab(tester, client);
+    final payload = base64.encode(utf8.encode('unsolicited'));
+
+    for (var generation = 0; generation < 2; generation++) {
+      final view = tester.widget<TerminalView>(find.byType(TerminalView));
+      view.focusNode!.requestFocus();
+      await tester.pump();
+      expect(view.focusNode!.hasFocus, isTrue);
+      client.writes.clear();
+      client.emitOutput(
+        'session-tab-1',
+        Uint8List.fromList(
+          utf8.encode('\x1b]52;c;?\x07\x1b]52;c;$payload\x07'),
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(clipboardCalls, isEmpty);
+      expect(client.writes, isEmpty);
+
+      if (generation == 0) {
+        client.emitOutput(
+          'session-tab-1',
+          Uint8List.fromList(utf8.encode('restored')),
+          replacesScrollback: true,
+        );
+        await tester.pumpAndSettle();
+        expect(_terminalOf(tester), isNot(same(view.terminal)));
+      }
+    }
+    await tester.pumpWidget(const SizedBox());
+  });
+}

--- a/mobile/test/terminal_tab_view_composer_test.dart
+++ b/mobile/test/terminal_tab_view_composer_test.dart
@@ -10,7 +10,7 @@ import 'package:alera_mobile/src/features/workbench/application/workbench_provid
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:xterm/xterm.dart';
+import 'package:xterm2/xterm.dart';
 
 import 'support/fake_terminal_client.dart';
 import 'support/memory_accessory_layout_repository.dart';

--- a/mobile/test/terminal_tab_view_test.dart
+++ b/mobile/test/terminal_tab_view_test.dart
@@ -16,7 +16,10 @@ import 'package:xterm2/xterm.dart';
 import 'support/fake_terminal_client.dart';
 import 'support/memory_accessory_layout_repository.dart';
 
+part 'terminal_tab_view_clipboard_cases.dart';
+
 void main() {
+  _registerTerminalClipboardSecurityTests();
   testWidgets(
     'Refresh control remounts the view and preserves terminal state',
     (tester) async {

--- a/mobile/test/terminal_tab_view_test.dart
+++ b/mobile/test/terminal_tab_view_test.dart
@@ -11,7 +11,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:alera_mobile/src/features/terminal/application/terminal_accessory_layout_controller.dart';
-import 'package:xterm/xterm.dart';
+import 'package:xterm2/xterm.dart';
 
 import 'support/fake_terminal_client.dart';
 import 'support/memory_accessory_layout_repository.dart';
@@ -336,6 +336,14 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(_terminalOf(tester), isNot(same(before)));
+    final retiredText = before.buffer.getText();
+    before.write('must not reach a retired emulator');
+    expect(before.buffer.getText(), retiredText);
+    final current = _terminalOf(tester);
+    await tester.pumpWidget(const SizedBox());
+    final closedText = current.buffer.getText();
+    current.write('must not reach a closed emulator');
+    expect(current.buffer.getText(), closedText);
   });
 
   testWidgets('A dead connection offers explicit recovery', (tester) async {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1888,13 +1888,13 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.1"
-  xterm:
+  xterm2:
     dependency: "direct main"
     description:
       path: "third_party/xterm"
       relative: true
     source: path
-    version: "4.0.0"
+    version: "5.3.0"
   yaml:
     dependency: "direct dev"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
   ghostty_vte_flutter: ^0.1.5
   ffi: ^2.2.0
   portable_pty: ^0.0.5
-  xterm: ^4.0.0
+  xterm2: ^5.3.0
   desktop_updater: ^2.7.0
   http: ^1.6.0
   record: ^7.1.1
@@ -91,7 +91,7 @@ dependency_overrides:
   ghostty_vte_flutter:
     path: third_party/dart_terminal/pkgs/vte/ghostty_vte_flutter
   # Keeps local terminal fixes pinned while upstream PRs are reviewed.
-  xterm:
+  xterm2:
     path: third_party/xterm
 
 flutter_launcher_icons:

--- a/test/unit/terminal_buffer_budget_test.dart
+++ b/test/unit/terminal_buffer_budget_test.dart
@@ -1,6 +1,6 @@
 import 'package:alera/src/features/workbench/presentation/terminal_buffer_budget.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:xterm/xterm.dart' as xterm;
+import 'package:xterm2/xterm.dart' as xterm;
 
 const int _mb = 1024 * 1024;
 

--- a/test/unit/terminal_link_resolver_test.dart
+++ b/test/unit/terminal_link_resolver_test.dart
@@ -1,8 +1,45 @@
 import 'package:alera/src/features/workbench/presentation/terminal_link_resolver.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:xterm/xterm.dart' as xterm;
+import 'package:xterm2/xterm.dart' as xterm;
 
 void main() {
+  test('native links follow reflow and disappear when overwritten', () {
+    final terminal = xterm.Terminal()..resize(10, 4);
+    addTearDown(terminal.dispose);
+    terminal.write(
+      '\x1b]8;;https://example.com\x1b\\abcdef'
+      '\x1b]8;;\x1b\\',
+    );
+    terminal.resize(4, 4);
+    final link = resolveTerminalLinkAt(
+      terminal: terminal,
+      offset: const xterm.CellOffset(1, 1),
+    );
+    expect(link?.start, const xterm.CellOffset(0, 0));
+    expect(link?.end, const xterm.CellOffset(2, 1));
+    terminal.setCursor(0, 1 - terminal.buffer.scrollBack);
+    terminal.write('XX');
+    expect(
+      resolveTerminalLinkAt(
+        terminal: terminal,
+        offset: const xterm.CellOffset(1, 1),
+      ),
+      isNull,
+    );
+  });
+
+  test('visible URL spans include combining characters in their label', () {
+    final terminal = xterm.Terminal()..resize(80, 4);
+    addTearDown(terminal.dispose);
+    terminal.write('https://example.com/e\u0301');
+    final link = resolveVisibleHttpLinkAt(
+      terminal: terminal,
+      offset: const xterm.CellOffset(20, 0),
+    );
+    expect(link?.uri, Uri.parse('https://example.com/e\u0301'));
+    expect(link?.end.x, 21);
+  });
+
   test('terminal link ranges handle multiline containment and equality', () {
     final range = TerminalLinkRange(
       uri: Uri.parse('https://example.com'),
@@ -123,19 +160,16 @@ void main() {
     expect(link!.uri.toString(), 'https://example.com/path');
   });
 
-  test('tracks osc8 hyperlinks from private OSC sequences', () {
+  test('resolves native OSC 8 hyperlinks', () {
     final terminal = xterm.Terminal();
     terminal.resize(80, 24);
-    final tracker = Osc8TerminalLinkTracker(terminal: terminal);
-    addTearDown(tracker.dispose);
-    terminal.onPrivateOSC = tracker.handlePrivateOsc;
+    addTearDown(terminal.dispose);
 
     terminal.write('\x1b]8;;https://example.com\x1b\\click here\x1b]8;;\x1b\\');
 
     final link = resolveTerminalLinkAt(
       terminal: terminal,
       offset: const xterm.CellOffset(2, 0),
-      osc8Tracker: tracker,
     );
 
     expect(link, isNotNull);
@@ -145,13 +179,15 @@ void main() {
   test('tracks active osc8 links before they are explicitly closed', () {
     final terminal = xterm.Terminal();
     terminal.resize(80, 24);
-    final tracker = Osc8TerminalLinkTracker(terminal: terminal);
-    addTearDown(tracker.dispose);
+    addTearDown(terminal.dispose);
 
-    tracker.handlePrivateOsc('8', <String>['', 'https://example.com']);
+    terminal.write('\x1b]8;;https://example.com\x1b\\');
     terminal.write('hover me');
 
-    final link = tracker.linkAt(const xterm.CellOffset(2, 0));
+    final link = resolveTerminalLinkAt(
+      terminal: terminal,
+      offset: const xterm.CellOffset(2, 0),
+    );
 
     expect(link, isNotNull);
     expect(link!.uri, Uri.parse('https://example.com'));
@@ -160,16 +196,27 @@ void main() {
   test('ignores invalid osc8 targets and discards empty links on close', () {
     final terminal = xterm.Terminal();
     terminal.resize(80, 24);
-    final tracker = Osc8TerminalLinkTracker(terminal: terminal);
-    addTearDown(tracker.dispose);
+    addTearDown(terminal.dispose);
 
-    tracker.handlePrivateOsc('8', <String>['', 'mailto:test@example.com']);
-    expect(tracker.linkAt(const xterm.CellOffset(0, 0)), isNull);
+    terminal.write('\x1b]8;;mailto:test@example.com\x1b\\');
+    expect(
+      resolveTerminalLinkAt(
+        terminal: terminal,
+        offset: const xterm.CellOffset(0, 0),
+      ),
+      isNull,
+    );
 
-    tracker.handlePrivateOsc('8', <String>['', 'https://example.com']);
-    tracker.handlePrivateOsc('8', const <String>['', '']);
+    terminal.write('\x1b]8;;https://example.com\x1b\\');
+    terminal.write('\x1b]8;;\x1b\\');
 
-    expect(tracker.linkAt(const xterm.CellOffset(0, 0)), isNull);
+    expect(
+      resolveTerminalLinkAt(
+        terminal: terminal,
+        offset: const xterm.CellOffset(0, 0),
+      ),
+      isNull,
+    );
   });
 
   test('keeps visible url spans aligned after wide characters', () {
@@ -201,19 +248,24 @@ void main() {
     expect(link.uri, Uri.parse('https://example.com'));
   });
 
-  test('prunes detached osc8 anchors after scrolling them away', () {
+  test('discards native OSC 8 links after scrolling them away', () {
     final terminal = xterm.Terminal(maxLines: 64);
     terminal.resize(8, 4);
-    final tracker = Osc8TerminalLinkTracker(terminal: terminal);
-    addTearDown(tracker.dispose);
+    addTearDown(terminal.dispose);
 
-    tracker.handlePrivateOsc('8', <String>['', 'https://example.com']);
+    terminal.write('\x1b]8;;https://example.com\x1b\\');
     terminal.write('link');
-    tracker.handlePrivateOsc('8', const <String>['', '']);
+    terminal.write('\x1b]8;;\x1b\\');
     for (var index = 0; index < 100; index += 1) {
       terminal.write('\r\nline $index');
     }
 
-    expect(tracker.linkAt(const xterm.CellOffset(0, 0)), isNull);
+    expect(
+      resolveTerminalLinkAt(
+        terminal: terminal,
+        offset: const xterm.CellOffset(0, 0),
+      ),
+      isNull,
+    );
   });
 }

--- a/test/unit/terminal_runtime_clipboard_cases.dart
+++ b/test/unit/terminal_runtime_clipboard_cases.dart
@@ -30,6 +30,16 @@ void _registerXtermRuntimeClipboardTests() {
     await Future<void>.delayed(Duration.zero);
 
     expect(clipboard.writes, <String>['from tui']);
+    handlePrivateOscForTesting(session, '52', ['', payload]);
+    handlePrivateOscForTesting(session, '52', ['c', '?']);
+    handlePrivateOscForTesting(session, '52', ['c', '====']);
+    handlePrivateOscForTesting(session, '52', ['c', 'A' * (128 * 1024 + 4)]);
+    writeTerminalOutputForTesting(
+      session,
+      '\x1b]1337;CopyToClipboard=c\x07secret\x1b]1337;EndCopy\x07',
+    );
+    await Future<void>.delayed(Duration.zero);
+    expect(clipboard.writes, <String>['from tui']);
   });
 
   test('pastes clipboard text before probing for an image', () async {

--- a/test/unit/terminal_runtime_clipboard_cases.dart
+++ b/test/unit/terminal_runtime_clipboard_cases.dart
@@ -1,6 +1,29 @@
 part of 'terminal_runtime_native_test.dart';
 
 void _registerXtermRuntimeClipboardTests() {
+  for (final size in [7000, 98304]) {
+    test('gated OSC 52 copies $size bytes through the escape parser', () async {
+      final clipboard = _FakeTerminalClipboard();
+      final runtime = XtermTerminalRuntime(
+        terminalClipboard: clipboard,
+        ptySessionFactory: _FakeTerminalPtySessionFactory(),
+        shellLaunchesBuilder: () => <GhosttyTerminalShellLaunch>[
+          _launch('shell', shell: '/bin/sh'),
+        ],
+      );
+      addTearDown(runtime.dispose);
+      runtime.updateSettings(
+        TerminalSettings.defaults.copyWith(allowOsc52Clipboard: true),
+      );
+      final session = runtime.sessionFor(workspace: _workspace(), tab: _tab());
+      final text = 'a' * size;
+      final payload = base64.encode(utf8.encode(text));
+      handlePrivateOscForTesting(session, '52', ['c', payload]);
+      await Future<void>.delayed(Duration.zero);
+      expect(clipboard.writes, [text]);
+    });
+  }
+
   test('handles gated OSC 52 clipboard writes once per runtime', () async {
     final clipboard = _FakeTerminalClipboard();
     final notices = <String>[];
@@ -32,6 +55,8 @@ void _registerXtermRuntimeClipboardTests() {
     expect(clipboard.writes, <String>['from tui']);
     handlePrivateOscForTesting(session, '52', ['', payload]);
     handlePrivateOscForTesting(session, '52', ['c', '?']);
+    handlePrivateOscForTesting(session, '52', ['c', payload, 'trailing']);
+    handlePrivateOscForTesting(session, '5522', ['type=write', payload]);
     handlePrivateOscForTesting(session, '52', ['c', '====']);
     handlePrivateOscForTesting(session, '52', ['c', 'A' * (128 * 1024 + 4)]);
     writeTerminalOutputForTesting(

--- a/test/unit/terminal_runtime_native_test.dart
+++ b/test/unit/terminal_runtime_native_test.dart
@@ -20,7 +20,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:ghostty_vte_flutter/ghostty_vte_flutter.dart';
-import 'package:xterm/xterm.dart' as xterm;
+import 'package:xterm2/xterm.dart' as xterm;
 
 part 'terminal_runtime_helper_group.dart';
 part 'terminal_login_shell_group.dart';

--- a/test/unit/terminal_search_controller_test.dart
+++ b/test/unit/terminal_search_controller_test.dart
@@ -1,7 +1,7 @@
 import 'package:alera/src/features/workbench/domain/terminal_search.dart';
 import 'package:alera/src/features/workbench/presentation/terminal_search_controller.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:xterm/xterm.dart' as xterm;
+import 'package:xterm2/xterm.dart' as xterm;
 
 void main() {
   test('finds literal matches case-insensitively by default', () {

--- a/test/unit/xterm_regression_test.dart
+++ b/test/unit/xterm_regression_test.dart
@@ -1,10 +1,13 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:xterm/xterm.dart';
+import 'package:xterm2/xterm.dart';
 
 void main() {
   test('xterm preserves Shift+Enter as CSI-u input', () {
     final output = <String>[];
-    final terminal = Terminal(onOutput: output.add);
+    final terminal = Terminal(
+      reflowWithHiddenCursor: false,
+      onOutput: output.add,
+    );
 
     terminal.keyInput(TerminalKey.enter, shift: true);
 
@@ -12,7 +15,11 @@ void main() {
   });
 
   test('xterm handles resize while scrollback and margins are active', () {
-    final terminal = Terminal(maxLines: 120, reflowEnabled: false);
+    final terminal = Terminal(
+      reflowWithHiddenCursor: false,
+      maxLines: 120,
+      reflowEnabled: false,
+    );
 
     terminal.resize(10, 5);
     for (var i = 0; i < 100; i++) {
@@ -30,7 +37,7 @@ void main() {
   });
 
   test('xterm reflows narrow wide-character prompts without RangeError', () {
-    final terminal = Terminal();
+    final terminal = Terminal(reflowWithHiddenCursor: false);
 
     terminal
       ..resize(1, 4)
@@ -40,7 +47,7 @@ void main() {
   });
 
   test('xterm keeps reflowed scrollback aligned after a circular trim', () {
-    final terminal = Terminal(maxLines: 100);
+    final terminal = Terminal(reflowWithHiddenCursor: false, maxLines: 100);
 
     terminal.resize(10, 3);
     for (var i = 0; i < 20; i++) {
@@ -69,7 +76,7 @@ void main() {
   test(
     'xterm handles line feeds at the bottom of a scroll region after resize',
     () {
-      final terminal = Terminal(maxLines: 10000);
+      final terminal = Terminal(reflowWithHiddenCursor: false, maxLines: 10000);
 
       terminal
         ..resize(56, 27)
@@ -85,7 +92,10 @@ void main() {
   );
 
   test('xterm does not restore stale alt-buffer cells after resize', () {
-    final terminal = Terminal(reflowEnabled: false);
+    final terminal = Terminal(
+      reflowWithHiddenCursor: false,
+      reflowEnabled: false,
+    );
 
     terminal
       ..resize(12, 4)
@@ -101,7 +111,7 @@ void main() {
   test(
     'xterm does not reveal stale main-buffer rows after Claude-like resize',
     () {
-      final terminal = Terminal();
+      final terminal = Terminal(reflowWithHiddenCursor: false);
 
       terminal
         ..resize(20, 6)
@@ -131,7 +141,7 @@ void main() {
   test(
     'xterm clears hidden main-buffer cells with reflow enabled after resize',
     () {
-      final terminal = Terminal();
+      final terminal = Terminal(reflowWithHiddenCursor: false);
 
       terminal
         ..resize(18, 4)
@@ -151,7 +161,7 @@ void main() {
   test(
     'xterm discards incremental resize scrollback for cursor-hidden apps',
     () {
-      final terminal = Terminal();
+      final terminal = Terminal(reflowWithHiddenCursor: false);
 
       terminal
         ..resize(24, 8)
@@ -185,7 +195,7 @@ void main() {
   );
 
   test('xterm repairs a stale row before writing past its capacity', () {
-    final terminal = Terminal()..resize(680, 24);
+    final terminal = Terminal(reflowWithHiddenCursor: false)..resize(680, 24);
     terminal.mainBuffer.lines[0] = BufferLine(80);
 
     terminal.write('\x1b[1;171Hx');

--- a/test/widget/terminal_surface_clipboard_test_cases.dart
+++ b/test/widget/terminal_surface_clipboard_test_cases.dart
@@ -1,0 +1,63 @@
+part of 'terminal_surface_test.dart';
+
+void _registerTerminalSurfaceClipboardTests() {
+  testWidgets('focused terminal denies clipboard reads and gates writes', (
+    tester,
+  ) async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.linux;
+    try {
+      final clipboardCalls = <MethodCall>[];
+      tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        SystemChannels.platform,
+        (call) async {
+          if (call.method == 'Clipboard.getData' ||
+              call.method == 'Clipboard.setData') {
+            clipboardCalls.add(call);
+          }
+          if (call.method == 'Clipboard.getData') return {'text': 'private'};
+          return null;
+        },
+      );
+      addTearDown(
+        () => tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+          SystemChannels.platform,
+          null,
+        ),
+      );
+      final factory = _FakeTerminalPtySessionFactory();
+      final runtime = XtermTerminalRuntime(
+        ptySessionFactory: factory,
+        shellLaunchesBuilder: _testShellLaunches,
+      );
+      addTearDown(runtime.dispose);
+      final session = runtime.sessionFor(workspace: _workspace(), tab: _tab());
+      await _pumpTerminalSurface(tester, session);
+      final view = tester.widget<xterm.TerminalView>(
+        find.byType(xterm.TerminalView),
+      );
+      view.focusNode!.requestFocus();
+      await tester.pump();
+      expect(view.focusNode!.hasFocus, isTrue);
+      final pty = factory.sessions.single;
+      pty.writes.clear();
+      final payload = base64.encode(utf8.encode('allowed write'));
+
+      pty.emitOutput(utf8.encode('\x1b]52;c;?\x07\x1b]52;c;$payload\x07'));
+      await _pumpTerminalOutput(tester);
+      expect(clipboardCalls, isEmpty);
+      expect(pty.writes, isEmpty);
+
+      runtime.updateSettings(
+        TerminalSettings.defaults.copyWith(allowOsc52Clipboard: true),
+      );
+      pty.emitOutput(utf8.encode('\x1b]52;c;?\x07\x1b]52;c;$payload\x07'));
+      await _pumpTerminalOutput(tester);
+      expect(clipboardCalls.map((call) => call.method), ['Clipboard.setData']);
+      expect(clipboardCalls.single.arguments, {'text': 'allowed write'});
+      expect(pty.writes, isEmpty);
+      await tester.pumpWidget(const SizedBox());
+    } finally {
+      debugDefaultTargetPlatformOverride = null;
+    }
+  });
+}

--- a/test/widget/terminal_surface_test.dart
+++ b/test/widget/terminal_surface_test.dart
@@ -27,6 +27,7 @@ import 'package:ghostty_vte_flutter/ghostty_vte_flutter.dart';
 import 'package:xterm2/xterm.dart' as xterm;
 
 part 'terminal_surface_core_test_cases.dart';
+part 'terminal_surface_clipboard_test_cases.dart';
 part 'terminal_surface_composer_test_cases.dart';
 part 'terminal_surface_composer_submit_test_cases.dart';
 part 'terminal_surface_interaction_test_cases.dart';
@@ -36,6 +37,7 @@ part 'terminal_surface_test_harness.dart';
 
 void main() {
   _registerTerminalSurfaceRuntimeTests();
+  _registerTerminalSurfaceClipboardTests();
   _registerTerminalSurfaceComposerTests();
   _registerTerminalSurfaceComposerSubmitTests();
   _registerTerminalSurfaceInteractionTests();

--- a/test/widget/terminal_surface_test.dart
+++ b/test/widget/terminal_surface_test.dart
@@ -24,7 +24,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:ghostty_vte_flutter/ghostty_vte_flutter.dart';
-import 'package:xterm/xterm.dart' as xterm;
+import 'package:xterm2/xterm.dart' as xterm;
 
 part 'terminal_surface_core_test_cases.dart';
 part 'terminal_surface_composer_test_cases.dart';


### PR DESCRIPTION
## Summary

- Migrate desktop and mobile terminal integrations to maintained xterm2 dependency forks.
- Update terminal runtime, clipboard, search, link handling, restore progress, themes, and buffer budgeting.
- Add fork provenance and migration validation documentation.
- Extend terminal regression coverage and rendering/restore benchmarks.

## Testing

- Added and updated unit, widget, mobile, regression, and benchmark coverage.
- Not run (not requested).