### PR TITLE
fix: fail ssh-target remove when the id is missing

### DIFF
--- a/docs/remote-host-bootstrap.md
+++ b/docs/remote-host-bootstrap.md
@@ -33,6 +33,12 @@ Add a target:
 alera ssh-target --json add --alias build-mac --host mac.example.test --username leynier --auth agent
 ```
 
+Remove a saved target. Unknown ids fail with `ssh target not found`, matching `status` and `bootstrap-plan`:
+
+```bash
+alera ssh-target --json remove --id <target-id>
+```
+
 Probe live SSH connectivity and, when an install directory is known, the remote runtime sidecar. The command persists `lastStatus` (`reachable`, `unreachable`, or `runtimeReady`) and updates `lastCheckedAt` on every call. Unknown ids still fail with `ssh target not found`:
 
 ```bash

--- a/rust/alera-cli/tests/ssh_target_cli_conformance.rs
+++ b/rust/alera-cli/tests/ssh_target_cli_conformance.rs
@@ -1,0 +1,149 @@
+//! CLI coverage for `alera ssh-target remove` when the target is missing.
+
+mod agent_integration_home_isolation;
+
+use std::path::Path;
+use std::process::{Child, Output};
+use std::time::{Duration, Instant};
+
+use agent_integration_home_isolation::alera_command_with_isolated_home;
+use serde_json::{json, Value};
+
+struct HostGuard(Child);
+
+impl Drop for HostGuard {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+fn run_ssh_target(runtime_dir: &Path, args: &[&str]) -> Output {
+    alera_command_with_isolated_home(runtime_dir)
+        .arg("ssh-target")
+        .arg("--runtime-dir")
+        .arg(runtime_dir)
+        .arg("--json")
+        .args(args)
+        .output()
+        .expect("failed to run alera ssh-target")
+}
+
+fn success_json(runtime_dir: &Path, args: &[&str]) -> Value {
+    let output = run_ssh_target(runtime_dir, args);
+    assert!(
+        output.status.success(),
+        "command failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    serde_json::from_slice(&output.stdout).expect("command did not return JSON")
+}
+
+fn add_target(runtime_dir: &Path, id: &str) -> Value {
+    success_json(
+        runtime_dir,
+        &[
+            "add",
+            "--id",
+            id,
+            "--alias",
+            "Build Mac",
+            "--host",
+            "mac.example.test",
+            "--username",
+            "alera",
+            "--auth",
+            "agent",
+        ],
+    )
+}
+
+fn assert_missing_id_error(output: &Output, id: &str) {
+    let expected = format!("ssh target not found: {id}");
+    assert!(
+        !output.status.success(),
+        "missing-id command should fail: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        output.stdout.is_empty(),
+        "json error path should leave stdout empty: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains(&expected),
+        "stderr should match status/bootstrap-plan: {stderr}"
+    );
+}
+
+fn spawn_host(runtime_dir: &Path) -> HostGuard {
+    std::fs::create_dir_all(runtime_dir).unwrap();
+    let control_path = runtime_dir.join("host.json");
+    let child = alera_command_with_isolated_home(runtime_dir)
+        .args([
+            "runtime-host",
+            "--runtime-dir",
+            runtime_dir.to_str().unwrap(),
+            "--control-file",
+            control_path.to_str().unwrap(),
+            "--token",
+            "ssh-remove-missing-token",
+            "--empty-shutdown-delay-seconds",
+            "60",
+            "--detached-session-shutdown-delay-seconds",
+            "60",
+        ])
+        .spawn()
+        .expect("failed to spawn alera runtime-host");
+    let guard = HostGuard(child);
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        if let Ok(contents) = std::fs::read_to_string(&control_path) {
+            if serde_json::from_str::<Value>(&contents)
+                .ok()
+                .and_then(|value| value.get("port").and_then(Value::as_u64))
+                .is_some()
+            {
+                return guard;
+            }
+        }
+        assert!(Instant::now() < deadline, "control file was never written");
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+fn remove_existing_then_missing(runtime_dir: &Path) {
+    let added = add_target(runtime_dir, "remote-1");
+    assert_eq!(added["id"], json!("remote-1"));
+
+    let removed = success_json(runtime_dir, &["remove", "--id", "remote-1"]);
+    assert_eq!(removed, json!({ "id": "remote-1" }));
+
+    let listed = success_json(runtime_dir, &["list"]);
+    assert_eq!(listed["items"], json!([]));
+
+    let already_gone = run_ssh_target(runtime_dir, &["remove", "--id", "remote-1"]);
+    assert_missing_id_error(&already_gone, "remote-1");
+
+    let missing = run_ssh_target(runtime_dir, &["remove", "--id", "definitely-missing-637"]);
+    assert_missing_id_error(&missing, "definitely-missing-637");
+
+    let status = run_ssh_target(runtime_dir, &["status", "--id", "definitely-missing-637"]);
+    assert_missing_id_error(&status, "definitely-missing-637");
+}
+
+#[test]
+fn ssh_target_remove_rejects_missing_id_through_the_store() {
+    let dir = tempfile::tempdir().unwrap();
+    remove_existing_then_missing(dir.path());
+}
+
+#[test]
+fn ssh_target_remove_rejects_missing_id_through_the_runtime_host() {
+    let dir = tempfile::tempdir().unwrap();
+    let _host = spawn_host(dir.path());
+    remove_existing_then_missing(dir.path());
+}

--- a/rust/alera-core/src/runtime/store.rs
+++ b/rust/alera-core/src/runtime/store.rs
@@ -1467,10 +1467,15 @@ impl RuntimeStore {
     }
 
     pub async fn remove_ssh_target(&self, target_id: &str) -> Result<()> {
-        sqlx::query("DELETE FROM sshTargets WHERE id = ?")
+        let result = sqlx::query("DELETE FROM sshTargets WHERE id = ?")
             .bind(target_id)
             .execute(&self.pool)
             .await?;
+        if result.rows_affected() == 0 {
+            return Err(anyhow::anyhow!(RuntimeStoreError::Message(format!(
+                "ssh target not found: {target_id}"
+            ))));
+        }
         Ok(())
     }
 
@@ -2145,5 +2150,24 @@ mod tests {
         assert!(missing
             .to_string()
             .contains("ssh target not found: missing"));
+    }
+
+    #[tokio::test]
+    async fn remove_ssh_target_rejects_missing_id_and_deletes_existing() {
+        let (_dir, store) = store().await;
+        store.upsert_ssh_target(ssh_target("remote")).await.unwrap();
+
+        store.remove_ssh_target("remote").await.unwrap();
+        assert!(store.find_ssh_target("remote").await.unwrap().is_none());
+
+        let missing = store.remove_ssh_target("missing").await.unwrap_err();
+        assert!(missing
+            .to_string()
+            .contains("ssh target not found: missing"));
+
+        let already_gone = store.remove_ssh_target("remote").await.unwrap_err();
+        assert!(already_gone
+            .to_string()
+            .contains("ssh target not found: remote"));
     }
 }

--- a/skills/alera-cli/SKILL.md
+++ b/skills/alera-cli/SKILL.md
@@ -253,12 +253,13 @@ JSON list commands return a consistent `{ "kind": "...", "items": [...], "filter
 
 ## SSH Targets
 
-List saved hosts, or probe live connectivity and persist `lastStatus` (`reachable`, `unreachable`, or `runtimeReady`) plus `lastCheckedAt`:
+List saved hosts, probe live connectivity, or remove a saved target. Status persists `lastStatus` (`reachable`, `unreachable`, or `runtimeReady`) plus `lastCheckedAt`:
 
 ```bash
 alera ssh-target --json list
 alera ssh-target --json status
 alera ssh-target --json status --id <target-id>
+alera ssh-target --json remove --id <target-id>
 ```
 
 Unknown ids fail with `ssh target not found`. `status` without `--id` probes every saved target and returns a JSON array.


### PR DESCRIPTION
## Summary

`alera ssh-target remove --id <missing>` exited 0 and printed `{"id":"<missing>"}` because store DELETE was unconditional and the CLI treated any successful RPC/store call as removal.

Remove now fails when no row is deleted, with `ssh target not found: <id>`, matching `status` and `bootstrap-plan`. Existing ids still return JSON `{id}` and exit 0. `--json` errors stay on stderr with empty stdout.

Closes #670

## Screenshots

No visual change.

## Testing

- [x] `cargo test -p alera-core --features runtime remove_ssh_target_rejects_missing_id --offline`
- [x] `cargo test -p alera-cli --test ssh_target_cli_conformance --offline`
- [x] `cargo clippy -p alera-core --features runtime --all-targets --offline -- -D warnings`
- [x] `cargo clippy -p alera-cli --all-targets --offline -- -D warnings`
- [ ] Dart/Flutter format, analyze, and tests (Rust CLI/store only)
- [ ] Golden tests (no UI change)
- [ ] Desktop E2E (no app-shell change)

## AI Review Report

Self-reviewed the diff before opening:
- Missing-id failure is in `RuntimeStore::remove_ssh_target` via `rows_affected`, so both the direct CLI store path and `sshTarget.remove` host RPC inherit the same `ssh target not found: <id>` error.
- Existing ids still delete and return `{ "id": "..." }` with exit 0.
- `--json` errors use `print_error` (stderr, exit 1, empty stdout), matching `status` and `bootstrap-plan`.
- CLI coverage runs both without a host and against a live runtime-host.

Cross-platform: this is SQLite row-count plus existing CLI/RPC error plumbing; no path, shell, or shortcut changes.

## Security Audit

Remove still only deletes by the caller-supplied id. The change adds a not-found error; it does not broaden delete scope or change auth.

## Notes

- Demo waived.
- Docs: `docs/remote-host-bootstrap.md` and `skills/alera-cli/SKILL.md` now document remove and the missing-id error.