### PR TITLE
feat: show tool icons in add tab menu

### DIFF
--- a/lib/src/features/workbench/presentation/experimental_workspace_panel_menus.dart
+++ b/lib/src/features/workbench/presentation/experimental_workspace_panel_menus.dart
@@ -308,10 +308,20 @@ class const _ExperimentalPanelAddButton({
           AleraDropdownEntry(
             value: _ExperimentalAddToolMenuAction(tool.key),
             label: tool.label,
+            leading: Icon(
+              _iconForTool(tool),
+              size: AleraTokens.iconLg,
+              color: AleraTokens.foregroundMuted,
+            ),
           ),
         const AleraDropdownEntry(
           value: _ExperimentalAddTerminalMenuAction(),
           label: 'Terminal',
+          leading: Icon(
+            AleraIcons.terminal,
+            size: AleraTokens.iconLg,
+            color: AleraTokens.foregroundMuted,
+          ),
         ),
         for (final profile in profiles)
           if (profile.showInNewTabMenu)
@@ -321,7 +331,7 @@ class const _ExperimentalPanelAddButton({
               leading: AgentIdentityIcon(
                 agentType:
                     AgentType.tryParse(profile.agentType) ?? AgentType.codex,
-                size: 16,
+                size: AleraTokens.iconLg,
                 showTooltip: false,
               ),
             ),

--- a/test/widget/experimental_workspace_panel_profiles_test.dart
+++ b/test/widget/experimental_workspace_panel_profiles_test.dart
@@ -1,3 +1,4 @@
+import 'package:alera/src/design_system/icons/alera_icons.dart';
 import 'package:alera/src/features/agent_profiles/domain/agent_profile.dart';
 import 'package:alera/src/features/workbench/domain/experimental_workspace_panel.dart';
 import 'package:alera/src/features/workbench/presentation/experimental_workspace_panel_view.dart';
@@ -63,6 +64,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('Terminal'), findsOneWidget);
+    expect(find.byIcon(AleraIcons.terminal), findsOneWidget);
     expect(find.text('Shown Codex'), findsOneWidget);
     expect(find.text('Hidden Codex'), findsNothing);
     expect(

--- a/test/widget/experimental_workspace_panel_view_test.dart
+++ b/test/widget/experimental_workspace_panel_view_test.dart
@@ -1,3 +1,4 @@
+import 'package:alera/src/design_system/icons/alera_icons.dart';
 import 'package:alera/src/design_system/menus/alera_dropdown_entry.dart';
 import 'package:alera/src/features/workbench/domain/experimental_workspace_panel.dart';
 import 'package:alera/src/features/workbench/domain/workbench_layout.dart';
@@ -169,6 +170,52 @@ void main() {
       find.byWidgetPredicate((w) => w is AleraDropdownEntry),
       findsNWidgets(3),
     );
+  });
+
+  testWidgets('add tab menu shows icons for tools and Terminal', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Align(
+            alignment: Alignment.topLeft,
+            child: SizedBox(
+              width: 800,
+              height: 500,
+              child: ExperimentalWorkspacePanelView(
+                panel: const ExperimentalWorkspacePanel(
+                  tabKeys: ['tool:explorer'],
+                  activeKey: 'tool:explorer',
+                ),
+                tabs: const [],
+                onSelect: (_) {},
+                onClose: (_) {},
+                onNewTerminal: () {},
+                onHide: () {},
+                content: const Text('Selected Surface'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.tap(find.byTooltip('Add Tab'));
+    await tester.pumpAndSettle();
+
+    Finder menuIcon(IconData icon) {
+      return find.descendant(
+        of: find.byWidgetPredicate((widget) => widget is AleraDropdownEntry),
+        matching: find.byIcon(icon),
+      );
+    }
+
+    expect(menuIcon(AleraIcons.search), findsOneWidget);
+    expect(menuIcon(AleraIcons.gitBranch), findsOneWidget);
+    expect(menuIcon(AleraIcons.gitPullRequest), findsOneWidget);
+    expect(menuIcon(AleraIcons.terminal), findsOneWidget);
+    expect(menuIcon(AleraIcons.folder), findsNothing);
   });
 
   testWidgets('add tab pins beside Hide Panel when the strip overflows', (


### PR DESCRIPTION
Add icons for tools, Terminal, and agent profiles in the workspace add-tab menu. Standardize icon sizing and add widget coverage to verify supported tool icons are displayed while hidden tools remain excluded.