### PR TITLE
chore: configure monthly dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,151 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    cooldown:
+      default-days: 7
+    commit-message:
+      prefix: chore
+      include: scope
+    groups:
+      monthly-batch:
+        applies-to: version-updates
+        patterns: ["*"]
+
+  - package-ecosystem: pub
+    directories:
+      - /
+      - /mobile
+      - /mobile/rust_builder
+      - /packages/alera_browser
+      - /packages/alera_configuration
+      - /rust_builder
+      - /tool/release/runtime_packager
+    schedule:
+      interval: monthly
+    cooldown:
+      default-days: 7
+    commit-message:
+      prefix: chore
+      include: scope
+    groups:
+      monthly-batch:
+        applies-to: version-updates
+        group-by: dependency-name
+        patterns: ["*"]
+
+  - package-ecosystem: cargo
+    directories:
+      - /cloud
+      - /rust
+    schedule:
+      interval: monthly
+    cooldown:
+      default-days: 7
+    commit-message:
+      prefix: chore
+      include: scope
+    groups:
+      monthly-batch:
+        applies-to: version-updates
+        group-by: dependency-name
+        patterns: ["*"]
+
+  - package-ecosystem: bun
+    directories:
+      - /edge
+      - /landing
+    schedule:
+      interval: monthly
+    cooldown:
+      default-days: 7
+    commit-message:
+      prefix: chore
+      include: scope
+    groups:
+      monthly-batch:
+        applies-to: version-updates
+        group-by: dependency-name
+        patterns: ["*"]
+
+  - package-ecosystem: gradle
+    directories:
+      - /mobile/android
+      - /mobile/rust_builder/android
+      - /rust_builder/android
+    schedule:
+      interval: monthly
+    cooldown:
+      default-days: 7
+    commit-message:
+      prefix: chore
+      include: scope
+    groups:
+      monthly-batch:
+        applies-to: version-updates
+        group-by: dependency-name
+        patterns: ["*"]
+
+  - package-ecosystem: opentofu
+    directories:
+      - /infra/bootstrap/github
+      - /infra/production
+    schedule:
+      interval: monthly
+    cooldown:
+      default-days: 7
+    commit-message:
+      prefix: chore
+      include: scope
+    groups:
+      monthly-batch:
+        applies-to: version-updates
+        group-by: dependency-name
+        patterns: ["*"]
+
+  - package-ecosystem: docker
+    directory: /cloud
+    schedule:
+      interval: monthly
+    cooldown:
+      default-days: 7
+    commit-message:
+      prefix: chore
+      include: scope
+    groups:
+      monthly-batch:
+        applies-to: version-updates
+        patterns: ["*"]
+
+  - package-ecosystem: docker-compose
+    directory: /cloud
+    schedule:
+      interval: monthly
+    cooldown:
+      default-days: 7
+    commit-message:
+      prefix: chore
+      include: scope
+    groups:
+      monthly-batch:
+        applies-to: version-updates
+        patterns: ["*"]
+
+  - package-ecosystem: rust-toolchain
+    directories:
+      - /cloud
+      - /rust
+    schedule:
+      interval: monthly
+    cooldown:
+      default-days: 7
+    commit-message:
+      prefix: chore
+      include: scope
+    groups:
+      monthly-batch:
+        applies-to: version-updates
+        group-by: dependency-name
+        patterns: ["*"]


### PR DESCRIPTION
Add monthly Dependabot version updates with a seven-day cooldown and an explicit version-only monthly-batch group. Major, minor and patch updates remain eligible.

- Cover GitHub Actions, seven owned Pub roots, the Rust workspace and cloud Cargo root, Bun projects, Android Gradle roots, OpenTofu roots, Docker, Docker Compose and Rust toolchains.
- Use group-by: dependency-name across independent directories: one PR per dependency across directories, not one PR for the entire ecosystem. Keep the shared Rust lockfile under /rust.
- Exclude vendored Cargokit, reference projects and submodules. CocoaPods is not supported by Dependabot.
- Dependency graph, alerts and security updates were already enabled: REST alerts returned 204, security fixes returned enabled=true/paused=false, and GraphQL reported 38 graph manifests. Bun, Docker, Docker Compose, OpenTofu and Rust toolchains do not support automatic security updates; the other configured ecosystems do. Version grouping and cooldown do not delay security fixes.

Validation: PyYAML parsing, current Dependabot JSON schema, 21 unique ecosystem/directory pairs, manifest and workspace boundaries, version/security separation, and git diff --check passed. No dependency versions, lockfiles, workflows or application code changed, so no application builds or production operations were run. No visual or platform behavior change. No separate documentation changes are needed; the configuration and this PR describe the maintenance policy.

References: [options](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference), [ecosystem support](https://docs.github.com/en/code-security/reference/supply-chain-security/supported-ecosystems-and-repositories).
