### PR TITLE
feat: embed manual workspace form in creation dialog

### DIFF
--- a/lib/src/features/workbench/presentation/create_workspace_dialog.dart
+++ b/lib/src/features/workbench/presentation/create_workspace_dialog.dart
@@ -65,6 +65,7 @@ class const CreateWorkspaceDialog({
   final String? initialHostId,
   final bool initialReuseExistingBranch = false,
   final String? initialCreationError,
+  final bool embedded = false,
 }) extends StatefulWidget {
   @override
   State<CreateWorkspaceDialog> createState() => _CreateWorkspaceDialogState();
@@ -454,6 +455,7 @@ class _CreateWorkspaceDialogState extends State<CreateWorkspaceDialog> {
     final selectedProject = _selectedProject;
     if (widget.projects.isEmpty) {
       return _EmptyProjectsDialog(
+        embedded: widget.embedded,
         onAddProject: widget.onAddProject,
         onCancel: () => Navigator.of(context).pop(),
       );
@@ -511,6 +513,7 @@ class _CreateWorkspaceDialogState extends State<CreateWorkspaceDialog> {
           );
 
     return _CreateWorkspaceDialogFrame(
+      embedded: widget.embedded,
       isSelectionStep: isSelectionStep,
       creating: _creating,
       creationError: _creationError,

--- a/lib/src/features/workbench/presentation/create_workspace_dialog_frame.dart
+++ b/lib/src/features/workbench/presentation/create_workspace_dialog_frame.dart
@@ -3,34 +3,36 @@ part of 'create_workspace_dialog.dart';
 class const _EmptyProjectsDialog({
   required final VoidCallback? onAddProject,
   required final VoidCallback onCancel,
+  final bool embedded = false,
 }) extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return AleraDialog(
-      maxWidth: 440,
-      child: Padding(
-        padding: const EdgeInsets.all(AleraTokens.space24),
-        child: Column(
-          mainAxisSize: .min,
-          children: [
-            AleraEmptyState(
-              icon: AleraIcons.folderOff,
-              title: 'No Git projects yet',
-              message: 'Linked workspaces require a Git project. Add one to get started.',
-              action: onAddProject != null
-                  ? FilledButton.icon(
-                      onPressed: onAddProject,
-                      icon: const Icon(AleraIcons.add, size: 16),
-                      label: const Text('Add Git Project'),
-                    )
-                  : null,
-            ),
-            const SizedBox(height: AleraTokens.space8),
-            TextButton(onPressed: onCancel, child: const Text('Cancel')),
-          ],
-        ),
+    final content = Padding(
+      padding: EdgeInsets.all(embedded ? 0 : AleraTokens.space24),
+      child: Column(
+        mainAxisSize: .min,
+        children: [
+          AleraEmptyState(
+            icon: AleraIcons.folderOff,
+            title: 'No Git projects yet',
+            message: 'Linked workspaces require a Git project. Add one to get started.',
+            action: onAddProject != null
+                ? FilledButton.icon(
+                    onPressed: onAddProject,
+                    icon: const Icon(AleraIcons.add, size: 16),
+                    label: const Text('Add Git Project'),
+                  )
+                : null,
+          ),
+          const SizedBox(height: AleraTokens.space8),
+          TextButton(onPressed: onCancel, child: const Text('Cancel')),
+        ],
       ),
     );
+    if (embedded) {
+      return content;
+    }
+    return AleraDialog(maxWidth: 440, child: content);
   }
 }
 
@@ -45,72 +47,78 @@ class const _CreateWorkspaceDialogFrame({
   required final VoidCallback onBack,
   required final VoidCallback? onContinue,
   required final VoidCallback? onCreate,
+  final bool embedded = false,
 }) extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
+    final content = Column(
+      mainAxisSize: .min,
+      crossAxisAlignment: .start,
+      children: <Widget>[
+        _CreateWorkspaceDialogHeader(
+          isSelectionStep: isSelectionStep,
+          creating: creating,
+          onBack: onBack,
+          embedded: embedded,
+        ),
+        const SizedBox(height: AleraTokens.space16),
+        if (creationError case final error?) ...[
+          _CreateWorkspaceError(message: error),
+          const SizedBox(height: AleraTokens.space12),
+        ],
+        Flexible(
+          child: AnimatedSwitcher(
+            duration: AleraTokens.durationMid,
+            transitionBuilder: (child, animation) {
+              return FadeTransition(
+                opacity: animation,
+                child: SlideTransition(
+                  position: Tween<Offset>(
+                    begin: const Offset(0.05, 0.0),
+                    end: .zero,
+                  ).animate(animation),
+                  child: child,
+                ),
+              );
+            },
+            child: KeyedSubtree(
+              key: ValueKey(isSelectionStep ? 'step1' : 'step2'),
+              child: SingleChildScrollView(child: step),
+            ),
+          ),
+        ),
+        const SizedBox(height: AleraTokens.space16),
+        if (!isSelectionStep) ...<Widget>[
+          Align(
+            alignment: Alignment.centerLeft,
+            child: AleraCheckbox(
+              value: createAnother,
+              enabled: !creating,
+              onChanged: onCreateAnotherChanged,
+              label: 'Create Another',
+            ),
+          ),
+          const SizedBox(height: AleraTokens.space8),
+        ],
+        _CreateWorkspaceDialogActions(
+          isSelectionStep: isSelectionStep,
+          creating: creating,
+          onCancel: onCancel,
+          onBack: onBack,
+          onContinue: onContinue,
+          onCreate: onCreate,
+        ),
+      ],
+    );
+    if (embedded) {
+      return content;
+    }
     return AleraDialog(
       maxWidth: isSelectionStep ? 680 : 560,
       maxHeight: 740,
       child: Padding(
         padding: const EdgeInsets.all(AleraTokens.space20),
-        child: Column(
-          mainAxisSize: .min,
-          crossAxisAlignment: .start,
-          children: <Widget>[
-            _CreateWorkspaceDialogHeader(
-              isSelectionStep: isSelectionStep,
-              creating: creating,
-              onBack: onBack,
-            ),
-            const SizedBox(height: AleraTokens.space16),
-            if (creationError case final error?) ...[
-              _CreateWorkspaceError(message: error),
-              const SizedBox(height: AleraTokens.space12),
-            ],
-            Flexible(
-              child: AnimatedSwitcher(
-                duration: AleraTokens.durationMid,
-                transitionBuilder: (child, animation) {
-                  return FadeTransition(
-                    opacity: animation,
-                    child: SlideTransition(
-                      position: Tween<Offset>(
-                        begin: const Offset(0.05, 0.0),
-                        end: .zero,
-                      ).animate(animation),
-                      child: child,
-                    ),
-                  );
-                },
-                child: KeyedSubtree(
-                  key: ValueKey(isSelectionStep ? 'step1' : 'step2'),
-                  child: SingleChildScrollView(child: step),
-                ),
-              ),
-            ),
-            const SizedBox(height: AleraTokens.space16),
-            if (!isSelectionStep) ...<Widget>[
-              Align(
-                alignment: Alignment.centerLeft,
-                child: AleraCheckbox(
-                  value: createAnother,
-                  enabled: !creating,
-                  onChanged: onCreateAnotherChanged,
-                  label: 'Create Another',
-                ),
-              ),
-              const SizedBox(height: AleraTokens.space8),
-            ],
-            _CreateWorkspaceDialogActions(
-              isSelectionStep: isSelectionStep,
-              creating: creating,
-              onCancel: onCancel,
-              onBack: onBack,
-              onContinue: onContinue,
-              onCreate: onCreate,
-            ),
-          ],
-        ),
+        child: content,
       ),
     );
   }
@@ -120,6 +128,7 @@ class const _CreateWorkspaceDialogHeader({
   required final bool isSelectionStep,
   required final bool creating,
   required final VoidCallback onBack,
+  final bool embedded = false,
 }) extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
@@ -136,8 +145,10 @@ class const _CreateWorkspaceDialogHeader({
           ),
           const SizedBox(width: AleraTokens.space12),
         ],
-        const Icon(AleraIcons.gitFork, color: AleraTokens.accent),
-        const SizedBox(width: AleraTokens.space8),
+        if (!embedded) ...[
+          const Icon(AleraIcons.gitFork, color: AleraTokens.accent),
+          const SizedBox(width: AleraTokens.space8),
+        ],
         Expanded(
           child: Text(
             isSelectionStep

--- a/lib/src/features/workbench/presentation/create_workspace_dialog_submission.dart
+++ b/lib/src/features/workbench/presentation/create_workspace_dialog_submission.dart
@@ -102,6 +102,8 @@ extension _CreateWorkspaceDialogSubmission on _CreateWorkspaceDialogState {
       if (_createAnother) {
         widget.onWorkspaceCreated?.call(result);
         _resetAfterCreation(project);
+      } else if (widget.embedded) {
+        Navigator.of(context).pop();
       } else {
         Navigator.of(context).pop(result);
       }

--- a/lib/src/features/workbench/presentation/prompt_workspace_dialog.dart
+++ b/lib/src/features/workbench/presentation/prompt_workspace_dialog.dart
@@ -35,7 +35,6 @@ enum NewWorkspaceMode { fromPrompt, manual }
 class const PromptWorkspaceDialogResult({
   final WorkspaceCreationResult? creation,
   final String? agentTabId,
-  final bool openManual = false,
 });
 
 class const PromptWorkspaceDialog({
@@ -90,6 +89,8 @@ class const PromptWorkspaceDialog({
   final String? initialParentWorkspaceId,
   final String? initialHostId,
   final String? initialError,
+  final NewWorkspaceMode initialMode = .fromPrompt,
+  final Widget? manualForm,
 }) extends StatefulWidget {
   @override
   State<PromptWorkspaceDialog> createState() => _PromptWorkspaceDialogState();
@@ -118,6 +119,7 @@ class _PromptWorkspaceDialogState extends State<PromptWorkspaceDialog> {
   @override
   void initState() {
     super.initState();
+    _mode = widget.initialMode;
     _project = _initialProject();
     final restoringRetry =
         widget.initialError != null || widget.initialPrompt != null;

--- a/lib/src/features/workbench/presentation/prompt_workspace_dialog_shell.dart
+++ b/lib/src/features/workbench/presentation/prompt_workspace_dialog_shell.dart
@@ -3,8 +3,8 @@ part of 'prompt_workspace_dialog.dart';
 extension _PromptWorkspaceDialogShell on _PromptWorkspaceDialogState {
   Widget _buildShell(ThemeData theme) {
     return AleraDialog(
-      maxWidth: 620,
-      maxHeight: 720,
+      maxWidth: 680,
+      maxHeight: 740,
       child: Padding(
         padding: const EdgeInsets.all(AleraTokens.space20),
         child: Column(
@@ -52,37 +52,12 @@ extension _PromptWorkspaceDialogShell on _PromptWorkspaceDialogState {
             ),
             const SizedBox(height: AleraTokens.space20),
             if (_mode == NewWorkspaceMode.manual)
-              _buildManualMode(theme)
+              Flexible(child: widget.manualForm ?? const SizedBox.shrink())
             else
               _buildPromptMode(theme),
           ],
         ),
       ),
-    );
-  }
-
-  Widget _buildManualMode(ThemeData theme) {
-    return Column(
-      mainAxisSize: .min,
-      crossAxisAlignment: .start,
-      children: <Widget>[
-        Text(
-          'Choose every workspace setting yourself, including the branch name and optional parent workspace.',
-          style: theme.textTheme.bodyMedium?.copyWith(
-            color: AleraTokens.foregroundMuted,
-          ),
-        ),
-        const SizedBox(height: AleraTokens.space24),
-        Align(
-          alignment: Alignment.centerRight,
-          child: FilledButton(
-            onPressed: () =>
-                Navigator.of(context)
-                    .pop(const PromptWorkspaceDialogResult(openManual: true)),
-            child: const Text('Continue Manually'),
-          ),
-        ),
-      ],
     );
   }
 }

--- a/lib/src/features/workbench/presentation/workbench_dialog_launchers_create_workspace.dart
+++ b/lib/src/features/workbench/presentation/workbench_dialog_launchers_create_workspace.dart
@@ -104,21 +104,6 @@ Future<void> _showCreateWorkspaceDialogs(
   String? remainingRetryJobId,
 }) async {
   var boundJobId = remainingRetryJobId;
-  if (retryManual != null) {
-    await _showManualWorkspaceDialog(
-      context,
-      ref,
-      controller: controller,
-      projects: projects,
-      parentCandidates: parentCandidates,
-      sshTargets: sshTargets,
-      resolvedInitialProject: resolvedInitialProject,
-      retryManual: retryManual,
-      retryError: retryError,
-      retryJobId: boundJobId,
-    );
-    return;
-  }
   final promptResult = await showDialog<PromptWorkspaceDialogResult>(
     context: context,
     builder: (_) => PromptWorkspaceDialog(
@@ -134,6 +119,32 @@ Future<void> _showCreateWorkspaceDialogs(
       initialParentWorkspaceId: retryPrompt?.parentWorkspaceId,
       initialHostId: retryPrompt?.hostId,
       initialError: retryPrompt == null ? null : retryError,
+      initialMode: retryManual != null
+          ? NewWorkspaceMode.manual
+          : NewWorkspaceMode.fromPrompt,
+      manualForm: _buildManualWorkspaceForm(
+        context,
+        ref,
+        controller: controller,
+        projects: projects,
+        parentCandidates: parentCandidates,
+        sshTargets: sshTargets,
+        resolvedInitialProject: resolvedInitialProject,
+        retryManual: retryManual,
+        retryError: retryError,
+        enqueueCreate: (request) {
+          boundJobId ??= const Uuid().v4();
+          final done = ref
+              .read(backgroundSetupJobsProvider.notifier)
+              .enqueueManualWorkspace(request, jobId: boundJobId);
+          if (done == null) {
+            return null;
+          }
+          return done.then((_) {
+            boundJobId = const Uuid().v4();
+          });
+        },
+      ),
       enqueuePrompt: (request) {
         boundJobId ??= const Uuid().v4();
         final done = ref
@@ -202,34 +213,19 @@ Future<void> _showCreateWorkspaceDialogs(
     return;
   }
 
-  WorkspaceCreationResult? result = promptResult.creation;
-  if (promptResult.openManual) {
-    result = await _showManualWorkspaceDialog(
-      context,
-      ref,
-      controller: controller,
-      projects: projects,
-      parentCandidates: parentCandidates,
-      sshTargets: sshTargets,
-      resolvedInitialProject: resolvedInitialProject,
-      retryJobId: boundJobId,
+  final creation = promptResult.creation;
+  if (creation != null) {
+    await controller.completePromptWorkspaceCreation(
+      creation: creation,
+      agentTabId: promptResult.agentTabId,
     );
-  } else {
-    final creation = promptResult.creation;
-    if (creation != null) {
-      await controller.completePromptWorkspaceCreation(
-        creation: creation,
-        agentTabId: promptResult.agentTabId,
-      );
+    if (context.mounted) {
+      _showWorkspaceCreationToast(context, creation);
     }
-  }
-
-  if (result != null && context.mounted) {
-    _showWorkspaceCreationToast(context, result);
   }
 }
 
-Future<WorkspaceCreationResult?> _showManualWorkspaceDialog(
+Widget _buildManualWorkspaceForm(
   BuildContext context,
   WidgetRef ref, {
   required WorkbenchController controller,
@@ -237,98 +233,85 @@ Future<WorkspaceCreationResult?> _showManualWorkspaceDialog(
   required List<WorkspaceParentCandidate> parentCandidates,
   required List<SshTarget> sshTargets,
   required Project? resolvedInitialProject,
+  required Future<void>? Function(ManualWorkspaceCreateRequest request)
+  enqueueCreate,
   ManualWorkspaceCreateRequest? retryManual,
   String? retryError,
-  String? retryJobId,
 }) {
-  var boundJobId = retryJobId;
-  return showDialog<WorkspaceCreationResult>(
-    context: context,
-    builder: (_) => CreateWorkspaceDialog(
-      projects: projects,
-      initialProject: resolvedInitialProject,
-      initialSourceBranch: retryManual?.sourceBranch,
-      initialNewBranchName: retryManual?.newBranchName,
-      initialName: retryManual?.name,
-      initialParentWorkspaceId: retryManual?.parentWorkspaceId,
-      initialHostId: retryManual?.hostId,
-      initialReuseExistingBranch: retryManual?.reuseExistingBranch ?? false,
-      initialCreationError: retryManual == null ? null : retryError,
-      enqueueCreate: (request) {
-        boundJobId ??= const Uuid().v4();
-        final done = ref
-            .read(backgroundSetupJobsProvider.notifier)
-            .enqueueManualWorkspace(request, jobId: boundJobId);
-        if (done == null) {
-          return null;
-        }
-        return done.then((_) {
-          boundJobId = const Uuid().v4();
-        });
-      },
-      parentCandidates: parentCandidates,
-      sshTargets: sshTargets,
-      loadBranches: controller.listSourceBranches,
-      getProjectActiveBranch: (project) {
-        final state = ref.read(workbenchControllerProvider);
-        final workspaces = state.workspacesFor(project.id);
-        if (workspaces.isEmpty) return null;
-        try {
-          final activeWorkspace = workspaces.firstWhere(
-            (w) => w.id == state.activeWorkspaceId,
-            orElse: () => workspaces.firstWhere(
-              (w) => w.isMain,
-              orElse: () => workspaces.first,
-            ),
+  return CreateWorkspaceDialog(
+    embedded: true,
+    projects: projects,
+    initialProject: resolvedInitialProject,
+    initialSourceBranch: retryManual?.sourceBranch,
+    initialNewBranchName: retryManual?.newBranchName,
+    initialName: retryManual?.name,
+    initialParentWorkspaceId: retryManual?.parentWorkspaceId,
+    initialHostId: retryManual?.hostId,
+    initialReuseExistingBranch: retryManual?.reuseExistingBranch ?? false,
+    initialCreationError: retryManual == null ? null : retryError,
+    enqueueCreate: enqueueCreate,
+    parentCandidates: parentCandidates,
+    sshTargets: sshTargets,
+    loadBranches: controller.listSourceBranches,
+    getProjectActiveBranch: (project) {
+      final state = ref.read(workbenchControllerProvider);
+      final workspaces = state.workspacesFor(project.id);
+      if (workspaces.isEmpty) return null;
+      try {
+        final activeWorkspace = workspaces.firstWhere(
+          (w) => w.id == state.activeWorkspaceId,
+          orElse: () => workspaces.firstWhere(
+            (w) => w.isMain,
+            orElse: () => workspaces.first,
+          ),
+        );
+        return activeWorkspace.branch;
+      } catch (_) {
+        return null;
+      }
+    },
+    getProjectWorkspaceBranches: (project) {
+      final state = ref.read(workbenchControllerProvider);
+      return state
+          .workspacesFor(project.id)
+          .where((workspace) => workspace.isActive)
+          .map((workspace) => workspace.branch?.trim() ?? '')
+          .where((branch) => branch.isNotEmpty)
+          .toSet();
+    },
+    checkBranchExists: (project, branchName) async {
+      final gitBackend = ref.read(gitBackendProvider);
+      return gitBackend.branchExists(project.repoPath, branchName);
+    },
+    onCreateWorkspace:
+        ({
+          required project,
+          required sourceBranch,
+          required newBranchName,
+          required reuseExistingBranch,
+          name,
+          parentWorkspaceId,
+          hostId,
+        }) async {
+          return controller.createWorkspace(
+            project: project,
+            sourceBranch: sourceBranch,
+            newBranchName: newBranchName,
+            reuseExistingBranch: reuseExistingBranch,
+            name: name,
+            parentWorkspaceId: parentWorkspaceId,
+            hostId: hostId,
           );
-          return activeWorkspace.branch;
-        } catch (_) {
-          return null;
-        }
-      },
-      getProjectWorkspaceBranches: (project) {
-        final state = ref.read(workbenchControllerProvider);
-        return state
-            .workspacesFor(project.id)
-            .where((workspace) => workspace.isActive)
-            .map((workspace) => workspace.branch?.trim() ?? '')
-            .where((branch) => branch.isNotEmpty)
-            .toSet();
-      },
-      checkBranchExists: (project, branchName) async {
-        final gitBackend = ref.read(gitBackendProvider);
-        return gitBackend.branchExists(project.repoPath, branchName);
-      },
-      onCreateWorkspace:
-          ({
-            required project,
-            required sourceBranch,
-            required newBranchName,
-            required reuseExistingBranch,
-            name,
-            parentWorkspaceId,
-            hostId,
-          }) async {
-            return controller.createWorkspace(
-              project: project,
-              sourceBranch: sourceBranch,
-              newBranchName: newBranchName,
-              reuseExistingBranch: reuseExistingBranch,
-              name: name,
-              parentWorkspaceId: parentWorkspaceId,
-              hostId: hostId,
-            );
-          },
-      onAddProject: () {
-        Navigator.of(context).pop();
-        unawaited(showAddProjectFlow(context, ref));
-      },
-      onWorkspaceCreated: (creation) {
-        if (context.mounted) {
-          _showWorkspaceCreationToast(context, creation);
-        }
-      },
-    ),
+        },
+    onAddProject: () {
+      Navigator.of(context).pop();
+      unawaited(showAddProjectFlow(context, ref));
+    },
+    onWorkspaceCreated: (creation) {
+      if (context.mounted) {
+        _showWorkspaceCreationToast(context, creation);
+      }
+    },
   );
 }
 

--- a/test/widget/prompt_workspace_dialog_mode_test_cases.dart
+++ b/test/widget/prompt_workspace_dialog_mode_test_cases.dart
@@ -1,0 +1,107 @@
+part of 'prompt_workspace_dialog_test.dart';
+
+void _registerPromptWorkspaceModeTests() {
+  testWidgets('switches between From Prompt and Manual in the same dialog', (
+    tester,
+  ) async {
+    final now = DateTime.utc(2026, 7, 29);
+    final project = _project(id: 'project-1', name: 'Alera', now: now);
+    final profile = _profile(id: 'profile-1', name: 'Codex Builder', now: now);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          settingsControllerProvider.overrideWith(
+            _PromptSettingsController.new,
+          ),
+        ],
+        child: MaterialApp(
+          home: Builder(
+            builder: (context) => Scaffold(
+              body: FilledButton(
+                onPressed: () {
+                  showDialog<PromptWorkspaceDialogResult>(
+                    context: context,
+                    builder: (_) => PromptWorkspaceDialog(
+                      projects: <Project>[project],
+                      agentProfiles: <AgentProfile>[profile],
+                      loadBranches: (_) async => <String>['main'],
+                      checkBranchExists: (_, _) async => false,
+                      workspaceBranches: (_) => const <String>{},
+                      parentWorkspaces: const <Workspace>[],
+                      generateIdentity:
+                          ({
+                            required operationId,
+                            required projectId,
+                            required prompt,
+                          }) async => const GeneratedWorkspaceIdentity(
+                            workspaceName: 'Prompt Workspace',
+                            branchName: 'feat/prompt-workspace',
+                          ),
+                      cancelGeneration: (_) async {},
+                      createWorkspace:
+                          ({
+                            required project,
+                            required sourceBranch,
+                            required newBranchName,
+                            required name,
+                            parentWorkspaceId,
+                            hostId,
+                          }) async {
+                            throw UnimplementedError();
+                          },
+                      launchAgent:
+                          ({
+                            required workspaceId,
+                            required profileId,
+                            required prompt,
+                            required clientMutationId,
+                            required requireIdempotency,
+                          }) async {
+                            throw UnimplementedError();
+                          },
+                      supportsIdempotentAgentLaunch: () async => true,
+                      manualForm: const Text('Manual Workspace Form'),
+                    ),
+                  );
+                },
+                child: const Text('Open'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('Open'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Initial Prompt'), findsOneWidget);
+    expect(find.text('Continue Manually'), findsNothing);
+    expect(find.text('Manual Workspace Form'), findsNothing);
+
+    await tester.enterText(
+      find.widgetWithText(TextField, 'Initial Prompt'),
+      'Keep this prompt',
+    );
+    await tester.tap(find.text('Manual'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Manual Workspace Form'), findsOneWidget);
+    expect(find.text('Initial Prompt'), findsNothing);
+    expect(find.text('Continue Manually'), findsNothing);
+
+    await tester.tap(find.text('From Prompt'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Initial Prompt'), findsOneWidget);
+    expect(find.text('Manual Workspace Form'), findsNothing);
+    expect(
+      tester
+          .widget<TextField>(find.widgetWithText(TextField, 'Initial Prompt'))
+          .controller
+          ?.text,
+      'Keep this prompt',
+    );
+  });
+}

--- a/test/widget/prompt_workspace_dialog_test.dart
+++ b/test/widget/prompt_workspace_dialog_test.dart
@@ -484,4 +484,108 @@ void main() {
       expect(createdParentWorkspaceId, orcaFeature.id);
     },
   );
+
+  testWidgets('switches between From Prompt and Manual in the same dialog', (
+    tester,
+  ) async {
+    final now = DateTime.utc(2026, 7, 29);
+    final project = _project(id: 'project-1', name: 'Alera', now: now);
+    final profile = _profile(id: 'profile-1', name: 'Codex Builder', now: now);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          settingsControllerProvider.overrideWith(
+            _PromptSettingsController.new,
+          ),
+        ],
+        child: MaterialApp(
+          home: Builder(
+            builder: (context) => Scaffold(
+              body: FilledButton(
+                onPressed: () {
+                  showDialog<PromptWorkspaceDialogResult>(
+                    context: context,
+                    builder: (_) => PromptWorkspaceDialog(
+                      projects: <Project>[project],
+                      agentProfiles: <AgentProfile>[profile],
+                      loadBranches: (_) async => <String>['main'],
+                      checkBranchExists: (_, _) async => false,
+                      workspaceBranches: (_) => const <String>{},
+                      parentWorkspaces: const <Workspace>[],
+                      generateIdentity:
+                          ({
+                            required operationId,
+                            required projectId,
+                            required prompt,
+                          }) async => const GeneratedWorkspaceIdentity(
+                            workspaceName: 'Prompt Workspace',
+                            branchName: 'feat/prompt-workspace',
+                          ),
+                      cancelGeneration: (_) async {},
+                      createWorkspace:
+                          ({
+                            required project,
+                            required sourceBranch,
+                            required newBranchName,
+                            required name,
+                            parentWorkspaceId,
+                            hostId,
+                          }) async {
+                            throw UnimplementedError();
+                          },
+                      launchAgent:
+                          ({
+                            required workspaceId,
+                            required profileId,
+                            required prompt,
+                            required clientMutationId,
+                            required requireIdempotency,
+                          }) async {
+                            throw UnimplementedError();
+                          },
+                      supportsIdempotentAgentLaunch: () async => true,
+                      manualForm: const Text('Manual Workspace Form'),
+                    ),
+                  );
+                },
+                child: const Text('Open'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('Open'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Initial Prompt'), findsOneWidget);
+    expect(find.text('Continue Manually'), findsNothing);
+    expect(find.text('Manual Workspace Form'), findsNothing);
+
+    await tester.enterText(
+      find.widgetWithText(TextField, 'Initial Prompt'),
+      'Keep this prompt',
+    );
+    await tester.tap(find.text('Manual'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Manual Workspace Form'), findsOneWidget);
+    expect(find.text('Initial Prompt'), findsNothing);
+    expect(find.text('Continue Manually'), findsNothing);
+
+    await tester.tap(find.text('From Prompt'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Initial Prompt'), findsOneWidget);
+    expect(find.text('Manual Workspace Form'), findsNothing);
+    expect(
+      tester
+          .widget<TextField>(find.widgetWithText(TextField, 'Initial Prompt'))
+          .controller
+          ?.text,
+      'Keep this prompt',
+    );
+  });
 }

--- a/test/widget/prompt_workspace_dialog_test.dart
+++ b/test/widget/prompt_workspace_dialog_test.dart
@@ -16,10 +16,12 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 part 'prompt_workspace_dialog_clipboard_test_cases.dart';
+part 'prompt_workspace_dialog_mode_test_cases.dart';
 part 'prompt_workspace_dialog_test_support.dart';
 
 void main() {
   _registerPromptWorkspaceClipboardTests();
+  _registerPromptWorkspaceModeTests();
 
   testWidgets('creates an AI-named workspace and launches the profile', (
     tester,
@@ -484,108 +486,4 @@ void main() {
       expect(createdParentWorkspaceId, orcaFeature.id);
     },
   );
-
-  testWidgets('switches between From Prompt and Manual in the same dialog', (
-    tester,
-  ) async {
-    final now = DateTime.utc(2026, 7, 29);
-    final project = _project(id: 'project-1', name: 'Alera', now: now);
-    final profile = _profile(id: 'profile-1', name: 'Codex Builder', now: now);
-
-    await tester.pumpWidget(
-      ProviderScope(
-        overrides: [
-          settingsControllerProvider.overrideWith(
-            _PromptSettingsController.new,
-          ),
-        ],
-        child: MaterialApp(
-          home: Builder(
-            builder: (context) => Scaffold(
-              body: FilledButton(
-                onPressed: () {
-                  showDialog<PromptWorkspaceDialogResult>(
-                    context: context,
-                    builder: (_) => PromptWorkspaceDialog(
-                      projects: <Project>[project],
-                      agentProfiles: <AgentProfile>[profile],
-                      loadBranches: (_) async => <String>['main'],
-                      checkBranchExists: (_, _) async => false,
-                      workspaceBranches: (_) => const <String>{},
-                      parentWorkspaces: const <Workspace>[],
-                      generateIdentity:
-                          ({
-                            required operationId,
-                            required projectId,
-                            required prompt,
-                          }) async => const GeneratedWorkspaceIdentity(
-                            workspaceName: 'Prompt Workspace',
-                            branchName: 'feat/prompt-workspace',
-                          ),
-                      cancelGeneration: (_) async {},
-                      createWorkspace:
-                          ({
-                            required project,
-                            required sourceBranch,
-                            required newBranchName,
-                            required name,
-                            parentWorkspaceId,
-                            hostId,
-                          }) async {
-                            throw UnimplementedError();
-                          },
-                      launchAgent:
-                          ({
-                            required workspaceId,
-                            required profileId,
-                            required prompt,
-                            required clientMutationId,
-                            required requireIdempotency,
-                          }) async {
-                            throw UnimplementedError();
-                          },
-                      supportsIdempotentAgentLaunch: () async => true,
-                      manualForm: const Text('Manual Workspace Form'),
-                    ),
-                  );
-                },
-                child: const Text('Open'),
-              ),
-            ),
-          ),
-        ),
-      ),
-    );
-
-    await tester.tap(find.text('Open'));
-    await tester.pumpAndSettle();
-
-    expect(find.text('Initial Prompt'), findsOneWidget);
-    expect(find.text('Continue Manually'), findsNothing);
-    expect(find.text('Manual Workspace Form'), findsNothing);
-
-    await tester.enterText(
-      find.widgetWithText(TextField, 'Initial Prompt'),
-      'Keep this prompt',
-    );
-    await tester.tap(find.text('Manual'));
-    await tester.pumpAndSettle();
-
-    expect(find.text('Manual Workspace Form'), findsOneWidget);
-    expect(find.text('Initial Prompt'), findsNothing);
-    expect(find.text('Continue Manually'), findsNothing);
-
-    await tester.tap(find.text('From Prompt'));
-    await tester.pumpAndSettle();
-
-    expect(find.text('Initial Prompt'), findsOneWidget);
-    expect(find.text('Manual Workspace Form'), findsNothing);
-    expect(
-      tester
-          .widget<TextField>(find.widgetWithText(TextField, 'Initial Prompt'))
-          .controller
-          ?.text,
-      'Keep this prompt',
-    );
-  });
 }

--- a/test/widget/welcome_dashboard_test.dart
+++ b/test/widget/welcome_dashboard_test.dart
@@ -131,8 +131,6 @@ void main() {
 
     await tester.tap(find.text('Manual'));
     await tester.pumpAndSettle();
-    await tester.tap(find.text('Continue Manually'));
-    await tester.pumpAndSettle();
 
     // Tap Continue to go to Step 2
     await tester.tap(find.text('Continue'));

--- a/test/widget/workbench_dialog_launchers_test.dart
+++ b/test/widget/workbench_dialog_launchers_test.dart
@@ -231,6 +231,56 @@ void main() {
     );
 
     testWidgets(
+      'showCreateWorkspaceFlow switches between From Prompt and Manual in one dialog',
+      (tester) async {
+        final project = buildProject('project-1', 'Alera');
+        final controller = DialogLaunchersTestController(
+          WorkbenchState(projects: <Project>[project]),
+        )..sourceBranches = <String>['main'];
+
+        await pumpFlowHarness(
+          tester,
+          controller: controller,
+          onPressed: (context, ref) => showCreateWorkspaceFlow(context, ref),
+        );
+
+        await tester.tap(find.text('Open'));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Initial Prompt'), findsOneWidget);
+        expect(find.text('Continue Manually'), findsNothing);
+        expect(find.text('Search projects'), findsNothing);
+
+        await tester.enterText(
+          find.widgetWithText(TextField, 'Initial Prompt'),
+          'Keep this prompt',
+        );
+        await tester.tap(find.text('Manual'));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Initial Prompt'), findsNothing);
+        expect(find.text('Continue Manually'), findsNothing);
+        expect(find.text('Search projects'), findsOneWidget);
+        expect(find.text('Continue'), findsOneWidget);
+
+        await tester.tap(find.text('From Prompt'));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Initial Prompt'), findsOneWidget);
+        expect(find.text('Search projects'), findsNothing);
+        expect(
+          tester
+              .widget<TextField>(
+                find.widgetWithText(TextField, 'Initial Prompt'),
+              )
+              .controller
+              ?.text,
+          'Keep this prompt',
+        );
+      },
+    );
+
+    testWidgets(
       'showCreateWorkspaceFlow creates a workspace and shows success',
       (tester) async {
         final project = buildProject('project-1', 'Alera');

--- a/test/widget/workbench_dialog_launchers_test_support.dart
+++ b/test/widget/workbench_dialog_launchers_test_support.dart
@@ -393,8 +393,6 @@ class DialogLaunchersBackgroundSetupJobs extends BackgroundSetupJobs {
 Future<void> openManualWorkspaceDialog(WidgetTester tester) async {
   await tester.tap(find.text('Manual'));
   await tester.pumpAndSettle();
-  await tester.tap(find.text('Continue Manually'));
-  await tester.pumpAndSettle();
 }
 
 class DialogLaunchersSettingsController(final AleraSettings _seed)


### PR DESCRIPTION
## What changed

- Embed the manual workspace form directly in the prompt workspace dialog.
- Preserve form state when switching between “From Prompt” and “Manual”.
- Support embedded styling and completion behavior for the manual form.
- Remove the intermediate “Continue Manually” step.
- Add widget coverage for mode switching and preserved prompt input.

## Why

This streamlines workspace creation by keeping prompt-based and manual configuration in a single dialog while preserving the existing manual creation flow.