### PR TITLE
fix: retire removed features only during owned runtime startup

### DIFF
--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -2,6 +2,8 @@
 
 Alera writes rotating log files on the machine so an error can be reviewed after it happened. Logging is always on; sending anything off the machine is opt-in and off by default.
 
+If a v0.81.0 runtime log reports `no such table: main.codexChatState` during startup, the feature-removal migration left a legacy trigger on `workspaceTabs`. The corrected host removes that trigger before removing the obsolete table, including when a previous startup already removed the table. This cleanup and removal of retired tabs run in one transaction after acquiring runtime ownership and before publishing the control file. Ordinary database opens, including `alera runtime status`, preserve the legacy tables so an older running host can continue using them. Keep the existing runtime database: clearing it is unnecessary and would discard supported workspace state.
+
 ## Where Logs Live
 
 | Surface | Directory | Base name |

--- a/rust/alera-cli/src/terminal_host/server_runner.rs
+++ b/rust/alera-cli/src/terminal_host/server_runner.rs
@@ -26,6 +26,7 @@ pub async fn run_terminal_host_server(
     };
     let store = TerminalHostHistoryStore::open(&runtime_dir).await?;
     let runtime_store = RuntimeStore::open(&runtime_dir).await?;
+    runtime_store.retire_removed_features().await?;
     crate::hosted_review_retention::reconcile(&runtime_store).await;
 
     crate::automation_autostart::reconcile_runtime_autostart(&runtime_store, &runtime_dir).await;
@@ -59,15 +60,6 @@ pub async fn run_terminal_host_server(
         let _ = crate::login_shell_environment::login_shell_path_segments().await;
     });
 
