### PR TITLE
fix: restore macos tray and dock badge startup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,6 +146,7 @@ When planning is needed, use a spec-driven development flow. Do not jump straigh
 
 - Alera targets macOS, Windows, and Linux.
 - macOS `AppDelegate.applicationDidFinishLaunching` MUST NOT call `super`: `FlutterAppDelegate` does not implement that optional Objective-C callback. AppKit catches the resulting exception and leaves the app running without its native speech and desktop-presence channels. Validate startup, tray installation, Dock badge updates, and hide-on-close with `flutter test integration_test/desktop_presence_macos_test.dart -d macos`.
+- macOS `applicationShouldTerminateAfterLastWindowClosed` MUST return false: AppKit can request termination when the last window is hidden, even when `windowShouldClose` prevented its closure. The Dart lifecycle decides whether to hide or exit; an explicit close without a tray or Quit still reaches `NSApp.terminate` through `window_manager.destroy`.
 - Use `Platform` checks or framework abstractions for platform-specific behavior; do not assume POSIX paths or commands.
 - Use `path` package utilities for filesystem paths.
 - Keep terminal, process, workspace, updater, and release code explicit about platform support.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,6 +145,7 @@ When planning is needed, use a spec-driven development flow. Do not jump straigh
 ## Cross-Platform Desktop Rules
 
 - Alera targets macOS, Windows, and Linux.
+- macOS `AppDelegate.applicationDidFinishLaunching` MUST NOT call `super`: `FlutterAppDelegate` does not implement that optional Objective-C callback. AppKit catches the resulting exception and leaves the app running without its native speech and desktop-presence channels. Validate startup, tray installation, Dock badge updates, and hide-on-close with `flutter test integration_test/desktop_presence_macos_test.dart -d macos`.
 - Use `Platform` checks or framework abstractions for platform-specific behavior; do not assume POSIX paths or commands.
 - Use `path` package utilities for filesystem paths.
 - Keep terminal, process, workspace, updater, and release code explicit about platform support.

--- a/integration_test/desktop_presence_macos_test.dart
+++ b/integration_test/desktop_presence_macos_test.dart
@@ -6,6 +6,7 @@ import 'package:alera/src/features/app_window/domain/app_window_state.dart';
 import 'package:alera/src/features/app_window/infra/window_manager_app_window_controller.dart';
 import 'package:alera/src/features/desktop_presence/application/desktop_presence_coordinator.dart';
 import 'package:alera/src/features/desktop_presence/infra/desktop_presence_channel.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:window_manager/window_manager.dart';
