### PR TITLE
fix: reject password ssh targets at add and bootstrap-plan

### DIFF
--- a/docs/remote-host-bootstrap.md
+++ b/docs/remote-host-bootstrap.md
@@ -6,7 +6,7 @@ Alera can register SSH targets in the Home Runtime and install the standalone `a
 
 ## Supported Targets
 
-Bootstrap supports `x64` and `arm64` macOS, Linux, and Windows hosts reachable through the local OpenSSH tools. Authentication is intentionally limited to SSH agent or key configuration in `~/.ssh/config`; password bootstrap is rejected. Platform and architecture can be saved on the target or overridden per bootstrap, otherwise Alera probes the remote host.
+Bootstrap supports `x64` and `arm64` macOS, Linux, and Windows hosts reachable through the local OpenSSH tools. Authentication is intentionally limited to SSH agent or key configuration in `~/.ssh/config`. Password authentication is rejected at add, upsert, `bootstrap-plan`, and bootstrap with `password SSH targets are not supported for bootstrap; configure SSH agent or key authentication.` Settings keeps Password listed but disabled for new targets. Platform and architecture can be saved on the target or overridden per bootstrap, otherwise Alera probes the remote host.
 
 Default install directories are:
 
@@ -35,6 +35,8 @@ Add a target. Duplicate aliases, including different casing, fail with `ssh targ
 alera ssh-target --json add --alias build-mac --host mac.example.test --username leynier --auth agent
 ```
 
+`--auth password` is rejected with the same product error as bootstrap and does not persist the target.
+
 Remove a saved target. Unknown ids fail with `ssh target not found`, matching `status` and `bootstrap-plan`:
 
 ```bash
@@ -48,7 +50,7 @@ alera ssh-target --json status
 alera ssh-target --json status --id <target-id>
 ```
 
-Preview a bootstrap:
+Preview a bootstrap. Password targets fail with the same product error as bootstrap:
 
 ```bash
 alera ssh-target --json bootstrap-plan --id <target-id>

