### PR TITLE
fix: allow draft automation lifecycle without alera.toml declaration

### DIFF
--- a/docs/worktree-setup-config.md
+++ b/docs/worktree-setup-config.md
@@ -81,6 +81,17 @@ The command is delivered once. After it is on its way the host drops it from the
 
 `alera workspace add` keeps running the setup inline and reporting it, because the CLI has no terminal tab to show it in. `alera workspace setup --id <workspace>` applies a project's setup to an existing workspace, with `--copies-only` for just the copy actions. An older runtime host that does not understand `deferSetup` ignores it and runs the setup inline, which is the behavior described in the rest of this page.
 
+## Automation declaration
+
+Scheduled and manual automation execution require an explicit repository opt-in in `alera.toml`. Draft create, edit, trash, restore, and approve do not.
+
+```toml
+[automation]
+declared = true
+```
+
+Alera also accepts the top-level form `automation_declared = true`. `[automation] enabled = true` is an alias of `declared`. The host reads the workspace checkout first, then the project repository root. Settings shows this as a read-only switch; it cannot be granted from the UI. Agent profile execution opt-in (`mayExecute`) is a separate policy.
+
 ## Git hosting provider
 
 The same config carries the project's git hosting provider, used by the Pull Requests panel to talk to `gh` (GitHub), `glab` (GitLab), or `az` (Azure DevOps). Authenticate first with the corresponding CLI. It can be set in **Settings > Projects** (UI override) or in `alera.toml`:

