### PR TITLE
fix: include selected workspace when toggling tree pin state

### DIFF
--- a/lib/src/features/workbench/application/workbench_controller_projects.dart
+++ b/lib/src/features/workbench/application/workbench_controller_projects.dart
@@ -5,9 +5,8 @@ mixin _WorkbenchControllerProjects
         _$WorkbenchController,
         _WorkbenchControllerInternals,
         _WorkbenchControllerTabOpening {
-  Future<List<String>> listSourceBranches(Project project) {
-    return _workspaceService.listSourceBranches(project);
-  }
+  Future<List<String>> listSourceBranches(Project project) =>
+      _workspaceService.listSourceBranches(project);
 
   Future<Project> addLocalProject({required String path, String? name}) async {
     try {
@@ -42,9 +41,8 @@ mixin _WorkbenchControllerProjects
     }
   }
 
-  Future<Project> addProject({required String repoPath, String? name}) {
-    return addLocalProject(path: repoPath, name: name);
-  }
+  Future<Project> addProject({required String repoPath, String? name}) =>
+      addLocalProject(path: repoPath, name: name);
 
   Future<void> renameProject({
     required String projectId,
@@ -248,8 +246,8 @@ mixin _WorkbenchControllerProjects
     }
   }
 
-  /// Pins or unpins every descendant of [workspaceId], leaving the workspace
-  /// itself unchanged. No-ops descendants that already match [isPinned].
+  /// Pins or unpins [workspaceId] and every descendant of [workspaceId].
+  /// No-ops workspaces that already match [isPinned].
   Future<void> setWorkspaceTreePinned({
     required String workspaceId,
     required bool isPinned,
@@ -257,7 +255,10 @@ mixin _WorkbenchControllerProjects
     final workspaces = <Workspace>[
       for (final group in state.workspacesByProject.values) ...group,
     ];
-    for (final id in workspaceIdsDescendedFrom(workspaces, workspaceId)) {
+    for (final id in [
+      workspaceId,
+      ...workspaceIdsDescendedFrom(workspaces, workspaceId),
+    ]) {
       Workspace? current;
       for (final workspace in workspaces) {
         if (workspace.id == id) {

--- a/mobile/lib/src/features/workbench/application/workspace_list_controller.dart
+++ b/mobile/lib/src/features/workbench/application/workspace_list_controller.dart
@@ -139,16 +139,19 @@ class WorkspaceListController extends _$WorkspaceListController {
     _invalidateIfMounted();
   }
 
-  /// Pins or unpins every descendant of [workspaceId], leaving the workspace
-  /// itself unchanged. Reloads once after the last mutation.
+  /// Pins or unpins [workspaceId] and every descendant of [workspaceId].
+  /// Reloads once after the last mutation.
   Future<void> setTreePinned(String workspaceId, bool isPinned) async {
     final data = state.value;
     if (data == null) {
       return;
     }
-    final descendantIds = workspaceDescendantIds(data.workspaces, workspaceId);
+    final targetIds = <String>[
+      workspaceId,
+      ...workspaceDescendantIds(data.workspaces, workspaceId),
+    ];
     final client = await ref.read(workspaceClientProvider(hostId).future);
-    for (final id in descendantIds) {
+    for (final id in targetIds) {
       final workspace = data.workspaceById(id);
       if (workspace == null || workspace.isPinned == isPinned) {
         continue;

--- a/mobile/lib/src/features/workbench/application/workspace_list_controller.g.dart
+++ b/mobile/lib/src/features/workbench/application/workspace_list_controller.g.dart
@@ -52,7 +52,7 @@ final class WorkspaceListControllerProvider
 }
 
 String _$workspaceListControllerHash() =>
-    r'5ebe9317cb1f78eca3906a4897b0fb7ec5f3306c';
+    r'458c7aaee0503a7fcd56ec981b009cf4f5a14ca3';
 
 final class WorkspaceListControllerFamily extends $Family
     with

--- a/mobile/test/workspace_list_controller_test.dart
+++ b/mobile/test/workspace_list_controller_test.dart
@@ -107,16 +107,10 @@ void main() {
     );
     await container.read(workspaceListControllerProvider('host-1').future);
 
-    await notifier.setPinned('a', true);
-    expect(client.calls, contains('setPinned a true'));
-
     await notifier.setTreePinned('a', true);
+    expect(client.calls, contains('setPinned a true'));
     expect(client.calls, contains('setPinned child true'));
     expect(client.calls, contains('setPinned grandchild true'));
-    expect(
-      client.calls.where((call) => call == 'setPinned a true'),
-      hasLength(1),
-    );
 
     await notifier.linkParent(childWorkspaceId: 'a', parentWorkspaceId: 'b');
     expect(client.calls, contains('link b a'));

--- a/test/unit/workbench_controller_pinning_test_cases.dart
+++ b/test/unit/workbench_controller_pinning_test_cases.dart
@@ -42,7 +42,7 @@ void _registerWorkbenchControllerPinningTests() {
     expect(_controller.state.error, isNull);
   });
 
-  test('pins every descendant without changing the parent pin', () async {
+  test('pins the workspace and every descendant', () async {
     await _controller.bootstrap();
     final parent = await _selectMainWorkspace(_controller, _harness);
     final child = await _harness.workbenchRepository.upsertWorkspace(
@@ -77,7 +77,7 @@ void _registerWorkbenchControllerPinningTests() {
           .workspacesFor(parent.projectId)
           .firstWhere((workspace) => workspace.id == parent.id)
           .isPinned,
-      isFalse,
+      isTrue,
     );
     expect(
       _controller.state


### PR DESCRIPTION
## What changed
- Updated `setWorkspaceTreePinned` in `lib/src/features/workbench/application/workbench_controller_projects.dart` to pin/unpin both the selected workspace and all descendants.
- Updated `setTreePinned` in `mobile/lib/src/features/workbench/application/workspace_list_controller.dart` to use the same selection scope (workspace + descendants), keeping behavior consistent across desktop and mobile.
- Refined doc comments in both controllers to describe the new tree-pinning scope.
- Minor cleanup in `workbench_controller_projects.dart` by simplifying two trivial forwarding methods to expression-bodied style.
- Adjusted tests to match the new behavior:
  - `mobile/test/workbench_list_controller_test.dart` now expects the selected workspace `a` to be pinned as part of tree pinning.
  - `test/unit/workbench_controller_pinning_test_cases.dart` now verifies the selected workspace is pinned, not left unchanged.

## Why
The previous implementation only toggled descendants when pinning a tree, so the chosen root workspace remained unchanged, which created a confusing and inconsistent user expectation. This change makes tree pin/unpin operations act on the full selected subtree including the root node, matching typical UI behavior.