--- a/rust/alera-cli/src/cli.rs
+++ b/rust/alera-cli/src/cli.rs
@@ -461,6 +461,9 @@ pub struct SshTargetAddArgs {
 
 #[derive(Debug, Clone, Copy, ValueEnum)]
 pub enum SshAuthKindArg {
+    /// Hidden so help does not advertise it; add still parses it and rejects
+    /// with the bootstrap product error.
+    #[value(hide = true)]
     Password,
     Key,
     Agent,

--- a/rust/alera-cli/src/main.rs
+++ b/rust/alera-cli/src/main.rs
@@ -86,7 +86,8 @@ use crate::mobile_access::{
 };
 use crate::runtime_host_client::RuntimeHostRpcClient;
 use crate::ssh_bootstrap::{
-    build_ssh_bootstrap_plan, new_bootstrap_job_id, run_ssh_bootstrap, SshTargetBootstrapRequest,
+    build_ssh_bootstrap_plan, new_bootstrap_job_id, reject_password_ssh_bootstrap_auth,
+    run_ssh_bootstrap, SshTargetBootstrapRequest,
 };
 use crate::ssh_target_status::{collect_ssh_target_status, LiveSshTargetProbe};
 use crate::tab_record_factory::tab_from_args;
@@ -630,6 +631,9 @@ async fn run_ssh_target_command(command: SshTargetCommand) -> i32 {
         },
         SshTargetAction::Add(args) => {
             let target = ssh_target_from_args(args);
+            if let Err(error) = reject_password_ssh_bootstrap_auth(target.auth_kind) {
+                return print_error(error);
+            }
             match upsert_ssh_target_from_cli(&runtime, target).await {
                 Ok(target) => print_value(&target, json_output, "ssh target saved"),
                 Err(error) => return print_error(error),

--- a/rust/alera-cli/src/ssh_bootstrap.rs
+++ b/rust/alera-cli/src/ssh_bootstrap.rs
@@ -81,6 +81,32 @@ pub(crate) struct SshTargetBootstrapProgress {
     pub error: Option<String>,
 }
 
+pub(crate) const SSH_PASSWORD_BOOTSTRAP_UNSUPPORTED: &str =
+    "password SSH targets are not supported for bootstrap; configure SSH agent or key authentication.";
+
+pub(crate) fn reject_password_ssh_bootstrap_auth(auth_kind: SshAuthKind) -> Result<()> {
+    if matches!(auth_kind, SshAuthKind::Password) {
+        bail!("{SSH_PASSWORD_BOOTSTRAP_UNSUPPORTED}");
+    }
+    Ok(())
+}
+
+/// Rejects creating a password target or converting agent/key auth to
+/// password. An existing password target may be re-saved so Settings can
+/// still edit alias or host without forcing a conversion on every save.
+pub(crate) fn reject_new_password_ssh_target(
+    auth_kind: SshAuthKind,
+    existing_auth_kind: Option<SshAuthKind>,
+) -> Result<()> {
+    if !matches!(auth_kind, SshAuthKind::Password) {
+        return Ok(());
+    }
+    if matches!(existing_auth_kind, Some(SshAuthKind::Password)) {
+        return Ok(());
+    }
+    bail!("{SSH_PASSWORD_BOOTSTRAP_UNSUPPORTED}");
+}
+
 #[derive(Debug)]
 struct RemoteCommandOutput {
     stdout: String,
@@ -95,6 +121,7 @@ pub(crate) async fn build_ssh_bootstrap_plan(
     request: &SshTargetBootstrapRequest,
 ) -> Result<SshTargetBootstrapPlan> {
     let target = find_target(store, &request.target_id).await?;
+    reject_password_ssh_bootstrap_auth(target.auth_kind)?;
     let channel = parse_channel(request.channel.as_deref())?;
     let platform = request
         .platform
@@ -164,9 +191,7 @@ where
 {
     let target = find_target(&store, &request.target_id).await?;
     let result = async {
-        if matches!(target.auth_kind, SshAuthKind::Password) {
-            bail!("password SSH targets are not supported for bootstrap; configure SSH agent or key authentication.");
-        }
+        reject_password_ssh_bootstrap_auth(target.auth_kind)?;
         mark_ssh_bootstrap_installing(&store, &target.id).await?;
         emit(progress(
             &job_id,

--- a/rust/alera-cli/src/ssh_bootstrap_tests.rs
+++ b/rust/alera-cli/src/ssh_bootstrap_tests.rs
@@ -270,3 +270,84 @@ fn truncate_error_handles_multibyte_text() {
     assert!(truncated.ends_with("..."));
     assert_eq!(truncated.trim_end_matches("...").chars().count(), 600);
 }
+
+#[test]
+fn password_auth_is_rejected_for_new_targets_and_allowed_for_legacy_resave() {
+    assert!(reject_password_ssh_bootstrap_auth(SshAuthKind::Agent).is_ok());
+    assert!(reject_password_ssh_bootstrap_auth(SshAuthKind::Key).is_ok());
+    assert_eq!(
+        reject_password_ssh_bootstrap_auth(SshAuthKind::Password)
+            .unwrap_err()
+            .to_string(),
+        SSH_PASSWORD_BOOTSTRAP_UNSUPPORTED
+    );
+    assert!(
+        reject_new_password_ssh_target(SshAuthKind::Password, Some(SshAuthKind::Password)).is_ok()
+    );
+    assert_eq!(
+        reject_new_password_ssh_target(SshAuthKind::Password, None)
+            .unwrap_err()
+            .to_string(),
+        SSH_PASSWORD_BOOTSTRAP_UNSUPPORTED
+    );
+    assert_eq!(
+        reject_new_password_ssh_target(SshAuthKind::Password, Some(SshAuthKind::Agent))
+            .unwrap_err()
+            .to_string(),
+        SSH_PASSWORD_BOOTSTRAP_UNSUPPORTED
+    );
+    assert!(reject_new_password_ssh_target(SshAuthKind::Agent, None).is_ok());
+}
+
+fn password_ssh_target(id: &str) -> SshTarget {
+    let now = chrono::Utc::now();
+    SshTarget {
+        id: id.to_string(),
+        alias: id.to_string(),
+        host: "192.168.1.66".to_string(),
+        port: 22,
+        username: "alera".to_string(),
+        platform: None,
+        arch: None,
+        auth_kind: SshAuthKind::Password,
+        created_at: now,
+        updated_at: now,
+        last_status: None,
+        install_dir: None,
+        runtime_version: None,
+        runtime_platform: None,
+        runtime_arch: None,
+        bootstrap_status: SshBootstrapStatus::NotInstalled,
+        last_bootstrap_at: None,
+        last_checked_at: None,
+        last_error: None,
+    }
+}
+
+fn empty_plan_request(target_id: &str) -> SshTargetBootstrapRequest {
+    SshTargetBootstrapRequest {
+        target_id: target_id.to_string(),
+        channel: None,
+        version: None,
+        install_dir: None,
+        platform: None,
+        arch: None,
+        archive_url: None,
+        archive_path: None,
+        artifact_path: None,
+        manifest_public_key: None,
+    }
+}
+
+#[tokio::test]
+async fn build_ssh_bootstrap_plan_rejects_password_target() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = RuntimeStore::open(dir.path()).await.unwrap();
+    let target = password_ssh_target("audit-674-pass");
+    store.upsert_ssh_target(target.clone()).await.unwrap();
+
+    let error = build_ssh_bootstrap_plan(&store, &empty_plan_request(&target.id))
+        .await
+        .unwrap_err();
+    assert_eq!(error.to_string(), SSH_PASSWORD_BOOTSTRAP_UNSUPPORTED);
+}

--- a/rust/alera-cli/src/terminal_host/server.rs
+++ b/rust/alera-cli/src/terminal_host/server.rs
@@ -5,8 +5,8 @@ use std::sync::{atomic::AtomicU64, Arc};
 use std::time::{Duration, Instant};
 
 use alera_core::runtime::{
-    prepare_private_runtime_directory, MobileAccessSettings, RuntimeStore, SshAuthKind,
-    SshBootstrapStatus, SshTarget,
+    prepare_private_runtime_directory, MobileAccessSettings, RuntimeStore, SshBootstrapStatus,
+    SshTarget,
 };
 use anyhow::Result;
 use serde_json::{json, Value};
@@ -18,8 +18,9 @@ use tokio::task::JoinHandle;
 
 use crate::agent_status::{start_agent_integrations, start_fx_herdr_receiver, start_hook_receiver};
 use crate::ssh_bootstrap::{
-    cancel_ssh_bootstrap, mark_ssh_bootstrap_installing, new_bootstrap_job_id, run_ssh_bootstrap,
-    SshTargetBootstrapJob, SshTargetBootstrapProgress, SshTargetBootstrapRequest,
+    cancel_ssh_bootstrap, mark_ssh_bootstrap_installing, new_bootstrap_job_id,
+    reject_password_ssh_bootstrap_auth, run_ssh_bootstrap, SshTargetBootstrapJob,
+    SshTargetBootstrapProgress, SshTargetBootstrapRequest,
 };
 use crate::terminal_host::client::{
     connection_loop, ClientFrame, ClientHandle, CLIENT_TERMINAL_OUT_QUEUE_CAPACITY,
@@ -899,11 +900,8 @@ impl ServerActor {
             .ok_or_else(|| {
                 HostError::state(format!("ssh target not found: {}", request.target_id))
             })?;
-        if matches!(target.auth_kind, SshAuthKind::Password) {
-            return Err(HostError::state(
-                "password SSH targets are not supported for bootstrap; configure SSH agent or key authentication.",
-            ));
-        }
+        reject_password_ssh_bootstrap_auth(target.auth_kind)
+            .map_err(|error| HostError::state(error.to_string()))?;
         let job_id = new_bootstrap_job_id();
         mark_ssh_bootstrap_installing(&self.runtime_store, &target.id)
             .await

--- a/rust/alera-cli/src/terminal_host/server/declared_catalog_requests.rs
+++ b/rust/alera-cli/src/terminal_host/server/declared_catalog_requests.rs
@@ -9,6 +9,7 @@ use chrono::Utc;
 use serde_json::{json, Value};
 use uuid::Uuid;
 
+use crate::ssh_bootstrap::reject_new_password_ssh_target;
 use crate::terminal_host::host_error::{HostError, HostResult};
 use crate::terminal_host::orchestration::agent_registry::{adapter_for, AGENT_ADAPTERS};
 use crate::terminal_host::orchestration::managed_agent_launch::build_managed_agent_launch;
@@ -31,15 +32,20 @@ impl ServerActor {
     pub(super) async fn ssh_target_upsert(&mut self, payload: &Value) -> HostResult<Value> {
         let mut target: SshTarget = serde_json::from_value(payload.clone())
             .map_err(|error| HostError::format(error.to_string()))?;
+        let existing = self
+            .runtime_store
+            .find_ssh_target(&target.id)
+            .await
+            .map_err(|error| HostError::state(error.to_string()))?;
+        reject_new_password_ssh_target(
+            target.auth_kind,
+            existing.as_ref().map(|existing| existing.auth_kind),
+        )
+        .map_err(|error| HostError::state(error.to_string()))?;
         // An omitted installDir means "leave it alone", not "clear it": the app
         // only sends it when the user edited the bootstrap location.
         if payload.get("installDir").is_none() {
-            if let Some(existing) = self
-                .runtime_store
-                .find_ssh_target(&target.id)
-                .await
-                .map_err(|error| HostError::state(error.to_string()))?
-            {
+            if let Some(existing) = existing {
                 target.install_dir = existing.install_dir;
             }
         }

--- a/rust/alera-cli/tests/ssh_target_cli_conformance.rs
+++ b/rust/alera-cli/tests/ssh_target_cli_conformance.rs
@@ -1,4 +1,5 @@
-//! CLI coverage for `alera ssh-target` missing-id and duplicate-alias errors.
+//! CLI coverage for `alera ssh-target` missing-id, duplicate-alias, and
+//! password-auth errors.
 
 mod agent_integration_home_isolation;
 
@@ -58,6 +59,60 @@ fn add_target_args<'a>(id: &'a str, alias: &'a str) -> [&'a str; 11] {
 
 fn add_target(runtime_dir: &Path, id: &str) -> Value {
     success_json(runtime_dir, &add_target_args(id, "Build Mac"))
+}
+
+const PASSWORD_BOOTSTRAP_UNSUPPORTED: &str =
+    "password SSH targets are not supported for bootstrap; configure SSH agent or key authentication.";
+
+fn password_add_args<'a>(id: &'a str, alias: &'a str) -> [&'a str; 11] {
+    [
+        "add",
+        "--id",
+        id,
+        "--alias",
+        alias,
+        "--host",
+        "192.168.1.66",
+        "--username",
+        "leynier",
+        "--auth",
+        "password",
+    ]
+}
+
+fn seed_password_target(runtime_dir: &Path, id: &str) {
+    let now = chrono::Utc::now();
+    let target = alera_core::runtime::SshTarget {
+        id: id.to_string(),
+        alias: id.to_string(),
+        host: "192.168.1.66".to_string(),
+        port: 22,
+        username: "leynier".to_string(),
+        platform: None,
+        arch: None,
+        auth_kind: alera_core::runtime::SshAuthKind::Password,
+        created_at: now,
+        updated_at: now,
+        last_status: None,
+        install_dir: None,
+        runtime_version: None,
+        runtime_platform: None,
+        runtime_arch: None,
+        bootstrap_status: Default::default(),
+        last_bootstrap_at: None,
+        last_checked_at: None,
+        last_error: None,
+    };
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+        .block_on(async {
+            let store = alera_core::runtime::RuntimeStore::open(runtime_dir)
+                .await
+                .unwrap();
+            store.upsert_ssh_target(target).await.unwrap();
+        });
 }
 
 fn assert_json_error(output: &Output, expected: &str) {
@@ -192,4 +247,49 @@ fn ssh_target_add_rejects_duplicate_alias_through_the_runtime_host() {
     let dir = tempfile::tempdir().unwrap();
     let _host = spawn_host(dir.path());
     reject_duplicate_aliases(dir.path());
+}
+
+fn reject_password_add(runtime_dir: &Path) {
+    let output = run_ssh_target(
+        runtime_dir,
+        &password_add_args("audit-674-pass", "audit-674-pass"),
+    );
+    assert_json_error(&output, PASSWORD_BOOTSTRAP_UNSUPPORTED);
+
+    let listed = success_json(runtime_dir, &["list"]);
+    assert_eq!(listed["items"], json!([]));
+}
+
+fn reject_password_bootstrap_plan(runtime_dir: &Path) {
+    seed_password_target(runtime_dir, "audit-674-pass");
+    let output = run_ssh_target(runtime_dir, &["bootstrap-plan", "--id", "audit-674-pass"]);
+    assert_json_error(&output, PASSWORD_BOOTSTRAP_UNSUPPORTED);
+}
+
+#[test]
+fn ssh_target_add_rejects_password_auth_through_the_store() {
+    let dir = tempfile::tempdir().unwrap();
+    reject_password_add(dir.path());
+}
+
+#[test]
+fn ssh_target_add_rejects_password_auth_through_the_runtime_host() {
+    let dir = tempfile::tempdir().unwrap();
+    let _host = spawn_host(dir.path());
+    reject_password_add(dir.path());
+}
+
+#[test]
+fn ssh_target_bootstrap_plan_rejects_password_auth_through_the_store() {
+    let dir = tempfile::tempdir().unwrap();
+    reject_password_bootstrap_plan(dir.path());
+}
+
+#[test]
+fn ssh_target_bootstrap_plan_rejects_password_auth_through_the_runtime_host() {
+    let dir = tempfile::tempdir().unwrap();
+    seed_password_target(dir.path(), "audit-674-pass");
+    let _host = spawn_host(dir.path());
+    let output = run_ssh_target(dir.path(), &["bootstrap-plan", "--id", "audit-674-pass"]);
+    assert_json_error(&output, PASSWORD_BOOTSTRAP_UNSUPPORTED);
 }

--- a/rust/alera-cli/tests/terminal_host_conformance.rs
+++ b/rust/alera-cli/tests/terminal_host_conformance.rs
@@ -272,6 +272,27 @@ fn ssh_target_payload(id: &str, bootstrap_status: &str) -> Value {
     })
 }
 
+const PASSWORD_BOOTSTRAP_UNSUPPORTED: &str =
+    "password SSH targets are not supported for bootstrap; configure SSH agent or key authentication.";
+
+fn seed_ssh_target(runtime_dir: &std::path::Path, payload: Value) {
+    let target: alera_core::runtime::SshTarget =
+        serde_json::from_value(payload).expect("ssh target payload");
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+        .block_on(async {
+            let store = alera_core::runtime::RuntimeStore::open(runtime_dir)
+                .await
+                .expect("open runtime store");
+            store
+                .upsert_ssh_target(target)
+                .await
+                .expect("seed ssh target");
+        });
+}
+
 fn fake_blocking_ssh_path(root: &std::path::Path) -> String {
     let bin_dir = root.join("fake-bin");
     std::fs::create_dir_all(&bin_dir).unwrap();
@@ -899,10 +920,10 @@ fn runtime_bootstrap_start_rejects_missing_target_before_job() {
 }
 
 #[test]
-fn runtime_bootstrap_start_rejects_password_target_before_job() {
+fn runtime_ssh_target_upsert_rejects_password_auth() {
     let dir = tempfile::tempdir().unwrap();
     let control_path = dir.path().join("runtime-host.json");
-    let token = "ssh-password-token";
+    let token = "ssh-password-upsert-token";
     let (_guard, port) = spawn_host(dir.path(), &control_path, token);
     let (mut writer, mut reader) = connect(port);
     handshake(&mut writer, &mut reader, token);
@@ -917,13 +938,154 @@ fn runtime_bootstrap_start_rejects_password_target_before_job() {
             "payload": target
         }),
     );
-    let saved = read_response(&mut reader, 1);
-    assert_eq!(saved["ok"], json!(true), "upsert failed: {saved}");
+    let response = read_response(&mut reader, 1);
+    assert_eq!(
+        response["ok"],
+        json!(false),
+        "password upsert should fail: {response}"
+    );
+    assert_eq!(
+        response["error"].as_str(),
+        Some(PASSWORD_BOOTSTRAP_UNSUPPORTED),
+        "error should match bootstrap: {response}"
+    );
+
+    send(
+        &mut writer,
+        json!({"id": 2, "type": "sshTarget.list", "payload": {}}),
+    );
+    let listed = read_response(&mut reader, 2);
+    assert_eq!(listed["ok"], json!(true), "list failed: {listed}");
+    assert_eq!(listed["payload"], json!([]));
 
     send(
         &mut writer,
         json!({
-            "id": 2,
+            "id": 3,
+            "type": "sshTarget.upsert",
+            "payload": ssh_target_payload("remote-agent", "notInstalled")
+        }),
+    );
+    let saved = read_response(&mut reader, 3);
+    assert_eq!(saved["ok"], json!(true), "agent upsert failed: {saved}");
+
+    let mut converted = ssh_target_payload("remote-agent", "notInstalled");
+    converted["authKind"] = json!("password");
+    send(
+        &mut writer,
+        json!({
+            "id": 4,
+            "type": "sshTarget.upsert",
+            "payload": converted
+        }),
+    );
+    let converted_response = read_response(&mut reader, 4);
+    assert_eq!(
+        converted_response["ok"],
+        json!(false),
+        "converting to password should fail: {converted_response}"
+    );
+    assert_eq!(
+        converted_response["error"].as_str(),
+        Some(PASSWORD_BOOTSTRAP_UNSUPPORTED),
+        "conversion error should match bootstrap: {converted_response}"
+    );
+
+    send(
+        &mut writer,
+        json!({"id": 5, "type": "sshTarget.list", "payload": {}}),
+    );
+    let listed = read_response(&mut reader, 5);
+    assert_eq!(listed["ok"], json!(true), "list failed: {listed}");
+    assert_eq!(listed["payload"][0]["id"], json!("remote-agent"));
+    assert_eq!(listed["payload"][0]["authKind"], json!("agent"));
+}
+
+#[test]
+fn runtime_ssh_target_upsert_keeps_existing_password_target() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut target = ssh_target_payload("remote-password", "notInstalled");
+    target["authKind"] = json!("password");
+    seed_ssh_target(dir.path(), target.clone());
+
+    let control_path = dir.path().join("runtime-host.json");
+    let token = "ssh-password-legacy-token";
+    let (_guard, port) = spawn_host(dir.path(), &control_path, token);
+    let (mut writer, mut reader) = connect(port);
+    handshake(&mut writer, &mut reader, token);
+
+    target["alias"] = json!("Renamed Password");
+    send(
+        &mut writer,
+        json!({
+            "id": 1,
+            "type": "sshTarget.upsert",
+            "payload": target
+        }),
+    );
+    let saved = read_response(&mut reader, 1);
+    assert_eq!(
+        saved["ok"],
+        json!(true),
+        "legacy password upsert failed: {saved}"
+    );
+    assert_eq!(saved["payload"]["authKind"], json!("password"));
+    assert_eq!(saved["payload"]["alias"], json!("Renamed Password"));
+}
+
+#[test]
+fn runtime_bootstrap_plan_rejects_password_target() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut target = ssh_target_payload("remote-password", "notInstalled");
+    target["authKind"] = json!("password");
+    seed_ssh_target(dir.path(), target);
+
+    let control_path = dir.path().join("runtime-host.json");
+    let token = "ssh-password-plan-token";
+    let (_guard, port) = spawn_host(dir.path(), &control_path, token);
+    let (mut writer, mut reader) = connect(port);
+    handshake(&mut writer, &mut reader, token);
+
+    send(
+        &mut writer,
+        json!({
+            "id": 1,
+            "type": "sshTarget.bootstrap.plan",
+            "payload": {
+                "targetId": "remote-password"
+            }
+        }),
+    );
+    let response = read_response(&mut reader, 1);
+    assert_eq!(
+        response["ok"],
+        json!(false),
+        "bootstrap-plan should fail: {response}"
+    );
+    assert_eq!(
+        response["error"].as_str(),
+        Some(PASSWORD_BOOTSTRAP_UNSUPPORTED),
+        "error should match bootstrap: {response}"
+    );
+}
+
+#[test]
+fn runtime_bootstrap_start_rejects_password_target_before_job() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut target = ssh_target_payload("remote-password", "notInstalled");
+    target["authKind"] = json!("password");
+    seed_ssh_target(dir.path(), target);
+
+    let control_path = dir.path().join("runtime-host.json");
+    let token = "ssh-password-token";
+    let (_guard, port) = spawn_host(dir.path(), &control_path, token);
+    let (mut writer, mut reader) = connect(port);
+    handshake(&mut writer, &mut reader, token);
+
+    send(
+        &mut writer,
+        json!({
+            "id": 1,
             "type": "sshTarget.bootstrap.start",
             "payload": {
                 "targetId": "remote-password",
@@ -933,24 +1095,23 @@ fn runtime_bootstrap_start_rejects_password_target_before_job() {
             }
         }),
     );
-    let response = read_response(&mut reader, 2);
+    let response = read_response(&mut reader, 1);
     assert_eq!(
         response["ok"],
         json!(false),
         "bootstrap should fail: {response}"
     );
-    assert!(
-        response["error"]
-            .as_str()
-            .is_some_and(|error| error.contains("password SSH targets are not supported")),
+    assert_eq!(
+        response["error"].as_str(),
+        Some(PASSWORD_BOOTSTRAP_UNSUPPORTED),
         "error should explain the unsupported auth: {response}"
     );
 
     send(
         &mut writer,
-        json!({"id": 3, "type": "sshTarget.bootstrap.jobs", "payload": {}}),
+        json!({"id": 2, "type": "sshTarget.bootstrap.jobs", "payload": {}}),
     );
-    let jobs = read_response(&mut reader, 3);
+    let jobs = read_response(&mut reader, 2);
     assert_eq!(jobs["ok"], json!(true), "jobs failed: {jobs}");
     assert_eq!(jobs["payload"], json!([]));
 }


### PR DESCRIPTION
## Summary

Password SSH auth is not supported for bootstrap. Settings already disables Password as a new choice, but the CLI still accepted `--auth password` and `bootstrap-plan` still returned a plan whose first step was key/agent validation. Only `bootstrap` failed.

This PR rejects password at add/upsert (CLI and host) with the same product error bootstrap uses, and fails `bootstrap-plan` the same way so a password target is not persisted or planned for bootstrap. Settings still lists Password as disabled for new targets. Existing password targets can be re-saved so alias/host edits keep working; plan and bootstrap still fail.

Closes #674.

## Screenshots

No visual change.

## Testing

- [x] Added or updated tests that would catch regressions, or explained why tests were not needed
- [x] `cargo test -p alera-cli --bin alera --test ssh_target_cli_conformance --test terminal_host_conformance password`
- [x] `cargo fmt --all` on the Rust workspace
- [x] `cargo clippy -p alera-cli --bin alera -- -D warnings`
- [x] `cargo clippy -p alera-cli --tests -- -D warnings`
- Golden tests: no UI layout change
- Desktop E2E: no app-shell flow change
- Demo waived (AC 5)

## AI Review Report

Self-reviewed the diff before opening:

- CLI `ssh-target add --auth password` fails before persist (store path and runtime-host path).
- Host `sshTarget.upsert` rejects new password targets and agent/key-to-password conversions with the bootstrap product error.
- `bootstrap-plan` (CLI, host, and `build_ssh_bootstrap_plan`) uses the same error string as bootstrap.
- Settings Password row is unchanged: listed, `enabled: false` for new selections.
- Legacy password rows can still be re-saved from Settings; they are not newly creatable through add/upsert.

Cross-platform: auth-kind validation is the same on macOS, Linux, and Windows. No path, shell, or shortcut changes.

## Security Audit

New password SSH targets are no longer persisted through CLI add or host upsert. The store still allows seeding/reading already-persisted password rows so plan/bootstrap can fail with the product error instead of a missing-target error. No new command execution, credentials, or process spawn.

## Notes

- Demo waived; CI+QA HARD.
- `AGENTS.md` was left unchanged: operator-facing behavior is in `docs/remote-host-bootstrap.md`.