@@ -13,9 +14,10 @@ import 'package:window_manager/window_manager.dart';
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  test(
+  testWidgets(
     'macOS startup registers tray and badge and closing hides the window',
-    () async {
+    (tester) async {
+      await tester.pumpWidget(const SizedBox());
       await windowManager.ensureInitialized();
       final window = WindowManagerAppWindowController();
       final repository = _MemoryWindowStateRepository();

--- a/integration_test/desktop_presence_macos_test.dart
+++ b/integration_test/desktop_presence_macos_test.dart
@@ -1,0 +1,91 @@
+import 'dart:io';
+
+import 'package:alera/src/features/app_window/application/app_window_controller.dart';
+import 'package:alera/src/features/app_window/application/app_window_state_repository.dart';
+import 'package:alera/src/features/app_window/domain/app_window_state.dart';
+import 'package:alera/src/features/app_window/infra/window_manager_app_window_controller.dart';
+import 'package:alera/src/features/desktop_presence/application/desktop_presence_coordinator.dart';
+import 'package:alera/src/features/desktop_presence/infra/desktop_presence_channel.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:window_manager/window_manager.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  test(
+    'macOS startup registers tray and badge and closing hides the window',
+    () async {
+      await windowManager.ensureInitialized();
+      final window = WindowManagerAppWindowController();
+      final repository = _MemoryWindowStateRepository();
+      final lifecycle = AppWindowLifecycleCoordinator(
+        repository: repository,
+        window: window,
+        // A regression must fail the test instead of terminating its runner.
+        closeGate: () async => false,
+      );
+      final backend = MethodChannelDesktopPresenceBackend();
+      final presence = DesktopPresenceCoordinator(
+        backend: backend,
+        window: window,
+        lifecycle: lifecycle,
+      );
+      addTearDown(() async {
+        await window.show();
+        await presence.destroy();
+        await lifecycle.stop();
+      });
+      presence.start();
+      lifecycle.bindHideOnClose(() => presence.trayInstalled);
+      await lifecycle.start();
+      await window.show();
+      expect(await window.isVisible(), isTrue);
+
+      await presence.apply(
+        const DesktopPresenceSnapshot(
+          trayVisible: true,
+          tooltip: 'Alera desktop presence test',
+          badgeCount: 3,
+        ),
+      );
+      expect(presence.trayInstalled, isTrue);
+
+      await window.close();
+      final deadline = DateTime.now().add(const Duration(seconds: 5));
+      while (await window.isVisible() && DateTime.now().isBefore(deadline)) {
+        await Future<void>.delayed(const Duration(milliseconds: 20));
+      }
+      await lifecycle.waitForPendingHide();
+      expect(await window.isVisible(), isFalse);
+      expect(repository.state, isNotNull);
+      expect(lifecycle.isQuitting, isFalse);
+
+      // Removing the tray must restore the hidden window before removing the
+      // user's way back into the app, and must clear the Dock badge.
+      await presence.apply(
+        const DesktopPresenceSnapshot(
+          trayVisible: false,
+          tooltip: '',
+          badgeCount: 0,
+        ),
+      );
+      expect(presence.trayInstalled, isFalse);
+      expect(await window.isVisible(), isTrue);
+    },
+    skip: !Platform.isMacOS,
+  );
+}
+
+class _MemoryWindowStateRepository implements AppWindowStateRepository {
+  AppWindowState? state;
+
+  @override
+  Future<AppWindowState?> load() async => state;
+
+  @override
+  Future<void> save(AppWindowState state) async => this.state = state;
+
+  @override
+  Future<void> clear() async => state = null;
+}

--- a/macos/Runner/AppDelegate.swift
+++ b/macos/Runner/AppDelegate.swift
@@ -7,7 +7,8 @@ class AppDelegate: FlutterAppDelegate {
   private var desktopPresence: DesktopPresence?
 
   override func applicationDidFinishLaunching(_ notification: Notification) {
-    super.applicationDidFinishLaunching(notification)
+    // FlutterAppDelegate does not implement this optional Objective-C callback.
+    // Calling super throws before the native channels can be registered.
     guard let controller = mainFlutterWindow?.contentViewController as? FlutterViewController else {
       return
     }

--- a/macos/Runner/AppDelegate.swift
+++ b/macos/Runner/AppDelegate.swift
@@ -40,9 +40,9 @@ class AppDelegate: FlutterAppDelegate {
   }
 
   override func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
-    // Hide-on-close uses NSWindow.orderOut, so the window still exists.
-    // Destroying it (Quit) is what should terminate the process.
-    return true
+    // AppKit can request termination when the last window is hidden too.
+    // The Dart close/quit flow calls NSApp.terminate explicitly when needed.
+    return false
   }
 
   override func applicationSupportsSecureRestorableState(_ app: NSApplication) -> Bool {

--- a/rust/alera-cli/tests/terminal_host_headless_runtime.rs
+++ b/rust/alera-cli/tests/terminal_host_headless_runtime.rs
@@ -8,9 +8,7 @@ use std::net::TcpStream;
 use std::process::Child;
 use std::time::{Duration, Instant};
 
-use alera_core::runtime::{
-    RuntimeAgentStatusHookSettings, RuntimeStore, Workspace, WorkspaceTabRecord,
-};
+use alera_core::runtime::{RuntimeAgentStatusHookSettings, RuntimeStore};
 use base64::engine::general_purpose::STANDARD;
 use base64::Engine as _;
 use serde_json::{json, Value};
@@ -19,6 +17,8 @@ use serde_json::{json, Value};
 mod profile_snapshot_restart_cases;
 #[path = "terminal_host_headless_runtime/startup_command_cases.rs"]
 mod startup_command_cases;
+#[path = "terminal_host_headless_runtime/startup_reconciliation_case.rs"]
+mod startup_reconciliation_case;
 
 const PROTOCOL_VERSION: i64 = 4;
 
@@ -342,50 +342,6 @@ fn spawn_on_create_starts_headless_without_an_app_client() {
     assert_eq!(read_response(&mut reader, 3)["ok"], json!(true));
     std::thread::sleep(Duration::from_millis(300));
     assert_eq!(std::fs::read_to_string(&marker).unwrap(), "X");
-}
-
-#[test]
-#[cfg(unix)]
-fn runtime_start_reconciles_persisted_spawn_on_create_tabs() {
-    let dir = tempfile::tempdir().unwrap();
-    let marker = dir.path().join("reconciled.txt");
-    let runtime = tokio::runtime::Runtime::new().unwrap();
-    runtime.block_on(async {
-        let store = RuntimeStore::open(dir.path()).await.unwrap();
-        let workspace: Workspace =
-            serde_json::from_value(workspace_payload("reconcile-workspace", dir.path())).unwrap();
-        store.upsert_workspace(workspace).await.unwrap();
-        let tab: WorkspaceTabRecord = serde_json::from_value(json!({
-            "id": "reconcile-tab", "workspaceId": "reconcile-workspace", "kind": "terminal",
-            "title": "Reconcile Terminal", "createdAt": "2026-07-19T00:00:00Z",
-            "updatedAt": "2026-07-19T00:00:00Z", "payload": {
-                "terminalSessionId": "reconcile-session",
-                "initialCommand": format!("printf RESTORED > {}; exit", marker.display()),
-                "spawnOnCreate": true
-            }
-        }))
-        .unwrap();
-        store.upsert_workspace_tab(tab).await.unwrap();
-    });
-
-    let token = "reconcile-spawn-token";
-    let (_guard, port) = spawn_host(dir.path(), token);
-    let deadline = Instant::now() + Duration::from_secs(10);
-    while !marker.exists() {
-        assert!(
-            Instant::now() < deadline,
-            "persisted command was never executed"
-        );
-        std::thread::sleep(Duration::from_millis(25));
-    }
-    assert_eq!(std::fs::read_to_string(&marker).unwrap(), "RESTORED");
-
-    let (mut writer, mut reader) = connect(port, token);
-    send(
-        &mut writer,
-        json!({"id": 1, "type": "tab.find", "payload": {"id": "reconcile-tab"}}),
-    );
-    assert_eq!(read_response(&mut reader, 1)["payload"], Value::Null);
 }
 
 #[test]

--- a/rust/alera-cli/tests/terminal_host_headless_runtime/startup_reconciliation_case.rs
+++ b/rust/alera-cli/tests/terminal_host_headless_runtime/startup_reconciliation_case.rs
@@ -1,0 +1,61 @@
+use std::time::{Duration, Instant};
+
+use alera_core::runtime::{RuntimeStore, Workspace, WorkspaceTabRecord};
+use serde_json::{json, Value};
+
+use super::{connect, read_response, send, spawn_host, workspace_payload};
+
+#[test]
+fn runtime_start_reconciles_persisted_spawn_on_create_tabs() {
+    let dir = tempfile::tempdir().unwrap();
+    let marker = dir.path().join("reconciled.txt");
+    let runtime = tokio::runtime::Runtime::new().unwrap();
+    runtime.block_on(async {
+        let store = RuntimeStore::open(dir.path()).await.unwrap();
+        let workspace: Workspace =
+            serde_json::from_value(workspace_payload("reconcile-workspace", dir.path())).unwrap();
+        store.upsert_workspace(workspace).await.unwrap();
+        let tab: WorkspaceTabRecord = serde_json::from_value(json!({
+            "id": "reconcile-tab", "workspaceId": "reconcile-workspace", "kind": "terminal",
+            "title": "Reconcile Terminal", "createdAt": "2026-07-19T00:00:00Z",
+            "updatedAt": "2026-07-19T00:00:00Z", "payload": {
+                "terminalSessionId": "reconcile-session",
+                "initialCommand": format!("printf RESTORED > {}; exit", marker.display()),
+                "spawnOnCreate": true
+            }
+        }))
+        .unwrap();
+        store.upsert_workspace_tab(tab).await.unwrap();
+    });
+
+    let token = "reconcile-spawn-token";
+    let (_guard, port) = spawn_host(dir.path(), token);
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while !std::fs::read_to_string(&marker).is_ok_and(|value| value == "RESTORED") {
+        assert!(
+            Instant::now() < deadline,
+            "persisted command was never executed"
+        );
+        std::thread::sleep(Duration::from_millis(25));
+    }
+
+    let (mut writer, mut reader) = connect(port, token);
+    // The marker is written before shell exit and asynchronous tab cleanup.
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        send(
+            &mut writer,
+            json!({"id": 1, "type": "tab.find", "payload": {"id": "reconcile-tab"}}),
+        );
+        let response = read_response(&mut reader, 1);
+        assert_eq!(response["ok"], json!(true));
+        if response["payload"] == Value::Null {
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "exited startup tab was not removed"
+        );
+        std::thread::sleep(Duration::from_millis(25));
+    }
+}

--- a/test/unit/macos_app_delegate_startup_test.dart
+++ b/test/unit/macos_app_delegate_startup_test.dart
@@ -13,4 +13,14 @@ void main() {
       isNot(matches(r'super\s*\.\s*applicationDidFinishLaunching\s*\(')),
     );
   });
+
+  test('macOS leaves process exit to the explicit close and quit flow', () {
+    final source = File('macos/Runner/AppDelegate.swift').readAsStringSync();
+    expect(
+      source,
+      matches(
+        r'applicationShouldTerminateAfterLastWindowClosed[^}]+return false',
+      ),
+    );
+  });
 }

