### PR TITLE
feat: use desktop file-type icons on mobile

### DIFF
--- a/docs/ui-styleguide.md
+++ b/docs/ui-styleguide.md
@@ -111,7 +111,7 @@ Experimental has a separate requested panel width, constrained at render time to
 Icons come from Lucide (`lucide_icons_flutter`), the same family Orca uses and the de-facto standard for modern developer tooling. Reference icons by semantic role through `AleraIcons` (e.g. `AleraIcons.delete`, `AleraIcons.gitBranch`), never raw `Icons.*` or `LucideIcons.*` at call sites.
 
 - `AleraIcons` (`lib/src/design_system/icons/alera_icons.dart`) is the single source of truth and the only entry point to `lucide_icons_flutter`. Add a new semantic role there rather than reaching for a glyph at the call site.
-- File-type icons in the explorer keep using `vscode_material_icon_theme` (the VSCode standard for file trees) via `AleraFileIcon`; its fallbacks resolve through `AleraIcons`.
+- File-type icons in the explorer keep using `vscode_material_icon_theme` (the VSCode standard for file trees) via `AleraFileIcon`; its fallbacks resolve through `AleraIcons`. The mobile app draws the same glyphs in Explorer, Source Control, Search, Quick Open, and the file and diff viewers through its own copy of `AleraFileIcon` (`mobile/lib/src/design_system/icons/alera_file_icon.dart`), pinned to the same package version.
 
 ## Reference Paths
 

--- a/mobile/AGENTS.md
+++ b/mobile/AGENTS.md
@@ -8,6 +8,7 @@ This file applies under `mobile/`. The root `AGENTS.md` also applies; this file 
 
 - The mobile companion app is a separate Flutter package (`alera_mobile`) so mobile plugins and manifests never leak into the desktop package at the repo root.
 - Source follows the desktop feature architecture: `lib/src/app/` (app shell and theme), `lib/src/core/` (protocol constants and payload parsing), `lib/src/design_system/` (presentational shared widgets with `@AleraPreview` previews), and `lib/src/features/<feature>/{domain,application,infra,presentation}`.
+- `AleraFileIcon` (`lib/src/design_system/icons/alera_file_icon.dart`) is a copy of the desktop widget, because `alera_mobile` has no dependency on the root package. Keep both copies and the `vscode_material_icon_theme` version in sync, so a path draws the same glyph on the phone and on the desktop. File rows use it rather than Material icons picked by extension.
 - Mobile UI values MUST come from the mobile `AleraTokens` (`lib/src/app/theme/alera_tokens.dart`) and `ThemeData`. The app is dark-only, Inter for general text and JetBrains Mono for monospaced text, matching the desktop rules.
 
 ## State Management

