### PR TITLE
fix: stamp ssh-target laststatus on live status probes

### DIFF
--- a/docs/remote-host-bootstrap.md
+++ b/docs/remote-host-bootstrap.md
@@ -33,6 +33,13 @@ Add a target:
 alera ssh-target --json add --alias build-mac --host mac.example.test --username leynier --auth agent
 ```
 
+Probe live SSH connectivity and, when an install directory is known, the remote runtime sidecar. The command persists `lastStatus` (`reachable`, `unreachable`, or `runtimeReady`) and updates `lastCheckedAt` on every call. Unknown ids still fail with `ssh target not found`:
+
+```bash
+alera ssh-target --json status
+alera ssh-target --json status --id <target-id>
+```
+
 Preview a bootstrap:
 
 ```bash
@@ -72,7 +79,7 @@ The generated pairing payload can be pasted or scanned in the Flutter app under 
 
 ## Settings
 
-Settings includes a **Remote Hosts** section for adding SSH targets, choosing optional platform/architecture/install directory overrides, previewing the bootstrap plan, starting bootstrap, and cancelling an active job. Bootstrap progress is delivered through runtime-host events and the persisted target status records the install directory, runtime version, platform, architecture, timestamps, and last redacted error.
+Settings includes a **Remote Hosts** section for adding SSH targets, choosing optional platform/architecture/install directory overrides, previewing the bootstrap plan, starting bootstrap, and cancelling an active job. Bootstrap progress is delivered through runtime-host events and the persisted target status records the install directory, runtime version, platform, architecture, timestamps, and last redacted error. A successful bootstrap also stamps `lastStatus` as `runtimeReady`. `alera ssh-target status` then refreshes that live check independently of bootstrap.
 
 Settings also includes a **Mobile Devices** section covering the full mobile companion lifecycle: gateway enable/bind host/port, pairing QR generation, active offer management, and paired device rename/revocation/deletion, all backed by the local runtime host.
 

--- a/rust/alera-cli/src/main.rs
+++ b/rust/alera-cli/src/main.rs
@@ -38,6 +38,7 @@ mod runtime_commands;
 mod runtime_host_client;
 mod runtime_host_command;
 mod ssh_bootstrap;
+mod ssh_target_status;
 mod tab_record_factory;
 mod tailscale;
 mod terminal_alias_commands;
@@ -85,6 +86,7 @@ use crate::runtime_host_client::RuntimeHostRpcClient;
 use crate::ssh_bootstrap::{
     build_ssh_bootstrap_plan, new_bootstrap_job_id, run_ssh_bootstrap, SshTargetBootstrapRequest,
 };
+use crate::ssh_target_status::{collect_ssh_target_status, LiveSshTargetProbe};
 use crate::tab_record_factory::tab_from_args;
 
 /// Usage-error exit code, matching the Dart CLI (`_usageExitCode`).
@@ -655,21 +657,11 @@ async fn run_ssh_target_command(command: SshTargetCommand) -> i32 {
                 Ok(store) => store,
                 Err(error) => return print_error(error),
             };
-            let value = if let Some(id) = id {
-                match store.find_ssh_target(&id).await {
-                    Ok(Some(target)) => json!(target),
-                    Ok(None) => {
-                        eprintln!("ssh target not found: {id}");
-                        return 1;
-                    }
+            let value =
+                match collect_ssh_target_status(&store, id.as_deref(), &LiveSshTargetProbe).await {
+                    Ok(value) => value,
                     Err(error) => return print_error(error),
-                }
-            } else {
-                match store.list_ssh_targets().await {
-                    Ok(targets) => json!(targets),
-                    Err(error) => return print_error(error),
-                }
-            };
+                };
             print_value(&value, json_output, "ssh target status ready");
         }
         SshTargetAction::BootstrapPlan(args) => {

--- a/rust/alera-cli/src/ssh_bootstrap.rs
+++ b/rust/alera-cli/src/ssh_bootstrap.rs
@@ -4,6 +4,7 @@ use std::process::Stdio;
 use alera_core::child_process::windowless_async_command;
 use alera_core::runtime::{
     RuntimeStore, SshAuthKind, SshBootstrapStatus, SshTarget, SshTargetBootstrapStateUpdate,
+    SshTargetLastStatus,
 };
 use anyhow::{anyhow, bail, Context, Result};
 use base64::prelude::*;
@@ -362,7 +363,9 @@ where
             },
         )
         .await?;
