### PR TITLE
fix: show mobile workspace agent titles instead of activity

### DIFF
--- a/mobile/lib/src/features/runtime/domain/workspace_sidebar_snapshot.dart
+++ b/mobile/lib/src/features/runtime/domain/workspace_sidebar_snapshot.dart
@@ -31,6 +31,9 @@ class const AgentPresenceSummary({
   final String? toolInput,
   final String? lastAssistantMessage,
   final bool? interrupted,
+
+  /// Workspace tab title. Additive: an older host omits it.
+  final String title = '',
 }) {
   factory fromJson(Map<String, Object?> json) {
     return AgentPresenceSummary(
@@ -49,6 +52,7 @@ class const AgentPresenceSummary({
       toolInput: json.optionalString('toolInput'),
       lastAssistantMessage: json.optionalString('lastAssistantMessage'),
       interrupted: json['interrupted'] as bool?,
+      title: json.optionalString('title') ?? '',
     );
   }
 }

--- a/mobile/lib/src/features/workbench/presentation/mobile_agent_run_labels.dart
+++ b/mobile/lib/src/features/workbench/presentation/mobile_agent_run_labels.dart
@@ -1,0 +1,40 @@
+import 'package:alera_mobile/src/features/runtime/domain/workspace_sidebar_snapshot.dart';
+import 'package:alera_mobile/src/features/workbench/presentation/agent_identity_icon.dart';
+
+/// Primary label for a workspace agent row. Matches the desktop tab title
+/// when the host sent one; never falls back to activity text.
+String mobileAgentRunTitle(AgentPresenceSummary status) {
+  final title = status.title.trim();
+  if (title.isNotEmpty) {
+    return title;
+  }
+  return agentDisplayName(status.agentType);
+}
+
+/// Tool or assistant activity for the secondary line. Null when there is
+/// nothing to show besides the title.
+String? mobileAgentRunActivity(AgentPresenceSummary status) {
+  final activity = _mobileAgentRunActivityText(status);
+  if (activity == null || activity == mobileAgentRunTitle(status)) {
+    return null;
+  }
+  return activity;
+}
+
+String? _mobileAgentRunActivityText(AgentPresenceSummary status) {
+  if (status.state == 'working') {
+    final toolName = status.toolName?.trim() ?? '';
+    final toolInput = status.toolInput?.trim() ?? '';
+    if (toolName.isNotEmpty && toolInput.isNotEmpty) {
+      return '$toolName: $toolInput';
+    }
+    if (toolName.isNotEmpty) {
+      return toolName;
+    }
+  }
+  final assistantMessage = status.lastAssistantMessage?.trim() ?? '';
+  if (assistantMessage.isEmpty) {
+    return null;
+  }
+  return assistantMessage;
+}

--- a/mobile/lib/src/features/workbench/presentation/workspace_row_trays.dart
+++ b/mobile/lib/src/features/workbench/presentation/workspace_row_trays.dart
@@ -140,7 +140,8 @@ class const _AgentPresenceRow({
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final description = _agentRunDescription(status);
+    final title = mobileAgentRunTitle(status);
+    final activity = mobileAgentRunActivity(status);
     return InkWell(
       onTap: onTap,
       borderRadius: .circular(AleraTokens.radiusSm),
@@ -163,14 +164,30 @@ class const _AgentPresenceRow({
               ),
               const SizedBox(width: AleraTokens.space6),
               Expanded(
-                child: Text(
-                  description,
-                  maxLines: 1,
-                  overflow: .ellipsis,
-                  style: theme.textTheme.labelSmall?.copyWith(
-                    color: AleraTokens.foregroundMuted,
-                    fontWeight: .w500,
-                  ),
+                child: Column(
+                  crossAxisAlignment: .start,
+                  mainAxisSize: .min,
+                  children: <Widget>[
+                    Text(
+                      title,
+                      maxLines: 1,
+                      overflow: .ellipsis,
+                      style: theme.textTheme.labelSmall?.copyWith(
+                        color: AleraTokens.foreground,
+                        fontWeight: .w600,
+                      ),
+                    ),
+                    if (activity != null)
+                      Text(
+                        activity,
+                        maxLines: 1,
+                        overflow: .ellipsis,
+                        style: theme.textTheme.labelSmall?.copyWith(
+                          color: AleraTokens.foregroundMuted,
+                          fontWeight: .w500,
+                        ),
+                      ),
+                  ],
                 ),
               ),
               Padding(
@@ -202,24 +219,6 @@ List<String> _tagLabels(WorkspaceSummary workspace) {
       .map((tag) => tag.trim())
       .where((tag) => tag.isNotEmpty)
       .toList(growable: false);
-}
-
-String _agentRunDescription(AgentPresenceSummary status) {
-  if (status.state == 'working') {
-    final toolName = status.toolName?.trim() ?? '';
-    final toolInput = status.toolInput?.trim() ?? '';
-    if (toolName.isNotEmpty && toolInput.isNotEmpty) {
-      return '$toolName: $toolInput';
-    }
-    if (toolName.isNotEmpty) {
-      return toolName;
-    }
-  }
-  final assistantMessage = status.lastAssistantMessage?.trim() ?? '';
-  if (assistantMessage.isNotEmpty) {
-    return assistantMessage;
-  }
-  return '${agentDisplayName(status.agentType)} · ${agentRunStateLabel(status)}';
 }
 
 Color _stateColor(String state) => switch (state) {

--- a/mobile/lib/src/features/workbench/presentation/workspace_row_widgets.dart
+++ b/mobile/lib/src/features/workbench/presentation/workspace_row_widgets.dart
@@ -7,6 +7,7 @@ import 'package:alera_mobile/src/features/runtime/domain/workspace_sidebar_snaps
 import 'package:alera_mobile/src/features/workbench/application/workspace_agent_run_groups.dart';
 import 'package:alera_mobile/src/features/workbench/presentation/agent_identity_icon.dart';
 import 'package:alera_mobile/src/features/workbench/presentation/agent_run_state_indicator.dart';
+import 'package:alera_mobile/src/features/workbench/presentation/mobile_agent_run_labels.dart';
 import 'package:alera_mobile/src/features/workbench/presentation/mobile_workspace_agent_compact_summary.dart';
 import 'package:flutter/material.dart';
 

--- a/mobile/test/mobile_agent_run_labels_test.dart
+++ b/mobile/test/mobile_agent_run_labels_test.dart
@@ -1,0 +1,77 @@
+import 'package:alera_mobile/src/features/runtime/domain/workspace_sidebar_snapshot.dart';
+import 'package:alera_mobile/src/features/workbench/presentation/mobile_agent_run_labels.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('prefers the tab title over activity text', () {
+    final status = _presence(
+      title: 'Map Monetization',
+      state: 'waiting',
+      lastAssistantMessage: '**paymentBroker**',
+    );
+
+    expect(mobileAgentRunTitle(status), 'Map Monetization');
+    expect(mobileAgentRunActivity(status), '**paymentBroker**');
+  });
+
+  test('keeps working tool activity on the secondary line', () {
+    final status = _presence(
+      title: 'Map Monetization',
+      state: 'working',
+      toolName: 'Read',
+      toolInput: 'lib/foo.dart',
+      lastAssistantMessage: 'Ready to continue',
+    );
+
+    expect(mobileAgentRunTitle(status), 'Map Monetization');
+    expect(mobileAgentRunActivity(status), 'Read: lib/foo.dart');
+  });
+
+  test('falls back to the agent name when the host omitted title', () {
+    final status = _presence(
+      state: 'waiting',
+      lastAssistantMessage: 'Waiting for approval',
+    );
+
+    expect(mobileAgentRunTitle(status), 'Codex');
+    expect(mobileAgentRunActivity(status), 'Waiting for approval');
+  });
+
+  test('omits activity when it would duplicate the title', () {
+    final status = _presence(
+      title: 'Map Monetization',
+      state: 'done',
+      lastAssistantMessage: 'Map Monetization',
+    );
+
+    expect(mobileAgentRunTitle(status), 'Map Monetization');
+    expect(mobileAgentRunActivity(status), isNull);
+  });
+
+  test('omits activity when the agent has no tool or assistant text', () {
+    final status = _presence(title: 'Map Monetization', state: 'waiting');
+
+    expect(mobileAgentRunTitle(status), 'Map Monetization');
+    expect(mobileAgentRunActivity(status), isNull);
+  });
+}
+
+AgentPresenceSummary _presence({
+  String title = '',
+  required String state,
+  String? toolName,
+  String? toolInput,
+  String? lastAssistantMessage,
+}) {
+  return AgentPresenceSummary(
+    terminalSessionId: 'session-1',
+    workspaceId: 'workspace-1',
+    tabId: 'tab-1',
+    agentType: 'codex',
+    state: state,
+    title: title,
+    toolName: toolName,
+    toolInput: toolInput,
+    lastAssistantMessage: lastAssistantMessage,
+  );
+}

--- a/mobile/test/workspace_agent_presence_row_test.dart
+++ b/mobile/test/workspace_agent_presence_row_test.dart
@@ -1,0 +1,121 @@
+import 'package:alera_mobile/src/app/theme/alera_theme.dart';
+import 'package:alera_mobile/src/app/theme/alera_tokens.dart';
+import 'package:alera_mobile/src/features/runtime/domain/workspace_sidebar_snapshot.dart';
+import 'package:alera_mobile/src/features/runtime/domain/workspace_summary.dart';
+import 'package:alera_mobile/src/features/workbench/application/mobile_workspace_rows.dart';
+import 'package:alera_mobile/src/features/workbench/application/workspace_listing_tree.dart';
+import 'package:alera_mobile/src/features/workbench/presentation/workspace_row_widgets.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('expanded agent rows show title with activity as subtitle', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _rowApp(
+        _presence(
+          title: 'Map Monetization',
+          state: 'waiting',
+          lastAssistantMessage: '**paymentBroker**',
+        ),
+      ),
+    );
+
+    final title = tester.widget<Text>(find.text('Map Monetization'));
+    final activity = tester.widget<Text>(find.text('**paymentBroker**'));
+    expect(title.style?.color, AleraTokens.foreground);
+    expect(title.style?.fontWeight, FontWeight.w600);
+    expect(activity.style?.color, AleraTokens.foregroundMuted);
+    expect(find.text('Codex · Waiting for input'), findsNothing);
+  });
+
+  testWidgets('working tool activity does not replace the title', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _rowApp(
+        _presence(
+          title: 'Map Monetization',
+          state: 'working',
+          toolName: 'Read',
+          toolInput: 'lib/foo.dart',
+        ),
+      ),
+    );
+
+    expect(find.text('Map Monetization'), findsOneWidget);
+    expect(find.text('Read: lib/foo.dart'), findsOneWidget);
+  });
+
+  testWidgets('missing title uses the agent name instead of activity', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _rowApp(
+        _presence(
+          state: 'waiting',
+          lastAssistantMessage: 'Waiting for approval',
+        ),
+      ),
+    );
+
+    final title = tester.widget<Text>(find.text('Codex'));
+    expect(title.style?.color, AleraTokens.foreground);
+    expect(find.text('Waiting for approval'), findsOneWidget);
+    expect(find.text('Codex · Waiting for input'), findsNothing);
+  });
+}
+
+Widget _rowApp(AgentPresenceSummary status) {
+  return MaterialApp(
+    theme: buildAleraMobileDarkTheme(),
+    home: Scaffold(
+      body: MobileWorkspaceListRow(
+        row: const MobileWorkspaceEntryRow(
+          entry: WorkspaceTreeEntry(
+            workspace: WorkspaceSummary(
+              id: 'workspace-1',
+              projectId: 'project-1',
+              name: 'Workspace',
+              path: '/repo',
+            ),
+            depth: 0,
+            visibleChildCount: 0,
+            childrenCollapsed: false,
+          ),
+        ),
+        onTap: () {},
+        onLongPress: () {},
+        onMore: () {},
+        onToggleChildren: () {},
+        terminalTabCount: 1,
+        agentsExpanded: true,
+        onToggleAgents: () {},
+        onAgentTap: (_) {},
+        onCloseAgent: (_) {},
+        agentPresence: <AgentPresenceSummary>[status],
+      ),
+    ),
+  );
+}
+
+AgentPresenceSummary _presence({
+  String title = '',
+  required String state,
+  String? toolName,
+  String? toolInput,
+  String? lastAssistantMessage,
+}) {
+  return AgentPresenceSummary(
+    terminalSessionId: 'session-1',
+    workspaceId: 'workspace-1',
+    tabId: 'tab-1',
+    agentType: 'codex',
+    state: state,
+    title: title,
+    toolName: toolName,
+    toolInput: toolInput,
+    lastAssistantMessage: lastAssistantMessage,
+  );
+}

