### PR TITLE
fix: list automation policies and fill template timestamps

### DIFF
--- a/rust/alera-cli/src/cli/automation.rs
+++ b/rust/alera-cli/src/cli/automation.rs
@@ -51,7 +51,7 @@ pub enum AutomationAction {
     Extend(AutomationExtendArgs),
     /// Complete a run with a required summary.
     Complete(AutomationCompleteArgs),
-    /// List or upsert prompt templates.
+    /// List prompt templates, or upsert from JSON. updatedAt is optional on upsert.
     Templates(AutomationCatalogFileArgs),
     /// List or upsert tags and assignments.
     Tags(AutomationCatalogFileArgs),
@@ -59,7 +59,7 @@ pub enum AutomationAction {
     Import(AutomationImportArgs),
     /// Export a runtime-local automation catalog.
     Export(AutomationExportArgs),
-    /// Show or update an agent/project automation policy.
+    /// List, show, or update agent and project automation policies.
     Policy(AutomationPolicyArgs),
 }
 
@@ -232,7 +232,7 @@ pub struct AutomationExportArgs {
 
 #[derive(Debug, Args)]
 pub struct AutomationPolicyArgs {
-    /// Policy kind: show, agent, or project.
+    /// Policy kind: show (list all, or one agent/project when ids are passed), agent, or project.
     #[arg(long, default_value = "show", value_parser = ["show", "agent", "project"])]
     pub kind: String,
     #[arg(long = "profile-id")]
@@ -341,5 +341,37 @@ mod tests {
             "done",
         ])
         .is_err());
+    }
+
+    #[test]
+    fn policy_defaults_to_show_without_ids() {
+        let parsed = Cli::try_parse_from(["alera", "automation", "policy"]).unwrap();
+        match parsed.command {
+            Command::Automation(command) => match command.action {
+                AutomationAction::Policy(args) => {
+                    assert_eq!(args.kind, "show");
+                    assert!(args.profile_id.is_none());
+                    assert!(args.project_id.is_none());
+                    assert!(args.file.is_none());
+                }
+                other => panic!("expected policy, got {other:?}"),
+            },
+            other => panic!("expected automation, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn templates_accepts_file_without_other_flags() {
+        let parsed =
+            Cli::try_parse_from(["alera", "automation", "templates", "--file", "t.json"]).unwrap();
+        match parsed.command {
+            Command::Automation(command) => match command.action {
+                AutomationAction::Templates(args) => {
+                    assert_eq!(args.file.as_deref(), Some("t.json"));
+                }
+                other => panic!("expected templates, got {other:?}"),
+            },
+            other => panic!("expected automation, got {other:?}"),
+        }
     }
 }

--- a/rust/alera-cli/src/terminal_host/server.rs
+++ b/rust/alera-cli/src/terminal_host/server.rs
@@ -77,11 +77,15 @@ mod ai_dictation_remote_requests;
 mod ai_dictation_requests;
 mod automation_actor;
 mod automation_catalog_requests;
+#[cfg(test)]
+mod automation_catalog_requests_tests;
 mod automation_definition_requests;
 #[cfg(test)]
 mod automation_definition_requests_tests;
 mod automation_dispatch;
 mod automation_policy_requests;
+#[cfg(test)]
+mod automation_policy_requests_tests;
 mod automation_request_authorization;
 mod automation_request_routes;
 mod automation_requests;

--- a/rust/alera-cli/src/terminal_host/server/automation_catalog_requests.rs
+++ b/rust/alera-cli/src/terminal_host/server/automation_catalog_requests.rs
@@ -1,5 +1,6 @@
-use alera_core::runtime::{AutomationActor, AutomationImportBundle};
-use serde_json::{json, Value};
+use alera_core::runtime::{AutomationActor, AutomationImportBundle, AutomationTemplate};
+use chrono::Utc;
+use serde_json::{json, Map, Value};
 use std::collections::BTreeMap;
 use uuid::Uuid;
 
@@ -10,9 +11,7 @@ use super::ServerActor;
 impl ServerActor {
     pub(super) async fn automation_templates_request(&self, payload: &Value) -> HostResult<Value> {
         if let Some(value) = payload.get("template") {
-            let template = serde_json::from_value(value.clone()).map_err(|error| {
-                HostError::format(format!("invalid automation template: {error}"))
-            })?;
+            let template = decode_automation_template(value)?;
             let saved = self
                 .runtime_store
                 .upsert_automation_template(template)
@@ -348,6 +347,22 @@ fn normalize_portable_tags(bundle: &mut Value) -> HostResult<BTreeMap<String, St
     Ok(tag_ids)
 }
 
+fn decode_automation_template(value: &Value) -> HostResult<AutomationTemplate> {
+    let mut object = value
+        .as_object()
+        .cloned()
+        .ok_or_else(|| HostError::format("automation template must be a JSON object"))?;
+    fill_timestamp(&mut object, "updatedAt");
+    serde_json::from_value(Value::Object(object))
+        .map_err(|error| HostError::format(format!("invalid automation template: {error}")))
+}
+
+fn fill_timestamp(object: &mut Map<String, Value>, key: &str) {
+    object
+        .entry(key.to_string())
+        .or_insert_with(|| json!(Utc::now()));
+}
+
 fn remap_value(
     remap: &std::collections::BTreeMap<String, String>,
     key: &str,
@@ -367,7 +382,7 @@ fn remap_value(
 mod tests {
     use std::collections::BTreeMap;
 
-    use super::normalize_portable_import;
+    use super::{decode_automation_template, normalize_portable_import};
     use serde_json::json;
 
     #[test]
@@ -432,5 +447,40 @@ mod tests {
         assert_eq!(normalized["templates"][0]["tagIds"][0], tag_id);
         assert_eq!(normalized["templates"][0]["projectId"], "project");
         assert!(normalized["definitions"][0].get("tagKeys").is_none());
+    }
+
+    #[test]
+    fn template_upsert_payload_accepts_missing_updated_at() {
+        let template = decode_automation_template(&json!({
+            "id": "t",
+            "name": "T",
+            "promptTemplate": "ping",
+            "createdAt": "2026-09-08T00:00:00Z",
+            "createdBy": {"kind": "localCli"}
+        }))
+        .unwrap();
+        assert_eq!(template.id, "t");
+        assert_eq!(template.name, "T");
+        assert_eq!(template.prompt_template, "ping");
+        assert!(template.updated_at.timestamp() > 0);
+    }
+
+    #[test]
+    fn template_upsert_payload_keeps_supplied_updated_at() {
+        let template = decode_automation_template(&json!({
+            "id": "t",
+            "name": "T",
+            "promptTemplate": "ping",
+            "createdAt": "2026-09-08T00:00:00Z",
+            "updatedAt": "2026-01-02T03:04:05Z",
+            "createdBy": {"kind": "localCli"}
+        }))
+        .unwrap();
+        assert_eq!(
+            template.updated_at,
+            "2026-01-02T03:04:05Z"
+                .parse::<chrono::DateTime<chrono::Utc>>()
+                .unwrap()
+        );
     }
 }

--- a/rust/alera-cli/src/terminal_host/server/automation_catalog_requests_tests.rs
+++ b/rust/alera-cli/src/terminal_host/server/automation_catalog_requests_tests.rs
@@ -1,0 +1,52 @@
+use std::collections::HashMap;
+
+use serde_json::json;
+
+use super::actor_test_harness::{local_client, test_actor};
+use crate::terminal_host::client::ClientHandle;
+
+#[tokio::test]
+async fn templates_upsert_fills_missing_updated_at() {
+    let runtime_dir = tempfile::tempdir().unwrap();
+    let (handle, _events) = ClientHandle::test_channels();
+    let mut actor = test_actor(
+        &runtime_dir,
+        HashMap::from([(1, local_client(handle))]),
+        HashMap::new(),
+    )
+    .await;
+
+    let saved = actor
+        .handle_automation_request(
+            1,
+            "automation.templates",
+            &json!({
+                "template": {
+                    "id": "t",
+                    "name": "T",
+                    "promptTemplate": "ping",
+                    "createdAt": "2026-09-08T00:00:00Z",
+                    "createdBy": {"kind": "localCli"}
+                }
+            }),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(saved["id"], "t");
+    assert_eq!(saved["name"], "T");
+    assert_eq!(saved["promptTemplate"], "ping");
+    assert!(
+        saved["updatedAt"]
+            .as_str()
+            .is_some_and(|value| !value.is_empty()),
+        "host must fill updatedAt on save, got {saved}"
+    );
+
+    let listed = actor
+        .handle_automation_request(1, "automation.templates", &json!({}))
+        .await
+        .unwrap();
+    assert_eq!(listed["items"][0]["id"], "t");
+    assert!(listed["items"][0]["updatedAt"].as_str().is_some());
+}

--- a/rust/alera-cli/src/terminal_host/server/automation_policy_requests.rs
+++ b/rust/alera-cli/src/terminal_host/server/automation_policy_requests.rs
@@ -71,8 +71,13 @@ impl ServerActor {
                 serde_json::to_value(policy).map_err(|error| HostError::state(error.to_string()))
             }
             "show" => {
+                let profile_id = optional_id(payload, "profileId");
+                let project_id = optional_id(payload, "projectId");
+                if profile_id.is_none() && project_id.is_none() {
+                    return self.list_all_automation_policies().await;
+                }
                 let mut result = Map::new();
-                if let Some(profile_id) = payload.get("profileId").and_then(Value::as_str) {
+                if let Some(profile_id) = profile_id {
                     let policy = self
                         .runtime_store
                         .automation_agent_policy(profile_id)
@@ -84,7 +89,7 @@ impl ServerActor {
                             .map_err(|error| HostError::state(error.to_string()))?,
                     );
                 }
-                if let Some(project_id) = payload.get("projectId").and_then(Value::as_str) {
+                if let Some(project_id) = project_id {
                     let policy = self.effective_project_policy(project_id).await?;
                     result.insert(
                         "project".to_string(),
@@ -92,20 +97,13 @@ impl ServerActor {
                             .map_err(|error| HostError::state(error.to_string()))?,
                     );
                 }
-                if result.is_empty() {
-                    return Err(HostError::format(
-                        "policy show requires profileId or projectId",
-                    ));
-                }
-                if let Some(profile_id) = payload.get("profileId").and_then(Value::as_str) {
+                if let Some(profile_id) = profile_id {
                     let policy = self
                         .runtime_store
                         .automation_agent_policy(profile_id)
                         .await
                         .map_err(|error| HostError::state(error.to_string()))?;
-                    let project = if let Some(project_id) =
-                        payload.get("projectId").and_then(Value::as_str)
-                    {
+                    let project = if let Some(project_id) = project_id {
                         Some(self.effective_project_policy(project_id).await?)
                     } else {
                         None
@@ -301,6 +299,33 @@ impl ServerActor {
         Ok(policy)
     }
 
+    async fn list_all_automation_policies(&self) -> HostResult<Value> {
+        let agents = self
+            .runtime_store
+            .list_automation_agent_policies()
+            .await
+            .map_err(|error| HostError::state(error.to_string()))?;
+        let projects = self
+            .runtime_store
+            .list_automation_project_policies()
+            .await
+            .map_err(|error| HostError::state(error.to_string()))?;
+        let mut projects_json = Vec::with_capacity(projects.len());
+        for mut policy in projects {
+            policy.repo_declared = self
+                .repository_declared_for_project(&policy.project_id)
+                .await?;
+            projects_json.push(
+                serde_json::to_value(policy)
+                    .map_err(|error| HostError::state(error.to_string()))?,
+            );
+        }
+        Ok(json!({
+            "agents": agents,
+            "projects": projects_json,
+        }))
+    }
+
     async fn repository_declared_for_project(&self, project_id: &str) -> HostResult<bool> {
         let Some(project) = self
             .runtime_store
@@ -398,6 +423,14 @@ fn policy_object(value: &Value, kind: &str) -> HostResult<Map<String, Value>> {
         .as_object()
         .cloned()
         .ok_or_else(|| HostError::format(format!("{kind} policy must be a JSON object")))
+}
+
+fn optional_id<'a>(payload: &'a Value, key: &str) -> Option<&'a str> {
+    payload
+        .get(key)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
 }
 
 #[cfg(test)]

--- a/rust/alera-cli/src/terminal_host/server/automation_policy_requests_tests.rs
+++ b/rust/alera-cli/src/terminal_host/server/automation_policy_requests_tests.rs
@@ -1,0 +1,169 @@
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use alera_core::runtime::{AutomationAgentPolicy, AutomationProjectPolicy, Project, ProjectKind};
+use chrono::Utc;
+use serde_json::json;
+
+use super::actor_test_harness::{local_client, test_actor};
+use super::ServerActor;
+use crate::terminal_host::client::ClientHandle;
+
+struct Harness {
+    _runtime_dir: tempfile::TempDir,
+    repo_path: PathBuf,
+    actor: ServerActor,
+}
+
+async fn harness() -> Harness {
+    let runtime_dir = tempfile::tempdir().unwrap();
+    let repo_path = runtime_dir.path().join("repo");
+    std::fs::create_dir(&repo_path).unwrap();
+    let (handle, _events) = ClientHandle::test_channels();
+    let actor = test_actor(
+        &runtime_dir,
+        HashMap::from([(1, local_client(handle))]),
+        HashMap::new(),
+    )
+    .await;
+    Harness {
+        _runtime_dir: runtime_dir,
+        repo_path,
+        actor,
+    }
+}
+
+async fn insert_profile(actor: &ServerActor, id: &str, name: &str) {
+    sqlx::query(
+        "INSERT INTO agentProfiles (id, name, agentType, command, createdAt, updatedAt) \
+         VALUES (?, ?, 'codex', 'codex', datetime('now'), datetime('now'))",
+    )
+    .bind(id)
+    .bind(name)
+    .execute(actor.runtime_store.pool())
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
+async fn policy_show_without_ids_lists_empty_agent_and_project_policies() {
+    let mut harness = harness().await;
+
+    let listed = harness
+        .actor
+        .handle_automation_request(1, "automation.policy", &json!({}))
+        .await
+        .unwrap();
+
+    assert_eq!(listed["agents"], json!([]));
+    assert_eq!(listed["projects"], json!([]));
+}
+
+#[tokio::test]
+async fn policy_show_without_ids_lists_all_persisted_policies() {
+    let mut harness = harness().await;
+    insert_profile(&harness.actor, "profile-b", "Profile B").await;
+    insert_profile(&harness.actor, "profile-a", "Profile A").await;
+    let now = Utc::now();
+    harness
+        .actor
+        .runtime_store
+        .upsert_project(Project {
+            id: "project-1".into(),
+            name: "Project".into(),
+            repo_path: harness.repo_path.to_string_lossy().into_owned(),
+            created_at: now,
+            updated_at: now,
+            kind: ProjectKind::GitRepository,
+        })
+        .await
+        .unwrap();
+    std::fs::write(
+        harness.repo_path.join("alera.toml"),
+        "[automation]\ndeclared = true\n",
+    )
+    .unwrap();
+    harness
+        .actor
+        .runtime_store
+        .set_automation_agent_policy(AutomationAgentPolicy {
+            profile_id: "profile-b".into(),
+            may_activate_or_edit_active: true,
+            may_execute: false,
+            updated_at: now,
+        })
+        .await
+        .unwrap();
+    harness
+        .actor
+        .runtime_store
+        .set_automation_agent_policy(AutomationAgentPolicy {
+            profile_id: "profile-a".into(),
+            may_activate_or_edit_active: false,
+            may_execute: true,
+            updated_at: now,
+        })
+        .await
+        .unwrap();
+    harness
+        .actor
+        .runtime_store
+        .set_automation_project_policy(AutomationProjectPolicy {
+            project_id: "project-1".into(),
+            repo_declared: false,
+            local_approved: true,
+            restrictive: true,
+            updated_at: now,
+        })
+        .await
+        .unwrap();
+
+    let listed = harness
+        .actor
+        .handle_automation_request(
+            1,
+            "automation.policy",
+            &json!({"kind": "show", "profileId": "", "projectId": ""}),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(listed["agents"][0]["profileId"], "profile-a");
+    assert_eq!(listed["agents"][0]["mayExecute"], true);
+    assert_eq!(listed["agents"][1]["profileId"], "profile-b");
+    assert_eq!(listed["agents"].as_array().unwrap().len(), 2);
+    assert_eq!(listed["projects"][0]["projectId"], "project-1");
+    assert_eq!(listed["projects"][0]["localApproved"], true);
+    assert_eq!(listed["projects"][0]["repoDeclared"], true);
+}
+
+#[tokio::test]
+async fn policy_show_with_profile_id_still_returns_agent_and_effective() {
+    let mut harness = harness().await;
+    insert_profile(&harness.actor, "profile-1", "Profile 1").await;
+    harness
+        .actor
+        .runtime_store
+        .set_automation_agent_policy(AutomationAgentPolicy {
+            profile_id: "profile-1".into(),
+            may_activate_or_edit_active: true,
+            may_execute: true,
+            updated_at: Utc::now(),
+        })
+        .await
+        .unwrap();
+
+    let shown = harness
+        .actor
+        .handle_automation_request(
+            1,
+            "automation.policy",
+            &json!({"kind": "show", "profileId": "profile-1"}),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(shown["agent"]["profileId"], "profile-1");
+    assert_eq!(shown["effective"]["targetProfile"]["mayExecute"], true);
+    assert!(shown.get("agents").is_none());
+}

--- a/rust/alera-core/src/runtime/automation_catalog_store.rs
+++ b/rust/alera-core/src/runtime/automation_catalog_store.rs
@@ -143,6 +143,20 @@ impl RuntimeStore {
         })
     }
 
+    pub async fn list_automation_agent_policies(&self) -> Result<Vec<AutomationAgentPolicy>> {
+        let rows = sqlx::query(
+            "SELECT dataJson FROM automationAgentPolicies ORDER BY profileId COLLATE NOCASE ASC",
+        )
+        .fetch_all(self.pool())
+        .await?;
+        rows.into_iter()
+            .map(|row| {
+                let data: String = row.try_get("dataJson")?;
+                Ok(serde_json::from_str(&data)?)
+            })
+            .collect()
+    }
+
     pub async fn set_automation_project_policy(
         &self,
         policy: AutomationProjectPolicy,
@@ -180,6 +194,20 @@ impl RuntimeStore {
                 updated_at: Utc::now(),
             },
         })
+    }
+
+    pub async fn list_automation_project_policies(&self) -> Result<Vec<AutomationProjectPolicy>> {
+        let rows = sqlx::query(
+            "SELECT dataJson FROM automationProjectPolicies ORDER BY projectId COLLATE NOCASE ASC",
+        )
+        .fetch_all(self.pool())
+        .await?;
+        rows.into_iter()
+            .map(|row| {
+                let data: String = row.try_get("dataJson")?;
+                Ok(serde_json::from_str(&data)?)
+            })
+            .collect()
     }
 
     pub async fn export_automation_catalog(&self) -> Result<AutomationExportBundle> {


### PR DESCRIPTION
## Summary

Default `alera automation policy` / `policy --kind show` listed nothing useful: the host required `profileId` or `projectId` and returned `FormatException`. Template upsert from a JSON file without `updatedAt` failed the same way, even though the store already overwrites `updatedAt` on save and tags upsert does not require that field.

This PR:

- Lists persisted agent and project policies when `kind=show` has no ids (`{ "agents": [...], "projects": [...] }`).
- Fills missing `updatedAt` on template upsert before deserialize (same host-fill pattern as policy decode). The store still stamps `updatedAt` on write.
- Updates CLI help so `--kind show` and optional `updatedAt` match the shipped contract.

Show with `--profile-id` / `--project-id` is unchanged. No policy-model or settings UX redesign. No #648 work.

Closes #664

## AC

- [x] `alera automation policy` / `policy --kind show` without profileId/projectId lists all persisted agent/project policies (not just help-docs)
- [x] `alera automation templates --file` accepts templates missing `updatedAt`; host fills on save
- [x] Help matches shipped contract
- [x] Focused CLI/host fix; no policy-model redesign; no #648 scope
- [x] Rust/CLI tests for both happy paths; PR `Closes #664`
- [x] Demo waived (CLI)
- [x] Leftover `audit-636-template` cleanup out of scope (live runtime leftover, not in repo)

## Screenshots

No visual change. Demo waived: CLI/host only.

## Testing

- [x] Added or updated tests that would catch regressions
- [x] `cd rust && cargo test -p alera-cli --bin alera policy_show` (3 passed: empty list-all, persisted list-all with `repoDeclared`, show-with-id regression)
- [x] `cd rust && cargo test -p alera-cli --bin alera policy_defaults` / `templates_accepts` (CLI parse of default policy and `templates --file`)
- [x] `cd rust && cargo test -p alera-cli --bin alera template_upsert` / `templates_upsert` (decode missing/supplied `updatedAt`, host upsert fills and lists)
- [x] `cd rust && cargo clippy -p alera-cli --all-targets -- -D warnings`
- [x] `cd rust && cargo clippy -p alera-core --features runtime --all-targets -- -D warnings`
- [x] `cd rust && cargo fmt --all -- --check`
- [ ] `dart format` / `flutter analyze` / `flutter test` (no Dart changes)

Author notes: list-all returns persisted policy rows, not synthetic defaults for every profile/project. `show --profile-id` still returns a default policy when none is stored. Template `createdAt` remains required. `updatedAt` supplied by the client is kept through decode and then overwritten by `upsert_automation_template`, matching existing save behavior.

## AI Review Report

Checked that show-without-ids no longer errors, that show-with-ids keeps the `agent` / `project` / `effective` shape, that template upsert no longer requires `updatedAt`, and that policy save/decode still fills timestamps itself. No editor or settings UX change.

Cross-platform: JSON host protocol on Linux, macOS, and Windows. No shortcut, path, shell quoting, or updater behavior changed.

## Security Audit

Policy list-all is the existing show read path with no new admin requirement. Template upsert still goes through the same catalog write. No command execution, secrets, or process-spawn changes.

## Notes

Demo waived (CLI). Out of scope: #648, policy UX redesign, and leftover `audit-636-template` in a live runtime. No documentation updates beyond CLI help: `docs/` does not describe these commands, and AGENTS.md does not need a process change.