--- a/test/unit/macos_app_delegate_startup_test.dart
+++ b/test/unit/macos_app_delegate_startup_test.dart
@@ -1,0 +1,16 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('macOS startup does not call the unimplemented superclass callback', () {
+    final source = File('macos/Runner/AppDelegate.swift').readAsStringSync();
+
+    // Swift accepts this optional Objective-C callback, but FlutterAppDelegate
+    // does not implement it. AppKit catches the exception and skips our setup.
+    expect(
+      source,
+      isNot(matches(r'super\s*\.\s*applicationDidFinishLaunching\s*\(')),
+    );
+  });
+}


### PR DESCRIPTION
## Summary

- Remove the unsupported `FlutterAppDelegate.applicationDidFinishLaunching` super call that aborts native channel registration on macOS.
- Disable AppKit's automatic last-window termination so hide-on-close keeps the app alive; explicit Quit still exits.
- Restore menu-bar presence and pending-review Dock badges without changing Windows/Linux behavior or protocols.
- Add a CI regression guard, a real macOS channel/window integration test with in-memory state, and contributor guidance.

## Validation

- Regression guard fails before the fix and passes after it.
- All 22 focused startup, desktop-presence, and window-lifecycle tests pass.
- Full static analysis, formatting, and the max-lines check pass.
- Fixed an existing Rust test race exposed by CI: wait for asynchronous startup-tab cleanup, not only the command's marker file. All 10 headless-runtime tests, 10 repeated reconciliation runs, and focused clippy pass.
- Native macOS build and integration pass: real tray/badge channel, native close interception, hidden-window survival, and restoring the window before removing the tray. The integration exposed the last-window termination and passes after its fix.
- Manual macOS check with an isolated in-memory probe: X preserves the process, reopening uses the same PID, and Cmd+Q exits.

## Notes

- Restores existing UI behavior; no visual redesign or dependency changes.
- No user settings, runtime data, credentials, release signing, or updater behavior changed.
