### PR TITLE
feat: show pull request status in workspace sidebar

### DIFF
--- a/lib/src/app/theme/alera_tokens.dart
+++ b/lib/src/app/theme/alera_tokens.dart
@@ -117,6 +117,7 @@ abstract final class AleraTokens {
   static const Color codexDiffDeletionBackground = Color(0x1AF87171);
   static const Color onError = Color(0xFF2C0D0D);
   static const Color warning = Color(0xFFF59E0B);
+  static const Color done = Color(0xFFA78BFA);
   static const Color syntaxKeyword = Color(0xFFC792EA);
   static const Color syntaxOperator = Color(0xFF89DDFF);
   static const Color syntaxFunction = Color(0xFF82AAFF);

--- a/lib/src/design_system/icons/alera_icons.dart
+++ b/lib/src/design_system/icons/alera_icons.dart
@@ -104,6 +104,7 @@ abstract final class const AleraIcons._() {
   static const IconData gitMerge = LucideIcons.gitMerge;
   static const IconData gitPullRequest = LucideIcons.gitPullRequest;
   static const IconData gitPullRequestClosed = LucideIcons.gitPullRequestClosed;
+  static const IconData gitPullRequestDraft = LucideIcons.gitPullRequestDraft;
   static const IconData review = LucideIcons.fileSearch;
   static const IconData checks = LucideIcons.listChecks;
   static const IconData diff = LucideIcons.gitCompare;

--- a/lib/src/features/agent_status/infra/desktop_agent_status_notification_service.dart
+++ b/lib/src/features/agent_status/infra/desktop_agent_status_notification_service.dart
@@ -19,6 +19,8 @@ class DesktopAgentStatusNotificationService({
   this : _plugin = plugin ?? FlutterLocalNotificationsPlugin();
 
   final FlutterLocalNotificationsPlugin _plugin;
+  final List<AgentStatusNotificationSelectionHandler> _selectionHandlers =
+      <AgentStatusNotificationSelectionHandler>[];
   Future<void>? _initializing;
   bool _initialized = false;
 
@@ -26,15 +28,16 @@ class DesktopAgentStatusNotificationService({
   Future<void> initialize({
     required AgentStatusNotificationSelectionHandler onSelected,
   }) {
+    if (!_selectionHandlers.contains(onSelected)) {
+      _selectionHandlers.add(onSelected);
+    }
     if (_initialized) {
       return Future<void>.value();
     }
-    return _initializing ??= _initialize(onSelected);
+    return _initializing ??= _initialize();
   }
 
-  Future<void> _initialize(
-    AgentStatusNotificationSelectionHandler onSelected,
-  ) async {
+  Future<void> _initialize() async {
     await _plugin.initialize(
       settings: const InitializationSettings(
         macOS: DarwinInitializationSettings(
@@ -56,7 +59,12 @@ class DesktopAgentStatusNotificationService({
         if (payload == null || payload.isEmpty) {
           return;
         }
-        onSelected(payload);
+        for (final handler
+            in List<AgentStatusNotificationSelectionHandler>.from(
+              _selectionHandlers,
+            )) {
+          handler(payload);
+        }
       },
     );
     _initialized = true;

--- a/lib/src/features/pull_requests/application/forge_review_batch_provider.dart
+++ b/lib/src/features/pull_requests/application/forge_review_batch_provider.dart
@@ -1,0 +1,33 @@
+import 'package:alera/src/features/pull_requests/domain/hosted_review.dart';
+import 'package:alera/src/features/pull_requests/domain/review_check.dart';
+import 'package:alera/src/shared/git_hosting/domain/git_remote_identity.dart';
+
+/// One hosted review plus the check runs attached to its current head commit.
+class const ForgeReviewSnapshot({
+  required this.review,
+  this.checks = const <ReviewCheck>[],
+}) {
+  final HostedReview review;
+  final List<ReviewCheck> checks;
+}
+
+/// Results of one provider request, indexed both by branch and review number.
+class const ForgeReviewBatch({
+  this.byBranch = const <String, ForgeReviewSnapshot>{},
+  this.byNumber = const <int, ForgeReviewSnapshot>{},
+}) {
+  final Map<String, ForgeReviewSnapshot> byBranch;
+  final Map<int, ForgeReviewSnapshot> byNumber;
+}
+
+/// Optional fast path for forge implementations that can retrieve multiple
+/// branches and review numbers in one request. The monitor falls back to the
+/// regular forge methods when this interface is unavailable.
+abstract interface class ForgeReviewBatchProvider {
+  Future<ForgeReviewBatch> getReviewBatch({
+    required GitRemoteIdentity identity,
+    required String repoPath,
+    required Set<String> branches,
+    required Set<int> reviewNumbers,
+  });
+}

--- a/lib/src/features/pull_requests/application/workspace_pull_request_controller.dart
+++ b/lib/src/features/pull_requests/application/workspace_pull_request_controller.dart
@@ -13,6 +13,7 @@ import 'package:alera/src/features/pull_requests/application/pull_request_provid
 import 'package:alera/src/features/pull_requests/application/review_reference_parser.dart';
 import 'package:alera/src/features/pull_requests/application/workspace_pull_request_state.dart';
 import 'package:alera/src/features/pull_requests/application/workspace_pull_request_loader.dart';
+import 'package:alera/src/features/pull_requests/application/workspace_pull_request_refresh_signal.dart';
 import 'package:alera/src/features/pull_requests/domain/create_review_input.dart';
 import 'package:alera/src/features/pull_requests/domain/create_review_result.dart';
 import 'package:alera/src/features/pull_requests/domain/forge_auth_status.dart';
@@ -222,6 +223,12 @@ class WorkspacePullRequestController extends _$WorkspacePullRequestController
     );
   }
 
+  void _refreshWorkspacePullRequestMonitor() {
+    ref
+        .read(workspacePullRequestRefreshSignalProvider.notifier)
+        .requestRefresh();
+  }
+
   /// Clears the in-flight action; a non-null [failureMessage] surfaces it.
   void _applyActionOutcome({String? failureMessage}) {
     if (_disposed) {
@@ -297,6 +304,7 @@ class WorkspacePullRequestController extends _$WorkspacePullRequestController
       if (!_disposed) {
         state = AsyncData(_applyPendingCommentBodies(reloaded));
         _resetPollInterval();
+        _refreshWorkspacePullRequestMonitor();
       }
     } on _ActionError catch (error) {
       await _recordActionFailure(

--- a/lib/src/features/pull_requests/application/workspace_pull_request_controller.g.dart
+++ b/lib/src/features/pull_requests/application/workspace_pull_request_controller.g.dart
@@ -57,7 +57,7 @@ final class WorkspacePullRequestControllerProvider
 }
 
 String _$workspacePullRequestControllerHash() =>
-    r'83182b160444190446483481a3cabff6a89936e8';
+    r'71a690b3532dc3c612db11cc2af968bd079c427a';
 
 final class WorkspacePullRequestControllerFamily extends $Family
     with

--- a/lib/src/features/pull_requests/application/workspace_pull_request_monitor.dart
+++ b/lib/src/features/pull_requests/application/workspace_pull_request_monitor.dart
@@ -1,0 +1,289 @@
+import 'package:alera/src/features/pull_requests/application/forge_provider.dart';
+import 'package:alera/src/features/pull_requests/application/forge_provider_registry.dart';
+import 'package:alera/src/features/pull_requests/application/forge_review_batch_provider.dart';
+import 'package:alera/src/features/pull_requests/application/linked_review_repository.dart';
+import 'package:alera/src/features/pull_requests/domain/hosted_review.dart';
+import 'package:alera/src/features/pull_requests/domain/linked_review.dart';
+import 'package:alera/src/features/pull_requests/domain/review_check.dart';
+import 'package:alera/src/features/pull_requests/domain/workspace_pull_request_summary.dart';
+import 'package:alera/src/shared/git_hosting/application/hosting_provider_resolver.dart';
+import 'package:alera/src/shared/git_hosting/domain/git_hosting_provider.dart';
+import 'package:alera/src/shared/git_hosting/domain/git_remote_identity.dart';
+import 'package:alera/src/shared/infra/git/git_backend.dart';
+import 'package:logging/logging.dart';
+
+final Logger _monitorLog = Logger('WorkspacePullRequestMonitor');
+
+/// Immutable input describing one workspace that can be matched to a hosted
+/// pull request. Workspaces in the same repository share one provider request.
+class const WorkspacePullRequestMonitorTarget({
+  required this.projectId,
+  required this.projectName,
+  required this.workspaceId,
+  required this.workspaceName,
+  required this.repoPath,
+  required this.branch,
+  this.providerOverride,
+}) {
+  final String projectId;
+  final String projectName;
+  final String workspaceId;
+  final String workspaceName;
+  final String repoPath;
+  final String branch;
+  final GitHostingProvider? providerOverride;
+
+  String get configurationKey => <Object?>[
+    projectId,
+    projectName,
+    workspaceId,
+    workspaceName,
+    repoPath,
+    branch,
+    providerOverride?.name,
+  ].join('|');
+}
+
+class const WorkspacePullRequestMonitorLoadResult({
+  required this.summaries,
+  this.hadErrors = false,
+}) {
+  final Map<String, WorkspacePullRequestSummary> summaries;
+  final bool hadErrors;
+}
+
+/// Loads compact PR/check status while doing repository/provider work once per
+/// repository. GitHub supplies a true one-request batch; other forges use the
+/// existing neutral methods sequentially as a bounded fallback.
+class const WorkspacePullRequestMonitorLoader(
+  this._gitBackend,
+  this._registry,
+  this._linkedReviews,
+) {
+  final GitBackend _gitBackend;
+  final ForgeProviderRegistry _registry;
+  final LinkedReviewRepository _linkedReviews;
+
+  Future<WorkspacePullRequestMonitorLoadResult> load({
+    required List<WorkspacePullRequestMonitorTarget> targets,
+    Map<String, WorkspacePullRequestSummary> previous =
+        const <String, WorkspacePullRequestSummary>{},
+  }) async {
+    final activeIds = <String>{
+      for (final target in targets) target.workspaceId,
+    };
+    final next = <String, WorkspacePullRequestSummary>{
+      for (final entry in previous.entries)
+        if (activeIds.contains(entry.key)) entry.key: entry.value,
+    };
+    final grouped = <String, List<WorkspacePullRequestMonitorTarget>>{};
+    var hadErrors = false;
+    for (final target in targets) {
+      final key = <Object?>[
+        target.repoPath,
+        target.providerOverride?.name,
+      ].join('|');
+      grouped
+          .putIfAbsent(key, () => <WorkspacePullRequestMonitorTarget>[])
+          .add(target);
+    }
+
+    for (final group in grouped.values) {
+      try {
+        final loaded = await _loadProject(group, previous);
+        for (final target in group) {
+          next.remove(target.workspaceId);
+        }
+        next.addAll(loaded);
+      } on Object catch (error, stackTrace) {
+        hadErrors = true;
+        // Preserve the last known status for one transient provider failure;
+        // the single monitor timer will retry with backoff.
+        _monitorLog.warning(
+          'could not refresh pull requests for ${group.first.projectName}',
+          error,
+          stackTrace,
+        );
+      }
+    }
+    return WorkspacePullRequestMonitorLoadResult(
+      summaries: Map<String, WorkspacePullRequestSummary>.unmodifiable(next),
+      hadErrors: hadErrors,
+    );
+  }
+
+  Future<Map<String, WorkspacePullRequestSummary>> _loadProject(
+    List<WorkspacePullRequestMonitorTarget> targets,
+    Map<String, WorkspacePullRequestSummary> previous,
+  ) async {
+    final first = targets.first;
+    final remotes = await _gitBackend.listRemotes(first.repoPath);
+    final resolution = resolveHostingProvider(
+      remotes: remotes,
+      override: first.providerOverride,
+    );
+    if (resolution is! HostingProviderResolved) {
+      return const <String, WorkspacePullRequestSummary>{};
+    }
+    final identity = resolution.identity;
+    final forge = _registry.forProvider(identity.provider);
+    if (forge == null) {
+      return const <String, WorkspacePullRequestSummary>{};
+    }
+
+    final linkedByWorkspace = <String, LinkedReview?>{};
+    final branches = <String>{};
+    final reviewNumbers = <int>{};
+    for (final target in targets) {
+      final linked = await _linkedReviews.find(target.workspaceId);
+      linkedByWorkspace[target.workspaceId] = linked;
+      if (linked?.hasReview == true) {
+        reviewNumbers.add(linked!.number!);
+      } else {
+        branches.add(target.branch);
+      }
+      final previousNumber = previous[target.workspaceId]?.review.number;
+      if (previousNumber != null) {
+        // Keeps terminal transitions visible on providers whose branch lookup
+        // only returns open reviews.
+        reviewNumbers.add(previousNumber);
+      }
+    }
+
+    final ForgeReviewBatch batch;
+    if (forge case final ForgeReviewBatchProvider batchProvider) {
+      batch = await batchProvider.getReviewBatch(
+        identity: identity,
+        repoPath: first.repoPath,
+        branches: branches,
+        reviewNumbers: reviewNumbers,
+      );
+    } else {
+      batch = await _loadSequentially(
+        forge: forge,
+        identity: identity,
+        repoPath: first.repoPath,
+        branches: branches,
+        reviewNumbers: reviewNumbers,
+      );
+    }
+
+    final summaries = <String, WorkspacePullRequestSummary>{};
+    for (final target in targets) {
+      final linked = linkedByWorkspace[target.workspaceId];
+      ForgeReviewSnapshot? snapshot;
+      if (linked?.hasReview == true) {
+        snapshot = batch.byNumber[linked!.number];
+      } else {
+        snapshot = batch.byBranch[target.branch];
+        final previousNumber = previous[target.workspaceId]?.review.number;
+        snapshot ??= previousNumber == null
+            ? null
+            : batch.byNumber[previousNumber];
+      }
+      if (snapshot == null || _isDismissed(linked, snapshot, identity)) {
+        continue;
+      }
+      summaries[target.workspaceId] = WorkspacePullRequestSummary.fromChecks(
+        review: snapshot.review,
+        checks: snapshot.checks,
+      );
+    }
+    return summaries;
+  }
+
+  Future<ForgeReviewBatch> _loadSequentially({
+    required ForgeProvider forge,
+    required GitRemoteIdentity identity,
+    required String repoPath,
+    required Set<String> branches,
+    required Set<int> reviewNumbers,
+  }) async {
+    final byBranch = <String, ForgeReviewSnapshot>{};
+    final byNumber = <int, ForgeReviewSnapshot>{};
+    final orderedBranches = branches.toList()..sort();
+    for (final branch in orderedBranches) {
+      final review = await forge.getReviewForBranch(
+        identity: identity,
+        repoPath: repoPath,
+        branch: branch,
+      );
+      if (review == null) {
+        continue;
+      }
+      final snapshot = ForgeReviewSnapshot(
+        review: review,
+        checks: await _getChecksForActiveReview(
+          forge: forge,
+          identity: identity,
+          repoPath: repoPath,
+          review: review,
+        ),
+      );
+      byBranch[branch] = snapshot;
+      byNumber[review.number] = snapshot;
+    }
+    final orderedNumbers = reviewNumbers.toList()..sort();
+    for (final number in orderedNumbers) {
+      if (byNumber.containsKey(number)) {
+        continue;
+      }
+      final review = await forge.getReviewByNumber(
+        identity: identity,
+        repoPath: repoPath,
+        number: number,
+      );
+      if (review == null) {
+        continue;
+      }
+      final snapshot = ForgeReviewSnapshot(
+        review: review,
+        checks: await _getChecksForActiveReview(
+          forge: forge,
+          identity: identity,
+          repoPath: repoPath,
+          review: review,
+        ),
+      );
+      byNumber[number] = snapshot;
+      final branch = review.headBranch;
+      if (branch != null && branch.isNotEmpty) {
+        byBranch.putIfAbsent(branch, () => snapshot);
+      }
+    }
+    return ForgeReviewBatch(byBranch: byBranch, byNumber: byNumber);
+  }
+
+  Future<List<ReviewCheck>> _getChecksForActiveReview({
+    required ForgeProvider forge,
+    required GitRemoteIdentity identity,
+    required String repoPath,
+    required HostedReview review,
+  }) {
+    if (review.state == HostedReviewState.merged ||
+        review.state == HostedReviewState.closed) {
+      return Future<List<ReviewCheck>>.value(const <ReviewCheck>[]);
+    }
+    return forge.getChecks(
+      identity: identity,
+      repoPath: repoPath,
+      number: review.number,
+    );
+  }
+
+  bool _isDismissed(
+    LinkedReview? linked,
+    ForgeReviewSnapshot snapshot,
+    GitRemoteIdentity identity,
+  ) {
+    if (linked?.dismissed != true) {
+      return false;
+    }
+    if (linked!.hasDismissedReview) {
+      return linked.provider == identity.provider &&
+          linked.number == snapshot.review.number;
+    }
+    final createdAt = snapshot.review.createdAt;
+    return createdAt == null || !createdAt.isAfter(linked.linkedAt);
+  }
+}

--- a/lib/src/features/pull_requests/application/workspace_pull_request_monitor_providers.dart
+++ b/lib/src/features/pull_requests/application/workspace_pull_request_monitor_providers.dart
@@ -1,0 +1,327 @@
+import 'dart:async';
+
+import 'package:alera/src/features/app_window/application/app_window_providers.dart';
+import 'package:alera/src/features/projects/domain/project.dart';
+import 'package:alera/src/features/pull_requests/application/pull_request_providers.dart';
+import 'package:alera/src/features/pull_requests/application/workspace_pull_request_monitor.dart';
+import 'package:alera/src/features/pull_requests/application/workspace_pull_request_refresh_signal.dart';
+import 'package:alera/src/features/pull_requests/domain/workspace_pull_request_summary.dart';
+import 'package:alera/src/features/settings/application/settings_controller.dart';
+import 'package:alera/src/features/workbench/application/workbench_controller.dart';
+import 'package:alera/src/shared/infra/git/git_providers.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'workspace_pull_request_monitor_providers.g.dart';
+
+const Duration workspacePullRequestPendingPollInterval = Duration(seconds: 30);
+const Duration workspacePullRequestInitialPollInterval = Duration(minutes: 1);
+const Duration workspacePullRequestMaxPollInterval = Duration(minutes: 5);
+
+class const WorkspacePullRequestMonitorConfiguration({
+  required this.targets,
+  required this.showStatusInSidebar,
+  required this.failureNotificationsEnabled,
+}) {
+  final List<WorkspacePullRequestMonitorTarget> targets;
+  final bool showStatusInSidebar;
+  final bool failureNotificationsEnabled;
+
+  String get signature => <Object?>[
+    showStatusInSidebar,
+    failureNotificationsEnabled,
+    for (final target in targets) target.configurationKey,
+  ].join('\n');
+}
+
+class const WorkspacePullRequestMonitorState({
+  this.summaries = const <String, WorkspacePullRequestSummary>{},
+  this.refreshRevision = 0,
+}) {
+  final Map<String, WorkspacePullRequestSummary> summaries;
+  final int refreshRevision;
+}
+
+@Riverpod(keepAlive: true)
+WorkspacePullRequestMonitorLoader workspacePullRequestMonitorLoader(Ref ref) {
+  return WorkspacePullRequestMonitorLoader(
+    ref.watch(gitBackendProvider),
+    ref.watch(forgeProviderRegistryProvider),
+    ref.watch(linkedReviewRepositoryProvider),
+  );
+}
+
+@Riverpod(keepAlive: true)
+WorkspacePullRequestMonitorConfiguration
+workspacePullRequestMonitorConfiguration(Ref ref) {
+  final preferences = ref.watch(
+    settingsControllerProvider.select(
+      (settings) => (
+        showStatusInSidebar: settings.general.showPullRequestStatusInSidebar,
+        failureNotificationsEnabled:
+            settings.general.pullRequestFailureNotificationsEnabled,
+      ),
+    ),
+  );
+  final topology = ref.watch(
+    workbenchControllerProvider.select(
+      (state) => (
+        bootstrapped: state.bootstrapped,
+        projects: state.projects,
+        workspacesByProject: state.workspacesByProject,
+      ),
+    ),
+  );
+  final targets = <WorkspacePullRequestMonitorTarget>[];
+  if (topology.bootstrapped &&
+      (preferences.showStatusInSidebar ||
+          preferences.failureNotificationsEnabled)) {
+    for (final project in topology.projects) {
+      if (project.kind != ProjectKind.gitRepository) {
+        continue;
+      }
+      final providerOverride = ref
+          .watch(effectiveHostingProviderOverrideProvider(project.id))
+          .asData
+          ?.value;
+      for (final workspace
+          in topology.workspacesByProject[project.id] ?? const []) {
+        final branch = workspace.branch?.trim() ?? '';
+        if (!workspace.isActive || branch.isEmpty || branch == 'HEAD') {
+          continue;
+        }
+        targets.add(
+          WorkspacePullRequestMonitorTarget(
+            projectId: project.id,
+            projectName: project.name,
+            workspaceId: workspace.id,
+            workspaceName: workspace.name,
+            repoPath: project.repoPath,
+            branch: branch,
+            providerOverride: providerOverride,
+          ),
+        );
+      }
+    }
+  }
+  targets.sort((left, right) {
+    final projectOrder = left.projectId.compareTo(right.projectId);
+    return projectOrder != 0
+        ? projectOrder
+        : left.workspaceId.compareTo(right.workspaceId);
+  });
+  return WorkspacePullRequestMonitorConfiguration(
+    targets: List<WorkspacePullRequestMonitorTarget>.unmodifiable(targets),
+    showStatusInSidebar: preferences.showStatusInSidebar,
+    failureNotificationsEnabled: preferences.failureNotificationsEnabled,
+  );
+}
+
+/// One timer and one refresh pipeline for every workspace. Provider calls are
+/// grouped by repository in [WorkspacePullRequestMonitorLoader], and the timer
+/// parks while the app is hidden unless failure notifications are enabled.
+@Riverpod(keepAlive: true)
+class WorkspacePullRequestMonitorController
+    extends _$WorkspacePullRequestMonitorController {
+  List<WorkspacePullRequestMonitorTarget> _targets =
+      const <WorkspacePullRequestMonitorTarget>[];
+  String _configurationSignature = '';
+  bool _showStatusInSidebar = false;
+  bool _failureNotificationsEnabled = false;
+  bool _isForeground = true;
+  bool _refreshing = false;
+  bool _refreshRequested = false;
+  bool _disposed = false;
+  int _generation = 0;
+  Duration _pollInterval = workspacePullRequestInitialPollInterval;
+  Timer? _timer;
+  StreamSubscription<bool>? _foregroundSubscription;
+
+  @override
+  WorkspacePullRequestMonitorState build() {
+    final foreground = ref.watch(appForegroundProvider);
+    _isForeground = foreground.isForeground;
+    _foregroundSubscription = foreground.changes.distinct().listen(
+      _handleForegroundChanged,
+    );
+    ref.listen<WorkspacePullRequestMonitorConfiguration>(
+      workspacePullRequestMonitorConfigurationProvider,
+      (_, configuration) {
+        scheduleMicrotask(() => _configure(configuration));
+      },
+      fireImmediately: true,
+    );
+    ref.listen<int>(workspacePullRequestRefreshSignalProvider, (
+      previous,
+      next,
+    ) {
+      if (previous != null && next != previous) {
+        _schedule(Duration.zero);
+      }
+    });
+    ref.onDispose(() {
+      _disposed = true;
+      _timer?.cancel();
+      unawaited(_foregroundSubscription?.cancel());
+    });
+    return const WorkspacePullRequestMonitorState();
+  }
+
+  Future<void> refreshNow() async {
+    if (_disposed || !_shouldRun) {
+      return;
+    }
+    if (_refreshing) {
+      _refreshRequested = true;
+      return;
+    }
+    _timer?.cancel();
+    _timer = null;
+    _refreshing = true;
+    final generation = _generation;
+    final targets = List<WorkspacePullRequestMonitorTarget>.from(_targets);
+    try {
+      final result = await ref
+          .read(workspacePullRequestMonitorLoaderProvider)
+          .load(targets: targets, previous: state.summaries);
+      if (_disposed || generation != _generation) {
+        _refreshRequested = true;
+        return;
+      }
+      final next = result.summaries;
+      final changed = !_summaryMapsEqual(state.summaries, next);
+      state = WorkspacePullRequestMonitorState(
+        summaries: next,
+        refreshRevision: state.refreshRevision + 1,
+      );
+      if (result.hadErrors) {
+        _pollInterval = _doubleCapped(
+          _pollInterval,
+          workspacePullRequestMaxPollInterval,
+        );
+      } else if (next.values.any((summary) => summary.checksPending)) {
+        _pollInterval = workspacePullRequestPendingPollInterval;
+      } else if (changed) {
+        _pollInterval = workspacePullRequestInitialPollInterval;
+      } else {
+        _pollInterval = _doubleCapped(
+          _pollInterval,
+          workspacePullRequestMaxPollInterval,
+        );
+      }
+    } finally {
+      _refreshing = false;
+      if (!_disposed) {
+        if (_refreshRequested) {
+          _refreshRequested = false;
+          _schedule(Duration.zero);
+        } else {
+          _schedule(_pollInterval);
+        }
+      }
+    }
+  }
+
+  bool get _shouldRun =>
+      _targets.isNotEmpty &&
+      (_failureNotificationsEnabled || (_showStatusInSidebar && _isForeground));
+
+  void _configure(WorkspacePullRequestMonitorConfiguration configuration) {
+    if (_disposed || configuration.signature == _configurationSignature) {
+      return;
+    }
+    _configurationSignature = configuration.signature;
+    _targets = configuration.targets;
+    _showStatusInSidebar = configuration.showStatusInSidebar;
+    _failureNotificationsEnabled = configuration.failureNotificationsEnabled;
+    _generation++;
+    _pollInterval = workspacePullRequestInitialPollInterval;
+    final activeWorkspaceIds = <String>{
+      for (final target in _targets) target.workspaceId,
+    };
+    final pruned = <String, WorkspacePullRequestSummary>{
+      for (final entry in state.summaries.entries)
+        if (activeWorkspaceIds.contains(entry.key)) entry.key: entry.value,
+    };
+    if (!_summaryMapsEqual(state.summaries, pruned)) {
+      state = WorkspacePullRequestMonitorState(
+        summaries: Map<String, WorkspacePullRequestSummary>.unmodifiable(
+          pruned,
+        ),
+        refreshRevision: state.refreshRevision,
+      );
+    }
+    if (!_shouldRun) {
+      _timer?.cancel();
+      _timer = null;
+      return;
+    }
+    _schedule(Duration.zero);
+  }
+
+  void _handleForegroundChanged(bool foreground) {
+    if (_disposed || foreground == _isForeground) {
+      return;
+    }
+    _isForeground = foreground;
+    if (_shouldRun) {
+      _pollInterval = workspacePullRequestInitialPollInterval;
+      _schedule(Duration.zero);
+    } else {
+      _timer?.cancel();
+      _timer = null;
+    }
+  }
+
+  void _schedule(Duration delay) {
+    _timer?.cancel();
+    _timer = null;
+    if (!_shouldRun || _disposed) {
+      return;
+    }
+    _timer = Timer(delay, () => unawaited(refreshNow()));
+  }
+}
+
+@riverpod
+WorkspacePullRequestSummary? workspacePullRequestSummary(
+  Ref ref,
+  String workspaceId,
+) {
+  final visible = ref.watch(
+    settingsControllerProvider.select(
+      (settings) => settings.general.showPullRequestStatusInSidebar,
+    ),
+  );
+  if (!visible) {
+    return null;
+  }
+  return ref.watch(
+    workspacePullRequestMonitorControllerProvider.select(
+      (monitor) => monitor.summaries[workspaceId],
+    ),
+  );
+}
+
+Duration _doubleCapped(Duration value, Duration maximum) {
+  final doubled = Duration(microseconds: value.inMicroseconds * 2);
+  return doubled > maximum ? maximum : doubled;
+}
+
+bool _summaryMapsEqual(
+  Map<String, WorkspacePullRequestSummary> left,
+  Map<String, WorkspacePullRequestSummary> right,
+) {
+  if (identical(left, right)) {
+    return true;
+  }
+  if (left.length != right.length) {
+    return false;
+  }
+  for (final entry in left.entries) {
+    if (right[entry.key] != entry.value) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/lib/src/features/pull_requests/application/workspace_pull_request_monitor_providers.g.dart
+++ b/lib/src/features/pull_requests/application/workspace_pull_request_monitor_providers.g.dart
@@ -1,0 +1,284 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'workspace_pull_request_monitor_providers.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(workspacePullRequestMonitorLoader)
+final workspacePullRequestMonitorLoaderProvider =
+    WorkspacePullRequestMonitorLoaderProvider._();
+
+final class WorkspacePullRequestMonitorLoaderProvider
+    extends
+        $FunctionalProvider<
+          WorkspacePullRequestMonitorLoader,
+          WorkspacePullRequestMonitorLoader,
+          WorkspacePullRequestMonitorLoader
+        >
+    with $Provider<WorkspacePullRequestMonitorLoader> {
+  WorkspacePullRequestMonitorLoaderProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'workspacePullRequestMonitorLoaderProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() =>
+      _$workspacePullRequestMonitorLoaderHash();
+
+  @$internal
+  @override
+  $ProviderElement<WorkspacePullRequestMonitorLoader> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  WorkspacePullRequestMonitorLoader create(Ref ref) {
+    return workspacePullRequestMonitorLoader(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(WorkspacePullRequestMonitorLoader value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<WorkspacePullRequestMonitorLoader>(
+        value,
+      ),
+    );
+  }
+}
+
+String _$workspacePullRequestMonitorLoaderHash() =>
+    r'd7e7ca104e8dca739c1770121996783eba2dbecb';
+
+@ProviderFor(workspacePullRequestMonitorConfiguration)
+final workspacePullRequestMonitorConfigurationProvider =
+    WorkspacePullRequestMonitorConfigurationProvider._();
+
+final class WorkspacePullRequestMonitorConfigurationProvider
+    extends
+        $FunctionalProvider<
+          WorkspacePullRequestMonitorConfiguration,
+          WorkspacePullRequestMonitorConfiguration,
+          WorkspacePullRequestMonitorConfiguration
+        >
+    with $Provider<WorkspacePullRequestMonitorConfiguration> {
+  WorkspacePullRequestMonitorConfigurationProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'workspacePullRequestMonitorConfigurationProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() =>
+      _$workspacePullRequestMonitorConfigurationHash();
+
+  @$internal
+  @override
+  $ProviderElement<WorkspacePullRequestMonitorConfiguration> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  WorkspacePullRequestMonitorConfiguration create(Ref ref) {
+    return workspacePullRequestMonitorConfiguration(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(WorkspacePullRequestMonitorConfiguration value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride:
+          $SyncValueProvider<WorkspacePullRequestMonitorConfiguration>(value),
+    );
+  }
+}
+
+String _$workspacePullRequestMonitorConfigurationHash() =>
+    r'b3b6b7e4b4a94c6b98d9c4b525cbfa0fc2b60d9d';
+
+/// One timer and one refresh pipeline for every workspace. Provider calls are
+/// grouped by repository in [WorkspacePullRequestMonitorLoader], and the timer
+/// parks while the app is hidden unless failure notifications are enabled.
+
+@ProviderFor(WorkspacePullRequestMonitorController)
+final workspacePullRequestMonitorControllerProvider =
+    WorkspacePullRequestMonitorControllerProvider._();
+
+/// One timer and one refresh pipeline for every workspace. Provider calls are
+/// grouped by repository in [WorkspacePullRequestMonitorLoader], and the timer
+/// parks while the app is hidden unless failure notifications are enabled.
+final class WorkspacePullRequestMonitorControllerProvider
+    extends
+        $NotifierProvider<
+          WorkspacePullRequestMonitorController,
+          WorkspacePullRequestMonitorState
+        > {
+  /// One timer and one refresh pipeline for every workspace. Provider calls are
+  /// grouped by repository in [WorkspacePullRequestMonitorLoader], and the timer
+  /// parks while the app is hidden unless failure notifications are enabled.
+  WorkspacePullRequestMonitorControllerProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'workspacePullRequestMonitorControllerProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() =>
+      _$workspacePullRequestMonitorControllerHash();
+
+  @$internal
+  @override
+  WorkspacePullRequestMonitorController create() =>
+      WorkspacePullRequestMonitorController();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(WorkspacePullRequestMonitorState value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<WorkspacePullRequestMonitorState>(
+        value,
+      ),
+    );
+  }
+}
+
+String _$workspacePullRequestMonitorControllerHash() =>
+    r'5f7bc0c16f96007d8db2b1ff4f7526eb834404a5';
+
+/// One timer and one refresh pipeline for every workspace. Provider calls are
+/// grouped by repository in [WorkspacePullRequestMonitorLoader], and the timer
+/// parks while the app is hidden unless failure notifications are enabled.
+
+abstract class _$WorkspacePullRequestMonitorController
+    extends $Notifier<WorkspacePullRequestMonitorState> {
+  WorkspacePullRequestMonitorState build();
+  @$mustCallSuper
+  @override
+  WhenComplete runBuild() {
+    final ref =
+        this.ref
+            as $Ref<
+              WorkspacePullRequestMonitorState,
+              WorkspacePullRequestMonitorState
+            >;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<
+                WorkspacePullRequestMonitorState,
+                WorkspacePullRequestMonitorState
+              >,
+              WorkspacePullRequestMonitorState,
+              Object?,
+              Object?
+            >;
+    return element.handleCreate(ref, build);
+  }
+}
+
+@ProviderFor(workspacePullRequestSummary)
+final workspacePullRequestSummaryProvider =
+    WorkspacePullRequestSummaryFamily._();
+
+final class WorkspacePullRequestSummaryProvider
+    extends
+        $FunctionalProvider<
+          WorkspacePullRequestSummary?,
+          WorkspacePullRequestSummary?,
+          WorkspacePullRequestSummary?
+        >
+    with $Provider<WorkspacePullRequestSummary?> {
+  WorkspacePullRequestSummaryProvider._({
+    required WorkspacePullRequestSummaryFamily super.from,
+    required String super.argument,
+  }) : super(
+         retry: null,
+         name: r'workspacePullRequestSummaryProvider',
+         isAutoDispose: true,
+         dependencies: null,
+         $allTransitiveDependencies: null,
+       );
+
+  @override
+  String debugGetCreateSourceHash() => _$workspacePullRequestSummaryHash();
+
+  @override
+  String toString() {
+    return r'workspacePullRequestSummaryProvider'
+        ''
+        '($argument)';
+  }
+
+  @$internal
+  @override
+  $ProviderElement<WorkspacePullRequestSummary?> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  WorkspacePullRequestSummary? create(Ref ref) {
+    final argument = this.argument as String;
+    return workspacePullRequestSummary(ref, argument);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(WorkspacePullRequestSummary? value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<WorkspacePullRequestSummary?>(value),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is WorkspacePullRequestSummaryProvider &&
+        other.argument == argument;
+  }
+
+  @override
+  int get hashCode {
+    return argument.hashCode;
+  }
+}
+
+String _$workspacePullRequestSummaryHash() =>
+    r'34d2c215c2e39426fceefe7274280cdd3538f1cb';
+
+final class WorkspacePullRequestSummaryFamily extends $Family
+    with $FunctionalFamilyOverride<WorkspacePullRequestSummary?, String> {
+  WorkspacePullRequestSummaryFamily._()
+    : super(
+        retry: null,
+        name: r'workspacePullRequestSummaryProvider',
+        dependencies: null,
+        $allTransitiveDependencies: null,
+        isAutoDispose: true,
+      );
+
+  WorkspacePullRequestSummaryProvider call(String workspaceId) =>
+      WorkspacePullRequestSummaryProvider._(argument: workspaceId, from: this);
+
+  @override
+  String toString() => r'workspacePullRequestSummaryProvider';
+}

--- a/lib/src/features/pull_requests/application/workspace_pull_request_notification_providers.dart
+++ b/lib/src/features/pull_requests/application/workspace_pull_request_notification_providers.dart
@@ -1,0 +1,135 @@
+import 'dart:async';
+
+import 'package:alera/src/features/agent_status/application/agent_status_notifications.dart';
+import 'package:alera/src/features/agent_status/application/agent_status_providers.dart';
+import 'package:alera/src/features/pull_requests/application/workspace_pull_request_monitor_providers.dart';
+import 'package:alera/src/features/pull_requests/application/workspace_pull_request_notifications.dart';
+import 'package:alera/src/features/settings/application/settings_controller.dart';
+import 'package:alera/src/features/workbench/application/workbench_controller.dart';
+import 'package:alera/src/features/workbench/application/workbench_providers.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'workspace_pull_request_notification_providers.g.dart';
+
+@Riverpod(keepAlive: true)
+void workspacePullRequestFailureNotificationCoordinator(Ref ref) {
+  final presenter = ref.watch(agentStatusNotificationPresenterProvider);
+  final windowActivator = ref.watch(
+    agentStatusNotificationWindowActivatorProvider,
+  );
+  final tracker = WorkspacePullRequestFailureTracker();
+  var initialized = false;
+  Future<void>? initializing;
+
+  bool notificationsEnabled() => ref
+      .read(settingsControllerProvider)
+      .general
+      .pullRequestFailureNotificationsEnabled;
+
+  Future<void> activatePayload(String payload) async {
+    final decoded = decodeWorkspacePullRequestNotificationPayload(payload);
+    if (decoded == null) {
+      return;
+    }
+    await windowActivator.showAndFocus();
+    final state = ref.read(workbenchControllerProvider);
+    final workspace = findWorkspaceById(state, decoded.workspaceId);
+    if (workspace == null) {
+      return;
+    }
+    final project = findProjectById(state, workspace.projectId);
+    if (project == null) {
+      return;
+    }
+    await ref
+        .read(workbenchControllerProvider.notifier)
+        .selectWorkspace(project: project, workspace: workspace);
+  }
+
+  Future<void> ensureInitialized() async {
+    if (initialized) {
+      return;
+    }
+    initializing ??= presenter
+        .initialize(
+          onSelected: (payload) {
+            unawaited(activatePayload(payload).catchError(_ignorePrAsyncError));
+          },
+        )
+        .then<void>((_) {
+          initialized = true;
+        });
+    await initializing;
+  }
+
+  if (notificationsEnabled()) {
+    unawaited(ensureInitialized().catchError(_ignorePrAsyncError));
+  }
+  ref.listen<bool>(
+    settingsControllerProvider.select(
+      (settings) => settings.general.pullRequestFailureNotificationsEnabled,
+    ),
+    (previous, next) {
+      if (!next) {
+        tracker.reset();
+        return;
+      }
+      tracker.baseline(
+        ref.read(workspacePullRequestMonitorControllerProvider).summaries,
+      );
+      unawaited(ensureInitialized().catchError(_ignorePrAsyncError));
+    },
+  );
+
+  ref.listen<WorkspacePullRequestMonitorState>(
+    workspacePullRequestMonitorControllerProvider,
+    (previous, next) {
+      if (!notificationsEnabled() ||
+          previous?.refreshRevision == next.refreshRevision) {
+        return;
+      }
+      if (previous == null || previous.refreshRevision == 0) {
+        tracker.baseline(next.summaries);
+        return;
+      }
+      final failures = tracker.pending(next.summaries);
+      if (failures.isEmpty) {
+        return;
+      }
+      unawaited(
+        _showWorkspacePullRequestFailureNotifications(
+          ref: ref,
+          presenter: presenter,
+          ensureInitialized: ensureInitialized,
+          failures: failures,
+        ).catchError(_ignorePrAsyncError),
+      );
+    },
+  );
+}
+
+Future<void> _showWorkspacePullRequestFailureNotifications({
+  required Ref ref,
+  required Future<void> Function() ensureInitialized,
+  required AgentStatusNotificationPresenter presenter,
+  required List<WorkspacePullRequestFailure> failures,
+}) async {
+  await ensureInitialized();
+  final state = ref.read(workbenchControllerProvider);
+  for (final failure in failures) {
+    final workspace = findWorkspaceById(state, failure.workspaceId);
+    final project = workspace == null
+        ? null
+        : findProjectById(state, workspace.projectId);
+    await presenter.show(
+      composeWorkspacePullRequestFailureNotification(
+        failure: failure,
+        projectName: project?.name,
+        workspaceName: workspace?.name,
+      ),
+    );
+  }
+}
+
+void _ignorePrAsyncError(Object _, StackTrace _) {}

--- a/lib/src/features/pull_requests/application/workspace_pull_request_notification_providers.g.dart
+++ b/lib/src/features/pull_requests/application/workspace_pull_request_notification_providers.g.dart
@@ -1,0 +1,54 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'workspace_pull_request_notification_providers.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(workspacePullRequestFailureNotificationCoordinator)
+final workspacePullRequestFailureNotificationCoordinatorProvider =
+    WorkspacePullRequestFailureNotificationCoordinatorProvider._();
+
+final class WorkspacePullRequestFailureNotificationCoordinatorProvider
+    extends $FunctionalProvider<void, void, void>
+    with $Provider<void> {
+  WorkspacePullRequestFailureNotificationCoordinatorProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'workspacePullRequestFailureNotificationCoordinatorProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() =>
+      _$workspacePullRequestFailureNotificationCoordinatorHash();
+
+  @$internal
+  @override
+  $ProviderElement<void> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  void create(Ref ref) {
+    return workspacePullRequestFailureNotificationCoordinator(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(void value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<void>(value),
+    );
+  }
+}
+
+String _$workspacePullRequestFailureNotificationCoordinatorHash() =>
+    r'a9bae8698a010684d8ae1202e76bbc80b9e49f79';

--- a/lib/src/features/pull_requests/application/workspace_pull_request_notifications.dart
+++ b/lib/src/features/pull_requests/application/workspace_pull_request_notifications.dart
@@ -1,0 +1,170 @@
+import 'dart:convert';
+
+import 'package:alera/src/features/agent_status/application/agent_status_notifications.dart';
+import 'package:alera/src/features/pull_requests/domain/hosted_review.dart';
+import 'package:alera/src/features/pull_requests/domain/workspace_pull_request_summary.dart';
+
+class const WorkspacePullRequestFailure({
+  required this.workspaceId,
+  required this.summary,
+}) {
+  final String workspaceId;
+  final WorkspacePullRequestSummary summary;
+}
+
+/// Emits only transitions into a failed-check state. Clearing the failure
+/// removes its dedupe key, so a later failing run on the same PR can notify.
+class WorkspacePullRequestFailureTracker {
+  final Map<String, String> _activeFailureSignatures = <String, String>{};
+  bool _baselined = false;
+
+  void baseline(Map<String, WorkspacePullRequestSummary> summaries) {
+    _activeFailureSignatures
+      ..clear()
+      ..addEntries(_failureEntries(summaries));
+    _baselined = true;
+  }
+
+  List<WorkspacePullRequestFailure> pending(
+    Map<String, WorkspacePullRequestSummary> summaries,
+  ) {
+    if (!_baselined) {
+      baseline(summaries);
+      return const <WorkspacePullRequestFailure>[];
+    }
+    final current = <String, String>{
+      for (final entry in _failureEntries(summaries)) entry.key: entry.value,
+    };
+    final failures = <WorkspacePullRequestFailure>[];
+    for (final entry in current.entries) {
+      if (_activeFailureSignatures[entry.key] == entry.value) {
+        continue;
+      }
+      failures.add(
+        WorkspacePullRequestFailure(
+          workspaceId: entry.key,
+          summary: summaries[entry.key]!,
+        ),
+      );
+    }
+    _activeFailureSignatures
+      ..clear()
+      ..addAll(current);
+    return failures;
+  }
+
+  void reset() {
+    _activeFailureSignatures.clear();
+    _baselined = false;
+  }
+
+  Iterable<MapEntry<String, String>> _failureEntries(
+    Map<String, WorkspacePullRequestSummary> summaries,
+  ) sync* {
+    for (final entry in summaries.entries) {
+      final summary = entry.value;
+      if (!summary.checksFailed ||
+          summary.review.state == HostedReviewState.merged ||
+          summary.review.state == HostedReviewState.closed) {
+        continue;
+      }
+      yield MapEntry<String, String>(
+        entry.key,
+        <Object?>[summary.review.number, summary.review.headSha].join(':'),
+      );
+    }
+  }
+}
+
+class const WorkspacePullRequestNotificationPayload({
+  required this.workspaceId,
+  required this.reviewNumber,
+  required this.reviewUrl,
+}) {
+  final String workspaceId;
+  final int reviewNumber;
+  final String reviewUrl;
+
+  String encode() => jsonEncode(<String, Object?>{
+    'kind': 'pullRequestChecksFailed',
+    'workspaceId': workspaceId,
+    'reviewNumber': reviewNumber,
+    'reviewUrl': reviewUrl,
+  });
+}
+
+WorkspacePullRequestNotificationPayload?
+decodeWorkspacePullRequestNotificationPayload(String? payload) {
+  if (payload == null || payload.trim().isEmpty) {
+    return null;
+  }
+  try {
+    final decoded = jsonDecode(payload);
+    if (decoded is! Map) {
+      return null;
+    }
+    final record = Map<String, Object?>.from(decoded);
+    if (record['kind'] != 'pullRequestChecksFailed') {
+      return null;
+    }
+    final workspaceId = record['workspaceId'];
+    final reviewNumber = record['reviewNumber'];
+    final reviewUrl = record['reviewUrl'];
+    if (workspaceId is! String ||
+        workspaceId.isEmpty ||
+        reviewNumber is! num ||
+        reviewUrl is! String ||
+        reviewUrl.isEmpty) {
+      return null;
+    }
+    return WorkspacePullRequestNotificationPayload(
+      workspaceId: workspaceId,
+      reviewNumber: reviewNumber.toInt(),
+      reviewUrl: reviewUrl,
+    );
+  } catch (_) {
+    return null;
+  }
+}
+
+AgentStatusNotification composeWorkspacePullRequestFailureNotification({
+  required WorkspacePullRequestFailure failure,
+  String? projectName,
+  String? workspaceName,
+}) {
+  final summary = failure.summary;
+  final names = summary.failingCheckNames.join(', ');
+  final hidden = summary.failedCheckCount - summary.failingCheckNames.length;
+  final failedChecks = names.isEmpty
+      ? '${summary.failedCheckCount} checks failed'
+      : hidden > 0
+      ? '$names, +$hidden more'
+      : names;
+  final project = projectName?.trim() ?? '';
+  final workspace = workspaceName?.trim() ?? '';
+  final location = <String>[
+    if (project.isNotEmpty) project,
+    if (workspace.isNotEmpty && workspace != project) workspace,
+  ].join(' · ');
+  return AgentStatusNotification(
+    id: _fnv1a(
+      '${failure.workspaceId}|${summary.review.number}|${summary.review.headSha}',
+    ),
+    title: 'PR #${summary.review.number} checks failed',
+    body: location.isEmpty ? failedChecks : '$location — $failedChecks',
+    payload: WorkspacePullRequestNotificationPayload(
+      workspaceId: failure.workspaceId,
+      reviewNumber: summary.review.number,
+      reviewUrl: summary.review.url,
+    ).encode(),
+  );
+}
+
+int _fnv1a(String value) {
+  var hash = 0x811c9dc5;
+  for (final codeUnit in value.codeUnits) {
+    hash ^= codeUnit;
+    hash = (hash * 0x01000193) & 0x7fffffff;
+  }
+  return hash == 0 ? 1 : hash;
+}

--- a/lib/src/features/pull_requests/application/workspace_pull_request_refresh_signal.dart
+++ b/lib/src/features/pull_requests/application/workspace_pull_request_refresh_signal.dart
@@ -1,0 +1,15 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'workspace_pull_request_refresh_signal.g.dart';
+
+/// Lightweight invalidation signal shared by PR mutations and the global
+/// sidebar monitor. Reading this provider never initializes settings, storage,
+/// git, or forge dependencies.
+@Riverpod(keepAlive: true)
+class WorkspacePullRequestRefreshSignal
+    extends _$WorkspacePullRequestRefreshSignal {
+  @override
+  int build() => 0;
+
+  void requestRefresh() => state++;
+}

--- a/lib/src/features/pull_requests/application/workspace_pull_request_refresh_signal.g.dart
+++ b/lib/src/features/pull_requests/application/workspace_pull_request_refresh_signal.g.dart
@@ -1,0 +1,79 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'workspace_pull_request_refresh_signal.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// Lightweight invalidation signal shared by PR mutations and the global
+/// sidebar monitor. Reading this provider never initializes settings, storage,
+/// git, or forge dependencies.
+
+@ProviderFor(WorkspacePullRequestRefreshSignal)
+final workspacePullRequestRefreshSignalProvider =
+    WorkspacePullRequestRefreshSignalProvider._();
+
+/// Lightweight invalidation signal shared by PR mutations and the global
+/// sidebar monitor. Reading this provider never initializes settings, storage,
+/// git, or forge dependencies.
+final class WorkspacePullRequestRefreshSignalProvider
+    extends $NotifierProvider<WorkspacePullRequestRefreshSignal, int> {
+  /// Lightweight invalidation signal shared by PR mutations and the global
+  /// sidebar monitor. Reading this provider never initializes settings, storage,
+  /// git, or forge dependencies.
+  WorkspacePullRequestRefreshSignalProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'workspacePullRequestRefreshSignalProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() =>
+      _$workspacePullRequestRefreshSignalHash();
+
+  @$internal
+  @override
+  WorkspacePullRequestRefreshSignal create() =>
+      WorkspacePullRequestRefreshSignal();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(int value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<int>(value),
+    );
+  }
+}
+
+String _$workspacePullRequestRefreshSignalHash() =>
+    r'867695d764da709de59a83a3caba8ec9ab61b7fc';
+
+/// Lightweight invalidation signal shared by PR mutations and the global
+/// sidebar monitor. Reading this provider never initializes settings, storage,
+/// git, or forge dependencies.
+
+abstract class _$WorkspacePullRequestRefreshSignal extends $Notifier<int> {
+  int build();
+  @$mustCallSuper
+  @override
+  WhenComplete runBuild() {
+    final ref = this.ref as $Ref<int, int>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<int, int>,
+              int,
+              Object?,
+              Object?
+            >;
+    return element.handleCreate(ref, build);
+  }
+}

--- a/lib/src/features/pull_requests/application/workspace_pull_request_review_editing.dart
+++ b/lib/src/features/pull_requests/application/workspace_pull_request_review_editing.dart
@@ -74,6 +74,7 @@ mixin _WorkspacePullRequestReviewEditing on _$WorkspacePullRequestController {
           url: result.review.url,
         ),
       );
+      controller._refreshWorkspacePullRequestMonitor();
     }
     controller._applyActionOutcome(
       failureMessage: result is CreateReviewFailure ? result.message : null,
@@ -159,6 +160,9 @@ mixin _WorkspacePullRequestReviewEditing on _$WorkspacePullRequestController {
     controller._applyActionOutcome(
       failureMessage: result is UpdateReviewFailure ? result.message : null,
     );
+    if (result is UpdateReviewSuccess) {
+      controller._refreshWorkspacePullRequestMonitor();
+    }
     // Reload only on success; the refresh path would clear the error message.
     if (!controller._disposed &&
         controller._visible &&

--- a/lib/src/features/pull_requests/domain/workspace_pull_request_summary.dart
+++ b/lib/src/features/pull_requests/domain/workspace_pull_request_summary.dart
@@ -1,0 +1,87 @@
+import 'package:alera/src/features/pull_requests/domain/hosted_review.dart';
+import 'package:alera/src/features/pull_requests/domain/review_check.dart';
+
+/// Compact, workspace-facing projection of a hosted review and its checks.
+///
+/// The sidebar keeps only counts plus at most three failing check names rather
+/// than retaining the complete provider response for every workspace.
+class const WorkspacePullRequestSummary({
+  required this.review,
+  required this.checksRollup,
+  this.pendingCheckCount = 0,
+  this.failedCheckCount = 0,
+  this.failingCheckNames = const <String>[],
+}) {
+  factory WorkspacePullRequestSummary.fromChecks({
+    required HostedReview review,
+    required List<ReviewCheck> checks,
+  }) {
+    var pendingCheckCount = 0;
+    var failedCheckCount = 0;
+    final failingCheckNames = <String>[];
+    for (final check in checks) {
+      final failed = switch (check.conclusion) {
+        ReviewCheckConclusion.failure ||
+        ReviewCheckConclusion.cancelled ||
+        ReviewCheckConclusion.timedOut ||
+        ReviewCheckConclusion.actionRequired => true,
+        ReviewCheckConclusion.success ||
+        ReviewCheckConclusion.neutral ||
+        ReviewCheckConclusion.skipped ||
+        ReviewCheckConclusion.pending => false,
+      };
+      if (failed) {
+        failedCheckCount++;
+        if (failingCheckNames.length < 3) {
+          failingCheckNames.add(check.name);
+        }
+        continue;
+      }
+      if (check.status != ReviewCheckStatus.completed ||
+          check.conclusion == ReviewCheckConclusion.pending) {
+        pendingCheckCount++;
+      }
+    }
+    return WorkspacePullRequestSummary(
+      review: review,
+      checksRollup: deriveReviewChecksRollup(checks),
+      pendingCheckCount: pendingCheckCount,
+      failedCheckCount: failedCheckCount,
+      failingCheckNames: List<String>.unmodifiable(failingCheckNames),
+    );
+  }
+
+  final HostedReview review;
+  final ReviewChecksRollup checksRollup;
+  final int pendingCheckCount;
+  final int failedCheckCount;
+  final List<String> failingCheckNames;
+
+  bool get checksPending => checksRollup == ReviewChecksRollup.pending;
+  bool get checksFailed => checksRollup == ReviewChecksRollup.failure;
+  bool get hasMergeConflict =>
+      review.state == HostedReviewState.open &&
+      review.mergeable == HostedReviewMergeable.conflicting;
+
+  /// Stable display/notification signature. Provider refreshes that produce
+  /// the same compact state do not rebuild the sidebar or notify again.
+  String get signature => <Object?>[
+    review.number,
+    review.state.name,
+    review.title,
+    review.url,
+    review.headSha,
+    review.mergeable.name,
+    checksRollup.name,
+    pendingCheckCount,
+    failedCheckCount,
+    failingCheckNames.join('|'),
+  ].join(':');
+
+  @override
+  bool operator ==(Object other) =>
+      other is WorkspacePullRequestSummary && signature == other.signature;
+
+  @override
+  int get hashCode => signature.hashCode;
+}

--- a/lib/src/features/pull_requests/infra/github_forge_provider.dart
+++ b/lib/src/features/pull_requests/infra/github_forge_provider.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import 'package:alera/src/features/pull_requests/application/forge_exception.dart';
 import 'package:alera/src/features/pull_requests/application/forge_provider.dart';
+import 'package:alera/src/features/pull_requests/application/forge_review_batch_provider.dart';
 import 'package:alera/src/features/pull_requests/application/forge_stack_provider.dart';
 import 'package:alera/src/features/pull_requests/domain/create_review_input.dart';
 import 'package:alera/src/features/pull_requests/domain/create_review_result.dart';
@@ -22,6 +23,7 @@ import 'package:alera/src/features/pull_requests/infra/github_stack_mappers.dart
 import 'package:alera/src/shared/infra/process/process_runner.dart';
 
 part 'github_review_actions.dart';
+part 'github_review_batch.dart';
 part 'github_stack_actions.dart';
 part 'github_review_comments.dart';
 
@@ -29,9 +31,13 @@ part 'github_review_comments.dart';
 /// relies on the user being logged in via `gh auth login`. Follows the
 /// `GitHubStarService` pattern: constructor-injected [ProcessRunner], typed
 /// errors instead of leaked stderr.
-class const GitHubForgeProvider(final ProcessRunner _processRunner)
-    with _GitHubReviewActions, _GitHubReviewComments, _GitHubStackActions
-    implements ForgeProvider, ForgeStackProvider {
+class const GitHubForgeProvider(@override final ProcessRunner _processRunner)
+    with
+        _GitHubReviewActions,
+        _GitHubReviewBatch,
+        _GitHubReviewComments,
+        _GitHubStackActions
+    implements ForgeProvider, ForgeReviewBatchProvider, ForgeStackProvider {
   static const List<String> _reviewJsonFields = <String>[
     'number',
     'title',
@@ -96,6 +102,7 @@ class const GitHubForgeProvider(final ProcessRunner _processRunner)
     return 'https://${identity.host}/${identity.owner}/${identity.repo}';
   }
 
+  @override
   void _ensureSupportedHost(GitRemoteIdentity identity) {
     if (Uri.parse('https://${identity.host}').hasPort) {
       throw const ForgeRequestFailed(
@@ -419,6 +426,7 @@ class const GitHubForgeProvider(final ProcessRunner _processRunner)
     _throwClassified(result);
   }
 
+  @override
   Never _throwClassified(ProcessRunOutput result) {
     final stderr = result.stderr.toLowerCase();
     if (stderr.contains('not logged') ||
@@ -431,6 +439,7 @@ class const GitHubForgeProvider(final ProcessRunner _processRunner)
     );
   }
 
+  @override
   Object? _decodeJson(String? raw) {
     if (raw == null) {
       return null;

--- a/lib/src/features/pull_requests/infra/github_review_batch.dart
+++ b/lib/src/features/pull_requests/infra/github_review_batch.dart
@@ -1,0 +1,178 @@
+part of 'github_forge_provider.dart';
+
+mixin _GitHubReviewBatch implements ForgeReviewBatchProvider {
+  ProcessRunner get _processRunner;
+
+  void _ensureSupportedHost(GitRemoteIdentity identity);
+
+  Object? _decodeJson(String? raw);
+
+  Never _throwClassified(ProcessRunOutput result);
+
+  @override
+  Future<ForgeReviewBatch> getReviewBatch({
+    required GitRemoteIdentity identity,
+    required String repoPath,
+    required Set<String> branches,
+    required Set<int> reviewNumbers,
+  }) async {
+    if (branches.isEmpty && reviewNumbers.isEmpty) {
+      return const ForgeReviewBatch();
+    }
+    _ensureSupportedHost(identity);
+    final orderedBranches = branches.toList()..sort();
+    final orderedNumbers = reviewNumbers.toList()..sort();
+    final query = _buildReviewBatchQuery(
+      branchCount: orderedBranches.length,
+      reviewNumberCount: orderedNumbers.length,
+    );
+    final arguments = <String>[
+      'api',
+      'graphql',
+      '--hostname',
+      identity.host,
+      '-f',
+      'owner=${identity.owner}',
+      '-f',
+      'name=${identity.repo}',
+      for (final (index, branch) in orderedBranches.indexed) ...<String>[
+        '-f',
+        'branch$index=$branch',
+      ],
+      for (final (index, number) in orderedNumbers.indexed) ...<String>[
+        '-F',
+        'number$index=$number',
+      ],
+      '-f',
+      'query=$query',
+    ];
+
+    ProcessRunOutput result;
+    try {
+      result = await _processRunner.run(
+        'gh',
+        arguments,
+        workingDirectory: repoPath,
+      );
+    } catch (_) {
+      throw const ForgeCliMissing('gh not found');
+    }
+    if (result.exitCode != 0) {
+      if (ghLooksLikeMissingCli(result)) {
+        throw const ForgeCliMissing('gh not found');
+      }
+      _throwClassified(result);
+    }
+    final decoded = _decodeJson(result.stdout);
+    if (decoded is! Map) {
+      throw const ForgeRequestFailed('Unexpected gh GraphQL response.');
+    }
+    final data = _objectMap(decoded['data']);
+    final repository = _objectMap(data?['repository']);
+    if (repository == null) {
+      throw const ForgeRequestFailed(
+        'GitHub did not return repository pull requests.',
+      );
+    }
+
+    final byBranch = <String, ForgeReviewSnapshot>{};
+    final byNumber = <int, ForgeReviewSnapshot>{};
+    for (final (index, branch) in orderedBranches.indexed) {
+      final connection = _objectMap(repository['branch$index']);
+      final nodes = connection?['nodes'];
+      final node = nodes is List && nodes.isNotEmpty
+          ? _objectMap(nodes.first)
+          : null;
+      final snapshot = _snapshotFromGraphQl(node);
+      if (snapshot == null) {
+        continue;
+      }
+      byBranch[branch] = snapshot;
+      byNumber[snapshot.review.number] = snapshot;
+    }
+    for (final (index, requestedNumber) in orderedNumbers.indexed) {
+      final snapshot = _snapshotFromGraphQl(
+        _objectMap(repository['review$index']),
+      );
+      if (snapshot == null) {
+        continue;
+      }
+      byNumber[requestedNumber] = snapshot;
+      final headBranch = snapshot.review.headBranch;
+      if (headBranch != null && headBranch.isNotEmpty) {
+        byBranch.putIfAbsent(headBranch, () => snapshot);
+      }
+    }
+    return ForgeReviewBatch(
+      byBranch: Map<String, ForgeReviewSnapshot>.unmodifiable(byBranch),
+      byNumber: Map<int, ForgeReviewSnapshot>.unmodifiable(byNumber),
+    );
+  }
+}
+
+String _buildReviewBatchQuery({
+  required int branchCount,
+  required int reviewNumberCount,
+}) {
+  final variables = <String>[
+    r'$owner:String!',
+    r'$name:String!',
+    for (var index = 0; index < branchCount; index++) '\$branch$index:String!',
+    for (var index = 0; index < reviewNumberCount; index++)
+      '\$number$index:Int!',
+  ];
+  final selections = <String>[
+    for (var index = 0; index < branchCount; index++)
+      'branch$index:pullRequests(first:1,headRefName:\$branch$index,'
+          'states:[OPEN,MERGED,CLOSED],'
+          'orderBy:{field:CREATED_AT,direction:DESC})'
+          '{nodes{...ReviewStatus}}',
+    for (var index = 0; index < reviewNumberCount; index++)
+      'review$index:pullRequest(number:\$number$index){...ReviewStatus}',
+  ];
+  return 'query(${variables.join(',')})'
+      '{repository(owner:\$owner,name:\$name){${selections.join()}}}'
+      'fragment ReviewStatus on PullRequest{'
+      'number title state url createdAt updatedAt isDraft mergeable '
+      'headRefName baseRefName headRefOid '
+      'commits(last:1){nodes{commit{statusCheckRollup{contexts(first:100)'
+      '{nodes{__typename '
+      '... on CheckRun{name status conclusion detailsUrl}'
+      '... on StatusContext{context state targetUrl}'
+      '}}}}}}}';
+}
+
+ForgeReviewSnapshot? _snapshotFromGraphQl(Map<String, Object?>? json) {
+  if (json == null) {
+    return null;
+  }
+  final checks = <ReviewCheck>[];
+  final commits = _objectMap(json['commits']);
+  final commitNodes = commits?['nodes'];
+  if (commitNodes is List && commitNodes.isNotEmpty) {
+    final commitNode = _objectMap(commitNodes.first);
+    final commit = _objectMap(commitNode?['commit']);
+    final rollup = _objectMap(commit?['statusCheckRollup']);
+    final contexts = _objectMap(rollup?['contexts']);
+    final contextNodes = contexts?['nodes'];
+    if (contextNodes is List) {
+      for (final raw in contextNodes) {
+        final context = _objectMap(raw);
+        if (context != null) {
+          checks.add(mapGitHubStatusRollupCheck(context));
+        }
+      }
+    }
+  }
+  return ForgeReviewSnapshot(
+    review: mapGitHubReview(json),
+    checks: List<ReviewCheck>.unmodifiable(checks),
+  );
+}
+
+Map<String, Object?>? _objectMap(Object? value) {
+  if (value is! Map) {
+    return null;
+  }
+  return Map<String, Object?>.from(value);
+}

--- a/lib/src/features/pull_requests/infra/github_review_mappers.dart
+++ b/lib/src/features/pull_requests/infra/github_review_mappers.dart
@@ -65,6 +65,52 @@ ReviewCheck mapGitHubCheck(Map<String, Object?> json) {
   );
 }
 
+/// Maps one GraphQL `StatusCheckRollupContext` union entry. GitHub returns
+/// modern Actions runs as `CheckRun` and legacy commit statuses as
+/// `StatusContext`, so both forms must participate in the sidebar rollup.
+ReviewCheck mapGitHubStatusRollupCheck(Map<String, Object?> json) {
+  final type = json['__typename'] as String?;
+  if (type == 'StatusContext') {
+    final state = (json['state'] as String? ?? 'PENDING').toUpperCase();
+    final pending = state == 'EXPECTED' || state == 'PENDING';
+    return ReviewCheck(
+      name: json['context'] as String? ?? 'status',
+      status: pending
+          ? ReviewCheckStatus.inProgress
+          : ReviewCheckStatus.completed,
+      conclusion: switch (state) {
+        'SUCCESS' => ReviewCheckConclusion.success,
+        'ERROR' || 'FAILURE' => ReviewCheckConclusion.failure,
+        _ => ReviewCheckConclusion.pending,
+      },
+      url: _nonEmpty(json['targetUrl'] as String?),
+    );
+  }
+
+  final statusValue = (json['status'] as String? ?? 'QUEUED').toUpperCase();
+  final completed = statusValue == 'COMPLETED';
+  final conclusionValue = (json['conclusion'] as String? ?? '').toUpperCase();
+  return ReviewCheck(
+    name: json['name'] as String? ?? 'check',
+    status: completed
+        ? ReviewCheckStatus.completed
+        : statusValue == 'QUEUED'
+        ? ReviewCheckStatus.queued
+        : ReviewCheckStatus.inProgress,
+    conclusion: switch (conclusionValue) {
+      'SUCCESS' => ReviewCheckConclusion.success,
+      'FAILURE' || 'STARTUP_FAILURE' => ReviewCheckConclusion.failure,
+      'CANCELLED' || 'STALE' => ReviewCheckConclusion.cancelled,
+      'TIMED_OUT' => ReviewCheckConclusion.timedOut,
+      'ACTION_REQUIRED' => ReviewCheckConclusion.actionRequired,
+      'NEUTRAL' => ReviewCheckConclusion.neutral,
+      'SKIPPED' => ReviewCheckConclusion.skipped,
+      _ => ReviewCheckConclusion.pending,
+    },
+    url: _nonEmpty(json['detailsUrl'] as String?),
+  );
+}
+
 ReviewCheckDetails mapGitHubCheckDetails(Map<String, Object?> json) {
   return ReviewCheckDetails(
     description: _nonEmpty(json['description'] as String?),

--- a/lib/src/features/pull_requests/presentation/workspace_pull_request_status_indicator.dart
+++ b/lib/src/features/pull_requests/presentation/workspace_pull_request_status_indicator.dart
@@ -1,0 +1,147 @@
+import 'package:alera/src/app/theme/alera_tokens.dart';
+import 'package:alera/src/design_system/icons/alera_icons.dart';
+import 'package:alera/src/features/pull_requests/domain/hosted_review.dart';
+import 'package:alera/src/features/pull_requests/domain/workspace_pull_request_summary.dart';
+import 'package:flutter/material.dart';
+
+/// GitHub-style pull-request lifecycle icon with a small, static check badge.
+/// The badge deliberately does not animate: dozens of workspace rows still use
+/// zero per-row tickers while running checks remain immediately recognizable.
+class const WorkspacePullRequestStatusIndicator({
+  super.key,
+  required this.summary,
+  this.size = AleraTokens.iconSm,
+}) extends StatelessWidget {
+  final WorkspacePullRequestSummary summary;
+  final double size;
+
+  @override
+  Widget build(BuildContext context) {
+    final badge = _badgeFor(summary);
+    return Tooltip(
+      message: workspacePullRequestStatusTooltip(summary),
+      child: SizedBox.square(
+        dimension: size + 2,
+        child: Stack(
+          clipBehavior: Clip.none,
+          children: <Widget>[
+            Align(
+              alignment: Alignment.topLeft,
+              child: Icon(
+                _iconFor(summary.review.state),
+                size: size,
+                color: _colorFor(summary.review.state),
+              ),
+            ),
+            if (badge != null)
+              Positioned(
+                right: -1,
+                bottom: -1,
+                child: DecoratedBox(
+                  decoration: const BoxDecoration(
+                    color: AleraTokens.surfaceVariant,
+                    shape: BoxShape.circle,
+                  ),
+                  child: Padding(
+                    padding: const EdgeInsets.all(0.5),
+                    child: Icon(
+                      badge.icon,
+                      size: size * 0.62,
+                      color: badge.color,
+                    ),
+                  ),
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+String workspacePullRequestStatusTooltip(WorkspacePullRequestSummary summary) {
+  final review = summary.review;
+  final lines = <String>['PR #${review.number}: ${review.title}'];
+  switch (review.state) {
+    case HostedReviewState.merged:
+      lines.add('Merged');
+    case HostedReviewState.closed:
+      lines.add('Closed without merging');
+    case HostedReviewState.draft:
+      lines.add('Draft');
+      _appendCheckProgress(lines, summary);
+    case HostedReviewState.open:
+      if (summary.hasMergeConflict) {
+        lines.add('Merge conflict');
+      } else if (!_appendCheckProgress(lines, summary)) {
+        lines.add(
+          review.mergeable == HostedReviewMergeable.mergeable
+              ? 'Ready to merge'
+              : 'Open',
+        );
+      }
+  }
+  return lines.join('\n');
+}
+
+bool _appendCheckProgress(
+  List<String> lines,
+  WorkspacePullRequestSummary summary,
+) {
+  if (summary.checksFailed) {
+    lines
+      ..add('Checks failed')
+      ..add(_failureDetails(summary));
+    return true;
+  }
+  if (summary.checksPending) {
+    lines.add(
+      _countLabel(summary.pendingCheckCount, 'check running', 'checks running'),
+    );
+    return true;
+  }
+  return false;
+}
+
+String _failureDetails(WorkspacePullRequestSummary summary) {
+  final names = summary.failingCheckNames.join(', ');
+  final hidden = summary.failedCheckCount - summary.failingCheckNames.length;
+  if (names.isEmpty) {
+    return summary.failedCheckCount == 1
+        ? '1 failed check'
+        : '${summary.failedCheckCount} failed checks';
+  }
+  return hidden > 0 ? '$names, +$hidden more' : names;
+}
+
+String _countLabel(int count, String singular, String plural) {
+  return count == 1 ? '1 $singular' : '$count $plural';
+}
+
+IconData _iconFor(HostedReviewState state) => switch (state) {
+  HostedReviewState.open => AleraIcons.gitPullRequest,
+  HostedReviewState.draft => AleraIcons.gitPullRequestDraft,
+  HostedReviewState.merged => AleraIcons.gitMerge,
+  HostedReviewState.closed => AleraIcons.gitPullRequestClosed,
+};
+
+Color _colorFor(HostedReviewState state) => switch (state) {
+  HostedReviewState.open => AleraTokens.success,
+  HostedReviewState.draft => AleraTokens.foregroundMuted,
+  HostedReviewState.merged => AleraTokens.done,
+  HostedReviewState.closed => AleraTokens.error,
+};
+
+({IconData icon, Color color})? _badgeFor(WorkspacePullRequestSummary summary) {
+  if (summary.review.state
+      case HostedReviewState.merged || HostedReviewState.closed) {
+    return null;
+  }
+  if (summary.checksFailed || summary.hasMergeConflict) {
+    return (icon: AleraIcons.cancel, color: AleraTokens.error);
+  }
+  if (summary.checksPending) {
+    return (icon: AleraIcons.loading, color: AleraTokens.warning);
+  }
+  return null;
+}

--- a/lib/src/features/settings/application/settings_controller.dart
+++ b/lib/src/features/settings/application/settings_controller.dart
@@ -13,9 +13,11 @@ import 'package:logging/logging.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'settings_controller.g.dart';
+part 'settings_controller_pull_requests.dart';
 
 @Riverpod(keepAlive: true)
-class SettingsController extends _$SettingsController {
+class SettingsController extends _$SettingsController
+    with _SettingsControllerPullRequestSettings {
   bool _loadStarted = false;
 
   SettingsRepository get _repository => ref.read(settingsRepositoryProvider);
@@ -191,34 +193,6 @@ class SettingsController extends _$SettingsController {
       state.copyWith(general: state.general.copyWith(showTrayBadge: value)),
     );
   });
-
-  Future<void> setShowPullRequestStatusInSidebar(bool value) =>
-      _serialize(() async {
-        if (state.general.showPullRequestStatusInSidebar == value) {
-          return;
-        }
-        await _save(
-          state.copyWith(
-            general: state.general.copyWith(
-              showPullRequestStatusInSidebar: value,
-            ),
-          ),
-        );
-      });
-
-  Future<void> setPullRequestFailureNotificationsEnabled(bool value) =>
-      _serialize(() async {
-        if (state.general.pullRequestFailureNotificationsEnabled == value) {
-          return;
-        }
-        await _save(
-          state.copyWith(
-            general: state.general.copyWith(
-              pullRequestFailureNotificationsEnabled: value,
-            ),
-          ),
-        );
-      });
 
   Future<void> setAgentStatusHookEnabled(AgentType agentType, bool value) =>
       _serialize(() async {

--- a/lib/src/features/settings/application/settings_controller.dart
+++ b/lib/src/features/settings/application/settings_controller.dart
@@ -192,6 +192,34 @@ class SettingsController extends _$SettingsController {
     );
   });
 
+  Future<void> setShowPullRequestStatusInSidebar(bool value) =>
+      _serialize(() async {
+        if (state.general.showPullRequestStatusInSidebar == value) {
+          return;
+        }
+        await _save(
+          state.copyWith(
+            general: state.general.copyWith(
+              showPullRequestStatusInSidebar: value,
+            ),
+          ),
+        );
+      });
+
+  Future<void> setPullRequestFailureNotificationsEnabled(bool value) =>
+      _serialize(() async {
+        if (state.general.pullRequestFailureNotificationsEnabled == value) {
+          return;
+        }
+        await _save(
+          state.copyWith(
+            general: state.general.copyWith(
+              pullRequestFailureNotificationsEnabled: value,
+            ),
+          ),
+        );
+      });
+
   Future<void> setAgentStatusHookEnabled(AgentType agentType, bool value) =>
       _serialize(() async {
         final current = state.agents.agentStatusHooks;

--- a/lib/src/features/settings/application/settings_controller.g.dart
+++ b/lib/src/features/settings/application/settings_controller.g.dart
@@ -42,7 +42,7 @@ final class SettingsControllerProvider
 }
 
 String _$settingsControllerHash() =>
-    r'cee30b540957f432f1e67fe6729dba42322dc1b9';
+    r'371aaa0d916651e208d68444f2f30a79a6ff894f';
 
 abstract class _$SettingsController extends $Notifier<AleraSettings> {
   AleraSettings build();

--- a/lib/src/features/settings/application/settings_controller.g.dart
+++ b/lib/src/features/settings/application/settings_controller.g.dart
@@ -42,7 +42,7 @@ final class SettingsControllerProvider
 }
 
 String _$settingsControllerHash() =>
-    r'371aaa0d916651e208d68444f2f30a79a6ff894f';
+    r'6bffe602f795b1a5b1fea4d33719df48a8818e40';
 
 abstract class _$SettingsController extends $Notifier<AleraSettings> {
   AleraSettings build();

--- a/lib/src/features/settings/application/settings_controller_pull_requests.dart
+++ b/lib/src/features/settings/application/settings_controller_pull_requests.dart
@@ -1,0 +1,38 @@
+part of 'settings_controller.dart';
+
+mixin _SettingsControllerPullRequestSettings on _$SettingsController {
+  SettingsController get _pullRequestSettingsController =>
+      this as SettingsController;
+
+  Future<void> setShowPullRequestStatusInSidebar(bool value) {
+    final controller = _pullRequestSettingsController;
+    return controller._serialize(() async {
+      if (state.general.showPullRequestStatusInSidebar == value) {
+        return;
+      }
+      await controller._save(
+        state.copyWith(
+          general: state.general.copyWith(
+            showPullRequestStatusInSidebar: value,
+          ),
+        ),
+      );
+    });
+  }
+
+  Future<void> setPullRequestFailureNotificationsEnabled(bool value) {
+    final controller = _pullRequestSettingsController;
+    return controller._serialize(() async {
+      if (state.general.pullRequestFailureNotificationsEnabled == value) {
+        return;
+      }
+      await controller._save(
+        state.copyWith(
+          general: state.general.copyWith(
+            pullRequestFailureNotificationsEnabled: value,
+          ),
+        ),
+      );
+    });
+  }
+}

--- a/lib/src/features/settings/domain/alera_settings.dart
+++ b/lib/src/features/settings/domain/alera_settings.dart
@@ -292,6 +292,8 @@ class const GeneralSettings({
   this.showTrayIcon = true,
   this.showDockBadge = true,
   this.showTrayBadge = true,
+  this.showPullRequestStatusInSidebar = true,
+  this.pullRequestFailureNotificationsEnabled = false,
 }) with GeneralSettingsMappable {
   /// User-configured root directory where new linked workspaces are created.
   /// `null` falls back to the platform default (`~/.alera/workspaces`).
@@ -317,6 +319,13 @@ class const GeneralSettings({
 
   /// Pending-review count drawn onto the tray icon itself.
   final bool showTrayBadge;
+
+  /// Show compact hosted pull-request and check state beside each workspace.
+  final bool showPullRequestStatusInSidebar;
+
+  /// Keep monitoring while hidden and notify when checks enter a failed state.
+  final bool pullRequestFailureNotificationsEnabled;
+
   static const GeneralSettings defaults = GeneralSettings();
 
   factory fromJson(Map<String, Object?> json) =>

--- a/lib/src/features/settings/domain/alera_settings.mapper.dart
+++ b/lib/src/features/settings/domain/alera_settings.mapper.dart
@@ -1437,6 +1437,24 @@ class GeneralSettingsMapper extends ClassMapperBase<GeneralSettings> {
     opt: true,
     def: true,
   );
+  static bool _$showPullRequestStatusInSidebar(GeneralSettings v) =>
+      v.showPullRequestStatusInSidebar;
+  static const Field<GeneralSettings, bool> _f$showPullRequestStatusInSidebar =
+      Field(
+        'showPullRequestStatusInSidebar',
+        _$showPullRequestStatusInSidebar,
+        opt: true,
+        def: true,
+      );
+  static bool _$pullRequestFailureNotificationsEnabled(GeneralSettings v) =>
+      v.pullRequestFailureNotificationsEnabled;
+  static const Field<GeneralSettings, bool>
+  _f$pullRequestFailureNotificationsEnabled = Field(
+    'pullRequestFailureNotificationsEnabled',
+    _$pullRequestFailureNotificationsEnabled,
+    opt: true,
+    def: false,
+  );
 
   @override
   final MappableFields<GeneralSettings> fields = const {
@@ -1448,6 +1466,9 @@ class GeneralSettingsMapper extends ClassMapperBase<GeneralSettings> {
     #showTrayIcon: _f$showTrayIcon,
     #showDockBadge: _f$showDockBadge,
     #showTrayBadge: _f$showTrayBadge,
+    #showPullRequestStatusInSidebar: _f$showPullRequestStatusInSidebar,
+    #pullRequestFailureNotificationsEnabled:
+        _f$pullRequestFailureNotificationsEnabled,
   };
 
   static GeneralSettings _instantiate(DecodingData data) {
@@ -1460,6 +1481,12 @@ class GeneralSettingsMapper extends ClassMapperBase<GeneralSettings> {
       showTrayIcon: data.dec(_f$showTrayIcon),
       showDockBadge: data.dec(_f$showDockBadge),
       showTrayBadge: data.dec(_f$showTrayBadge),
+      showPullRequestStatusInSidebar: data.dec(
+        _f$showPullRequestStatusInSidebar,
+      ),
+      pullRequestFailureNotificationsEnabled: data.dec(
+        _f$pullRequestFailureNotificationsEnabled,
+      ),
     );
   }
 
@@ -1534,6 +1561,8 @@ abstract class GeneralSettingsCopyWith<$R, $In extends GeneralSettings, $Out>
     bool? showTrayIcon,
     bool? showDockBadge,
     bool? showTrayBadge,
+    bool? showPullRequestStatusInSidebar,
+    bool? pullRequestFailureNotificationsEnabled,
   });
   GeneralSettingsCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(
     Then<$Out2, $R2> t,
@@ -1558,6 +1587,8 @@ class _GeneralSettingsCopyWithImpl<$R, $Out>
     bool? showTrayIcon,
     bool? showDockBadge,
     bool? showTrayBadge,
+    bool? showPullRequestStatusInSidebar,
+    bool? pullRequestFailureNotificationsEnabled,
   }) => $apply(
     FieldCopyWithData({
       if (workspaceDirectory != $none) #workspaceDirectory: workspaceDirectory,
@@ -1570,6 +1601,11 @@ class _GeneralSettingsCopyWithImpl<$R, $Out>
       if (showTrayIcon != null) #showTrayIcon: showTrayIcon,
       if (showDockBadge != null) #showDockBadge: showDockBadge,
       if (showTrayBadge != null) #showTrayBadge: showTrayBadge,
+      if (showPullRequestStatusInSidebar != null)
+        #showPullRequestStatusInSidebar: showPullRequestStatusInSidebar,
+      if (pullRequestFailureNotificationsEnabled != null)
+        #pullRequestFailureNotificationsEnabled:
+            pullRequestFailureNotificationsEnabled,
     }),
   );
   @override
@@ -1591,6 +1627,14 @@ class _GeneralSettingsCopyWithImpl<$R, $Out>
     showTrayIcon: data.get(#showTrayIcon, or: $value.showTrayIcon),
     showDockBadge: data.get(#showDockBadge, or: $value.showDockBadge),
     showTrayBadge: data.get(#showTrayBadge, or: $value.showTrayBadge),
+    showPullRequestStatusInSidebar: data.get(
+      #showPullRequestStatusInSidebar,
+      or: $value.showPullRequestStatusInSidebar,
+    ),
+    pullRequestFailureNotificationsEnabled: data.get(
+      #pullRequestFailureNotificationsEnabled,
+      or: $value.pullRequestFailureNotificationsEnabled,
+    ),
   );
 
   @override

--- a/lib/src/features/settings/presentation/panes/application_pane.dart
+++ b/lib/src/features/settings/presentation/panes/application_pane.dart
@@ -94,6 +94,30 @@ class const ApplicationSettingsPane({
         ),
         const SizedBox(height: AleraTokens.space16),
         KeyedSubtree(
+          key: groupKeys['pullRequests'],
+          child: AleraSettingsGroup(
+            title: 'Pull Requests',
+            description: 'Compact review and CI status for workspaces backed by a hosted Git repository.',
+            children: <Widget>[
+              SettingsSwitchRow(
+                title: 'Show Pull Request Status',
+                description: 'Show draft, ready, running, failed, merged, and closed state beside each workspace. Alera batches GitHub workspaces into one refresh per repository.',
+                value: general.showPullRequestStatusInSidebar,
+                onChanged: (value) =>
+                    controller.setShowPullRequestStatusInSidebar(value),
+              ),
+              SettingsSwitchRow(
+                title: 'Notify When Checks Fail',
+                description: 'Show one native notification when a pull request enters a failed-check state. Enabling this keeps the lightweight monitor active while Alera is hidden.',
+                value: general.pullRequestFailureNotificationsEnabled,
+                onChanged: (value) =>
+                    controller.setPullRequestFailureNotificationsEnabled(value),
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(height: AleraTokens.space16),
+        KeyedSubtree(
           key: groupKeys['runtime'],
           child: AleraSettingsGroup(
             title: 'Runtime',

--- a/lib/src/features/settings/presentation/settings_dialog.dart
+++ b/lib/src/features/settings/presentation/settings_dialog.dart
@@ -156,6 +156,7 @@ class _SettingsDialogState extends ConsumerState<SettingsDialog> {
       SettingsGroupSpec(id: 'storage', title: 'Storage'),
       SettingsGroupSpec(id: 'safety', title: 'Safety'),
       SettingsGroupSpec(id: 'desktop', title: 'Desktop'),
+      SettingsGroupSpec(id: 'pullRequests', title: 'Pull Requests'),
       SettingsGroupSpec(id: 'runtime', title: 'Runtime'),
       SettingsGroupSpec(id: 'diagnostics', title: 'Diagnostics'),
       SettingsGroupSpec(id: 'updates', title: 'Updates'),

--- a/lib/src/features/settings/presentation/settings_search_entries.dart
+++ b/lib/src/features/settings/presentation/settings_search_entries.dart
@@ -1,5 +1,6 @@
 import 'package:alera/src/features/settings/presentation/settings_sections.dart';
 import 'package:alera/src/features/settings/presentation/settings_search_entry_catalog.dart';
+import 'package:alera/src/features/settings/presentation/settings_search_entries_pull_requests.dart';
 import 'package:alera/src/features/settings/presentation/settings_search_entries_reading_diff.dart';
 
 final List<SettingsSearchEntry>
@@ -61,31 +62,7 @@ applicationSearchEntries = buildSettingsSearchEntryCatalog(const {
       ],
     ),
   },
-  'pullRequests': {
-    'Show Pull Request Status': SettingsSearchEntryDetails(
-      description: 'Show hosted review and CI state beside each workspace.',
-      keywords: <String>[
-        'pull request',
-        'pr',
-        'checks',
-        'ci',
-        'sidebar',
-        'draft',
-        'merged',
-      ],
-    ),
-    'Notify When Checks Fail': SettingsSearchEntryDetails(
-      description: 'Show a native notification when PR checks start failing.',
-      keywords: <String>[
-        'pull request',
-        'pr',
-        'checks',
-        'ci',
-        'failure',
-        'notification',
-      ],
-    ),
-  },
+  ...pullRequestApplicationSearchGroups,
   'runtime': {
     'Keep Computer Awake': SettingsSearchEntryDetails(
       description:

--- a/lib/src/features/settings/presentation/settings_search_entries.dart
+++ b/lib/src/features/settings/presentation/settings_search_entries.dart
@@ -61,6 +61,31 @@ applicationSearchEntries = buildSettingsSearchEntryCatalog(const {
       ],
     ),
   },
+  'pullRequests': {
+    'Show Pull Request Status': SettingsSearchEntryDetails(
+      description: 'Show hosted review and CI state beside each workspace.',
+      keywords: <String>[
+        'pull request',
+        'pr',
+        'checks',
+        'ci',
+        'sidebar',
+        'draft',
+        'merged',
+      ],
+    ),
+    'Notify When Checks Fail': SettingsSearchEntryDetails(
+      description: 'Show a native notification when PR checks start failing.',
+      keywords: <String>[
+        'pull request',
+        'pr',
+        'checks',
+        'ci',
+        'failure',
+        'notification',
+      ],
+    ),
+  },
   'runtime': {
     'Keep Computer Awake': SettingsSearchEntryDetails(
       description:

--- a/lib/src/features/settings/presentation/settings_search_entries_pull_requests.dart
+++ b/lib/src/features/settings/presentation/settings_search_entries_pull_requests.dart
@@ -1,0 +1,32 @@
+import 'package:alera/src/features/settings/presentation/settings_search_entry_catalog.dart';
+
+const Map<String, Map<String, SettingsSearchEntryDetails>>
+pullRequestApplicationSearchGroups =
+    <String, Map<String, SettingsSearchEntryDetails>>{
+      'pullRequests': <String, SettingsSearchEntryDetails>{
+        'Show Pull Request Status': SettingsSearchEntryDetails(
+          description: 'Show hosted review and CI state beside each workspace.',
+          keywords: <String>[
+            'pull request',
+            'pr',
+            'checks',
+            'ci',
+            'sidebar',
+            'draft',
+            'merged',
+          ],
+        ),
+        'Notify When Checks Fail': SettingsSearchEntryDetails(
+          description:
+              'Show a native notification when PR checks start failing.',
+          keywords: <String>[
+            'pull request',
+            'pr',
+            'checks',
+            'ci',
+            'failure',
+            'notification',
+          ],
+        ),
+      },
+    };

--- a/lib/src/features/shell/presentation/alera_shell_page.dart
+++ b/lib/src/features/shell/presentation/alera_shell_page.dart
@@ -21,6 +21,8 @@ import 'package:alera/src/features/browser/presentation/browser_native_callback_
 import 'package:alera/src/features/keyboard/presentation/keyboard_shortcuts_scope.dart';
 import 'package:alera/src/features/mobile_emulator/presentation/mobile_emulator_device_picker.dart';
 import 'package:alera/src/features/projects/domain/project.dart';
+import 'package:alera/src/features/pull_requests/application/workspace_pull_request_monitor_providers.dart';
+import 'package:alera/src/features/pull_requests/application/workspace_pull_request_notification_providers.dart';
 import 'package:alera/src/features/workbench/application/workspace_file_service.dart';
 import 'package:alera/src/features/workbench/application/workspace_source_control_controller.dart';
 import 'package:alera/src/features/workbench/application/workbench_tab_attention.dart';

--- a/lib/src/features/shell/presentation/alera_shell_page_body.dart
+++ b/lib/src/features/shell/presentation/alera_shell_page_body.dart
@@ -19,6 +19,8 @@ class _AleraShellPageBodyState extends ConsumerState<_AleraShellPageBody> {
     ref.watch(runtimeAgentStatusSyncProvider);
     ref.watch(agentCanvasRuntimeSyncProvider);
     ref.watch(agentStatusNotificationCoordinatorProvider);
+    ref.watch(workspacePullRequestMonitorControllerProvider.notifier);
+    ref.watch(workspacePullRequestFailureNotificationCoordinatorProvider);
     ref.watch(agentAwakeCoordinatorProvider);
     ref.watch(keepAliveCoordinatorProvider);
     ref.watch(terminalRuntimeExitCoordinatorProvider);

--- a/lib/src/features/workbench/presentation/project_workbench_sidebar.dart
+++ b/lib/src/features/workbench/presentation/project_workbench_sidebar.dart
@@ -30,6 +30,8 @@ import 'package:alera/src/features/workbench/application/workspace_agent_status_
 import 'package:alera/src/features/workbench/application/repository_browser_opener.dart';
 import 'package:alera/src/features/workbench/application/repository_browser_providers.dart';
 import 'package:alera/src/features/pull_requests/application/pull_request_providers.dart';
+import 'package:alera/src/features/pull_requests/application/workspace_pull_request_monitor_providers.dart';
+import 'package:alera/src/features/pull_requests/presentation/workspace_pull_request_status_indicator.dart';
 import 'package:alera/src/shared/git_hosting/domain/git_hosting_provider.dart';
 import 'package:alera/src/features/workbench/domain/workspace_tab_record.dart';
 import 'package:alera/src/features/workbench/domain/workspace.dart';

--- a/lib/src/features/workbench/presentation/project_workbench_workspace_rows.dart
+++ b/lib/src/features/workbench/presentation/project_workbench_workspace_rows.dart
@@ -205,6 +205,32 @@ class _WorkspaceRowState extends State<_WorkspaceRow> {
                                     key: Key('workspace-tray-branch'),
                                   ),
                                 ),
+                                Consumer(
+                                  builder: (context, ref, child) {
+                                    final summary = ref.watch(
+                                      workspacePullRequestSummaryProvider(
+                                        widget.workspace.id,
+                                      ),
+                                    );
+                                    if (summary == null) {
+                                      return const SizedBox.shrink();
+                                    }
+                                    return Row(
+                                      mainAxisSize: .min,
+                                      children: <Widget>[
+                                        const SizedBox(
+                                          width: AleraTokens.space6,
+                                        ),
+                                        WorkspacePullRequestStatusIndicator(
+                                          key: const Key(
+                                            'workspace-tray-pull-request',
+                                          ),
+                                          summary: summary,
+                                        ),
+                                      ],
+                                    );
+                                  },
+                                ),
                                 if (tags.isNotEmpty) ...<Widget>[
                                   const SizedBox(width: AleraTokens.space6),
                                   Tooltip(

--- a/test/unit/alera_settings_test.dart
+++ b/test/unit/alera_settings_test.dart
@@ -45,6 +45,8 @@ void main() {
       expect(general.showTrayIcon, isTrue);
       expect(general.showDockBadge, isTrue);
       expect(general.showTrayBadge, isTrue);
+      expect(general.showPullRequestStatusInSidebar, isTrue);
+      expect(general.pullRequestFailureNotificationsEnabled, isFalse);
     });
 
     test('agent defaults are conservative', () {
@@ -158,6 +160,8 @@ void main() {
       expect(general.starClicked, isTrue);
       expect(general.showTrayIcon, isTrue);
       expect(general.showDockBadge, isTrue);
+      expect(general.showPullRequestStatusInSidebar, isTrue);
+      expect(general.pullRequestFailureNotificationsEnabled, isFalse);
       expect(agents.agentStatusHooks.codex, isTrue);
       expect(agents.agentStatusHooks.claude, isFalse);
       expect(agents.agentStatusHooks.copilot, isTrue);

--- a/test/unit/github_forge_provider_batch_test.dart
+++ b/test/unit/github_forge_provider_batch_test.dart
@@ -1,0 +1,61 @@
+import 'package:alera/src/features/pull_requests/domain/hosted_review.dart';
+import 'package:alera/src/features/pull_requests/domain/review_check.dart';
+import 'package:alera/src/features/pull_requests/infra/github_forge_provider.dart';
+import 'package:alera/src/shared/git_hosting/domain/git_remote_identity.dart';
+import 'package:alera/src/shared/infra/process/process_runner.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'fake_recording_process_runner.dart';
+
+const _identity = GitRemoteIdentity(
+  provider: .github,
+  host: 'github.com',
+  owner: 'leynier',
+  repo: 'alera',
+);
+
+ProcessRunOutput _ok(String stdout) =>
+    ProcessRunOutput(exitCode: 0, stdout: stdout, stderr: '');
+
+void main() {
+  test('loads branches and linked PRs in one GraphQL process', () async {
+    final runner = FakeRecordingProcessRunner(<Object>[
+      _ok('''
+{"data":{"repository":{
+  "branch0":{"nodes":[{"number":123,"title":"feat: sidebar status","state":"OPEN","url":"https://github.com/leynier/alera/pull/123","createdAt":"2026-09-01T00:00:00Z","isDraft":false,"mergeable":"MERGEABLE","headRefName":"feature","baseRefName":"main","headRefOid":"abc","commits":{"nodes":[{"commit":{"statusCheckRollup":{"contexts":{"nodes":[{"__typename":"CheckRun","name":"build","status":"IN_PROGRESS","conclusion":null,"detailsUrl":"https://ci/build"},{"__typename":"StatusContext","context":"lint","state":"FAILURE","targetUrl":"https://ci/lint"}]}}}}]}}]},
+  "review0":{"number":77,"title":"merged work","state":"MERGED","url":"https://github.com/leynier/alera/pull/77","createdAt":"2026-08-01T00:00:00Z","isDraft":false,"mergeable":"UNKNOWN","headRefName":"old-feature","baseRefName":"main","headRefOid":"def","commits":{"nodes":[]}}
+}}}
+'''),
+    ]);
+    final provider = GitHubForgeProvider(runner);
+
+    final batch = await provider.getReviewBatch(
+      identity: _identity,
+      repoPath: '/repo',
+      branches: const <String>{'feature'},
+      reviewNumbers: const <int>{77},
+    );
+
+    final call = runner.calls.single;
+    expect(call.executable, 'gh');
+    expect(call.arguments.take(2), <String>['api', 'graphql']);
+    expect(call.workingDirectory, '/repo');
+    expect(call.arguments, contains('branch0=feature'));
+    expect(call.arguments, contains('number0=77'));
+    expect(
+      call.arguments.firstWhere((argument) => argument.startsWith('query=')),
+      contains('statusCheckRollup'),
+    );
+
+    final feature = batch.byBranch['feature'];
+    expect(feature, isNotNull);
+    expect(feature!.review.number, 123);
+    expect(feature.checks, hasLength(2));
+    expect(feature.checks[0].status, ReviewCheckStatus.inProgress);
+    expect(feature.checks[0].conclusion, ReviewCheckConclusion.pending);
+    expect(feature.checks[1].conclusion, ReviewCheckConclusion.failure);
+    expect(batch.byNumber[123], same(feature));
+    expect(batch.byNumber[77]!.review.state, HostedReviewState.merged);
+    expect(batch.byBranch['old-feature']!.review.number, 77);
+  });
+}

--- a/test/unit/github_forge_provider_test.dart
+++ b/test/unit/github_forge_provider_test.dart
@@ -96,6 +96,49 @@ void main() {
     });
   });
 
+  group('GitHubForgeProvider.getReviewBatch', () {
+    test('loads branches and linked PRs in one GraphQL process', () async {
+      final runner = FakeRecordingProcessRunner(<Object>[
+        _ok('''
+{"data":{"repository":{
+  "branch0":{"nodes":[{"number":123,"title":"feat: sidebar status","state":"OPEN","url":"https://github.com/leynier/alera/pull/123","createdAt":"2026-09-01T00:00:00Z","isDraft":false,"mergeable":"MERGEABLE","headRefName":"feature","baseRefName":"main","headRefOid":"abc","commits":{"nodes":[{"commit":{"statusCheckRollup":{"contexts":{"nodes":[{"__typename":"CheckRun","name":"build","status":"IN_PROGRESS","conclusion":null,"detailsUrl":"https://ci/build"},{"__typename":"StatusContext","context":"lint","state":"FAILURE","targetUrl":"https://ci/lint"}]}}}}]}}]},
+  "review0":{"number":77,"title":"merged work","state":"MERGED","url":"https://github.com/leynier/alera/pull/77","createdAt":"2026-08-01T00:00:00Z","isDraft":false,"mergeable":"UNKNOWN","headRefName":"old-feature","baseRefName":"main","headRefOid":"def","commits":{"nodes":[]}}
+}}}
+'''),
+      ]);
+      final provider = GitHubForgeProvider(runner);
+
+      final batch = await provider.getReviewBatch(
+        identity: _identity,
+        repoPath: '/repo',
+        branches: const <String>{'feature'},
+        reviewNumbers: const <int>{77},
+      );
+
+      final call = runner.calls.single;
+      expect(call.executable, 'gh');
+      expect(call.arguments.take(2), <String>['api', 'graphql']);
+      expect(call.workingDirectory, '/repo');
+      expect(call.arguments, contains('branch0=feature'));
+      expect(call.arguments, contains('number0=77'));
+      expect(
+        call.arguments.firstWhere((argument) => argument.startsWith('query=')),
+        contains('statusCheckRollup'),
+      );
+
+      final feature = batch.byBranch['feature'];
+      expect(feature, isNotNull);
+      expect(feature!.review.number, 123);
+      expect(feature.checks, hasLength(2));
+      expect(feature.checks[0].status, ReviewCheckStatus.inProgress);
+      expect(feature.checks[0].conclusion, ReviewCheckConclusion.pending);
+      expect(feature.checks[1].conclusion, ReviewCheckConclusion.failure);
+      expect(batch.byNumber[123], same(feature));
+      expect(batch.byNumber[77]!.review.state, HostedReviewState.merged);
+      expect(batch.byBranch['old-feature']!.review.number, 77);
+    });
+  });
+
   group('GitHubForgeProvider.getChecks', () {
     test('maps buckets to conclusions and status', () async {
       final runner = FakeRecordingProcessRunner(<Object>[

--- a/test/unit/github_forge_provider_test.dart
+++ b/test/unit/github_forge_provider_test.dart
@@ -96,49 +96,6 @@ void main() {
     });
   });
 
-  group('GitHubForgeProvider.getReviewBatch', () {
-    test('loads branches and linked PRs in one GraphQL process', () async {
-      final runner = FakeRecordingProcessRunner(<Object>[
-        _ok('''
-{"data":{"repository":{
-  "branch0":{"nodes":[{"number":123,"title":"feat: sidebar status","state":"OPEN","url":"https://github.com/leynier/alera/pull/123","createdAt":"2026-09-01T00:00:00Z","isDraft":false,"mergeable":"MERGEABLE","headRefName":"feature","baseRefName":"main","headRefOid":"abc","commits":{"nodes":[{"commit":{"statusCheckRollup":{"contexts":{"nodes":[{"__typename":"CheckRun","name":"build","status":"IN_PROGRESS","conclusion":null,"detailsUrl":"https://ci/build"},{"__typename":"StatusContext","context":"lint","state":"FAILURE","targetUrl":"https://ci/lint"}]}}}}]}}]},
-  "review0":{"number":77,"title":"merged work","state":"MERGED","url":"https://github.com/leynier/alera/pull/77","createdAt":"2026-08-01T00:00:00Z","isDraft":false,"mergeable":"UNKNOWN","headRefName":"old-feature","baseRefName":"main","headRefOid":"def","commits":{"nodes":[]}}
-}}}
-'''),
-      ]);
-      final provider = GitHubForgeProvider(runner);
-
-      final batch = await provider.getReviewBatch(
-        identity: _identity,
-        repoPath: '/repo',
-        branches: const <String>{'feature'},
-        reviewNumbers: const <int>{77},
-      );
-
-      final call = runner.calls.single;
-      expect(call.executable, 'gh');
-      expect(call.arguments.take(2), <String>['api', 'graphql']);
-      expect(call.workingDirectory, '/repo');
-      expect(call.arguments, contains('branch0=feature'));
-      expect(call.arguments, contains('number0=77'));
-      expect(
-        call.arguments.firstWhere((argument) => argument.startsWith('query=')),
-        contains('statusCheckRollup'),
-      );
-
-      final feature = batch.byBranch['feature'];
-      expect(feature, isNotNull);
-      expect(feature!.review.number, 123);
-      expect(feature.checks, hasLength(2));
-      expect(feature.checks[0].status, ReviewCheckStatus.inProgress);
-      expect(feature.checks[0].conclusion, ReviewCheckConclusion.pending);
-      expect(feature.checks[1].conclusion, ReviewCheckConclusion.failure);
-      expect(batch.byNumber[123], same(feature));
-      expect(batch.byNumber[77]!.review.state, HostedReviewState.merged);
-      expect(batch.byBranch['old-feature']!.review.number, 77);
-    });
-  });
-
   group('GitHubForgeProvider.getChecks', () {
     test('maps buckets to conclusions and status', () async {
       final runner = FakeRecordingProcessRunner(<Object>[

--- a/test/unit/settings_controller_test.dart
+++ b/test/unit/settings_controller_test.dart
@@ -243,6 +243,8 @@ void main() {
         await controller.setShowTrayIcon(false);
         await controller.setShowDockBadge(false);
         await controller.setShowTrayBadge(false);
+        await controller.setShowPullRequestStatusInSidebar(false);
+        await controller.setPullRequestFailureNotificationsEnabled(true);
 
         final restored = await repository.load();
         expect(
@@ -278,6 +280,8 @@ void main() {
         expect(restored.general.showTrayIcon, isFalse);
         expect(restored.general.showDockBadge, isFalse);
         expect(restored.general.showTrayBadge, isFalse);
+        expect(restored.general.showPullRequestStatusInSidebar, isFalse);
+        expect(restored.general.pullRequestFailureNotificationsEnabled, isTrue);
       },
     );
 

--- a/test/unit/settings_search_entries_test.dart
+++ b/test/unit/settings_search_entries_test.dart
@@ -31,7 +31,7 @@ void main() {
 
     expect(
       _catalogFingerprint(catalogs),
-      '99cdaa6c91977c947d2b099c764031db9f8063bda46b9256f0106da1c7469ada',
+      '3f5bcd1ea73ed8210cdd50a9f4de90b15f1b9a019a9d6842d3637a20631edc22',
     );
   });
 
@@ -82,6 +82,14 @@ void main() {
         entries: applicationSearchEntries,
         query: 'taskbar',
         expected: <(String, String?)>[('Show Dock Badge', 'desktop')],
+      ),
+      (
+        entries: applicationSearchEntries,
+        query: 'pull request',
+        expected: <(String, String?)>[
+          ('Show Pull Request Status', 'pullRequests'),
+          ('Notify When Checks Fail', 'pullRequests'),
+        ],
       ),
       (
         entries: agentsSearchEntries,

--- a/test/unit/workspace_pull_request_monitor_test.dart
+++ b/test/unit/workspace_pull_request_monitor_test.dart
@@ -1,0 +1,274 @@
+import 'package:alera/src/features/pull_requests/application/forge_provider.dart';
+import 'package:alera/src/features/pull_requests/application/forge_provider_registry.dart';
+import 'package:alera/src/features/pull_requests/application/forge_review_batch_provider.dart';
+import 'package:alera/src/features/pull_requests/application/linked_review_repository.dart';
+import 'package:alera/src/features/pull_requests/application/workspace_pull_request_monitor.dart';
+import 'package:alera/src/features/pull_requests/domain/forge_auth_status.dart';
+import 'package:alera/src/features/pull_requests/domain/hosted_review.dart';
+import 'package:alera/src/features/pull_requests/domain/linked_review.dart';
+import 'package:alera/src/features/pull_requests/domain/review_check.dart';
+import 'package:alera/src/features/pull_requests/domain/workspace_pull_request_summary.dart';
+import 'package:alera/src/shared/git_hosting/domain/git_hosting_provider.dart';
+import 'package:alera/src/shared/git_hosting/domain/git_remote_identity.dart';
+import 'package:alera/src/shared/infra/git/git_backend.dart';
+import 'package:alera/src/shared/infra/git/git_remote.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test(
+    'batches every workspace for one repository into one provider call',
+    () async {
+      final git = _FakeGitBackend();
+      final forge = _FakeBatchForge(
+        batch: ForgeReviewBatch(
+          byBranch: <String, ForgeReviewSnapshot>{
+            'feat/one': _snapshot(number: 1, branch: 'feat/one'),
+            'feat/two': _snapshot(
+              number: 2,
+              branch: 'feat/two',
+              checks: const <ReviewCheck>[_pendingCheck],
+            ),
+          },
+        ),
+      );
+      final links = _FakeLinkedReviewRepository();
+      final loader = WorkspacePullRequestMonitorLoader(
+        git,
+        ForgeProviderRegistry(<ForgeProvider>[forge]),
+        links,
+      );
+
+      final result = await loader.load(
+        targets: const <WorkspacePullRequestMonitorTarget>[
+          WorkspacePullRequestMonitorTarget(
+            projectId: 'project-a',
+            projectName: 'Alera A',
+            workspaceId: 'workspace-one',
+            workspaceName: 'One',
+            repoPath: '/repo',
+            branch: 'feat/one',
+          ),
+          // A duplicate project registration for the same repository should not
+          // launch a second gh process.
+          WorkspacePullRequestMonitorTarget(
+            projectId: 'project-b',
+            projectName: 'Alera B',
+            workspaceId: 'workspace-two',
+            workspaceName: 'Two',
+            repoPath: '/repo',
+            branch: 'feat/two',
+          ),
+        ],
+      );
+
+      expect(result.hadErrors, isFalse);
+      expect(result.summaries.keys, <String>['workspace-one', 'workspace-two']);
+      expect(result.summaries['workspace-two']!.checksPending, isTrue);
+      expect(git.listRemoteCalls, 1);
+      expect(links.findCalls, 2);
+      expect(forge.batchCalls, 1);
+      expect(forge.authCalls, 0, reason: 'the batch classifies auth failures');
+      expect(forge.lastBranches, <String>{'feat/one', 'feat/two'});
+      expect(forge.lastReviewNumbers, isEmpty);
+    },
+  );
+
+  test(
+    'uses a manually linked review number instead of branch discovery',
+    () async {
+      final forge = _FakeBatchForge(
+        batch: ForgeReviewBatch(
+          byNumber: <int, ForgeReviewSnapshot>{
+            77: _snapshot(number: 77, branch: 'remote-branch'),
+          },
+        ),
+      );
+      final links = _FakeLinkedReviewRepository(
+        values: <String, LinkedReview>{
+          'workspace': LinkedReview.linked(
+            workspaceId: 'workspace',
+            provider: .github,
+            number: 77,
+            url: 'https://github.com/acme/app/pull/77',
+          ),
+        },
+      );
+      final loader = WorkspacePullRequestMonitorLoader(
+        _FakeGitBackend(),
+        ForgeProviderRegistry(<ForgeProvider>[forge]),
+        links,
+      );
+
+      final result = await loader.load(
+        targets: const <WorkspacePullRequestMonitorTarget>[
+          WorkspacePullRequestMonitorTarget(
+            projectId: 'project',
+            projectName: 'Alera',
+            workspaceId: 'workspace',
+            workspaceName: 'Workspace',
+            repoPath: '/repo',
+            branch: 'local-branch',
+          ),
+        ],
+      );
+
+      expect(result.summaries['workspace']!.review.number, 77);
+      expect(forge.lastBranches, isEmpty);
+      expect(forge.lastReviewNumbers, <int>{77});
+    },
+  );
+
+  test(
+    'preserves the last snapshot and reports provider errors for backoff',
+    () async {
+      final previous = <String, WorkspacePullRequestSummary>{
+        'workspace': WorkspacePullRequestSummary.fromChecks(
+          review: _review(number: 42, branch: 'feat/status'),
+          checks: const <ReviewCheck>[_pendingCheck],
+        ),
+      };
+      final forge = _FakeBatchForge(
+        batch: const ForgeReviewBatch(),
+        error: StateError('network unavailable'),
+      );
+      final loader = WorkspacePullRequestMonitorLoader(
+        _FakeGitBackend(),
+        ForgeProviderRegistry(<ForgeProvider>[forge]),
+        _FakeLinkedReviewRepository(),
+      );
+
+      final result = await loader.load(
+        targets: const <WorkspacePullRequestMonitorTarget>[
+          WorkspacePullRequestMonitorTarget(
+            projectId: 'project',
+            projectName: 'Alera',
+            workspaceId: 'workspace',
+            workspaceName: 'Workspace',
+            repoPath: '/repo',
+            branch: 'feat/status',
+          ),
+        ],
+        previous: previous,
+      );
+
+      expect(result.hadErrors, isTrue);
+      expect(result.summaries['workspace'], previous['workspace']);
+      expect(forge.batchCalls, 1);
+    },
+  );
+}
+
+const ReviewCheck _pendingCheck = ReviewCheck(
+  name: 'build',
+  status: .inProgress,
+  conclusion: .pending,
+);
+
+ForgeReviewSnapshot _snapshot({
+  required int number,
+  required String branch,
+  List<ReviewCheck> checks = const <ReviewCheck>[],
+}) {
+  return ForgeReviewSnapshot(
+    review: _review(number: number, branch: branch),
+    checks: checks,
+  );
+}
+
+HostedReview _review({required int number, required String branch}) {
+  return HostedReview(
+    provider: .github,
+    number: number,
+    title: 'PR $number',
+    state: .open,
+    url: 'https://github.com/acme/app/pull/$number',
+    headBranch: branch,
+    headSha: 'sha-$number',
+    mergeable: .mergeable,
+  );
+}
+
+class _FakeGitBackend implements GitBackend {
+  int listRemoteCalls = 0;
+
+  @override
+  Future<List<GitRemote>> listRemotes(String path) async {
+    listRemoteCalls++;
+    return const <GitRemote>[
+      GitRemote(name: 'origin', url: 'git@github.com:acme/app.git'),
+    ];
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _FakeLinkedReviewRepository implements LinkedReviewRepository {
+  _FakeLinkedReviewRepository({Map<String, LinkedReview>? values})
+    : _values = values ?? <String, LinkedReview>{};
+
+  final Map<String, LinkedReview> _values;
+  int findCalls = 0;
+
+  @override
+  Future<LinkedReview?> find(String workspaceId) async {
+    findCalls++;
+    return _values[workspaceId];
+  }
+
+  @override
+  Future<void> remove(String workspaceId) async {
+    _values.remove(workspaceId);
+  }
+
+  @override
+  Future<void> save(LinkedReview review) async {
+    _values[review.workspaceId] = review;
+  }
+
+  @override
+  Stream<LinkedReview?> watch(String workspaceId) =>
+      Stream<LinkedReview?>.value(_values[workspaceId]);
+}
+
+class _FakeBatchForge implements ForgeProvider, ForgeReviewBatchProvider {
+  _FakeBatchForge({required this.batch, this.error});
+
+  final ForgeReviewBatch batch;
+  final Object? error;
+  int batchCalls = 0;
+  int authCalls = 0;
+  Set<String> lastBranches = const <String>{};
+  Set<int> lastReviewNumbers = const <int>{};
+
+  @override
+  GitHostingProvider get id => GitHostingProvider.github;
+
+  @override
+  Future<ForgeAuthStatus> checkAuth({
+    required GitRemoteIdentity identity,
+  }) async {
+    authCalls++;
+    return ForgeAuthStatus.authenticated;
+  }
+
+  @override
+  Future<ForgeReviewBatch> getReviewBatch({
+    required GitRemoteIdentity identity,
+    required String repoPath,
+    required Set<String> branches,
+    required Set<int> reviewNumbers,
+  }) async {
+    batchCalls++;
+    lastBranches = Set<String>.from(branches);
+    lastReviewNumbers = Set<int>.from(reviewNumbers);
+    final failure = error;
+    if (failure != null) {
+      throw failure;
+    }
+    return batch;
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}

--- a/test/unit/workspace_pull_request_notifications_test.dart
+++ b/test/unit/workspace_pull_request_notifications_test.dart
@@ -1,0 +1,219 @@
+import 'package:alera/src/features/pull_requests/application/workspace_pull_request_notifications.dart';
+import 'package:alera/src/features/pull_requests/domain/hosted_review.dart';
+import 'package:alera/src/features/pull_requests/domain/review_check.dart';
+import 'package:alera/src/features/pull_requests/domain/workspace_pull_request_summary.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('WorkspacePullRequestSummary', () {
+    test('failure dominates pending and keeps a bounded failure preview', () {
+      final summary = _summary(
+        checks: const <ReviewCheck>[
+          ReviewCheck(name: 'build', status: .inProgress, conclusion: .pending),
+          ReviewCheck(name: 'linux', status: .completed, conclusion: .failure),
+          ReviewCheck(name: 'macos', status: .completed, conclusion: .timedOut),
+          ReviewCheck(
+            name: 'windows',
+            status: .completed,
+            conclusion: .cancelled,
+          ),
+          ReviewCheck(
+            name: 'android',
+            status: .completed,
+            conclusion: .actionRequired,
+          ),
+        ],
+      );
+
+      expect(summary.checksRollup, ReviewChecksRollup.failure);
+      expect(summary.checksFailed, isTrue);
+      expect(summary.pendingCheckCount, 1);
+      expect(summary.failedCheckCount, 4);
+      expect(summary.failingCheckNames, <String>['linux', 'macos', 'windows']);
+    });
+
+    test('reports merge conflicts only for open pull requests', () {
+      final open = _summary(mergeable: .conflicting);
+      final merged = _summary(state: .merged, mergeable: .conflicting);
+
+      expect(open.hasMergeConflict, isTrue);
+      expect(merged.hasMergeConflict, isFalse);
+    });
+  });
+
+  group('WorkspacePullRequestFailureTracker', () {
+    test('does not replay failures already present at startup', () {
+      final tracker = WorkspacePullRequestFailureTracker();
+      final failed = <String, WorkspacePullRequestSummary>{
+        'workspace': _failedSummary(),
+      };
+
+      expect(tracker.pending(failed), isEmpty);
+      expect(tracker.pending(failed), isEmpty);
+    });
+
+    test('notifies once per failure transition and again after recovery', () {
+      final tracker = WorkspacePullRequestFailureTracker();
+      final pending = <String, WorkspacePullRequestSummary>{
+        'workspace': _summary(checks: const <ReviewCheck>[_pendingCheck]),
+      };
+      final failed = <String, WorkspacePullRequestSummary>{
+        'workspace': _failedSummary(),
+      };
+      final successful = <String, WorkspacePullRequestSummary>{
+        'workspace': _summary(checks: const <ReviewCheck>[_successfulCheck]),
+      };
+
+      tracker.baseline(pending);
+      expect(tracker.pending(failed), hasLength(1));
+      expect(tracker.pending(failed), isEmpty);
+      expect(tracker.pending(successful), isEmpty);
+      expect(tracker.pending(failed), hasLength(1));
+    });
+
+    test('does not repeat while more checks fail on the same head', () {
+      final tracker = WorkspacePullRequestFailureTracker();
+      final first = <String, WorkspacePullRequestSummary>{
+        'workspace': _failedSummary(headSha: 'sha-1'),
+      };
+      final second = <String, WorkspacePullRequestSummary>{
+        'workspace': _summary(
+          headSha: 'sha-1',
+          checks: const <ReviewCheck>[
+            ReviewCheck(
+              name: 'build',
+              status: .completed,
+              conclusion: .failure,
+            ),
+            ReviewCheck(name: 'lint', status: .completed, conclusion: .failure),
+          ],
+        ),
+      };
+
+      tracker.baseline(first);
+
+      expect(tracker.pending(second), isEmpty);
+    });
+
+    test('notifies for a new failing head commit on the same pull request', () {
+      final tracker = WorkspacePullRequestFailureTracker();
+      final first = <String, WorkspacePullRequestSummary>{
+        'workspace': _failedSummary(headSha: 'sha-1'),
+      };
+      final second = <String, WorkspacePullRequestSummary>{
+        'workspace': _failedSummary(headSha: 'sha-2'),
+      };
+
+      tracker.baseline(first);
+      final pending = tracker.pending(second);
+
+      expect(pending, hasLength(1));
+      expect(pending.single.summary.review.headSha, 'sha-2');
+    });
+
+    test('does not notify for checks left failed after the PR is terminal', () {
+      final tracker = WorkspacePullRequestFailureTracker();
+      tracker.baseline(const <String, WorkspacePullRequestSummary>{});
+
+      final pending = tracker.pending(<String, WorkspacePullRequestSummary>{
+        'workspace': _summary(
+          state: HostedReviewState.merged,
+          checks: const <ReviewCheck>[
+            ReviewCheck(
+              name: 'build',
+              status: .completed,
+              conclusion: .failure,
+            ),
+          ],
+        ),
+      });
+
+      expect(pending, isEmpty);
+    });
+  });
+
+  group('pull request failure notification', () {
+    test('payload round-trips and ignores other notification kinds', () {
+      const payload = WorkspacePullRequestNotificationPayload(
+        workspaceId: 'workspace',
+        reviewNumber: 42,
+        reviewUrl: 'https://github.com/acme/app/pull/42',
+      );
+
+      final decoded = decodeWorkspacePullRequestNotificationPayload(
+        payload.encode(),
+      );
+
+      expect(decoded, isNotNull);
+      expect(decoded!.workspaceId, 'workspace');
+      expect(decoded.reviewNumber, 42);
+      expect(decoded.reviewUrl, 'https://github.com/acme/app/pull/42');
+      expect(
+        decodeWorkspacePullRequestNotificationPayload(
+          '{"kind":"agentStatus","workspaceId":"workspace"}',
+        ),
+        isNull,
+      );
+    });
+
+    test('includes location and failing checks in the native notification', () {
+      final notification = composeWorkspacePullRequestFailureNotification(
+        failure: WorkspacePullRequestFailure(
+          workspaceId: 'workspace',
+          summary: _failedSummary(),
+        ),
+        projectName: 'Alera',
+        workspaceName: 'PR status',
+      );
+
+      expect(notification.title, 'PR #42 checks failed');
+      expect(notification.body, 'Alera · PR status — build');
+      expect(notification.id, isPositive);
+      expect(
+        decodeWorkspacePullRequestNotificationPayload(notification.payload),
+        isNotNull,
+      );
+    });
+  });
+}
+
+const ReviewCheck _pendingCheck = ReviewCheck(
+  name: 'build',
+  status: .inProgress,
+  conclusion: .pending,
+);
+
+const ReviewCheck _successfulCheck = ReviewCheck(
+  name: 'build',
+  status: .completed,
+  conclusion: .success,
+);
+
+WorkspacePullRequestSummary _failedSummary({String headSha = 'sha-1'}) =>
+    _summary(
+      headSha: headSha,
+      checks: const <ReviewCheck>[
+        ReviewCheck(name: 'build', status: .completed, conclusion: .failure),
+      ],
+    );
+
+WorkspacePullRequestSummary _summary({
+  HostedReviewState state = HostedReviewState.open,
+  HostedReviewMergeable mergeable = HostedReviewMergeable.mergeable,
+  String headSha = 'sha-1',
+  List<ReviewCheck> checks = const <ReviewCheck>[],
+}) {
+  return WorkspacePullRequestSummary.fromChecks(
+    review: HostedReview(
+      provider: .github,
+      number: 42,
+      title: 'feat: show PR status',
+      state: state,
+      url: 'https://github.com/acme/app/pull/42',
+      headBranch: 'feat/pr-status',
+      headSha: headSha,
+      mergeable: mergeable,
+    ),
+    checks: checks,
+  );
+}

--- a/test/unit/workspace_pull_request_notifications_test.dart
+++ b/test/unit/workspace_pull_request_notifications_test.dart
@@ -30,6 +30,7 @@ void main() {
       expect(summary.pendingCheckCount, 1);
       expect(summary.failedCheckCount, 4);
       expect(summary.failingCheckNames, <String>['linux', 'macos', 'windows']);
+      expect(summary.hashCode, summary.signature.hashCode);
     });
 
     test('reports merge conflicts only for open pull requests', () {

--- a/test/widget/workspace_pull_request_status_indicator_test.dart
+++ b/test/widget/workspace_pull_request_status_indicator_test.dart
@@ -1,0 +1,100 @@
+import 'package:alera/src/app/theme/alera_tokens.dart';
+import 'package:alera/src/design_system/icons/alera_icons.dart';
+import 'package:alera/src/features/pull_requests/domain/hosted_review.dart';
+import 'package:alera/src/features/pull_requests/domain/review_check.dart';
+import 'package:alera/src/features/pull_requests/domain/workspace_pull_request_summary.dart';
+import 'package:alera/src/features/pull_requests/presentation/workspace_pull_request_status_indicator.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('uses standard lifecycle icons and colors', (tester) async {
+    await _pump(tester, _summary(state: .open));
+    _expectIcon(tester, AleraIcons.gitPullRequest, AleraTokens.success);
+    expect(_tooltip(tester), contains('Ready to merge'));
+
+    await _pump(tester, _summary(state: .draft));
+    _expectIcon(
+      tester,
+      AleraIcons.gitPullRequestDraft,
+      AleraTokens.foregroundMuted,
+    );
+    expect(_tooltip(tester), contains('Draft'));
+
+    await _pump(tester, _summary(state: .merged));
+    _expectIcon(tester, AleraIcons.gitMerge, AleraTokens.done);
+    expect(_tooltip(tester), contains('Merged'));
+
+    await _pump(tester, _summary(state: .closed));
+    _expectIcon(tester, AleraIcons.gitPullRequestClosed, AleraTokens.error);
+    expect(_tooltip(tester), contains('Closed without merging'));
+  });
+
+  testWidgets('shows a static running-check badge', (tester) async {
+    await _pump(
+      tester,
+      _summary(
+        checks: const <ReviewCheck>[
+          ReviewCheck(name: 'build', status: .inProgress, conclusion: .pending),
+        ],
+      ),
+    );
+
+    _expectIcon(tester, AleraIcons.gitPullRequest, AleraTokens.success);
+    _expectIcon(tester, AleraIcons.loading, AleraTokens.warning);
+    expect(_tooltip(tester), contains('1 check running'));
+  });
+
+  testWidgets('shows failed checks and their names', (tester) async {
+    await _pump(
+      tester,
+      _summary(
+        checks: const <ReviewCheck>[
+          ReviewCheck(name: 'build', status: .completed, conclusion: .failure),
+        ],
+      ),
+    );
+
+    _expectIcon(tester, AleraIcons.cancel, AleraTokens.error);
+    expect(_tooltip(tester), contains('Checks failed'));
+    expect(_tooltip(tester), contains('build'));
+  });
+}
+
+Future<void> _pump(WidgetTester tester, WorkspacePullRequestSummary summary) {
+  return tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: Center(
+          child: WorkspacePullRequestStatusIndicator(summary: summary),
+        ),
+      ),
+    ),
+  );
+}
+
+void _expectIcon(WidgetTester tester, IconData data, Color color) {
+  final icon = tester.widget<Icon>(find.byIcon(data));
+  expect(icon.color, color);
+}
+
+String _tooltip(WidgetTester tester) {
+  return tester.widget<Tooltip>(find.byType(Tooltip)).message ?? '';
+}
+
+WorkspacePullRequestSummary _summary({
+  HostedReviewState state = HostedReviewState.open,
+  List<ReviewCheck> checks = const <ReviewCheck>[],
+}) {
+  return WorkspacePullRequestSummary.fromChecks(
+    review: HostedReview(
+      provider: .github,
+      number: 42,
+      title: 'feat: show PR status',
+      state: state,
+      url: 'https://github.com/acme/app/pull/42',
+      mergeable: .mergeable,
+    ),
+    checks: checks,
+  );
+}


### PR DESCRIPTION
## Summary

- show a compact pull-request lifecycle indicator beside each workspace in the left sidebar
- batch GitHub PR and check status lookups per repository with one adaptive monitor instead of per-workspace polling
- expose draft, running, failed, ready, merged, closed, and conflict states using conventional GitHub-style icons and tooltips
- add configurable native notifications when PR checks transition into failure, with deduplication per PR head
- preserve last-known status through transient provider failures and refresh immediately after local PR mutations

## Screenshots

- Not captured in this CLI-only workflow; the new indicator and tooltip states are covered by widget tests.

## Testing

- [ ] `dart format --set-exit-if-changed lib test integration_test tool`
- [x] `flutter analyze`
- [ ] `flutter test --coverage --exclude-tags golden`
- [ ] `dart run tool/quality/coverage_report.dart --input coverage/lcov.info --min-lines 100 --worst 25`
- [ ] Golden tests, if UI changed: `flutter test --tags golden`
- [ ] Desktop E2E, if app-shell flow changed: `flutter test integration_test -d macos`
- [ ] Relevant desktop build: `flutter build macos`, `flutter build windows`, or `flutter build linux`
- [ ] Landing build, if applicable: `cd landing && bun run build`
- [x] Added or updated tests that would catch regressions, or explained why tests were not needed

Additional validation:

- [x] full `flutter test` suite before rebasing onto current `main`
- [x] targeted PR-provider, monitor, notification, indicator, Ship, unlink, and stacked-PR tests after the rebase
- [x] `dart run build_runner build` after resolving the generated Riverpod conflict
- [x] `git diff --check`

## AI Review Report

Reviewed the implementation around provider batching, adaptive polling, transient-error preservation, stale-response protection, notification transition deduplication, generated-provider consistency, and interaction with the newly merged Ship action. The rebase produced one generated Riverpod hash conflict; it was regenerated from the combined source and the affected PR test suites were rerun successfully.

## Security Audit

- no secrets or credentials are persisted
- GitHub access continues through the existing authenticated `gh` CLI/process boundary
- provider errors are classified and last-known UI state is retained rather than treating failures as successful checks
- notification payloads contain only workspace/PR navigation metadata
- no new shell interpolation accepts user-provided input

## Notes

- the sidebar indicator setting defaults to enabled
- failed-check notifications default to disabled
- monitoring parks while the app is hidden unless failure notifications are enabled
- GitHub uses one GraphQL request per repository refresh; other configured forges use the existing provider abstraction as a bounded fallback
