### PR TITLE
feat: show agent tab titles in the workspace sidebar

### DIFF
--- a/docs/agent-titles.md
+++ b/docs/agent-titles.md
@@ -4,7 +4,9 @@ AI Assist names new agent conversations automatically in terminal tabs and Codex
 
 The initial title uses the first user prompt. Profile launches capture that prompt before adding profile or project instructions. Hooks supply prompts for agents launched directly in a terminal. When the prompt is unavailable, a short deferred job uses recent terminal output. Codex Chat uses its structured messages instead of a PTY. Internal generation runs in a separate temporary directory without the originating terminal's hook identity.
 
-Use **Generate Title** or **Regenerate Title** in the tab menu on desktop or mobile. Regeneration combines the retained initial prompt with recent context and applies a valid result directly. Context is limited to 16 KiB; terminal control sequences and adjacent duplicate redraw lines are removed. Empty context or an invalid result leaves the old name intact. A title is at most 80 characters; the generation prompt requests 3 to 7 words in the task's language.
+Use **Generate Title** or **Regenerate Title** in the tab menu on desktop or mobile. The same generate action is also available from the agent-run rows under a workspace in the desktop sidebar. Regeneration combines the retained initial prompt with recent context and applies a valid result directly. Context is limited to 16 KiB; terminal control sequences and adjacent duplicate redraw lines are removed. Empty context or an invalid result leaves the old name intact. A title is at most 80 characters; the generation prompt requests 3 to 7 words in the task's language.
+
+**Show Tab Titles in Sidebar** (Settings > Agents > Behavior, portable through Configuration Sync) replaces the latest activity text in those sidebar rows with each tab's persisted title. Turn it off to keep the current tool or assistant snippet.
 
 Manual names take precedence over automatic generation, including when a new conversation starts in the same tab. An explicit regeneration may replace a manual name, but a rename made while that job runs wins. Closing the tab or switching conversations invalidates pending results. Multiple clients cannot start simultaneous jobs for the same tab.
 

--- a/lib/src/features/ai_assist/application/agent_title_service.dart
+++ b/lib/src/features/ai_assist/application/agent_title_service.dart
@@ -3,6 +3,19 @@ import 'package:alera/src/features/workbench/infra/terminal_host/terminal_host_p
 
 const agentTitleCapability = 'aiTextAgentTitleV1';
 
+String agentTitleActionLabel(Map<String, Object?> payload) {
+  if (isAgentTitleGenerating(payload)) {
+    return 'Generating title...';
+  }
+  if (payload['agentTitleSource'] == 'generated') {
+    return 'Regenerate Title';
+  }
+  return 'Generate Title';
+}
+
+bool isAgentTitleGenerating(Map<String, Object?> payload) =>
+    payload['agentTitleStatus'] == 'generating';
+
 class const AgentTitleService(final RuntimeHostClient client) {
   Future<bool> isAvailable() async {
     final status = await client.runtimeRequest('status.get');

--- a/lib/src/features/settings/application/settings_controller.dart
+++ b/lib/src/features/settings/application/settings_controller.dart
@@ -257,6 +257,17 @@ class SettingsController extends _$SettingsController {
         );
       });
 
