### PR TITLE
chore(deps): ignore Dependabot major version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,10 @@ updates:
     directory: /
     schedule:
       interval: monthly
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
     cooldown:
       default-days: 7
     commit-message:
@@ -25,6 +29,10 @@ updates:
       - /tool/release/runtime_packager
     schedule:
       interval: monthly
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
     cooldown:
       default-days: 7
     commit-message:
@@ -42,6 +50,10 @@ updates:
       - /rust
     schedule:
       interval: monthly
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
     cooldown:
       default-days: 7
     commit-message:
@@ -59,6 +71,10 @@ updates:
       - /landing
     schedule:
       interval: monthly
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
     cooldown:
       default-days: 7
     commit-message:
@@ -77,6 +93,10 @@ updates:
       - /rust_builder/android
     schedule:
       interval: monthly
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
     cooldown:
       default-days: 7
     commit-message:
@@ -94,6 +114,10 @@ updates:
       - /infra/production
     schedule:
       interval: monthly
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
     cooldown:
       default-days: 7
     commit-message:
@@ -109,6 +133,10 @@ updates:
     directory: /cloud
     schedule:
       interval: monthly
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
     cooldown:
       default-days: 7
     commit-message:
@@ -123,6 +151,10 @@ updates:
     directory: /cloud
     schedule:
       interval: monthly
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
     cooldown:
       default-days: 7
     commit-message:
@@ -139,6 +171,10 @@ updates:
       - /rust
     schedule:
       interval: monthly
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
     cooldown:
       default-days: 7
     commit-message:


### PR DESCRIPTION
## Summary

- Add an `ignore` rule with `dependency-name: "*"` and `update-types: ["version-update:semver-major"]` to every `updates` entry in the Dependabot config.
- Dependabot will now only open version-update PRs for **minor** and **patch** releases; major bumps no longer arrive as PRs.

Security updates are unaffected: `ignore` only filters version updates.

Refs: [Dependabot options reference — `ignore`](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#ignore)
