### PR TITLE
fix: resolve windows remote runtime-proxy via current.txt

### DIFF
--- a/lib/src/features/agent_quota/infra/runtime_proxy_client.dart
+++ b/lib/src/features/agent_quota/infra/runtime_proxy_client.dart
@@ -174,9 +174,12 @@ class RuntimeProxyClient({
       final installExpression = installDir.startsWith(r'%LOCALAPPDATA%\')
           ? "\$env:LOCALAPPDATA + '$localAppDataSuffix'"
           : "'${installDir.replaceAll("'", "''")}'";
-      return 'powershell -NoProfile -Command '
-          '"& (Join-Path ($installExpression) '
-          '\'current\\alera.exe\') runtime-proxy"';
+      // Windows bootstrap writes current.txt; it never creates a current\ directory.
+      final script =
+          "\$ErrorActionPreference = 'Stop'; "
+          "\$current = Get-Content -Raw -Path (Join-Path ($installExpression) 'current.txt'); "
+          "& (Join-Path \$current 'alera.exe') runtime-proxy";
+      return "powershell -NoProfile -Command \"$script\"";
     }
     final executablePath = installDir.startsWith('~/')
         ? '\$HOME/${installDir.substring(2)}/current/alera'

--- a/test/unit/runtime_proxy_client_test.dart
+++ b/test/unit/runtime_proxy_client_test.dart
@@ -65,8 +65,33 @@ void main() {
     );
 
     expect(runner.arguments!.last, contains('powershell -NoProfile'));
-    expect(runner.arguments!.last, contains(r'current\alera.exe'));
+    expect(runner.arguments!.last, contains('Get-Content -Raw -Path'));
+    expect(runner.arguments!.last, contains('current.txt'));
+    expect(runner.arguments!.last, contains(r"Join-Path $current 'alera.exe'"));
     expect(runner.arguments!.last, contains('runtime-proxy'));
+    expect(runner.arguments!.last, isNot(contains(r'current\alera.exe')));
+  });
+
+  test('resolves a custom Windows install dir through current.txt', () async {
+    final runner = _RecordingRunner();
+    final client = RuntimeProxyClient(processRunner: runner);
+
+    await client.request(
+      hostId: 'windows',
+      target: _target(
+        runtimePlatform: 'windows',
+        installDir: r"D:\Alera's runtime",
+      ),
+      type: 'agentQuota.fetch',
+      payload: const <String, Object?>{},
+    );
+
+    expect(
+      runner.arguments!.last,
+      contains(r"Join-Path ('D:\Alera''s runtime') 'current.txt'"),
+    );
+    expect(runner.arguments!.last, contains(r"Join-Path $current 'alera.exe'"));
+    expect(runner.arguments!.last, isNot(contains(r'current\alera.exe')));
   });
 
   test(
@@ -387,7 +412,7 @@ class _RecordingRuntimeHostClient({
   }
 }
 
-SshTarget _target({required String runtimePlatform}) {
+SshTarget _target({required String runtimePlatform, String? installDir}) {
   final now = DateTime.utc(2026);
   return SshTarget(
     id: runtimePlatform,
@@ -398,6 +423,7 @@ SshTarget _target({required String runtimePlatform}) {
     authKind: .key,
     createdAt: now,
     updatedAt: now,
+    installDir: installDir,
     runtimePlatform: runtimePlatform,
     bootstrapStatus: .installed,
   );


### PR DESCRIPTION
## Summary
- Windows SSH bootstrap records the sidecar version directory in `current.txt` (plus `bin\alera.cmd`) and never creates a `current\` directory.
- Desktop `RuntimeProxyClient` now resolves the Windows remote exe the same way `windows_validate_script` does: `Get-Content` of `current.txt`, then `& (Join-Path $current 'alera.exe') runtime-proxy`.
- POSIX remote command construction is unchanged.

Closes #672

## Screenshots
No visual change.

## Testing
- [x] `dart format` on the two touched files
- [x] `flutter analyze` on the two touched files (no issues)
- [x] `flutter test test/unit/runtime_proxy_client_test.dart` (15 passed)
- [x] Updated PowerShell remote-command assertions so they require `current.txt` and reject `current\alera.exe`
- [ ] Full `flutter test --coverage --exclude-tags golden` (not run; command-construction unit tests cover this change)
- [ ] Desktop E2E against a Windows OpenSSH host (not available in this workspace)

## AI Review Report
Checked the Windows bootstrap layout (`windows_install_script` / `windows_validate_script`) against `_remoteCommand`. The previous `Join-Path <installDir> 'current\alera.exe'` path cannot exist on Windows remotes. The new command keeps the existing PowerShell `-Command` quoting and `%LOCALAPPDATA%` expansion, and still single-quote-escapes custom install dirs.

Cross-platform: POSIX still uses `<installDir>/current/alera` (symlink layout). Windows now uses `current.txt` instead of inventing a `current\` directory.

## Security Audit
The remote command still interpolates `installDir` into a PowerShell string. Custom dirs remain single-quoted with `'` doubled, matching the previous Windows branch. `Get-Content` reads a path under the install dir, not SSH stdin (quota JSON still flows to `alera.exe runtime-proxy`).

## Notes
Docs were not updated: `docs/agent-quotas.md` already says SSH workspaces run `alera runtime-proxy` on the remote host and does not document the Windows path layout.