-    let installed = store.mark_ssh_target_checked(&installed.id).await?;
+    let installed = store
+        .mark_ssh_target_checked(&installed.id, SshTargetLastStatus::RuntimeReady)
+        .await?;
     emit(progress(
         &job_id,
         &target.id,
@@ -596,7 +599,7 @@ async fn install_runtime_artifact(
     Ok(())
 }
 
-async fn validate_remote_runtime(
+pub(crate) async fn validate_remote_runtime(
     target: &SshTarget,
     platform: &str,
     install_dir: &str,
@@ -740,6 +743,18 @@ set "ALERA_RUNTIME_DIR=%~dp0..\data"
         staging_archive = powershell_string(staging_archive),
         entrypoint = powershell_string(entrypoint),
     )
+}
+
+pub(crate) async fn ssh_target_answers_posix(target: &SshTarget) -> bool {
+    run_remote_command(target, "posix", "printf ready")
+        .await
+        .is_ok()
+}
+
+pub(crate) async fn ssh_target_answers_windows(target: &SshTarget) -> bool {
+    run_remote_command(target, "windows", "Write-Output ready")
+        .await
+        .is_ok()
 }
 
 async fn run_remote_command(

--- a/rust/alera-cli/src/ssh_target_status.rs
+++ b/rust/alera-cli/src/ssh_target_status.rs
@@ -1,0 +1,121 @@
+use std::future::Future;
+
+use alera_core::runtime::{RuntimeStore, SshTarget, SshTargetLastStatus};
+use anyhow::{anyhow, Result};
+use serde_json::{json, Value};
+
+use crate::ssh_bootstrap::{
+    normalize_platform, ssh_target_answers_posix, ssh_target_answers_windows,
+    validate_remote_runtime,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RemoteShellKind {
+    Posix,
+    Windows,
+}
+
+pub(crate) trait SshTargetProbe {
+    fn probe_connectivity(
+        &self,
+        target: &SshTarget,
+    ) -> impl Future<Output = Option<RemoteShellKind>> + Send;
+
+    fn probe_runtime(
+        &self,
+        target: &SshTarget,
+        platform: &str,
+        install_dir: &str,
+    ) -> impl Future<Output = bool> + Send;
+}
+
+pub(crate) struct LiveSshTargetProbe;
+
+impl SshTargetProbe for LiveSshTargetProbe {
+    async fn probe_connectivity(&self, target: &SshTarget) -> Option<RemoteShellKind> {
+        if ssh_target_answers_posix(target).await {
+            return Some(RemoteShellKind::Posix);
+        }
+        if ssh_target_answers_windows(target).await {
+            return Some(RemoteShellKind::Windows);
+        }
+        None
+    }
+
+    async fn probe_runtime(&self, target: &SshTarget, platform: &str, install_dir: &str) -> bool {
+        validate_remote_runtime(target, platform, install_dir)
+            .await
+            .is_ok()
+    }
+}
+
+pub(crate) async fn collect_ssh_target_status<P: SshTargetProbe>(
+    store: &RuntimeStore,
+    id: Option<&str>,
+    probe: &P,
+) -> Result<Value> {
+    if let Some(id) = id {
+        let target = store
+            .find_ssh_target(id)
+            .await?
+            .ok_or_else(|| anyhow!("ssh target not found: {id}"))?;
+        let target = refresh_ssh_target_status(store, target, probe).await?;
+        return Ok(json!(target));
+    }
+    let targets = store.list_ssh_targets().await?;
+    let mut refreshed = Vec::with_capacity(targets.len());
+    for target in targets {
+        refreshed.push(refresh_ssh_target_status(store, target, probe).await?);
+    }
+    Ok(json!(refreshed))
+}
+
+pub(crate) async fn refresh_ssh_target_status<P: SshTargetProbe>(
+    store: &RuntimeStore,
+    target: SshTarget,
+    probe: &P,
+) -> Result<SshTarget> {
+    let status = probe_ssh_target_status(&target, probe).await;
+    store.mark_ssh_target_checked(&target.id, status).await
+}
+
+pub(crate) async fn probe_ssh_target_status<P: SshTargetProbe>(
+    target: &SshTarget,
+    probe: &P,
+) -> SshTargetLastStatus {
+    let Some(shell) = probe.probe_connectivity(target).await else {
+        return SshTargetLastStatus::Unreachable;
+    };
+    let Some(install_dir) = target
+        .install_dir
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    else {
+        return SshTargetLastStatus::Reachable;
+    };
+    let platform = runtime_probe_platform(target, shell);
+    if probe.probe_runtime(target, &platform, install_dir).await {
+        SshTargetLastStatus::RuntimeReady
+    } else {
+        SshTargetLastStatus::Reachable
+    }
+}
+
+fn runtime_probe_platform(target: &SshTarget, shell: RemoteShellKind) -> String {
+    let configured = target
+        .runtime_platform
+        .as_deref()
+        .or(target.platform.as_deref())
+        .map(normalize_platform);
+    match (configured.as_deref(), shell) {
+        (Some("windows"), RemoteShellKind::Windows) => "windows".to_string(),
+        (Some(platform), RemoteShellKind::Posix) if platform != "windows" => platform.to_string(),
+        (_, RemoteShellKind::Windows) => "windows".to_string(),
+        (_, RemoteShellKind::Posix) => "linux".to_string(),
+    }
+}
+
+#[cfg(test)]
+#[path = "ssh_target_status_tests.rs"]
+mod tests;

--- a/rust/alera-cli/src/ssh_target_status_tests.rs
+++ b/rust/alera-cli/src/ssh_target_status_tests.rs
@@ -1,0 +1,234 @@
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use alera_core::runtime::{
+    RuntimeStore, SshAuthKind, SshBootstrapStatus, SshTarget, SshTargetLastStatus,
+};
+use chrono::Utc;
+
+use super::{
+    collect_ssh_target_status, probe_ssh_target_status, refresh_ssh_target_status,
+    runtime_probe_platform, RemoteShellKind, SshTargetProbe,
+};
+
+struct MapProbe {
+    connectivity: HashMap<String, Option<RemoteShellKind>>,
+    runtime: HashMap<String, bool>,
+    runtime_calls: Arc<AtomicUsize>,
+}
+
+impl SshTargetProbe for MapProbe {
+    async fn probe_connectivity(&self, target: &SshTarget) -> Option<RemoteShellKind> {
+        self.connectivity.get(&target.id).copied().flatten()
+    }
+
+    async fn probe_runtime(&self, target: &SshTarget, _platform: &str, _install_dir: &str) -> bool {
+        self.runtime_calls.fetch_add(1, Ordering::SeqCst);
+        self.runtime.get(&target.id).copied().unwrap_or(false)
+    }
+}
+
+impl MapProbe {
+    fn new() -> Self {
+        Self {
+            connectivity: HashMap::new(),
+            runtime: HashMap::new(),
+            runtime_calls: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+
+    fn with_target(
+        mut self,
+        id: &str,
+        connectivity: Option<RemoteShellKind>,
+        runtime: bool,
+    ) -> Self {
+        self.connectivity.insert(id.to_string(), connectivity);
+        self.runtime.insert(id.to_string(), runtime);
+        self
+    }
+}
+
+async fn store() -> (tempfile::TempDir, RuntimeStore) {
+    let dir = tempfile::tempdir().unwrap();
+    let store = RuntimeStore::open(dir.path()).await.unwrap();
+    (dir, store)
+}
+
+fn target(id: &str) -> SshTarget {
+    let now = Utc::now();
+    SshTarget {
+        id: id.to_string(),
+        alias: id.to_string(),
+        host: format!("{id}.example.test"),
+        port: 22,
+        username: "alera".to_string(),
+        platform: None,
+        arch: None,
+        auth_kind: SshAuthKind::Agent,
+        created_at: now,
+        updated_at: now,
+        last_status: None,
+        install_dir: None,
+        runtime_version: None,
+        runtime_platform: None,
+        runtime_arch: None,
+        bootstrap_status: SshBootstrapStatus::NotInstalled,
+        last_bootstrap_at: None,
+        last_checked_at: None,
+        last_error: None,
+    }
+}
+
+#[test]
+fn runtime_probe_platform_prefers_matching_configured_values() {
+    let mut posix = target("remote");
+    posix.runtime_platform = Some("Darwin".to_string());
+    assert_eq!(
+        runtime_probe_platform(&posix, RemoteShellKind::Posix),
+        "macos"
+    );
+
+    let mut windows = target("remote");
+    windows.platform = Some("windows".to_string());
+    assert_eq!(
+        runtime_probe_platform(&windows, RemoteShellKind::Windows),
+        "windows"
+    );
+}
+
+#[test]
+fn runtime_probe_platform_falls_back_to_the_shell_that_answered() {
+    let mut mismatched = target("remote");
+    mismatched.platform = Some("windows".to_string());
+    assert_eq!(
+        runtime_probe_platform(&mismatched, RemoteShellKind::Posix),
+        "linux"
+    );
+    assert_eq!(
+        runtime_probe_platform(&target("remote"), RemoteShellKind::Windows),
+        "windows"
+    );
+}
+
+#[tokio::test]
+async fn missing_target_keeps_the_existing_not_found_error() {
+    let (_dir, store) = store().await;
+    let probe = MapProbe::new();
+    let error = collect_ssh_target_status(&store, Some("missing"), &probe)
+        .await
+        .unwrap_err();
+    assert_eq!(error.to_string(), "ssh target not found: missing");
+}
+
+#[tokio::test]
+async fn unreachable_probe_stamps_last_status_and_checked_at() {
+    let (_dir, store) = store().await;
+    store.upsert_ssh_target(target("remote")).await.unwrap();
+    let probe = MapProbe::new().with_target("remote", None, false);
+
+    let value = collect_ssh_target_status(&store, Some("remote"), &probe)
+        .await
+        .unwrap();
+
+    assert_eq!(value["lastStatus"], "unreachable");
+    assert!(value["lastCheckedAt"].as_str().is_some());
+    let stored = store.find_ssh_target("remote").await.unwrap().unwrap();
+    assert_eq!(stored.last_status.as_deref(), Some("unreachable"));
+    assert!(stored.last_checked_at.is_some());
+}
+
+#[tokio::test]
+async fn reachable_host_without_install_dir_skips_the_runtime_probe() {
+    let probe = MapProbe::new().with_target("remote", Some(RemoteShellKind::Posix), true);
+    let status = probe_ssh_target_status(&target("remote"), &probe).await;
+    assert_eq!(status, SshTargetLastStatus::Reachable);
+    assert_eq!(probe.runtime_calls.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn reachable_host_with_failed_runtime_stays_reachable() {
+    let mut remote = target("remote");
+    remote.install_dir = Some("/home/alera/.alera/sidecar".to_string());
+    remote.runtime_platform = Some("linux".to_string());
+    let probe = MapProbe::new().with_target("remote", Some(RemoteShellKind::Posix), false);
+    let status = probe_ssh_target_status(&remote, &probe).await;
+    assert_eq!(status, SshTargetLastStatus::Reachable);
+    assert_eq!(probe.runtime_calls.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn reachable_runtime_probe_stamps_runtime_ready() {
+    let (_dir, store) = store().await;
+    let mut remote = target("remote");
+    remote.install_dir = Some("/home/alera/.alera/sidecar".to_string());
+    remote.runtime_platform = Some("linux".to_string());
+    store.upsert_ssh_target(remote).await.unwrap();
+    let probe = MapProbe::new().with_target("remote", Some(RemoteShellKind::Posix), true);
+
+    let refreshed = refresh_ssh_target_status(
+        &store,
+        store.find_ssh_target("remote").await.unwrap().unwrap(),
+        &probe,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(
+        refreshed.last_status.as_deref(),
+        Some(SshTargetLastStatus::RuntimeReady.as_str())
+    );
+    assert!(refreshed.last_checked_at.is_some());
+}
+
+#[tokio::test]
+async fn status_updates_last_checked_at_on_every_call() {
+    let (_dir, store) = store().await;
+    store.upsert_ssh_target(target("remote")).await.unwrap();
+    let probe = MapProbe::new().with_target("remote", Some(RemoteShellKind::Posix), false);
+
+    let first = collect_ssh_target_status(&store, Some("remote"), &probe)
+        .await
+        .unwrap();
+    tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+    let second = collect_ssh_target_status(&store, Some("remote"), &probe)
+        .await
+        .unwrap();
+
+    assert_eq!(first["lastStatus"], "reachable");
+    assert_eq!(second["lastStatus"], "reachable");
+    assert_ne!(first["lastCheckedAt"], second["lastCheckedAt"]);
+}
+
+#[tokio::test]
+async fn list_status_probes_each_target_and_keeps_array_shape() {
+    let (_dir, store) = store().await;
+    store.upsert_ssh_target(target("alpha")).await.unwrap();
+    let mut beta = target("beta");
+    beta.install_dir = Some("~/.alera/sidecar".to_string());
+    store.upsert_ssh_target(beta).await.unwrap();
+    let probe = MapProbe::new()
+        .with_target("alpha", None, false)
+        .with_target("beta", Some(RemoteShellKind::Posix), true);
+
+    let value = collect_ssh_target_status(&store, None, &probe)
+        .await
+        .unwrap();
+
+    assert!(value.is_array());
+    assert_eq!(value.as_array().unwrap().len(), 2);
+    let by_id = value
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|item| {
+            (
+                item["id"].as_str().unwrap().to_string(),
+                item["lastStatus"].as_str().unwrap().to_string(),
+            )
+        })
+        .collect::<HashMap<_, _>>();
+    assert_eq!(by_id.get("alpha").map(String::as_str), Some("unreachable"));
+    assert_eq!(by_id.get("beta").map(String::as_str), Some("runtimeReady"));
+}

--- a/rust/alera-core/src/runtime/models.rs
+++ b/rust/alera-core/src/runtime/models.rs
@@ -407,6 +407,28 @@ impl SshBootstrapStatus {
     }
 }
 
+/// Live connectivity result persisted on `SshTarget.last_status`.
+///
+/// Distinct from `SshBootstrapStatus`, which records install progress rather
+/// than whether the host answers SSH or its runtime sidecar is usable.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum SshTargetLastStatus {
+    Unreachable,
+    Reachable,
+    RuntimeReady,
+}
+
+impl SshTargetLastStatus {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            SshTargetLastStatus::Unreachable => "unreachable",
+            SshTargetLastStatus::Reachable => "reachable",
+            SshTargetLastStatus::RuntimeReady => "runtimeReady",
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct CascadePreview {

--- a/rust/alera-core/src/runtime/store.rs
+++ b/rust/alera-core/src/runtime/store.rs
@@ -13,8 +13,9 @@ use super::{harden_sqlite_files, open_private_runtime_file, prepare_private_runt
 use super::{
     CascadePreview, LinkedReview, MobileAccessSettings, MobileDevice, MobileDevicePermission,
     MobilePairingOffer, Project, ProjectConfig, ProjectConfigMap, ProjectConfigRecord, ProjectKind,
-    RuntimeSettings, SshAuthKind, SshBootstrapStatus, SshTarget, WorkbenchLayoutRecord, Workspace,
-    WorkspaceKind, WorkspaceRelation, WorkspaceStatus, WorkspaceTabRecord, WorkspaceTag,
+    RuntimeSettings, SshAuthKind, SshBootstrapStatus, SshTarget, SshTargetLastStatus,
+    WorkbenchLayoutRecord, Workspace, WorkspaceKind, WorkspaceRelation, WorkspaceStatus,
+    WorkspaceTabRecord, WorkspaceTag,
 };
 
 pub const RUNTIME_DATABASE_FILE_NAME: &str = "runtime.sqlite";
@@ -1443,14 +1444,21 @@ impl RuntimeStore {
         })
     }
 
-    pub async fn mark_ssh_target_checked(&self, target_id: &str) -> Result<SshTarget> {
+    pub async fn mark_ssh_target_checked(
+        &self,
+        target_id: &str,
+        last_status: SshTargetLastStatus,
+    ) -> Result<SshTarget> {
         let now = format_timestamp(Utc::now());
-        sqlx::query("UPDATE sshTargets SET lastCheckedAt = ?, updatedAt = ? WHERE id = ?")
-            .bind(&now)
-            .bind(&now)
-            .bind(target_id)
-            .execute(&self.pool)
-            .await?;
+        sqlx::query(
+            "UPDATE sshTargets SET lastStatus = ?, lastCheckedAt = ?, updatedAt = ? WHERE id = ?",
+        )
+        .bind(last_status.as_str())
+        .bind(&now)
+        .bind(&now)
+        .bind(target_id)
+        .execute(&self.pool)
+        .await?;
         self.find_ssh_target(target_id).await?.ok_or_else(|| {
             anyhow::anyhow!(RuntimeStoreError::Message(format!(
                 "ssh target not found: {target_id}"
@@ -2114,5 +2122,28 @@ mod tests {
             updated.install_dir.as_deref(),
             Some("/custom/alera/runtime")
         );
+    }
+
+    #[tokio::test]
+    async fn mark_ssh_target_checked_stamps_last_status_and_checked_at() {
+        let (_dir, store) = store().await;
+        store.upsert_ssh_target(ssh_target("remote")).await.unwrap();
+
+        let checked = store
+            .mark_ssh_target_checked("remote", SshTargetLastStatus::RuntimeReady)
+            .await
+            .unwrap();
+
+        assert_eq!(checked.last_status.as_deref(), Some("runtimeReady"));
+        assert!(checked.last_checked_at.is_some());
+        assert!(checked.updated_at >= checked.created_at);
+
+        let missing = store
+            .mark_ssh_target_checked("missing", SshTargetLastStatus::Unreachable)
+            .await
+            .unwrap_err();
+        assert!(missing
+            .to_string()
+            .contains("ssh target not found: missing"));
     }
 }

--- a/skills/alera-cli/SKILL.md
+++ b/skills/alera-cli/SKILL.md
@@ -251,6 +251,18 @@ alera terminal write --handle <terminal-handle> --stdin --enter
 
 JSON list commands return a consistent `{ "kind": "...", "items": [...], "filters": {...} }` envelope. Read `items` rather than relying on a resource-specific top-level array.
 
+## SSH Targets
+
+List saved hosts, or probe live connectivity and persist `lastStatus` (`reachable`, `unreachable`, or `runtimeReady`) plus `lastCheckedAt`:
+
+```bash
+alera ssh-target --json list
+alera ssh-target --json status
+alera ssh-target --json status --id <target-id>
+```
+
+Unknown ids fail with `ssh target not found`. `status` without `--id` probes every saved target and returns a JSON array.
+
 ## Agent Profiles
 
 Inspect the user-approved launch catalog:


### PR DESCRIPTION
## Summary

`alera ssh-target status` / `ssh-target --json status` returned saved target rows with `lastStatus` still null. `lastCheckedAt` was only stamped after a successful bootstrap.

Status now performs a live SSH connectivity probe and, when an install directory is stored, a remote runtime sidecar check. It persists `lastStatus` as `reachable`, `unreachable`, or `runtimeReady` and updates `lastCheckedAt` on every call. Missing ids still fail with `ssh target not found`. JSON shape stays the same (object for `--id`, array without it). Successful bootstrap also stamps `runtimeReady`.

Closes #668

## Screenshots

No visual change.

## Testing

- [x] `cargo test -p alera-cli ssh_target_status --offline` (9 tests)
- [x] `cargo test -p alera-core --features runtime mark_ssh_target_checked_stamps --offline`
- [x] `cargo clippy -p alera-core --features runtime --all-targets --offline -- -D warnings`
- [x] `cargo clippy -p alera-cli --all-targets --offline -- -D warnings`
- [ ] Dart/Flutter format, analyze, and tests (Rust CLI/store only)
- [ ] Golden tests (no UI change)
- [ ] Desktop E2E (no app-shell change)

## AI Review Report

Self-reviewed the diff before opening:
- Status still talks to the store directly, matching the previous CLI path, so an older running host is not asked for a new RPC.
- Probe values are the existing camelCase strings (`reachable` / `unreachable` / `runtimeReady`); `lastStatus` stays an optional string on the wire.
- Unknown targets keep the `ssh target not found: {id}` error.
- Live SSH is injected behind `SshTargetProbe`; unit tests use a fake so they do not wait on `ConnectTimeout=15`.

Cross-platform: the live probe reuses the existing bootstrap SSH helpers (posix `sh -lc`, then Windows encoded PowerShell) with the same `BatchMode` and 15s connect timeout.

## Security Audit

Status still uses `BatchMode=yes` and does not add password authentication. Probe failures are stored as `unreachable` / `reachable` without writing SSH stderr into `lastError`.

## Notes

- Demo waived.
- Docs: `docs/remote-host-bootstrap.md` and `skills/alera-cli/SKILL.md` describe the live status probe.
- Host RPC was not added: routing status through a new `sshTarget.status` verb would break CLI status against an already-running older sidecar.