### PR TITLE
feat: create and switch branches from source control

### DIFF
--- a/integration_test/e2e_git_backend.dart
+++ b/integration_test/e2e_git_backend.dart
@@ -24,6 +24,12 @@ class const E2eGitBackend() implements GitBackend {
   }) async {}
 
   @override
+  Future<void> checkoutBranch({
+    required String path,
+    required String branch,
+  }) async {}
+
+  @override
   Future<bool> branchExists(String repoPath, String branch) async => false;
 
   @override

--- a/lib/src/features/workbench/application/workspace_source_control_controller.dart
+++ b/lib/src/features/workbench/application/workspace_source_control_controller.dart
@@ -214,10 +214,13 @@ class WorkspaceSourceControlController
     (backend) => backend.stashPop(path: workspacePath, stashIndex: stashIndex),
   );
 
-  Future<void> checkoutBranch(String branch) => _run(
-    .checkout,
-    (backend) => backend.checkoutBranch(path: workspacePath, branch: branch),
-  );
+  Future<String> checkoutBranch(String branch) async {
+    await _run(
+      .checkout,
+      (backend) => backend.checkoutBranch(path: workspacePath, branch: branch),
+    );
+    return state.requireValue.repositoryState.branch;
+  }
 
   Future<void> createAndCheckoutBranch(String branch) => _run(
     .createBranch,

--- a/lib/src/features/workbench/application/workspace_source_control_controller.dart
+++ b/lib/src/features/workbench/application/workspace_source_control_controller.dart
@@ -61,6 +61,8 @@ enum WorkspaceSourceControlAction {
   sync,
   stash,
   stashPop,
+  checkout,
+  createBranch,
 }
 
 @riverpod
@@ -210,6 +212,17 @@ class WorkspaceSourceControlController
   Future<void> stashPop(int stashIndex) => _run(
     .stashPop,
     (backend) => backend.stashPop(path: workspacePath, stashIndex: stashIndex),
+  );
+
+  Future<void> checkoutBranch(String branch) => _run(
+    .checkout,
+    (backend) => backend.checkoutBranch(path: workspacePath, branch: branch),
+  );
+
+  Future<void> createAndCheckoutBranch(String branch) => _run(
+    .createBranch,
+    (backend) =>
+        backend.createAndCheckoutBranch(path: workspacePath, branch: branch),
   );
 
   Future<WorkspaceSourceControlState> _load() async {

--- a/lib/src/features/workbench/application/workspace_source_control_controller.g.dart
+++ b/lib/src/features/workbench/application/workspace_source_control_controller.g.dart
@@ -58,7 +58,7 @@ final class WorkspaceSourceControlControllerProvider
 }
 
 String _$workspaceSourceControlControllerHash() =>
-    r'78b3d3cfcdf4aae2791abc49ea8f62e53a5d8f24';
+    r'e4361eda28d70e842975a3cd20200688f7ee66b1';
 
 final class WorkspaceSourceControlControllerFamily extends $Family
     with

--- a/lib/src/features/workbench/application/workspace_source_control_controller.g.dart
+++ b/lib/src/features/workbench/application/workspace_source_control_controller.g.dart
@@ -58,7 +58,7 @@ final class WorkspaceSourceControlControllerProvider
 }
 
 String _$workspaceSourceControlControllerHash() =>
-    r'e4361eda28d70e842975a3cd20200688f7ee66b1';
+    r'18ed3fa0a2929fa602af03ade60d0e1888434d93';
 
 final class WorkspaceSourceControlControllerFamily extends $Family
     with

--- a/lib/src/features/workbench/presentation/workspace_git_diff_panel.dart
+++ b/lib/src/features/workbench/presentation/workspace_git_diff_panel.dart
@@ -363,15 +363,30 @@ class _WorkspaceGitDiffPanelState extends ConsumerState<WorkspaceGitDiffPanel> {
         if (branch == currentBranch) {
           return;
         }
-        await _run(
-          () => _notifier.checkoutBranch(branch),
-          successMessage: 'Switched to $branch',
-        );
+        await _switchBranch(branch);
       case _CreateBranchResult(:final branch):
         await _run(
           () => _notifier.createAndCheckoutBranch(branch),
           successMessage: 'Created $branch',
         );
+    }
+  }
+
+  Future<void> _switchBranch(String branch) async {
+    try {
+      final activeBranch = await _notifier.checkoutBranch(branch);
+      if (mounted) {
+        AleraToast.show(
+          context,
+          message: 'Switched to $activeBranch',
+          tone: .success,
+        );
+        _invalidateGitHistoryAfterMutation();
+      }
+    } catch (error) {
+      if (mounted) {
+        AleraToast.show(context, message: _messageFor(error), tone: .error);
+      }
     }
   }
 

--- a/lib/src/features/workbench/presentation/workspace_git_diff_panel.dart
+++ b/lib/src/features/workbench/presentation/workspace_git_diff_panel.dart
@@ -3,10 +3,13 @@ import 'dart:async';
 import 'package:alera/src/app/theme/alera_tokens.dart';
 import 'package:alera/src/design_system/buttons/alera_icon_button.dart';
 import 'package:alera/src/design_system/feedback/alera_toast.dart';
+import 'package:alera/src/design_system/feedback/alera_empty_state.dart';
 import 'package:alera/src/design_system/forms/alera_search_field.dart';
 import 'package:alera/src/design_system/forms/alera_text_actions_scope.dart';
+import 'package:alera/src/design_system/forms/alera_text_field.dart';
 import 'package:alera/src/design_system/icons/alera_file_icon.dart';
 import 'package:alera/src/design_system/icons/alera_icons.dart';
+import 'package:alera/src/design_system/menus/alera_menu_item.dart';
 import 'package:alera/src/design_system/layout/alera_confirm_dialog.dart';
 import 'package:alera/src/design_system/layout/alera_dialog.dart';
 import 'package:alera/src/design_system/menus/alera_dropdown_entry.dart';
@@ -38,6 +41,7 @@ part 'workspace_git_diff_panel_groups.dart';
 part 'workspace_git_diff_panel_rows.dart';
 part 'workspace_git_diff_panel_amend_dialog.dart';
 part 'workspace_git_diff_panel_stash_dialog.dart';
+part 'workspace_git_diff_panel_branch_dialog.dart';
 part 'workspace_git_diff_panel_toolbar.dart';
 part 'workspace_git_diff_panel_commit_message_field.dart';
 part 'workspace_git_diff_panel_tree.dart';
@@ -187,6 +191,7 @@ class _WorkspaceGitDiffPanelState extends ConsumerState<WorkspaceGitDiffPanel> {
           ),
           onPrimaryAction: (action) => unawaited(_runToolbarAction(action)),
           onSelectMenuAction: (action) => unawaited(_handleMenuAction(action)),
