### PR TITLE
feat: keep mobile source control visible while git status refreshes

### DIFF
--- a/mobile/lib/src/features/workbench/application/source_control_controller.dart
+++ b/mobile/lib/src/features/workbench/application/source_control_controller.dart
@@ -21,8 +21,14 @@ class SourceControlController extends _$SourceControlController {
     );
   }
 
+  /// Refreshes in place. Riverpod keeps the previous snapshot on a rebuild,
+  /// so the panel keeps its list on screen instead of blanking to a spinner.
   Future<void> reload() async {
-    state = const AsyncLoading();
-    state = await AsyncValue.guard(() => build(hostId, workspaceId));
+    ref.invalidateSelf();
+    try {
+      await future;
+    } on Object {
+      // The failure is already on `state`, next to the previous snapshot.
+    }
   }
 }

--- a/mobile/lib/src/features/workbench/application/source_control_controller.g.dart
+++ b/mobile/lib/src/features/workbench/application/source_control_controller.g.dart
@@ -56,7 +56,7 @@ final class SourceControlControllerProvider
 }
 
 String _$sourceControlControllerHash() =>
-    r'890d5465497c52762073596d5391c5ea59069c37';
+    r'd5febd0ad4656e6eec728f3c647e4922b4bfa827';
 
 final class SourceControlControllerFamily extends $Family
     with

--- a/mobile/lib/src/features/workbench/presentation/source_control_panel.dart
+++ b/mobile/lib/src/features/workbench/presentation/source_control_panel.dart
@@ -20,26 +20,40 @@ class const SourceControlPanel({
     final state = ref.watch(
       sourceControlControllerProvider(hostId, workspaceId),
     );
-    return switch (state) {
-      AsyncData(value: final snapshot) => _Body(
-        hostId: hostId,
-        workspaceId: workspaceId,
-        snapshot: snapshot,
-      ),
-      AsyncError(:final error) => AleraEmptyState(
+    final controller = ref.read(
+      sourceControlControllerProvider(hostId, workspaceId).notifier,
+    );
+    if (state.value case final snapshot?) {
+      return Column(
+        children: <Widget>[
+          if (state.isLoading) const LinearProgressIndicator(minHeight: 2),
+          Expanded(
+            child: RefreshIndicator(
+              onRefresh: controller.reload,
+              child: _Body(
+                hostId: hostId,
+                workspaceId: workspaceId,
+                snapshot: snapshot,
+                refreshError: state.hasError && !state.isLoading
+                    ? state.error
+                    : null,
+              ),
+            ),
+          ),
+        ],
+      );
+    }
+    if (state case AsyncError(:final error) when !state.isLoading) {
+      return AleraEmptyState(
         icon: AleraIcons.gitCompare,
         message: error.toString(),
         action: FilledButton(
-          onPressed: () => ref
-              .read(
-                sourceControlControllerProvider(hostId, workspaceId).notifier,
-              )
-              .reload(),
+          onPressed: controller.reload,
           child: const Text('Retry'),
         ),
-      ),
-      _ => const Center(child: CircularProgressIndicator()),
-    };
+      );
+    }
+    return const Center(child: CircularProgressIndicator());
   }
 }
 
@@ -47,14 +61,28 @@ class const _Body({
   required final String hostId,
   required final String workspaceId,
   required final MobileGitStatusSnapshot snapshot,
+  final Object? refreshError,
 }) extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
