### PR TITLE
fix: map duplicate ssh target alias to a product error

### DIFF
--- a/docs/remote-host-bootstrap.md
+++ b/docs/remote-host-bootstrap.md
@@ -27,7 +27,7 @@ List targets:
 alera ssh-target --json list
 ```
 
-Add a target:
+Add a target. Duplicate aliases, including different casing, fail with `ssh target alias already exists: <alias>` using the attempted alias:
 
 ```bash
 alera ssh-target --json add --alias build-mac --host mac.example.test --username leynier --auth agent

--- a/rust/alera-cli/tests/ssh_target_cli_conformance.rs
+++ b/rust/alera-cli/tests/ssh_target_cli_conformance.rs
@@ -1,4 +1,4 @@
-//! CLI coverage for `alera ssh-target remove` when the target is missing.
+//! CLI coverage for `alera ssh-target` missing-id and duplicate-alias errors.
 
 mod agent_integration_home_isolation;
 
@@ -40,30 +40,30 @@ fn success_json(runtime_dir: &Path, args: &[&str]) -> Value {
     serde_json::from_slice(&output.stdout).expect("command did not return JSON")
 }
 
-fn add_target(runtime_dir: &Path, id: &str) -> Value {
-    success_json(
-        runtime_dir,
-        &[
-            "add",
-            "--id",
-            id,
-            "--alias",
-            "Build Mac",
-            "--host",
-            "mac.example.test",
-            "--username",
-            "alera",
-            "--auth",
-            "agent",
-        ],
-    )
+fn add_target_args<'a>(id: &'a str, alias: &'a str) -> [&'a str; 11] {
+    [
+        "add",
+        "--id",
+        id,
+        "--alias",
+        alias,
+        "--host",
+        "mac.example.test",
+        "--username",
+        "alera",
+        "--auth",
+        "agent",
+    ]
 }
 