+          onSelectBranch: () => unawaited(_openBranchSwitcher()),
         ),
         const Divider(height: 1, color: AleraTokens.borderSubtle),
         Expanded(
@@ -313,6 +318,59 @@ class _WorkspaceGitDiffPanelState extends ConsumerState<WorkspaceGitDiffPanel> {
         await _run(
           () => _notifier.stashPop(stash.index),
           successMessage: 'Stash popped',
+        );
+    }
+  }
+
+  Future<void> _openBranchSwitcher() async {
+    final current = ref
+        .read(
+          workspaceSourceControlControllerProvider(
+            widget.sourceControlScope.path,
+          ),
+        )
+        .asData
+        ?.value;
+    if (current == null || current.isBusy) {
+      return;
+    }
+    final backend = ref.read(gitBackendProvider);
+    List<String> branches;
+    try {
+      branches = await backend.listBranches(widget.sourceControlScope.path);
+    } catch (error) {
+      if (mounted) {
+        AleraToast.show(context, message: _messageFor(error), tone: .error);
+      }
+      return;
+    }
+    if (!mounted) {
+      return;
+    }
+    final currentBranch = current.repositoryState.branch;
+    final selection = await showDialog<_BranchDialogResult>(
+      context: context,
+      builder: (_) => _SourceControlBranchDialog(
+        branches: branches,
+        currentBranch: currentBranch,
+      ),
+    );
+    if (selection == null || !mounted) {
+      return;
+    }
+    switch (selection) {
+      case _SwitchBranchResult(:final branch):
+        if (branch == currentBranch) {
+          return;
+        }
+        await _run(
+          () => _notifier.checkoutBranch(branch),
+          successMessage: 'Switched to $branch',
+        );
+      case _CreateBranchResult(:final branch):
+        await _run(
+          () => _notifier.createAndCheckoutBranch(branch),
+          successMessage: 'Created $branch',
         );
     }
   }