--- a/mobile/test/workspace_sidebar_snapshot_test.dart
+++ b/mobile/test/workspace_sidebar_snapshot_test.dart
@@ -48,6 +48,7 @@ void main() {
           'toolInput': '{"environment":"production"}',
           'lastAssistantMessage': 'Waiting for approval',
           'interrupted': false,
+          'title': 'Map Monetization',
         },
       ],
     });
@@ -63,5 +64,28 @@ void main() {
     expect(status.toolName, 'request_user_input');
     expect(status.lastAssistantMessage, 'Waiting for approval');
     expect(status.interrupted, isFalse);
+    expect(status.title, 'Map Monetization');
+  });
+
+  test('Parses agent presence without a title from an older host', () {
+    final snapshot = WorkspaceSidebarSnapshot.fromJson(<String, Object?>{
+      'projects': <Object?>[],
+      'workspaces': <Object?>[],
+      'tags': <Object?>[],
+      'activity': <String, Object?>{},
+      'viewPrefs': <String, Object?>{},
+      'runtimeSettings': <String, Object?>{},
+      'agentPresence': <Object?>[
+        <String, Object?>{
+          'handle': 'session-1',
+          'workspaceId': 'workspace-1',
+          'tabId': 'tab-1',
+          'agentType': 'codex',
+          'agentState': 'waiting',
+        },
+      ],
+    });
+
+    expect(snapshot.agentPresence.single.title, isEmpty);
   });
 }

