### PR TITLE
fix: rewrite linux /home install dirs on macos ssh bootstrap

### DIFF
--- a/docs/remote-host-bootstrap.md
+++ b/docs/remote-host-bootstrap.md
@@ -15,6 +15,8 @@ Default install directories are:
 
 The POSIX default is the sidecar layout (`current/`, `bin/`, `versions/`, `data/`). It is separate from the CLI runtime profile (`ALERA_RUNTIME_DIR` or `~/.alera/runtime`). The install directory can be overridden from Settings or the CLI.
 
+Quote `~/...` in the shell so the local Home Runtime does not expand it before Alera sees the path. Absolute install directories are checked against the detected remote platform: a Linux `/home/...` path is rewritten to `/Users/...` on macOS (where `/home` is autofs), and POSIX home paths are rejected on Windows. Bootstrap errors keep the real path for debugging and redact credentials only.
+
 ## Artifact Trust
 
 Release bootstrap uses a signed runtime archive from GitHub Releases. The archive lists each `alera-runtime-<version>-<platform>-<arch>.tar.gz` artifact with SHA-256 and size metadata, and the archive itself is signed with the same Ed25519 manifest key used by desktop update indexes. A release build passes that public key to the runtime host sidecar through `ALERA_RUNTIME_ARCHIVE_PUBLIC_KEY`.

--- a/rust/alera-cli/src/ssh_bootstrap.rs
+++ b/rust/alera-cli/src/ssh_bootstrap.rs
@@ -3,8 +3,8 @@ use std::process::Stdio;
 
 use alera_core::child_process::windowless_async_command;
 use alera_core::runtime::{
-    RuntimeStore, SshAuthKind, SshBootstrapStatus, SshTarget, SshTargetBootstrapStateUpdate,
-    SshTargetLastStatus,
+    redact_known_patterns, RuntimeStore, SshAuthKind, SshBootstrapStatus, SshTarget,
+    SshTargetBootstrapStateUpdate, SshTargetLastStatus,
 };
 use anyhow::{anyhow, bail, Context, Result};
 use base64::prelude::*;
@@ -16,6 +16,10 @@ use crate::runtime_archive::{
     resolve_runtime_artifact, ResolvedRuntimeArtifact, RuntimeArchiveChannel,
     RuntimeArtifactRequest, RuntimeArtifactTrust,
 };