-fn assert_missing_id_error(output: &Output, id: &str) {
-    let expected = format!("ssh target not found: {id}");
+fn add_target(runtime_dir: &Path, id: &str) -> Value {
+    success_json(runtime_dir, &add_target_args(id, "Build Mac"))
+}
+
+fn assert_json_error(output: &Output, expected: &str) {
     assert!(
         !output.status.success(),
-        "missing-id command should fail: stdout={} stderr={}",
+        "command should fail: stdout={} stderr={}",
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
@@ -74,9 +74,24 @@ fn assert_missing_id_error(output: &Output, id: &str) {
     );
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        stderr.contains(&expected),
-        "stderr should match status/bootstrap-plan: {stderr}"
+        stderr.contains(expected),
+        "stderr should match the product error: {stderr}"
     );
+    let combined = format!("{}{}", String::from_utf8_lossy(&output.stdout), stderr);
+    assert!(
+        !combined.contains("UNIQUE")
+            && !combined.contains("2067")
+            && !combined.to_lowercase().contains("sqlite"),
+        "user-facing output leaked a SQLite unique-constraint: {combined}"
+    );
+}
+
+fn assert_missing_id_error(output: &Output, id: &str) {
+    assert_json_error(output, &format!("ssh target not found: {id}"));
+}
+
+fn assert_duplicate_alias_error(output: &Output, alias: &str) {
+    assert_json_error(output, &format!("ssh target alias already exists: {alias}"));
 }
 
 fn spawn_host(runtime_dir: &Path) -> HostGuard {
@@ -135,6 +150,24 @@ fn remove_existing_then_missing(runtime_dir: &Path) {
     assert_missing_id_error(&status, "definitely-missing-637");
 }
 
+fn reject_duplicate_aliases(runtime_dir: &Path) {
+    let added = success_json(runtime_dir, &add_target_args("remote-1", "audit-637-mac"));
+    assert_eq!(added["id"], json!("remote-1"));
+    assert_eq!(added["alias"], json!("audit-637-mac"));
+
+    let exact = run_ssh_target(runtime_dir, &add_target_args("remote-2", "audit-637-mac"));
+    assert_duplicate_alias_error(&exact, "audit-637-mac");
+
+    let nocase = run_ssh_target(runtime_dir, &add_target_args("remote-3", "Audit-637-mac"));
+    assert_duplicate_alias_error(&nocase, "Audit-637-mac");
+
+    let listed = success_json(runtime_dir, &["list"]);
+    assert_eq!(listed["items"].as_array().map(Vec::len), Some(1));
+
+    let free = success_json(runtime_dir, &add_target_args("remote-4", "build-linux"));
+    assert_eq!(free["alias"], json!("build-linux"));
+}
+
 #[test]
 fn ssh_target_remove_rejects_missing_id_through_the_store() {
     let dir = tempfile::tempdir().unwrap();
@@ -146,4 +179,17 @@ fn ssh_target_remove_rejects_missing_id_through_the_runtime_host() {
     let dir = tempfile::tempdir().unwrap();
     let _host = spawn_host(dir.path());
     remove_existing_then_missing(dir.path());
+}
+
+#[test]
+fn ssh_target_add_rejects_duplicate_alias_through_the_store() {
+    let dir = tempfile::tempdir().unwrap();
+    reject_duplicate_aliases(dir.path());
+}
+
+#[test]
+fn ssh_target_add_rejects_duplicate_alias_through_the_runtime_host() {
+    let dir = tempfile::tempdir().unwrap();
+    let _host = spawn_host(dir.path());
+    reject_duplicate_aliases(dir.path());
 }

--- a/rust/alera-core/src/runtime/mod.rs
+++ b/rust/alera-core/src/runtime/mod.rs
@@ -59,6 +59,8 @@ mod settings_models;
 mod settings_store;
 #[cfg(test)]
 mod settings_store_tests;
+#[cfg(test)]
+mod ssh_target_store_tests;
 mod store;
 mod store_error;
 mod text_actions_validation;

--- a/rust/alera-core/src/runtime/ssh_target_store_tests.rs
+++ b/rust/alera-core/src/runtime/ssh_target_store_tests.rs
@@ -1,0 +1,104 @@
+use chrono::Utc;
+
+use super::{RuntimeStore, SshAuthKind, SshBootstrapStatus, SshTarget};
+
+async fn store() -> (tempfile::TempDir, RuntimeStore) {
+    let dir = tempfile::tempdir().unwrap();
+    let store = RuntimeStore::open(dir.path()).await.unwrap();
+    (dir, store)
+}
+
+fn ssh_target(id: &str, alias: &str) -> SshTarget {
+    let now = Utc::now();
+    SshTarget {
+        id: id.to_string(),
+        alias: alias.to_string(),
+        host: format!("{id}.example.test"),
+        port: 22,
+        username: "alera".to_string(),
+        platform: None,
+        arch: None,
+        auth_kind: SshAuthKind::Agent,
+        created_at: now,
+        updated_at: now,
+        last_status: None,
+        install_dir: None,
+        runtime_version: None,
+        runtime_platform: None,
+        runtime_arch: None,
+        bootstrap_status: SshBootstrapStatus::NotInstalled,
+        last_bootstrap_at: None,
+        last_checked_at: None,
+        last_error: None,
+    }
+}
+
+fn assert_duplicate_alias(error: impl std::fmt::Display, alias: &str) {
+    let text = error.to_string();
+    assert_eq!(
+        text,
+        format!("ssh target alias already exists: {alias}"),
+        "unexpected error: {text}"
+    );
+    assert!(
+        !text.contains("UNIQUE")
+            && !text.contains("2067")
+            && !text.to_lowercase().contains("sqlite"),
+        "product error leaked a SQLite unique-constraint: {text}"
+    );
+}
+
+#[tokio::test]
+async fn upsert_ssh_target_rejects_duplicate_alias_exact_and_nocase() {
+    let (_dir, store) = store().await;
+    let created = store
+        .upsert_ssh_target(ssh_target("remote-1", "audit-637-mac"))
+        .await
+        .unwrap();
+    assert_eq!(created.alias, "audit-637-mac");
+    assert_eq!(store.list_ssh_targets().await.unwrap().len(), 1);
+
+    let exact = store
+        .upsert_ssh_target(ssh_target("remote-2", "audit-637-mac"))
+        .await
+        .unwrap_err();
+    assert_duplicate_alias(exact, "audit-637-mac");
+
+    let nocase = store
+        .upsert_ssh_target(ssh_target("remote-3", "Audit-637-mac"))
+        .await
+        .unwrap_err();
+    assert_duplicate_alias(nocase, "Audit-637-mac");
+
+    assert_eq!(store.list_ssh_targets().await.unwrap().len(), 1);
+}
+
+#[tokio::test]
+async fn upsert_ssh_target_keeps_own_alias_and_accepts_a_free_alias() {
+    let (_dir, store) = store().await;
+    store
+        .upsert_ssh_target(ssh_target("remote-1", "audit-637-mac"))
+        .await
+        .unwrap();
+    store
+        .upsert_ssh_target(ssh_target("remote-2", "build-linux"))
+        .await
+        .unwrap();
+
+    let mut same = ssh_target("remote-1", "audit-637-mac");
+    same.host = "renamed.example.test".to_string();
+    let updated = store.upsert_ssh_target(same).await.unwrap();
+    assert_eq!(updated.host, "renamed.example.test");
+    assert_eq!(updated.alias, "audit-637-mac");
+
+    let mut own_case = ssh_target("remote-1", "AUDIT-637-MAC");
+    own_case.host = "renamed.example.test".to_string();
+    let recased = store.upsert_ssh_target(own_case).await.unwrap();
+    assert_eq!(recased.alias, "AUDIT-637-MAC");
+
+    let stolen = store
+        .upsert_ssh_target(ssh_target("remote-1", "build-linux"))
+        .await
+        .unwrap_err();
+    assert_duplicate_alias(stolen, "build-linux");
+}

--- a/rust/alera-core/src/runtime/store.rs
+++ b/rust/alera-core/src/runtime/store.rs
@@ -1375,6 +1375,22 @@ impl RuntimeStore {
     }
 
     pub async fn upsert_ssh_target(&self, target: SshTarget) -> Result<SshTarget> {
+        // Pre-check instead of relying on the unique index, so a duplicate alias
+        // reports the attempted alias rather than a SQLite error.
+        if sqlx::query(
+            "SELECT id FROM sshTargets WHERE alias = ? COLLATE NOCASE AND id <> ? LIMIT 1",
+        )
+        .bind(&target.alias)
+        .bind(&target.id)
+        .fetch_optional(&self.pool)
+        .await?
+        .is_some()
+        {
+            anyhow::bail!(RuntimeStoreError::Message(format!(
+                "ssh target alias already exists: {}",
+                target.alias
+            )));
+        }
         sqlx::query(
             "INSERT INTO sshTargets \
              (id, alias, host, port, username, platform, arch, authKind, createdAt, updatedAt, lastStatus, \

--- a/skills/alera-cli/SKILL.md
+++ b/skills/alera-cli/SKILL.md
@@ -257,12 +257,13 @@ List saved hosts, probe live connectivity, or remove a saved target. Status pers
 
 ```bash
 alera ssh-target --json list
+alera ssh-target --json add --alias build-mac --host mac.example.test --username leynier --auth agent
 alera ssh-target --json status
 alera ssh-target --json status --id <target-id>
 alera ssh-target --json remove --id <target-id>
 ```
 
-Unknown ids fail with `ssh target not found`. `status` without `--id` probes every saved target and returns a JSON array.
+Unknown ids fail with `ssh target not found`. Duplicate aliases, including different casing, fail with `ssh target alias already exists`. `status` without `--id` probes every saved target and returns a JSON array.
 
 ## Agent Profiles
 


### PR DESCRIPTION
## Summary

Creating an SSH target whose alias collides with an existing one (exact or case-insensitive) returned a raw SQLite UNIQUE constraint instead of a product error. `RuntimeStore::upsert_ssh_target` now pre-checks the NOCASE unique alias, excluding the current id, and fails with `ssh target alias already exists: <alias>` using the attempted alias. CLI `--json` errors stay on stderr with empty stdout, matching missing-id / not-found. Settings → Remote Hosts uses the same store/host path.

Closes #671

## Screenshots

No visual change.

## Testing

- [x] Added or updated tests that would catch regressions, or explained why tests were not needed
- `cargo test -p alera-core --features runtime ssh_target --offline`
- `cargo test -p alera-cli --test ssh_target_cli_conformance --offline`
- `cargo clippy -p alera-core --features runtime --all-targets --offline -- -D warnings`
- `cargo clippy -p alera-cli --all-targets --offline -- -D warnings`
- Dart/Flutter format, analyze, and tests (Rust CLI/store only)
- Golden tests (no UI change)
- Desktop E2E (no app-shell change)

## AI Review Report

Self-reviewed the diff before opening:

- Duplicate alias failure is in `RuntimeStore::upsert_ssh_target` via a NOCASE pre-check that excludes the current id, so both the direct CLI store path and `sshTarget.upsert` host RPC inherit `ssh target alias already exists: <alias>`.
- Exact and case-insensitive collisions fail; a free alias still creates; updating the same target keeps its own alias (including recasing).
- `--json` errors use `print_error` (stderr, exit 1, empty stdout), matching missing-id / not-found.
- CLI coverage runs both without a host and against a live runtime-host.

Cross-platform: this is SQLite uniqueness plus existing CLI/RPC error plumbing; no path, shell, or shortcut changes.

## Security Audit

Upsert still only writes the caller-supplied target. The change maps a uniqueness failure to a product error; it does not broaden write scope or change auth.

## Notes

- Demo waived (CLI/error mapping).
- Docs: `docs/remote-host-bootstrap.md` and `skills/alera-cli/SKILL.md` now document the duplicate-alias error.