--- a/rust/alera-cli/src/terminal_host/server.rs
+++ b/rust/alera-cli/src/terminal_host/server.rs
@@ -173,6 +173,8 @@ mod workspace_section_requests;
 #[cfg(test)]
 mod workspace_section_requests_tests;
 mod workspace_sidebar_requests;
+#[cfg(test)]
+mod workspace_sidebar_requests_tests;
 
 pub use server_command::ServerCommand;
 

--- a/rust/alera-cli/src/terminal_host/server/requests.rs
+++ b/rust/alera-cli/src/terminal_host/server/requests.rs
@@ -497,7 +497,7 @@ impl ServerActor {
             "workspaceActivity.remove" => self.remove_workspace_activity(client_id, payload).await,
             "agentPresence.list" => {
                 self.require_auth(client_id)?;
-                Ok(self.agent_presence_items())
+                self.agent_presence_items_with_titles().await
             }
             "project.list" => {
                 self.require_auth(client_id)?;

--- a/rust/alera-cli/src/terminal_host/server/workspace_sidebar_requests.rs
+++ b/rust/alera-cli/src/terminal_host/server/workspace_sidebar_requests.rs
@@ -41,6 +41,35 @@ impl ServerActor {
         Value::Array(items)
     }
 
+    /// Additive `title` from the workspace tab. Must not bump protocol versions:
+    /// older clients ignore the field, and older hosts omit it.
+    pub(super) async fn agent_presence_items_with_titles(&self) -> HostResult<Value> {
+        let mut items = match self.agent_presence_items() {
+            Value::Array(items) => items,
+            other => return Ok(other),
+        };
+        if items.is_empty() {
+            return Ok(Value::Array(items));
+        }
+        let titles = self
+            .runtime_store
+            .workspace_tab_titles()
+            .await
+            .map_err(state_error)?;
+        for item in &mut items {
+            let Some(tab_id) = item.get("tabId").and_then(Value::as_str).map(str::to_owned) else {
+                continue;
+            };
+            let Some(title) = titles.get(&tab_id).map(|value| value.trim().to_string()) else {
+                continue;
+            };
+            if !title.is_empty() {
+                item["title"] = json!(title);
+            }
+        }
+        Ok(Value::Array(items))
+    }
+
     pub(super) fn agent_presence_timestamp(&self, entry: &Value) -> chrono::DateTime<Utc> {
         entry
             .get("stateStartedAt")
@@ -87,6 +116,7 @@ impl ServerActor {
             .terminal_tab_counts_by_workspace()
             .await
             .map_err(state_error)?;
+        let agent_presence = self.agent_presence_items_with_titles().await?;
         Ok(json!({
             "projects": projects,
             "workspaces": workspaces,
@@ -95,7 +125,7 @@ impl ServerActor {
             "activity": activity,
             "viewPrefs": view_prefs,
             "runtimeSettings": runtime_settings,
-            "agentPresence": self.agent_presence_items(),
+            "agentPresence": agent_presence,
             "terminalTabCountByWorkspaceId": terminal_tab_count_by_workspace_id,
         }))
     }

--- a/rust/alera-cli/src/terminal_host/server/workspace_sidebar_requests_tests.rs
+++ b/rust/alera-cli/src/terminal_host/server/workspace_sidebar_requests_tests.rs
@@ -1,0 +1,52 @@
+use std::collections::HashMap;
+
+use alera_core::runtime::WorkspaceTabRecord;
+use chrono::Utc;
+use serde_json::json;
+
+use super::actor_test_harness::{mobile_client, test_actor};
+use crate::terminal_host::client::ClientHandle;
+use crate::terminal_host::orchestration::agent_presence::AgentPresenceState;
+use crate::terminal_host::session::Session;
+
+#[tokio::test]
+async fn sidebar_agent_presence_includes_tab_title() {
+    let dir = tempfile::tempdir().unwrap();
+    let (mobile, _events) = ClientHandle::test_channels();
+    let mut session = Session::driver_test_stub("session-1", 80, 24);
+    session.workspace_id = "workspace-1".into();
+    session.tab_id = "tab-1".into();
+    let mut actor = test_actor(
+        &dir,
+        HashMap::from([(2, mobile_client(mobile, "phone"))]),
+        HashMap::from([("session-1".into(), session)]),
+    )
+    .await;
+    let now = Utc::now();
+    actor
+        .runtime_store
+        .upsert_workspace_tab(WorkspaceTabRecord {
+            id: "tab-1".into(),
+            workspace_id: "workspace-1".into(),
+            kind: "terminal".into(),
+            title: "Map Monetization".into(),
+            created_at: now,
+            updated_at: now,
+            payload: json!({}),
+        })
+        .await
+        .unwrap();
+    actor
+        .agent_presence
+        .update("session-1", "codex".into(), AgentPresenceState::Working);
+
+    let snapshot = actor.workspace_sidebar_snapshot(2).await.unwrap();
+    let presence = &snapshot["agentPresence"][0];
+    assert_eq!(presence["tabId"], "tab-1");
+    assert_eq!(presence["title"], "Map Monetization");
+    assert_eq!(presence["agentType"], "codex");
+    assert_eq!(presence["lastAssistantMessage"], serde_json::Value::Null);
+
+    let listed = actor.agent_presence_items_with_titles().await.unwrap();
+    assert_eq!(listed[0]["title"], "Map Monetization");
+}

--- a/rust/alera-core/src/runtime/store.rs
+++ b/rust/alera-core/src/runtime/store.rs
@@ -945,6 +945,20 @@ impl RuntimeStore {
         Ok(counts)
     }
 
+    pub async fn workspace_tab_titles(&self) -> Result<BTreeMap<String, String>> {
+        let rows = sqlx::query("SELECT id, title FROM workspaceTabs")
+            .fetch_all(&self.pool)
+            .await?;
+        let mut titles = BTreeMap::new();
+        for row in rows {
+            titles.insert(
+                row.try_get::<String, _>("id")?,
+                row.try_get::<String, _>("title")?,
+            );
+        }
+        Ok(titles)
+    }
+
     pub async fn find_workspace_tab(&self, tab_id: &str) -> Result<Option<WorkspaceTabRecord>> {
         let row = sqlx::query(
             "SELECT id, workspaceId, kind, title, createdAt, updatedAt, payloadJson \

--- a/rust/alera-core/src/runtime/workbench_shared_state_store_tests.rs
+++ b/rust/alera-core/src/runtime/workbench_shared_state_store_tests.rs
@@ -184,6 +184,47 @@ async fn tab_rename_preserves_payload_and_marks_manual_title() {
 }
 
 #[tokio::test]
+async fn workspace_tab_titles_map_ids_to_titles() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = RuntimeStore::open(dir.path()).await.unwrap();
+    let now = Utc::now();
+    store
+        .upsert_workspace_tab(WorkspaceTabRecord {
+            id: "tab-1".to_string(),
+            workspace_id: "workspace-1".to_string(),
+            kind: "terminal".to_string(),
+            title: "Map Monetization".to_string(),
+            created_at: now,
+            updated_at: now,
+            payload: serde_json::json!({}),
+        })
+        .await
+        .unwrap();
+    store
+        .upsert_workspace_tab(WorkspaceTabRecord {
+            id: "tab-2".to_string(),
+            workspace_id: "workspace-1".to_string(),
+            kind: "terminal".to_string(),
+            title: "  Ready To Continue  ".to_string(),
+            created_at: now,
+            updated_at: now,
+            payload: serde_json::json!({}),
+        })
+        .await
+        .unwrap();
+
+    let titles = store.workspace_tab_titles().await.unwrap();
+    assert_eq!(
+        titles.get("tab-1").map(String::as_str),
+        Some("Map Monetization")
+    );
+    assert_eq!(
+        titles.get("tab-2").map(String::as_str),
+        Some("  Ready To Continue  ")
+    );
+}
+
+#[tokio::test]
 async fn workspace_tab_removal_is_idempotent() {
     let dir = tempfile::tempdir().unwrap();
     let store = RuntimeStore::open(dir.path()).await.unwrap();


### PR DESCRIPTION
## Summary

Mobile workspace agent rows (`_AgentPresenceRow` in `workspace_row_trays.dart`) were binding `_agentRunDescription` (tool name/input or `lastAssistantMessage`) as the only label. Desktop shows the tab **title** for the same agents.

This PR:
- Attaches additive `title` from the workspace tab onto `agentPresence` items in `workspaceSidebar.snapshot` and `agentPresence.list` (no protocol version bump).
- Shows that title as the primary row label.
- Keeps activity as the muted subtitle only.
- Falls back to the agent display name when an older host omits `title`, never to activity.

Desktop list UI is unchanged.

Closes #681

## Screenshots

UI change: expanded mobile workspace agent rows now show title + optional activity subtitle. Device screenshots and the short demo video are the post-QA BOX step below, not this PR.

## Testing

- [x] Mobile unit tests: `mobile/test/mobile_agent_run_labels_test.dart`, `mobile/test/workspace_sidebar_snapshot_test.dart`
- [x] Mobile widget tests: `mobile/test/workspace_agent_presence_row_test.dart` (title is primary / foreground; activity is subtitle / muted; activity does not replace title)
- [x] Host tests: `sidebar_agent_presence_includes_tab_title`, `workspace_tab_titles_map_ids_to_titles`
- [x] `flutter analyze` on the touched mobile files
- [x] `cargo clippy -p alera-cli -p alera-core --all-targets --features runtime -- -D warnings`
- [ ] Full mobile `flutter test` suite (targeted files above were run)
- [ ] Golden tests (not used for this row)
- [ ] Desktop E2E (desktop list not changed)

## Device QA (author)

Pair a phone with a runtime that has this host build. For a workspace whose desktop sidebar shows generated/manual agent titles:

1. Open the host workspace list on mobile.
2. Expand the workspace agent tray.
3. Confirm each agent row title matches desktop (for example `Map Monetization`), not tool text or `lastAssistantMessage`.
4. Confirm activity (tool `Name: input` while working, otherwise last assistant message) is the secondary muted line only.
5. Confirm tapping the row still opens that agent tab.

Also check an older-host fallback if available: missing `title` should show the agent name (Codex, Claude Code, ...) with activity still as subtitle.

## Post-QA BOX demo

After device QA passes, record a short UI demo on the **bot BOX computer, not leynier-minipc**. Show desktop titles vs mobile expanded agent rows for the same workspace. Then hand off to Orchestrator.

## AI Review Report

Self-reviewed the diff before opening:
- Confirmed the wrong bind was `_AgentPresenceRow` using `_agentRunDescription` as the only `Text`.
- Confirmed desktop still uses `tab.title` in `_agentRunLabel` and was not redesigned.
- Additive `title` is ignored by older phones and omitted by older hosts; neither protocol version is bumped.
- `agentPresence.list` extra field is ignored by the desktop presence parser.

Cross-platform: mobile UI only. Host title lookup is sqlite and path-agnostic.

## Security Audit

No new input, process, auth, or secret handling. Tab titles already stored in `workspaceTabs` are copied onto an existing authenticated presence payload.

## Notes

- Docs: no AGENTS.md / docs update. Additive presence field, existing protocol rules already cover this.
- Out of scope as locked: model redesign, desktop list redesign, #639 panels.
- DoD remaining after merge of this PR: author device QA → BOX demo → Orchestrator.