--- a/mobile/lib/src/app/theme/alera_tokens.dart
+++ b/mobile/lib/src/app/theme/alera_tokens.dart
@@ -25,6 +25,9 @@ abstract final class AleraTokens {
   static const double minTapTarget = space48;
   static const double iconSm = space12;
 
+  /// File-type glyphs in phone rows: larger than the desktop sidebar's 16.
+  static const double iconMd = space20;
+
   static const double emptyStateMaxWidth = 520.0;
   static const double conversationMaxWidth = 760.0;
   static const double chatBubbleMaxWidth = 620.0;

--- a/mobile/lib/src/design_system/icons/alera_file_icon.dart
+++ b/mobile/lib/src/design_system/icons/alera_file_icon.dart
@@ -1,0 +1,87 @@
+import 'package:alera_mobile/src/app/theme/alera_tokens.dart';
+import 'package:alera_mobile/src/design_system/icons/alera_icons.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:vscode_material_icon_theme/vscode_material_icon_theme.dart';
+
+// Duplicated from the desktop `lib/src/design_system/icons/alera_file_icon.dart`
+// because `alera_mobile` does not depend on the root package. Keep both in sync
+// so the phone and the desktop draw the same glyph for a given path.
+
+enum AleraFileIconKind {
+  file,
+  folder,
+  symlink,
+  generic;
+
+  /// Maps a workspace entry `kind` reported by the runtime host.
+  static AleraFileIconKind fromEntryKind(String kind) => switch (kind) {
+    'directory' => folder,
+    'file' => file,
+    'symlink' => symlink,
+    _ => generic,
+  };
+}
+
+class const AleraFileIcon({
+  super.key,
+  required final String pathOrName,
+  required final AleraFileIconKind kind,
+  final bool isExpanded = false,
+  final double size = AleraTokens.iconMd,
+  final Color fallbackColor = AleraTokens.foregroundMuted,
+}) extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox.square(
+      dimension: size,
+      child: switch (kind) {
+        AleraFileIconKind.file => _svgIcon(
+          fileToIcon(aleraFileIconName(pathOrName)),
+          fallback: AleraIcons.file,
+        ),
+        AleraFileIconKind.folder => _svgIcon(
+          directoryToIcon(
+            aleraFileIconName(pathOrName),
+            isExpanded: isExpanded,
+          ),
+          fallback: isExpanded ? AleraIcons.folderOpen : AleraIcons.folder,
+        ),
+        AleraFileIconKind.symlink => Icon(
+          AleraIcons.link,
+          size: size,
+          color: fallbackColor,
+        ),
+        AleraFileIconKind.generic => Icon(
+          AleraIcons.fileGeneric,
+          size: size,
+          color: fallbackColor,
+        ),
+      },
+    );
+  }
+
+  Widget _svgIcon(BytesLoader loader, {required IconData fallback}) {
+    return SvgPicture(
+      loader,
+      width: size,
+      height: size,
+      fit: .contain,
+      excludeFromSemantics: true,
+      placeholderBuilder: (_) =>
+          Icon(fallback, size: size, color: fallbackColor),
+      errorBuilder: (_, _, _) =>
+          Icon(fallback, size: size, color: fallbackColor),
+    );
+  }
+}
+
+/// Lowercase basename the icon theme matches against, for `/` and `\` paths.
+@visibleForTesting
+String aleraFileIconName(String pathOrName) {
+  final lastSlash = pathOrName.lastIndexOf('/');
+  final lastBackslash = pathOrName.lastIndexOf(r'\');
+  final index = lastSlash > lastBackslash ? lastSlash : lastBackslash;
+  final basename = index < 0 ? pathOrName : pathOrName.substring(index + 1);
+  return basename.toLowerCase();
+}

--- a/mobile/lib/src/design_system/icons/alera_file_icon.preview.dart
+++ b/mobile/lib/src/design_system/icons/alera_file_icon.preview.dart
@@ -1,0 +1,32 @@
+import 'package:alera_mobile/src/app/theme/alera_tokens.dart';
+import 'package:alera_mobile/src/design_system/alera_preview.dart';
+import 'package:alera_mobile/src/design_system/icons/alera_file_icon.dart';
+import 'package:flutter/material.dart';
+
+@AleraPreview(name: 'Files', group: 'File Icon')
+Widget aleraFileIconFilesPreview() => const Row(
+  mainAxisSize: .min,
+  children: <Widget>[
+    AleraFileIcon(pathOrName: 'pubspec.yaml', kind: .file),
+    SizedBox(width: AleraTokens.space12),
+    AleraFileIcon(pathOrName: 'lib/main.dart', kind: .file),
+    SizedBox(width: AleraTokens.space12),
+    AleraFileIcon(pathOrName: 'rust/src/lib.rs', kind: .file),
+    SizedBox(width: AleraTokens.space12),
+    AleraFileIcon(pathOrName: '.gitignore', kind: .file),
+  ],
+);
+
+@AleraPreview(name: 'Folders', group: 'File Icon')
+Widget aleraFileIconFoldersPreview() => const Row(
+  mainAxisSize: .min,
+  children: <Widget>[
+    AleraFileIcon(pathOrName: 'src', kind: .folder),
+    SizedBox(width: AleraTokens.space12),
+    AleraFileIcon(pathOrName: 'src', kind: .folder, isExpanded: true),
+    SizedBox(width: AleraTokens.space12),
+    AleraFileIcon(pathOrName: 'link', kind: .symlink),
+    SizedBox(width: AleraTokens.space12),
+    AleraFileIcon(pathOrName: 'socket', kind: .generic),
+  ],
+);

--- a/mobile/lib/src/design_system/icons/alera_icons.dart
+++ b/mobile/lib/src/design_system/icons/alera_icons.dart
@@ -54,6 +54,8 @@ abstract final class const AleraIcons._() {
   static const IconData folder = LucideIcons.folder;
   static const IconData folderOpen = LucideIcons.folderOpen;
   static const IconData folderOff = LucideIcons.folderX;
+  static const IconData file = LucideIcons.fileText;
+  static const IconData fileGeneric = LucideIcons.file;
   static const IconData cloudOff = LucideIcons.cloudOff;
   static const IconData systemUpdate = LucideIcons.download;
   static const IconData contextCompact = LucideIcons.foldHorizontal;

--- a/mobile/lib/src/features/workbench/presentation/explorer_panel.dart
+++ b/mobile/lib/src/features/workbench/presentation/explorer_panel.dart
@@ -1,8 +1,8 @@
 import 'package:alera_mobile/src/app/theme/alera_tokens.dart';
 import 'package:alera_mobile/src/design_system/feedback/alera_empty_state.dart';
+import 'package:alera_mobile/src/design_system/icons/alera_file_icon.dart';
 import 'package:alera_mobile/src/design_system/icons/alera_icons.dart';
 import 'package:alera_mobile/src/features/workbench/application/explorer_controller.dart';
-import 'package:alera_mobile/src/features/workbench/presentation/workspace_file_picker_sheet.dart';
 import 'package:alera_mobile/src/features/workbench/presentation/workspace_file_viewer_screen.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -72,12 +72,10 @@ class const _ExplorerBody({
                   height: AleraTokens.space20,
                   child: CircularProgressIndicator(strokeWidth: 2),
                 )
-              : Icon(
-                  row.entry.isDirectory
-                      ? (row.expanded
-                            ? AleraIcons.folderOpen
-                            : AleraIcons.folder)
-                      : workspaceFileIcon(row.entry.relativePath),
+              : AleraFileIcon(
+                  pathOrName: row.entry.name,
+                  kind: AleraFileIconKind.fromEntryKind(row.entry.kind),
+                  isExpanded: row.expanded,
                 ),
           title: Text(row.entry.name),
           trailing: row.entry.isDirectory

--- a/mobile/lib/src/features/workbench/presentation/source_control_panel.dart
+++ b/mobile/lib/src/features/workbench/presentation/source_control_panel.dart
@@ -1,6 +1,7 @@
 import 'package:alera_mobile/src/app/theme/alera_tokens.dart';
 import 'package:alera_mobile/src/design_system/feedback/alera_empty_state.dart';
 import 'package:alera_mobile/src/design_system/feedback/alera_notice.dart';
+import 'package:alera_mobile/src/design_system/icons/alera_file_icon.dart';
 import 'package:alera_mobile/src/design_system/icons/alera_icons.dart';
 import 'package:alera_mobile/src/design_system/layout/alera_section_header.dart';
 import 'package:alera_mobile/src/features/runtime/domain/mobile_workspace_panels.dart';
@@ -215,18 +216,8 @@ class const _ChangeRow({
             ),
             child: Row(
               children: <Widget>[
-                SizedBox(
-                  width: 16,
-                  child: Text(
-                    letter,
-                    textAlign: .center,
-                    style: theme.textTheme.labelSmall?.copyWith(
-                      color: color,
-                      fontWeight: .w600,
-                    ),
-                  ),
-                ),
-                const SizedBox(width: AleraTokens.space8),
+                AleraFileIcon(pathOrName: change.path, kind: .file),
+                const SizedBox(width: AleraTokens.space12),
                 Expanded(
                   child: Column(
                     crossAxisAlignment: .start,
@@ -245,6 +236,18 @@ class const _ChangeRow({
                           style: theme.textTheme.bodySmall,
                         ),
                     ],
+                  ),
+                ),
+                const SizedBox(width: AleraTokens.space8),
+                SizedBox(
+                  width: AleraTokens.space16,
+                  child: Text(
+                    letter,
+                    textAlign: .center,
+                    style: theme.textTheme.labelSmall?.copyWith(
+                      color: color,
+                      fontWeight: .w600,
+                    ),
                   ),
                 ),
                 const SizedBox(width: AleraTokens.space8),

--- a/mobile/lib/src/features/workbench/presentation/workspace_diff_viewer_screen.dart
+++ b/mobile/lib/src/features/workbench/presentation/workspace_diff_viewer_screen.dart
@@ -1,7 +1,7 @@
 import 'package:alera_mobile/src/app/theme/alera_tokens.dart';
 import 'package:alera_mobile/src/features/runtime/domain/mobile_workspace_panels.dart';
 import 'package:alera_mobile/src/features/workbench/application/workbench_providers.dart';
-import 'package:alera_mobile/src/features/workbench/presentation/workspace_path_display.dart';
+import 'package:alera_mobile/src/features/workbench/presentation/workspace_file_app_bar_title.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -14,9 +14,7 @@ class const WorkspaceDiffViewerScreen({
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return Scaffold(
-      appBar: AppBar(
-        title: Text(workspaceFileBaseName(change.path), overflow: .ellipsis),
-      ),
+      appBar: AppBar(title: WorkspaceFileAppBarTitle(change.path)),
       body: FutureBuilder<MobileGitDiffFile>(
         future: _load(ref),
         builder: (context, snapshot) {

--- a/mobile/lib/src/features/workbench/presentation/workspace_file_app_bar_title.dart
+++ b/mobile/lib/src/features/workbench/presentation/workspace_file_app_bar_title.dart
@@ -1,0 +1,20 @@
+import 'package:alera_mobile/src/app/theme/alera_tokens.dart';
+import 'package:alera_mobile/src/design_system/icons/alera_file_icon.dart';
+import 'package:alera_mobile/src/features/workbench/presentation/workspace_path_display.dart';
+import 'package:flutter/material.dart';
+
+/// File viewer and diff viewer app bar title: file-type icon plus basename.
+class const WorkspaceFileAppBarTitle(final String path, {super.key})
+    extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisSize: .min,
+      children: <Widget>[
+        AleraFileIcon(pathOrName: path, kind: .file),
+        const SizedBox(width: AleraTokens.space8),
+        Flexible(child: Text(workspaceFileBaseName(path), overflow: .ellipsis)),
+      ],
+    );
+  }
+}

--- a/mobile/lib/src/features/workbench/presentation/workspace_file_picker_sheet.dart
+++ b/mobile/lib/src/features/workbench/presentation/workspace_file_picker_sheet.dart
@@ -1,10 +1,10 @@
 import 'dart:async';
 
 import 'package:alera_mobile/src/app/theme/alera_tokens.dart';
+import 'package:alera_mobile/src/design_system/icons/alera_file_icon.dart';
 import 'package:alera_mobile/src/features/runtime/domain/mobile_codex_workspace.dart';
 import 'package:flutter/material.dart';
 import 'package:logging/logging.dart';
-import 'package:path/path.dart' as p;
 
 final Logger _logger = Logger('WorkspaceFilePickerSheet');
 
@@ -186,7 +186,10 @@ class _WorkspaceFilePickerSheetState extends State<WorkspaceFilePickerSheet> {
                     final match = _matches[index];
                     return ListTile(
                       minTileHeight: AleraTokens.minTapTarget,
-                      leading: Icon(workspaceFileIcon(match.relativePath)),
+                      leading: AleraFileIcon(
+                        pathOrName: match.relativePath,
+                        kind: .file,
+                      ),
                       title: Text(match.relativePath),
                       onTap: () =>
                           Navigator.of(context).pop(match.relativePath),
@@ -220,15 +223,3 @@ Future<String?> showWorkspaceFilePickerSheet(
     ),
   );
 }
-
-IconData workspaceFileIcon(String path) =>
-    switch (p.extension(path).toLowerCase()) {
-      '.dart' => Icons.flutter_dash,
-      '.rs' => Icons.settings_outlined,
-      '.md' || '.mdx' => Icons.description_outlined,
-      '.json' || '.yaml' || '.yml' || '.toml' => Icons.data_object,
-      '.png' || '.jpg' || '.jpeg' || '.gif' || '.webp' => Icons.image_outlined,
-      '.sql' => Icons.storage_outlined,
-      '.sh' || '.ps1' || '.bat' => Icons.terminal,
-      _ => Icons.insert_drive_file_outlined,
-    };

--- a/mobile/lib/src/features/workbench/presentation/workspace_file_viewer_screen.dart
+++ b/mobile/lib/src/features/workbench/presentation/workspace_file_viewer_screen.dart
@@ -10,8 +10,8 @@ import 'package:alera_mobile/src/features/runtime/domain/runtime_client_surfaces
 import 'package:alera_mobile/src/features/updater/infra/mobile_external_browser.dart';
 import 'package:alera_mobile/src/features/workbench/application/workbench_providers.dart';
 import 'package:alera_mobile/src/features/workbench/domain/workspace_markdown_uri_policy.dart';
+import 'package:alera_mobile/src/features/workbench/presentation/workspace_file_app_bar_title.dart';
 import 'package:alera_mobile/src/features/workbench/presentation/workspace_file_markdown_preview.dart';
-import 'package:alera_mobile/src/features/workbench/presentation/workspace_path_display.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:logging/logging.dart';
@@ -103,10 +103,7 @@ class _WorkspaceFileViewerScreenState
     final previewing = _mode == WorkspaceFileViewMode.preview;
     return Scaffold(
       appBar: AppBar(
-        title: Text(
-          workspaceFileBaseName(widget.relativePath),
-          overflow: .ellipsis,
-        ),
+        title: WorkspaceFileAppBarTitle(widget.relativePath),
         actions: <Widget>[
           if (isWorkspaceMarkdownPath(widget.relativePath))
             IconButton(

--- a/mobile/lib/src/features/workbench/presentation/workspace_text_search_panel.dart
+++ b/mobile/lib/src/features/workbench/presentation/workspace_text_search_panel.dart
@@ -2,6 +2,7 @@ import 'package:alera_mobile/src/app/theme/alera_tokens.dart';
 import 'package:alera_mobile/src/design_system/feedback/alera_empty_state.dart';
 import 'package:alera_mobile/src/design_system/forms/alera_search_field.dart';
 import 'package:alera_mobile/src/design_system/forms/alera_text_field.dart';
+import 'package:alera_mobile/src/design_system/icons/alera_file_icon.dart';
 import 'package:alera_mobile/src/design_system/icons/alera_icons.dart';
 import 'package:alera_mobile/src/features/workbench/application/workspace_text_search_controller.dart';
 import 'package:alera_mobile/src/features/workbench/presentation/workspace_file_viewer_screen.dart';
@@ -155,6 +156,7 @@ class const _Results({
       itemBuilder: (context, index) {
         final file = result.files[index];
         return ExpansionTile(
+          leading: AleraFileIcon(pathOrName: file.relativePath, kind: .file),
           title: Text(file.relativePath),
           subtitle: Text(
             '${file.matches.length} ${file.matches.length == 1 ? 'match' : 'matches'}',

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -1627,6 +1627,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "15.3.0"
+  vscode_material_icon_theme:
+    dependency: "direct main"
+    description:
+      name: vscode_material_icon_theme
+      sha256: bb97923e7242262106fce803d2dbd3ed82ff62c1101b291d843a31e357f69da0
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.37.0"
   watcher:
     dependency: transitive
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -52,6 +52,7 @@ dependencies:
   shared_preferences: ^2.5.5
   package_info_plus: ^10.2.1
   url_launcher: ^6.3.2
+  vscode_material_icon_theme: ^5.37.0
   web_socket_channel: ^3.0.3
   xterm2:
     path: ../third_party/xterm

--- a/mobile/test/alera_file_icon_test.dart
+++ b/mobile/test/alera_file_icon_test.dart
@@ -1,0 +1,172 @@
+import 'package:alera_mobile/src/design_system/icons/alera_file_icon.dart';
+import 'package:alera_mobile/src/design_system/icons/alera_file_icon.preview.dart';
+import 'package:alera_mobile/src/design_system/icons/alera_icons.dart';
+import 'package:alera_mobile/src/features/runtime/domain/mobile_workspace_panels.dart';
+import 'package:alera_mobile/src/features/workbench/application/source_control_controller.dart';
+import 'package:alera_mobile/src/features/workbench/presentation/source_control_panel.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+Future<void> _pump(WidgetTester tester, Widget child) => tester.pumpWidget(
+  MaterialApp(
+    home: Scaffold(body: Center(child: child)),
+  ),
+);
+
+class _FixedSourceControlController extends SourceControlController {
+  @override
+  Future<MobileGitStatusSnapshot> build(String hostId, String workspaceId) =>
+      Future.value(
+        const MobileGitStatusSnapshot(
+          isRepository: true,
+          branch: 'main',
+          entries: <MobileGitChange>[
+            MobileGitChange(
+              path: 'lib/src/main.dart',
+              area: 'unstaged',
+              status: 'modified',
+              added: 3,
+              removed: 1,
+            ),
+          ],
+        ),
+      );
+}
+
+void main() {
+  group('AleraFileIconKind.fromEntryKind', () {
+    test('maps runtime entry kinds like the desktop explorer', () {
+      expect(
+        AleraFileIconKind.fromEntryKind('directory'),
+        AleraFileIconKind.folder,
+      );
+      expect(AleraFileIconKind.fromEntryKind('file'), AleraFileIconKind.file);
+      expect(
+        AleraFileIconKind.fromEntryKind('symlink'),
+        AleraFileIconKind.symlink,
+      );
+      expect(
+        AleraFileIconKind.fromEntryKind('other'),
+        AleraFileIconKind.generic,
+      );
+      expect(
+        AleraFileIconKind.fromEntryKind('socket'),
+        AleraFileIconKind.generic,
+      );
+    });
+  });
+
+  test('matches the lowercase basename of POSIX and Windows paths', () {
+    expect(aleraFileIconName('lib/src/Main.DART'), 'main.dart');
+    expect(aleraFileIconName(r'rust\src\lib.rs'), 'lib.rs');
+    expect(aleraFileIconName('Makefile'), 'makefile');
+  });
+
+  testWidgets('files and folders render the icon theme glyph at the size', (
+    tester,
+  ) async {
+    await _pump(
+      tester,
+      const Row(
+        mainAxisSize: .min,
+        children: <Widget>[
+          AleraFileIcon(pathOrName: 'lib/main.dart', kind: .file, size: 20),
+          AleraFileIcon(pathOrName: 'src', kind: .folder, size: 20),
+          AleraFileIcon(
+            pathOrName: 'src',
+            kind: .folder,
+            isExpanded: true,
+            size: 20,
+          ),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byType(SvgPicture), findsNWidgets(3));
+    for (final element in find.byType(AleraFileIcon).evaluate()) {
+      expect(tester.getSize(find.byWidget(element.widget)), const Size(20, 20));
+    }
+    final folders = tester
+        .widgetList<SvgPicture>(find.byType(SvgPicture))
+        .skip(1)
+        .map((picture) => picture.bytesLoader)
+        .toList();
+    expect(folders[0], isNot(folders[1]));
+  });
+
+  testWidgets('symlinks and other entries use the Alera fallback glyphs', (
+    tester,
+  ) async {
+    await _pump(
+      tester,
+      const Row(
+        mainAxisSize: .min,
+        children: <Widget>[
+          AleraFileIcon(pathOrName: 'current', kind: .symlink),
+          AleraFileIcon(pathOrName: 'fifo', kind: .generic),
+        ],
+      ),
+    );
+
+    expect(find.byType(SvgPicture), findsNothing);
+    expect(find.byIcon(AleraIcons.link), findsOneWidget);
+    expect(find.byIcon(AleraIcons.fileGeneric), findsOneWidget);
+  });
+
+  testWidgets('previews lay out without exceptions', (tester) async {
+    await _pump(
+      tester,
+      Column(
+        children: <Widget>[
+          aleraFileIconFilesPreview(),
+          aleraFileIconFoldersPreview(),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byType(AleraFileIcon), findsNWidgets(8));
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('source control rows lead with the icon and trail the status', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          sourceControlControllerProvider(
+            'host-1',
+            'workspace-1',
+          ).overrideWith(_FixedSourceControlController.new),
+        ],
+        child: const MaterialApp(
+          home: Scaffold(
+            body: SourceControlPanel(
+              hostId: 'host-1',
+              workspaceId: 'workspace-1',
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final row = find.ancestor(
+      of: find.byType(AleraFileIcon),
+      matching: find.byType(InkWell),
+    );
+    Offset centerOf(Finder finder) =>
+        tester.getCenter(find.descendant(of: row.first, matching: finder));
+    final icon = centerOf(find.byType(AleraFileIcon));
+    final name = centerOf(find.text('main.dart'));
+    final status = centerOf(find.text('M'));
+    final added = centerOf(find.text('+3'));
+    expect(icon.dx, lessThan(name.dx));
+    expect(name.dx, lessThan(status.dx));
+    expect(status.dx, lessThan(added.dx));
+  });
+}


### PR DESCRIPTION
## Summary

Mobile file lists now draw the same file-type and folder glyphs as desktop (`vscode_material_icon_theme` 5.37.0) instead of generic Material icons picked by extension.

- New presentational `AleraFileIcon` in `mobile/lib/src/design_system/icons/`, copied from desktop because `alera_mobile` does not depend on the root package, plus `AleraFileIconKind.fromEntryKind` for runtime entry kinds and an `@AleraPreview`.
- Explorer: file glyphs plus open/closed folder states, and symlink/other fallbacks.
- Source Control: icon on the left, status letter moved beside the `+/-` stats, as on desktop.
- Search result headers, Quick Open, and the file and diff viewer app bars show the icon too.
- Removes `workspaceFileIcon`; adds `AleraTokens.iconMd` (20) for phone rows; documents the duplication in `mobile/AGENTS.md` and `docs/ui-styleguide.md`.

Closes #747

## Validation

- `flutter analyze` (mobile): no issues.
- `flutter test` (mobile): 450 passed, including new `alera_file_icon_test.dart` (kind mapping, basename normalization, SVG vs fallback glyphs, previews, Source Control row order).
- `dart run tool/quality/check_max_lines.dart`: ok.
- Rendered a throwaway golden of the Source Control panel and the icon set to check the glyphs and row layout visually.

## Risks

- `vscode_material_icon_theme` adds about 4.7 MB of uncompressed icon assets to the mobile bundle.
- Not yet checked on a real device against a paired runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hy8dFi2VG3eCRBUeAbJHQV
