### PR TITLE
fix: move rename tab above generate title action

### DIFF
--- a/lib/src/features/workbench/presentation/workspace_workbench_tab_menu.dart
+++ b/lib/src/features/workbench/presentation/workspace_workbench_tab_menu.dart
@@ -83,15 +83,6 @@ extension _WorkspaceTabMenu on _WorkspaceTabChip {
           ),
           enabled: closeRight.isNotEmpty,
         ),
-        if ((tab.kind == WorkspaceTabKind.terminal ||
-                tab.kind == WorkspaceTabKind.codex) &&
-            ref.read(agentTitleAvailableProvider).value == true)
-          AleraDropdownEntry<_TabMenuAction>(
-            value: .generateTitle,
-            label: agentTitleActionLabel(tab.payload),
-            enabled: !isAgentTitleGenerating(tab.payload),
-            leading: const Icon(AleraIcons.ai, size: 16),
-          ),
         if (tab.kind !=
             WorkspaceTabKind.codex) ...<PopupMenuEntry<_TabMenuAction>>[
           const PopupMenuDivider(height: AleraTokens.space8),
@@ -101,6 +92,15 @@ extension _WorkspaceTabMenu on _WorkspaceTabChip {
             leading: Icon(AleraIcons.edit, size: 16),
           ),
         ],
+        if ((tab.kind == WorkspaceTabKind.terminal ||
+                tab.kind == WorkspaceTabKind.codex) &&
+            ref.read(agentTitleAvailableProvider).value == true)
+          AleraDropdownEntry<_TabMenuAction>(
+            value: .generateTitle,
+            label: agentTitleActionLabel(tab.payload),
+            enabled: !isAgentTitleGenerating(tab.payload),
+            leading: const Icon(AleraIcons.ai, size: 16),
+          ),
       ],
     );
     if (selected == null || !context.mounted) {

--- a/mobile/lib/src/features/terminal/presentation/workspace_tabs_screen.dart
+++ b/mobile/lib/src/features/terminal/presentation/workspace_tabs_screen.dart
@@ -197,6 +197,12 @@ class _WorkspaceTabsScreenState extends ConsumerState<WorkspaceTabsScreen> {
         child: Column(
           mainAxisSize: .min,
           children: <Widget>[
+            if (canRename)
+              ListTile(
+                leading: const Icon(Icons.edit_outlined),
+                title: const Text('Rename Tab'),
+                onTap: () => Navigator.of(context).pop('rename'),
+              ),
             if (canGenerateTitle && (tab.isTerminal || tab.isCodex))
               ListTile(
                 leading: const Icon(Icons.auto_awesome_outlined),
@@ -209,12 +215,6 @@ class _WorkspaceTabsScreenState extends ConsumerState<WorkspaceTabsScreen> {
                 ),
                 enabled: tab.payload['agentTitleStatus'] != 'generating',
                 onTap: () => Navigator.of(context).pop('generateTitle'),
-              ),
-            if (canRename)
-              ListTile(
-                leading: const Icon(Icons.edit_outlined),
-                title: const Text('Rename Tab'),
-                onTap: () => Navigator.of(context).pop('rename'),
               ),
             if (tab.isTerminal || tab.isCodex)
               ListTile(

--- a/mobile/test/agent_title_actions_test.dart
+++ b/mobile/test/agent_title_actions_test.dart
@@ -76,6 +76,12 @@ void main() {
           find.text(label),
           mode == 'unsupported' ? findsNothing : findsOneWidget,
         );
+        if (kind == 'terminal' && mode != 'unsupported') {
+          expect(
+            tester.getTopLeft(find.text('Rename Tab')).dy,
+            lessThan(tester.getTopLeft(find.text(label)).dy),
+          );
+        }
         if (mode == 'busy') {
           expect(find.byTooltip('Generating title...'), findsOneWidget);
           expect(

--- a/test/widget/workspace_workbench_view_tab_test_cases.dart
+++ b/test/widget/workspace_workbench_view_tab_test_cases.dart
@@ -46,6 +46,12 @@ void _registerWorkspaceWorkbenchViewTabTests() {
           find.text(label),
           mode == 'unsupported' ? findsNothing : findsOneWidget,
         );
+        if (kind == WorkspaceTabKind.terminal && mode != 'unsupported') {
+          expect(
+            tester.getTopLeft(find.text('Change Title')).dy,
+            lessThan(tester.getTopLeft(find.text(label)).dy),
+          );
+        }
         if (mode != 'unsupported') {
           final entry = tester.widget<AleraDropdownEntry<Object?>>(
             find.ancestor(


### PR DESCRIPTION
## What changed

- Reordered the desktop workspace tab menu so **Rename Tab** appears before **Generate Title**.
- Reordered the mobile workspace tab sheet actions so **Rename Tab** appears before **Generate Title** for terminal/codex tabs.
- Kept both actions gated by the same existing conditions (availability/feature flags and busy state handling).
- Updated widget tests to validate ordering on both desktop and mobile flows so regression coverage includes this menu-priority behavior.

## Why

- This aligns the action list with expected user flow by surfacing explicit, direct renaming first and moving AI-assisted title generation to a secondary position.
- The change is a UI behavior-only adjustment, preserving existing action behavior while improving usability consistency across platforms.