### PR TITLE
fix: preserve source control filename width

### DIFF
--- a/lib/src/features/workbench/presentation/workbench_scrollable_actions.dart
+++ b/lib/src/features/workbench/presentation/workbench_scrollable_actions.dart
@@ -1,22 +1,20 @@
 import 'package:flutter/material.dart';
 
-/// Trailing toolbar or row actions that scroll instead of overflowing a
-/// narrow parent [Row]. Must be a direct child of that [Row].
+/// Trailing toolbar or row actions sized to their intrinsic width so a
+/// sibling [Expanded] can use the rest of the parent [Row].
+///
+/// Must be a direct child of that [Row]. If this widget receives a bounded
+/// max width smaller than the actions, they scroll horizontally.
 class const WorkbenchScrollableActions({
   super.key,
   required final List<Widget> children,
 }) extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return Flexible(
-      child: Align(
-        alignment: .centerRight,
-        child: SingleChildScrollView(
-          scrollDirection: Axis.horizontal,
-          reverse: true,
-          child: Row(mainAxisSize: .min, children: children),
-        ),
-      ),
+    return SingleChildScrollView(
+      scrollDirection: Axis.horizontal,
+      reverse: true,
+      child: Row(mainAxisSize: .min, children: children),
     );
   }
 }

--- a/test/widget/workbench_scrollable_actions_test.dart
+++ b/test/widget/workbench_scrollable_actions_test.dart
@@ -1,0 +1,72 @@
+import 'package:alera/src/features/workbench/presentation/workbench_scrollable_actions.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('leaves leftover row width to the expanded sibling', (
+    tester,
+  ) async {
+    const label = 'lib/src/features/projects/application/projects_service.dart';
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: SizedBox(
+            width: 640,
+            height: 40,
+            child: Row(
+              children: <Widget>[
+                Expanded(
+                  child: Text(
+                    label,
+                    maxLines: 1,
+                    overflow: .ellipsis,
+                    style: TextStyle(fontSize: 8),
+                  ),
+                ),
+                WorkbenchScrollableActions(
+                  children: <Widget>[SizedBox(width: 80, child: Text('M'))],
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final row = tester.getRect(find.byType(Row).first);
+    expect(tester.getSize(find.text(label)).width, closeTo(560, 0.5));
+    expect(
+      tester.renderObject<RenderParagraph>(find.text(label)).didExceedMaxLines,
+      isFalse,
+    );
+    expect(tester.getRect(find.text('M')).right, closeTo(row.right, 0.5));
+  });
+
+  testWidgets(
+    'scrolls trailing actions when they exceed the incoming max width',
+    (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: SizedBox(
+              width: 80,
+              height: 40,
+              child: WorkbenchScrollableActions(
+                children: <Widget>[
+                  SizedBox(width: 60, child: Text('A')),
+                  SizedBox(width: 60, child: Text('B')),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+
+      expect(tester.takeException(), isNull);
+      expect(tester.getSize(find.byType(WorkbenchScrollableActions)).width, 80);
+      expect(find.text('A'), findsOneWidget);
+      expect(find.text('B'), findsOneWidget);
+    },
+  );
+}

--- a/test/widget/workspace_git_diff_panel_test.dart
+++ b/test/widget/workspace_git_diff_panel_test.dart
@@ -1427,6 +1427,38 @@ void main() {
       },
     );
   });
+
+  testWidgets('flat file rows use leftover width before ellipsizing paths', (
+    tester,
+  ) async {
+    const path = 'lib/src/features/projects/application/projects_service.dart';
+    final backend = FakeGitBackend()
+      ..gitRepositoryStateResult = const GitRepositoryState(
+        branch: 'main',
+        upstream: 'origin/main',
+      )
+      ..gitStatusResult = const GitStatusResult(
+        entries: <GitChangeEntry>[
+          GitChangeEntry(
+            path: path,
+            area: .unstaged,
+            status: .modified,
+            added: 2,
+            removed: 0,
+          ),
+        ],
+      );
+
+    await _pumpPanel(tester, backend: backend, width: 720);
+    await tester.pumpAndSettle();
+
+    final pathFinder = find.text(path);
+    expect(pathFinder, findsOneWidget);
+    final pathRect = tester.getRect(pathFinder);
+    final statusRect = tester.getRect(find.text('M'));
+    expect(pathRect.width, greaterThan(360));
+    expect(statusRect.left - pathRect.right, lessThan(32));
+  });
 }
 
 Future<void> _pumpPanel(
@@ -1445,6 +1477,7 @@ Future<void> _pumpPanel(
   ValueChanged<String>? onRevealInExplorer,
   VoidCallback? onClearSourceControlRoot,
   WorkspaceSourceControlController Function()? sourceControlController,
+  double width = 420,
 }) {
   final resolvedWorkspace = workspace ?? _workspace();
   final resolvedScope =
@@ -1467,7 +1500,7 @@ Future<void> _pumpPanel(
       child: MaterialApp(
         home: Scaffold(
           body: SizedBox(
-            width: 420,
+            width: width,
             height: 520,
             child: WorkspaceGitDiffPanel(
               workspace: resolvedWorkspace,


### PR DESCRIPTION
Adjust trailing source control actions to use intrinsic width while allowing horizontal scrolling when constrained. This gives sibling filename labels the remaining row width before ellipsizing.

Add widget coverage for expanded-row sizing and oversized action scrolling, plus an integration test confirming wider filename rendering in the Git diff panel.