-    runtime_store
-        .remove_workspace_tabs_with_kind("mobileEmulator")
-        .await?;
-    runtime_store
-        .remove_workspace_tabs_with_kind("browser")
-        .await?;
-    runtime_store
-        .remove_workspace_tabs_with_kind("codex")
-        .await?;
     let mut actor = ServerActor {
         runtime_dir,
         control_file_path,

--- a/rust/alera-cli/tests/runtime_owner_conformance.rs
+++ b/rust/alera-cli/tests/runtime_owner_conformance.rs
@@ -318,3 +318,67 @@ fn stale_owner_is_recovered_after_the_process_exits() {
     assert_eq!(owner["pid"], replacement_pid);
     assert!(replacement.child_mut().try_wait().unwrap().is_none());
 }
+
+#[test]
+fn runtime_status_preserves_legacy_state_until_the_owner_restarts() {
+    let dir = tempfile::tempdir().unwrap();
+    let runtime_dir = dir.path().join("runtime");
+    let control_path = runtime_dir.join("runtime-host.json");
+    std::fs::create_dir_all(&runtime_dir).unwrap();
+    let mut owner = HostGuard::new(spawn_host(&runtime_dir, &control_path, "owner-token"));
+    let owner_pid = owner.child_mut().id();
+    read_control_for_pid(&control_path, owner_pid);
+
+    let runtime = tokio::runtime::Runtime::new().unwrap();
+    let store = runtime.block_on(async {
+        let store = alera_core::runtime::RuntimeStore::open(&runtime_dir)
+            .await
+            .unwrap();
+        // Model a compatible older owner with an outstanding persisted chat.
+        for statement in [
+            "CREATE TABLE codexChatState (threadId TEXT PRIMARY KEY, tabId TEXT NOT NULL, revision INTEGER NOT NULL, stateJson TEXT NOT NULL)",
+            "CREATE TRIGGER codexChatStateDeleteTab AFTER DELETE ON workspaceTabs BEGIN DELETE FROM codexChatState WHERE tabId = OLD.id; END",
+            "INSERT INTO codexChatState VALUES ('thread-1', 'tab-1', 1, '{\"messages\":[{\"status\":\"queued\"}]}')",
+        ] {
+            sqlx::query(statement).execute(store.pool()).await.unwrap();
+        }
+        store
+    });
+
+    let output = windowless_command(env!("CARGO_BIN_EXE_alera"))
+        .args([
+            "runtime",
+            "--runtime-dir",
+            runtime_dir.to_str().unwrap(),
+            "--json",
+            "status",
+        ])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let status: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(status["running"], true);
+    assert!(owner.child_mut().try_wait().unwrap().is_none());
+    runtime.block_on(async {
+        let state: String = sqlx::query_scalar("SELECT stateJson FROM codexChatState")
+            .fetch_one(store.pool())
+            .await
+            .unwrap();
+        assert_eq!(state, r#"{"messages":[{"status":"queued"}]}"#);
+    });
+
+    owner.stop();
+    let mut replacement =
+        HostGuard::new(spawn_host(&runtime_dir, &control_path, "replacement-token"));
+    read_control_for_pid(&control_path, replacement.child_mut().id());
+    runtime.block_on(async {
+        let legacy_objects: i64 = sqlx::query_scalar(
+            "SELECT count(*) FROM sqlite_master WHERE name IN ('codexChatState', 'codexChatStateDeleteTab')",
+        )
+        .fetch_one(store.pool())
+        .await
+        .unwrap();
+        assert_eq!(legacy_objects, 0);
+        store.pool().close().await;
+    });
+}

--- a/rust/alera-core/src/runtime/mod.rs
+++ b/rust/alera-core/src/runtime/mod.rs
@@ -51,6 +51,8 @@ mod project_clone_models;
 mod runtime_file_security;
 mod runtime_schema;
 mod schema_migrations;
+#[cfg(test)]
+mod schema_migrations_tests;
 mod settings_models;
 mod settings_store;
 #[cfg(test)]

--- a/rust/alera-core/src/runtime/schema_migrations.rs
+++ b/rust/alera-core/src/runtime/schema_migrations.rs
@@ -4,6 +4,31 @@ use sqlx::Row;
 use super::RuntimeStore;
 
 impl RuntimeStore {
+    /// Only the host holding exclusive runtime ownership may retire feature data.
+    /// Ordinary store opens can share a profile with an older, still-running host.
+    pub async fn retire_removed_features(&self) -> Result<()> {
+        let mut transaction = self.pool().begin().await?;
+        for statement in [
+            // The trigger belongs to workspaceTabs and survives dropping its target table.
+            "DROP TRIGGER IF EXISTS codexChatStateDeleteTab",
+            "DROP TABLE IF EXISTS agentCanvasEvents",
+            "DROP TABLE IF EXISTS agentCanvasDecisions",
+            "DROP TABLE IF EXISTS agentCanvasRevisions",
+            "DROP TABLE IF EXISTS agentCanvases",
+            "DROP TABLE IF EXISTS browserTrustedCertificates",
+            "DROP TABLE IF EXISTS browserPermissions",
+            "DROP TABLE IF EXISTS browserClosedTabs",
+            "DROP TABLE IF EXISTS browserHistory",
+            "DROP TABLE IF EXISTS browserProfiles",
+            "DROP TABLE IF EXISTS codexChatState",
+            "DELETE FROM workspaceTabs WHERE kind IN ('mobileEmulator', 'browser', 'codex')",
+        ] {
+            sqlx::query(statement).execute(&mut *transaction).await?;
+        }
+        transaction.commit().await?;
+        Ok(())
+    }
+
     pub(super) async fn ensure_column(
         &self,
         table: &str,

--- a/rust/alera-core/src/runtime/schema_migrations_tests.rs
+++ b/rust/alera-core/src/runtime/schema_migrations_tests.rs
@@ -1,0 +1,222 @@
+use chrono::Utc;
+
+use super::{RuntimeStore, WorkspaceTabRecord};
+
+// This trigger belongs to workspaceTabs, so dropping codexChatState leaves it behind.
+const LEGACY_CODEX_SCHEMA: &[&str] = &[
+    "CREATE TABLE codexChatState (threadId TEXT PRIMARY KEY, tabId TEXT NOT NULL, revision INTEGER NOT NULL, stateJson TEXT NOT NULL)",
+    "CREATE INDEX codexChatStateTab ON codexChatState(tabId)",
+    "CREATE TRIGGER codexChatStateDeleteTab AFTER DELETE ON workspaceTabs BEGIN DELETE FROM codexChatState WHERE tabId = OLD.id; END",
+];
+
+#[tokio::test]
+async fn opening_another_store_preserves_state_used_by_the_running_host() {
+    let dir = tempfile::tempdir().unwrap();
+    let host_store = RuntimeStore::open(dir.path()).await.unwrap();
+    for statement in LEGACY_CODEX_SCHEMA {
+        sqlx::query(*statement)
+            .execute(host_store.pool())
+            .await
+            .unwrap();
+    }
+    let pending_state = r#"{"messages":[{"status":"queued"}]}"#;
+    sqlx::query("INSERT INTO codexChatState VALUES ('thread-1', 'legacy-codex', 1, ?)")
+        .bind(pending_state)
+        .execute(host_store.pool())
+        .await
+        .unwrap();
+
+    let client_store = RuntimeStore::open(dir.path()).await.unwrap();
+    let state: String =
+        sqlx::query_scalar("SELECT stateJson FROM codexChatState WHERE threadId = 'thread-1'")
+            .fetch_one(host_store.pool())
+            .await
+            .unwrap();
+    assert_eq!(state, pending_state);
+    let trigger_count: i64 = sqlx::query_scalar(
+        "SELECT count(*) FROM sqlite_master WHERE name = 'codexChatStateDeleteTab'",
+    )
+    .fetch_one(host_store.pool())
+    .await
+    .unwrap();
+    assert_eq!(trigger_count, 1);
+    client_store.pool().close().await;
+    host_store.pool().close().await;
+}
+
+async fn verify_legacy_codex_migration(table_already_dropped: bool) {
+    let dir = tempfile::tempdir().unwrap();
+    let store = RuntimeStore::open(dir.path()).await.unwrap();
+    let now = Utc::now();
+    let terminal = WorkspaceTabRecord {
+        id: "terminal-1".into(),
+        workspace_id: "workspace-1".into(),
+        kind: "terminal".into(),
+        title: "Codex".into(),
+        created_at: now,
+        updated_at: now,
+        payload: serde_json::json!({"initialCommand": "codex"}),
+    };
+    store.upsert_workspace_tab(terminal.clone()).await.unwrap();
+    let persisted_terminal = store
+        .find_workspace_tab(&terminal.id)
+        .await
+        .unwrap()
+        .unwrap();
+    for kind in ["mobileEmulator", "browser", "codex"] {
+        store
+            .upsert_workspace_tab(WorkspaceTabRecord {
+                id: format!("legacy-{kind}"),
+                kind: kind.into(),
+                ..terminal.clone()
+            })
+            .await
+            .unwrap();
+    }
+    for statement in LEGACY_CODEX_SCHEMA {
+        sqlx::query(*statement).execute(store.pool()).await.unwrap();
+    }
+    sqlx::query("INSERT INTO codexChatState VALUES ('thread-1', 'legacy-codex', 1, '{}')")
+        .execute(store.pool())
+        .await
+        .unwrap();
+    if table_already_dropped {
+        sqlx::query("DROP TABLE codexChatState")
+            .execute(store.pool())
+            .await
+            .unwrap();
+    }
+    store.pool().close().await;
+
+    let store = RuntimeStore::open(dir.path()).await.unwrap();
+    store.retire_removed_features().await.unwrap();
+    let tabs = store.list_workspace_tabs("workspace-1").await.unwrap();
+    assert_eq!(tabs.len(), 1);
+    assert_eq!(
+        serde_json::to_value(&tabs[0]).unwrap(),
+        serde_json::to_value(&persisted_terminal).unwrap()
+    );
+    let legacy_objects: i64 = sqlx::query_scalar(
+        "SELECT count(*) FROM sqlite_master WHERE name IN ('codexChatState', 'codexChatStateTab', 'codexChatStateDeleteTab')",
+    )
+    .fetch_one(store.pool())
+    .await
+    .unwrap();
+    assert_eq!(legacy_objects, 0);
+    store.pool().close().await;
+
+    let store = RuntimeStore::open(dir.path()).await.unwrap();
+    store.retire_removed_features().await.unwrap();
+    assert_eq!(
+        store
+            .list_workspace_tabs("workspace-1")
+            .await
+            .unwrap()
+            .len(),
+        1
+    );
+    store.remove_workspace_tab(&terminal.id).await.unwrap();
+    assert!(store
+        .list_workspace_tabs("workspace-1")
+        .await
+        .unwrap()
+        .is_empty());
+    store.pool().close().await;
+}
+
+#[tokio::test]
+async fn legacy_codex_migration_allows_startup_cleanup() {
+    verify_legacy_codex_migration(false).await;
+}
+
+#[tokio::test]
+async fn legacy_codex_migration_recovers_after_failed_feature_cut_startup() {
+    verify_legacy_codex_migration(true).await;
+}
+
+#[tokio::test]
+async fn legacy_codex_migration_recovers_with_no_workspace_tabs() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = RuntimeStore::open(dir.path()).await.unwrap();
+    for statement in LEGACY_CODEX_SCHEMA {
+        sqlx::query(*statement).execute(store.pool()).await.unwrap();
+    }
+    sqlx::query("DROP TABLE codexChatState")
+        .execute(store.pool())
+        .await
+        .unwrap();
+    store.pool().close().await;
+
+    let store = RuntimeStore::open(dir.path()).await.unwrap();
+    store.retire_removed_features().await.unwrap();
+    assert!(store
+        .list_workspace_tabs("workspace-1")
+        .await
+        .unwrap()
+        .is_empty());
+    store.pool().close().await;
+}
+
+#[tokio::test]
+async fn feature_retirement_rolls_back_schema_and_data_when_tab_cleanup_fails() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = RuntimeStore::open(dir.path()).await.unwrap();
+    for statement in LEGACY_CODEX_SCHEMA {
+        sqlx::query(*statement).execute(store.pool()).await.unwrap();
+    }
+    sqlx::query("INSERT INTO codexChatState VALUES ('thread-1', 'legacy-codex', 1, '{}')")
+        .execute(store.pool())
+        .await
+        .unwrap();
+    let now = Utc::now();
+    store
+        .upsert_workspace_tab(WorkspaceTabRecord {
+            id: "legacy-codex".into(),
+            workspace_id: "workspace-1".into(),
+            kind: "codex".into(),
+            title: "Pending Chat".into(),
+            created_at: now,
+            updated_at: now,
+            payload: serde_json::json!({"threadId": "thread-1"}),
+        })
+        .await
+        .unwrap();
+    sqlx::query(
+        "CREATE TRIGGER failFeatureRetirement BEFORE DELETE ON workspaceTabs BEGIN SELECT RAISE(ABORT, 'blocked retirement'); END",
+    )
+    .execute(store.pool())
+    .await
+    .unwrap();
+
+    let error = store.retire_removed_features().await.unwrap_err();
+    assert!(error.to_string().contains("blocked retirement"));
+    let state: String = sqlx::query_scalar("SELECT stateJson FROM codexChatState")
+        .fetch_one(store.pool())
+        .await
+        .unwrap();
+    assert_eq!(state, "{}");
+    let objects: i64 = sqlx::query_scalar(
+        "SELECT count(*) FROM sqlite_master WHERE name IN ('codexChatState', 'codexChatStateTab', 'codexChatStateDeleteTab')",
+    )
+    .fetch_one(store.pool())
+    .await
+    .unwrap();
+    assert_eq!(objects, 3);
+    assert!(store
+        .find_workspace_tab("legacy-codex")
+        .await
+        .unwrap()
+        .is_some());
+
+    sqlx::query("DROP TRIGGER failFeatureRetirement")
+        .execute(store.pool())
+        .await
+        .unwrap();
+    store.retire_removed_features().await.unwrap();
+    assert!(store
+        .find_workspace_tab("legacy-codex")
+        .await
+        .unwrap()
+        .is_none());
+    store.pool().close().await;
+}

--- a/rust/alera-core/src/runtime/store.rs
+++ b/rust/alera-core/src/runtime/store.rs
@@ -77,20 +77,6 @@ impl RuntimeStore {
         for statement in super::orchestration_message_store::ORCHESTRATION_SCHEMA {
             sqlx::query(*statement).execute(&self.pool).await?;
         }
-        for statement in [
-            "DROP TABLE IF EXISTS agentCanvasEvents",
-            "DROP TABLE IF EXISTS agentCanvasDecisions",
-            "DROP TABLE IF EXISTS agentCanvasRevisions",
-            "DROP TABLE IF EXISTS agentCanvases",
-            "DROP TABLE IF EXISTS browserTrustedCertificates",
-            "DROP TABLE IF EXISTS browserPermissions",
-            "DROP TABLE IF EXISTS browserClosedTabs",
-            "DROP TABLE IF EXISTS browserHistory",
-            "DROP TABLE IF EXISTS browserProfiles",
-            "DROP TABLE IF EXISTS codexChatState",
-        ] {
-            sqlx::query(statement).execute(&self.pool).await?;
-        }
         self.set_metadata(
             "orchestration.schemaVersion",
             super::orchestration_message_store::ORCHESTRATION_SCHEMA_VERSION,
@@ -929,14 +915,6 @@ impl RuntimeStore {
             self.remove_workspace(&workspace.id, true).await?;
         }
         Ok(())
-    }
-
-    pub async fn remove_workspace_tabs_with_kind(&self, kind: &str) -> Result<u64> {
-        let result = sqlx::query("DELETE FROM workspaceTabs WHERE kind = ?")
-            .bind(kind)
-            .execute(&self.pool)
-            .await?;
-        Ok(result.rows_affected())
     }
 
     pub async fn list_workspace_tabs(&self, workspace_id: &str) -> Result<Vec<WorkspaceTabRecord>> {


### PR DESCRIPTION
## Summary

Recover runtime startup after the feature-removal migration left a dangling Codex trigger. Retire obsolete tables and tabs atomically only after the new host acquires runtime ownership, so commands such as `runtime status` cannot delete state used by an older running host. Cleanup finishes before the host publishes its control file. No visual change.

## Validation

- `make rust-test`: formatting, Clippy and 1,383 tests passed.
- Desktop: 2,985 Flutter tests passed; mobile: 407 passed. Both static analyses passed.
- Six regression tests cover legacy and partially migrated databases, concurrent store opens, rollback, idempotence and executable-level status/owner restart behavior.
- `make cli-build` and an isolated release-binary persistence/restart/integrity smoke passed.
- Two reviews of the full feature-removal PR plus accumulated fixes completed; the final pass reported no actionable findings.

## Security And Platform Notes

The migration preserves supported workspace data and keeps destructive schema retirement behind exclusive host ownership. No auth, secrets, dependencies or protocol versions change. Diagnostics documentation explains recovery without clearing the database. Local validation ran on Linux; native macOS and Windows release builds remain required before publication.
