### PR TITLE
fix: refuse hand on when live git head diverges from metadata

### DIFF
--- a/rust/alera-cli/src/managed_workspace_handoff.rs
+++ b/rust/alera-cli/src/managed_workspace_handoff.rs
@@ -108,16 +108,7 @@ pub async fn hand_on_managed_workspace(
         .await?
         .ok_or_else(|| anyhow!("Project not found: {}", child.project_id))?;
     let mut main = find_main_workspace(store, &project.id).await?;
-    let branch = child
-        .branch
-        .as_deref()
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .ok_or_else(|| anyhow!("Child workspace has no branch to bring onto main"))?
-        .to_string();
-    if branch == "HEAD" {
-        bail!("Cannot hand on a detached HEAD");
-    }
+    let branch = require_live_child_branch(&child)?;
     if !core_git::is_worktree_clean(&main.path)? {
         bail!("The main worktree has local changes. Commit, stash, or discard them before handing on.");
     }
@@ -309,6 +300,23 @@ fn filesystem_entry_is_missing(path: &str) -> bool {
         std::fs::symlink_metadata(path),
         Err(error) if error.kind() == std::io::ErrorKind::NotFound
     )
+}
+
+fn require_live_child_branch(child: &Workspace) -> Result<String> {
+    let live = core_git::current_branch(&child.path)?;
+    if live == "HEAD" {
+        bail!("Cannot hand on a detached HEAD");
+    }
+    let expected = child
+        .branch
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| anyhow!("Child workspace has no branch to bring onto main"))?;
+    if expected != live {
+        bail!("Workspace branch does not match live worktree: expected {expected}, found {live}");
+    }
+    Ok(live)
 }
 
 fn require_trimmed(value: &str, message: &str) -> Result<String> {

--- a/rust/alera-cli/src/managed_workspace_handoff_tests.rs
+++ b/rust/alera-cli/src/managed_workspace_handoff_tests.rs
@@ -255,6 +255,116 @@ async fn hand_on_rejects_a_dirty_main_worktree() {
     assert!(worktree_path.exists());
 }
 
+#[tokio::test]
+async fn hand_on_rejects_stale_metadata_when_child_checkout_moved() {
+    let fixture = Fixture::new().await;
+    let worktree_path = fixture.child_path("stale-child");
+    let created = hand_off_managed_workspace(
+        &fixture.store,
+        ManagedWorkspaceHandOffRequest {
+            id: "main".to_string(),
+            branch: "feat/stale-meta".to_string(),
+            name: Some("Stale Meta".to_string()),
+            reuse_existing_branch: false,
+            workspace_root: None,
+            path: Some(worktree_path.to_string_lossy().into_owned()),
+            defer_setup: false,
+            setup_script_directory: None,
+        },
+    )
+    .await
+    .unwrap();
+    run_git(&worktree_path, &["checkout", "-b", "feat/live-head"]);
+    std::fs::write(worktree_path.join("only-on-live.txt"), "do-not-move\n").unwrap();
+
+    let error = hand_on_managed_workspace(
+        &fixture.store,
+        ManagedWorkspaceHandOnRequest {
+            id: created.workspace.id.clone(),
+            close_sessions: true,
+            active_workspace_id: None,
+        },
+    )
+    .await
+    .unwrap_err()
+    .to_string();
+
+    assert!(error.to_lowercase().contains("does not match"), "{error}");
+    assert!(error.contains("feat/stale-meta"), "{error}");
+    assert!(error.contains("feat/live-head"), "{error}");
+    assert_eq!(
+        git::current_branch(worktree_path.to_str().unwrap()).unwrap(),
+        "feat/live-head"
+    );
+    assert_eq!(
+        std::fs::read_to_string(worktree_path.join("only-on-live.txt")).unwrap(),
+        "do-not-move\n"
+    );
+    assert!(!fixture.repo.join("only-on-live.txt").exists());
+    assert_eq!(
+        git::current_branch(fixture.repo.to_str().unwrap()).unwrap(),
+        "main"
+    );
+    assert!(worktree_path.exists());
+    assert!(fixture
+        .store
+        .find_workspace(&created.workspace.id)
+        .await
+        .unwrap()
+        .is_some());
+}
+
+#[tokio::test]
+async fn hand_on_rejects_a_detached_child_head() {
+    let fixture = Fixture::new().await;
+    let worktree_path = fixture.child_path("detached-child");
+    let created = hand_off_managed_workspace(
+        &fixture.store,
+        ManagedWorkspaceHandOffRequest {
+            id: "main".to_string(),
+            branch: "feat/detached".to_string(),
+            name: Some("Detached".to_string()),
+            reuse_existing_branch: false,
+            workspace_root: None,
+            path: Some(worktree_path.to_string_lossy().into_owned()),
+            defer_setup: false,
+            setup_script_directory: None,
+        },
+    )
+    .await
+    .unwrap();
+    run_git(&worktree_path, &["checkout", "--detach"]);
+
+    let error = hand_on_managed_workspace(
+        &fixture.store,
+        ManagedWorkspaceHandOnRequest {
+            id: created.workspace.id.clone(),
+            close_sessions: true,
+            active_workspace_id: None,
+        },
+    )
+    .await
+    .unwrap_err()
+    .to_string();
+
+    assert!(error.to_lowercase().contains("detached"), "{error}");
+    assert_eq!(
+        git::current_branch(worktree_path.to_str().unwrap()).unwrap(),
+        "HEAD"
+    );
+    assert_eq!(
+        git::current_branch(fixture.repo.to_str().unwrap()).unwrap(),
+        "main"
+    );
+    assert!(worktree_path.exists());
+    assert!(fixture
+        .store
+        .find_workspace(&created.workspace.id)
+        .await
+        .unwrap()
+        .is_some());
+}
+
 struct Fixture {
     store: RuntimeStore,
     repo: PathBuf,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #707.

## Summary

Hand on now reads the child worktree's live branch via `current_branch(&child.path)` instead of trusting workspace metadata alone. It fails closed before stashing when HEAD is detached or the live branch does not match `child.branch`. Dirty work from a mutated checkout is therefore never applied onto the stale metadata tip.

Hand off is unchanged.

## Screenshots

No visual change.

## Testing

- [x] Focused `alera-cli` cargo tests for managed workspace handoff: `cargo test -p alera-cli --bin alera managed_workspace_handoff` (8 passed, including `hand_on_rejects_stale_metadata_when_child_checkout_moved` and `hand_on_rejects_a_detached_child_head`)
- [ ] `dart format --set-exit-if-changed lib test integration_test tool` (not applicable: Rust-only)
- [ ] `flutter analyze` (not applicable)
- [ ] `flutter test --coverage --exclude-tags golden` (not applicable)
- [ ] `dart run tool/quality/coverage_report.dart --input coverage/lcov.info --min-lines 100 --worst 25` (not applicable)
- [ ] Golden tests, if UI changed: `flutter test --tags golden` (not applicable)
- [ ] Desktop E2E, if app-shell flow changed: `flutter test integration_test -d macos` (not applicable)
- [ ] Relevant desktop build: `flutter build macos`, `flutter build windows`, or `flutter build linux` (not applicable)
- [ ] Landing build, if applicable: `cd landing && bun run build` (not applicable)
- [x] Added or updated tests that would catch regressions, or explained why tests were not needed

## AI Review Report

Checked fail-closed ordering: live `current_branch` and metadata mismatch run before stash, so a mutated child checkout cannot move dirty files onto the stale metadata tip. Detached HEAD is refused with the existing product error. Hand off still uses live HEAD on main only and was not changed.

Cross-platform: git2 `current_branch` is already used by hand off on macOS, Linux, and Windows. This path uses the same helper.

## Security Audit

No new command execution, path handling, auth, secrets, or process spawn. Branch identity is read from the existing git2 `current_branch` helper on the already-validated child worktree path.

## Notes

Matches `prepare_managed_workspace_removal`, which already refuses when the live worktree branch disagrees with the store. Metadata is not rewritten to follow a silent checkout change; hand on refuses instead.

No `AGENTS.md` or CLI skill update: hand on still brings the child's current work onto main, and the new behavior is a fail-closed error on stale metadata or detached HEAD.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8f0aff52-0df5-43de-af78-08b3061b8ae9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8f0aff52-0df5-43de-af78-08b3061b8ae9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

