### PR TITLE
feat: polish mobile workspace panel experience

### DIFF
--- a/mobile/lib/src/app/theme/alera_theme.dart
+++ b/mobile/lib/src/app/theme/alera_theme.dart
@@ -162,35 +162,6 @@ ThemeData buildAleraMobileDarkTheme() {
       iconColor: AleraTokens.foregroundMuted,
       textColor: AleraTokens.foreground,
     ),
-    navigationBarTheme: NavigationBarThemeData(
-      height: 68,
-      backgroundColor: AleraTokens.surface,
-      elevation: 0,
-      shadowColor: AleraTokens.shadowSoft,
-      surfaceTintColor: AleraTokens.surface,
-      indicatorColor: AleraTokens.surfaceElevated,
-      labelTextStyle: WidgetStateProperty.resolveWith((states) {
-        final selected = states.contains(WidgetState.selected);
-        return TextStyle(
-          fontFamily: AleraTokens.fontFamily,
-          fontSize: 11,
-          fontWeight: selected ? FontWeight.w600 : FontWeight.w500,
-          height: 1.1,
-          color: selected
-              ? AleraTokens.foreground
-              : AleraTokens.foregroundMuted,
-        );
-      }),
-      iconTheme: WidgetStateProperty.resolveWith((states) {
-        final selected = states.contains(WidgetState.selected);
-        return IconThemeData(
-          size: 22,
-          color: selected
-              ? AleraTokens.foreground
-              : AleraTokens.foregroundMuted,
-        );
-      }),
-    ),
     filledButtonTheme: FilledButtonThemeData(
       style: ButtonStyle(
         shape: buttonShape,

--- a/mobile/lib/src/app/theme/alera_theme.dart
+++ b/mobile/lib/src/app/theme/alera_theme.dart
@@ -162,6 +162,35 @@ ThemeData buildAleraMobileDarkTheme() {
       iconColor: AleraTokens.foregroundMuted,
       textColor: AleraTokens.foreground,
     ),
+    navigationBarTheme: NavigationBarThemeData(
+      height: 68,
+      backgroundColor: AleraTokens.surface,
+      elevation: 0,
+      shadowColor: AleraTokens.shadowSoft,
+      surfaceTintColor: AleraTokens.surface,
+      indicatorColor: AleraTokens.surfaceElevated,
+      labelTextStyle: WidgetStateProperty.resolveWith((states) {
+        final selected = states.contains(WidgetState.selected);
+        return TextStyle(
+          fontFamily: AleraTokens.fontFamily,
+          fontSize: 11,
+          fontWeight: selected ? FontWeight.w600 : FontWeight.w500,
+          height: 1.1,
+          color: selected
+              ? AleraTokens.foreground
+              : AleraTokens.foregroundMuted,
+        );
+      }),
+      iconTheme: WidgetStateProperty.resolveWith((states) {
+        final selected = states.contains(WidgetState.selected);
+        return IconThemeData(
+          size: 22,
+          color: selected
+              ? AleraTokens.foreground
+              : AleraTokens.foregroundMuted,
+        );
+      }),
+    ),
     filledButtonTheme: FilledButtonThemeData(
       style: ButtonStyle(
         shape: buttonShape,

--- a/mobile/lib/src/design_system/feedback/alera_notice.dart
+++ b/mobile/lib/src/design_system/feedback/alera_notice.dart
@@ -1,0 +1,44 @@
+import 'package:alera_mobile/src/app/theme/alera_tokens.dart';
+import 'package:flutter/material.dart';
+
+/// Compact helper callout for a constraint or read-only state.
+class const AleraNotice({
+  super.key,
+  required final String message,
+  final IconData? icon,
+}) extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: AleraTokens.surfaceVariant,
+        borderRadius: BorderRadius.circular(AleraTokens.radiusLg),
+        border: Border.all(color: AleraTokens.borderSubtle),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(
+          horizontal: AleraTokens.space12,
+          vertical: AleraTokens.space8,
+        ),
+        child: Row(
+          crossAxisAlignment: .start,
+          children: <Widget>[
+            if (icon != null) ...<Widget>[
+              Icon(icon, size: 14, color: AleraTokens.foregroundMuted),
+              const SizedBox(width: AleraTokens.space8),
+            ],
+            Expanded(
+              child: Text(
+                message,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: AleraTokens.foregroundMuted,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/src/design_system/feedback/alera_notice.preview.dart
+++ b/mobile/lib/src/design_system/feedback/alera_notice.preview.dart
@@ -1,0 +1,10 @@
+import 'package:alera_mobile/src/design_system/alera_preview.dart';
+import 'package:alera_mobile/src/design_system/feedback/alera_notice.dart';
+import 'package:alera_mobile/src/design_system/icons/alera_icons.dart';
+import 'package:flutter/widgets.dart';
+
+@AleraPreview(name: 'Read-Only Notice', group: 'Feedback')
+Widget aleraNoticePreview() => const AleraNotice(
+  icon: AleraIcons.info,
+  message: 'Source control is read-only on mobile. Stage, unstage, and commit stay on desktop.',
+);

--- a/mobile/lib/src/design_system/icons/alera_icons.dart
+++ b/mobile/lib/src/design_system/icons/alera_icons.dart
@@ -41,7 +41,6 @@ abstract final class const AleraIcons._() {
   static const IconData workspaces = LucideIcons.folders;
   static const IconData terminal = LucideIcons.terminal;
   static const IconData files = LucideIcons.files;
-  static const IconData copyFiles = LucideIcons.files;
   static const IconData gitPullRequest = LucideIcons.gitPullRequest;
   static const IconData gitCompare = LucideIcons.gitCompare;
   static const IconData listView = LucideIcons.list;

--- a/mobile/lib/src/design_system/icons/alera_icons.dart
+++ b/mobile/lib/src/design_system/icons/alera_icons.dart
@@ -33,12 +33,15 @@ abstract final class const AleraIcons._() {
   static const IconData paste = LucideIcons.clipboard;
   static const IconData refresh = LucideIcons.refreshCw;
   static const IconData loading = LucideIcons.loaderCircle;
+  static const IconData info = LucideIcons.info;
+  static const IconData circle = LucideIcons.circle;
   static const IconData link = LucideIcons.link;
   static const IconData external = LucideIcons.externalLink;
   static const IconData theme = LucideIcons.moon;
   static const IconData workspaces = LucideIcons.folders;
   static const IconData terminal = LucideIcons.terminal;
   static const IconData files = LucideIcons.files;
+  static const IconData copyFiles = LucideIcons.files;
   static const IconData gitPullRequest = LucideIcons.gitPullRequest;
   static const IconData gitCompare = LucideIcons.gitCompare;
   static const IconData listView = LucideIcons.list;

--- a/mobile/lib/src/features/terminal/presentation/workspace_tab_strip.dart
+++ b/mobile/lib/src/features/terminal/presentation/workspace_tab_strip.dart
@@ -256,38 +256,19 @@ class const _EmptyTabs({
 }) extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return Center(
-      child: Padding(
-        padding: AleraTokens.contentPadding,
-        child: Column(
-          mainAxisSize: .min,
-          children: <Widget>[
-            Icon(
-              Icons.terminal,
-              size: AleraTokens.emptyIcon,
-              color: Theme.of(context).colorScheme.onSurfaceVariant,
-            ),
-            const SizedBox(height: AleraTokens.spaceLg),
-            Text(
-              targetUnavailable ? 'Terminal unavailable' : 'No tabs yet',
-              style: Theme.of(context).textTheme.titleLarge,
-            ),
-            if (targetUnavailable) ...<Widget>[
-              const SizedBox(height: AleraTokens.space8),
-              Text(
-                'Choose another terminal above.',
-                style: Theme.of(context).textTheme.bodySmall,
-              ),
-            ],
-            const SizedBox(height: AleraTokens.spaceMd),
-            FilledButton.icon(
+    return AleraEmptyState(
+      icon: AleraIcons.terminal,
+      title: targetUnavailable ? 'Terminal unavailable' : 'No terminals',
+      message: targetUnavailable
+          ? 'Choose another terminal above.'
+          : 'Open a terminal to start working in this workspace.',
+      action: targetUnavailable
+          ? null
+          : FilledButton.icon(
               onPressed: creating ? null : onNewTab,
-              icon: const Icon(Icons.add),
-              label: const Text('New Tab'),
+              icon: const Icon(AleraIcons.add),
+              label: const Text('New Terminal'),
             ),
-          ],
-        ),
-      ),
     );
   }
 }

--- a/mobile/lib/src/features/terminal/presentation/workspace_tabs_panel_menu.dart
+++ b/mobile/lib/src/features/terminal/presentation/workspace_tabs_panel_menu.dart
@@ -1,0 +1,58 @@
+part of 'workspace_tabs_screen.dart';
+
+IconData _panelIcon(WorkspacePanelDestination destination) {
+  return switch (destination) {
+    WorkspacePanelDestination.terminal => AleraIcons.terminal,
+    WorkspacePanelDestination.explorer => AleraIcons.folder,
+    WorkspacePanelDestination.search => AleraIcons.search,
+    WorkspacePanelDestination.sourceControl => AleraIcons.gitBranch,
+    WorkspacePanelDestination.pullRequest => AleraIcons.gitPullRequest,
+  };
+}
+
+String _panelLabel(WorkspacePanelDestination destination) {
+  return switch (destination) {
+    WorkspacePanelDestination.terminal => 'Terminal',
+    WorkspacePanelDestination.explorer => 'Explorer',
+    WorkspacePanelDestination.search => 'Search',
+    WorkspacePanelDestination.sourceControl => 'Source Control',
+    WorkspacePanelDestination.pullRequest => 'Pull Request',
+  };
+}
+
+class const _PanelMenuRow({
+  required final IconData icon,
+  required final String label,
+  required final bool selected,
+}) extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: <Widget>[
+        Icon(icon, size: 18, color: AleraTokens.foregroundMuted),
+        const SizedBox(width: AleraTokens.space12),
+        Expanded(child: Text(label)),
+        if (selected)
+          const Icon(AleraIcons.check, size: 16, color: AleraTokens.foreground),
+      ],
+    );
+  }
+}
+
+sealed class _NewTabAction {
+  const _NewTabAction();
+}
+
+class const _NewTerminalTabAction() extends _NewTabAction {}
+
+class const _NewAgentProfileTabAction(final String profileId)
+    extends _NewTabAction {}
+
+sealed class _TabsMenuAction {
+  const _TabsMenuAction();
+}
+
+class const _QuickKeysMenuAction() extends _TabsMenuAction {}
+
+class const _SelectPanelAction(final WorkspacePanelDestination destination)
+    extends _TabsMenuAction {}

--- a/mobile/lib/src/features/terminal/presentation/workspace_tabs_screen.dart
+++ b/mobile/lib/src/features/terminal/presentation/workspace_tabs_screen.dart
@@ -4,6 +4,7 @@ import 'package:alera_mobile/src/features/runtime/domain/agent_profile_summary.d
 import 'package:alera_mobile/src/features/runtime/domain/runtime_client_surfaces.dart';
 
 import 'package:alera_mobile/src/app/theme/alera_tokens.dart';
+import 'package:alera_mobile/src/design_system/feedback/alera_empty_state.dart';
 import 'package:alera_mobile/src/design_system/forms/alera_rename_dialog.dart';
 import 'package:alera_mobile/src/design_system/icons/alera_icons.dart';
 import 'package:alera_mobile/src/features/workbench/application/workspace_panels_controller.dart';
@@ -324,17 +325,41 @@ class _WorkspaceTabsScreenState extends ConsumerState<WorkspaceTabsScreen> {
             tooltip: 'More Actions',
             onSelected: (action) {
               switch (action) {
-                case _TabsMenuAction.quickKeys:
+                case _QuickKeysMenuAction():
                   Navigator.of(context).push(
                     MaterialPageRoute<void>(
                       builder: (_) => const TerminalKeysSettingsScreen(),
                     ),
                   );
+                case _SelectPanelAction(:final destination):
+                  ref
+                      .read(
+                        selectedWorkspacePanelControllerProvider(
+                          widget.hostId,
+                          widget.workspace.id,
+                        ).notifier,
+                      )
+                      .select(destination);
               }
             },
             itemBuilder: (context) => <PopupMenuEntry<_TabsMenuAction>>[
+              if (panelCapabilities
+                  .hasAny) ...<PopupMenuEntry<_TabsMenuAction>>[
+                for (final destination in destinations)
+                  PopupMenuItem<_TabsMenuAction>(
+                    value: _SelectPanelAction(destination),
+                    height: AleraTokens.minTapTarget,
+                    child: _PanelMenuRow(
+                      icon: _panelIcon(destination),
+                      label: _panelLabel(destination),
+                      selected: destination == panel,
+                    ),
+                  ),
+                const PopupMenuDivider(),
+              ],
               const PopupMenuItem<_TabsMenuAction>(
-                value: .quickKeys,
+                value: _QuickKeysMenuAction(),
+                height: AleraTokens.minTapTarget,
                 child: Text('Terminal Quick Keys'),
               ),
             ],
@@ -368,28 +393,6 @@ class _WorkspaceTabsScreenState extends ConsumerState<WorkspaceTabsScreen> {
       body: SafeArea(
         child: showTerminalChrome ? _terminalBody(tabs) : _panelBody(panel),
       ),
-      bottomNavigationBar: panelCapabilities.hasAny
-          ? NavigationBar(
-              selectedIndex: destinations.indexOf(panel),
-              onDestinationSelected: (index) {
-                ref
-                    .read(
-                      selectedWorkspacePanelControllerProvider(
-                        widget.hostId,
-                        widget.workspace.id,
-                      ).notifier,
-                    )
-                    .select(destinations[index]);
-              },
-              destinations: <NavigationDestination>[
-                for (final destination in destinations)
-                  NavigationDestination(
-                    icon: Icon(_panelIcon(destination)),
-                    label: _panelLabel(destination),
-                  ),
-              ],
-            )
-          : null,
     );
   }
 
@@ -453,9 +456,9 @@ class _WorkspaceTabsScreenState extends ConsumerState<WorkspaceTabsScreen> {
 IconData _panelIcon(WorkspacePanelDestination destination) {
   return switch (destination) {
     WorkspacePanelDestination.terminal => AleraIcons.terminal,
-    WorkspacePanelDestination.explorer => AleraIcons.files,
+    WorkspacePanelDestination.explorer => AleraIcons.folder,
     WorkspacePanelDestination.search => AleraIcons.search,
-    WorkspacePanelDestination.sourceControl => AleraIcons.gitCompare,
+    WorkspacePanelDestination.sourceControl => AleraIcons.gitBranch,
     WorkspacePanelDestination.pullRequest => AleraIcons.gitPullRequest,
   };
 }
@@ -470,6 +473,25 @@ String _panelLabel(WorkspacePanelDestination destination) {
   };
 }
 
+class const _PanelMenuRow({
+  required final IconData icon,
+  required final String label,
+  required final bool selected,
+}) extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: <Widget>[
+        Icon(icon, size: 18, color: AleraTokens.foregroundMuted),
+        const SizedBox(width: AleraTokens.space12),
+        Expanded(child: Text(label)),
+        if (selected)
+          const Icon(AleraIcons.check, size: 16, color: AleraTokens.foreground),
+      ],
+    );
+  }
+}
+
 sealed class _NewTabAction {
   const _NewTabAction();
 }
@@ -479,4 +501,11 @@ class const _NewTerminalTabAction() extends _NewTabAction {}
 class const _NewAgentProfileTabAction(final String profileId)
     extends _NewTabAction {}
 
-enum _TabsMenuAction { quickKeys }
+sealed class _TabsMenuAction {
+  const _TabsMenuAction();
+}
+
+class const _QuickKeysMenuAction() extends _TabsMenuAction {}
+
+class const _SelectPanelAction(final WorkspacePanelDestination destination)
+    extends _TabsMenuAction {}

--- a/mobile/lib/src/features/terminal/presentation/workspace_tabs_screen.dart
+++ b/mobile/lib/src/features/terminal/presentation/workspace_tabs_screen.dart
@@ -29,6 +29,7 @@ import 'package:logging/logging.dart';
 
 part 'workspace_tab_strip.dart';
 part 'workspace_tabs_close.dart';
+part 'workspace_tabs_panel_menu.dart';
 
 /// Tabs of one workspace: a horizontally scrollable chip switcher with one
 /// tab visible at a time. Splits stay a desktop concept.
@@ -452,60 +453,3 @@ class _WorkspaceTabsScreenState extends ConsumerState<WorkspaceTabsScreen> {
     };
   }
 }
-
-IconData _panelIcon(WorkspacePanelDestination destination) {
-  return switch (destination) {
-    WorkspacePanelDestination.terminal => AleraIcons.terminal,
-    WorkspacePanelDestination.explorer => AleraIcons.folder,
-    WorkspacePanelDestination.search => AleraIcons.search,
-    WorkspacePanelDestination.sourceControl => AleraIcons.gitBranch,
-    WorkspacePanelDestination.pullRequest => AleraIcons.gitPullRequest,
-  };
-}
-
-String _panelLabel(WorkspacePanelDestination destination) {
-  return switch (destination) {
-    WorkspacePanelDestination.terminal => 'Terminal',
-    WorkspacePanelDestination.explorer => 'Explorer',
-    WorkspacePanelDestination.search => 'Search',
-    WorkspacePanelDestination.sourceControl => 'Source Control',
-    WorkspacePanelDestination.pullRequest => 'Pull Request',
-  };
-}
-
-class const _PanelMenuRow({
-  required final IconData icon,
-  required final String label,
-  required final bool selected,
-}) extends StatelessWidget {
-  @override
-  Widget build(BuildContext context) {
-    return Row(
-      children: <Widget>[
-        Icon(icon, size: 18, color: AleraTokens.foregroundMuted),
-        const SizedBox(width: AleraTokens.space12),
-        Expanded(child: Text(label)),
-        if (selected)
-          const Icon(AleraIcons.check, size: 16, color: AleraTokens.foreground),
-      ],
-    );
-  }
-}
-
-sealed class _NewTabAction {
-  const _NewTabAction();
-}
-
-class const _NewTerminalTabAction() extends _NewTabAction {}
-
-class const _NewAgentProfileTabAction(final String profileId)
-    extends _NewTabAction {}
-
-sealed class _TabsMenuAction {
-  const _TabsMenuAction();
-}
-
-class const _QuickKeysMenuAction() extends _TabsMenuAction {}
-
-class const _SelectPanelAction(final WorkspacePanelDestination destination)
-    extends _TabsMenuAction {}

--- a/mobile/lib/src/features/workbench/presentation/pull_request_panel.dart
+++ b/mobile/lib/src/features/workbench/presentation/pull_request_panel.dart
@@ -1,11 +1,29 @@
+import 'dart:async';
+
 import 'package:alera_mobile/src/app/theme/alera_tokens.dart';
+import 'package:alera_mobile/src/design_system/badges/alera_badge.dart';
+import 'package:alera_mobile/src/design_system/buttons/alera_icon_button.dart';
 import 'package:alera_mobile/src/design_system/feedback/alera_empty_state.dart';
+import 'package:alera_mobile/src/design_system/feedback/alera_notice.dart';
 import 'package:alera_mobile/src/design_system/icons/alera_icons.dart';
+import 'package:alera_mobile/src/design_system/layout/alera_section_header.dart';
 import 'package:alera_mobile/src/features/runtime/domain/mobile_workspace_panels.dart';
 import 'package:alera_mobile/src/features/workbench/application/pull_request_controller.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:url_launcher/url_launcher.dart';
+
+final _githubExpression = RegExp(r'\$\{\{\s*([^}]+?)\s*\}\}');
+
+/// Collapses GitHub Actions `${{ matrix.platform }}` tokens so check names
+/// stay readable on a phone.
+String displayPullRequestCheckName(String name) {
+  return name.replaceAllMapped(_githubExpression, (match) {
+    final inner = match[1]!.trim();
+    final parts = inner.split('.');
+    return '{${parts.last.trim()}}';
+  });
+}
 
 class const PullRequestPanel({
   super.key,
@@ -40,92 +58,325 @@ class const _Body({required final MobilePullRequestSnapshot snapshot})
     if (review == null) {
       return AleraEmptyState(
         icon: AleraIcons.gitPullRequest,
-        title: snapshot.identity?.label ?? snapshot.branch ?? 'Pull request',
+        title: snapshot.identity?.label ?? snapshot.branch ?? 'Pull Request',
         message:
             snapshot.unavailableReason ??
             'No pull request is available for this workspace.',
       );
     }
+    final theme = Theme.of(context);
     return ListView(
-      padding: AleraTokens.contentPadding,
+      padding: const EdgeInsets.fromLTRB(
+        AleraTokens.space16,
+        AleraTokens.space16,
+        AleraTokens.space16,
+        AleraTokens.space24,
+      ),
       children: <Widget>[
-        if (snapshot.identity?.label != null)
-          Text(
-            snapshot.identity!.label!,
-            style: Theme.of(context).textTheme.labelLarge,
-          ),
-        Text(review.title, style: Theme.of(context).textTheme.titleLarge),
-        const SizedBox(height: AleraTokens.space8),
-        Text(
-          '#${review.number} · ${review.isDraft ? 'Draft' : review.state}'
-          '${review.author == null ? '' : ' · ${review.author}'}',
-        ),
-        if (review.baseRefName != null &&
-            review.headRefName != null) ...<Widget>[
-          const SizedBox(height: AleraTokens.space8),
-          Text('${review.headRefName} into ${review.baseRefName}'),
-        ],
+        _Header(snapshot: snapshot, review: review),
         const SizedBox(height: AleraTokens.space12),
-        Text(
-          'Comments are read-only. Reply, edit, and merge stay on desktop.',
-          style: Theme.of(context).textTheme.bodySmall,
+        const AleraNotice(
+          icon: AleraIcons.info,
+          message:
+              'Comments are read-only. Reply, edit, and merge stay on desktop.',
         ),
-        if (review.url.isNotEmpty) ...<Widget>[
-          const SizedBox(height: AleraTokens.space16),
-          FilledButton.icon(
-            onPressed: () => _open(review.url),
-            icon: const Icon(AleraIcons.external),
-            label: const Text('Open In Browser'),
-          ),
-        ],
-        const SizedBox(height: AleraTokens.space24),
-        Text('Checks', style: Theme.of(context).textTheme.titleMedium),
-        const SizedBox(height: AleraTokens.space8),
-        if (review.checks.isEmpty)
-          const Text('No checks were returned for this pull request.')
-        else
-          for (final check in review.checks)
-            ListTile(
-              contentPadding: EdgeInsets.zero,
-              leading: Icon(
-                check.bucket == 'pass' ? AleraIcons.success : AleraIcons.review,
-              ),
-              title: Text(check.name),
-              subtitle: Text(check.bucket.isEmpty ? check.state : check.bucket),
-              onTap: check.url == null ? null : () => _open(check.url!),
-            ),
         const SizedBox(height: AleraTokens.space16),
-        Text('Comments', style: Theme.of(context).textTheme.titleMedium),
-        const SizedBox(height: AleraTokens.space8),
+        AleraSectionHeader(
+          label: 'Checks',
+          padding: const EdgeInsets.only(bottom: AleraTokens.space8),
+          trailing: review.checks.isEmpty
+              ? null
+              : Text(
+                  _checksSummary(review.checks),
+                  style: theme.textTheme.labelSmall?.copyWith(
+                    color: AleraTokens.foregroundFaint,
+                  ),
+                ),
+        ),
+        if (review.checks.isEmpty)
+          Text(
+            'No checks were returned for this pull request.',
+            style: theme.textTheme.bodySmall,
+          )
+        else
+          for (final check in review.checks) _CheckRow(check: check),
+        const SizedBox(height: AleraTokens.space16),
+        const AleraSectionHeader(
+          label: 'Comments',
+          padding: EdgeInsets.only(bottom: AleraTokens.space8),
+        ),
         if (review.comments.isEmpty)
-          const Text('No conversation comments yet.')
+          Text(
+            'No conversation comments yet.',
+            style: theme.textTheme.bodySmall,
+          )
         else
           for (final comment in review.comments)
-            Card(
-              child: Padding(
-                padding: AleraTokens.contentPadding,
-                child: Column(
-                  crossAxisAlignment: .start,
-                  children: <Widget>[
-                    Text(
-                      comment.author ?? 'Comment',
-                      style: Theme.of(context).textTheme.titleSmall,
-                    ),
-                    const SizedBox(height: AleraTokens.space8),
-                    Text(comment.body),
-                  ],
+            Padding(
+              padding: const EdgeInsets.only(bottom: AleraTokens.space8),
+              child: Card(
+                child: Padding(
+                  padding: const EdgeInsets.all(AleraTokens.space12),
+                  child: Column(
+                    crossAxisAlignment: .start,
+                    children: <Widget>[
+                      Text(
+                        comment.author ?? 'Comment',
+                        style: theme.textTheme.titleSmall,
+                      ),
+                      const SizedBox(height: AleraTokens.space8),
+                      Text(comment.body, style: theme.textTheme.bodyMedium),
+                    ],
+                  ),
                 ),
               ),
             ),
       ],
     );
   }
+}
 
-  Future<void> _open(String url) async {
-    final parsed = Uri.tryParse(url);
-    if (parsed == null) {
-      return;
-    }
-    await launchUrl(parsed, mode: .externalApplication);
+class const _Header({
+  required final MobilePullRequestSnapshot snapshot,
+  required final MobilePullRequestReview review,
+}) extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final identity = snapshot.identity?.label;
+    final stateLabel = _reviewStateLabel(review);
+    return Column(
+      crossAxisAlignment: .start,
+      children: <Widget>[
+        if (identity != null)
+          Text(
+            identity,
+            maxLines: 1,
+            overflow: .ellipsis,
+            style: theme.textTheme.labelLarge?.copyWith(
+              color: AleraTokens.foregroundMuted,
+            ),
+          ),
+        Row(
+          crossAxisAlignment: .center,
+          children: <Widget>[
+            Expanded(
+              child: Text(review.title, style: theme.textTheme.titleLarge),
+            ),
+            if (review.url.isNotEmpty)
+              AleraIconButton(
+                tooltip: 'Open In Browser',
+                icon: AleraIcons.external,
+                onPressed: () => _openUrl(review.url),
+              ),
+          ],
+        ),
+        const SizedBox(height: AleraTokens.space8),
+        Wrap(
+          spacing: AleraTokens.space8,
+          runSpacing: AleraTokens.space6,
+          crossAxisAlignment: WrapCrossAlignment.center,
+          children: <Widget>[
+            AleraBadge(
+              label: stateLabel,
+              color: _reviewStateColor(stateLabel).withValues(alpha: 0.16),
+              foregroundColor: _reviewStateColor(stateLabel),
+            ),
+            Text('#${review.number}', style: theme.textTheme.bodySmall),
+            if (review.author != null)
+              Text(review.author!, style: theme.textTheme.bodySmall),
+          ],
+        ),
+        if (review.baseRefName != null &&
+            review.headRefName != null) ...<Widget>[
+          const SizedBox(height: AleraTokens.space8),
+          Row(
+            children: <Widget>[
+              const Icon(
+                AleraIcons.gitBranch,
+                size: 14,
+                color: AleraTokens.foregroundMuted,
+              ),
+              const SizedBox(width: AleraTokens.space6),
+              Expanded(
+                child: Text(
+                  review.headRefName!,
+                  maxLines: 1,
+                  overflow: .ellipsis,
+                  style: AleraTokens.monoStyle,
+                ),
+              ),
+              Padding(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: AleraTokens.space6,
+                ),
+                child: Text('into', style: theme.textTheme.bodySmall),
+              ),
+              Flexible(
+                child: Text(
+                  review.baseRefName!,
+                  maxLines: 1,
+                  overflow: .ellipsis,
+                  style: AleraTokens.monoStyle,
+                ),
+              ),
+            ],
+          ),
+        ],
+      ],
+    );
   }
+}
+
+class const _CheckRow({required final MobilePullRequestCheck check})
+    extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final visual = pullRequestCheckVisual(check);
+    final displayName = displayPullRequestCheckName(check.name);
+    final row = ConstrainedBox(
+      constraints: const BoxConstraints(minHeight: AleraTokens.minTapTarget),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: AleraTokens.space6),
+        child: Row(
+          children: <Widget>[
+            Icon(visual.icon, size: 16, color: visual.color),
+            const SizedBox(width: AleraTokens.space8),
+            Expanded(
+              child: Text(
+                displayName,
+                maxLines: 1,
+                overflow: .ellipsis,
+                style: theme.textTheme.bodyMedium,
+              ),
+            ),
+            const SizedBox(width: AleraTokens.space8),
+            Text(
+              visual.label,
+              style: theme.textTheme.labelSmall?.copyWith(color: visual.color),
+            ),
+          ],
+        ),
+      ),
+    );
+    final url = check.url;
+    return Tooltip(
+      message: check.name,
+      child: url == null
+          ? row
+          : InkWell(onTap: () => _openUrl(url), child: row),
+    );
+  }
+}
+
+class const PullRequestCheckVisual({
+  required final String label,
+  required final IconData icon,
+  required final Color color,
+});
+
+PullRequestCheckVisual pullRequestCheckVisual(MobilePullRequestCheck check) {
+  final key = (check.bucket.isEmpty ? check.state : check.bucket).toLowerCase();
+  return switch (key) {
+    'pass' || 'success' => const PullRequestCheckVisual(
+      label: 'Pass',
+      icon: AleraIcons.success,
+      color: AleraTokens.success,
+    ),
+    'fail' || 'failure' || 'error' => const PullRequestCheckVisual(
+      label: 'Fail',
+      icon: AleraIcons.cancel,
+      color: AleraTokens.error,
+    ),
+    'skipping' ||
+    'skipped' ||
+    'skip' ||
+    'neutral' => const PullRequestCheckVisual(
+      label: 'Skipped',
+      icon: AleraIcons.circle,
+      color: AleraTokens.foregroundMuted,
+    ),
+    'cancel' || 'cancelled' => const PullRequestCheckVisual(
+      label: 'Cancelled',
+      icon: AleraIcons.cancel,
+      color: AleraTokens.foregroundMuted,
+    ),
+    'pending' ||
+    'in_progress' ||
+    'queued' ||
+    'waiting' => const PullRequestCheckVisual(
+      label: 'Pending',
+      icon: AleraIcons.loading,
+      color: AleraTokens.warning,
+    ),
+    _ => PullRequestCheckVisual(
+      label: key.isEmpty ? 'Check' : _titleCase(key),
+      icon: AleraIcons.review,
+      color: AleraTokens.foregroundMuted,
+    ),
+  };
+}
+
+String _checksSummary(List<MobilePullRequestCheck> checks) {
+  var passed = 0;
+  var failed = 0;
+  var skipped = 0;
+  var pending = 0;
+  for (final check in checks) {
+    switch (pullRequestCheckVisual(check).label) {
+      case 'Pass':
+        passed += 1;
+      case 'Fail':
+        failed += 1;
+      case 'Skipped' || 'Cancelled':
+        skipped += 1;
+      default:
+        pending += 1;
+    }
+  }
+  return <String>[
+    if (failed > 0) '$failed failed',
+    if (pending > 0) '$pending pending',
+    if (passed > 0) '$passed passed',
+    if (skipped > 0) '$skipped skipped',
+  ].join(' · ');
+}
+
+String _reviewStateLabel(MobilePullRequestReview review) {
+  if (review.isDraft) {
+    return 'Draft';
+  }
+  return switch (review.state.toUpperCase()) {
+    'MERGED' => 'Merged',
+    'CLOSED' => 'Closed',
+    'OPEN' => 'Open',
+    _ => _titleCase(review.state),
+  };
+}
+
+Color _reviewStateColor(String label) {
+  return switch (label) {
+    'Open' => AleraTokens.success,
+    'Merged' => AleraTokens.info,
+    'Draft' => AleraTokens.warning,
+    'Closed' => AleraTokens.foregroundMuted,
+    _ => AleraTokens.foregroundMuted,
+  };
+}
+
+String _titleCase(String value) {
+  if (value.isEmpty) {
+    return value;
+  }
+  final lower = value.toLowerCase().replaceAll('_', ' ');
+  return lower[0].toUpperCase() + lower.substring(1);
+}
+
+void _openUrl(String url) {
+  final parsed = Uri.tryParse(url);
+  if (parsed == null) {
+    return;
+  }
+  unawaited(launchUrl(parsed, mode: .externalApplication));
 }

