### PR TITLE
fix: label old-side lines for deletion-only comment anchors

### DIFF
--- a/lib/src/features/workspace_agent_comments/domain/workspace_agent_comment.dart
+++ b/lib/src/features/workspace_agent_comments/domain/workspace_agent_comment.dart
@@ -1,28 +1,42 @@
 /// A local draft comment destined for an agent, not a hosted review thread.
 enum WorkspaceAgentCommentKind { file, diff }
 
+/// Which side of a diff a line number refers to.
+///
+/// File comments and added/context diff lines use [newSide] (working tree).
+/// Deletion-only anchors exist only on [oldSide] and must not be labeled as a
+/// bare `line N`, or an agent will treat them as working-tree numbers.
+enum WorkspaceAgentCommentLineSide { newSide, oldSide }
+
 class const WorkspaceAgentCommentLineRange({
   required final int startLine,
   required final int endLine,
+  final WorkspaceAgentCommentLineSide side =
+      WorkspaceAgentCommentLineSide.newSide,
 }) {
   bool get isSingleLine => startLine == endLine;
 
+  bool get isOldSide => side == WorkspaceAgentCommentLineSide.oldSide;
+
   String get label {
-    if (isSingleLine) {
-      return 'line $startLine';
+    if (isOldSide) {
+      return isSingleLine
+          ? 'old line $startLine'
+          : 'old lines $startLine-$endLine';
     }
-    return 'lines $startLine-$endLine';
+    return isSingleLine ? 'line $startLine' : 'lines $startLine-$endLine';
   }
 
   @override
   bool operator ==(Object other) {
     return other is WorkspaceAgentCommentLineRange &&
         startLine == other.startLine &&
-        endLine == other.endLine;
+        endLine == other.endLine &&
+        side == other.side;
   }
 
   @override
-  int get hashCode => Object.hash(startLine, endLine);
+  int get hashCode => Object.hash(startLine, endLine, side);
 }
 
 class const WorkspaceAgentComment({

--- a/lib/src/features/workspace_agent_comments/domain/workspace_agent_comment_location.dart
+++ b/lib/src/features/workspace_agent_comments/domain/workspace_agent_comment_location.dart
@@ -181,7 +181,11 @@ WorkspaceAgentCommentLineRange? workspaceAgentCommentRangeForDiffAnchor(
   }
   final oldLine = anchor.oldLine;
   if (oldLine != null) {
-    return WorkspaceAgentCommentLineRange(startLine: oldLine, endLine: oldLine);
+    return WorkspaceAgentCommentLineRange(
+      startLine: oldLine,
+      endLine: oldLine,
+      side: WorkspaceAgentCommentLineSide.oldSide,
+    );
   }
   return null;
 }

--- a/test/unit/workspace_agent_comment_location_test.dart
+++ b/test/unit/workspace_agent_comment_location_test.dart
@@ -166,8 +166,22 @@ void main() {
         workspaceAgentCommentRangeForDiffAnchor(anchors[0]),
         const WorkspaceAgentCommentLineRange(startLine: 12, endLine: 14),
       );
+      expect(anchors[2].oldLine, 11);
+      expect(anchors[2].newLine, isNull);
+      expect(
+        workspaceAgentCommentRangeForDiffAnchor(anchors[2]),
+        const WorkspaceAgentCommentLineRange(
+          startLine: 11,
+          endLine: 11,
+          side: WorkspaceAgentCommentLineSide.oldSide,
+        ),
+      );
       expect(anchors[3].newLine, 13);
       expect(anchors[4].newLine, 14);
+      expect(
+        workspaceAgentCommentRangeForDiffAnchor(anchors[3]),
+        const WorkspaceAgentCommentLineRange(startLine: 13, endLine: 13),
+      );
       expect(
         workspaceAgentCommentSnippetForDiffAnchor(
           lines: lines,
@@ -187,6 +201,14 @@ void main() {
       expect(anchors[2].newLine, 1);
       expect(
         workspaceAgentCommentRangeForDiffAnchor(anchors[1]),
+        const WorkspaceAgentCommentLineRange(
+          startLine: 1,
+          endLine: 1,
+          side: WorkspaceAgentCommentLineSide.oldSide,
+        ),
+      );
+      expect(
+        workspaceAgentCommentRangeForDiffAnchor(anchors[2]),
         const WorkspaceAgentCommentLineRange(startLine: 1, endLine: 1),
       );
     });
@@ -220,10 +242,27 @@ void main() {
       expect(removed[0].hunkNewEnd, isNull);
       expect(workspaceAgentCommentRangeForDiffAnchor(removed[0]), isNull);
       expect(removed[1].oldLine, 4);
+      expect(removed[1].newLine, isNull);
       expect(removed[2].oldLine, 5);
       expect(
         workspaceAgentCommentRangeForDiffAnchor(removed[1]),
-        const WorkspaceAgentCommentLineRange(startLine: 4, endLine: 4),
+        const WorkspaceAgentCommentLineRange(
+          startLine: 4,
+          endLine: 4,
+          side: WorkspaceAgentCommentLineSide.oldSide,
+        ),
+      );
+      expect(
+        workspaceAgentCommentRangeForDiffAnchor(removed[2]),
+        const WorkspaceAgentCommentLineRange(
+          startLine: 5,
+          endLine: 5,
+          side: WorkspaceAgentCommentLineSide.oldSide,
+        ),
+      );
+      expect(
+        workspaceAgentCommentRangeForDiffAnchor(removed[1])!.label,
+        'old line 4',
       );
       expect(
         workspaceAgentCommentSnippetForDiffAnchor(

--- a/test/unit/workspace_agent_comment_test.dart
+++ b/test/unit/workspace_agent_comment_test.dart
@@ -1,6 +1,8 @@
 import 'package:alera/src/features/workspace_agent_comments/application/workspace_agent_comment_controller.dart';
 import 'package:alera/src/features/workspace_agent_comments/domain/workspace_agent_comment.dart';
+import 'package:alera/src/features/workspace_agent_comments/domain/workspace_agent_comment_location.dart';
 import 'package:alera/src/features/workspace_agent_comments/domain/workspace_agent_comment_prompt.dart';
+import 'package:alera/src/shared/infra/git/git_diff_models.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -55,6 +57,48 @@ void main() {
       );
       expect(prompt, contains('+  return null;'));
       expect(prompt, contains('This looks wrong.'));
+    });
+
+    test('labels deletion-only diff anchors as old-side lines', () {
+      const lines = <GitDiffLine>[
+        GitDiffLine.hunk('@@ -4,2 +0,0 @@ class Gone'),
+        GitDiffLine.deletion('-old one'),
+      ];
+      final anchor = workspaceAgentDiffLineAnchors(lines)[1];
+      final prompt = workspaceAgentCommentPrompt(<WorkspaceAgentComment>[
+        WorkspaceAgentComment(
+          id: '1',
+          kind: WorkspaceAgentCommentKind.diff,
+          path: 'lib/gone.dart',
+          body: 'Keep this helper elsewhere before deleting it.',
+          hunkHeader: anchor.hunkHeader,
+          lineRange: workspaceAgentCommentRangeForDiffAnchor(anchor),
+          snippet: workspaceAgentCommentSnippetForDiffAnchor(
+            lines: lines,
+            anchor: anchor,
+          ),
+        ),
+      ]);
+      expect(
+        prompt,
+        contains(
+          '## 1. Diff `lib/gone.dart` hunk `@@ -4,2 +0,0 @@ class Gone` old line 4',
+        ),
+      );
+      expect(prompt, contains('-old one'));
+      expect(
+        workspaceAgentCommentLocationLabel(
+          WorkspaceAgentComment(
+            id: '1',
+            kind: WorkspaceAgentCommentKind.diff,
+            path: 'lib/gone.dart',
+            body: 'x',
+            hunkHeader: anchor.hunkHeader,
+            lineRange: workspaceAgentCommentRangeForDiffAnchor(anchor),
+          ),
+        ),
+        'lib/gone.dart · @@ -4,2 +0,0 @@ class Gone · old line 4',
+      );
     });
 
     test('omits blank area, hunk, range, and snippet from a file comment', () {
@@ -203,6 +247,23 @@ void main() {
         ),
         'lib/a.dart · (Unstaged) · @@ -1 +1 @@ · line 4',
       );
+      expect(
+        workspaceAgentCommentLocationLabel(
+          const WorkspaceAgentComment(
+            id: '1',
+            kind: WorkspaceAgentCommentKind.diff,
+            path: 'lib/gone.dart',
+            body: 'x',
+            hunkHeader: '@@ -4,2 +0,0 @@ class Gone',
+            lineRange: WorkspaceAgentCommentLineRange(
+              startLine: 4,
+              endLine: 5,
+              side: WorkspaceAgentCommentLineSide.oldSide,
+            ),
+          ),
+        ),
+        'lib/gone.dart · @@ -4,2 +0,0 @@ class Gone · old lines 4-5',
+      );
     });
 
     test('formats single and multi line ranges', () {
@@ -216,6 +277,30 @@ void main() {
       expect(
         const WorkspaceAgentCommentLineRange(startLine: 4, endLine: 4).label,
         'line 4',
+      );
+      expect(
+        const WorkspaceAgentCommentLineRange(
+          startLine: 4,
+          endLine: 4,
+          side: WorkspaceAgentCommentLineSide.oldSide,
+        ).label,
+        'old line 4',
+      );
+      expect(
+        const WorkspaceAgentCommentLineRange(
+          startLine: 4,
+          endLine: 6,
+          side: WorkspaceAgentCommentLineSide.oldSide,
+        ).label,
+        'old lines 4-6',
+      );
+      expect(
+        const WorkspaceAgentCommentLineRange(
+          startLine: 4,
+          endLine: 4,
+          side: WorkspaceAgentCommentLineSide.oldSide,
+        ),
+        isNot(const WorkspaceAgentCommentLineRange(startLine: 4, endLine: 4)),
       );
       expect(
         const WorkspaceAgentCommentLineRange(startLine: 4, endLine: 6),


### PR DESCRIPTION
## Summary

Deletion-only workspace agent comment anchors still carry the old-file line number, but prompts and location labels used a bare `line N`. Agents treated that as a working-tree line unless the hunk or snippet saved them.

The range now records a side. File comments and added/context diff lines stay `line N` / `lines N-M`. Deletion-only anchors render as `old line N` / `old lines N-M` in both the injected prompt and the draft location label.

Follow-up from pullfrog on #693 / #648. Closes #697.

## Confirmed ACs

- [x] Prompts and location labels distinguish old-side vs new-side line numbers for deletion-only anchors (or omit a bare line number and rely on hunk + snippet only).
- [x] Focused test coverage for deletion-only anchors.
- [x] Demo waived.

## Screenshots

No visual layout change. Draft location copy and the agent prompt now say `old line N` for deletion-only anchors.

## Author testing

- `puro -e v3_47_2 dart format` on the four changed files (0 further edits).
- `puro -e v3_47_2 dart run tool/quality/check_max_lines.dart` — ratchet ok.
- `puro -e v3_47_2 flutter analyze lib/src/features/workspace_agent_comments test/unit/workspace_agent_comment_test.dart test/unit/workspace_agent_comment_location_test.dart` — no issues.
- `puro -e v3_47_2 flutter test` on the suites below: **29 passed.**

| Suite | Result |
| --- | --- |
| `test/unit/workspace_agent_comment_test.dart` | pass |
| `test/unit/workspace_agent_comment_location_test.dart` | pass |
| `test/widget/workspace_agent_comment_bar_test.dart` | pass |
| `test/widget/workspace_agent_comment_dialog_test.dart` | pass |

No `build_runner` regeneration: Riverpod / Drift / dart_mappable surfaces were not touched.

## Testing

- [x] `dart format` on changed files
- [x] `flutter analyze` on the comment feature + focused tests
- [ ] `flutter test --coverage --exclude-tags golden` (focused suites only)
- [ ] `dart run tool/quality/coverage_report.dart` (not run)
- [ ] Golden tests (no golden surface)
- [ ] Desktop E2E (no app-shell change)
- [x] Added tests that would catch a regression to bare `line N` on deletion-only anchors

## Test plan

- [x] Author: deletion-only diff line range is `WorkspaceAgentCommentLineSide.oldSide`
- [x] Author: prompt header uses `old line 4`, not a bare working-tree `line 4`
- [x] Author: location label uses `old line 4` / `old lines 4-5`
- [x] Author: mixed-hunk addition stays `line N`; mixed-hunk deletion is old-side
- [ ] QA: comment on a deleted line in SCM diff, send to agent, confirm prompt says `old line N`

## AI Review Report

Self-reviewed the diff before opening:
- New-side labels are unchanged, so file comments and additions keep the working-tree wording agents already understand.
- Old-side is applied only when a diff anchor has no new-side number (deletion-only fallback).
- Equality includes `side`, so old line 4 is not equal to new-side line 4.
- Deleted-file hunk headers still omit a line range and rely on hunk + snippet (the other AC path).

Cross-platform: label strings are shared Dart copy, not platform-specific.

## Security Audit

No command execution, path, auth, secrets, or process changes. Comments remain in-memory drafts sent through the existing agent task dispatch prompt.

## Notes

- Demo waived.
- Docs: no update. `docs/architecture.md` glossary already describes workspace agent comments; this is label wording on the existing prompt/location path.