### PR TITLE
fix: honor advertised configurationSyncV1 capability

### DIFF
--- a/lib/src/features/configuration_sync/application/configuration_sync_controller.dart
+++ b/lib/src/features/configuration_sync/application/configuration_sync_controller.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:alera_configuration/alera_configuration.dart';
 import 'package:alera/src/features/settings/application/settings_providers.dart';
+import 'package:alera/src/features/workbench/infra/terminal_host/terminal_host_protocol.dart';
 import 'package:alera/src/shared/infra/runtime/runtime_host_providers.dart';
 import 'package:logging/logging.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -10,7 +11,9 @@ part 'configuration_sync_controller.g.dart';
 @riverpod
 Future<ConfigurationSyncService> configurationSyncService(Ref ref) async {
   final client = ref.watch(runtimeHostClientProvider);
-  if (!await client.supportsRuntimeCapability('configurationSyncV1')) {
+  if (!await client.supportsRuntimeCapability(
+    aleraRuntimeHostConfigurationSyncCapability,
+  )) {
     throw StateError('Update the runtime to synchronize configuration.');
   }
   await ref.watch(settingsRepositoryProvider).load();

--- a/lib/src/features/configuration_sync/application/configuration_sync_controller.g.dart
+++ b/lib/src/features/configuration_sync/application/configuration_sync_controller.g.dart
@@ -49,7 +49,7 @@ final class ConfigurationSyncServiceProvider
 }
 
 String _$configurationSyncServiceHash() =>
-    r'4f716cb785d13225fd61d0f46df150e49dd72354';
+    r'75da83c5dd9944f74c82388c8b6208886dc65109';
 
 @ProviderFor(ConfigurationSyncController)
 final configurationSyncControllerProvider =

--- a/lib/src/features/settings/infra/runtime_settings_repository.dart
+++ b/lib/src/features/settings/infra/runtime_settings_repository.dart
@@ -122,7 +122,9 @@ class RuntimeSettingsRepository({
     final capabilityClient = client;
     return capabilityClient is RuntimeHostCapabilityClient &&
         await (capabilityClient as RuntimeHostCapabilityClient)
-            .supportsRuntimeCapability('configurationSyncV1');
+            .supportsRuntimeCapability(
+              aleraRuntimeHostConfigurationSyncCapability,
+            );
   }
 }
 

--- a/lib/src/features/workbench/infra/terminal_host/terminal_host_client_capabilities.dart
+++ b/lib/src/features/workbench/infra/terminal_host/terminal_host_client_capabilities.dart
@@ -29,7 +29,7 @@ mixin _RuntimeHostCapabilitySupport
         connection.supportsRemoteAiDictation,
       aleraRuntimeHostWorkspaceSectionsCapability =>
         connection.supportsWorkspaceSections,
-      _ => false,
+      _ => connection.runtimeCapabilities.contains(capability),
     };
   }
 }

--- a/lib/src/features/workbench/infra/terminal_host/terminal_host_client_socket_reader.dart
+++ b/lib/src/features/workbench/infra/terminal_host/terminal_host_client_socket_reader.dart
@@ -134,6 +134,7 @@ Future<_TerminalHostConnection> _openHostConnection(
       supportsTerminalPulse: control.supportsTerminalPulse,
       supportsRemoteAiDictation: control.supportsRemoteAiDictation,
       supportsWorkspaceSections: control.supportsWorkspaceSections,
+      runtimeCapabilities: control.runtimeCapabilities,
     );
   }
   final socket = await Socket.connect(
@@ -150,5 +151,6 @@ Future<_TerminalHostConnection> _openHostConnection(
     supportsTerminalPulse: control.supportsTerminalPulse,
     supportsRemoteAiDictation: control.supportsRemoteAiDictation,
     supportsWorkspaceSections: control.supportsWorkspaceSections,
+    runtimeCapabilities: control.runtimeCapabilities,
   );
 }

