### PR TITLE
fix: hide unlinked merged and closed pr indicators

### DIFF
--- a/lib/src/features/pull_requests/application/workspace_pull_request_monitor.dart
+++ b/lib/src/features/pull_requests/application/workspace_pull_request_monitor.dart
@@ -171,16 +171,12 @@ class const WorkspacePullRequestMonitorLoader(
     final summaries = <String, WorkspacePullRequestSummary>{};
     for (final target in targets) {
       final linked = linkedByWorkspace[target.workspaceId];
-      ForgeReviewSnapshot? snapshot;
-      if (linked?.hasReview == true) {
-        snapshot = batch.byNumber[linked!.number];
-      } else {
-        snapshot = batch.byBranch[target.branch];
-        final previousNumber = previous[target.workspaceId]?.review.number;
-        snapshot ??= previousNumber == null
-            ? null
-            : batch.byNumber[previousNumber];
-      }
+      final snapshot = _snapshotForTarget(
+        target: target,
+        linked: linked,
+        batch: batch,
+        previous: previous,
+      );
       if (snapshot == null || _isDismissed(linked, snapshot, identity)) {
         continue;
       }
@@ -190,6 +186,27 @@ class const WorkspacePullRequestMonitorLoader(
       );
     }
     return summaries;
+  }
+
+  /// Branch lookup only auto-detects open reviews, matching
+  /// [ForgeProvider.getReviewForBranch]. Merged or closed reviews stay visible
+  /// when the workspace linked that number, or when this session already showed
+  /// it (so a merge mid-poll still reaches the terminal state).
+  ForgeReviewSnapshot? _snapshotForTarget({
+    required WorkspacePullRequestMonitorTarget target,
+    required LinkedReview? linked,
+    required ForgeReviewBatch batch,
+    required Map<String, WorkspacePullRequestSummary> previous,
+  }) {
+    if (linked?.hasReview == true) {
+      return batch.byNumber[linked!.number];
+    }
+    final detected = batch.byBranch[target.branch];
+    if (detected != null && detected.review.isOpen) {
+      return detected;
+    }
+    final previousNumber = previous[target.workspaceId]?.review.number;
+    return previousNumber == null ? null : batch.byNumber[previousNumber];
   }
 
   Future<ForgeReviewBatch> _loadSequentially({

--- a/lib/src/features/pull_requests/infra/github_review_batch.dart
+++ b/lib/src/features/pull_requests/infra/github_review_batch.dart
@@ -121,10 +121,13 @@ String _buildReviewBatchQuery({
     for (var index = 0; index < reviewNumberCount; index++)
       '\$number$index:Int!',
   ];
+  // Branch lookup is open-only. Merged/closed PRs are fetched by number when
+  // linked or already shown, so a historical PR cannot appear on a workspace
+  // that only shares the branch name.
   final selections = <String>[
     for (var index = 0; index < branchCount; index++)
       'branch$index:pullRequests(first:1,headRefName:\$branch$index,'
-          'states:[OPEN,MERGED,CLOSED],'
+          'states:[OPEN],'
           'orderBy:{field:CREATED_AT,direction:DESC})'
           '{nodes{...ReviewStatus}}',
     for (var index = 0; index < reviewNumberCount; index++)

--- a/test/unit/github_forge_provider_batch_test.dart
+++ b/test/unit/github_forge_provider_batch_test.dart
@@ -42,10 +42,13 @@ void main() {
     expect(call.workingDirectory, '/repo');
     expect(call.arguments, contains('branch0=feature'));
     expect(call.arguments, contains('number0=77'));
-    expect(
-      call.arguments.firstWhere((argument) => argument.startsWith('query=')),
-      contains('statusCheckRollup'),
+    final query = call.arguments.firstWhere(
+      (argument) => argument.startsWith('query='),
     );
+    expect(query, contains('statusCheckRollup'));
+    expect(query, contains('states:[OPEN]'));
+    expect(query, isNot(contains('MERGED')));
+    expect(query, isNot(contains('CLOSED')));
 
     final feature = batch.byBranch['feature'];
     expect(feature, isNotNull);

--- a/test/unit/workspace_pull_request_monitor_test.dart
+++ b/test/unit/workspace_pull_request_monitor_test.dart
@@ -118,6 +118,80 @@ void main() {
     },
   );
 
+  test('hides a merged or closed branch PR when the workspace has no linked review', () async {
+    final forge = _FakeBatchForge(
+      batch: ForgeReviewBatch(
+        byBranch: <String, ForgeReviewSnapshot>{
+          'feat/old': _snapshot(number: 9, branch: 'feat/old', state: .merged),
+        },
+        byNumber: <int, ForgeReviewSnapshot>{
+          9: _snapshot(number: 9, branch: 'feat/old', state: .merged),
+        },
+      ),
+    );
+    final loader = WorkspacePullRequestMonitorLoader(
+      _FakeGitBackend(),
+      ForgeProviderRegistry(<ForgeProvider>[forge]),
+      _FakeLinkedReviewRepository(),
+    );
+
+    final result = await loader.load(
+      targets: const <WorkspacePullRequestMonitorTarget>[
+        WorkspacePullRequestMonitorTarget(
+          projectId: 'project',
+          projectName: 'Alera',
+          workspaceId: 'workspace',
+          workspaceName: 'Workspace',
+          repoPath: '/repo',
+          branch: 'feat/old',
+        ),
+      ],
+    );
+
+    expect(result.summaries, isEmpty);
+    expect(forge.lastBranches, <String>{'feat/old'});
+    expect(forge.lastReviewNumbers, isEmpty);
+  });
+
+  test('keeps a previously shown review after the branch lookup stops returning it', () async {
+    final previous = <String, WorkspacePullRequestSummary>{
+      'workspace': WorkspacePullRequestSummary.fromChecks(
+        review: _review(number: 42, branch: 'feat/status'),
+        checks: const <ReviewCheck>[_pendingCheck],
+      ),
+    };
+    final merged = _snapshot(number: 42, branch: 'feat/status', state: .merged);
+    final forge = _FakeBatchForge(
+      batch: ForgeReviewBatch(byNumber: <int, ForgeReviewSnapshot>{42: merged}),
+    );
+    final loader = WorkspacePullRequestMonitorLoader(
+      _FakeGitBackend(),
+      ForgeProviderRegistry(<ForgeProvider>[forge]),
+      _FakeLinkedReviewRepository(),
+    );
+
+    final result = await loader.load(
+      targets: const <WorkspacePullRequestMonitorTarget>[
+        WorkspacePullRequestMonitorTarget(
+          projectId: 'project',
+          projectName: 'Alera',
+          workspaceId: 'workspace',
+          workspaceName: 'Workspace',
+          repoPath: '/repo',
+          branch: 'feat/status',
+        ),
+      ],
+      previous: previous,
+    );
+
+    expect(result.summaries['workspace']!.review.number, 42);
+    expect(
+      result.summaries['workspace']!.review.state,
+      HostedReviewState.merged,
+    );
+    expect(forge.lastReviewNumbers, <int>{42});
+  });
+
   test(
     'preserves the last snapshot and reports provider errors for backoff',
     () async {
@@ -167,20 +241,25 @@ const ReviewCheck _pendingCheck = ReviewCheck(
 ForgeReviewSnapshot _snapshot({
   required int number,
   required String branch,
+  HostedReviewState state = HostedReviewState.open,
   List<ReviewCheck> checks = const <ReviewCheck>[],
 }) {
   return ForgeReviewSnapshot(
-    review: _review(number: number, branch: branch),
+    review: _review(number: number, branch: branch, state: state),
     checks: checks,
   );
 }
 
-HostedReview _review({required int number, required String branch}) {
+HostedReview _review({
+  required int number,
+  required String branch,
+  HostedReviewState state = HostedReviewState.open,
+}) {
   return HostedReview(
     provider: .github,
     number: number,
     title: 'PR $number',
-    state: .open,
+    state: state,
     url: 'https://github.com/acme/app/pull/$number',
     headBranch: branch,
     headSha: 'sha-$number',


### PR DESCRIPTION
Stop showing merged or closed pull request status on workspaces that only share a branch name and never linked that review.

Branch lookup now matches `ForgeProvider.getReviewForBranch`: it auto-detects open reviews only. GitHub batch queries request `states:[OPEN]` instead of `OPEN,MERGED,CLOSED`, so a historical PR cannot appear just because the workspace reuses the branch.

Merged and closed reviews stay visible when the workspace linked that number, or when this session already showed it, so a merge mid-poll still reaches the terminal state.

Tests cover hiding an unlinked merged branch PR and keeping a previously shown review after branch lookup stops returning it.