### PR TITLE
fix: align branch switcher cursor with busy state

### DIFF
--- a/lib/src/features/workbench/presentation/workspace_git_diff_panel_toolbar.dart
+++ b/lib/src/features/workbench/presentation/workspace_git_diff_panel_toolbar.dart
@@ -305,6 +305,9 @@ class const _SourceControlBranchSummary({
           child: Tooltip(
             message: 'Switch Branch',
             child: InkWell(
+              mouseCursor: busy
+                  ? SystemMouseCursors.basic
+                  : SystemMouseCursors.click,
               onTap: busy ? null : onSelectBranch,
               borderRadius: BorderRadius.circular(AleraTokens.radiusMd),
               child: Padding(

--- a/test/widget/workspace_git_diff_panel_branch_test_cases.dart
+++ b/test/widget/workspace_git_diff_panel_branch_test_cases.dart
@@ -11,6 +11,14 @@ void _registerWorkspaceGitDiffPanelBranchTests() {
     await _pumpPanel(tester, backend: backend);
     await tester.pumpAndSettle();
 
+    final branchInkWell = tester.widget<InkWell>(
+      find.descendant(
+        of: find.byTooltip('Switch Branch'),
+        matching: find.byType(InkWell),
+      ),
+    );
+    expect(branchInkWell.mouseCursor, SystemMouseCursors.click);
+
     expect(find.byTooltip('Switch Branch'), findsOneWidget);
     await tester.tap(find.byTooltip('Switch Branch'));
     await tester.pumpAndSettle();
@@ -124,4 +132,39 @@ void _registerWorkspaceGitDiffPanelBranchTests() {
     );
     expect(find.text('ship/login'), findsWidgets);
   });
+
+  testWidgets('source control branch control uses basic cursor when busy', (
+    tester,
+  ) async {
+    final backend = FakeGitBackend()
+      ..gitRepositoryStateResult = const GitRepositoryState(branch: 'main');
+
+    await _pumpPanel(
+      tester,
+      backend: backend,
+      sourceControlController: _BusyWorkspaceSourceControlController.new,
+    );
+    await tester.pumpAndSettle();
+
+    final branchInkWell = tester.widget<InkWell>(
+      find.descendant(
+        of: find.byTooltip('Switch Branch'),
+        matching: find.byType(InkWell),
+      ),
+    );
+    expect(branchInkWell.mouseCursor, SystemMouseCursors.basic);
+  });
+}
+
+class _BusyWorkspaceSourceControlController
+    extends WorkspaceSourceControlController {
+  @override
+  Future<WorkspaceSourceControlState> build(String workspacePath) async {
+    return const WorkspaceSourceControlState(
+      status: GitStatusResult(entries: <GitChangeEntry>[]),
+      repositoryState: GitRepositoryState(branch: 'main'),
+      stashes: <GitStashEntry>[],
+      action: WorkspaceSourceControlAction.refresh,
+    );
+  }
 }

--- a/test/widget/workspace_git_diff_panel_test.dart
+++ b/test/widget/workspace_git_diff_panel_test.dart
@@ -1444,8 +1444,11 @@ Future<void> _pumpPanel(
   ValueChanged<String>? onOpenFile,
   ValueChanged<String>? onRevealInExplorer,
   VoidCallback? onClearSourceControlRoot,
+  WorkspaceSourceControlController Function()? sourceControlController,
 }) {
   final resolvedWorkspace = workspace ?? _workspace();
+  final resolvedScope =
+      sourceControlScope ?? _sourceControlScope(resolvedWorkspace);
   return tester.pumpWidget(
     ProviderScope(
       overrides: [
@@ -1457,6 +1460,9 @@ Future<void> _pumpPanel(
           () => _PanelSettingsController(settings),
         ),
         if (service != null) aiAssistServiceProvider.overrideWithValue(service),
+        if (sourceControlController != null)
+          workspaceSourceControlControllerProvider(resolvedScope.path)
+              .overrideWith(sourceControlController),
       ],
       child: MaterialApp(
         home: Scaffold(
@@ -1465,8 +1471,7 @@ Future<void> _pumpPanel(
             height: 520,
             child: WorkspaceGitDiffPanel(
               workspace: resolvedWorkspace,
-              sourceControlScope:
-                  sourceControlScope ?? _sourceControlScope(resolvedWorkspace),
+              sourceControlScope: resolvedScope,
               viewMode: viewMode,
               onViewModeChanged: (_) {},
               groupMode: groupMode,


### PR DESCRIPTION
## what changed
- updated `workspace_git_diff_panel_toolbar.dart` so the branch switch `InkWell` now sets `mouseCursor` to `SystemMouseCursors.click` only when branch switching is available and `SystemMouseCursors.basic` when `busy` is true.
- updated `workspace_git_diff_panel_branch_test_cases.dart` to verify cursor behavior:
  - branch switch control uses pointer cursor in normal state.
  - branch switch control uses basic cursor while source control is busy.
  - added `_BusyWorkspaceSourceControlController` fixture to force the panel into a busy-like state for test coverage.
- updated `workspace_git_diff_panel_test.dart` test wiring to support injecting a custom `WorkspaceSourceControlController` in `_pumpPanel` and to reuse a resolved control scope consistently.

## why
- the branch switcher is non-interactive while busy, so it should not show a clickable pointer cursor.
- this change keeps hover affordances consistent with action availability and avoids misleading UI feedback.
- added regression tests lock in the new behavior so future edits preserve cursor semantics in both active and busy states.