### PR TITLE
fix: accept camelcase nested automation serde fields

### DIFF
--- a/rust/alera-core/src/runtime/agent_profile_removal_store_tests.rs
+++ b/rust/alera-core/src/runtime/agent_profile_removal_store_tests.rs
@@ -261,7 +261,7 @@ async fn database_guards_reject_references_committed_after_profile_removal() {
     assert_eq!(
         serde_json::to_value(&definition)
             .unwrap()
-            .pointer("/target/freshTab/agent_profile_id"),
+            .pointer("/target/freshTab/agentProfileId"),
         Some(&json!("prof_a"))
     );
     let automation_error = store

--- a/rust/alera-core/src/runtime/automation_models.rs
+++ b/rust/alera-core/src/runtime/automation_models.rs
@@ -71,7 +71,7 @@ impl AutomationScheduleKind {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", rename_all_fields = "camelCase")]
 pub enum AutomationSchedule {
     OneTime {
         at: DateTime<Utc>,
@@ -80,11 +80,11 @@ pub enum AutomationSchedule {
     Recurring {
         cron: String,
         timezone: String,
-        #[serde(default)]
+        #[serde(default, alias = "start_at")]
         start_at: Option<DateTime<Utc>>,
-        #[serde(default)]
+        #[serde(default, alias = "end_at")]
         end_at: Option<DateTime<Utc>>,
-        #[serde(default)]
+        #[serde(default, alias = "max_scheduled_runs")]
         max_scheduled_runs: Option<i64>,
     },
 }
@@ -114,23 +114,30 @@ impl AutomationSchedule {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", rename_all_fields = "camelCase")]
 pub enum AutomationTarget {
     ExistingTab {
+        #[serde(alias = "workspace_id")]
         workspace_id: String,
+        #[serde(alias = "tab_id")]
         tab_id: String,
-        #[serde(default)]
+        #[serde(default, alias = "conversation_id")]
         conversation_id: Option<String>,
     },
     FreshTab {
+        #[serde(alias = "workspace_id")]
         workspace_id: String,
+        #[serde(alias = "agent_profile_id")]
         agent_profile_id: String,
     },
     ManagedWorkspace {
+        #[serde(alias = "source_workspace_id")]
         source_workspace_id: String,
+        #[serde(alias = "source_branch")]
         source_branch: String,
-        #[serde(default = "default_name_template")]
+        #[serde(default = "default_name_template", alias = "name_template")]
         name_template: String,
+        #[serde(alias = "agent_profile_id")]
         agent_profile_id: String,
     },
 }

--- a/rust/alera-core/src/runtime/automation_models_serde_tests.rs
+++ b/rust/alera-core/src/runtime/automation_models_serde_tests.rs
@@ -1,0 +1,171 @@
+use chrono::{DateTime, Utc};
+use serde_json::json;
+
+use super::{
+    AutomationDefinition, AutomationSchedule, AutomationTarget, AUTOMATION_DEFAULT_NAME_TEMPLATE,
+};
+
+fn utc(value: &str) -> DateTime<Utc> {
+    value.parse().unwrap()
+}
+
+#[test]
+fn accepts_desktop_fresh_tab_camel_case_definition() {
+    let value = json!({
+        "id": "repro-camel",
+        "slug": "repro-camel",
+        "name": "Repro Camel",
+        "promptTemplate": "ping",
+        "schedule": { "oneTime": { "at": "2027-01-01T00:00:00Z", "timezone": "UTC" } },
+        "target": {
+            "freshTab": {
+                "workspaceId": "workspace-1",
+                "agentProfileId": "profile-1"
+            }
+        },
+        "state": "draft",
+        "revision": 0,
+        "createdBy": { "kind": "localCli" },
+        "modifiedBy": { "kind": "localCli" },
+        "createdAt": "2026-09-08T00:00:00Z",
+        "updatedAt": "2026-09-08T00:00:00Z"
+    });
+
+    let definition: AutomationDefinition = serde_json::from_value(value).unwrap();
+    assert_eq!(
+        definition.target,
+        AutomationTarget::FreshTab {
+            workspace_id: "workspace-1".into(),
+            agent_profile_id: "profile-1".into(),
+        }
+    );
+
+    let encoded = serde_json::to_value(&definition).unwrap();
+    assert_eq!(
+        encoded.pointer("/target/freshTab/workspaceId"),
+        Some(&json!("workspace-1"))
+    );
+    assert_eq!(
+        encoded.pointer("/target/freshTab/agentProfileId"),
+        Some(&json!("profile-1"))
+    );
+    assert!(encoded.pointer("/target/freshTab/workspace_id").is_none());
+    assert!(encoded
+        .pointer("/target/freshTab/agent_profile_id")
+        .is_none());
+}
+
+#[test]
+fn accepts_recurring_schedule_camel_case_extras() {
+    let value = json!({
+        "recurring": {
+            "cron": "0 * * * *",
+            "timezone": "UTC",
+            "startAt": "2027-01-01T00:00:00Z",
+            "endAt": "2027-12-31T00:00:00Z",
+            "maxScheduledRuns": 5
+        }
+    });
+
+    let schedule: AutomationSchedule = serde_json::from_value(value).unwrap();
+    assert_eq!(
+        schedule,
+        AutomationSchedule::Recurring {
+            cron: "0 * * * *".into(),
+            timezone: "UTC".into(),
+            start_at: Some(utc("2027-01-01T00:00:00Z")),
+            end_at: Some(utc("2027-12-31T00:00:00Z")),
+            max_scheduled_runs: Some(5),
+        }
+    );
+
+    let encoded = serde_json::to_value(&schedule).unwrap();
+    assert_eq!(
+        encoded.pointer("/recurring/startAt"),
+        Some(&json!("2027-01-01T00:00:00Z"))
+    );
+    assert_eq!(
+        encoded.pointer("/recurring/endAt"),
+        Some(&json!("2027-12-31T00:00:00Z"))
+    );
+    assert_eq!(
+        encoded.pointer("/recurring/maxScheduledRuns"),
+        Some(&json!(5))
+    );
+    assert!(encoded.pointer("/recurring/start_at").is_none());
+    assert!(encoded.pointer("/recurring/end_at").is_none());
+    assert!(encoded.pointer("/recurring/max_scheduled_runs").is_none());
+}
+
+#[test]
+fn serializes_existing_tab_and_managed_workspace_fields_as_camel_case() {
+    let existing = AutomationTarget::ExistingTab {
+        workspace_id: "workspace-1".into(),
+        tab_id: "tab-1".into(),
+        conversation_id: Some("conversation-1".into()),
+    };
+    let encoded = serde_json::to_value(&existing).unwrap();
+    assert_eq!(
+        encoded.pointer("/existingTab/workspaceId"),
+        Some(&json!("workspace-1"))
+    );
+    assert_eq!(encoded.pointer("/existingTab/tabId"), Some(&json!("tab-1")));
+    assert_eq!(
+        encoded.pointer("/existingTab/conversationId"),
+        Some(&json!("conversation-1"))
+    );
+
+    let managed = AutomationTarget::ManagedWorkspace {
+        source_workspace_id: "workspace-1".into(),
+        source_branch: "main".into(),
+        name_template: AUTOMATION_DEFAULT_NAME_TEMPLATE.into(),
+        agent_profile_id: "profile-1".into(),
+    };
+    let encoded = serde_json::to_value(&managed).unwrap();
+    assert_eq!(
+        encoded.pointer("/managedWorkspace/sourceWorkspaceId"),
+        Some(&json!("workspace-1"))
+    );
+    assert_eq!(
+        encoded.pointer("/managedWorkspace/sourceBranch"),
+        Some(&json!("main"))
+    );
+    assert_eq!(
+        encoded.pointer("/managedWorkspace/nameTemplate"),
+        Some(&json!(AUTOMATION_DEFAULT_NAME_TEMPLATE))
+    );
+    assert_eq!(
+        encoded.pointer("/managedWorkspace/agentProfileId"),
+        Some(&json!("profile-1"))
+    );
+}
+
+#[test]
+fn still_accepts_legacy_snake_case_nested_fields() {
+    let target: AutomationTarget = serde_json::from_value(json!({
+        "freshTab": {
+            "workspace_id": "workspace-1",
+            "agent_profile_id": "profile-1"
+        }
+    }))
+    .unwrap();
+    assert_eq!(
+        target,
+        AutomationTarget::FreshTab {
+            workspace_id: "workspace-1".into(),
+            agent_profile_id: "profile-1".into(),
+        }
+    );
+
+    let schedule: AutomationSchedule = serde_json::from_value(json!({
+        "recurring": {
+            "cron": "0 * * * *",
+            "timezone": "UTC",
+            "start_at": "2027-01-01T00:00:00Z",
+            "end_at": "2027-12-31T00:00:00Z",
+            "max_scheduled_runs": 5
+        }
+    }))
+    .unwrap();
+    assert_eq!(schedule.max_scheduled_runs(), Some(5));
+}

--- a/rust/alera-core/src/runtime/automation_models_serde_tests.rs
+++ b/rust/alera-core/src/runtime/automation_models_serde_tests.rs
@@ -1,5 +1,5 @@
 use chrono::{DateTime, Utc};
-use serde_json::json;
+use serde_json::{json, Value};
 
 use super::{
     AutomationDefinition, AutomationSchedule, AutomationTarget, AUTOMATION_DEFAULT_NAME_TEMPLATE,
@@ -7,6 +7,19 @@ use super::{
 
 fn utc(value: &str) -> DateTime<Utc> {
     value.parse().unwrap()
+}
+
+fn assert_camel_case_object(value: &Value, pointer: &str) {
+    let object = value
+        .pointer(pointer)
+        .and_then(Value::as_object)
+        .unwrap_or_else(|| panic!("missing object at {pointer}"));
+    for key in object.keys() {
+        assert!(
+            !key.contains('_'),
+            "{pointer} serialized snake_case key {key}; rename_all_fields likely regressed"
+        );
+    }
 }
 
 #[test]
@@ -41,6 +54,8 @@ fn accepts_desktop_fresh_tab_camel_case_definition() {
     );
 
     let encoded = serde_json::to_value(&definition).unwrap();
+    let reread: AutomationDefinition = serde_json::from_value(encoded.clone()).unwrap();
+    assert_eq!(reread.target, definition.target);
     assert_eq!(
         encoded.pointer("/target/freshTab/workspaceId"),
         Some(&json!("workspace-1"))
@@ -49,10 +64,7 @@ fn accepts_desktop_fresh_tab_camel_case_definition() {
         encoded.pointer("/target/freshTab/agentProfileId"),
         Some(&json!("profile-1"))
     );
-    assert!(encoded.pointer("/target/freshTab/workspace_id").is_none());
-    assert!(encoded
-        .pointer("/target/freshTab/agent_profile_id")
-        .is_none());
+    assert_camel_case_object(&encoded, "/target/freshTab");
 }
 
 #[test]
@@ -80,6 +92,8 @@ fn accepts_recurring_schedule_camel_case_extras() {
     );
 
     let encoded = serde_json::to_value(&schedule).unwrap();
+    let reread: AutomationSchedule = serde_json::from_value(encoded.clone()).unwrap();
+    assert_eq!(reread, schedule);
     assert_eq!(
         encoded.pointer("/recurring/startAt"),
         Some(&json!("2027-01-01T00:00:00Z"))
@@ -92,18 +106,27 @@ fn accepts_recurring_schedule_camel_case_extras() {
         encoded.pointer("/recurring/maxScheduledRuns"),
         Some(&json!(5))
     );
-    assert!(encoded.pointer("/recurring/start_at").is_none());
-    assert!(encoded.pointer("/recurring/end_at").is_none());
-    assert!(encoded.pointer("/recurring/max_scheduled_runs").is_none());
+    assert_camel_case_object(&encoded, "/recurring");
 }
 
 #[test]
-fn serializes_existing_tab_and_managed_workspace_fields_as_camel_case() {
-    let existing = AutomationTarget::ExistingTab {
-        workspace_id: "workspace-1".into(),
-        tab_id: "tab-1".into(),
-        conversation_id: Some("conversation-1".into()),
-    };
+fn round_trips_existing_tab_and_managed_workspace_camel_case() {
+    let existing: AutomationTarget = serde_json::from_value(json!({
+        "existingTab": {
+            "workspaceId": "workspace-1",
+            "tabId": "tab-1",
+            "conversationId": "conversation-1"
+        }
+    }))
+    .unwrap();
+    assert_eq!(
+        existing,
+        AutomationTarget::ExistingTab {
+            workspace_id: "workspace-1".into(),
+            tab_id: "tab-1".into(),
+            conversation_id: Some("conversation-1".into()),
+        }
+    );
     let encoded = serde_json::to_value(&existing).unwrap();
     assert_eq!(
         encoded.pointer("/existingTab/workspaceId"),
@@ -114,13 +137,26 @@ fn serializes_existing_tab_and_managed_workspace_fields_as_camel_case() {
         encoded.pointer("/existingTab/conversationId"),
         Some(&json!("conversation-1"))
     );
+    assert_camel_case_object(&encoded, "/existingTab");
 
-    let managed = AutomationTarget::ManagedWorkspace {
-        source_workspace_id: "workspace-1".into(),
-        source_branch: "main".into(),
-        name_template: AUTOMATION_DEFAULT_NAME_TEMPLATE.into(),
-        agent_profile_id: "profile-1".into(),
-    };
+    let managed: AutomationTarget = serde_json::from_value(json!({
+        "managedWorkspace": {
+            "sourceWorkspaceId": "workspace-1",
+            "sourceBranch": "main",
+            "nameTemplate": AUTOMATION_DEFAULT_NAME_TEMPLATE,
+            "agentProfileId": "profile-1"
+        }
+    }))
+    .unwrap();
+    assert_eq!(
+        managed,
+        AutomationTarget::ManagedWorkspace {
+            source_workspace_id: "workspace-1".into(),
+            source_branch: "main".into(),
+            name_template: AUTOMATION_DEFAULT_NAME_TEMPLATE.into(),
+            agent_profile_id: "profile-1".into(),
+        }
+    );
     let encoded = serde_json::to_value(&managed).unwrap();
     assert_eq!(
         encoded.pointer("/managedWorkspace/sourceWorkspaceId"),
@@ -131,41 +167,85 @@ fn serializes_existing_tab_and_managed_workspace_fields_as_camel_case() {
         Some(&json!("main"))
     );
     assert_eq!(
-        encoded.pointer("/managedWorkspace/nameTemplate"),
-        Some(&json!(AUTOMATION_DEFAULT_NAME_TEMPLATE))
-    );
-    assert_eq!(
         encoded.pointer("/managedWorkspace/agentProfileId"),
         Some(&json!("profile-1"))
     );
+    assert_camel_case_object(&encoded, "/managedWorkspace");
 }
 
 #[test]
-fn still_accepts_legacy_snake_case_nested_fields() {
-    let target: AutomationTarget = serde_json::from_value(json!({
-        "freshTab": {
-            "workspace_id": "workspace-1",
-            "agent_profile_id": "profile-1"
-        }
+fn snake_case_nested_payloads_still_deserialize_and_emit_camel_case() {
+    let definition: AutomationDefinition = serde_json::from_value(json!({
+        "id": "repro-snake",
+        "slug": "repro-snake",
+        "name": "Repro Snake",
+        "promptTemplate": "ping",
+        "schedule": {
+            "recurring": {
+                "cron": "0 * * * *",
+                "timezone": "UTC",
+                "start_at": "2027-01-01T00:00:00Z",
+                "end_at": "2027-12-31T00:00:00Z",
+                "max_scheduled_runs": 5
+            }
+        },
+        "target": {
+            "freshTab": {
+                "workspace_id": "workspace-1",
+                "agent_profile_id": "profile-1"
+            }
+        },
+        "state": "draft",
+        "revision": 0,
+        "createdBy": { "kind": "localCli" },
+        "modifiedBy": { "kind": "localCli" },
+        "createdAt": "2026-09-08T00:00:00Z",
+        "updatedAt": "2026-09-08T00:00:00Z"
     }))
     .unwrap();
     assert_eq!(
-        target,
+        definition.target,
         AutomationTarget::FreshTab {
             workspace_id: "workspace-1".into(),
             agent_profile_id: "profile-1".into(),
         }
     );
+    assert_eq!(definition.schedule.max_scheduled_runs(), Some(5));
 
-    let schedule: AutomationSchedule = serde_json::from_value(json!({
-        "recurring": {
-            "cron": "0 * * * *",
-            "timezone": "UTC",
-            "start_at": "2027-01-01T00:00:00Z",
-            "end_at": "2027-12-31T00:00:00Z",
-            "max_scheduled_runs": 5
+    let encoded = serde_json::to_value(&definition).unwrap();
+    assert_eq!(
+        encoded.pointer("/target/freshTab/workspaceId"),
+        Some(&json!("workspace-1"))
+    );
+    assert_eq!(
+        encoded.pointer("/target/freshTab/agentProfileId"),
+        Some(&json!("profile-1"))
+    );
+    assert_eq!(
+        encoded.pointer("/schedule/recurring/startAt"),
+        Some(&json!("2027-01-01T00:00:00Z"))
+    );
+    assert_camel_case_object(&encoded, "/target/freshTab");
+    assert_camel_case_object(&encoded, "/schedule/recurring");
+
+    let existing: AutomationTarget = serde_json::from_value(json!({
+        "existingTab": {
+            "workspace_id": "workspace-1",
+            "tab_id": "tab-1",
+            "conversation_id": "conversation-1"
         }
     }))
     .unwrap();
-    assert_eq!(schedule.max_scheduled_runs(), Some(5));
+    assert_eq!(existing.workspace_id(), Some("workspace-1"));
+
+    let managed: AutomationTarget = serde_json::from_value(json!({
+        "managedWorkspace": {
+            "source_workspace_id": "workspace-1",
+            "source_branch": "main",
+            "name_template": AUTOMATION_DEFAULT_NAME_TEMPLATE,
+            "agent_profile_id": "profile-1"
+        }
+    }))
+    .unwrap();
+    assert_eq!(managed.agent_profile_id(), Some("profile-1"));
 }

--- a/rust/alera-core/src/runtime/mod.rs
+++ b/rust/alera-core/src/runtime/mod.rs
@@ -16,6 +16,8 @@ mod alera_account_store;
 mod alera_account_store_tests;
 mod automation_catalog_store;
 mod automation_models;
+#[cfg(test)]
+mod automation_models_serde_tests;
 mod automation_run_store;
 mod automation_schedule;
 mod automation_store;

--- a/rust/alera-core/src/runtime/runtime_schema.rs
+++ b/rust/alera-core/src/runtime/runtime_schema.rs
@@ -315,15 +315,21 @@ pub(super) const AGENT_PROFILE_REFERENCE_TRIGGERS: &[&str] = &[
          WHERE id = json_extract(NEW.payloadJson, '$.agentProfileLaunchV1.profile.id')
        )
      BEGIN SELECT RAISE(ABORT, 'agent profile reference does not exist'); END;",
+    "DROP TRIGGER IF EXISTS automationsAgentProfileInsertGuard;",
+    "DROP TRIGGER IF EXISTS automationsAgentProfileUpdateGuard;",
     "CREATE TRIGGER IF NOT EXISTS automationsAgentProfileInsertGuard
      BEFORE INSERT ON automations
      WHEN COALESCE(
+       json_extract(NEW.dataJson, '$.target.freshTab.agentProfileId'),
        json_extract(NEW.dataJson, '$.target.freshTab.agent_profile_id'),
+       json_extract(NEW.dataJson, '$.target.managedWorkspace.agentProfileId'),
        json_extract(NEW.dataJson, '$.target.managedWorkspace.agent_profile_id')
      ) IS NOT NULL
        AND NOT EXISTS (
          SELECT 1 FROM agentProfiles WHERE id = COALESCE(
+           json_extract(NEW.dataJson, '$.target.freshTab.agentProfileId'),
            json_extract(NEW.dataJson, '$.target.freshTab.agent_profile_id'),
+           json_extract(NEW.dataJson, '$.target.managedWorkspace.agentProfileId'),
            json_extract(NEW.dataJson, '$.target.managedWorkspace.agent_profile_id')
          )
        )
@@ -331,12 +337,16 @@ pub(super) const AGENT_PROFILE_REFERENCE_TRIGGERS: &[&str] = &[
     "CREATE TRIGGER IF NOT EXISTS automationsAgentProfileUpdateGuard
      BEFORE UPDATE OF dataJson ON automations
      WHEN COALESCE(
+       json_extract(NEW.dataJson, '$.target.freshTab.agentProfileId'),
        json_extract(NEW.dataJson, '$.target.freshTab.agent_profile_id'),
+       json_extract(NEW.dataJson, '$.target.managedWorkspace.agentProfileId'),
        json_extract(NEW.dataJson, '$.target.managedWorkspace.agent_profile_id')
      ) IS NOT NULL
        AND NOT EXISTS (
          SELECT 1 FROM agentProfiles WHERE id = COALESCE(
+           json_extract(NEW.dataJson, '$.target.freshTab.agentProfileId'),
            json_extract(NEW.dataJson, '$.target.freshTab.agent_profile_id'),
+           json_extract(NEW.dataJson, '$.target.managedWorkspace.agentProfileId'),
            json_extract(NEW.dataJson, '$.target.managedWorkspace.agent_profile_id')
          )
        )


### PR DESCRIPTION
## Summary

Host create/edit rejected camelCase nested `AutomationTarget` / `AutomationSchedule` fields that desktop and mobile already emit (`freshTab.workspaceId`, `agentProfileId`, `startAt`, `endAt`, `maxScheduledRuns`, …). `#[serde(rename_all = "camelCase")]` on those enums only renamed variants, not struct-variant fields.

This PR:

- Adds `rename_all_fields = "camelCase"` so create/edit/read round-trips camelCase for the editors.
- Adds snake_case field aliases so existing stored nested payloads still deserialize (no hard break).
- Recreates the automations agent-profile SQLite triggers so they still see `agentProfileId` after the serialize rename.

Closes #660

## Screenshots

No visual change. Demo skippable (config/serde chore).

## Testing

- [x] Added or updated tests that would catch regressions, or explained why tests were not needed
- [x] `cargo test -p alera-core --features runtime --lib -- automation` (18 passed, including camelCase accept + round-trip, snake_case still-works, and camelCase key assertions that fail if `rename_all_fields` regresses)
- [x] `cargo clippy -p alera-core --features runtime --all-targets -- -D warnings` (prior commit)
- [x] `cargo fmt --all -- --check` (from `rust/`)
- [ ] `dart format --set-exit-if-changed lib test integration_test tool` (no Dart changes)
- [ ] `flutter analyze` (no Dart/UI changes)
- [ ] `flutter test --coverage --exclude-tags golden` (no Dart/UI changes)

## AI Review Report

Checked the serde container vs field-rename split, camelCase round-trip for editor keys, stored snake_case compatibility via aliases, and the SQLite `json_extract` paths that must match serialized `dataJson`. No editor UI redesign.

Cross-platform: protocol JSON on Linux, macOS, and Windows. No shortcut, path, shell, or updater behavior changed.

## Security Audit

The automations agent-profile insert/update guards still reject unknown profile ids. Trigger JSON paths now include camelCase keys so the integrity check is not silently skipped after the serde rename. No command execution, secrets, or process-spawn changes.

## Notes

Scope is serde on `AutomationTarget` / `AutomationSchedule` only. No new schedule types and no product redesign. No documentation updates: clients already emitted camelCase.