+  Future<void> setShowTabTitlesInSidebar(bool value) => _serialize(() async {
+    if (state.agents.showTabTitlesInSidebar == value) {
+      return;
+    }
+    await _save(
+      state.copyWith(
+        agents: state.agents.copyWith(showTabTitlesInSidebar: value),
+      ),
+    );
+  });
+
   Future<void> setDefaultAgentProfile(String? profileId) => _serialize(
     () async {
       final normalized = profileId?.trim();

--- a/lib/src/features/settings/application/settings_controller.g.dart
+++ b/lib/src/features/settings/application/settings_controller.g.dart
@@ -42,7 +42,7 @@ final class SettingsControllerProvider
 }
 
 String _$settingsControllerHash() =>
-    r'64cb1240bba960328fb3757e29c08a25d4fd66d7';
+    r'cee30b540957f432f1e67fe6729dba42322dc1b9';
 
 abstract class _$SettingsController extends $Notifier<AleraSettings> {
   AleraSettings build();

--- a/lib/src/features/settings/domain/alera_settings.dart
+++ b/lib/src/features/settings/domain/alera_settings.dart
@@ -329,6 +329,7 @@ class const AgentSettings({
   this.agentStatusNotificationsEnabled = false,
   this.agentStatusFinishedNotificationsEnabled = false,
   this.keepComputerAwakeWhileAgentsWork = false,
+  this.showTabTitlesInSidebar = false,
   this.defaultAgentProfileId,
   this.quotas = AgentQuotaSettings.defaults,
 }) with AgentSettingsMappable {
@@ -347,6 +348,9 @@ class const AgentSettings({
 
   /// Keep the local computer awake while local hook-reported agents are working.
   final bool keepComputerAwakeWhileAgentsWork;
+
+  /// Use each agent tab title in the workspace sidebar instead of latest activity.
+  final bool showTabTitlesInSidebar;
 
   /// Runtime profile selected for flows that need an initial agent choice.
   final String? defaultAgentProfileId;

--- a/lib/src/features/settings/domain/alera_settings.mapper.dart
+++ b/lib/src/features/settings/domain/alera_settings.mapper.dart
@@ -1651,6 +1651,14 @@ class AgentSettingsMapper extends ClassMapperBase<AgentSettings> {
         opt: true,
         def: false,
       );
+  static bool _$showTabTitlesInSidebar(AgentSettings v) =>
+      v.showTabTitlesInSidebar;
+  static const Field<AgentSettings, bool> _f$showTabTitlesInSidebar = Field(
+    'showTabTitlesInSidebar',
+    _$showTabTitlesInSidebar,
+    opt: true,
+    def: false,
+  );
   static String? _$defaultAgentProfileId(AgentSettings v) =>
       v.defaultAgentProfileId;
   static const Field<AgentSettings, String> _f$defaultAgentProfileId = Field(
@@ -1673,6 +1681,7 @@ class AgentSettingsMapper extends ClassMapperBase<AgentSettings> {
     #agentStatusFinishedNotificationsEnabled:
         _f$agentStatusFinishedNotificationsEnabled,
     #keepComputerAwakeWhileAgentsWork: _f$keepComputerAwakeWhileAgentsWork,
+    #showTabTitlesInSidebar: _f$showTabTitlesInSidebar,
     #defaultAgentProfileId: _f$defaultAgentProfileId,
     #quotas: _f$quotas,
   };
@@ -1689,6 +1698,7 @@ class AgentSettingsMapper extends ClassMapperBase<AgentSettings> {
       keepComputerAwakeWhileAgentsWork: data.dec(
         _f$keepComputerAwakeWhileAgentsWork,
       ),
+      showTabTitlesInSidebar: data.dec(_f$showTabTitlesInSidebar),
       defaultAgentProfileId: data.dec(_f$defaultAgentProfileId),
       quotas: data.dec(_f$quotas),
     );
@@ -1769,6 +1779,7 @@ abstract class AgentSettingsCopyWith<$R, $In extends AgentSettings, $Out>
     bool? agentStatusNotificationsEnabled,
     bool? agentStatusFinishedNotificationsEnabled,
     bool? keepComputerAwakeWhileAgentsWork,
+    bool? showTabTitlesInSidebar,
     String? defaultAgentProfileId,
     AgentQuotaSettings? quotas,
   });
@@ -1800,6 +1811,7 @@ class _AgentSettingsCopyWithImpl<$R, $Out>
     bool? agentStatusNotificationsEnabled,
     bool? agentStatusFinishedNotificationsEnabled,
     bool? keepComputerAwakeWhileAgentsWork,
+    bool? showTabTitlesInSidebar,
     Object? defaultAgentProfileId = $none,
     AgentQuotaSettings? quotas,
   }) => $apply(
@@ -1812,6 +1824,8 @@ class _AgentSettingsCopyWithImpl<$R, $Out>
             agentStatusFinishedNotificationsEnabled,
       if (keepComputerAwakeWhileAgentsWork != null)
         #keepComputerAwakeWhileAgentsWork: keepComputerAwakeWhileAgentsWork,
+      if (showTabTitlesInSidebar != null)
+        #showTabTitlesInSidebar: showTabTitlesInSidebar,
       if (defaultAgentProfileId != $none)
         #defaultAgentProfileId: defaultAgentProfileId,
       if (quotas != null) #quotas: quotas,
@@ -1831,6 +1845,10 @@ class _AgentSettingsCopyWithImpl<$R, $Out>
     keepComputerAwakeWhileAgentsWork: data.get(
       #keepComputerAwakeWhileAgentsWork,
       or: $value.keepComputerAwakeWhileAgentsWork,
+    ),
+    showTabTitlesInSidebar: data.get(
+      #showTabTitlesInSidebar,
+      or: $value.showTabTitlesInSidebar,
     ),
     defaultAgentProfileId: data.get(
       #defaultAgentProfileId,

--- a/lib/src/features/settings/presentation/panes/agents_pane.dart
+++ b/lib/src/features/settings/presentation/panes/agents_pane.dart
@@ -175,6 +175,13 @@ class const AgentsSettingsPane({
             description: 'How Alera reacts while agents are running.',
             children: <Widget>[
               SettingsSwitchRow(
+                title: 'Show Tab Titles in Sidebar',
+                description: 'Use each agent tab title under a workspace instead of the latest activity.',
+                value: agents.showTabTitlesInSidebar,
+                onChanged: (value) =>
+                    controller.setShowTabTitlesInSidebar(value),
+              ),
+              SettingsSwitchRow(
                 title: 'Agent Status Notifications',
                 description: 'Show native notifications when an agent needs attention. Bursts are grouped into one notification.',
                 value: agents.agentStatusNotificationsEnabled,

--- a/lib/src/features/settings/presentation/settings_search_entries.dart
+++ b/lib/src/features/settings/presentation/settings_search_entries.dart
@@ -242,6 +242,17 @@ agentsSearchEntries = buildSettingsSearchEntryCatalog(const {
     ),
   },
   'behavior': {
+    'Show Tab Titles in Sidebar': SettingsSearchEntryDetails(
+      description: 'Use each agent tab title under a workspace instead of the latest activity.',
+      keywords: <String>[
+        'tab',
+        'title',
+        'sidebar',
+        'workspace',
+        'agent',
+        'regenerate',
+      ],
+    ),
     'Agent Status Notifications': SettingsSearchEntryDetails(
       description: 'Show native notifications when agents need attention.',
       keywords: <String>[

--- a/lib/src/features/workbench/presentation/project_workbench_agent_rows.dart
+++ b/lib/src/features/workbench/presentation/project_workbench_agent_rows.dart
@@ -7,12 +7,12 @@ class const _AgentRunRow({
   required final bool isActive,
   required final VoidCallback onTap,
   required final VoidCallback onClose,
-}) extends StatefulWidget {
+}) extends ConsumerStatefulWidget {
   @override
-  State<_AgentRunRow> createState() => _AgentRunRowState();
+  ConsumerState<_AgentRunRow> createState() => _AgentRunRowState();
 }
 
-class _AgentRunRowState extends State<_AgentRunRow> {
+class _AgentRunRowState extends ConsumerState<_AgentRunRow> {
   bool _hovered = false;
 
   @override
@@ -20,81 +20,150 @@ class _AgentRunRowState extends State<_AgentRunRow> {
     final theme = Theme.of(context);
     final isActive = widget.isActive;
     final actionsVisible = _hovered || isActive;
-    final description = _agentRunDescription(widget.status);
+    ref.watch(agentTitleAvailableProvider);
+    final showTabTitle = ref.watch(
+      settingsControllerProvider.select(
+        (settings) => settings.agents.showTabTitlesInSidebar,
+      ),
+    );
+    final description = _agentRunLabel(
+      tab: widget.tab,
+      status: widget.status,
+      showTabTitle: showTabTitle,
+    );
     return MouseRegion(
       onEnter: (_) => setState(() => _hovered = true),
       onExit: (_) => setState(() => _hovered = false),
-      child: AnimatedContainer(
-        width: .infinity,
-        duration: AleraTokens.durationFast,
-        decoration: BoxDecoration(
-          color: isActive
-              ? AleraTokens.accentSubtle
-              : (_hovered ? AleraTokens.surface : Colors.transparent),
-          borderRadius: BorderRadius.circular(AleraTokens.radiusSm),
-        ),
-        child: InkWell(
-          onTap: widget.onTap,
-          mouseCursor: SystemMouseCursors.click,
-          borderRadius: .circular(AleraTokens.radiusSm),
-          child: Padding(
-            padding: const EdgeInsets.symmetric(
-              horizontal: AleraTokens.space6,
-              vertical: AleraTokens.space4,
-            ),
-            child: Row(
-              crossAxisAlignment: .center,
-              children: <Widget>[
-                AgentRunStateIndicator(status: widget.status, size: 12),
-                const SizedBox(width: AleraTokens.space6),
-                AgentIdentityIcon(
-                  agentType: widget.status.agentType,
-                  size: 13,
-                  color: isActive
-                      ? AleraTokens.foreground
-                      : AleraTokens.foregroundMuted,
-                ),
-                const SizedBox(width: AleraTokens.space6),
-                Expanded(
-                  child: Text(
-                    description,
-                    maxLines: 1,
-                    overflow: .ellipsis,
-                    style: theme.textTheme.labelSmall?.copyWith(
-                      color: isActive
-                          ? AleraTokens.foreground
-                          : AleraTokens.foregroundMuted,
-                      fontWeight: isActive ? FontWeight.w600 : FontWeight.w500,
-                    ),
+      child: GestureDetector(
+        onSecondaryTapDown: (details) =>
+            unawaited(_openContextMenu(context, details.globalPosition)),
+        child: AnimatedContainer(
+          width: .infinity,
+          duration: AleraTokens.durationFast,
+          decoration: BoxDecoration(
+            color: isActive
+                ? AleraTokens.accentSubtle
+                : (_hovered ? AleraTokens.surface : Colors.transparent),
+            borderRadius: BorderRadius.circular(AleraTokens.radiusSm),
+          ),
+          child: InkWell(
+            onTap: widget.onTap,
+            mouseCursor: SystemMouseCursors.click,
+            borderRadius: .circular(AleraTokens.radiusSm),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(
+                horizontal: AleraTokens.space6,
+                vertical: AleraTokens.space4,
+              ),
+              child: Row(
+                crossAxisAlignment: .center,
+                children: <Widget>[
+                  AgentRunStateIndicator(status: widget.status, size: 12),
+                  const SizedBox(width: AleraTokens.space6),
+                  AgentIdentityIcon(
+                    agentType: widget.status.agentType,
+                    size: 13,
+                    color: isActive
+                        ? AleraTokens.foreground
+                        : AleraTokens.foregroundMuted,
                   ),
-                ),
-                IgnorePointer(
-                  ignoring: !actionsVisible,
-                  child: AnimatedOpacity(
-                    opacity: actionsVisible ? 1 : 0,
-                    duration: AleraTokens.durationFast,
-                    child: Padding(
-                      padding: const EdgeInsets.only(left: AleraTokens.space4),
-                      child: AleraIconButton(
-                        tooltip: widget.tab.kind == WorkspaceTabKind.codex
-                            ? 'Close Codex'
-                            : 'Close Terminal',
-                        onPressed: widget.onClose,
-                        icon: AleraIcons.close,
-                        iconSize: 12,
-                        minSize: 20,
-                        borderRadius: AleraTokens.radiusSm,
+                  const SizedBox(width: AleraTokens.space6),
+                  Expanded(
+                    child: Text(
+                      description,
+                      maxLines: 1,
+                      overflow: .ellipsis,
+                      style: theme.textTheme.labelSmall?.copyWith(
+                        color: isActive
+                            ? AleraTokens.foreground
+                            : AleraTokens.foregroundMuted,
+                        fontWeight: isActive
+                            ? FontWeight.w600
+                            : FontWeight.w500,
                       ),
                     ),
                   ),
-                ),
-              ],
+                  IgnorePointer(
+                    ignoring: !actionsVisible,
+                    child: AnimatedOpacity(
+                      opacity: actionsVisible ? 1 : 0,
+                      duration: AleraTokens.durationFast,
+                      child: Padding(
+                        padding: const EdgeInsets.only(
+                          left: AleraTokens.space4,
+                        ),
+                        child: AleraIconButton(
+                          tooltip: widget.tab.kind == WorkspaceTabKind.codex
+                              ? 'Close Codex'
+                              : 'Close Terminal',
+                          onPressed: widget.onClose,
+                          icon: AleraIcons.close,
+                          iconSize: 12,
+                          minSize: 20,
+                          borderRadius: AleraTokens.radiusSm,
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
             ),
           ),
         ),
       ),
     );
   }
+
+  Future<void> _openContextMenu(
+    BuildContext context,
+    Offset globalPosition,
+  ) async {
+    if (ref.read(agentTitleAvailableProvider).value != true) {
+      return;
+    }
+    final overlay =
+        Navigator.of(context).overlay!.context.findRenderObject()! as RenderBox;
+    final selected = await showMenu<String>(
+      context: context,
+      position: RelativeRect.fromRect(
+        Rect.fromPoints(globalPosition, globalPosition),
+        Offset.zero & overlay.size,
+      ),
+      items: <PopupMenuEntry<String>>[
+        AleraDropdownEntry<String>(
+          value: 'generateTitle',
+          label: agentTitleActionLabel(widget.tab.payload),
+          enabled: !isAgentTitleGenerating(widget.tab.payload),
+          leading: const Icon(AleraIcons.ai, size: 16),
+        ),
+      ],
+    );
+    if (selected != 'generateTitle' || !context.mounted) {
+      return;
+    }
+    try {
+      await ref.read(agentTitleServiceProvider).generate(widget.tab);
+    } on Object catch (error) {
+      AleraToast.publish(
+        message: 'Could not generate title: $error',
+        tone: .error,
+      );
+    }
+  }
+}
+
+String _agentRunLabel({
+  required WorkspaceTabRecord tab,
+  required AgentStatusEntry status,
+  required bool showTabTitle,
+}) {
+  if (showTabTitle) {
+    final title = tab.title.trim();
+    if (title.isNotEmpty) {
+      return title;
+    }
+  }
+  return _agentRunDescription(status);
 }
 
 String _agentRunDescription(AgentStatusEntry status) {

--- a/lib/src/features/workbench/presentation/project_workbench_sidebar.dart
+++ b/lib/src/features/workbench/presentation/project_workbench_sidebar.dart
@@ -4,6 +4,8 @@ import 'package:alera/src/features/workbench/presentation/workspace_section_dial
 import 'dart:async';
 
 import 'package:alera/src/app/providers.dart';
+import 'package:alera/src/features/ai_assist/application/agent_title_providers.dart';
+import 'package:alera/src/features/ai_assist/application/agent_title_service.dart';
 import 'package:alera/src/app/theme/alera_tokens.dart';
 import 'package:alera/src/design_system/icons/alera_icons.dart';
 import 'package:alera/src/features/projects/domain/project.dart';

--- a/lib/src/features/workbench/presentation/workspace_workbench_tab_menu.dart
+++ b/lib/src/features/workbench/presentation/workspace_workbench_tab_menu.dart
@@ -88,13 +88,9 @@ extension _WorkspaceTabMenu on _WorkspaceTabChip {
             ref.read(agentTitleAvailableProvider).value == true)
           AleraDropdownEntry<_TabMenuAction>(
             value: .generateTitle,
-            label: tab.payload['agentTitleStatus'] == 'generating'
-                ? 'Generating title...'
-                : tab.payload['agentTitleSource'] == 'generated'
-                ? 'Regenerate Title'
-                : 'Generate Title',
-            enabled: tab.payload['agentTitleStatus'] != 'generating',
-            leading: const Icon(AleraIcons.ai),
+            label: agentTitleActionLabel(tab.payload),
+            enabled: !isAgentTitleGenerating(tab.payload),
+            leading: const Icon(AleraIcons.ai, size: 16),
           ),
         if (tab.kind !=
             WorkspaceTabKind.codex) ...<PopupMenuEntry<_TabMenuAction>>[

--- a/lib/src/features/workbench/presentation/workspace_workbench_view.dart
+++ b/lib/src/features/workbench/presentation/workspace_workbench_view.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:alera/src/features/ai_assist/application/agent_title_providers.dart';
+import 'package:alera/src/features/ai_assist/application/agent_title_service.dart';
 import 'package:alera/src/design_system/feedback/alera_toast.dart';
 
 import 'dart:math' as math;

--- a/packages/alera_configuration/lib/src/portable_settings.dart
+++ b/packages/alera_configuration/lib/src/portable_settings.dart
@@ -35,6 +35,7 @@ const desktopPortableFields = <String, List<String>>{
     'agentStatusNotificationsEnabled',
     'agentStatusFinishedNotificationsEnabled',
     'defaultAgentProfileId',
+    'showTabTitlesInSidebar',
   ],
   'aiTextGeneration': [
     'enabled',

--- a/packages/alera_configuration/test/configuration_merge_test.dart
+++ b/packages/alera_configuration/test/configuration_merge_test.dart
@@ -141,6 +141,7 @@ void main() {
         'agents': {
           'agentStatusHooks': {'codex': true},
           'quotas': {'token': 'secret'},
+          'showTabTitlesInSidebar': true,
         },
         'aiDictation': {
           'remoteConsentVersion': 2,
@@ -154,7 +155,7 @@ void main() {
         },
       });
       expect(result['general'], {'showTrayIcon': true});
-      expect(result['agents'], isEmpty);
+      expect(result['agents'], {'showTabTitlesInSidebar': true});
       expect(result['aiDictation'], {'language': 'es'});
       expect(result['aiTextGeneration'], isEmpty);
     },

--- a/test/unit/agent_title_service_test.dart
+++ b/test/unit/agent_title_service_test.dart
@@ -55,6 +55,29 @@ void main() {
     },
   );
 
+  test('action labels follow generation status and source', () {
+    expect(agentTitleActionLabel(const <String, Object?>{}), 'Generate Title');
+    expect(
+      agentTitleActionLabel(const <String, Object?>{
+        'agentTitleSource': 'generated',
+      }),
+      'Regenerate Title',
+    );
+    expect(
+      agentTitleActionLabel(const <String, Object?>{
+        'agentTitleSource': 'generated',
+        'agentTitleStatus': 'generating',
+      }),
+      'Generating title...',
+    );
+    expect(
+      isAgentTitleGenerating(const <String, Object?>{
+        'agentTitleStatus': 'generating',
+      }),
+      isTrue,
+    );
+  });
+
   test('old hosts do not advertise generation actions', () async {
     final client = _Client();
     final service = AgentTitleService(client);

--- a/test/unit/alera_settings_json_test.dart
+++ b/test/unit/alera_settings_json_test.dart
@@ -31,6 +31,7 @@ void main() {
           ),
           agentStatusNotificationsEnabled: true,
           keepComputerAwakeWhileAgentsWork: true,
+          showTabTitlesInSidebar: true,
           defaultAgentProfileId: 'prof_1',
         ),
         editor: EditorSettings(
@@ -113,6 +114,7 @@ void main() {
       expect(restored.agents.agentStatusHooks.fx, isTrue);
       expect(restored.agents.agentStatusNotificationsEnabled, isTrue);
       expect(restored.agents.keepComputerAwakeWhileAgentsWork, isTrue);
+      expect(restored.agents.showTabTitlesInSidebar, isTrue);
       expect(restored.agents.defaultAgentProfileId, 'prof_1');
       expect(restored.editor.tabSize, 2);
       expect(restored.editor.themeName, EditorSyntaxThemeNames.nord);

--- a/test/unit/alera_settings_test.dart
+++ b/test/unit/alera_settings_test.dart
@@ -64,6 +64,7 @@ void main() {
       expect(agents.agentStatusHooks.anyEnabled, isFalse);
       expect(agents.agentStatusNotificationsEnabled, isFalse);
       expect(agents.keepComputerAwakeWhileAgentsWork, isFalse);
+      expect(agents.showTabTitlesInSidebar, isFalse);
       expect(agents.defaultAgentProfileId, isNull);
     });
 
@@ -147,6 +148,7 @@ void main() {
         },
         'agentStatusNotificationsEnabled': true,
         'keepComputerAwakeWhileAgentsWork': true,
+        'showTabTitlesInSidebar': true,
         'defaultAgentProfileId': 'prof_1',
       });
 
@@ -166,6 +168,7 @@ void main() {
       expect(agents.agentStatusHooks.amp, isTrue);
       expect(agents.agentStatusNotificationsEnabled, isTrue);
       expect(agents.keepComputerAwakeWhileAgentsWork, isTrue);
+      expect(agents.showTabTitlesInSidebar, isTrue);
       expect(agents.defaultAgentProfileId, 'prof_1');
 
       final hooks = AgentStatusHookSettings.fromJson(<String, Object?>{

--- a/test/unit/settings_controller_test.dart
+++ b/test/unit/settings_controller_test.dart
@@ -238,6 +238,7 @@ void main() {
         await controller.setAgentStatusHookEnabled(.fx, true);
         await controller.setAgentStatusNotificationsEnabled(true);
         await controller.setKeepComputerAwakeWhileAgentsWork(true);
+        await controller.setShowTabTitlesInSidebar(true);
         await controller.setKeepAliveEnabled(true);
         await controller.setShowTrayIcon(false);
         await controller.setShowDockBadge(false);
@@ -272,6 +273,7 @@ void main() {
         expect(restored.agents.agentStatusHooks.fx, isTrue);
         expect(restored.agents.agentStatusNotificationsEnabled, isTrue);
         expect(restored.agents.keepComputerAwakeWhileAgentsWork, isTrue);
+        expect(restored.agents.showTabTitlesInSidebar, isTrue);
         expect(restored.general.keepAliveEnabled, isTrue);
         expect(restored.general.showTrayIcon, isFalse);
         expect(restored.general.showDockBadge, isFalse);

--- a/test/unit/settings_search_entries_test.dart
+++ b/test/unit/settings_search_entries_test.dart
@@ -31,7 +31,7 @@ void main() {
 
     expect(
       _catalogFingerprint(catalogs),
-      '9899fa14f7e0490fac5b50efff87c4d9e3bd889fbdb89013ef7ffb8b71058811',
+      '03b7dccd26a070b27f20be5ccd85ab946ec9af945891530e47792c9b6650cd79',
     );
   });
 
@@ -87,6 +87,13 @@ void main() {
         entries: agentsSearchEntries,
         query: 'xai',
         expected: <(String, String?)>[('Grok Build Hooks', 'hooks')],
+      ),
+      (
+        entries: agentsSearchEntries,
+        query: 'sidebar',
+        expected: <(String, String?)>[
+          ('Show Tab Titles in Sidebar', 'behavior'),
+        ],
       ),
       (
         entries: browserSearchEntries,
@@ -149,6 +156,16 @@ void main() {
     expect(entry.matches('canvas'), isTrue);
     expect(entry.matches('decision'), isTrue);
     expect(entry.groupId, 'cliSkill');
+  });
+
+  test('sidebar tab titles are searchable in the agents behavior group', () {
+    final entry = agentsSearchEntries.singleWhere(
+      (candidate) => candidate.title == 'Show Tab Titles in Sidebar',
+    );
+
+    expect(entry.matches('sidebar'), isTrue);
+    expect(entry.matches('regenerate'), isTrue);
+    expect(entry.groupId, 'behavior');
   });
 
   test('Grok Build hooks are searchable in the hooks group', () {

--- a/test/widget/alera_shell_page_sidebar_states_test_cases.dart
+++ b/test/widget/alera_shell_page_sidebar_states_test_cases.dart
@@ -97,6 +97,105 @@ void _registerAleraShellSidebarStateTests() {
     expect(find.text('Ready to continue'), findsNothing);
   });
 
+  testWidgets('sidebar agent rows can show tab titles and regenerate them', (
+    tester,
+  ) async {
+    await _pumpShell(
+      tester,
+      state: _stackedWorkbenchState().copyWith(
+        tabsByWorkspace: <String, List<WorkspaceTabRecord>>{
+          'workspace-1': <WorkspaceTabRecord>[
+            WorkspaceTabRecord(
+              id: 'tab-1',
+              workspaceId: 'workspace-1',
+              title: 'Map Monetization',
+              createdAt: DateTime.utc(2026, 5, 22),
+              updatedAt: DateTime.utc(2026, 5, 22),
+              payload: const <String, Object?>{
+                'agentTitleSource': 'generated',
+                'manualTitle': true,
+              },
+            ),
+            WorkspaceTabRecord(
+              id: 'tab-2',
+              workspaceId: 'workspace-1',
+              title: 'Terminal 2',
+              createdAt: DateTime.utc(2026, 5, 22),
+              updatedAt: DateTime.utc(2026, 5, 22),
+            ),
+          ],
+        },
+      ),
+      settings: AleraSettings.defaults.copyWith(
+        agents: const AgentSettings(showTabTitlesInSidebar: true),
+      ),
+      agentTitlesAvailable: true,
+      agentStatuses: <String, AgentStatusEntry>{
+        'tab-1': _agentStatusEntry(
+          terminalSessionId: 'tab-1',
+          workspaceId: 'workspace-1',
+          tabId: 'tab-1',
+          state: .waiting,
+          lastAssistantMessage: '**paymentBroker**',
+        ),
+        'tab-2': _agentStatusEntry(
+          terminalSessionId: 'tab-2',
+          workspaceId: 'workspace-1',
+          tabId: 'tab-2',
+          state: .waiting,
+          lastAssistantMessage: 'Ready to continue',
+        ),
+      },
+    );
+
+    await tester.tap(find.byTooltip('Show Agent Runs'));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.descendant(
+        of: find.byType(ProjectWorkbenchSidebar),
+        matching: find.text('Map Monetization'),
+      ),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(
+        of: find.byType(ProjectWorkbenchSidebar),
+        matching: find.text('**paymentBroker**'),
+      ),
+      findsNothing,
+    );
+    expect(
+      find.descendant(
+        of: find.byType(ProjectWorkbenchSidebar),
+        matching: find.text('Ready to continue'),
+      ),
+      findsNothing,
+    );
+
+    await tester.tapAt(
+      tester.getCenter(
+        find.descendant(
+          of: find.byType(ProjectWorkbenchSidebar),
+          matching: find.text('Map Monetization'),
+        ),
+      ),
+      buttons: kSecondaryMouseButton,
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Regenerate Title'), findsOneWidget);
+    final entry = tester.widget<AleraDropdownEntry<Object?>>(
+      find.ancestor(
+        of: find.text('Regenerate Title'),
+        matching: find.byWidgetPredicate(
+          (widget) => widget is AleraDropdownEntry,
+        ),
+      ),
+    );
+    expect((entry.leading! as Icon).size, 16);
+  });
+
   testWidgets('selecting a workspace does not expand agent rows', (
     tester,
   ) async {

--- a/test/widget/alera_shell_page_test.dart
+++ b/test/widget/alera_shell_page_test.dart
@@ -6,8 +6,10 @@ import 'package:alera/src/features/workbench/infra/terminal_host/terminal_host_p
 import 'package:alera/src/app/providers.dart';
 import 'package:alera/src/app/theme/alera_tokens.dart';
 import 'package:alera/src/design_system/icons/alera_icons.dart';
+import 'package:alera/src/design_system/menus/alera_dropdown_entry.dart';
 import 'package:alera/src/design_system/feedback/alera_status_dot.dart';
 import 'package:alera/src/design_system/feedback/alera_toast.dart';
+import 'package:alera/src/features/ai_assist/application/agent_title_providers.dart';
 import 'package:alera/src/features/agent_profiles/application/agent_profile_providers.dart';
 import 'package:alera/src/features/agent_profiles/domain/agent_profile.dart';
 import 'package:alera/src/features/agent_status/domain/agent_status.dart';
@@ -68,6 +70,7 @@ Future<_ShellPumpHarness> _pumpShell(
   AleraSettings? settings,
   Map<String, AgentStatusEntry> agentStatuses =
       const <String, AgentStatusEntry>{},
+  bool agentTitlesAvailable = false,
 }) async {
   final shellController = controller ?? _ShellTestWorkbenchController(state);
   final runtime = terminalRuntime ?? _FakeTerminalRuntime();
@@ -102,6 +105,9 @@ Future<_ShellPumpHarness> _pumpShell(
           ),
         terminalHostWarmupCoordinatorProvider.overrideWith((ref) {}),
         settingsControllerProvider.overrideWith(() => settingsController),
+        agentTitleAvailableProvider.overrideWith(
+          (ref) async => agentTitlesAvailable,
+        ),
         if (workspaceFolderOpener != null)
           workspaceFolderOpenerProvider.overrideWith(
             (ref) => workspaceFolderOpener,

--- a/test/widget/settings_dialog_core_test_cases.dart
+++ b/test/widget/settings_dialog_core_test_cases.dart
@@ -550,6 +550,7 @@ void _registerSettingsDialogCoreTests() {
     ]) {
       expect(find.text(label), findsOneWidget);
     }
+    expect(find.text('Show Tab Titles in Sidebar'), findsOneWidget);
     expect(find.text('Agent Status Notifications'), findsOneWidget);
     expect(
       find.text('Keep Computer Awake While Agents Are Working'),
@@ -577,19 +578,23 @@ void _registerSettingsDialogCoreTests() {
       await tester.tap(find.byType(Switch).at(entry.switchIndex));
       await tester.pump(const Duration(milliseconds: 50));
     }
-    await tester.ensureVisible(find.text('Agent Status Notifications'));
+    await tester.ensureVisible(find.text('Show Tab Titles in Sidebar'));
     await tester.pump();
     await tester.tap(find.byType(Switch).at(11));
     await tester.pump(const Duration(milliseconds: 50));
-    await tester.ensureVisible(find.text('Agent Finished Notifications'));
+    await tester.ensureVisible(find.text('Agent Status Notifications'));
     await tester.pump();
     await tester.tap(find.byType(Switch).at(12));
+    await tester.pump(const Duration(milliseconds: 50));
+    await tester.ensureVisible(find.text('Agent Finished Notifications'));
+    await tester.pump();
+    await tester.tap(find.byType(Switch).at(13));
     await tester.pump(const Duration(milliseconds: 50));
     await tester.ensureVisible(
       find.text('Keep Computer Awake While Agents Are Working'),
     );
     await tester.pump();
-    await tester.tap(find.byType(Switch).at(13));
+    await tester.tap(find.byType(Switch).at(14));
     await tester.pump(const Duration(milliseconds: 50));
 
     final hooks = container
@@ -611,6 +616,7 @@ void _registerSettingsDialogCoreTests() {
     ], everyElement(isTrue));
     final behavior = container.read(settingsControllerProvider).agents;
     expect(<bool>[
+      behavior.showTabTitlesInSidebar,
       behavior.agentStatusNotificationsEnabled,
       behavior.agentStatusFinishedNotificationsEnabled,
       behavior.keepComputerAwakeWhileAgentsWork,

--- a/test/widget/workspace_workbench_view_tab_test_cases.dart
+++ b/test/widget/workspace_workbench_view_tab_test_cases.dart
@@ -46,6 +46,19 @@ void _registerWorkspaceWorkbenchViewTabTests() {
           find.text(label),
           mode == 'unsupported' ? findsNothing : findsOneWidget,
         );
+        if (mode != 'unsupported') {
+          final entry = tester.widget<AleraDropdownEntry<Object?>>(
+            find.ancestor(
+              of: find.text(label),
+              matching: find.byWidgetPredicate(
+                (widget) => widget is AleraDropdownEntry,
+              ),
+            ),
+          );
+          expect(entry.leading, isA<Icon>());
+          expect((entry.leading! as Icon).size, 16);
+          expect((entry.leading! as Icon).icon, AleraIcons.ai);
+        }
         if (mode == 'generating') {
           expect(find.byTooltip('Generating title...'), findsOneWidget);
           final entry = tester.widget<AleraDropdownEntry<Object?>>(


### PR DESCRIPTION
## Summary

The generate-title icon in the tab menu now matches the other 16px entries.

Workspace agent rows in the left sidebar can show each tab's persisted title instead of the latest activity snippet. Right-click on those rows offers Generate Title / Regenerate Title. The toggle lives in Settings > Agents > Behavior > Show Tab Titles in Sidebar and is included in portable Configuration Sync.

## Screenshots

No new screenshots. The visual changes are the smaller generate-title icon in the tab menu, optional title text in sidebar agent rows, and a new settings switch.

## Testing

- [x] `dart format --set-exit-if-changed lib test packages/alera_configuration`
- [x] `flutter analyze` on the changed Dart files
- [x] unit tests for settings, portable fields, title action labels, and search entries
- [x] widget tests for the tab menu icon, settings pane, and sidebar title/regenerate flow
- [ ] `flutter test --coverage --exclude-tags golden`
- [ ] Golden tests, if UI changed: `flutter test --tags golden`
- [ ] Desktop E2E, if app-shell flow changed: `flutter test integration_test -d macos`
- [ ] Relevant desktop build: `flutter build macos`, `flutter build windows`, or `flutter build linux`
- [ ] Landing build, if applicable: `cd landing && bun run build`
- [x] Added or updated tests that would catch regressions, or explained why tests were not needed

## AI Review Report

Checked locally against the existing tab-menu, sidebar, settings, and portable-settings tests. Cross-platform behavior is settings-driven and does not add platform-specific shortcuts, paths, or shell commands. The generate-title action reuses the existing runtime `aiText.agentTitle.generate` path already used from the tab menu.

## Security Audit

No new command execution, path handling, auth, secrets, or process-spawn paths. The setting is a boolean display preference added to the existing desktop portable allowlist.

## Notes

The setting defaults off so current activity snippets stay in the sidebar until it is enabled. Regeneration from sidebar rows is available whenever AI Assist title generation is advertised, independent of the display toggle.