--- a/lib/src/features/workbench/presentation/workspace_git_diff_panel_branch_dialog.dart
+++ b/lib/src/features/workbench/presentation/workspace_git_diff_panel_branch_dialog.dart
@@ -1,0 +1,163 @@
+part of 'workspace_git_diff_panel.dart';
+
+sealed class _BranchDialogResult {
+  const _BranchDialogResult();
+}
+
+class const _SwitchBranchResult(this.branch) extends _BranchDialogResult {
+  final String branch;
+}
+
+class const _CreateBranchResult(this.branch) extends _BranchDialogResult {
+  final String branch;
+}
+
+class const _SourceControlBranchDialog({
+  required final List<String> branches,
+  required final String currentBranch,
+}) extends StatefulWidget {
+  @override
+  State<_SourceControlBranchDialog> createState() =>
+      _SourceControlBranchDialogState();
+}
+
+class _SourceControlBranchDialogState
+    extends State<_SourceControlBranchDialog> {
+  final TextEditingController _filterController = TextEditingController();
+  final TextEditingController _nameController = TextEditingController();
+  String _query = '';
+  bool _creating = false;
+  String? _nameError;
+
+  @override
+  void dispose() {
+    _filterController.dispose();
+    _nameController.dispose();
+    super.dispose();
+  }
+
+  List<String> get _filteredBranches {
+    final normalized = _query.trim().toLowerCase();
+    if (normalized.isEmpty) {
+      return widget.branches;
+    }
+    return <String>[
+      for (final branch in widget.branches)
+        if (branch.toLowerCase().contains(normalized)) branch,
+    ];
+  }
+
+  void _switchTo(String branch) {
+    Navigator.of(context).pop(_SwitchBranchResult(branch));
+  }
+
+  void _submitCreate() {
+    final name = _nameController.text.trim();
+    if (name.isEmpty) {
+      setState(() => _nameError = 'Branch name is required');
+      return;
+    }
+    if (widget.branches.contains(name)) {
+      setState(() => _nameError = 'A branch named "$name" already exists');
+      return;
+    }
+    Navigator.of(context).pop(_CreateBranchResult(name));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return AleraDialog(
+      maxWidth: 460,
+      maxHeight: 520,
+      child: Padding(
+        padding: const EdgeInsets.all(AleraTokens.space20),
+        child: Column(
+          mainAxisSize: .min,
+          crossAxisAlignment: .stretch,
+          children: <Widget>[
+            Text(
+              _creating ? 'Create Branch' : 'Switch Branch',
+              style: theme.textTheme.titleMedium,
+            ),
+            const SizedBox(height: AleraTokens.space12),
+            if (_creating)
+              AleraTextField(
+                controller: _nameController,
+                autofocus: true,
+                labelText: 'Branch Name',
+                hintText: 'e.g. feature/login',
+                errorText: _nameError,
+                onChanged: (_) {
+                  if (_nameError != null) {
+                    setState(() => _nameError = null);
+                  }
+                },
+                onSubmitted: (_) => _submitCreate(),
+              )
+            else
+              AleraSearchField(
+                controller: _filterController,
+                hintText: 'Search branches',
+                autofocus: true,
+                onChanged: (value) => setState(() => _query = value),
+              ),
+            const SizedBox(height: AleraTokens.space12),
+            if (!_creating)
+              Flexible(
+                child: _filteredBranches.isEmpty
+                    ? AleraEmptyState(
+                        message: _query.trim().isEmpty
+                            ? 'No branches found'
+                            : 'No branches match "$_query"',
+                      )
+                    : ListView.builder(
+                        shrinkWrap: true,
+                        itemCount: _filteredBranches.length,
+                        itemBuilder: (context, index) {
+                          final branch = _filteredBranches[index];
+                          final selected = branch == widget.currentBranch;
+                          return AleraMenuItem(
+                            label: branch,
+                            selected: selected,
+                            onTap: () => _switchTo(branch),
+                          );
+                        },
+                      ),
+              ),
+            const SizedBox(height: AleraTokens.space12),
+            Row(
+              children: <Widget>[
+                if (!_creating)
+                  TextButton(
+                    onPressed: () => setState(() => _creating = true),
+                    child: const Text('Create Branch'),
+                  )
+                else
+                  TextButton(
+                    onPressed: () => setState(() {
+                      _creating = false;
+                      _nameError = null;
+                    }),
+                    child: const Text('Back'),
+                  ),
+                const Spacer(),
+                TextButton(
+                  onPressed: () => Navigator.of(context).pop(),
+                  child: const Text('Cancel'),
+                ),
+                if (_creating) ...<Widget>[
+                  const SizedBox(width: AleraTokens.space8),
+                  FilledButton(
+                    onPressed: _submitCreate,
+                    child: const Text('Create'),
+                  ),
+                ],
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/features/workbench/presentation/workspace_git_diff_panel_toolbar.dart
+++ b/lib/src/features/workbench/presentation/workspace_git_diff_panel_toolbar.dart
@@ -25,6 +25,7 @@ class const _SourceControlToolbar({
   required final VoidCallback onOpenAll,
   required final ValueChanged<_SourceControlMenuAction> onPrimaryAction,
   required final ValueChanged<_SourceControlMenuAction> onSelectMenuAction,
+  required final VoidCallback onSelectBranch,
 }) extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
@@ -44,6 +45,9 @@ class const _SourceControlToolbar({
       busy: busy,
       canCommit: canCommit,
     );
+    final branchDetails = data == null
+        ? ''
+        : _repoSummary(data, sourceControlRootLabel, includeBranch: false);
     return Padding(
       padding: const EdgeInsets.all(AleraTokens.space8),
       child: Column(
@@ -181,12 +185,11 @@ class const _SourceControlToolbar({
           const SizedBox(height: AleraTokens.space8),
           if (data case final state?) ...<Widget>[
             const SizedBox(height: AleraTokens.space6),
-            Text(
-              _repoSummary(state, sourceControlRootLabel),
-              maxLines: 1,
-              overflow: .ellipsis,
-              style: Theme.of(context).textTheme.labelSmall
-                  ?.copyWith(color: AleraTokens.foregroundFaint),
+            _SourceControlBranchSummary(
+              branch: state.repositoryState.branch,
+              details: branchDetails,
+              busy: busy,
+              onSelectBranch: onSelectBranch,
             ),
           ],
           if (filterVisible) ...<Widget>[
@@ -238,10 +241,14 @@ class const _SourceControlToolbar({
 
   String _repoSummary(
     WorkspaceSourceControlState state,
-    String? sourceControlRootLabel,
-  ) {
+    String? sourceControlRootLabel, {
+    bool includeBranch = true,
+  }) {
     final repo = state.repositoryState;
-    final parts = <String>[?sourceControlRootLabel, repo.branch];
+    final parts = <String>[
+      ?sourceControlRootLabel,
+      if (includeBranch) repo.branch,
+    ];
     if (repo.upstream case final upstream?) {
       parts.add(upstream);
     }
@@ -276,7 +283,77 @@ class const _SourceControlToolbar({
       WorkspaceSourceControlAction.sync => 'syncing',
       WorkspaceSourceControlAction.stash => 'stashing',
       WorkspaceSourceControlAction.stashPop => 'popping stash',
+      WorkspaceSourceControlAction.checkout => 'switching branches',
+      WorkspaceSourceControlAction.createBranch => 'creating branch',
     };
+  }
+}
+
+class const _SourceControlBranchSummary({
+  required final String branch,
+  required final String details,
+  required final bool busy,
+  required final VoidCallback onSelectBranch,
+}) extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    final labelStyle = Theme.of(context).textTheme.labelSmall
+        ?.copyWith(color: AleraTokens.foregroundFaint);
+    return Row(
+      children: <Widget>[
+        Flexible(
+          child: Tooltip(
+            message: 'Switch Branch',
+            child: InkWell(
+              onTap: busy ? null : onSelectBranch,
+              borderRadius: BorderRadius.circular(AleraTokens.radiusMd),
+              child: Padding(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: AleraTokens.space4,
+                  vertical: AleraTokens.space2,
+                ),
+                child: Row(
+                  mainAxisSize: .min,
+                  children: <Widget>[
+                    Icon(
+                      AleraIcons.gitBranch,
+                      size: 14,
+                      color: AleraTokens.foregroundFaint,
+                    ),
+                    const SizedBox(width: AleraTokens.space4),
+                    Flexible(
+                      child: Text(
+                        branch,
+                        maxLines: 1,
+                        overflow: .ellipsis,
+                        style: labelStyle,
+                      ),
+                    ),
+                    const SizedBox(width: AleraTokens.space2),
+                    Icon(
+                      AleraIcons.chevronDown,
+                      size: 12,
+                      color: AleraTokens.foregroundFaint,
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+        if (details.isNotEmpty) ...<Widget>[
+          const SizedBox(width: AleraTokens.space8),
+          Flexible(
+            child: Text(
+              details,
+              maxLines: 1,
+              overflow: .ellipsis,
+              style: labelStyle,
+            ),
+          ),
+        ],
+      ],
+    );
   }
 }
 

--- a/lib/src/features/workbench/presentation/workspace_git_diff_panel_types.dart
+++ b/lib/src/features/workbench/presentation/workspace_git_diff_panel_types.dart
@@ -7,6 +7,15 @@ String _messageFor(Object? error) {
   if (error is DetachedHeadException) {
     return 'Cannot push from detached HEAD.';
   }
+  if (error is BranchAlreadyExistsException) {
+    return 'A branch named "${error.context}" already exists.';
+  }
+  if (error is BranchNotFoundException) {
+    return 'Branch "${error.context}" was not found.';
+  }
+  if (error is InvalidBranchNameException) {
+    return 'Enter a valid branch name.';
+  }
   if (error is RemoteNotFoundException) {
     return 'Remote origin was not found.';
   }

--- a/lib/src/features/workbench/presentation/workspace_git_diff_panel_types.dart
+++ b/lib/src/features/workbench/presentation/workspace_git_diff_panel_types.dart
@@ -23,7 +23,8 @@ String _messageFor(Object? error) {
     return 'Nothing to commit.';
   }
   if (error is GitConflictException) {
-    return 'Resolve conflicts before continuing.';
+    final context = error.context.trim();
+    return context.isEmpty ? 'Resolve conflicts before continuing.' : context;
   }
   if (error is AiAssistException) {
     return error.message;

--- a/lib/src/rust/api/git/git_branch.dart
+++ b/lib/src/rust/api/git/git_branch.dart
@@ -22,6 +22,12 @@ Future<void> createAndCheckoutBranch({
   branch: branch,
 );
 
+Future<void> checkoutBranch({required String path, required String branch}) =>
+    RustLib.instance.api.crateApiGitGitBranchCheckoutBranch(
+      path: path,
+      branch: branch,
+    );
+
 Future<bool> branchExists({required String repoPath, required String branch}) =>
     RustLib.instance.api.crateApiGitGitBranchBranchExists(
       repoPath: repoPath,

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -127,6 +127,11 @@ abstract class RustLibApi extends BaseApi {
     required String branch,
   });
 
+  Future<void> crateApiGitGitBranchCheckoutBranch({
+    required String path,
+    required String branch,
+  });
+
   Future<WorkspaceFileEntry> crateApiWorkspaceFilesCreateWorkspaceDirectory({
     required String workspacePath,
     required String parentRelativePath,
@@ -786,6 +791,41 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   TaskConstMeta get kCrateApiGitGitBranchCreateAndCheckoutBranchConstMeta =>
       const TaskConstMeta(
         debugName: "create_and_checkout_branch",
+        argNames: ["path", "branch"],
+      );
+
+  @override
+  Future<void> crateApiGitGitBranchCheckoutBranch({
+    required String path,
+    required String branch,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_String(path, serializer);
+          sse_encode_String(branch, serializer);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 93,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_unit,
+          decodeErrorData: sse_decode_git_error,
+        ),
+        constMeta: kCrateApiGitGitBranchCheckoutBranchConstMeta,
+        argValues: [path, branch],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiGitGitBranchCheckoutBranchConstMeta =>
+      const TaskConstMeta(
+        debugName: "checkout_branch",
         argNames: ["path", "branch"],
       );
 

--- a/lib/src/shared/infra/git/git_backend.dart
+++ b/lib/src/shared/infra/git/git_backend.dart
@@ -30,6 +30,14 @@ abstract interface class GitBackend {
     required String branch,
   });
 
+  /// Checks out [branch] in the worktree at [path].
+  ///
+  /// Local branches switch in place. A remote-tracking name such as
+  /// `origin/feature` creates a local `feature` branch that tracks it when that
+  /// local name does not already exist. Local changes that would be overwritten
+  /// are rejected.
+  Future<void> checkoutBranch({required String path, required String branch});
+
   /// Whether a local branch named [branch] exists in [repoPath].
   Future<bool> branchExists(String repoPath, String branch);
 

--- a/lib/src/shared/infra/git/rust_git_backend.dart
+++ b/lib/src/shared/infra/git/rust_git_backend.dart
@@ -42,6 +42,10 @@ class const RustGitBackend()
   );
 
   @override
+  Future<void> checkoutBranch({required String path, required String branch}) =>
+      _guard(() => rust_branch.checkoutBranch(path: path, branch: branch));
+
+  @override
   Future<bool> branchExists(String repoPath, String branch) => _guard(
     () => rust_branch.branchExists(repoPath: repoPath, branch: branch),
   );

--- a/rust/alera-core/src/git.rs
+++ b/rust/alera-core/src/git.rs
@@ -11,7 +11,8 @@ mod branch_tests;
 pub mod hosted_review;
 mod repository_metadata;
 pub use branch_operations::{
-    branch_exists, create_and_checkout_branch, delete_branch, is_valid_branch_name, list_branches,
+    branch_exists, checkout_branch, create_and_checkout_branch, delete_branch,
+    is_valid_branch_name, list_branches,
 };
 pub use repository_metadata::{current_branch, is_worktree_clean, repository_remote_url};
 

--- a/rust/alera-core/src/git/branch_operations.rs
+++ b/rust/alera-core/src/git/branch_operations.rs
@@ -105,10 +105,31 @@ pub fn checkout_branch(path: &str, branch: &str) -> Result<(), GitError> {
 
     if repo.find_branch(branch, BranchType::Remote).is_ok() {
         let local_name = local_name_for_remote_branch(&repo, branch)?;
-        if current == local_name {
-            return Ok(());
-        }
-        if repo.find_branch(&local_name, BranchType::Local).is_ok() {
+        if let Ok(local) = repo.find_branch(&local_name, BranchType::Local) {
+            let remote = repo
+                .find_branch(branch, BranchType::Remote)
+                .map_err(GitError::from_git2)?;
+            let local_oid = local
+                .get()
+                .peel_to_commit()
+                .map_err(GitError::from_git2)?
+                .id();
+            let remote_oid = remote
+                .get()
+                .peel_to_commit()
+                .map_err(GitError::from_git2)?
+                .id();
+            if local_oid != remote_oid {
+                return Err(GitError::new(
+                    GitErrorKind::Conflict,
+                    format!(
+                        "local branch \"{local_name}\" differs from \"{branch}\"; switch to the local branch or rename it first"
+                    ),
+                ));
+            }
+            if current == local_name {
+                return Ok(());
+            }
             return checkout_local_branch(&repo, &local_name);
         }
         create_local_tracking_branch(&repo, branch, &local_name)?;

--- a/rust/alera-core/src/git/branch_operations.rs
+++ b/rust/alera-core/src/git/branch_operations.rs
@@ -1,4 +1,4 @@
-use git2::{Branch, BranchType, ErrorCode, RepositoryState};
+use git2::{build::CheckoutBuilder, Branch, BranchType, ErrorCode, Repository, RepositoryState};
 
 use super::{open_repo, GitError, GitErrorKind};
 
@@ -73,6 +73,134 @@ pub fn create_and_checkout_branch(path: &str, branch: &str) -> Result<(), GitErr
     // Both branches point at the same commit, so changing symbolic HEAD is
     // sufficient and intentionally preserves pending staged/unstaged changes.
     Ok(())
+}
+
+/// Checks out [branch] in the worktree at [path].
+///
+/// Local branches switch in place. A remote-tracking name such as
+/// `origin/feature` creates a local `feature` branch that tracks it when that
+/// local name does not already exist. Checkout is safe: local changes that
+/// would be overwritten are rejected.
+pub fn checkout_branch(path: &str, branch: &str) -> Result<(), GitError> {
+    let repo = open_repo(path)?;
+    let branch = branch.trim();
+    if branch.is_empty() {
+        return Err(GitError::new(GitErrorKind::InvalidBranchName, branch));
+    }
+    if repo.state() != RepositoryState::Clean {
+        return Err(GitError::new(
+            GitErrorKind::Conflict,
+            "finish or abort the in-progress git operation before switching branches",
+        ));
+    }
+
+    let current = super::current_branch(path)?;
+    if current == branch {
+        return Ok(());
+    }
+
+    if repo.find_branch(branch, BranchType::Local).is_ok() {
+        return checkout_local_branch(&repo, branch);
+    }
+
+    if repo.find_branch(branch, BranchType::Remote).is_ok() {
+        let local_name = local_name_for_remote_branch(&repo, branch)?;
+        if current == local_name {
+            return Ok(());
+        }
+        if repo.find_branch(&local_name, BranchType::Local).is_ok() {
+            return checkout_local_branch(&repo, &local_name);
+        }
+        create_local_tracking_branch(&repo, branch, &local_name)?;
+        if let Err(error) = checkout_local_branch(&repo, &local_name) {
+            if let Ok(mut created) = repo.find_branch(&local_name, BranchType::Local) {
+                let _ = created.delete();
+            }
+            return Err(error);
+        }
+        return Ok(());
+    }
+
+    Err(GitError::new(GitErrorKind::BranchNotFound, branch))
+}
+
+fn checkout_local_branch(repo: &Repository, branch: &str) -> Result<(), GitError> {
+    let reference_name = format!("refs/heads/{branch}");
+    let object = repo
+        .revparse_single(&reference_name)
+        .map_err(|error| match error.code() {
+            ErrorCode::NotFound => GitError::new(GitErrorKind::BranchNotFound, branch),
+            _ => GitError::from_git2(error),
+        })?;
+    let mut checkout = CheckoutBuilder::new();
+    repo.checkout_tree(&object, Some(&mut checkout))
+        .map_err(|error| match error.code() {
+            ErrorCode::Conflict => GitError::new(
+                GitErrorKind::Conflict,
+                "commit or stash local changes before switching branches",
+            ),
+            _ => GitError::from_git2(error),
+        })?;
+    repo.set_head(&reference_name)
+        .map_err(GitError::from_git2)?;
+    Ok(())
+}
+
+fn create_local_tracking_branch(
+    repo: &Repository,
+    remote_branch: &str,
+    local_name: &str,
+) -> Result<(), GitError> {
+    if local_name.is_empty() || !is_valid_branch_name(local_name)? {
+        return Err(GitError::new(GitErrorKind::InvalidBranchName, local_name));
+    }
+    let remote = repo
+        .find_branch(remote_branch, BranchType::Remote)
+        .map_err(|error| match error.code() {
+            ErrorCode::NotFound => GitError::new(GitErrorKind::BranchNotFound, remote_branch),
+            _ => GitError::from_git2(error),
+        })?;
+    let commit = remote.get().peel_to_commit().map_err(GitError::from_git2)?;
+    let mut created =
+        repo.branch(local_name, &commit, false)
+            .map_err(|error| match error.code() {
+                ErrorCode::Exists => GitError::new(GitErrorKind::BranchAlreadyExists, local_name),
+                ErrorCode::InvalidSpec => {
+                    GitError::new(GitErrorKind::InvalidBranchName, local_name)
+                }
+                _ => GitError::from_git2(error),
+            })?;
+    if let Err(error) = created.set_upstream(Some(remote_branch)) {
+        let _ = created.delete();
+        return Err(GitError::from_git2(error));
+    }
+    Ok(())
+}
+
+fn local_name_for_remote_branch(
+    repo: &Repository,
+    remote_branch: &str,
+) -> Result<String, GitError> {
+    let remotes = repo.remotes().map_err(GitError::from_git2)?;
+    let mut best: Option<String> = None;
+    for remote in remotes.iter() {
+        let Some(remote) = remote.map_err(GitError::from_git2)? else {
+            continue;
+        };
+        let prefix = format!("{remote}/");
+        if let Some(rest) = remote_branch.strip_prefix(&prefix) {
+            if rest.is_empty() {
+                continue;
+            }
+            if best
+                .as_ref()
+                .is_none_or(|current| rest.len() < current.len())
+            {
+                best = Some(rest.to_string());
+            }
+        }
+    }
+    best.ok_or_else(|| GitError::new(GitErrorKind::BranchNotFound, remote_branch))
 }
 
 pub fn is_valid_branch_name(name: &str) -> Result<bool, GitError> {

--- a/rust/alera-core/src/git_branch_tests.rs
+++ b/rust/alera-core/src/git_branch_tests.rs
@@ -164,6 +164,83 @@ fn checks_out_a_remote_tracking_branch_by_creating_a_local_tracker() {
     );
 }
 
+#[test]
+fn remote_selection_is_a_no_op_when_the_matching_local_is_current() {
+    let (_directory, repo) = init_repo();
+    repo.remote("origin", "https://example.invalid/repo.git")
+        .expect("add origin");
+    let head = repo
+        .head()
+        .expect("read HEAD")
+        .peel_to_commit()
+        .expect("read HEAD commit");
+    repo.branch("feature", &head, false)
+        .expect("create local feature");
+    repo.reference(
+        "refs/remotes/origin/feature",
+        head.id(),
+        true,
+        "remote tracking feature",
+    )
+    .expect("create remote tracking branch");
+    repo.set_head("refs/heads/feature")
+        .expect("switch symbolic HEAD");
+    drop(head);
+
+    checkout_branch(path_str(workdir(&repo)), "origin/feature").expect("matching remote selection");
+
+    assert_eq!(
+        current_branch(path_str(workdir(&repo))).expect("read current branch"),
+        "feature"
+    );
+}
+
+#[test]
+fn rejects_a_remote_selection_when_the_local_branch_has_diverged() {
+    let (_directory, repo) = init_repo();
+    repo.remote("origin", "https://example.invalid/repo.git")
+        .expect("add origin");
+    let head = repo
+        .head()
+        .expect("read HEAD")
+        .peel_to_commit()
+        .expect("read HEAD commit");
+    repo.branch("feature", &head, false)
+        .expect("create local feature");
+    let tree = head.tree().expect("read HEAD tree");
+    let signature = Signature::now("Alera Tests", "tests@alera.build").expect("signature");
+    let remote_oid = repo
+        .commit(
+            None,
+            &signature,
+            &signature,
+            "remote feature",
+            &tree,
+            &[&head],
+        )
+        .expect("create remote commit");
+    repo.reference(
+        "refs/remotes/origin/feature",
+        remote_oid,
+        true,
+        "remote tracking feature",
+    )
+    .expect("create remote tracking branch");
+    drop(tree);
+    drop(head);
+
+    let error = checkout_branch(path_str(workdir(&repo)), "origin/feature")
+        .expect_err("divergent local branch must block remote selection");
+
+    assert_eq!(error.kind, GitErrorKind::Conflict);
+    assert!(error.context.contains("local branch \"feature\""));
+    assert!(error.context.contains("\"origin/feature\""));
+    assert_eq!(
+        current_branch(path_str(workdir(&repo))).expect("read current branch"),
+        "main"
+    );
+}
+
 fn workdir(repo: &Repository) -> &Path {
     repo.workdir().expect("workdir")
 }

--- a/rust/alera-core/src/git_branch_tests.rs
+++ b/rust/alera-core/src/git_branch_tests.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 use git2::{BranchType, Repository, RepositoryInitOptions, Signature, StatusOptions};
 use tempfile::TempDir;
 
-use super::{create_and_checkout_branch, current_branch, GitErrorKind};
+use super::{checkout_branch, create_and_checkout_branch, current_branch, GitErrorKind};
 
 #[test]
 fn creates_and_checks_out_branch_without_touching_pending_changes() {
@@ -66,6 +66,138 @@ fn rejects_detached_head() {
         .expect_err("detached HEAD must fail");
 
     assert_eq!(error.kind, GitErrorKind::DetachedHead);
+}
+
+#[test]
+fn switches_to_an_existing_local_branch() {
+    let (_directory, repo) = init_repo();
+    commit_on_branch(&repo, "feature", "tracked.txt", "feature\n", "feature");
+
+    checkout_branch(path_str(workdir(&repo)), "feature").expect("checkout feature");
+
+    assert_eq!(
+        current_branch(path_str(workdir(&repo))).expect("read current branch"),
+        "feature"
+    );
+    assert_eq!(
+        fs::read_to_string(workdir(&repo).join("tracked.txt")).expect("read tracked file"),
+        "feature\n"
+    );
+}
+
+#[test]
+fn checkout_is_a_no_op_when_already_on_the_branch() {
+    let (_directory, repo) = init_repo();
+
+    checkout_branch(path_str(workdir(&repo)), "main").expect("checkout current branch");
+
+    assert_eq!(
+        current_branch(path_str(repo.path())).expect("read current branch"),
+        "main"
+    );
+}
+
+#[test]
+fn rejects_checkout_when_local_changes_would_be_overwritten() {
+    let (_directory, repo) = init_repo();
+    commit_on_branch(&repo, "feature", "tracked.txt", "feature\n", "feature");
+    fs::write(workdir(&repo).join("tracked.txt"), "conflict\n").expect("write conflicting file");
+
+    let error =
+        checkout_branch(path_str(workdir(&repo)), "feature").expect_err("dirty checkout must fail");
+
+    assert_eq!(error.kind, GitErrorKind::Conflict);
+    assert_eq!(
+        current_branch(path_str(repo.path())).expect("read current branch"),
+        "main"
+    );
+}
+
+#[test]
+fn rejects_a_missing_branch() {
+    let (_directory, repo) = init_repo();
+
+    let error =
+        checkout_branch(path_str(workdir(&repo)), "missing").expect_err("missing branch must fail");
+
+    assert_eq!(error.kind, GitErrorKind::BranchNotFound);
+}
+
+#[test]
+fn checks_out_a_remote_tracking_branch_by_creating_a_local_tracker() {
+    let (_directory, repo) = init_repo();
+    commit_on_branch(&repo, "feature", "tracked.txt", "feature\n", "feature");
+    repo.remote("origin", "https://example.invalid/repo.git")
+        .expect("add origin");
+    let feature = repo
+        .find_branch("feature", BranchType::Local)
+        .expect("find feature");
+    let feature_oid = feature.get().target().expect("feature target");
+    drop(feature);
+    repo.reference(
+        "refs/remotes/origin/feature",
+        feature_oid,
+        true,
+        "remote tracking feature",
+    )
+    .expect("create remote tracking branch");
+    checkout_branch(path_str(workdir(&repo)), "main").expect("return to main");
+    repo.find_branch("feature", BranchType::Local)
+        .expect("find local feature")
+        .delete()
+        .expect("delete local feature");
+
+    checkout_branch(path_str(workdir(&repo)), "origin/feature")
+        .expect("checkout remote tracking branch");
+
+    assert_eq!(
+        current_branch(path_str(workdir(&repo))).expect("read current branch"),
+        "feature"
+    );
+    let local = repo
+        .find_branch("feature", BranchType::Local)
+        .expect("local feature");
+    let upstream = local.upstream().expect("upstream");
+    assert_eq!(
+        upstream.name().expect("upstream name").expect("name"),
+        "origin/feature"
+    );
+}
+
+fn workdir(repo: &Repository) -> &Path {
+    repo.workdir().expect("workdir")
+}
+
+fn commit_on_branch(
+    repo: &Repository,
+    branch: &str,
+    file_name: &str,
+    content: &str,
+    message: &str,
+) {
+    let head = repo
+        .head()
+        .expect("read HEAD")
+        .peel_to_commit()
+        .expect("read HEAD commit");
+    repo.branch(branch, &head, false).expect("create branch");
+    let workdir = repo.workdir().expect("workdir");
+    fs::write(workdir.join(file_name), content).expect("write file");
+    let mut index = repo.index().expect("open index");
+    index.add_path(Path::new(file_name)).expect("stage file");
+    index.write().expect("write index");
+    let tree_oid = index.write_tree().expect("write tree");
+    let tree = repo.find_tree(tree_oid).expect("find tree");
+    let signature = Signature::now("Alera Tests", "tests@alera.build").expect("signature");
+    repo.commit(
+        Some(&format!("refs/heads/{branch}")),
+        &signature,
+        &signature,
+        message,
+        &tree,
+        &[&head],
+    )
+    .expect("commit on branch");
 }
 
 fn init_repo() -> (TempDir, Repository) {

--- a/rust/src/api/git_branch.rs
+++ b/rust/src/api/git_branch.rs
@@ -14,6 +14,10 @@ pub fn create_and_checkout_branch(path: String, branch: String) -> Result<(), Gi
     core_git::create_and_checkout_branch(&path, &branch).map_err(Into::into)
 }
 
+pub fn checkout_branch(path: String, branch: String) -> Result<(), GitError> {
+    core_git::checkout_branch(&path, &branch).map_err(Into::into)
+}
+
 pub fn branch_exists(repo_path: String, branch: String) -> Result<bool, GitError> {
     core_git::branch_exists(&repo_path, &branch).map_err(Into::into)
 }

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -268,6 +268,41 @@ fn wire__crate__api__workspace_files__copy_workspace_entry_impl(
         },
     )
 }
+fn wire__crate__api__git__git_branch__checkout_branch_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "checkout_branch",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_path = <String>::sse_decode(&mut deserializer);
+            let api_branch = <String>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, crate::api::git::GitError>((move || {
+                    let output_ok =
+                        crate::api::git::git_branch::checkout_branch(api_path, api_branch)?;
+                    std::result::Result::Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
 fn wire__crate__api__git__git_branch__create_and_checkout_branch_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
@@ -5923,6 +5958,12 @@ fn pde_ffi_dispatcher_primary_impl(
             data_len,
         ),
         92 => wire__crate__api__workspace_files__write_workspace_text_file_impl(
+            port,
+            ptr,
+            rust_vec_len,
+            data_len,
+        ),
+        93 => wire__crate__api__git__git_branch__checkout_branch_impl(
             port,
             ptr,
             rust_vec_len,

--- a/test/unit/fake_git_backend.dart
+++ b/test/unit/fake_git_backend.dart
@@ -111,6 +111,7 @@ class FakeGitBackend
   GitDiffResult gitCommitDiffResult = const GitDiffResult(files: []);
   GitRangeContext gitRangeContextResult = _defaultGitRangeContext();
   GitException? rangeContextError;
+  @override
   GitRepositoryState gitRepositoryStateResult = const GitRepositoryState(
     branch: 'main',
   );

--- a/test/unit/fake_git_backend_workspaces.dart
+++ b/test/unit/fake_git_backend_workspaces.dart
@@ -8,8 +8,11 @@ mixin _FakeGitBackendWorkspaceState {
   List<String> get sourceBranches;
   Map<String, String?> get remotesByName;
   bool get listRemotesFails;
+  GitRepositoryState get gitRepositoryStateResult;
+  set gitRepositoryStateResult(GitRepositoryState value);
 
   GitException? createAndCheckoutBranchError;
+  GitException? checkoutBranchError;
   final Map<String, String> currentBranchesByPath = <String, String>{};
   final Map<String, Map<String, String?>> remotesByPath =
       <String, Map<String, String?>>{};
@@ -38,8 +41,48 @@ mixin _FakeGitBackendWorkspaceState {
     }
     headBranch = branch;
     currentBranchesByPath[path] = branch;
+    gitRepositoryStateResult = GitRepositoryState(
+      branch: branch,
+      upstream: gitRepositoryStateResult.upstream,
+      ahead: gitRepositoryStateResult.ahead,
+      behind: gitRepositoryStateResult.behind,
+      hasConflicts: gitRepositoryStateResult.hasConflicts,
+      headMessage: gitRepositoryStateResult.headMessage,
+    );
     if (!sourceBranches.contains(branch)) {
       sourceBranches.add(branch);
+    }
+  }
+
+  Future<void> checkoutBranch({
+    required String path,
+    required String branch,
+  }) async {
+    calls.add(
+      GitBackendCall('checkoutBranch', <String, Object?>{
+        'path': path,
+        'branch': branch,
+      }),
+    );
+    final error = checkoutBranchError;
+    if (error != null) {
+      throw error;
+    }
+    final resolved = branch.contains('/') && !sourceBranches.contains(branch)
+        ? branch.split('/').skip(1).join('/')
+        : branch;
+    headBranch = resolved;
+    currentBranchesByPath[path] = resolved;
+    gitRepositoryStateResult = GitRepositoryState(
+      branch: resolved,
+      upstream: gitRepositoryStateResult.upstream,
+      ahead: gitRepositoryStateResult.ahead,
+      behind: gitRepositoryStateResult.behind,
+      hasConflicts: gitRepositoryStateResult.hasConflicts,
+      headMessage: gitRepositoryStateResult.headMessage,
+    );
+    if (!sourceBranches.contains(resolved)) {
+      sourceBranches.add(resolved);
     }
   }
 

--- a/test/unit/fake_git_backend_workspaces.dart
+++ b/test/unit/fake_git_backend_workspaces.dart
@@ -13,6 +13,7 @@ mixin _FakeGitBackendWorkspaceState {
 
   GitException? createAndCheckoutBranchError;
   GitException? checkoutBranchError;
+  String? checkoutBranchResult;
   final Map<String, String> currentBranchesByPath = <String, String>{};
   final Map<String, Map<String, String?>> remotesByPath =
       <String, Map<String, String?>>{};
@@ -68,9 +69,7 @@ mixin _FakeGitBackendWorkspaceState {
     if (error != null) {
       throw error;
     }
-    final resolved = branch.contains('/') && !sourceBranches.contains(branch)
-        ? branch.split('/').skip(1).join('/')
-        : branch;
+    final resolved = checkoutBranchResult ?? branch;
     headBranch = resolved;
     currentBranchesByPath[path] = resolved;
     gitRepositoryStateResult = GitRepositoryState(

--- a/test/unit/workspace_source_control_controller_test.dart
+++ b/test/unit/workspace_source_control_controller_test.dart
@@ -190,6 +190,59 @@ void main() {
     expect(entry.canDiscardFromParent, isFalse);
   });
 
+  test(
+    'checkoutBranch switches the current branch and reloads state',
+    () async {
+      final backend = FakeGitBackend()
+        ..sourceBranches = <String>['main', 'feature']
+        ..gitRepositoryStateResult = const GitRepositoryState(branch: 'main');
+      final watcher = FakeSourceControlWatcher();
+      addTearDown(watcher.dispose);
+      final (container, controller) = await _boot(backend, watcher);
+      final provider = workspaceSourceControlControllerProvider(_workspacePath);
+
+      await controller.checkoutBranch('feature');
+
+      expect(
+        backend.calls
+            .where((call) => call.method == 'checkoutBranch')
+            .single
+            .args,
+        <String, Object?>{'path': _workspacePath, 'branch': 'feature'},
+      );
+      expect(
+        container.read(provider).requireValue.repositoryState.branch,
+        'feature',
+      );
+    },
+  );
+
+  test(
+    'createAndCheckoutBranch creates a branch from HEAD and reloads state',
+    () async {
+      final backend = FakeGitBackend()
+        ..gitRepositoryStateResult = const GitRepositoryState(branch: 'main');
+      final watcher = FakeSourceControlWatcher();
+      addTearDown(watcher.dispose);
+      final (container, controller) = await _boot(backend, watcher);
+      final provider = workspaceSourceControlControllerProvider(_workspacePath);
+
+      await controller.createAndCheckoutBranch('ship/login');
+
+      expect(
+        backend.calls
+            .where((call) => call.method == 'createAndCheckoutBranch')
+            .single
+            .args,
+        <String, Object?>{'path': _workspacePath, 'branch': 'ship/login'},
+      );
+      expect(
+        container.read(provider).requireValue.repositoryState.branch,
+        'ship/login',
+      );
+    },
+  );
+
   test('submodule provider loads lazily and prefixes child paths', () async {
     final backend = FakeGitBackend()
       ..gitSubmoduleStatusResult = const GitStatusResult(

--- a/test/unit/workspace_source_control_controller_test.dart
+++ b/test/unit/workspace_source_control_controller_test.dart
@@ -201,7 +201,7 @@ void main() {
       final (container, controller) = await _boot(backend, watcher);
       final provider = workspaceSourceControlControllerProvider(_workspacePath);
 
-      await controller.checkoutBranch('feature');
+      final activeBranch = await controller.checkoutBranch('feature');
 
       expect(
         backend.calls
@@ -214,6 +214,7 @@ void main() {
         container.read(provider).requireValue.repositoryState.branch,
         'feature',
       );
+      expect(activeBranch, 'feature');
     },
   );
 

--- a/test/widget/workspace_git_diff_panel_branch_test_cases.dart
+++ b/test/widget/workspace_git_diff_panel_branch_test_cases.dart
@@ -1,0 +1,76 @@
+part of 'workspace_git_diff_panel_test.dart';
+
+void _registerWorkspaceGitDiffPanelBranchTests() {
+  testWidgets('source control branch control opens the switcher', (
+    tester,
+  ) async {
+    final backend = FakeGitBackend()
+      ..sourceBranches = <String>['main', 'feature']
+      ..gitRepositoryStateResult = const GitRepositoryState(branch: 'main');
+
+    await _pumpPanel(tester, backend: backend);
+    await tester.pumpAndSettle();
+
+    expect(find.byTooltip('Switch Branch'), findsOneWidget);
+    await tester.tap(find.byTooltip('Switch Branch'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Switch Branch'), findsWidgets);
+    expect(find.text('feature'), findsOneWidget);
+    expect(find.text('Create Branch'), findsOneWidget);
+  });
+
+  testWidgets('switching a branch from source control checks it out', (
+    tester,
+  ) async {
+    final backend = FakeGitBackend()
+      ..sourceBranches = <String>['main', 'feature']
+      ..gitRepositoryStateResult = const GitRepositoryState(branch: 'main');
+
+    await _pumpPanel(tester, backend: backend);
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byTooltip('Switch Branch'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('feature'));
+    await tester.pumpAndSettle();
+
+    expect(
+      backend.calls
+          .where((call) => call.method == 'checkoutBranch')
+          .single
+          .args,
+      <String, Object?>{'path': '/tmp/project', 'branch': 'feature'},
+    );
+    expect(find.byTooltip('Switch Branch'), findsOneWidget);
+    expect(find.text('feature'), findsWidgets);
+  });
+
+  testWidgets('creating a branch from source control checks it out', (
+    tester,
+  ) async {
+    final backend = FakeGitBackend()
+      ..gitRepositoryStateResult = const GitRepositoryState(branch: 'main');
+
+    await _pumpPanel(tester, backend: backend);
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byTooltip('Switch Branch'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Create Branch'));
+    await tester.pumpAndSettle();
+
+    await tester.enterText(find.byType(TextField).last, 'ship/login');
+    await tester.tap(find.text('Create'));
+    await tester.pumpAndSettle();
+
+    expect(
+      backend.calls
+          .where((call) => call.method == 'createAndCheckoutBranch')
+          .single
+          .args,
+      <String, Object?>{'path': '/tmp/project', 'branch': 'ship/login'},
+    );
+    expect(find.text('ship/login'), findsWidgets);
+  });
+}

--- a/test/widget/workspace_git_diff_panel_branch_test_cases.dart
+++ b/test/widget/workspace_git_diff_panel_branch_test_cases.dart
@@ -46,6 +46,57 @@ void _registerWorkspaceGitDiffPanelBranchTests() {
     expect(find.text('feature'), findsWidgets);
   });
 
+  testWidgets('remote checkout reports the local branch that became active', (
+    tester,
+  ) async {
+    final toasts = <AleraToastData>[];
+    final subscription = AleraToast.stream.listen(toasts.add);
+    addTearDown(subscription.cancel);
+    final backend = FakeGitBackend()
+      ..sourceBranches = <String>['main', 'origin/feature']
+      ..checkoutBranchResult = 'feature'
+      ..gitRepositoryStateResult = const GitRepositoryState(branch: 'main');
+
+    await _pumpPanel(tester, backend: backend);
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byTooltip('Switch Branch'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('origin/feature'));
+    await tester.pumpAndSettle();
+
+    expect(toasts.last.message, 'Switched to feature');
+    expect(toasts.last.tone, AleraToastTone.success);
+  });
+
+  testWidgets('branch checkout shows conflict guidance from Git', (
+    tester,
+  ) async {
+    final toasts = <AleraToastData>[];
+    final subscription = AleraToast.stream.listen(toasts.add);
+    addTearDown(subscription.cancel);
+    final backend = FakeGitBackend()
+      ..sourceBranches = <String>['main', 'feature']
+      ..checkoutBranchError = const GitConflictException(
+        'commit or stash local changes before switching branches',
+      )
+      ..gitRepositoryStateResult = const GitRepositoryState(branch: 'main');
+
+    await _pumpPanel(tester, backend: backend);
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byTooltip('Switch Branch'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('feature'));
+    await tester.pumpAndSettle();
+
+    expect(
+      toasts.last.message,
+      'commit or stash local changes before switching branches',
+    );
+    expect(toasts.last.tone, AleraToastTone.error);
+  });
+
   testWidgets('creating a branch from source control checks it out', (
     tester,
   ) async {

--- a/test/widget/workspace_git_diff_panel_test.dart
+++ b/test/widget/workspace_git_diff_panel_test.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:alera/src/app/theme/alera_tokens.dart';
+import 'package:alera/src/design_system/feedback/alera_toast.dart';
 import 'package:alera/src/design_system/icons/alera_icons.dart';
 import 'package:alera/src/features/ai_assist/application/ai_assist_providers.dart';
 import 'package:alera/src/features/ai_assist/application/ai_assist_service.dart';

--- a/test/widget/workspace_git_diff_panel_test.dart
+++ b/test/widget/workspace_git_diff_panel_test.dart
@@ -28,10 +28,12 @@ import '../unit/fake_source_control_watcher.dart';
 
 part 'workspace_git_diff_panel_preview_test_cases.dart';
 part 'workspace_git_diff_panel_context_menu_test_cases.dart';
+part 'workspace_git_diff_panel_branch_test_cases.dart';
 
 void main() {
   _registerWorkspaceGitDiffPanelPreviewTests();
   _registerWorkspaceGitDiffPanelContextMenuTests();
+  _registerWorkspaceGitDiffPanelBranchTests();
   testWidgets('git diff panel hides zero-valued line counts', (tester) async {
     final backend = FakeGitBackend()
       ..gitStatusResult = const GitStatusResult(

--- a/test/widget/workspace_git_history_panel_test.dart
+++ b/test/widget/workspace_git_history_panel_test.dart
@@ -26,7 +26,16 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('Add Feature'), findsOneWidget);
-    expect(find.text('feat/settings-fullscreen-modal'), findsOneWidget);
+    expect(
+      find.descendant(
+        of: find.ancestor(
+          of: find.text('Add Feature'),
+          matching: find.byType(InkWell),
+        ),
+        matching: find.text('feat/settings-fullscreen-modal'),
+      ),
+      findsOneWidget,
+    );
     expect(find.text('+2'), findsOneWidget);
   });
 
@@ -44,7 +53,16 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('Add Feature'), findsOneWidget);
-    expect(find.text('feat/settings-fullscreen-modal'), findsNothing);
+    expect(
+      find.descendant(
+        of: find.ancestor(
+          of: find.text('Add Feature'),
+          matching: find.byType(InkWell),
+        ),
+        matching: find.text('feat/settings-fullscreen-modal'),
+      ),
+      findsNothing,
+    );
     expect(find.text('+4'), findsOneWidget);
     expect(tester.takeException(), isNull);
   });


### PR DESCRIPTION
## Summary

- Add a searchable branch switcher to Source Control for local and remote-tracking branches.
- Add Create Branch from the current HEAD and switch to it immediately.
- Keep checkout safe by rejecting in-progress Git operations and local changes that would be overwritten.

Closes #647

## Screenshots

No committed screenshot or recording. The native Linux app could not be recorded in the orb because the Vulkan/Whisper desktop dependency was unavailable. An uncommitted HTML walkthrough was used for local visual inspection only.

## Testing

- [x] `dart format --set-exit-if-changed lib test integration_test tool`
- [x] `flutter analyze`
- [x] `flutter test --coverage --exclude-tags golden`
- [x] `dart run tool/quality/coverage_report.dart --input coverage/lcov.info --min-lines 100 --worst 25`
- [ ] Golden tests, if UI changed: `flutter test --tags golden` (the behavior is covered by focused widget tests; no golden was added)
- [ ] Desktop E2E, if app-shell flow changed: `flutter test integration_test -d macos` (macOS is unavailable in the Linux orb)
- [ ] Relevant desktop build: `flutter build macos`, `flutter build windows`, or `flutter build linux` (Linux native launch is blocked by the orb's missing Vulkan toolchain)
- [ ] Landing build, if applicable: not applicable
- [x] Added or updated tests that would catch regressions, or explained why tests were not needed
- [x] `dart tool/quality/check_max_lines.dart`
- [x] `cd rust && cargo fmt --check`
- [x] `cd rust && cargo clippy -p alera-core --all-targets -- -D warnings`
- [x] `cd rust && cargo test -p alera-core` (76 passed)

## AI Review Report

Reviewed the branch lifecycle end to end across the Flutter controller, backend boundary, generated bridge, and Rust implementation. Checked invalid names, detached and unborn HEAD, in-progress operations, existing branches, remote-tracking setup, rollback after failed setup or checkout, preservation of pending changes when creating from HEAD, and stale UI refresh behavior. Analysis found one missing override annotation and two history-panel assertions that needed scoping after the new branch label was introduced; both were fixed and the full Flutter suite passed afterward.

Cross-platform behavior was checked for macOS, Linux, and Windows. The implementation uses libgit2 and existing path/backend abstractions rather than platform-specific shell commands or path construction, and visible action labels remain consistent across platforms.

## Security Audit

Branch names are trimmed and validated by libgit2 before ref creation. Checkout uses safe checkout semantics, rejects repositories with an in-progress operation, does not force-overwrite local changes, and removes newly created tracking refs if setup or checkout fails. No auth, secrets, dependencies, process execution, or release-signing behavior changed.

## Notes

Full Rust workspace clippy/test was attempted but the Linux orb lacks Vulkan headers, libraries, and `glslc`, which blocks `whisper-rs-sys`. Formatting plus clippy and all tests for the changed `alera-core` crate passed; CI covers the workspace in its configured environment.

Documentation was considered and is not needed because this is a discoverable Source Control action with no new configuration or contributor workflow.