--- a/lib/src/features/automations/presentation/automation_policy_sections.dart
+++ b/lib/src/features/automations/presentation/automation_policy_sections.dart
@@ -227,13 +227,13 @@ class _AutomationProjectPolicySectionState
     }
     return AleraSettingsGroup(
       title: 'Automation Policy',
-      description: 'Repository declaration is read from alera.toml. Local approval can only restrict execution.',
+      description: 'Repository declaration is [automation] declared = true in alera.toml. Local approval can only restrict execution.',
       children: <Widget>[
         SettingsSwitchRow(
           title: 'Repository Declares Automations',
           description: _repoDeclared
               ? 'The repository declares automation use in alera.toml.'
-              : 'Add an automation declaration to alera.toml before execution.',
+              : 'Add [automation] declared = true to alera.toml before scheduled or manual execution. Drafts and approval do not need it.',
           value: _repoDeclared,
           onChanged: null,
         ),

--- a/mobile/lib/src/features/automations/infra/mobile_runtime_automation_repository.dart
+++ b/mobile/lib/src/features/automations/infra/mobile_runtime_automation_repository.dart
@@ -83,10 +83,15 @@ class MobileRuntimeAutomationRepository(final MobileRuntimeClient _client) {
   }
 
   Future<void> approve(String id, int revision) async {
-    await _client.request('automation.approve', <String, Object?>{
-      'id': id,
-      'revision': revision,
-    });
+    try {
+      await _client.request('automation.approve', <String, Object?>{
+        'id': id,
+        'revision': revision,
+      });
+    } on Object catch (error, stackTrace) {
+      _logger.warning('could not approve automation $id', error, stackTrace);
+      rethrow;
+    }
   }
 
   Future<void> cancel(String runId, Map<String, Object?> targetIdentity) async {

--- a/mobile/lib/src/features/automations/presentation/mobile_automation_detail_widgets.dart
+++ b/mobile/lib/src/features/automations/presentation/mobile_automation_detail_widgets.dart
@@ -120,10 +120,7 @@ class const MobileAutomationDetailSheet({
               ),
             if (!automation.isApproved)
               FilledButton(
-                onPressed: () async {
-                  await repository.approve(automation.id, automation.revision);
-                  onChanged();
-                },
+                onPressed: () => unawaited(_approve(context)),
                 child: const Text('Approve Revision'),
               ),
             FilledButton(
@@ -157,21 +154,39 @@ class const MobileAutomationDetailSheet({
               child: const Text('Cancel Active Runs'),
             ),
             OutlinedButton(
-              onPressed: () async {
-                if (automation.state == 'trashed') {
-                  await repository.restore(automation.id);
-                } else {
-                  await repository.trash(automation.id);
-                }
-                onChanged();
-                if (context.mounted) Navigator.pop(context);
-              },
+              onPressed: () => unawaited(_trashOrRestore(context)),
               child: Text(automation.state == 'trashed' ? 'Restore' : 'Trash'),
             ),
           ],
         ),
       ),
     );
+  }
+
+  Future<void> _approve(BuildContext context) async {
+    try {
+      await repository.approve(
+        detail.automation.id,
+        detail.automation.revision,
+      );
+      onChanged();
+    } on Object catch (error) {
+      if (context.mounted) _show(context, error.toString(), error: true);
+    }
+  }
+
+  Future<void> _trashOrRestore(BuildContext context) async {
+    try {
+      if (detail.automation.state == 'trashed') {
+        await repository.restore(detail.automation.id);
+      } else {
+        await repository.trash(detail.automation.id);
+      }
+      onChanged();
+      if (context.mounted) Navigator.pop(context);
+    } on Object catch (error) {
+      if (context.mounted) _show(context, error.toString(), error: true);
+    }
   }
 
   Future<void> _clone(BuildContext context) async {

--- a/rust/alera-cli/src/terminal_host/server.rs
+++ b/rust/alera-cli/src/terminal_host/server.rs
@@ -78,6 +78,8 @@ mod ai_dictation_requests;
 mod automation_actor;
 mod automation_catalog_requests;
 mod automation_definition_requests;
+#[cfg(test)]
+mod automation_definition_requests_tests;
 mod automation_dispatch;
 mod automation_policy_requests;
 mod automation_request_authorization;

--- a/rust/alera-cli/src/terminal_host/server/automation_definition_requests.rs
+++ b/rust/alera-cli/src/terminal_host/server/automation_definition_requests.rs
@@ -244,13 +244,9 @@ impl ServerActor {
             .await
             .map_err(|error| HostError::state(error.to_string()))?
             .ok_or_else(|| HostError::state(format!("automation not found: {id}")))?;
-        if matches!(
-            state,
-            AutomationState::Active
-                | AutomationState::Paused
-                | AutomationState::Trashed
-                | AutomationState::Draft
-        ) {
+        // Trash and restore are recoverable draft lifecycle, not execution.
+        // Keep the repository declaration and agent policy on Active/Paused.
+        if matches!(state, AutomationState::Active | AutomationState::Paused) {
             self.ensure_agent_policy(&definition, &actor, false).await?;
         }
         if state == AutomationState::Paused {

--- a/rust/alera-cli/src/terminal_host/server/automation_definition_requests_tests.rs
+++ b/rust/alera-cli/src/terminal_host/server/automation_definition_requests_tests.rs
@@ -1,0 +1,272 @@
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use alera_core::runtime::{
+    AutomationActor, AutomationActorKind, AutomationAgentPolicy, AutomationDefinition,
+    AutomationMisfirePolicy, AutomationOverlapPolicy, AutomationSchedule, AutomationSetupPolicy,
+    AutomationState, AutomationTarget, Project, ProjectKind, Workspace, WorkspaceKind,
+    WorkspaceStatus, LOCAL_HOST_ID,
+};
+use chrono::Utc;
+use serde_json::json;
+
+use super::actor_test_harness::{local_client, test_actor};
+use super::ServerActor;
+use crate::terminal_host::client::ClientHandle;
+
+struct Harness {
+    _runtime_dir: tempfile::TempDir,
+    repo_path: PathBuf,
+    actor: ServerActor,
+}
+
+async fn harness() -> Harness {
+    let runtime_dir = tempfile::tempdir().unwrap();
+    let repo_path = runtime_dir.path().join("repo");
+    std::fs::create_dir(&repo_path).unwrap();
+    let (handle, _events) = ClientHandle::test_channels();
+    let actor = test_actor(
+        &runtime_dir,
+        HashMap::from([(1, local_client(handle))]),
+        HashMap::new(),
+    )
+    .await;
+    let now = Utc::now();
+    sqlx::query(
+        "INSERT INTO agentProfiles (id, name, agentType, command, createdAt, updatedAt) \
+         VALUES ('profile-1', 'Profile 1', 'codex', 'codex', datetime('now'), datetime('now'))",
+    )
+    .execute(actor.runtime_store.pool())
+    .await
+    .unwrap();
+    let repo = repo_path.to_string_lossy().into_owned();
+    actor
+        .runtime_store
+        .upsert_project(Project {
+            id: "project-1".into(),
+            name: "Project".into(),
+            repo_path: repo.clone(),
+            created_at: now,
+            updated_at: now,
+            kind: ProjectKind::GitRepository,
+        })
+        .await
+        .unwrap();
+    actor
+        .runtime_store
+        .upsert_workspace(Workspace {
+            id: "workspace-1".into(),
+            instance_id: "instance-1".into(),
+            host_id: LOCAL_HOST_ID.into(),
+            project_id: "project-1".into(),
+            name: "Workspace".into(),
+            branch: Some("main".into()),
+            path: repo,
+            created_at: now,
+            updated_at: now,
+            kind: WorkspaceKind::Main,
+            status: WorkspaceStatus::Active,
+            source_branch: None,
+            reuses_existing_branch: true,
+            is_pinned: false,
+            tag_ids: Vec::new(),
+            tag_names: Vec::new(),
+            parent_workspace_id: None,
+            section_id: None,
+            child_count: 0,
+        })
+        .await
+        .unwrap();
+    Harness {
+        _runtime_dir: runtime_dir,
+        repo_path,
+        actor,
+    }
+}
+
+fn draft_definition() -> AutomationDefinition {
+    let now = Utc::now();
+    let actor = AutomationActor {
+        kind: AutomationActorKind::LocalCli,
+        id: None,
+        label: None,
+    };
+    AutomationDefinition {
+        id: "automation-1".into(),
+        slug: "review".into(),
+        name: "Review".into(),
+        description: String::new(),
+        project_id: None,
+        tag_ids: Vec::new(),
+        prompt_template: "Review {{workspace.name}}".into(),
+        schedule: AutomationSchedule::Recurring {
+            cron: "0 * * * *".into(),
+            timezone: "UTC".into(),
+            start_at: None,
+            end_at: None,
+            max_scheduled_runs: None,
+        },
+        target: AutomationTarget::FreshTab {
+            workspace_id: "workspace-1".into(),
+            agent_profile_id: "profile-1".into(),
+        },
+        setup_policy: AutomationSetupPolicy::Wait,
+        cleanup_policy: None,
+        overlap_policy: AutomationOverlapPolicy::Skip,
+        queue_cap: 10,
+        inactivity_timeout_seconds: 7200,
+        heartbeat_interval_seconds: 60,
+        misfire_grace_seconds: 900,
+        misfire_policy: AutomationMisfirePolicy::Skip,
+        retry_max_attempts: 3,
+        retry_backoff_seconds: 60,
+        circuit_failure_threshold: 3,
+        circuit_open_seconds: 900,
+        precheck: None,
+        notify_on_success: false,
+        circuit_opened: false,
+        state: AutomationState::Draft,
+        revision: 0,
+        approved_revision: None,
+        created_by: actor.clone(),
+        modified_by: actor,
+        created_at: now,
+        updated_at: now,
+    }
+}
+
+fn declare(repo: &Path) {
+    std::fs::write(repo.join("alera.toml"), "[automation]\ndeclared = true\n").unwrap();
+}
+
+async fn upsert_draft(actor: &mut ServerActor) -> AutomationDefinition {
+    let saved = actor
+        .handle_automation_request(
+            1,
+            "automation.upsert",
+            &json!({ "automation": draft_definition() }),
+        )
+        .await
+        .unwrap();
+    serde_json::from_value(saved).unwrap()
+}
+
+#[tokio::test]
+async fn draft_create_edit_trash_and_restore_work_without_alera_toml_declaration() {
+    let mut harness = harness().await;
+    assert!(!harness.repo_path.join("alera.toml").exists());
+
+    let created = upsert_draft(&mut harness.actor).await;
+    assert_eq!(created.state, AutomationState::Draft);
+
+    let mut edited = created.clone();
+    edited.description = "A draft edit".into();
+    let saved = harness
+        .actor
+        .handle_automation_request(1, "automation.upsert", &json!({ "automation": edited }))
+        .await
+        .unwrap();
+    assert_eq!(saved["state"], "draft");
+    assert_eq!(saved["description"], "A draft edit");
+
+    let trashed = harness
+        .actor
+        .handle_automation_request(1, "automation.trash", &json!({ "id": created.id }))
+        .await
+        .unwrap();
+    assert_eq!(trashed["state"], "trashed");
+
+    let restored = harness
+        .actor
+        .handle_automation_request(1, "automation.restore", &json!({ "id": created.id }))
+        .await
+        .unwrap();
+    assert_eq!(restored["state"], "draft");
+}
+
+#[tokio::test]
+async fn approve_and_pause_work_without_alera_toml_declaration() {
+    let mut harness = harness().await;
+    let created = upsert_draft(&mut harness.actor).await;
+
+    let approved = harness
+        .actor
+        .handle_automation_request(
+            1,
+            "automation.approve",
+            &json!({ "id": created.id, "revision": created.revision }),
+        )
+        .await
+        .unwrap();
+    assert_eq!(approved["state"], "active");
+    assert_eq!(approved["approvedRevision"], created.revision);
+
+    let paused = harness
+        .actor
+        .handle_automation_request(1, "automation.pause", &json!({ "id": created.id }))
+        .await
+        .unwrap();
+    assert_eq!(paused["state"], "paused");
+}
+
+#[tokio::test]
+async fn manual_execution_without_declaration_is_blocked() {
+    let mut harness = harness().await;
+    let created = upsert_draft(&mut harness.actor).await;
+    harness
+        .actor
+        .runtime_store
+        .set_automation_agent_policy(AutomationAgentPolicy {
+            profile_id: "profile-1".into(),
+            may_activate_or_edit_active: true,
+            may_execute: true,
+            updated_at: Utc::now(),
+        })
+        .await
+        .unwrap();
+
+    let error = harness
+        .actor
+        .handle_automation_request(
+            1,
+            "automation.runNow",
+            &json!({
+                "id": created.id,
+                "draftTest": true,
+                "precheck": false,
+                "overlap": "skip",
+            }),
+        )
+        .await
+        .unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("has no automation declaration in alera.toml"),
+        "{error}"
+    );
+}
+
+#[tokio::test]
+async fn execution_policy_accepts_a_declared_repository() {
+    let mut harness = harness().await;
+    let created = upsert_draft(&mut harness.actor).await;
+    declare(&harness.repo_path);
+    harness
+        .actor
+        .runtime_store
+        .set_automation_agent_policy(AutomationAgentPolicy {
+            profile_id: "profile-1".into(),
+            may_activate_or_edit_active: true,
+            may_execute: true,
+            updated_at: Utc::now(),
+        })
+        .await
+        .unwrap();
+    let actor = harness.actor.automation_actor(1, &json!({}));
+    harness
+        .actor
+        .ensure_agent_policy(&created, &actor, true)
+        .await
+        .unwrap();
+}

--- a/rust/alera-cli/src/terminal_host/server/automation_policy_requests.rs
+++ b/rust/alera-cli/src/terminal_host/server/automation_policy_requests.rs
@@ -162,6 +162,9 @@ impl ServerActor {
         Ok(actor)
     }
 
+    /// Agent and target checks for Active/Paused edits and for execution.
+    /// Repository declaration and restrictive local approval gate execution
+    /// only (`execute = true`). Do not call this for draft trash/restore.
     pub(super) async fn ensure_agent_policy(
         &self,
         definition: &AutomationDefinition,
@@ -238,6 +241,9 @@ impl ServerActor {
             return Err(HostError::state(
                 "managed workspace automations require a git repository project",
             ));
+        }
+        if !execute {
+            return Ok(());
         }
         let project_policy = self
             .runtime_store


### PR DESCRIPTION
## Summary

Draft automations could be created, then trash, restore, approve, and pause all failed unless the target repo contained an undocumented `alera.toml` automation declaration. The declaration now gates **scheduled/manual execution only**. Draft create, edit, trash, restore, approve, and pause no longer require it.

Approve policy shipped: **approve without declaration**. Execution (`automation.runNow` and the scheduler) still requires `[automation] declared = true` (or `automation_declared = true`) plus agent `mayExecute`.

- Skip `ensure_agent_policy` for trash/restore (Draft/Trashed recoverable lifecycle).
- Keep it for Active/Paused and approve (workspace/target and managed-agent edit checks).
- Move repository declaration and restrictive local approval into the `execute = true` path.
- Document the key in `docs/worktree-setup-config.md` and point Settings at that key.
- Surface Mobile Restore/Approve (and Trash) errors with a snackbar instead of a silent no-op.

Closes #661

## AC

- [x] Draft create/edit/trash/restore work without repo `alera.toml` automation declaration
- [x] Approve works without declaration (preferred policy)
- [x] Declaration gates scheduled/manual execution, not recoverable draft lifecycle
- [x] `ensure_agent_policy` is not applied to Draft trash/restore; kept for Active/Paused
- [x] Declaration key documented next to other `alera.toml` keys
- [x] Settings copy matches the documented key
- [x] Mobile Restore/Approve surface host errors (no silent no-op)
- [x] Focused fix; does not expand into #663/#664

## Screenshots

No visual redesign. Settings helper text now names `[automation] declared = true`. Mobile Restore/Approve show a snackbar on error (try/catch toast).

## Testing

- [x] Added host tests for draft lifecycle without declaration and execution still gated
- [x] `cargo test -p alera-cli --bin alera automation_definition_requests_tests` (4 passed: create/edit/trash/restore, approve/pause without declaration, `runNow` blocked without declaration, execution policy accepts a declared repo)
- [x] `cargo clippy -p alera-cli --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check` (from `rust/`)
- [x] Dart files formatted with Flutter 3.47.2 `dart format`
- [ ] `flutter analyze` / `flutter test` (Dart changes are copy + try/catch; not run in this worktree because package config is unresolved)

Author notes: host policy covered by the Rust tests above. CLI path is the same `automation.trash` / `automation.restore` / `automation.approve` / `automation.runNow` verbs. Mobile error surfacing is the existing snackbar helper already used by Cancel/Tags on the same sheet.

## AI Review Report

Checked that declaration no longer wraps trash/restore, that approve is not the execution gate, and that `runNow` / scheduler still call `ensure_agent_policy(..., execute: true)`. Restrictive local approval stays execution-only, matching the Settings copy. No #663 timeout termination or #664 CLI help changes.

Cross-platform: host policy is shared by desktop, CLI, and mobile. No shortcut, path, shell, or updater behavior changed.

## Security Audit

Repository declaration remains required before scheduled or manual execution. Agent `mayExecute` is unchanged. Draft lifecycle mutations still require an authenticated client on the existing automation request allowlist. No command execution, secrets, or process-spawn changes.

## Notes

Demo waived: host policy plus a try/catch toast. No new mobile error UI beyond the existing snackbar. Out of scope: #663 (timeout does not stop owned terminals), #664 (policy/templates default CLI invocations).