+    final refreshNotice = switch (refreshError) {
+      final error? => Padding(
+        padding: AleraTokens.contentPadding,
+        child: AleraNotice(
+          icon: AleraIcons.cloudOff,
+          message: 'Could not refresh source control: $error',
+        ),
+      ),
+      null => null,
+    };
     if (!snapshot.isRepository) {
-      return const AleraEmptyState(
-        icon: AleraIcons.gitBranch,
-        title: 'No repository',
-        message: 'This workspace is not a Git repository.',
+      return _ScrollableState(
+        notice: refreshNotice,
+        child: const AleraEmptyState(
+          icon: AleraIcons.gitBranch,
+          title: 'No repository',
+          message: 'This workspace is not a Git repository.',
+        ),
       );
     }
     final staged = snapshot.entries
@@ -67,17 +95,22 @@ class const _Body({
         .where((entry) => entry.area == 'untracked')
         .toList(growable: false);
     if (snapshot.entries.isEmpty) {
-      return AleraEmptyState(
-        icon: AleraIcons.check,
-        title: 'Clean working tree',
-        message: snapshot.branch == null
-            ? 'There are no local changes.'
-            : 'There are no local changes on ${snapshot.branch}.',
+      return _ScrollableState(
+        notice: refreshNotice,
+        child: AleraEmptyState(
+          icon: AleraIcons.check,
+          title: 'Clean working tree',
+          message: snapshot.branch == null
+              ? 'There are no local changes.'
+              : 'There are no local changes on ${snapshot.branch}.',
+        ),
       );
     }
     return ListView(
+      physics: const AlwaysScrollableScrollPhysics(),
       padding: const EdgeInsets.only(bottom: AleraTokens.space24),
       children: <Widget>[
+        ?refreshNotice,
         const Padding(
           padding: AleraTokens.contentPadding,
           child: AleraNotice(
@@ -130,6 +163,30 @@ class const _Body({
           ),
         ),
     ];
+  }
+}
+
+/// Keeps pull-to-refresh working on the empty states, which do not scroll.
+class const _ScrollableState({
+  required final Widget child,
+  final Widget? notice,
+}) extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) => SingleChildScrollView(
+        physics: const AlwaysScrollableScrollPhysics(),
+        child: ConstrainedBox(
+          constraints: BoxConstraints(minHeight: constraints.maxHeight),
+          child: Column(
+            children: <Widget>[
+              ?notice,
+              SizedBox(height: constraints.maxHeight, child: child),
+            ],
+          ),
+        ),
+      ),
+    );
   }
 }
 

--- a/mobile/test/source_control_refresh_test.dart
+++ b/mobile/test/source_control_refresh_test.dart
@@ -1,0 +1,127 @@
+import 'dart:async';
+
+import 'package:alera_mobile/src/app/theme/alera_theme.dart';
+import 'package:alera_mobile/src/features/runtime/domain/mobile_workspace_panels.dart';
+import 'package:alera_mobile/src/features/workbench/application/source_control_controller.dart';
+import 'package:alera_mobile/src/features/workbench/application/workbench_providers.dart';
+import 'package:alera_mobile/src/features/workbench/presentation/source_control_panel.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'support/fake_terminal_client.dart';
+
+void main() {
+  testWidgets('first load blocks with a spinner', (tester) async {
+    final client = _client()..gitStatusGate = Completer<void>();
+    addTearDown(client.dispose);
+
+    await _pumpPanel(tester, client);
+
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    expect(find.text('main.dart'), findsNothing);
+
+    client.gitStatusGate!.complete();
+    await tester.pumpAndSettle();
+
+    expect(find.byType(CircularProgressIndicator), findsNothing);
+    expect(find.text('main.dart'), findsOneWidget);
+  });
+
+  testWidgets('reload keeps the previous snapshot on screen', (tester) async {
+    final client = _client();
+    addTearDown(client.dispose);
+    await _pumpPanel(tester, client);
+    expect(find.text('main.dart'), findsOneWidget);
+
+    client.gitStatusGate = Completer<void>();
+    final reload = _controller(tester).reload();
+    await tester.pump();
+
+    expect(find.text('main.dart'), findsOneWidget);
+    expect(find.byType(LinearProgressIndicator), findsOneWidget);
+    expect(find.byType(CircularProgressIndicator), findsNothing);
+
+    client
+      ..gitStatusSnapshot = _snapshot('lib/app.dart')
+      ..gitStatusGate!.complete();
+    await reload;
+    await tester.pumpAndSettle();
+
+    expect(find.byType(LinearProgressIndicator), findsNothing);
+    expect(find.text('app.dart'), findsOneWidget);
+    expect(find.text('main.dart'), findsNothing);
+  });
+
+  testWidgets('failed reload keeps the list and reports the error', (
+    tester,
+  ) async {
+    final client = _client();
+    addTearDown(client.dispose);
+    await _pumpPanel(tester, client);
+
+    client.gitStatusError = StateError('socket closed');
+    await _controller(tester).reload();
+    await tester.pumpAndSettle();
+
+    expect(find.text('main.dart'), findsOneWidget);
+    expect(find.textContaining('Could not refresh source control'), findsOne);
+    expect(find.text('Retry'), findsNothing);
+  });
+
+  testWidgets('client rebuild does not blank the panel', (tester) async {
+    final client = _client();
+    addTearDown(client.dispose);
+    await _pumpPanel(tester, client);
+
+    client.gitStatusGate = Completer<void>();
+    ProviderScope.containerOf(tester.element(find.byType(SourceControlPanel)))
+        .invalidate(workspaceClientProvider('host-1'));
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.text('main.dart'), findsOneWidget);
+    expect(find.byType(CircularProgressIndicator), findsNothing);
+
+    client.gitStatusGate!.complete();
+    await tester.pumpAndSettle();
+    expect(find.text('main.dart'), findsOneWidget);
+  });
+}
+
+FakeTerminalClient _client() => FakeTerminalClient()
+  ..sourceControlSupported = true
+  ..gitStatusSnapshot = _snapshot('lib/main.dart');
+
+MobileGitStatusSnapshot _snapshot(String path) => MobileGitStatusSnapshot(
+  isRepository: true,
+  branch: 'main',
+  entries: <MobileGitChange>[
+    MobileGitChange(path: path, area: 'unstaged', status: 'modified'),
+  ],
+);
+
+SourceControlController _controller(WidgetTester tester) =>
+    ProviderScope.containerOf(
+      tester.element(find.byType(SourceControlPanel)),
+    ).read(sourceControlControllerProvider('host-1', 'workspace-1').notifier);
+
+Future<void> _pumpPanel(WidgetTester tester, FakeTerminalClient client) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        workspaceClientProvider('host-1').overrideWith((ref) async => client),
+      ],
+      child: MaterialApp(
+        theme: buildAleraMobileDarkTheme(),
+        home: const Scaffold(
+          body: SourceControlPanel(
+            hostId: 'host-1',
+            workspaceId: 'workspace-1',
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pump();
+}

--- a/mobile/test/support/fake_workspace_panels_client.dart
+++ b/mobile/test/support/fake_workspace_panels_client.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:alera_mobile/src/features/runtime/domain/mobile_workspace_panels.dart';
 
 mixin FakeWorkspacePanelsClient implements MobileWorkspacePanelsClient {
@@ -11,6 +13,10 @@ mixin FakeWorkspacePanelsClient implements MobileWorkspacePanelsClient {
   MobileWorkspaceSearchResult searchResult =
       const MobileWorkspaceSearchResult();
   MobileGitStatusSnapshot gitStatusSnapshot = const MobileGitStatusSnapshot();
+
+  /// Holds `gitStatus` open until completed, to observe a refresh in flight.
+  Completer<void>? gitStatusGate;
+  Object? gitStatusError;
   MobileGitDiffFile gitDiffFile = const MobileGitDiffFile(
     path: '',
     area: 'unstaged',
@@ -66,6 +72,10 @@ mixin FakeWorkspacePanelsClient implements MobileWorkspacePanelsClient {
   @override
   Future<MobileGitStatusSnapshot> gitStatus(String workspaceId) async {
     calls.add('gitStatus $workspaceId');
+    await gitStatusGate?.future;
+    if (gitStatusError case final error?) {
+      throw error;
+    }
     return gitStatusSnapshot;
   }
 


### PR DESCRIPTION
## Summary

Mobile Source Control no longer blanks to a full-screen spinner whenever git status reloads (#756).

- `SourceControlController.reload()` invalidates in place instead of assigning `AsyncLoading`, so Riverpod keeps the previous snapshot.
- The panel renders any available snapshot with a thin progress bar while a refresh is in flight. The blocking spinner shows only on the first load.
- A failed refresh keeps the list and shows a notice above it. Retry replaces the list only when there was never a snapshot.
- Pull-to-refresh works on the list and on the empty states.

This is the bottom of the stack for #749 (mobile source control write actions), which reloads status after every write.

## Validation

- `flutter test test/source_control_refresh_test.dart test/workspace_panels_test.dart`, with new tests for first load, reload in flight, failed reload, and client provider rebuild.
- `flutter analyze` (mobile): no issues.
- max-lines ratchet ok.

Related to #756 (the full panel-refresh fix lands in #766).