### PR TITLE
fix: stamp runtimeready when windows ssh answers posix sh

### DIFF
--- a/rust/alera-cli/src/ssh_target_status.rs
+++ b/rust/alera-cli/src/ssh_target_status.rs
@@ -33,11 +33,14 @@ pub(crate) struct LiveSshTargetProbe;
 
 impl SshTargetProbe for LiveSshTargetProbe {
     async fn probe_connectivity(&self, target: &SshTarget) -> Option<RemoteShellKind> {
-        if ssh_target_answers_posix(target).await {
-            return Some(RemoteShellKind::Posix);
-        }
-        if ssh_target_answers_windows(target).await {
-            return Some(RemoteShellKind::Windows);
+        for shell in connectivity_shell_order(target) {
+            let answered = match shell {
+                RemoteShellKind::Posix => ssh_target_answers_posix(target).await,
+                RemoteShellKind::Windows => ssh_target_answers_windows(target).await,
+            };
+            if answered {
+                return Some(shell);
+            }
         }
         None
     }
@@ -102,15 +105,28 @@ pub(crate) async fn probe_ssh_target_status<P: SshTargetProbe>(
     }
 }
 
-fn runtime_probe_platform(target: &SshTarget, shell: RemoteShellKind) -> String {
-    let configured = target
+fn configured_status_platform(target: &SshTarget) -> Option<String> {
+    target
         .runtime_platform
         .as_deref()
         .or(target.platform.as_deref())
-        .map(normalize_platform);
-    match (configured.as_deref(), shell) {
-        (Some("windows"), RemoteShellKind::Windows) => "windows".to_string(),
-        (Some(platform), RemoteShellKind::Posix) if platform != "windows" => platform.to_string(),
+        .map(normalize_platform)
+}
+
+fn connectivity_shell_order(target: &SshTarget) -> [RemoteShellKind; 2] {
+    // Windows OpenSSH + Git for Windows `sh` answers posix; try PowerShell first.
+    if configured_status_platform(target).as_deref() == Some("windows") {
+        [RemoteShellKind::Windows, RemoteShellKind::Posix]
+    } else {
+        [RemoteShellKind::Posix, RemoteShellKind::Windows]
+    }
+}
+
+fn runtime_probe_platform(target: &SshTarget, shell: RemoteShellKind) -> String {
+    match (configured_status_platform(target).as_deref(), shell) {
+        // Same false-posix fingerprint: keep the stored windows runtime path.
+        (Some("windows"), _) => "windows".to_string(),
+        (Some(platform), RemoteShellKind::Posix) => platform.to_string(),
         (_, RemoteShellKind::Windows) => "windows".to_string(),
         (_, RemoteShellKind::Posix) => "linux".to_string(),
     }

--- a/rust/alera-cli/src/ssh_target_status_tests.rs
+++ b/rust/alera-cli/src/ssh_target_status_tests.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use alera_core::runtime::{
     RuntimeStore, SshAuthKind, SshBootstrapStatus, SshTarget, SshTargetLastStatus,
@@ -8,8 +8,8 @@ use alera_core::runtime::{
 use chrono::Utc;
 
 use super::{
-    collect_ssh_target_status, probe_ssh_target_status, refresh_ssh_target_status,
-    runtime_probe_platform, RemoteShellKind, SshTargetProbe,
+    collect_ssh_target_status, connectivity_shell_order, probe_ssh_target_status,
+    refresh_ssh_target_status, runtime_probe_platform, RemoteShellKind, SshTargetProbe,
 };
 
 struct MapProbe {
@@ -81,6 +81,43 @@ fn target(id: &str) -> SshTarget {
     }
 }
 
+fn windows_runtime_target(id: &str) -> SshTarget {
+    let mut remote = target(id);
+    remote.install_dir = Some(r"%LOCALAPPDATA%\Alera\runtime".to_string());
+    remote.platform = Some("windows".to_string());
+    remote.runtime_platform = Some("windows".to_string());
+    remote
+}
+
+struct FalsePosixWindowsProbe {
+    runtime_ok_on_windows: bool,
+    probed_platform: Arc<Mutex<Option<String>>>,
+}
+
+impl FalsePosixWindowsProbe {
+    fn new(runtime_ok_on_windows: bool) -> Self {
+        Self {
+            runtime_ok_on_windows,
+            probed_platform: Arc::new(Mutex::new(None)),
+        }
+    }
+
+    fn probed_platform(&self) -> Option<String> {
+        self.probed_platform.lock().unwrap().clone()
+    }
+}
+
+impl SshTargetProbe for FalsePosixWindowsProbe {
+    async fn probe_connectivity(&self, _target: &SshTarget) -> Option<RemoteShellKind> {
+        Some(RemoteShellKind::Posix)
+    }
+
+    async fn probe_runtime(&self, _target: &SshTarget, platform: &str, _install_dir: &str) -> bool {
+        *self.probed_platform.lock().unwrap() = Some(platform.to_string());
+        self.runtime_ok_on_windows && platform == "windows"
+    }
+}
+
 #[test]
 fn runtime_probe_platform_prefers_matching_configured_values() {
     let mut posix = target("remote");
@@ -99,16 +136,70 @@ fn runtime_probe_platform_prefers_matching_configured_values() {
 }
 
 #[test]
-fn runtime_probe_platform_falls_back_to_the_shell_that_answered() {
-    let mut mismatched = target("remote");
-    mismatched.platform = Some("windows".to_string());
+fn runtime_probe_platform_trusts_stored_windows_over_posix_shell() {
+    let mut stored = target("remote");
+    stored.platform = Some("windows".to_string());
     assert_eq!(
-        runtime_probe_platform(&mismatched, RemoteShellKind::Posix),
-        "linux"
+        runtime_probe_platform(&stored, RemoteShellKind::Posix),
+        "windows"
     );
+
+    let mut runtime = target("remote");
+    runtime.runtime_platform = Some("Windows_NT".to_string());
+    assert_eq!(
+        runtime_probe_platform(&runtime, RemoteShellKind::Posix),
+        "windows"
+    );
+}
+
+#[test]
+fn runtime_probe_platform_falls_back_to_the_shell_that_answered() {
     assert_eq!(
         runtime_probe_platform(&target("remote"), RemoteShellKind::Windows),
         "windows"
+    );
+    assert_eq!(
+        runtime_probe_platform(&target("remote"), RemoteShellKind::Posix),
+        "linux"
+    );
+}
+
+#[test]
+fn connectivity_shell_order_prefers_windows_when_stored_platform_is_windows() {
+    let mut stored = target("remote");
+    stored.platform = Some("windows".to_string());
+    assert_eq!(
+        connectivity_shell_order(&stored),
+        [RemoteShellKind::Windows, RemoteShellKind::Posix]
+    );
+
+    let mut runtime = target("remote");
+    runtime.runtime_platform = Some("MINGW64_NT-10.0".to_string());
+    assert_eq!(
+        connectivity_shell_order(&runtime),
+        [RemoteShellKind::Windows, RemoteShellKind::Posix]
+    );
+}
+
+#[test]
+fn connectivity_shell_order_prefers_posix_when_unknown_or_unix() {
+    assert_eq!(
+        connectivity_shell_order(&target("remote")),
+        [RemoteShellKind::Posix, RemoteShellKind::Windows]
+    );
+
+    let mut linux = target("remote");
+    linux.runtime_platform = Some("linux".to_string());
+    assert_eq!(
+        connectivity_shell_order(&linux),
+        [RemoteShellKind::Posix, RemoteShellKind::Windows]
+    );
+
+    let mut macos = target("remote");
+    macos.platform = Some("Darwin".to_string());
+    assert_eq!(
+        connectivity_shell_order(&macos),
+        [RemoteShellKind::Posix, RemoteShellKind::Windows]
     );
 }
 
@@ -199,6 +290,36 @@ async fn status_updates_last_checked_at_on_every_call() {
     assert_eq!(first["lastStatus"], "reachable");
     assert_eq!(second["lastStatus"], "reachable");
     assert_ne!(first["lastCheckedAt"], second["lastCheckedAt"]);
+}
+
+#[tokio::test]
+async fn windows_false_posix_shell_stamps_runtime_ready() {
+    let (_dir, store) = store().await;
+    store
+        .upsert_ssh_target(windows_runtime_target("remote"))
+        .await
+        .unwrap();
+    let probe = FalsePosixWindowsProbe::new(true);
+
+    let value = collect_ssh_target_status(&store, Some("remote"), &probe)
+        .await
+        .unwrap();
+
+    assert_eq!(value["lastStatus"], "runtimeReady");
+    assert_eq!(probe.probed_platform().as_deref(), Some("windows"));
+    let stored = store.find_ssh_target("remote").await.unwrap().unwrap();
+    assert_eq!(
+        stored.last_status.as_deref(),
+        Some(SshTargetLastStatus::RuntimeReady.as_str())
+    );
+}
+
+#[tokio::test]
+async fn windows_false_posix_shell_stays_reachable_when_windows_runtime_fails() {
+    let probe = FalsePosixWindowsProbe::new(false);
+    let status = probe_ssh_target_status(&windows_runtime_target("remote"), &probe).await;
+    assert_eq!(status, SshTargetLastStatus::Reachable);
+    assert_eq!(probe.probed_platform().as_deref(), Some("windows"));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

`alera ssh-target status` treated a Windows OpenSSH host with Git for Windows `sh` on PATH as posix. Connectivity short-circuited on `sh -lc`, then `runtime_probe_platform` preferred that fingerprint over a stored `windows` platform and ran the linux validate script against a Windows install dir, so a good bootstrap stamped `reachable` instead of `runtimeReady`.

Status now probes PowerShell first when the stored platform is windows, and keeps the windows runtime validate path even if connectivity still reports posix. Posix-only targets are unchanged. Missing targets still error with `ssh target not found`.

Closes #694

## Screenshots

No visual change.

## Testing

- [x] `cargo test -p alera-cli ssh_target_status --offline` (14 tests)
- [x] `cargo clippy -p alera-cli --all-targets --offline -- -D warnings`
- [ ] Dart/Flutter format, analyze, and tests (Rust CLI only)
- [ ] Golden tests (no UI change)
- [ ] Desktop E2E (no app-shell change)

## AI Review Report

Self-reviewed the diff before opening:
- Stored `windows` (from `runtime_platform` or `platform`, including `Windows_NT` / MINGW) now wins over a posix shell fingerprint for the runtime probe.
- Connectivity order is windows-then-posix only when that stored platform is windows; unknown and unix targets stay posix-first.
- The false-posix regression probe succeeds only on the windows validate path, so a linux script cannot stamp `runtimeReady`.
- Missing ids keep `ssh target not found: {id}`.

Cross-platform: live SSH still uses the existing bootstrap helpers (`sh -lc` vs encoded PowerShell) with `BatchMode` and the 15s connect timeout.

## Security Audit

Status still uses `BatchMode=yes` and does not add password authentication. Probe failures stay `unreachable` / `reachable` without writing SSH stderr into `lastError`.

## Notes

- Demo waived.
- Docs: no update. `docs/remote-host-bootstrap.md` and `skills/alera-cli/SKILL.md` already describe live status as `reachable` / `unreachable` / `runtimeReady`; this change is probe-order internals after a stored windows bootstrap.