--- a/mobile/lib/src/features/workbench/presentation/source_control_panel.dart
+++ b/mobile/lib/src/features/workbench/presentation/source_control_panel.dart
@@ -1,9 +1,12 @@
 import 'package:alera_mobile/src/app/theme/alera_tokens.dart';
 import 'package:alera_mobile/src/design_system/feedback/alera_empty_state.dart';
+import 'package:alera_mobile/src/design_system/feedback/alera_notice.dart';
 import 'package:alera_mobile/src/design_system/icons/alera_icons.dart';
+import 'package:alera_mobile/src/design_system/layout/alera_section_header.dart';
 import 'package:alera_mobile/src/features/runtime/domain/mobile_workspace_panels.dart';
 import 'package:alera_mobile/src/features/workbench/application/source_control_controller.dart';
 import 'package:alera_mobile/src/features/workbench/presentation/workspace_diff_viewer_screen.dart';
+import 'package:alera_mobile/src/features/workbench/presentation/workspace_path_display.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -54,13 +57,15 @@ class const _Body({
         message: 'This workspace is not a Git repository.',
       );
     }
-    final staged = snapshot.entries.where((entry) => entry.area == 'staged');
-    final unstaged = snapshot.entries.where(
-      (entry) => entry.area == 'unstaged',
-    );
-    final untracked = snapshot.entries.where(
-      (entry) => entry.area == 'untracked',
-    );
+    final staged = snapshot.entries
+        .where((entry) => entry.area == 'staged')
+        .toList(growable: false);
+    final unstaged = snapshot.entries
+        .where((entry) => entry.area == 'unstaged')
+        .toList(growable: false);
+    final untracked = snapshot.entries
+        .where((entry) => entry.area == 'untracked')
+        .toList(growable: false);
     if (snapshot.entries.isEmpty) {
       return AleraEmptyState(
         icon: AleraIcons.check,
@@ -71,60 +76,49 @@ class const _Body({
       );
     }
     return ListView(
+      padding: const EdgeInsets.only(bottom: AleraTokens.space24),
       children: <Widget>[
-        Padding(
+        const Padding(
           padding: AleraTokens.contentPadding,
-          child: Text(
-            'Source control is read-only on mobile. Stage, unstage, and commit stay on desktop.',
-            style: Theme.of(context).textTheme.bodySmall,
+          child: AleraNotice(
+            icon: AleraIcons.info,
+            message: 'Read-only on mobile. Stage, unstage, and commit stay on desktop.',
           ),
         ),
-        if (snapshot.branch != null)
-          ListTile(
-            leading: const Icon(AleraIcons.gitBranch),
-            title: Text(snapshot.branch!),
-            subtitle: const Text('Current branch'),
-          ),
-        ListTile(
-          leading: const Icon(AleraIcons.gitCompare),
-          title: Text(
-            '${snapshot.changedFileCount} ${snapshot.changedFileCount == 1 ? 'file' : 'files'} · +${snapshot.addedLineCount} -${snapshot.removedLineCount}',
-          ),
-          subtitle: const Text('Diff summary'),
-        ),
-        ..._group(context, hostId, workspaceId, 'Staged', staged),
-        ..._group(context, hostId, workspaceId, 'Unstaged', unstaged),
-        ..._group(context, hostId, workspaceId, 'Untracked', untracked),
+        _Summary(snapshot: snapshot),
+        ..._group(context, 'Staged', staged),
+        ..._group(context, 'Unstaged', unstaged),
+        ..._group(context, 'Untracked', untracked),
       ],
     );
   }
 
   List<Widget> _group(
     BuildContext context,
-    String hostId,
-    String workspaceId,
     String title,
-    Iterable<MobileGitChange> entries,
+    List<MobileGitChange> items,
   ) {
-    final items = entries.toList(growable: false);
     if (items.isEmpty) {
       return const <Widget>[];
     }
     return <Widget>[
-      Padding(
+      AleraSectionHeader(
+        label: title,
         padding: const EdgeInsets.fromLTRB(
           AleraTokens.space16,
-          AleraTokens.space12,
+          AleraTokens.space16,
           AleraTokens.space16,
           AleraTokens.space4,
         ),
-        child: Text(title, style: Theme.of(context).textTheme.titleSmall),
+        trailing: Text(
+          '${items.length}',
+          style: Theme.of(context).textTheme.labelSmall
+              ?.copyWith(color: AleraTokens.foregroundFaint),
+        ),
       ),
       for (final change in items)
-        ListTile(
-          minTileHeight: AleraTokens.minTapTarget,
-          title: Text(change.path),
-          subtitle: Text(_subtitle(change)),
+        _ChangeRow(
+          change: change,
           onTap: () => Navigator.of(context).push<void>(
             MaterialPageRoute<void>(
               builder: (_) => WorkspaceDiffViewerScreen(
@@ -137,13 +131,168 @@ class const _Body({
         ),
     ];
   }
+}
 
-  String _subtitle(MobileGitChange change) {
-    final counts = <String>[
-      change.status,
-      if (change.added != null) '+${change.added}',
-      if (change.removed != null) '-${change.removed}',
-    ];
-    return counts.join(' · ');
+class const _Summary({required final MobileGitStatusSnapshot snapshot})
+    extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final fileCount = snapshot.changedFileCount;
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(
+        AleraTokens.space16,
+        0,
+        AleraTokens.space16,
+        AleraTokens.space8,
+      ),
+      child: Row(
+        children: <Widget>[
+          const Icon(
+            AleraIcons.gitBranch,
+            size: 16,
+            color: AleraTokens.foregroundMuted,
+          ),
+          const SizedBox(width: AleraTokens.space8),
+          Expanded(
+            child: Text(
+              snapshot.branch ?? 'Detached',
+              maxLines: 1,
+              overflow: .ellipsis,
+              style: theme.textTheme.titleSmall,
+            ),
+          ),
+          Text(
+            '$fileCount ${fileCount == 1 ? 'file' : 'files'}',
+            style: theme.textTheme.bodySmall,
+          ),
+          if (snapshot.addedLineCount > 0) ...<Widget>[
+            const SizedBox(width: AleraTokens.space8),
+            Text(
+              '+${snapshot.addedLineCount}',
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: AleraTokens.success,
+              ),
+            ),
+          ],
+          if (snapshot.removedLineCount > 0) ...<Widget>[
+            const SizedBox(width: AleraTokens.space8),
+            Text(
+              '-${snapshot.removedLineCount}',
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: AleraTokens.error,
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
   }
+}
+
+class const _ChangeRow({
+  required final MobileGitChange change,
+  required final VoidCallback onTap,
+}) extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final fileName = workspaceFileBaseName(change.path);
+    final parent = workspaceFileParentLabel(change.path);
+    final (letter, color) = _statusMark(change.status);
+    return Tooltip(
+      message: change.path,
+      child: InkWell(
+        onTap: onTap,
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(
+            minHeight: AleraTokens.minTapTarget,
+          ),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(
+              horizontal: AleraTokens.space16,
+              vertical: AleraTokens.space8,
+            ),
+            child: Row(
+              children: <Widget>[
+                SizedBox(
+                  width: 16,
+                  child: Text(
+                    letter,
+                    textAlign: .center,
+                    style: theme.textTheme.labelSmall?.copyWith(
+                      color: color,
+                      fontWeight: .w600,
+                    ),
+                  ),
+                ),
+                const SizedBox(width: AleraTokens.space8),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: .start,
+                    children: <Widget>[
+                      Text(
+                        fileName,
+                        maxLines: 1,
+                        overflow: .ellipsis,
+                        style: theme.textTheme.bodyMedium,
+                      ),
+                      if (parent != null)
+                        Text(
+                          parent,
+                          maxLines: 1,
+                          overflow: .ellipsis,
+                          style: theme.textTheme.bodySmall,
+                        ),
+                    ],
+                  ),
+                ),
+                const SizedBox(width: AleraTokens.space8),
+                _LineStats(added: change.added, removed: change.removed),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class const _LineStats({required final int? added, required final int? removed})
+    extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    final visibleAdded = added != null && added! > 0 ? added : null;
+    final visibleRemoved = removed != null && removed! > 0 ? removed : null;
+    if (visibleAdded == null && visibleRemoved == null) {
+      return const SizedBox.shrink();
+    }
+    final style = Theme.of(context).textTheme.labelSmall;
+    return Row(
+      mainAxisSize: .min,
+      children: <Widget>[
+        if (visibleAdded case final added?)
+          Text('+$added', style: style?.copyWith(color: AleraTokens.success)),
+        if (visibleRemoved case final removed?) ...<Widget>[
+          if (visibleAdded != null) const SizedBox(width: AleraTokens.space6),
+          Text('-$removed', style: style?.copyWith(color: AleraTokens.error)),
+        ],
+      ],
+    );
+  }
+}
+
+(String, Color) _statusMark(String status) {
+  return switch (status) {
+    'added' => ('A', AleraTokens.success),
+    'untracked' => ('U', AleraTokens.success),
+    'deleted' => ('D', AleraTokens.error),
+    'renamed' => ('R', AleraTokens.warning),
+    'copied' => ('C', AleraTokens.warning),
+    'modified' => ('M', AleraTokens.warning),
+    _ => (
+      status.isEmpty ? 'M' : status[0].toUpperCase(),
+      AleraTokens.foregroundMuted,
+    ),
+  };
 }

--- a/mobile/lib/src/features/workbench/presentation/workspace_diff_viewer_screen.dart
+++ b/mobile/lib/src/features/workbench/presentation/workspace_diff_viewer_screen.dart
@@ -1,7 +1,7 @@
 import 'package:alera_mobile/src/app/theme/alera_tokens.dart';
 import 'package:alera_mobile/src/features/runtime/domain/mobile_workspace_panels.dart';
 import 'package:alera_mobile/src/features/workbench/application/workbench_providers.dart';
-import 'package:alera_mobile/src/features/workbench/presentation/workspace_file_picker_sheet.dart';
+import 'package:alera_mobile/src/features/workbench/presentation/workspace_path_display.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 

--- a/mobile/lib/src/features/workbench/presentation/workspace_file_picker_sheet.dart
+++ b/mobile/lib/src/features/workbench/presentation/workspace_file_picker_sheet.dart
@@ -221,11 +221,6 @@ Future<String?> showWorkspaceFilePickerSheet(
   );
 }
 
-String workspaceFileBaseName(String path) {
-  final normalized = path.replaceAll('\\', '/');
-  return normalized.substring(normalized.lastIndexOf('/') + 1);
-}
-
 IconData workspaceFileIcon(String path) =>
     switch (p.extension(path).toLowerCase()) {
       '.dart' => Icons.flutter_dash,

--- a/mobile/lib/src/features/workbench/presentation/workspace_file_viewer_screen.dart
+++ b/mobile/lib/src/features/workbench/presentation/workspace_file_viewer_screen.dart
@@ -7,7 +7,7 @@ import 'package:alera_mobile/src/design_system/icons/alera_icons.dart';
 import 'package:alera_mobile/src/features/runtime/domain/mobile_codex_workspace.dart';
 import 'package:alera_mobile/src/features/runtime/domain/runtime_client_surfaces.dart';
 import 'package:alera_mobile/src/features/workbench/application/workbench_providers.dart';
-import 'package:alera_mobile/src/features/workbench/presentation/workspace_file_picker_sheet.dart';
+import 'package:alera_mobile/src/features/workbench/presentation/workspace_path_display.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 

--- a/mobile/lib/src/features/workbench/presentation/workspace_path_display.dart
+++ b/mobile/lib/src/features/workbench/presentation/workspace_path_display.dart
@@ -1,0 +1,31 @@
+/// File-name and parent-path labels for mobile file rows.
+String workspaceFileBaseName(String path) {
+  final normalized = path.replaceAll('\\', '/');
+  return normalized.substring(normalized.lastIndexOf('/') + 1);
+}
+
+String? workspaceFileDirectory(String path) {
+  final normalized = path.replaceAll('\\', '/');
+  final index = normalized.lastIndexOf('/');
+  if (index <= 0) {
+    return null;
+  }
+  return normalized.substring(0, index);
+}
+
+/// Last [maxSegments] directory segments, so long `lib/src/features/...`
+/// prefixes do not dominate a phone row.
+String? workspaceFileParentLabel(String path, {int maxSegments = 2}) {
+  final directory = workspaceFileDirectory(path);
+  if (directory == null || directory.isEmpty) {
+    return null;
+  }
+  final parts = directory
+      .split('/')
+      .where((part) => part.isNotEmpty)
+      .toList(growable: false);
+  if (parts.length <= maxSegments) {
+    return directory;
+  }
+  return parts.sublist(parts.length - maxSegments).join('/');
+}

--- a/mobile/test/workspace_panels_test.dart
+++ b/mobile/test/workspace_panels_test.dart
@@ -1,3 +1,5 @@
+import 'package:alera_mobile/src/app/theme/alera_theme.dart';
+import 'package:alera_mobile/src/design_system/icons/alera_icons.dart';
 import 'package:alera_mobile/src/features/runtime/domain/mobile_workspace_panels.dart';
 import 'package:alera_mobile/src/features/runtime/domain/workspace_summary.dart';
 import 'package:alera_mobile/src/features/runtime/domain/workspace_tab_summary.dart';
@@ -134,11 +136,20 @@ void main() {
       ),
     );
     await tester.pumpAndSettle();
-    expect(find.text('Terminal'), findsWidgets);
+    expect(find.byType(NavigationBar), findsNothing);
+
+    await tester.tap(find.byTooltip('More Actions'));
+    await tester.pumpAndSettle();
+    expect(find.text('Terminal'), findsOneWidget);
     expect(find.text('Explorer'), findsOneWidget);
     expect(find.text('Search'), findsOneWidget);
     expect(find.text('Source Control'), findsOneWidget);
     expect(find.text('Pull Request'), findsOneWidget);
+    expect(find.text('Terminal Quick Keys'), findsOneWidget);
+    expect(find.byIcon(AleraIcons.folder), findsOneWidget);
+    expect(find.byIcon(AleraIcons.search), findsOneWidget);
+    expect(find.byIcon(AleraIcons.gitBranch), findsOneWidget);
+    expect(find.byIcon(AleraIcons.gitPullRequest), findsOneWidget);
 
     await tester.tap(find.text('Explorer'));
     await tester.pumpAndSettle();
@@ -171,6 +182,12 @@ void main() {
     );
     await tester.pumpAndSettle();
     expect(find.byType(NavigationBar), findsNothing);
+    await tester.tap(find.byTooltip('More Actions'));
+    await tester.pumpAndSettle();
+    expect(find.text('Explorer'), findsNothing);
+    expect(find.text('Source Control'), findsNothing);
+    expect(find.text('Pull Request'), findsNothing);
+    expect(find.text('Terminal Quick Keys'), findsOneWidget);
     expect(
       ProviderScope.containerOf(
         tester.element(find.byType(WorkspaceTabsScreen)),
@@ -178,4 +195,164 @@ void main() {
       WorkspacePanelDestination.terminal,
     );
   });
+
+  testWidgets('empty terminal state invites a new terminal', (tester) async {
+    final client = FakeTerminalClient()
+      ..tabs = const <WorkspaceTabSummary>[]
+      ..explorerSupported = true
+      ..workspaceSearchSupported = true
+      ..sourceControlSupported = true
+      ..pullRequestsSupported = true;
+    addTearDown(client.dispose);
+
+    await _pumpWorkspace(tester, client);
+    expect(find.text('No terminals'), findsOneWidget);
+    expect(
+      find.text('Open a terminal to start working in this workspace.'),
+      findsOneWidget,
+    );
+    expect(find.text('New Terminal'), findsOneWidget);
+    expect(find.text('No tabs yet'), findsNothing);
+  });
+
+  testWidgets(
+    'source control shows compact file names instead of wrapping paths',
+    (tester) async {
+      const path =
+          'lib/src/features/pull_requests/domain/review_stack_workspace_models.dart';
+      final client = FakeTerminalClient()
+        ..tabs = <WorkspaceTabSummary>[
+          fakeTab(id: 'tab-1', title: 'Terminal 1'),
+        ]
+        ..explorerSupported = true
+        ..workspaceSearchSupported = true
+        ..sourceControlSupported = true
+        ..pullRequestsSupported = true
+        ..gitStatusSnapshot = const MobileGitStatusSnapshot(
+          isRepository: true,
+          branch: 'main',
+          entries: <MobileGitChange>[
+            MobileGitChange(
+              path: path,
+              area: 'unstaged',
+              status: 'modified',
+              added: 1,
+              removed: 0,
+            ),
+          ],
+        );
+      addTearDown(client.dispose);
+
+      await _pumpWorkspace(tester, client, surface: const Size(390, 844));
+      await _openWorkspacePanel(tester, 'Source Control');
+
+      expect(find.text('review_stack_workspace_models.dart'), findsOneWidget);
+      expect(find.text('pull_requests/domain'), findsOneWidget);
+      expect(find.text(path), findsNothing);
+      expect(find.text('UNSTAGED'), findsOneWidget);
+      expect(find.text('+1'), findsWidgets);
+      expect(find.text('-0'), findsNothing);
+      expect(
+        find.text(
+          'Read-only on mobile. Stage, unstage, and commit stay on desktop.',
+        ),
+        findsOneWidget,
+      );
+    },
+  );
+
+  testWidgets('pull request checks ellipsize names and color status', (
+    tester,
+  ) async {
+    final client = FakeTerminalClient()
+      ..tabs = <WorkspaceTabSummary>[fakeTab(id: 'tab-1', title: 'Terminal 1')]
+      ..explorerSupported = true
+      ..workspaceSearchSupported = true
+      ..sourceControlSupported = true
+      ..pullRequestsSupported = true
+      ..pullRequest = MobilePullRequestSnapshot.fromJson(
+        const <String, Object?>{
+          'branch': 'feat/panels',
+          'identity': <String, Object?>{'owner': 'leynier', 'repo': 'alera'},
+          'review': <String, Object?>{
+            'number': 629,
+            'title':
+                'fix: omit ignored-only directories from workspace listings',
+            'state': 'MERGED',
+            'url': 'https://github.com/leynier/alera/pull/629',
+            'author': 'leynier',
+            'headRefName':
+                'ship/omit-ignored-only-directories-from-workspace-listings',
+            'baseRefName': 'main',
+            'checks': <Object?>[
+              <String, Object?>{
+                'name': r'build app ${{ matrix.platform }}',
+                'bucket': 'skipping',
+              },
+              <String, Object?>{'name': 'cleanup', 'bucket': 'pass'},
+            ],
+            'comments': <Object?>[],
+          },
+        },
+      );
+    addTearDown(client.dispose);
+
+    await _pumpWorkspace(tester, client, surface: const Size(390, 844));
+    await _openWorkspacePanel(tester, 'Pull Request');
+
+    expect(find.text('leynier/alera'), findsOneWidget);
+    expect(find.text('Merged'), findsOneWidget);
+    expect(find.text('MERGED'), findsNothing);
+    expect(find.byTooltip('Open In Browser'), findsOneWidget);
+    expect(find.widgetWithText(FilledButton, 'Open In Browser'), findsNothing);
+    expect(find.text('build app {platform}'), findsOneWidget);
+    expect(find.text(r'build app ${{ matrix.platform }}'), findsNothing);
+    expect(find.text('Skipped'), findsOneWidget);
+    expect(find.text('Pass'), findsOneWidget);
+    expect(find.text('cleanup'), findsOneWidget);
+    expect(find.text('1 passed · 1 skipped'), findsOneWidget);
+    expect(
+      tester.getSize(find.text('build app {platform}')).height,
+      lessThan(24),
+    );
+  });
+}
+
+Future<void> _pumpWorkspace(
+  WidgetTester tester,
+  FakeTerminalClient client, {
+  Size? surface,
+}) async {
+  if (surface != null) {
+    await tester.binding.setSurfaceSize(surface);
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+  }
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        terminalClientProvider('host-1').overrideWith((ref) async => client),
+        workspaceClientProvider('host-1').overrideWith((ref) async => client),
+      ],
+      child: MaterialApp(
+        theme: buildAleraMobileDarkTheme(),
+        home: const WorkspaceTabsScreen(
+          hostId: 'host-1',
+          workspace: WorkspaceSummary(
+            id: 'workspace-1',
+            projectId: 'project-1',
+            name: 'Workspace',
+            path: '/repo',
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+Future<void> _openWorkspacePanel(WidgetTester tester, String label) async {
+  await tester.tap(find.byTooltip('More Actions'));
+  await tester.pumpAndSettle();
+  await tester.tap(find.text(label));
+  await tester.pumpAndSettle();
 }

--- a/mobile/test/workspace_path_display_test.dart
+++ b/mobile/test/workspace_path_display_test.dart
@@ -1,0 +1,62 @@
+import 'package:alera_mobile/src/features/workbench/presentation/pull_request_panel.dart';
+import 'package:alera_mobile/src/features/workbench/presentation/workspace_path_display.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('workspaceFileParentLabel', () {
+    test('returns the file name for a root file', () {
+      expect(workspaceFileBaseName('main.dart'), 'main.dart');
+      expect(workspaceFileDirectory('main.dart'), isNull);
+      expect(workspaceFileParentLabel('main.dart'), isNull);
+    });
+
+    test('keeps a short directory intact', () {
+      expect(workspaceFileBaseName('lib/main.dart'), 'main.dart');
+      expect(workspaceFileDirectory('lib/main.dart'), 'lib');
+      expect(workspaceFileParentLabel('lib/main.dart'), 'lib');
+    });
+
+    test('keeps the last two directory segments of a long path', () {
+      expect(
+        workspaceFileBaseName(
+          'lib/src/features/pull_requests/domain/review_stack_workspace_models.dart',
+        ),
+        'review_stack_workspace_models.dart',
+      );
+      expect(
+        workspaceFileParentLabel(
+          'lib/src/features/pull_requests/domain/review_stack_workspace_models.dart',
+        ),
+        'pull_requests/domain',
+      );
+    });
+
+    test('normalizes windows separators', () {
+      expect(
+        workspaceFileParentLabel(
+          r'lib\src\features\workbench\application\foo.dart',
+        ),
+        'workbench/application',
+      );
+    });
+  });
+
+  group('displayPullRequestCheckName', () {
+    test('collapses github matrix expressions', () {
+      expect(
+        displayPullRequestCheckName(r'build app ${{ matrix.platform }}'),
+        'build app {platform}',
+      );
+      expect(
+        displayPullRequestCheckName(
+          r'build runtime ${{ matrix.platform }} ${{ matrix.arch }}',
+        ),
+        'build runtime {platform} {arch}',
+      );
+    });
+
+    test('leaves ordinary check names unchanged', () {
+      expect(displayPullRequestCheckName('cleanup'), 'cleanup');
+    });
+  });
+}


### PR DESCRIPTION
Improve mobile workspace navigation and workspace panel readability:

- Replace the bottom navigation bar with a contextual panel selector in the overflow menu.
- Refresh empty terminal states, panel icons, and mobile navigation styling.
- Add reusable notices, section headers, badges, and compact workspace path labels.
- Redesign source control and pull request panels for clearer summaries, statuses, checks, comments, and read-only guidance.
- Add tests covering panel selection, empty states, compact paths, pull request check formatting, and status presentation.