### PR TITLE
fix: keep trashed automations visible in the trash filter

### DIFF
--- a/lib/src/features/automations/application/automation_providers.dart
+++ b/lib/src/features/automations/application/automation_providers.dart
@@ -16,13 +16,8 @@ Stream<List<AutomationRecord>> automationList(Ref ref) {
 }
 
 @riverpod
-Stream<List<AutomationRecord>> automationCatalog(
-  Ref ref,
-  bool includeTrashed,
-) async* {
-  final repository = ref.watch(automationRepositoryProvider);
-  yield await repository.list(includeTrashed: includeTrashed);
-  await for (final event in repository.watch()) {
-    yield event;
-  }
+Stream<List<AutomationRecord>> automationCatalog(Ref ref, bool includeTrashed) {
+  return ref
+      .watch(automationRepositoryProvider)
+      .watch(includeTrashed: includeTrashed);
 }

--- a/lib/src/features/automations/application/automation_providers.g.dart
+++ b/lib/src/features/automations/application/automation_providers.g.dart
@@ -155,7 +155,7 @@ final class AutomationCatalogProvider
   }
 }
 
-String _$automationCatalogHash() => r'624ddda329b97326c9e67880f83701fce0620c49';
+String _$automationCatalogHash() => r'1e18ccc8a62c269585a18484ae5d1051b78faebb';
 
 final class AutomationCatalogFamily extends $Family
     with $FunctionalFamilyOverride<Stream<List<AutomationRecord>>, bool> {

--- a/lib/src/features/automations/infra/runtime_automation_repository.dart
+++ b/lib/src/features/automations/infra/runtime_automation_repository.dart
@@ -29,12 +29,12 @@ class RuntimeAutomationRepository(final RuntimeHostClient _client) {
         .toList(growable: false);
   }
 
-  Stream<List<AutomationRecord>> watch() async* {
-    yield await list();
+  Stream<List<AutomationRecord>> watch({bool includeTrashed = false}) async* {
+    yield await list(includeTrashed: includeTrashed);
     await for (final event in _client.runtimeEvents) {
       if (event.name == 'automationsChanged' ||
           event.name == 'automationRunChanged') {
-        yield await list();
+        yield await list(includeTrashed: includeTrashed);
       }
     }
   }

--- a/lib/src/features/automations/presentation/automations_dialog.dart
+++ b/lib/src/features/automations/presentation/automations_dialog.dart
@@ -76,7 +76,7 @@ class _AutomationsDialogState extends ConsumerState<AutomationsDialog> {
                     title: 'Automations unavailable',
                     message: error.toString(),
                     action: FilledButton(
-                      onPressed: () => ref.invalidate(automationListProvider),
+                      onPressed: _invalidateCatalog,
                       child: const Text('Retry'),
                     ),
                   ),

--- a/lib/src/features/automations/presentation/automations_dialog_actions.dart
+++ b/lib/src/features/automations/presentation/automations_dialog_actions.dart
@@ -96,7 +96,7 @@ extension on _AutomationsDialogState {
       await ref
           .read(automationRepositoryProvider)
           .importCatalog(bundleMap, remap);
-      ref.invalidate(automationCatalogProvider(_includeTrashed));
+      _invalidateCatalog();
       _showMessage('Automation catalog imported as drafts');
     } catch (error) {
       _showMessage(error.toString(), error: true);
@@ -118,7 +118,7 @@ extension on _AutomationsDialogState {
         _selectedId = saved.id;
         _detailFuture = ref.read(automationRepositoryProvider).show(saved.id);
       });
-      ref.invalidate(automationListProvider);
+      _invalidateCatalog();
       _showMessage(message);
     } catch (error) {
       _showMessage(error.toString(), error: true);
@@ -131,7 +131,7 @@ extension on _AutomationsDialogState {
           .read(automationRepositoryProvider)
           .approve(automation.id, automation.revision);
       await _refresh(automation.id);
-      ref.invalidate(automationListProvider);
+      _invalidateCatalog();
       _showMessage('Automation approved');
     } catch (error) {
       _showMessage(error.toString(), error: true);
@@ -178,7 +178,7 @@ extension on _AutomationsDialogState {
           .read(automationRepositoryProvider)
           .setState(request, id, activeRuns: activeRuns);
       await _refresh(id);
-      ref.invalidate(automationListProvider);
+      _invalidateCatalog();
       _showMessage(
         request == 'automation.pause'
             ? 'Automation paused'
@@ -229,6 +229,10 @@ extension on _AutomationsDialogState {
     } catch (error) {
       _showMessage(error.toString(), error: true);
     }
+  }
+
+  void _invalidateCatalog() {
+    ref.invalidate(automationCatalogProvider(_includeTrashed));
   }
 
   Future<void> _refresh(String id) async {

--- a/test/unit/features/automations/automation_catalog_provider_test.dart
+++ b/test/unit/features/automations/automation_catalog_provider_test.dart
@@ -1,0 +1,150 @@
+import 'dart:async';
+
+import 'package:alera/src/features/automations/application/automation_providers.dart';
+import 'package:alera/src/features/automations/infra/runtime_automation_repository.dart';
+import 'package:alera/src/features/workbench/infra/terminal_host/terminal_host_protocol.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  late _FakeRuntimeHostClient client;
+  late ProviderContainer container;
+
+  setUp(() {
+    client = _FakeRuntimeHostClient();
+    container = ProviderContainer(
+      overrides: [
+        automationRepositoryProvider.overrideWithValue(
+          RuntimeAutomationRepository(client),
+        ),
+      ],
+    );
+  });
+
+  tearDown(() {
+    container.dispose();
+    client.dispose();
+  });
+
+  test(
+    'trash catalog keeps trashed items after automationsChanged events',
+    () async {
+      final ids = <List<String>>[];
+      container.listen(automationCatalogProvider(true), (_, next) {
+        next.whenData(
+          (items) => ids.add(items.map((item) => item.id).toList()),
+        );
+      });
+
+      await Future.pause(const Duration(milliseconds: 20));
+      expect(ids, isNotEmpty);
+      expect(ids.first, <String>['active-1', 'trashed-1']);
+
+      client.addEvent(
+        const RuntimeHostEvent('automationsChanged', <String, Object?>{}),
+      );
+      await Future.pause(const Duration(milliseconds: 20));
+      client.addEvent(
+        const RuntimeHostEvent('automationRunChanged', <String, Object?>{}),
+      );
+      await Future.pause(const Duration(milliseconds: 20));
+
+      expect(ids, hasLength(3));
+      expect(
+        ids.every((emission) => emission.contains('trashed-1')),
+        isTrue,
+        reason: 'watch() must keep includeTrashed on every catalog emission',
+      );
+      expect(client.listIncludeTrashed, <bool>[true, true, true]);
+    },
+  );
+
+  test('default catalog omits trashed automations', () async {
+    container.listen(automationCatalogProvider(false), (_, _) {});
+    await Future.pause(const Duration(milliseconds: 20));
+
+    expect(
+      container
+          .read(automationCatalogProvider(false))
+          .requireValue
+          .map((item) => item.id),
+      <String>['active-1'],
+    );
+    expect(client.listIncludeTrashed, <bool>[false]);
+  });
+
+  test(
+    'retrying invalidates the catalog, not the unused list provider',
+    () async {
+      client.failNextList = 1;
+      container.listen(automationCatalogProvider(true), (_, _) {});
+      await Future.pause(const Duration(milliseconds: 20));
+
+      expect(container.read(automationCatalogProvider(true)).hasError, isTrue);
+
+      container.invalidate(automationListProvider);
+      await Future.pause(const Duration(milliseconds: 20));
+      expect(
+        container.read(automationCatalogProvider(true)).hasError,
+        isTrue,
+        reason: 'Retry used to invalidate automationListProvider, which the dialog does not watch',
+      );
+
+      container.invalidate(automationCatalogProvider(true));
+      await Future.pause(const Duration(milliseconds: 20));
+
+      final retry = container.read(automationCatalogProvider(true));
+      expect(retry.hasValue, isTrue);
+      expect(retry.requireValue.map((item) => item.id), contains('trashed-1'));
+    },
+  );
+}
+
+final class _FakeRuntimeHostClient implements RuntimeHostClient {
+  int failNextList = 0;
+  final List<bool> listIncludeTrashed = <bool>[];
+  final StreamController<RuntimeHostEvent> _events =
+      StreamController<RuntimeHostEvent>.broadcast();
+
+  @override
+  Stream<RuntimeHostEvent> get runtimeEvents => _events.stream;
+
+  void addEvent(RuntimeHostEvent event) => _events.add(event);
+
+  void dispose() => unawaited(_events.close());
+
+  @override
+  Future<Object?> runtimeRequest(
+    String type, [
+    Map<String, Object?> payload = const <String, Object?>{},
+    Duration? timeout,
+  ]) async {
+    if (type != 'automation.list') {
+      fail('unexpected runtime request: $type');
+    }
+    if (failNextList > 0) {
+      failNextList -= 1;
+      throw StateError('host unavailable');
+    }
+    final includeTrashed = payload['includeTrashed'] == true;
+    listIncludeTrashed.add(includeTrashed);
+    return <String, Object?>{
+      'items': <Object?>[
+        _record('active-1', 'Nightly Review', 'active'),
+        if (includeTrashed) _record('trashed-1', 'Trashed Draft', 'trashed'),
+      ],
+    };
+  }
+}
+
+Map<String, Object?> _record(String id, String name, String state) {
+  return <String, Object?>{
+    'id': id,
+    'slug': id,
+    'name': name,
+    'state': state,
+    'revision': 1,
+    'schedule': const <String, Object?>{'oneTime': '2026-09-08T12:00:00Z'},
+    'target': const <String, Object?>{'freshTab': true},
+  };
+}


### PR DESCRIPTION
## Summary

Fixes #662. Closes #662.

The desktop Automations Trash chip listed with `includeTrashed: true`, then immediately consumed `watch()`, whose first emission (and later `automationsChanged` / `automationRunChanged` refreshes) called `list()` with the default `includeTrashed: false`. Trashed items flashed and disappeared.

`watch()` now takes `includeTrashed` and forwards it to every `list()`. The catalog provider uses that stream instead of listing once and then overwriting from an unfiltered watch. Retry and other dialog refreshes invalidate `automationCatalogProvider` rather than the unused `automationListProvider`.

## Testing

- [x] `dart format --set-exit-if-changed` on touched Dart files
- [x] `flutter analyze` on touched files
- [x] `flutter test test/unit/features/automations/automation_catalog_provider_test.dart test/unit/features/automations/automation_models_test.dart`
- [ ] Full `flutter test --coverage --exclude-tags golden` (CI)
- [ ] Golden tests: not applicable
- [ ] Desktop E2E: not required for this watch/list plumbing fix

## Notes

- Desktop Automations dialog only. Mobile lists once and does not use this watch path.
- No documentation updates: internal catalog/watch plumbing, no user-facing docs change.