--- a/lib/src/features/workbench/infra/terminal_host/terminal_host_client_types.dart
+++ b/lib/src/features/workbench/infra/terminal_host/terminal_host_client_types.dart
@@ -12,6 +12,7 @@ final class _TerminalHostConnection {
     required this.supportsTerminalPulse,
     required this.supportsRemoteAiDictation,
     required this.supportsWorkspaceSections,
+    required this.runtimeCapabilities,
   }) : _reader = null {
     _socketSub = _socket!.cast<List<int>>().listen(
       _consume,
@@ -36,6 +37,7 @@ final class _TerminalHostConnection {
     required this.supportsTerminalPulse,
     required this.supportsRemoteAiDictation,
     required this.supportsWorkspaceSections,
+    required this.runtimeCapabilities,
   }) : _reader = reader,
        _socket = null {
     lines = reader.lines;
@@ -58,6 +60,7 @@ final class _TerminalHostConnection {
   final bool supportsTerminalPulse;
   final bool supportsRemoteAiDictation;
   final bool supportsWorkspaceSections;
+  final Set<String> runtimeCapabilities;
 
   /// One reader for the whole connection. It starts newline-delimited so the
   /// handshake works against a host without the capability, and switches to
@@ -155,6 +158,7 @@ final class const _TerminalHostControl({
   final bool supportsTerminalPulse = false,
   final bool supportsRemoteAiDictation = false,
   final bool supportsWorkspaceSections = false,
+  final Set<String> runtimeCapabilities = const <String>{},
 });
 
 final class const _PendingHostRequest(

--- a/lib/src/features/workbench/infra/terminal_host/terminal_host_control_file.dart
+++ b/lib/src/features/workbench/infra/terminal_host/terminal_host_control_file.dart
@@ -130,6 +130,7 @@ Future<_TerminalHostControl?> _readControl(File file) async {
       supportsWorkspaceSections: capabilities.contains(
         aleraRuntimeHostWorkspaceSectionsCapability,
       ),
+      runtimeCapabilities: Set<String>.from(capabilities),
     );
   } catch (_) {
     return null;

--- a/lib/src/features/workbench/infra/terminal_host/terminal_host_protocol.dart
+++ b/lib/src/features/workbench/infra/terminal_host/terminal_host_protocol.dart
@@ -14,6 +14,8 @@ const String aleraRuntimeHostManagedWorkspaceCapability =
     'managedWorkspaceLifecycle';
 const String aleraRuntimeHostOrchestrationCapability = 'orchestration';
 const String aleraRuntimeHostAccountCapability = 'aleraAccountV1';
+const String aleraRuntimeHostConfigurationSyncCapability =
+    'configurationSyncV1';
 const String aleraRuntimeHostMobileCloudEnrollmentCapability =
     'mobileCloudEnrollmentV1';
 const String aleraRuntimeHostCloudPushCapability = 'cloudPushNotificationsV1';

--- a/test/unit/runtime_settings_repository_test.dart
+++ b/test/unit/runtime_settings_repository_test.dart
@@ -369,7 +369,8 @@ final class _RecordingRuntimeHostClient
 
   @override
   Future<bool> supportsRuntimeCapability(String capability) async =>
-      configurationSupported && capability == 'configurationSyncV1';
+      configurationSupported &&
+      capability == aleraRuntimeHostConfigurationSyncCapability;
 
   @override
   Stream<RuntimeHostEvent> get runtimeEvents => const Stream.empty();

--- a/test/unit/terminal_host_client_runtime_mutation_cases.dart
+++ b/test/unit/terminal_host_client_runtime_mutation_cases.dart
@@ -30,6 +30,35 @@ void _registerTerminalHostClientRuntimeMutationTests() {
     });
   }
 
+  for (final supported in [false, true]) {
+    test('socket client detects configuration sync ($supported)', () async {
+      final tempDir = await Directory.systemTemp.createTemp(
+        'alera-configuration-sync-capability-',
+      );
+      addTearDown(() => tempDir.delete(recursive: true));
+      final server = await _TerminalHostTestServer.start();
+      addTearDown(server.dispose);
+      await _writeControlFile(
+        tempDir: tempDir,
+        port: server.port,
+        token: server.token,
+        includeConfigurationSyncCapability: supported,
+      );
+      final client = SocketTerminalHostClient(
+        launcher: _NoopTerminalHostLauncher(),
+        applicationSupportDirectory: () async => tempDir,
+      );
+      addTearDown(client.dispose);
+      expect(
+        await client.supportsRuntimeCapability(
+          aleraRuntimeHostConfigurationSyncCapability,
+        ),
+        supported,
+      );
+      expect(await client.supportsRuntimeCapability('unknown'), isFalse);
+    });
+  }
+
   test(
     'status.get updates crash reports with the connected host version',
     () async {

--- a/test/unit/terminal_host_test_server.dart
+++ b/test/unit/terminal_host_test_server.dart
@@ -337,6 +337,7 @@ Future<void> _writeControlFile({
   bool includeOrchestrationCapability = true,
   bool includeBinaryFramesCapability = false,
   bool includeWorkspaceSectionsCapability = false,
+  bool includeConfigurationSyncCapability = false,
 }) async {
   final runtimeDir = Directory(p.join(tempDir.path, 'terminal_host'));
   await runtimeDir.create(recursive: true);
@@ -356,6 +357,8 @@ Future<void> _writeControlFile({
       if (includeBinaryFramesCapability) aleraRuntimeHostBinaryFramesCapability,
       if (includeWorkspaceSectionsCapability)
         aleraRuntimeHostWorkspaceSectionsCapability,
+      if (includeConfigurationSyncCapability)
+        aleraRuntimeHostConfigurationSyncCapability,
     ],
   ];
   if (capabilities.isNotEmpty) {


### PR DESCRIPTION
## Summary

Configuration Sync in Settings always failed with `Bad state: Update the runtime to synchronize configuration.`, including on Linux with a current runtime.

The runtime already advertises `configurationSyncV1` in the control file and hello. The desktop client ignored that list: `supportsRuntimeCapability` only recognized remote AI dictation and workspace sections, then returned `false` for every other capability. The Settings pane treated a live runtime as outdated.

The client now keeps the advertised capability set from the control file and honors `configurationSyncV1`. An older runtime that does not advertise it still shows the update message.

Closes #650
Fixes #650

## Demo (Linux)

PR build `40fcc2a6` on Linux: **Settings → Configuration Sync** opens and no longer shows the false **Update the runtime** Bad state when `configurationSyncV1` is advertised. Pane shows the correct account gate instead (*Sign in from Settings > Alera Account first*).

![Configuration Sync settings](https://github.com/leynier/alera/releases/download/demo-pr-653-configuration-sync/final-active.png)

- Video: https://github.com/leynier/alera/releases/download/demo-pr-653-configuration-sync/demo-650-configuration-sync.mp4
- Full desktop still: https://github.com/leynier/alera/releases/download/demo-pr-653-configuration-sync/final-full.png
- Release: https://github.com/leynier/alera/releases/tag/demo-pr-653-configuration-sync


## Screenshots

No visual chrome change when the runtime supports sync. The pane no longer sticks on the false "update the runtime" error in that case.

Linux demo (PR-built `alera-dev` @ `40fcc2a6`, Spectacle stills → short mp4; not `/opt/alera`): Configuration Sync loads past the false runtime-update Bad state. With an unsigned-in account it correctly shows sign-in required instead. Demo video + stills: https://github.com/leynier/alera/releases/download/demo-pr-653-configuration-sync/demo-650-configuration-sync.mp4

## Testing

- [x] `dart format` on the touched Dart files (Flutter 3.47.2 / Dart 3.13.2)
- [x] `flutter analyze` on the touched Dart files
- [x] `flutter test test/unit/terminal_host_client_test.dart test/unit/runtime_settings_repository_test.dart`
- [x] Added socket-client coverage for `configurationSyncV1` present and absent

## Notes

- Not Linux-specific. The gate was wrong on every desktop platform; the issue was reported on Linux.
- Docs already describe the intended capability check, so `docs/configuration-sync.md` was left unchanged.
- Cross-platform: capability detection is shared desktop client code. Mobile already checked `runtimeCapabilities.contains('configurationSyncV1')`.

## Security Audit

No change to auth, secrets, command execution, or update signing. The client now trusts the same advertised capability list it already parsed from the local control file.