+
+#[path = "ssh_bootstrap_install_dir.rs"]
+mod ssh_bootstrap_install_dir;
+use ssh_bootstrap_install_dir::{local_home_dir, prepare_remote_install_dir};
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -137,11 +141,15 @@ pub(crate) async fn build_ssh_bootstrap_plan(
         .or(target.runtime_arch.as_deref())
         .map(normalize_arch)
         .unwrap_or_else(|| "auto".to_string());
-    let install_dir = request
-        .install_dir
-        .clone()
-        .or(target.install_dir.clone())
-        .unwrap_or_else(|| default_install_dir(&platform));
+    let install_dir = prepare_remote_install_dir(
+        &platform,
+        request
+            .install_dir
+            .as_deref()
+            .or(target.install_dir.as_deref())
+            .unwrap_or(""),
+        local_home_dir().as_deref(),
+    )?;
     let local_override = request.artifact_path.is_some();
     Ok(SshTargetBootstrapPlan {
         target_id: target.id,
@@ -215,7 +223,7 @@ where
     match result {
         Ok(target) => Ok(target),
         Err(error) => {
-            let redacted = redact_error(&error.to_string(), &target);
+            let redacted = redact_error(&error.to_string());
             let _ = store
                 .update_ssh_target_bootstrap_state(
                     &target.id,
@@ -297,11 +305,15 @@ where
     if !matches!(arch.as_str(), "x64" | "arm64") {
         bail!("unsupported remote architecture: {arch}");
     }
-    let install_dir_input = request
-        .install_dir
-        .clone()
-        .or(target.install_dir.clone())
-        .unwrap_or_else(|| default_install_dir(&platform));
+    let install_dir_input = prepare_remote_install_dir(
+        &platform,
+        request
+            .install_dir
+            .as_deref()
+            .or(target.install_dir.as_deref())
+            .unwrap_or(""),
+        local_home_dir().as_deref(),
+    )?;
     let install_dir = resolve_remote_install_dir(&target, &platform, &install_dir_input).await?;
 
     let installing = store
@@ -1045,12 +1057,11 @@ fn progress(
     }
 }
 
-fn redact_error(message: &str, target: &SshTarget) -> String {
-    truncate_error(
-        &message
-            .replace(&target.host, "<host>")
-            .replace(&target.username, "<user>"),
-    )
+fn redact_error(message: &str) -> String {
+    // Keep real paths such as `/home/leynier` so mkdir failures stay
+    // diagnosable. Replacing the SSH username used to turn that into
+    // `/home/<user>`, which looked like a template bug. See #675.
+    truncate_error(&redact_known_patterns(message))
 }
 
 fn truncate_error(message: &str) -> String {

--- a/rust/alera-cli/src/ssh_bootstrap_install_dir.rs
+++ b/rust/alera-cli/src/ssh_bootstrap_install_dir.rs
@@ -1,0 +1,138 @@
+use anyhow::{bail, Result};
+
+use super::default_install_dir;
+
+pub(super) fn local_home_dir() -> Option<String> {
+    dirs::home_dir().map(|path| path.to_string_lossy().into_owned())
+}
+
+/// Rewrites or rejects an install dir that is not valid on `platform`.
+///
+/// Local-shell `~` expansion (Linux `/home/<user>/...`, macOS `/Users/<user>/...`)
+/// is folded back to `~/...` for POSIX remotes so the remote home is used.
+/// Remaining Linux `/home/...` paths are rewritten to `/Users/...` on macOS
+/// because `/home` is autofs there. See #675.
+pub(super) fn prepare_remote_install_dir(
+    platform: &str,
+    install_dir: &str,
+    local_home: Option<&str>,
+) -> Result<String> {
+    let trimmed = install_dir.trim();
+    if trimmed.is_empty() {
+        return Ok(default_install_dir(platform));
+    }
+    let candidate = if platform == "windows" {
+        trimmed.to_string()
+    } else {
+        rewrite_local_home_to_tilde(trimmed, local_home)
+    };
+    match platform {
+        "windows" => prepare_windows_install_dir(trimmed),
+        "macos" => prepare_macos_install_dir(&candidate),
+        "linux" => prepare_linux_install_dir(&candidate),
+        _ => Ok(candidate),
+    }
+}
+
+fn rewrite_local_home_to_tilde(install_dir: &str, local_home: Option<&str>) -> String {
+    let Some(home) = local_home.map(str::trim).filter(|value| !value.is_empty()) else {
+        return install_dir.to_string();
+    };
+    if is_tilde_path(install_dir) {
+        return install_dir.to_string();
+    }
+    let home = posix_slashes(home).trim_end_matches('/').to_string();
+    let dir = posix_slashes(install_dir);
+    let dir_trimmed = dir.trim_end_matches('/');
+    if dir_trimmed == home {
+        return "~".to_string();
+    }
+    match dir_trimmed.strip_prefix(&format!("{home}/")) {
+        Some(rest) if !rest.is_empty() => format!("~/{rest}"),
+        Some(_) => "~".to_string(),
+        None => install_dir.to_string(),
+    }
+}
+
+fn prepare_macos_install_dir(install_dir: &str) -> Result<String> {
+    if looks_like_windows_path(install_dir) {
+        bail!(
+            "install directory {install_dir} is not valid on macOS; use ~/.alera/sidecar or a path under /Users."
+        );
+    }
+    if looks_like_linux_home_path(install_dir) {
+        return rewrite_linux_home_prefix_to_macos(install_dir);
+    }
+    Ok(install_dir.to_string())
+}
+
+fn prepare_linux_install_dir(install_dir: &str) -> Result<String> {
+    if looks_like_windows_path(install_dir) {
+        bail!(
+            "install directory {install_dir} is not valid on Linux; use ~/.alera/sidecar or an absolute POSIX path."
+        );
+    }
+    Ok(install_dir.to_string())
+}
+
+fn prepare_windows_install_dir(install_dir: &str) -> Result<String> {
+    if is_tilde_path(install_dir)
+        || looks_like_linux_home_path(install_dir)
+        || looks_like_macos_users_path(install_dir)
+    {
+        bail!(
+            "install directory {install_dir} is not valid on Windows; use %LOCALAPPDATA%\\Alera\\runtime or an absolute Windows path."
+        );
+    }
+    Ok(install_dir.to_string())
+}
+
+fn rewrite_linux_home_prefix_to_macos(install_dir: &str) -> Result<String> {
+    let trimmed = posix_slashes(install_dir).trim_end_matches('/').to_string();
+    if trimmed == "/home" {
+        bail!("{}", macos_linux_home_error(install_dir));
+    }
+    let Some(rest) = trimmed.strip_prefix("/home/") else {
+        return Ok(install_dir.to_string());
+    };
+    Ok(format!("/Users/{rest}"))
+}
+
+fn macos_linux_home_error(install_dir: &str) -> String {
+    format!(
+        "install directory {install_dir} uses the Linux home prefix /home, which is autofs on macOS; use ~/.alera/sidecar or a path under /Users."
+    )
+}
+
+fn is_tilde_path(value: &str) -> bool {
+    value == "~" || value.starts_with("~/")
+}
+
+fn looks_like_linux_home_path(install_dir: &str) -> bool {
+    let trimmed = posix_slashes(install_dir).trim_end_matches('/').to_string();
+    trimmed == "/home" || trimmed.starts_with("/home/")
+}
+
+fn looks_like_macos_users_path(install_dir: &str) -> bool {
+    let trimmed = posix_slashes(install_dir).trim_end_matches('/').to_string();
+    trimmed == "/Users" || trimmed.starts_with("/Users/")
+}
+
+fn looks_like_windows_path(install_dir: &str) -> bool {
+    let normalized = posix_slashes(install_dir);
+    if normalized.to_ascii_uppercase().contains("%LOCALAPPDATA%")
+        || normalized.to_ascii_uppercase().contains("%USERPROFILE%")
+    {
+        return true;
+    }
+    let without_leading = normalized.trim_start_matches('/');
+    let mut chars = without_leading.chars();
+    matches!(
+        (chars.next(), chars.next()),
+        (Some(drive), Some(':')) if drive.is_ascii_alphabetic()
+    )
+}
+
+fn posix_slashes(value: &str) -> String {
+    value.replace('\\', "/")
+}

--- a/rust/alera-cli/src/ssh_bootstrap_tests.rs
+++ b/rust/alera-cli/src/ssh_bootstrap_tests.rs
@@ -455,15 +455,10 @@ async fn build_ssh_bootstrap_plan_rewrites_linux_home_on_macos_target() {
     let mut request = empty_plan_request(&target.id);
     request.install_dir = Some("/home/leynier/.alera/audit-637-home-probe".to_string());
     let plan = build_ssh_bootstrap_plan(&store, &request).await.unwrap();
+    // Avoid formatting install_dir into assert messages (CodeQL cleartext-logging FP on username paths).
     assert!(
         plan.install_dir == "~/.alera/audit-637-home-probe"
-            || plan.install_dir == "/Users/leynier/.alera/audit-637-home-probe",
-        "plan install_dir should be remote-home relative or /Users, got {}",
-        plan.install_dir
+            || plan.install_dir == "/Users/leynier/.alera/audit-637-home-probe"
     );
-    assert!(
-        !plan.install_dir.starts_with("/home/"),
-        "Linux /home must not reach a macOS target: {}",
-        plan.install_dir
-    );
+    assert!(!plan.install_dir.starts_with("/home/"));
 }

--- a/rust/alera-cli/src/ssh_bootstrap_tests.rs
+++ b/rust/alera-cli/src/ssh_bootstrap_tests.rs
@@ -263,6 +263,96 @@ printf '%s\n' "$install_dir"
 }
 
 #[test]
+fn prepare_rewrites_linux_home_expansion_to_tilde_for_macos() {
+    let resolved = prepare_remote_install_dir(
+        "macos",
+        "/home/leynier/.alera/audit-637-home-probe",
+        Some("/home/leynier"),
+    )
+    .unwrap();
+    assert_eq!(resolved, "~/.alera/audit-637-home-probe");
+}
+
+#[test]
+fn prepare_rewrites_explicit_linux_home_to_users_on_macos() {
+    let resolved = prepare_remote_install_dir(
+        "macos",
+        "/home/leynier/.alera/audit-637-home-probe",
+        Some("/var/empty"),
+    )
+    .unwrap();
+    assert_eq!(resolved, "/Users/leynier/.alera/audit-637-home-probe");
+}
+
+#[test]
+fn prepare_rejects_linux_home_root_on_macos() {
+    let error = prepare_remote_install_dir("macos", "/home", Some("/var/empty"))
+        .unwrap_err()
+        .to_string();
+    assert!(error.contains("autofs"), "{error}");
+    assert!(error.contains("/Users"), "{error}");
+    assert!(!error.contains("<user>"), "{error}");
+}
+
+#[test]
+fn prepare_does_not_treat_homebrew_as_linux_home_on_macos() {
+    let resolved =
+        prepare_remote_install_dir("macos", "/homebrew/opt/alera", Some("/home/leynier")).unwrap();
+    assert_eq!(resolved, "/homebrew/opt/alera");
+}
+
+#[test]
+fn prepare_keeps_quoted_tilde_install_dir_on_macos() {
+    let resolved =
+        prepare_remote_install_dir("macos", "~/.alera/sidecar", Some("/home/leynier")).unwrap();
+    assert_eq!(resolved, "~/.alera/sidecar");
+}
+
+#[test]
+fn prepare_folds_macos_home_expansion_to_tilde_for_linux() {
+    let resolved = prepare_remote_install_dir(
+        "linux",
+        "/Users/leynier/.alera/sidecar",
+        Some("/Users/leynier"),
+    )
+    .unwrap();
+    assert_eq!(resolved, "~/.alera/sidecar");
+}
+
+#[test]
+fn prepare_rejects_linux_home_on_windows() {
+    let error = prepare_remote_install_dir(
+        "windows",
+        "/home/leynier/.alera/sidecar",
+        Some("/home/leynier"),
+    )
+    .unwrap_err()
+    .to_string();
+    assert!(error.contains("not valid on Windows"), "{error}");
+    assert!(error.contains("/home/leynier/.alera/sidecar"), "{error}");
+}
+
+#[test]
+fn redact_error_keeps_real_linux_home_path() {
+    let redacted = redact_error("ssh failed: mkdir: /home/leynier: Operation not supported");
+    assert!(redacted.contains("/home/leynier"), "{redacted}");
+    assert!(!redacted.contains("/home/<user>"), "{redacted}");
+    assert!(!redacted.contains("<user>"), "{redacted}");
+    assert!(!redacted.contains("<host>"), "{redacted}");
+}
+
+#[test]
+fn redact_error_redacts_credentials_only() {
+    let redacted = redact_error(
+        "ssh failed: mkdir: /home/leynier/.alera token=super-secret-value sk-secretvalue",
+    );
+    assert!(redacted.contains("/home/leynier/.alera"), "{redacted}");
+    assert!(!redacted.contains("super-secret-value"), "{redacted}");
+    assert!(!redacted.contains("sk-secretvalue"), "{redacted}");
+    assert!(redacted.contains("[redacted]"), "{redacted}");
+}
+
+#[test]
 fn truncate_error_handles_multibyte_text() {
     let message = "falló ".repeat(200);
     let truncated = truncate_error(&message);
@@ -350,4 +440,30 @@ async fn build_ssh_bootstrap_plan_rejects_password_target() {
         .await
         .unwrap_err();
     assert_eq!(error.to_string(), SSH_PASSWORD_BOOTSTRAP_UNSUPPORTED);
+}
+
+#[tokio::test]
+async fn build_ssh_bootstrap_plan_rewrites_linux_home_on_macos_target() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = RuntimeStore::open(dir.path()).await.unwrap();
+    let mut target = password_ssh_target("audit-675-macos");
+    target.auth_kind = SshAuthKind::Agent;
+    target.platform = Some("macos".to_string());
+    target.username = "leynier".to_string();
+    store.upsert_ssh_target(target.clone()).await.unwrap();
+
+    let mut request = empty_plan_request(&target.id);
+    request.install_dir = Some("/home/leynier/.alera/audit-637-home-probe".to_string());
+    let plan = build_ssh_bootstrap_plan(&store, &request).await.unwrap();
+    assert!(
+        plan.install_dir == "~/.alera/audit-637-home-probe"
+            || plan.install_dir == "/Users/leynier/.alera/audit-637-home-probe",
+        "plan install_dir should be remote-home relative or /Users, got {}",
+        plan.install_dir
+    );
+    assert!(
+        !plan.install_dir.starts_with("/home/"),
+        "Linux /home must not reach a macOS target: {}",
+        plan.install_dir
+    );
 }


### PR DESCRIPTION
## Summary

SSH bootstrap to macOS was sending Linux `/home/<user>/...` (from local `~` expansion or an explicit path) to `mkdir`. macOS `/home` is autofs, so that fails with `Operation not supported`. `redact_error` then replaced the username and turned `/home/leynier` into `/home/<user>`, which looked like a template bug.

This PR prepares the install dir against the detected remote platform before the remote mkdir:

- Local-shell `~` expansion under the current home is folded back to `~/...` for POSIX remotes so the remote home is used.
- Remaining Linux `/home/...` paths are rewritten to `/Users/...` on macOS.
- POSIX home paths are rejected on Windows.
- Bootstrap errors keep the real path and redact credentials only (`redact_known_patterns`).

Closes #675.

## Screenshots

No visual change.

## Testing

- [x] Added or updated tests that would catch regressions, or explained why tests were not needed
- [x] `cargo test --manifest-path rust/Cargo.toml -p alera-cli --bin alera -- ssh_bootstrap::tests` (25 passed)
- [x] `cargo fmt --manifest-path rust/Cargo.toml -p alera-cli`
- [x] `cargo clippy --manifest-path rust/Cargo.toml -p alera-cli --all-targets -- -D warnings`
- Golden tests: no UI layout change
- Desktop E2E: no app-shell flow change
- Demo waived (AC 5)

## AI Review Report

Self-reviewed the diff before opening:

- `prepare_remote_install_dir` runs in both `bootstrap-plan` and bootstrap after platform is known, so the plan preview matches what will be mkdir'd.
- `/homebrew/...` is not treated as a Linux home prefix.
- Quoted `~/...` is left for remote expansion (distinct from #666).
- Username/host are no longer substituted in bootstrap errors; `token=` / `sk-` still redact.

Cross-platform: path rewrite/reject is explicit for macOS, Linux, and Windows. No shortcut or updater changes.

## Security Audit

Error redaction no longer masks the SSH username or host. That is intentional so `/home/leynier` stays diagnosable. Credentials still go through `redact_known_patterns`. No new process spawn, auth, or credential storage.

## Notes

- Demo waived; CI+QA HARD.
- Distinct from #666 (tilde-join) and #669 (default install dir).
- `AGENTS.md` was left unchanged: operator-facing behavior is in `docs/remote-host-bootstrap.md`.