### PR TITLE
feat: make watch and fix also resolve review comments and merge conflicts

### DIFF
--- a/lib/src/design_system/menus/alera_dropdown_toggle_entry.dart
+++ b/lib/src/design_system/menus/alera_dropdown_toggle_entry.dart
@@ -1,0 +1,86 @@
+import 'package:alera/src/app/theme/alera_tokens.dart';
+import 'package:alera/src/design_system/forms/alera_checkbox.dart';
+import 'package:flutter/material.dart';
+
+/// [PopupMenuEntry] with a checkbox that toggles in place.
+///
+/// Unlike [AleraDropdownEntry] it never closes the menu, so several options
+/// can be adjusted before picking an action from the same popover. It keeps
+/// its own checked state because a menu route does not rebuild when the
+/// caller's data changes.
+class const AleraDropdownToggleEntry<T>({
+  super.key,
+  required final String label,
+  required final bool checked,
+  required final ValueChanged<bool> onChanged,
+  final bool enabled = true,
+}) extends PopupMenuEntry<T> {
+  @override
+  double get height => 36;
+
+  @override
+  bool represents(T? value) => false;
+
+  @override
+  State<AleraDropdownToggleEntry<T>> createState() =>
+      _AleraDropdownToggleEntryState<T>();
+}
+
+class _AleraDropdownToggleEntryState<T>
+    extends State<AleraDropdownToggleEntry<T>> {
+  late bool _checked = widget.checked;
+
+  @override
+  void didUpdateWidget(covariant AleraDropdownToggleEntry<T> oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.checked != widget.checked) {
+      _checked = widget.checked;
+    }
+  }
+
+  void _toggle([bool? value]) {
+    final next = value ?? !_checked;
+    setState(() => _checked = next);
+    widget.onChanged(next);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final color = widget.enabled
+        ? AleraTokens.foreground
+        : AleraTokens.foregroundFaint;
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 1),
+      child: InkWell(
+        onTap: widget.enabled ? _toggle : null,
+        mouseCursor: widget.enabled
+            ? SystemMouseCursors.click
+            : SystemMouseCursors.basic,
+        borderRadius: .circular(AleraTokens.radiusLg),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(
+            horizontal: AleraTokens.space4,
+            vertical: AleraTokens.space2,
+          ),
+          child: Row(
+            children: <Widget>[
+              AleraCheckbox(
+                value: _checked,
+                enabled: widget.enabled,
+                onChanged: _toggle,
+              ),
+              const SizedBox(width: AleraTokens.space4),
+              Expanded(
+                child: Text(
+                  widget.label,
+                  style: Theme.of(context).textTheme.bodyMedium
+                      ?.copyWith(color: color),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/design_system/menus/alera_dropdown_toggle_entry.preview.dart
+++ b/lib/src/design_system/menus/alera_dropdown_toggle_entry.preview.dart
@@ -1,0 +1,40 @@
+import 'package:alera/src/app/theme/alera_tokens.dart';
+import 'package:alera/src/design_system/alera_preview.dart';
+import 'package:alera/src/design_system/menus/alera_dropdown_toggle_entry.dart';
+import 'package:flutter/material.dart';
+
+@AleraPreview(
+  name: 'Menu',
+  group: 'Dropdown Toggle Entry',
+  size: Size(220, 160),
+)
+Widget aleraDropdownToggleEntryPreview() => Material(
+  color: AleraTokens.surfaceElevated,
+  borderRadius: BorderRadius.circular(AleraTokens.radiusLg),
+  child: const Padding(
+    padding: EdgeInsets.all(AleraTokens.space8),
+    child: Column(
+      mainAxisSize: .min,
+      children: <Widget>[
+        AleraDropdownToggleEntry<String>(
+          label: 'Failed Checks',
+          checked: true,
+          onChanged: _ignoreValue,
+        ),
+        AleraDropdownToggleEntry<String>(
+          label: 'Review Comments',
+          checked: false,
+          onChanged: _ignoreValue,
+        ),
+        AleraDropdownToggleEntry<String>(
+          label: 'Disabled',
+          checked: true,
+          enabled: false,
+          onChanged: _ignoreValue,
+        ),
+      ],
+    ),
+  ),
+);
+
+void _ignoreValue(bool _) {}

--- a/lib/src/features/pull_requests/application/pull_request_agent_watch_providers.dart
+++ b/lib/src/features/pull_requests/application/pull_request_agent_watch_providers.dart
@@ -8,6 +8,7 @@ import 'package:alera/src/features/pull_requests/application/workspace_pull_requ
 import 'package:alera/src/features/pull_requests/application/workspace_pull_request_state.dart';
 import 'package:alera/src/features/pull_requests/domain/pull_request_agent_prompts.dart';
 import 'package:alera/src/features/pull_requests/domain/pull_request_agent_watch.dart';
+import 'package:alera/src/features/pull_requests/domain/pull_request_agent_watch_scope.dart';
 import 'package:alera/src/features/pull_requests/domain/review_merge_method.dart';
 import 'package:alera/src/features/pull_requests/domain/workspace_pull_request_scope.dart';
 import 'package:alera/src/features/workbench/application/workbench_controller.dart';
@@ -57,7 +58,8 @@ class PullRequestAgentWatchController
     required int reviewNumber,
     required PullRequestAgentWatchMode mode,
     required AgentTaskDispatchBinding binding,
-    String? lastDispatchedFailureSignature,
+    PullRequestAgentWatchScope watchScope = PullRequestAgentWatchScope.defaults,
+    PullRequestAgentWatchDispatchMark? lastDispatch,
   }) {
     final existing = state[scope.workspaceId];
     if (existing == null) {
@@ -73,7 +75,8 @@ class PullRequestAgentWatchController
         mode: mode,
         binding: binding,
         scope: scope,
-        lastDispatchedFailureSignature: lastDispatchedFailureSignature,
+        watchScope: watchScope,
+        lastDispatch: lastDispatch,
       ),
     };
     _ensureTimer();
@@ -135,8 +138,8 @@ class PullRequestAgentWatchController
         case PullRequestAgentWatchAction.stop:
           _remove(workspaceId, detach: true);
           return;
-        case PullRequestAgentWatchAction.dispatchFix:
-          await _dispatchFix(session, evaluation.failureSignature);
+        case PullRequestAgentWatchAction.dispatch:
+          await _dispatch(session, evaluation);
         case PullRequestAgentWatchAction.merge:
           await _merge(session, evaluation.headSha);
       }
@@ -153,6 +156,7 @@ class PullRequestAgentWatchController
       return PullRequestAgentWatchSnapshot(
         review: panel.review,
         checksRollup: panel.checksRollup,
+        comments: panel.comments,
       );
     }
     final async = ref.read(
@@ -165,17 +169,27 @@ class PullRequestAgentWatchController
     return PullRequestAgentWatchSnapshot(
       review: current.review,
       checksRollup: current.checksRollup,
+      comments: current.comments,
     );
   }
 
-  Future<void> _dispatchFix(
+  Future<void> _dispatch(
     PullRequestAgentWatchSession session,
-    String? failureSignature,
+    PullRequestAgentWatchEvaluation evaluation,
   ) async {
+    final review = ref
+        .read(workspacePullRequestControllerProvider(session.scope))
+        .asData
+        ?.value
+        .review;
     final result = await completeAgentTaskDispatch(
       request: AgentTaskDispatchRequest(
         workspaceId: session.workspaceId,
-        prompt: pullRequestAgentWatchPrompt(session.reviewNumber),
+        prompt: pullRequestAgentWatchPrompt(
+          reviewNumber: session.reviewNumber,
+          concerns: evaluation.concerns,
+          baseBranch: review?.baseBranch,
+        ),
       ),
       binding: session.binding,
       service: readAgentTaskDispatchServiceFromRef(
@@ -190,7 +204,8 @@ class PullRequestAgentWatchController
     final next = pullRequestAgentWatchAfterDispatch(
       session: latest,
       result: result,
-      failureSignature: failureSignature,
+      concerns: evaluation.concerns,
+      headSha: evaluation.headSha,
     );
     if (identical(next, latest)) {
       return;

--- a/lib/src/features/pull_requests/application/pull_request_agent_watch_providers.g.dart
+++ b/lib/src/features/pull_requests/application/pull_request_agent_watch_providers.g.dart
@@ -48,7 +48,7 @@ final class PullRequestAgentWatchControllerProvider
 }
 
 String _$pullRequestAgentWatchControllerHash() =>
-    r'82a22c191c283487fb9f80056fbea15e13fb81fc';
+    r'977f491478d384a722e796cda66e669ee11f5809';
 
 abstract class _$PullRequestAgentWatchController
     extends $Notifier<Map<String, PullRequestAgentWatchSession>> {

--- a/lib/src/features/pull_requests/application/workspace_pull_request_state.dart
+++ b/lib/src/features/pull_requests/application/workspace_pull_request_state.dart
@@ -169,13 +169,18 @@ class const WorkspacePullRequestState({
         .map((c) => '${c.name}:${c.status.name}:${c.conclusion.name}')
         .join('|');
     final commentPart = comments
-        .map((comment) => '${comment.id}:${comment.createdAt}:${comment.body}')
+        .map(
+          (comment) =>
+              '${comment.id}:${comment.createdAt}:${comment.resolved}:'
+              '${comment.outdated}:${comment.body}',
+        )
         .join('|');
     final stackPart = stack == null
         ? ''
         : '${stack!.number}:${stack!.open}:'
               '${stack!.entries.map((entry) => '${entry.review.number}:${entry.review.state.name}:${entry.review.baseBranch}').join('|')}';
     return '${review?.number}:${review?.state.name}:${review?.title}:'
+        '${review?.mergeable.name}:'
         '${suggestedReview?.number}:${suggestedReview?.state.name}:$dismissed:'
         '${review?.baseBranch}:$stackPart:$checkPart:$commentPart';
   }

--- a/lib/src/features/pull_requests/domain/pull_request_agent_prompts.dart
+++ b/lib/src/features/pull_requests/domain/pull_request_agent_prompts.dart
@@ -1,3 +1,5 @@
+import 'package:alera/src/features/pull_requests/domain/pull_request_agent_watch.dart';
+
 /// Short, log-free prompt for failed pull request checks.
 ///
 /// Check names, logs, and payloads stay out of the prompt so the agent looks
@@ -6,6 +8,58 @@ String pullRequestFailedChecksPrompt(int reviewNumber) {
   return 'Pull request #$reviewNumber checks failed. Please fix them.';
 }
 
-String pullRequestAgentWatchPrompt(int reviewNumber) {
-  return pullRequestFailedChecksPrompt(reviewNumber);
+/// One prompt naming every pending problem, still free of comment bodies and
+/// CI logs so the agent reads the current threads and conflicts itself.
+///
+/// The prompt may reach a shell as a launch argument, so it avoids backticks
+/// and other characters a shell would expand.
+String pullRequestAgentWatchPrompt({
+  required int reviewNumber,
+  required PullRequestAgentWatchConcerns concerns,
+  String? baseBranch,
+}) {
+  final threadCount = concerns.threads.length;
+  if (concerns.isEmpty) {
+    return 'Please check pull request #$reviewNumber and fix anything that '
+        'blocks it.';
+  }
+  if (concerns.checksFailed && !concerns.conflict && threadCount == 0) {
+    return pullRequestFailedChecksPrompt(reviewNumber);
+  }
+  final base = baseBranch?.trim();
+  final problems = <String>[
+    if (concerns.conflict)
+      base == null || base.isEmpty
+          ? 'merge conflicts with its base branch'
+          : 'merge conflicts with $base',
+    if (concerns.checksFailed) 'failing checks',
+    if (threadCount > 0)
+      threadCount == 1
+          ? '1 unresolved review thread'
+          : '$threadCount unresolved review threads',
+  ];
+  final requests = <String>[
+    if (concerns.conflict) 'resolve the conflicts',
+    if (concerns.checksFailed) 'fix the checks',
+    if (threadCount > 0) 'address the review comments',
+  ];
+  final buffer = StringBuffer(
+    'Pull request #$reviewNumber has ${_joinPhrases(problems)}. '
+    'Please ${_joinPhrases(requests)}.',
+  );
+  if (threadCount > 0) {
+    buffer.write(' Resolve each review thread once its fix is pushed.');
+  }
+  return buffer.toString();
+}
+
+String _joinPhrases(List<String> phrases) {
+  return switch (phrases.length) {
+    0 => '',
+    1 => phrases.single,
+    2 => '${phrases.first} and ${phrases.last}',
+    _ =>
+      '${phrases.sublist(0, phrases.length - 1).join(', ')}, '
+          'and ${phrases.last}',
+  };
 }

--- a/lib/src/features/pull_requests/domain/pull_request_agent_watch.dart
+++ b/lib/src/features/pull_requests/domain/pull_request_agent_watch.dart
@@ -1,11 +1,26 @@
 import 'package:alera/src/features/agent_task_dispatch/domain/agent_task_dispatch.dart';
 import 'package:alera/src/features/pull_requests/domain/hosted_review.dart';
+import 'package:alera/src/features/pull_requests/domain/pull_request_agent_watch_scope.dart';
 import 'package:alera/src/features/pull_requests/domain/review_check.dart';
+import 'package:alera/src/features/pull_requests/domain/review_comment.dart';
+import 'package:alera/src/features/pull_requests/domain/review_thread_backlog.dart';
 import 'package:alera/src/features/pull_requests/domain/workspace_pull_request_scope.dart';
 
 enum PullRequestAgentWatchMode { fix, fixAndMerge }
 
-enum PullRequestAgentWatchAction { none, dispatchFix, merge, stop }
+enum PullRequestAgentWatchAction { none, dispatch, merge, stop }
+
+/// What the watch already asked the agent to fix on [headSha].
+///
+/// Dispatch only reacts to additions: a reviewer resolving one of several
+/// threads shrinks the pending set without adding work, so it must not send
+/// the agent the same request again.
+class const PullRequestAgentWatchDispatchMark({
+  final String? headSha,
+  final bool checksFailed = false,
+  final bool conflict = false,
+  final Set<String> threadIds = const <String>{},
+});
 
 class const PullRequestAgentWatchSession({
   required final String workspaceId,
@@ -13,31 +28,118 @@ class const PullRequestAgentWatchSession({
   required final PullRequestAgentWatchMode mode,
   required final AgentTaskDispatchBinding binding,
   required final WorkspacePullRequestScope scope,
-  final String? lastDispatchedFailureSignature,
+  final PullRequestAgentWatchScope watchScope =
+      PullRequestAgentWatchScope.defaults,
+  final PullRequestAgentWatchDispatchMark? lastDispatch,
   final String? lastMergedHeadSha,
-});
+}) {
+  PullRequestAgentWatchSession copyWith({
+    AgentTaskDispatchBinding? binding,
+    PullRequestAgentWatchDispatchMark? lastDispatch,
+    String? lastMergedHeadSha,
+  }) {
+    return PullRequestAgentWatchSession(
+      workspaceId: workspaceId,
+      reviewNumber: reviewNumber,
+      mode: mode,
+      binding: binding ?? this.binding,
+      scope: scope,
+      watchScope: watchScope,
+      lastDispatch: lastDispatch ?? this.lastDispatch,
+      lastMergedHeadSha: lastMergedHeadSha ?? this.lastMergedHeadSha,
+    );
+  }
+}
 
 class const PullRequestAgentWatchSnapshot({
   final bool loaded = true,
   final HostedReview? review,
   final ReviewChecksRollup checksRollup = ReviewChecksRollup.none,
+  final List<ReviewComment> comments = const <ReviewComment>[],
 });
+
+/// Problems inside the watch scope that an agent should fix.
+class const PullRequestAgentWatchConcerns({
+  final bool checksFailed = false,
+  final bool conflict = false,
+  final List<PendingReviewThread> threads = const <PendingReviewThread>[],
+}) {
+  bool get isEmpty => !checksFailed && !conflict && threads.isEmpty;
+
+  Set<String> get threadIds => <String>{
+    for (final thread in threads) thread.id,
+  };
+}
 
 class const PullRequestAgentWatchEvaluation({
   required final PullRequestAgentWatchAction action,
-  final String? failureSignature,
+  final PullRequestAgentWatchConcerns concerns =
+      const PullRequestAgentWatchConcerns(),
   final String? headSha,
 });
 
-bool pullRequestAgentWatchInjectsOnStart(ReviewChecksRollup rollup) {
-  return rollup == ReviewChecksRollup.failure;
+/// `unknown` mergeability is not a conflict: GitHub recomputes it after every
+/// push, so treating it as one would dispatch on each new commit.
+PullRequestAgentWatchConcerns pullRequestAgentWatchConcerns({
+  required PullRequestAgentWatchSnapshot snapshot,
+  required PullRequestAgentWatchScope scope,
+}) {
+  final review = snapshot.review;
+  return PullRequestAgentWatchConcerns(
+    checksFailed:
+        scope.checks && snapshot.checksRollup == ReviewChecksRollup.failure,
+    conflict:
+        scope.conflicts &&
+        review?.mergeable == HostedReviewMergeable.conflicting,
+    threads: scope.comments
+        ? pendingReviewThreads(
+            comments: snapshot.comments,
+            reviewAuthor: review?.author,
+          )
+        : const <PendingReviewThread>[],
+  );
 }
 
-String pullRequestAgentWatchFailureSignature({
-  required int reviewNumber,
+bool pullRequestAgentWatchInjectsOnStart(
+  PullRequestAgentWatchConcerns concerns,
+) {
+  return !concerns.isEmpty;
+}
+
+/// Whether [concerns] add anything the agent was not already asked to fix.
+bool pullRequestAgentWatchHasNewConcerns({
+  required PullRequestAgentWatchDispatchMark? mark,
   required String? headSha,
+  required PullRequestAgentWatchConcerns concerns,
 }) {
-  return '$reviewNumber:${headSha ?? ''}';
+  if (concerns.isEmpty) {
+    return false;
+  }
+  if (mark == null || mark.headSha != headSha) {
+    return true;
+  }
+  return (concerns.checksFailed && !mark.checksFailed) ||
+      (concerns.conflict && !mark.conflict) ||
+      concerns.threadIds.difference(mark.threadIds).isNotEmpty;
+}
+
+/// Records a dispatch. On the same head the mark accumulates, so a thread
+/// that is resolved and reopened does not repeat the request; a new head
+/// starts over because the agent's last push may not have fixed everything.
+PullRequestAgentWatchDispatchMark pullRequestAgentWatchDispatchMark({
+  required PullRequestAgentWatchDispatchMark? previous,
+  required String? headSha,
+  required PullRequestAgentWatchConcerns concerns,
+}) {
+  final carried = previous != null && previous.headSha == headSha
+      ? previous
+      : null;
+  return PullRequestAgentWatchDispatchMark(
+    headSha: headSha,
+    checksFailed: concerns.checksFailed || (carried?.checksFailed ?? false),
+    conflict: concerns.conflict || (carried?.conflict ?? false),
+    threadIds: <String>{...?carried?.threadIds, ...concerns.threadIds},
+  );
 }
 
 String pullRequestAgentWatchModeLabel(PullRequestAgentWatchMode mode) {
@@ -51,20 +153,19 @@ String pullRequestAgentWatchModeLabel(PullRequestAgentWatchMode mode) {
 PullRequestAgentWatchSession pullRequestAgentWatchAfterDispatch({
   required PullRequestAgentWatchSession session,
   required AgentTaskDispatchResult? result,
-  required String? failureSignature,
+  required PullRequestAgentWatchConcerns concerns,
+  required String? headSha,
 }) {
   if (result == null) {
     return session;
   }
-  return PullRequestAgentWatchSession(
-    workspaceId: session.workspaceId,
-    reviewNumber: session.reviewNumber,
-    mode: session.mode,
+  return session.copyWith(
     binding: result.binding,
-    scope: session.scope,
-    lastDispatchedFailureSignature:
-        failureSignature ?? session.lastDispatchedFailureSignature,
-    lastMergedHeadSha: session.lastMergedHeadSha,
+    lastDispatch: pullRequestAgentWatchDispatchMark(
+      previous: session.lastDispatch,
+      headSha: headSha,
+      concerns: concerns,
+    ),
   );
 }
 
@@ -77,15 +178,7 @@ PullRequestAgentWatchSession pullRequestAgentWatchAfterMerge({
   if (!merged) {
     return session;
   }
-  return PullRequestAgentWatchSession(
-    workspaceId: session.workspaceId,
-    reviewNumber: session.reviewNumber,
-    mode: session.mode,
-    binding: session.binding,
-    scope: session.scope,
-    lastDispatchedFailureSignature: session.lastDispatchedFailureSignature,
-    lastMergedHeadSha: headSha ?? session.lastMergedHeadSha,
-  );
+  return session.copyWith(lastMergedHeadSha: headSha);
 }
 
 PullRequestAgentWatchEvaluation evaluatePullRequestAgentWatch({
@@ -103,34 +196,35 @@ PullRequestAgentWatchEvaluation evaluatePullRequestAgentWatch({
       review.state == HostedReviewState.closed) {
     return const PullRequestAgentWatchEvaluation(action: .stop);
   }
-  final rollup = snapshot.checksRollup;
   final headSha = review.headSha;
-  if (rollup == ReviewChecksRollup.failure) {
-    final signature = pullRequestAgentWatchFailureSignature(
-      reviewNumber: review.number,
-      headSha: headSha,
-    );
-    if (signature == session.lastDispatchedFailureSignature) {
-      return PullRequestAgentWatchEvaluation(
-        action: .none,
-        failureSignature: signature,
-        headSha: headSha,
-      );
-    }
+  final concerns = pullRequestAgentWatchConcerns(
+    snapshot: snapshot,
+    scope: session.watchScope,
+  );
+  if (pullRequestAgentWatchHasNewConcerns(
+    mark: session.lastDispatch,
+    headSha: headSha,
+    concerns: concerns,
+  )) {
     return PullRequestAgentWatchEvaluation(
-      action: .dispatchFix,
-      failureSignature: signature,
+      action: .dispatch,
+      concerns: concerns,
       headSha: headSha,
     );
   }
   if (session.mode == PullRequestAgentWatchMode.fixAndMerge &&
-      rollup == ReviewChecksRollup.success &&
+      snapshot.checksRollup == ReviewChecksRollup.success &&
       review.state == HostedReviewState.open &&
       review.mergeable == HostedReviewMergeable.mergeable &&
+      concerns.threads.isEmpty &&
       headSha != null &&
       headSha.isNotEmpty &&
       headSha != session.lastMergedHeadSha) {
     return PullRequestAgentWatchEvaluation(action: .merge, headSha: headSha);
   }
-  return PullRequestAgentWatchEvaluation(action: .none, headSha: headSha);
+  return PullRequestAgentWatchEvaluation(
+    action: .none,
+    concerns: concerns,
+    headSha: headSha,
+  );
 }

--- a/lib/src/features/pull_requests/domain/pull_request_agent_watch_scope.dart
+++ b/lib/src/features/pull_requests/domain/pull_request_agent_watch_scope.dart
@@ -1,0 +1,29 @@
+import 'package:dart_mappable/dart_mappable.dart';
+
+part 'pull_request_agent_watch_scope.mapper.dart';
+
+/// Which pull-request problems Watch and Fix reacts to. Remembered globally so
+/// the next watch starts from the last choice.
+@MappableClass()
+class const PullRequestAgentWatchScope({
+  this.checks = true,
+  this.comments = true,
+  this.conflicts = true,
+}) with PullRequestAgentWatchScopeMappable {
+  /// Failing CI checks.
+  final bool checks;
+
+  /// Unresolved review threads from someone other than the pull request author.
+  final bool comments;
+
+  /// Merge conflicts with the base branch.
+  final bool conflicts;
+
+  bool get isEmpty => !checks && !comments && !conflicts;
+
+  static const PullRequestAgentWatchScope defaults =
+      PullRequestAgentWatchScope();
+
+  factory fromJson(Map<String, Object?> json) =>
+      PullRequestAgentWatchScopeMapper.fromMap(Map<String, dynamic>.from(json));
+}

--- a/lib/src/features/pull_requests/domain/pull_request_agent_watch_scope.mapper.dart
+++ b/lib/src/features/pull_requests/domain/pull_request_agent_watch_scope.mapper.dart
@@ -1,0 +1,178 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// dart format off
+// ignore_for_file: type=lint
+// ignore_for_file: invalid_use_of_protected_member
+// ignore_for_file: unused_element, unnecessary_cast, override_on_non_overriding_member
+// ignore_for_file: strict_raw_type, inference_failure_on_untyped_parameter
+
+part of 'pull_request_agent_watch_scope.dart';
+
+class PullRequestAgentWatchScopeMapper
+    extends ClassMapperBase<PullRequestAgentWatchScope> {
+  PullRequestAgentWatchScopeMapper._();
+
+  static PullRequestAgentWatchScopeMapper? _instance;
+  static PullRequestAgentWatchScopeMapper ensureInitialized() {
+    if (_instance == null) {
+      MapperContainer.globals.use(
+        _instance = PullRequestAgentWatchScopeMapper._(),
+      );
+    }
+    return _instance!;
+  }
+
+  @override
+  final String id = 'PullRequestAgentWatchScope';
+
+  static bool _$checks(PullRequestAgentWatchScope v) => v.checks;
+  static const Field<PullRequestAgentWatchScope, bool> _f$checks = Field(
+    'checks',
+    _$checks,
+    opt: true,
+    def: true,
+  );
+  static bool _$comments(PullRequestAgentWatchScope v) => v.comments;
+  static const Field<PullRequestAgentWatchScope, bool> _f$comments = Field(
+    'comments',
+    _$comments,
+    opt: true,
+    def: true,
+  );
+  static bool _$conflicts(PullRequestAgentWatchScope v) => v.conflicts;
+  static const Field<PullRequestAgentWatchScope, bool> _f$conflicts = Field(
+    'conflicts',
+    _$conflicts,
+    opt: true,
+    def: true,
+  );
+
+  @override
+  final MappableFields<PullRequestAgentWatchScope> fields = const {
+    #checks: _f$checks,
+    #comments: _f$comments,
+    #conflicts: _f$conflicts,
+  };
+
+  static PullRequestAgentWatchScope _instantiate(DecodingData data) {
+    return PullRequestAgentWatchScope(
+      checks: data.dec(_f$checks),
+      comments: data.dec(_f$comments),
+      conflicts: data.dec(_f$conflicts),
+    );
+  }
+
+  @override
+  final Function instantiate = _instantiate;
+
+  static PullRequestAgentWatchScope fromMap(Map<String, dynamic> map) {
+    return ensureInitialized().decodeMap<PullRequestAgentWatchScope>(map);
+  }
+
+  static PullRequestAgentWatchScope fromJson(String json) {
+    return ensureInitialized().decodeJson<PullRequestAgentWatchScope>(json);
+  }
+}
+
+mixin PullRequestAgentWatchScopeMappable {
+  String toJson() {
+    return PullRequestAgentWatchScopeMapper.ensureInitialized()
+        .encodeJson<PullRequestAgentWatchScope>(
+          this as PullRequestAgentWatchScope,
+        );
+  }
+
+  Map<String, dynamic> toMap() {
+    return PullRequestAgentWatchScopeMapper.ensureInitialized()
+        .encodeMap<PullRequestAgentWatchScope>(
+          this as PullRequestAgentWatchScope,
+        );
+  }
+
+  PullRequestAgentWatchScopeCopyWith<
+    PullRequestAgentWatchScope,
+    PullRequestAgentWatchScope,
+    PullRequestAgentWatchScope
+  >
+  get copyWith =>
+      _PullRequestAgentWatchScopeCopyWithImpl<
+        PullRequestAgentWatchScope,
+        PullRequestAgentWatchScope
+      >(this as PullRequestAgentWatchScope, $identity, $identity);
+  @override
+  String toString() {
+    return PullRequestAgentWatchScopeMapper.ensureInitialized().stringifyValue(
+      this as PullRequestAgentWatchScope,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return PullRequestAgentWatchScopeMapper.ensureInitialized().equalsValue(
+      this as PullRequestAgentWatchScope,
+      other,
+    );
+  }
+
+  @override
+  int get hashCode {
+    return PullRequestAgentWatchScopeMapper.ensureInitialized().hashValue(
+      this as PullRequestAgentWatchScope,
+    );
+  }
+}
+
+extension PullRequestAgentWatchScopeValueCopy<$R, $Out>
+    on ObjectCopyWith<$R, PullRequestAgentWatchScope, $Out> {
+  PullRequestAgentWatchScopeCopyWith<$R, PullRequestAgentWatchScope, $Out>
+  get $asPullRequestAgentWatchScope => $base.as(
+    (v, t, t2) => _PullRequestAgentWatchScopeCopyWithImpl<$R, $Out>(v, t, t2),
+  );
+}
+
+abstract class PullRequestAgentWatchScopeCopyWith<
+  $R,
+  $In extends PullRequestAgentWatchScope,
+  $Out
+>
+    implements ClassCopyWith<$R, $In, $Out> {
+  $R call({bool? checks, bool? comments, bool? conflicts});
+  PullRequestAgentWatchScopeCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(
+    Then<$Out2, $R2> t,
+  );
+}
+
+class _PullRequestAgentWatchScopeCopyWithImpl<$R, $Out>
+    extends ClassCopyWithBase<$R, PullRequestAgentWatchScope, $Out>
+    implements
+        PullRequestAgentWatchScopeCopyWith<
+          $R,
+          PullRequestAgentWatchScope,
+          $Out
+        > {
+  _PullRequestAgentWatchScopeCopyWithImpl(super.value, super.then, super.then2);
+
+  @override
+  late final ClassMapperBase<PullRequestAgentWatchScope> $mapper =
+      PullRequestAgentWatchScopeMapper.ensureInitialized();
+  @override
+  $R call({bool? checks, bool? comments, bool? conflicts}) => $apply(
+    FieldCopyWithData({
+      if (checks != null) #checks: checks,
+      if (comments != null) #comments: comments,
+      if (conflicts != null) #conflicts: conflicts,
+    }),
+  );
+  @override
+  PullRequestAgentWatchScope $make(CopyWithData data) =>
+      PullRequestAgentWatchScope(
+        checks: data.get(#checks, or: $value.checks),
+        comments: data.get(#comments, or: $value.comments),
+        conflicts: data.get(#conflicts, or: $value.conflicts),
+      );
+
+  @override
+  PullRequestAgentWatchScopeCopyWith<$R2, PullRequestAgentWatchScope, $Out2>
+  $chain<$R2, $Out2>(Then<$Out2, $R2> t) =>
+      _PullRequestAgentWatchScopeCopyWithImpl<$R2, $Out2>($value, $cast, t);
+}

--- a/lib/src/features/pull_requests/domain/review_comment.dart
+++ b/lib/src/features/pull_requests/domain/review_comment.dart
@@ -25,6 +25,7 @@ class const ReviewComment({
   final String? path,
   final int? line,
   final bool resolved = false,
+  final bool outdated = false,
   final ReviewCommentLocator? locator,
 }) {
   ReviewComment copyWith({String? body, ReviewCommentLocator? locator}) {
@@ -38,6 +39,7 @@ class const ReviewComment({
       path: path,
       line: line,
       resolved: resolved,
+      outdated: outdated,
       locator: locator ?? this.locator,
     );
   }

--- a/lib/src/features/pull_requests/domain/review_thread_backlog.dart
+++ b/lib/src/features/pull_requests/domain/review_thread_backlog.dart
@@ -1,0 +1,46 @@
+import 'package:alera/src/features/pull_requests/domain/review_comment.dart';
+
+/// A review thread that still asks for a change.
+class const PendingReviewThread({
+  required final String id,
+  final String? path,
+  final int? line,
+});
+
+/// Groups [comments] into threads and keeps the ones an agent should address.
+///
+/// Only comments with a thread id count: loose conversation comments cannot
+/// be resolved, so counting them would keep a watch dispatching forever. A
+/// thread is dropped when it is resolved, when every comment in it is outdated,
+/// or when [reviewAuthor] wrote all of it, because a note the author left for
+/// themselves is not review feedback. GitLab and Azure DevOps expose no
+/// outdated state, so their threads never drop for that reason.
+List<PendingReviewThread> pendingReviewThreads({
+  required List<ReviewComment> comments,
+  String? reviewAuthor,
+}) {
+  final threads = <String, List<ReviewComment>>{};
+  for (final comment in comments) {
+    final threadId = comment.locator?.parentId;
+    if (threadId == null || threadId.isEmpty) {
+      continue;
+    }
+    (threads[threadId] ??= <ReviewComment>[]).add(comment);
+  }
+  final author = reviewAuthor?.trim().toLowerCase();
+  return <PendingReviewThread>[
+    for (final MapEntry(key: id, value: thread) in threads.entries)
+      if (!thread.any((comment) => comment.resolved) &&
+          !thread.every((comment) => comment.outdated) &&
+          !(author != null &&
+              author.isNotEmpty &&
+              thread.every(
+                (comment) => comment.author.trim().toLowerCase() == author,
+              )))
+        PendingReviewThread(
+          id: id,
+          path: thread.first.path,
+          line: thread.first.line,
+        ),
+  ];
+}

--- a/lib/src/features/pull_requests/infra/github_review_comments.dart
+++ b/lib/src/features/pull_requests/infra/github_review_comments.dart
@@ -10,6 +10,7 @@ query($owner: String!, $repo: String!, $pr: Int!, $threadsAfter: String) {
         nodes {
           id
           isResolved
+          isOutdated
           line
           originalLine
           comments(first: 100) {
@@ -358,6 +359,7 @@ query($thread: ID!, $commentsAfter: String) {
         path: node['path'] as String?,
         line: line,
         resolved: thread['isResolved'] == true,
+        outdated: thread['isOutdated'] == true,
         locator: databaseId == null
             ? null
             : ReviewCommentLocator(

--- a/lib/src/features/pull_requests/presentation/pull_request_agent_dispatch.dart
+++ b/lib/src/features/pull_requests/presentation/pull_request_agent_dispatch.dart
@@ -1,10 +1,11 @@
+import 'package:alera/src/design_system/feedback/alera_toast.dart';
 import 'package:alera/src/features/agent_task_dispatch/domain/agent_task_dispatch.dart';
 import 'package:alera/src/features/agent_task_dispatch/presentation/agent_task_dispatch_launcher.dart';
 import 'package:alera/src/features/pull_requests/application/pull_request_agent_watch_providers.dart';
 import 'package:alera/src/features/pull_requests/domain/hosted_review.dart';
 import 'package:alera/src/features/pull_requests/domain/pull_request_agent_prompts.dart';
 import 'package:alera/src/features/pull_requests/domain/pull_request_agent_watch.dart';
-import 'package:alera/src/features/pull_requests/domain/review_check.dart';
+import 'package:alera/src/features/pull_requests/domain/pull_request_agent_watch_scope.dart';
 import 'package:alera/src/features/pull_requests/domain/workspace_pull_request_scope.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -32,14 +33,31 @@ Future<void> startPullRequestAgentWatch({
   required WorkspacePullRequestScope scope,
   required HostedReview review,
   required PullRequestAgentWatchMode mode,
-  ReviewChecksRollup checksRollup = ReviewChecksRollup.none,
+  required PullRequestAgentWatchScope watchScope,
+  required PullRequestAgentWatchSnapshot snapshot,
 }) async {
+  if (watchScope.isEmpty) {
+    AleraToast.show(
+      context,
+      message: 'Choose at least one problem to watch.',
+      tone: .error,
+    );
+    return;
+  }
+  final concerns = pullRequestAgentWatchConcerns(
+    snapshot: snapshot,
+    scope: watchScope,
+  );
   final choice = await chooseAgentTaskDispatchTarget(
     context,
     ref,
     request: AgentTaskDispatchRequest(
       workspaceId: scope.workspaceId,
-      prompt: pullRequestAgentWatchPrompt(review.number),
+      prompt: pullRequestAgentWatchPrompt(
+        reviewNumber: review.number,
+        concerns: concerns,
+        baseBranch: review.baseBranch,
+      ),
       title: mode == PullRequestAgentWatchMode.fixAndMerge
           ? 'Watch, Fix and Merge'
           : 'Watch and Fix',
@@ -50,8 +68,8 @@ Future<void> startPullRequestAgentWatch({
     return;
   }
   var binding = choice.binding;
-  String? dispatchedSignature;
-  if (pullRequestAgentWatchInjectsOnStart(checksRollup)) {
+  PullRequestAgentWatchDispatchMark? dispatched;
+  if (pullRequestAgentWatchInjectsOnStart(concerns)) {
     final result = await completeAgentTaskDispatch(
       ref: ref,
       request: choice.request,
@@ -60,9 +78,10 @@ Future<void> startPullRequestAgentWatch({
     );
     if (result != null) {
       binding = result.binding;
-      dispatchedSignature = pullRequestAgentWatchFailureSignature(
-        reviewNumber: review.number,
+      dispatched = pullRequestAgentWatchDispatchMark(
+        previous: null,
         headSha: review.headSha,
+        concerns: concerns,
       );
     }
   }
@@ -73,6 +92,7 @@ Future<void> startPullRequestAgentWatch({
         reviewNumber: review.number,
         mode: mode,
         binding: binding,
-        lastDispatchedFailureSignature: dispatchedSignature,
+        watchScope: watchScope,
+        lastDispatch: dispatched,
       );
 }

--- a/lib/src/features/pull_requests/presentation/pull_request_review_agent_actions.dart
+++ b/lib/src/features/pull_requests/presentation/pull_request_review_agent_actions.dart
@@ -109,9 +109,11 @@ class const _PullRequestWatchAgentButton({
   }
 
   Future<void> _openWatchMenu(BuildContext context) async {
-    var scope = watchScope;
+    // The menu route never rebuilds from this widget, so the mode rows listen
+    // to the scope the toggles edit instead of the value the menu opened with.
+    final scope = ValueNotifier<PullRequestAgentWatchScope>(watchScope);
     void update(PullRequestAgentWatchScope next) {
-      scope = next;
+      scope.value = next;
       onWatchScopeChanged?.call(next);
     }
 
@@ -120,45 +122,83 @@ class const _PullRequestWatchAgentButton({
       <PopupMenuEntry<_WatchMenuAction>>[
         AleraDropdownToggleEntry<_WatchMenuAction>(
           label: 'Failed Checks',
-          checked: scope.checks,
-          onChanged: (value) => update(scope.copyWith(checks: value)),
+          checked: scope.value.checks,
+          onChanged: (value) => update(scope.value.copyWith(checks: value)),
         ),
         AleraDropdownToggleEntry<_WatchMenuAction>(
           label: 'Review Comments',
-          checked: scope.comments,
-          onChanged: (value) => update(scope.copyWith(comments: value)),
+          checked: scope.value.comments,
+          onChanged: (value) => update(scope.value.copyWith(comments: value)),
         ),
         AleraDropdownToggleEntry<_WatchMenuAction>(
           label: 'Merge Conflicts',
-          checked: scope.conflicts,
-          onChanged: (value) => update(scope.copyWith(conflicts: value)),
+          checked: scope.value.conflicts,
+          onChanged: (value) => update(scope.value.copyWith(conflicts: value)),
         ),
         const PopupMenuDivider(),
         if (onWatchAndFix != null)
-          AleraDropdownEntry<_WatchMenuAction>(
+          _WatchModeMenuEntry(
             value: .watchAndFix,
             label: 'Watch and Fix',
-            enabled: !watchScope.isEmpty,
-            leading: const Icon(AleraIcons.agent, size: 16),
+            icon: AleraIcons.agent,
+            scope: scope,
           ),
         if (onWatchFixAndMerge != null)
-          AleraDropdownEntry<_WatchMenuAction>(
+          _WatchModeMenuEntry(
             value: .watchFixAndMerge,
             label: 'Watch, Fix and Merge',
-            enabled: !watchScope.isEmpty,
-            leading: const Icon(AleraIcons.gitMerge, size: 16),
+            icon: AleraIcons.gitMerge,
+            scope: scope,
           ),
       ],
     );
     switch (selected) {
       case _WatchMenuAction.watchAndFix:
-        onWatchAndFix?.call(scope);
+        onWatchAndFix?.call(scope.value);
       case _WatchMenuAction.watchFixAndMerge:
-        onWatchFixAndMerge?.call(scope);
+        onWatchFixAndMerge?.call(scope.value);
       case _WatchMenuAction.stop:
       case null:
         break;
     }
+  }
+}
+
+/// A watch mode row that is only selectable while [scope] has something to
+/// watch.
+class const _WatchModeMenuEntry({
+  required this.value,
+  required this.label,
+  required this.icon,
+  required this.scope,
+}) extends PopupMenuEntry<_WatchMenuAction> {
+  final _WatchMenuAction value;
+  final String label;
+  final IconData icon;
+  final ValueNotifier<PullRequestAgentWatchScope> scope;
+
+  @override
+  double get height => 36;
+
+  @override
+  bool represents(_WatchMenuAction? value) => false;
+
+  @override
+  State<_WatchModeMenuEntry> createState() => _WatchModeMenuEntryState();
+}
+
+class _WatchModeMenuEntryState extends State<_WatchModeMenuEntry> {
+  @override
+  Widget build(BuildContext context) {
+    return ValueListenableBuilder<PullRequestAgentWatchScope>(
+      valueListenable: widget.scope,
+      builder: (context, scope, _) => AleraDropdownEntry<_WatchMenuAction>(
+        value: widget.value,
+        label: widget.label,
+        enabled: !scope.isEmpty,
+        leading: Icon(widget.icon, size: 16),
+      ),
+    );
   }
 }
 

--- a/lib/src/features/pull_requests/presentation/pull_request_review_agent_actions.dart
+++ b/lib/src/features/pull_requests/presentation/pull_request_review_agent_actions.dart
@@ -1,30 +1,25 @@
 part of 'pull_request_review_view.dart';
 
+/// Checks section title plus the one-shot failed-checks dispatch, hidden while
+/// a watch already owns that work.
 class const _PullRequestCheckAgentHeader({
   required this.checkCount,
   required this.checksFailed,
   required this.reviewIsOpen,
   required this.busy,
-  required this.watchMode,
+  required this.watching,
   required this.onFixFailedChecks,
-  required this.onWatchAndFix,
-  required this.onWatchFixAndMerge,
-  required this.onStopAgentWatch,
 }) extends StatelessWidget {
   final int checkCount;
   final bool checksFailed;
   final bool reviewIsOpen;
   final bool busy;
-  final PullRequestAgentWatchMode? watchMode;
+  final bool watching;
   final VoidCallback? onFixFailedChecks;
-  final VoidCallback? onWatchAndFix;
-  final VoidCallback? onWatchFixAndMerge;
-  final VoidCallback? onStopAgentWatch;
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final watching = watchMode != null;
     return Row(
       children: <Widget>[
         Expanded(
@@ -35,105 +30,180 @@ class const _PullRequestCheckAgentHeader({
             ),
           ),
         ),
-        if (reviewIsOpen && !busy)
-          if (watching)
-            _watchingActions(theme)
-          else
-            _idleActions(context, theme),
-      ],
-    );
-  }
-
-  Widget _idleActions(BuildContext context, ThemeData theme) {
-    return Row(
-      mainAxisSize: .min,
-      children: <Widget>[
-        if (checksFailed && onFixFailedChecks != null)
+        if (reviewIsOpen &&
+            !busy &&
+            !watching &&
+            checksFailed &&
+            onFixFailedChecks != null)
           TextButton(
             onPressed: onFixFailedChecks,
             child: const Text('Fix Failed Checks'),
           ),
-        if (onWatchAndFix != null || onWatchFixAndMerge != null)
-          Builder(
-            builder: (buttonContext) => AleraIconButton(
-              tooltip: 'Ask Agent',
-              icon: AleraIcons.agent,
-              onPressed: () => unawaited(_openWatchMenu(buttonContext)),
-            ),
-          ),
       ],
     );
   }
+}
 
-  Widget _watchingActions(ThemeData theme) {
-    return Row(
-      mainAxisSize: .min,
-      children: <Widget>[
-        Flexible(
-          child: Text(
-            pullRequestAgentWatchModeLabel(watchMode!),
-            maxLines: 1,
-            overflow: .ellipsis,
-            style: theme.textTheme.labelSmall?.copyWith(
-              color: AleraTokens.foregroundMuted,
-            ),
-          ),
+/// Header control for Watch and Fix. Idle, it opens the watch scope and the
+/// watch modes; while watching, it offers Stop Watching.
+class const _PullRequestWatchAgentButton({
+  required this.reviewIsOpen,
+  required this.busy,
+  required this.watchMode,
+  required this.watchScope,
+  required this.onWatchScopeChanged,
+  required this.onWatchAndFix,
+  required this.onWatchFixAndMerge,
+  required this.onStopAgentWatch,
+}) extends StatelessWidget {
+  final bool reviewIsOpen;
+  final bool busy;
+  final PullRequestAgentWatchMode? watchMode;
+  final PullRequestAgentWatchScope watchScope;
+  final ValueChanged<PullRequestAgentWatchScope>? onWatchScopeChanged;
+  final ValueChanged<PullRequestAgentWatchScope>? onWatchAndFix;
+  final ValueChanged<PullRequestAgentWatchScope>? onWatchFixAndMerge;
+  final VoidCallback? onStopAgentWatch;
+
+  @override
+  Widget build(BuildContext context) {
+    final mode = watchMode;
+    if (mode != null) {
+      return Builder(
+        builder: (buttonContext) => AleraIconButton(
+          tooltip: pullRequestAgentWatchModeLabel(mode),
+          icon: AleraIcons.visible,
+          onPressed: onStopAgentWatch == null
+              ? null
+              : () => unawaited(_openWatchingMenu(buttonContext)),
         ),
-        if (onStopAgentWatch != null)
-          TextButton(
-            onPressed: onStopAgentWatch,
-            child: const Text('Stop Watching'),
-          ),
+      );
+    }
+    if (!reviewIsOpen ||
+        (onWatchAndFix == null && onWatchFixAndMerge == null)) {
+      return const SizedBox.shrink();
+    }
+    return Builder(
+      builder: (buttonContext) => AleraIconButton(
+        tooltip: 'Ask Agent',
+        icon: AleraIcons.agent,
+        onPressed: busy ? null : () => unawaited(_openWatchMenu(buttonContext)),
+      ),
+    );
+  }
+
+  Future<void> _openWatchingMenu(BuildContext context) async {
+    final selected = await _showAnchoredMenu<_WatchMenuAction>(
+      context,
+      const <PopupMenuEntry<_WatchMenuAction>>[
+        AleraDropdownEntry<_WatchMenuAction>(
+          value: .stop,
+          label: 'Stop Watching',
+          leading: Icon(AleraIcons.hidden, size: 16),
+        ),
       ],
     );
+    if (selected == _WatchMenuAction.stop) {
+      onStopAgentWatch?.call();
+    }
   }
 
   Future<void> _openWatchMenu(BuildContext context) async {
-    final renderBox = context.findRenderObject() as RenderBox?;
-    final overlay = Navigator.of(context).overlay?.context.findRenderObject();
-    if (renderBox == null || overlay is! RenderBox) {
-      return;
+    var scope = watchScope;
+    void update(PullRequestAgentWatchScope next) {
+      scope = next;
+      onWatchScopeChanged?.call(next);
     }
-    final topLeft = renderBox.localToGlobal(.zero, ancestor: overlay);
-    final bottomRight = renderBox.localToGlobal(
-      renderBox.size.bottomRight(.zero),
-      ancestor: overlay,
-    );
-    final selected = await showMenu<_WatchMenuAction>(
-      context: context,
-      position: .fromRect(
-        .fromPoints(topLeft, bottomRight),
-        Offset.zero & overlay.size,
-      ),
-      color: AleraTokens.surface,
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(AleraTokens.radiusMd),
-        side: const BorderSide(color: AleraTokens.border),
-      ),
-      items: <PopupMenuEntry<_WatchMenuAction>>[
+
+    final selected = await _showAnchoredMenu<_WatchMenuAction>(
+      context,
+      <PopupMenuEntry<_WatchMenuAction>>[
+        AleraDropdownToggleEntry<_WatchMenuAction>(
+          label: 'Failed Checks',
+          checked: scope.checks,
+          onChanged: (value) => update(scope.copyWith(checks: value)),
+        ),
+        AleraDropdownToggleEntry<_WatchMenuAction>(
+          label: 'Review Comments',
+          checked: scope.comments,
+          onChanged: (value) => update(scope.copyWith(comments: value)),
+        ),
+        AleraDropdownToggleEntry<_WatchMenuAction>(
+          label: 'Merge Conflicts',
+          checked: scope.conflicts,
+          onChanged: (value) => update(scope.copyWith(conflicts: value)),
+        ),
+        const PopupMenuDivider(),
         if (onWatchAndFix != null)
-          const AleraDropdownEntry<_WatchMenuAction>(
+          AleraDropdownEntry<_WatchMenuAction>(
             value: .watchAndFix,
             label: 'Watch and Fix',
-            leading: Icon(AleraIcons.agent, size: 16),
+            enabled: !watchScope.isEmpty,
+            leading: const Icon(AleraIcons.agent, size: 16),
           ),
         if (onWatchFixAndMerge != null)
-          const AleraDropdownEntry<_WatchMenuAction>(
+          AleraDropdownEntry<_WatchMenuAction>(
             value: .watchFixAndMerge,
             label: 'Watch, Fix and Merge',
-            leading: Icon(AleraIcons.gitMerge, size: 16),
+            enabled: !watchScope.isEmpty,
+            leading: const Icon(AleraIcons.gitMerge, size: 16),
           ),
       ],
     );
     switch (selected) {
       case _WatchMenuAction.watchAndFix:
-        onWatchAndFix?.call();
+        onWatchAndFix?.call(scope);
       case _WatchMenuAction.watchFixAndMerge:
-        onWatchFixAndMerge?.call();
+        onWatchFixAndMerge?.call(scope);
+      case _WatchMenuAction.stop:
       case null:
         break;
     }
   }
 }
 
-enum _WatchMenuAction { watchAndFix, watchFixAndMerge }
+/// Status line under the pull request title while a watch is running.
+class const _PullRequestWatchStatus({required this.mode})
+    extends StatelessWidget {
+  final PullRequestAgentWatchMode mode;
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      pullRequestAgentWatchModeLabel(mode),
+      style: Theme.of(context).textTheme.labelSmall
+          ?.copyWith(color: AleraTokens.foregroundMuted),
+    );
+  }
+}
+
+Future<T?> _showAnchoredMenu<T>(
+  BuildContext context,
+  List<PopupMenuEntry<T>> items,
+) async {
+  final renderBox = context.findRenderObject() as RenderBox?;
+  final overlay = Navigator.of(context).overlay?.context.findRenderObject();
+  if (renderBox == null || overlay is! RenderBox) {
+    return null;
+  }
+  final topLeft = renderBox.localToGlobal(.zero, ancestor: overlay);
+  final bottomRight = renderBox.localToGlobal(
+    renderBox.size.bottomRight(.zero),
+    ancestor: overlay,
+  );
+  return showMenu<T>(
+    context: context,
+    position: .fromRect(
+      .fromPoints(topLeft, bottomRight),
+      Offset.zero & overlay.size,
+    ),
+    color: AleraTokens.surface,
+    shape: RoundedRectangleBorder(
+      borderRadius: BorderRadius.circular(AleraTokens.radiusMd),
+      side: const BorderSide(color: AleraTokens.border),
+    ),
+    items: items,
+  );
+}
+
+enum _WatchMenuAction { watchAndFix, watchFixAndMerge, stop }

--- a/lib/src/features/pull_requests/presentation/pull_request_review_view.dart
+++ b/lib/src/features/pull_requests/presentation/pull_request_review_view.dart
@@ -7,6 +7,7 @@ import 'package:alera/src/design_system/forms/alera_text_actions_scope.dart';
 import 'package:alera/src/design_system/icons/alera_icons.dart';
 import 'package:alera/src/design_system/layout/alera_confirm_dialog.dart';
 import 'package:alera/src/design_system/menus/alera_dropdown_entry.dart';
+import 'package:alera/src/design_system/menus/alera_dropdown_toggle_entry.dart';
 import 'package:alera/src/features/pull_requests/application/workspace_pull_request_state.dart';
 import 'package:alera/src/features/pull_requests/domain/hosted_review.dart';
 import 'package:alera/src/features/pull_requests/domain/hosted_review_stack.dart';
@@ -15,6 +16,7 @@ import 'package:alera/src/features/pull_requests/domain/review_check_details.dar
 import 'package:alera/src/features/pull_requests/domain/review_comment.dart';
 import 'package:alera/src/features/pull_requests/domain/review_merge_method.dart';
 import 'package:alera/src/features/pull_requests/domain/pull_request_agent_watch.dart';
+import 'package:alera/src/features/pull_requests/domain/pull_request_agent_watch_scope.dart';
 import 'package:alera/src/features/pull_requests/domain/review_stack_workspace_models.dart';
 import 'package:alera/src/features/pull_requests/domain/update_review_input.dart';
 import 'package:alera/src/features/pull_requests/domain/update_review_result.dart';
@@ -73,9 +75,12 @@ class const PullRequestReviewView({
   required final Future<ReviewCheckDetails?> Function(ReviewCheck check)
   onLoadCheckDetails,
   final PullRequestAgentWatchMode? agentWatchMode,
+  final PullRequestAgentWatchScope agentWatchScope =
+      PullRequestAgentWatchScope.defaults,
+  final ValueChanged<PullRequestAgentWatchScope>? onAgentWatchScopeChanged,
   final VoidCallback? onFixFailedChecks,
-  final VoidCallback? onWatchAndFix,
-  final VoidCallback? onWatchFixAndMerge,
+  final ValueChanged<PullRequestAgentWatchScope>? onWatchAndFix,
+  final ValueChanged<PullRequestAgentWatchScope>? onWatchFixAndMerge,
   final VoidCallback? onStopAgentWatch,
 }) extends StatefulWidget {
   @override
@@ -206,11 +211,8 @@ class _PullRequestReviewViewState extends State<PullRequestReviewView> {
                       ReviewChecksRollup.failure,
                   reviewIsOpen: review.isOpen,
                   busy: _busy,
-                  watchMode: widget.agentWatchMode,
+                  watching: widget.agentWatchMode != null,
                   onFixFailedChecks: widget.onFixFailedChecks,
-                  onWatchAndFix: widget.onWatchAndFix,
-                  onWatchFixAndMerge: widget.onWatchFixAndMerge,
-                  onStopAgentWatch: widget.onStopAgentWatch,
                 ),
                 const SizedBox(height: AleraTokens.space8),
                 if (widget.checks.isEmpty)
@@ -319,6 +321,16 @@ class _PullRequestReviewViewState extends State<PullRequestReviewView> {
         const SizedBox(width: AleraTokens.space8),
         _StateChip(state: review.state),
         const Spacer(),
+        _PullRequestWatchAgentButton(
+          reviewIsOpen: review.isOpen,
+          busy: _busy,
+          watchMode: widget.agentWatchMode,
+          watchScope: widget.agentWatchScope,
+          onWatchScopeChanged: widget.onAgentWatchScopeChanged,
+          onWatchAndFix: widget.onWatchAndFix,
+          onWatchFixAndMerge: widget.onWatchFixAndMerge,
+          onStopAgentWatch: widget.onStopAgentWatch,
+        ),
         if (!_editing)
           AleraIconButton(
             tooltip: 'Edit Pull Request',
@@ -351,6 +363,10 @@ class _PullRequestReviewViewState extends State<PullRequestReviewView> {
       crossAxisAlignment: .start,
       children: <Widget>[
         Text(review.title, style: theme.textTheme.bodyMedium),
+        if (widget.agentWatchMode case final mode?) ...<Widget>[
+          const SizedBox(height: AleraTokens.space4),
+          _PullRequestWatchStatus(mode: mode),
+        ],
         if (subtitle.isNotEmpty) ...<Widget>[
           const SizedBox(height: AleraTokens.space4),
           Text(

--- a/lib/src/features/pull_requests/presentation/workspace_pull_requests_panel.dart
+++ b/lib/src/features/pull_requests/presentation/workspace_pull_requests_panel.dart
@@ -11,6 +11,7 @@ import 'package:alera/src/features/pull_requests/application/pull_request_agent_
 import 'package:alera/src/features/pull_requests/application/workspace_pull_request_controller.dart';
 import 'package:alera/src/features/pull_requests/application/workspace_pull_request_state.dart';
 import 'package:alera/src/features/pull_requests/domain/pull_request_agent_watch.dart';
+import 'package:alera/src/features/pull_requests/domain/pull_request_agent_watch_scope.dart';
 import 'package:alera/src/features/pull_requests/presentation/pull_request_agent_dispatch.dart';
 import 'package:alera/src/features/pull_requests/domain/create_review_input.dart';
 import 'package:alera/src/features/pull_requests/domain/forge_auth_status.dart';
@@ -177,6 +178,11 @@ class _VisiblePullRequestsPanelState
     final aiAssistSettings = ref.watch(
       settingsControllerProvider.select((settings) => settings.aiAssist),
     );
+    final agentWatchScope = ref.watch(
+      settingsControllerProvider.select(
+        (settings) => settings.general.pullRequestAgentWatchScope,
+      ),
+    );
     final agentWatchMode = ref.watch(
       pullRequestAgentWatchControllerProvider.select(
         (sessions) => sessions[widget.scope.workspaceId]?.mode,
@@ -215,6 +221,7 @@ class _VisiblePullRequestsPanelState
               .read(workbenchControllerProvider.notifier)
               .setPullRequestCreateAction(action),
           agentWatchMode: agentWatchMode,
+          agentWatchScope: agentWatchScope,
           ref: ref,
         );
       },

--- a/lib/src/features/pull_requests/presentation/workspace_pull_requests_panel_body.dart
+++ b/lib/src/features/pull_requests/presentation/workspace_pull_requests_panel_body.dart
@@ -13,6 +13,8 @@ class const _PullRequestBody({
   required final ValueChanged<HostedReview>? onOpenDiff,
   required final ValueChanged<PullRequestCreateAction> onCreateActionChanged,
   final PullRequestAgentWatchMode? agentWatchMode,
+  final PullRequestAgentWatchScope agentWatchScope =
+      PullRequestAgentWatchScope.defaults,
   required final WidgetRef ref,
 }) extends StatelessWidget {
   @override
@@ -90,6 +92,12 @@ class const _PullRequestBody({
         onUpdate: controller.updateReview,
         onLoadCheckDetails: controller.loadCheckDetails,
         agentWatchMode: agentWatchMode,
+        agentWatchScope: agentWatchScope,
+        onAgentWatchScopeChanged: (watchScope) => unawaited(
+          ref
+              .read(settingsControllerProvider.notifier)
+              .setPullRequestAgentWatchScope(watchScope),
+        ),
         onFixFailedChecks: review.isOpen
             ? () => unawaited(
                 dispatchPullRequestFailedChecks(
@@ -101,26 +109,36 @@ class const _PullRequestBody({
               )
             : null,
         onWatchAndFix: review.isOpen
-            ? () => unawaited(
+            ? (watchScope) => unawaited(
                 startPullRequestAgentWatch(
                   context: context,
                   ref: ref,
                   scope: controller.scope,
                   review: review,
                   mode: .fix,
-                  checksRollup: state.checksRollup,
+                  watchScope: watchScope,
+                  snapshot: PullRequestAgentWatchSnapshot(
+                    review: review,
+                    checksRollup: state.checksRollup,
+                    comments: state.comments,
+                  ),
                 ),
               )
             : null,
         onWatchFixAndMerge: review.isOpen
-            ? () => unawaited(
+            ? (watchScope) => unawaited(
                 startPullRequestAgentWatch(
                   context: context,
                   ref: ref,
                   scope: controller.scope,
                   review: review,
                   mode: .fixAndMerge,
-                  checksRollup: state.checksRollup,
+                  watchScope: watchScope,
+                  snapshot: PullRequestAgentWatchSnapshot(
+                    review: review,
+                    checksRollup: state.checksRollup,
+                    comments: state.comments,
+                  ),
                 ),
               )
             : null,

--- a/lib/src/features/settings/application/settings_controller.dart
+++ b/lib/src/features/settings/application/settings_controller.dart
@@ -6,6 +6,7 @@ import 'package:alera/src/features/settings/application/settings_providers.dart'
 import 'package:alera/src/features/settings/application/runtime_settings_changes.dart';
 import 'package:alera/src/features/agent_status/domain/agent_status.dart';
 import 'package:alera/src/features/keyboard/domain/keyboard_action.dart';
+import 'package:alera/src/features/pull_requests/domain/pull_request_agent_watch_scope.dart';
 import 'package:alera/src/features/settings/application/settings_repository.dart';
 import 'package:alera/src/features/settings/domain/alera_settings.dart';
 import 'package:alera/src/features/text_actions/domain/text_actions_settings.dart';

--- a/lib/src/features/settings/application/settings_controller_pull_requests.dart
+++ b/lib/src/features/settings/application/settings_controller_pull_requests.dart
@@ -20,6 +20,20 @@ mixin _SettingsControllerPullRequestSettings on _$SettingsController {
     });
   }
 
+  Future<void> setPullRequestAgentWatchScope(PullRequestAgentWatchScope value) {
+    final controller = _pullRequestSettingsController;
+    return controller._serialize(() async {
+      if (state.general.pullRequestAgentWatchScope == value) {
+        return;
+      }
+      await controller._save(
+        state.copyWith(
+          general: state.general.copyWith(pullRequestAgentWatchScope: value),
+        ),
+      );
+    });
+  }
+
   Future<void> setPullRequestFailureNotificationsEnabled(bool value) {
     final controller = _pullRequestSettingsController;
     return controller._serialize(() async {

--- a/lib/src/features/settings/domain/alera_settings.dart
+++ b/lib/src/features/settings/domain/alera_settings.dart
@@ -2,6 +2,7 @@ import 'package:alera/src/app/theme/alera_tokens.dart';
 import 'package:alera/src/features/ai_assist/domain/ai_assist_settings.dart';
 import 'package:alera/src/features/ai_dictation/domain/ai_dictation_settings.dart';
 import 'package:alera/src/features/keyboard/domain/keyboard_shortcut_settings.dart';
+import 'package:alera/src/features/pull_requests/domain/pull_request_agent_watch_scope.dart';
 import 'package:alera/src/features/settings/domain/editor_syntax_theme_catalog.dart';
 import 'package:alera/src/features/settings/domain/terminal_theme_catalog.dart';
 import 'package:alera/src/features/text_actions/domain/text_actions_settings.dart';
@@ -293,6 +294,7 @@ class const GeneralSettings({
   this.showTrayBadge = true,
   this.showPullRequestStatusInSidebar = true,
   this.pullRequestFailureNotificationsEnabled = false,
+  this.pullRequestAgentWatchScope = PullRequestAgentWatchScope.defaults,
 }) with GeneralSettingsMappable {
   /// User-configured root directory where new linked workspaces are created.
   /// `null` falls back to the platform default (`~/.alera/workspaces`).
@@ -324,6 +326,9 @@ class const GeneralSettings({
 
   /// Keep monitoring while hidden and notify when checks enter a failed state.
   final bool pullRequestFailureNotificationsEnabled;
+
+  /// Last problems chosen for pull request Watch and Fix.
+  final PullRequestAgentWatchScope pullRequestAgentWatchScope;
 
   static const GeneralSettings defaults = GeneralSettings();
 

--- a/lib/src/features/settings/domain/alera_settings.mapper.dart
+++ b/lib/src/features/settings/domain/alera_settings.mapper.dart
@@ -1372,6 +1372,7 @@ class GeneralSettingsMapper extends ClassMapperBase<GeneralSettings> {
   static GeneralSettingsMapper ensureInitialized() {
     if (_instance == null) {
       MapperContainer.globals.use(_instance = GeneralSettingsMapper._());
+      PullRequestAgentWatchScopeMapper.ensureInitialized();
     }
     return _instance!;
   }
@@ -1455,6 +1456,16 @@ class GeneralSettingsMapper extends ClassMapperBase<GeneralSettings> {
     opt: true,
     def: false,
   );
+  static PullRequestAgentWatchScope _$pullRequestAgentWatchScope(
+    GeneralSettings v,
+  ) => v.pullRequestAgentWatchScope;
+  static const Field<GeneralSettings, PullRequestAgentWatchScope>
+  _f$pullRequestAgentWatchScope = Field(
+    'pullRequestAgentWatchScope',
+    _$pullRequestAgentWatchScope,
+    opt: true,
+    def: PullRequestAgentWatchScope.defaults,
+  );
 
   @override
   final MappableFields<GeneralSettings> fields = const {
@@ -1469,6 +1480,7 @@ class GeneralSettingsMapper extends ClassMapperBase<GeneralSettings> {
     #showPullRequestStatusInSidebar: _f$showPullRequestStatusInSidebar,
     #pullRequestFailureNotificationsEnabled:
         _f$pullRequestFailureNotificationsEnabled,
+    #pullRequestAgentWatchScope: _f$pullRequestAgentWatchScope,
   };
 
   static GeneralSettings _instantiate(DecodingData data) {
@@ -1487,6 +1499,7 @@ class GeneralSettingsMapper extends ClassMapperBase<GeneralSettings> {
       pullRequestFailureNotificationsEnabled: data.dec(
         _f$pullRequestFailureNotificationsEnabled,
       ),
+      pullRequestAgentWatchScope: data.dec(_f$pullRequestAgentWatchScope),
     );
   }
 
@@ -1552,6 +1565,12 @@ extension GeneralSettingsValueCopy<$R, $Out>
 
 abstract class GeneralSettingsCopyWith<$R, $In extends GeneralSettings, $Out>
     implements ClassCopyWith<$R, $In, $Out> {
+  PullRequestAgentWatchScopeCopyWith<
+    $R,
+    PullRequestAgentWatchScope,
+    PullRequestAgentWatchScope
+  >
+  get pullRequestAgentWatchScope;
   $R call({
     String? workspaceDirectory,
     bool? starClicked,
@@ -1563,6 +1582,7 @@ abstract class GeneralSettingsCopyWith<$R, $In extends GeneralSettings, $Out>
     bool? showTrayBadge,
     bool? showPullRequestStatusInSidebar,
     bool? pullRequestFailureNotificationsEnabled,
+    PullRequestAgentWatchScope? pullRequestAgentWatchScope,
   });
   GeneralSettingsCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(
     Then<$Out2, $R2> t,
@@ -1578,6 +1598,14 @@ class _GeneralSettingsCopyWithImpl<$R, $Out>
   late final ClassMapperBase<GeneralSettings> $mapper =
       GeneralSettingsMapper.ensureInitialized();
   @override
+  PullRequestAgentWatchScopeCopyWith<
+    $R,
+    PullRequestAgentWatchScope,
+    PullRequestAgentWatchScope
+  >
+  get pullRequestAgentWatchScope => $value.pullRequestAgentWatchScope.copyWith
+      .$chain((v) => call(pullRequestAgentWatchScope: v));
+  @override
   $R call({
     Object? workspaceDirectory = $none,
     bool? starClicked,
@@ -1589,6 +1617,7 @@ class _GeneralSettingsCopyWithImpl<$R, $Out>
     bool? showTrayBadge,
     bool? showPullRequestStatusInSidebar,
     bool? pullRequestFailureNotificationsEnabled,
+    PullRequestAgentWatchScope? pullRequestAgentWatchScope,
   }) => $apply(
     FieldCopyWithData({
       if (workspaceDirectory != $none) #workspaceDirectory: workspaceDirectory,
@@ -1606,6 +1635,8 @@ class _GeneralSettingsCopyWithImpl<$R, $Out>
       if (pullRequestFailureNotificationsEnabled != null)
         #pullRequestFailureNotificationsEnabled:
             pullRequestFailureNotificationsEnabled,
+      if (pullRequestAgentWatchScope != null)
+        #pullRequestAgentWatchScope: pullRequestAgentWatchScope,
     }),
   );
   @override
@@ -1634,6 +1665,10 @@ class _GeneralSettingsCopyWithImpl<$R, $Out>
     pullRequestFailureNotificationsEnabled: data.get(
       #pullRequestFailureNotificationsEnabled,
       or: $value.pullRequestFailureNotificationsEnabled,
+    ),
+    pullRequestAgentWatchScope: data.get(
+      #pullRequestAgentWatchScope,
+      or: $value.pullRequestAgentWatchScope,
     ),
   );
 

--- a/roadmap.md
+++ b/roadmap.md
@@ -95,7 +95,7 @@ Comprehensive feature roadmap for Alera. Each feature is scored on two axes:
 
 | Feature | Difficulty | Utility | Status | Notes |
 |---|:---:|:---:|:---:|---|
-| Pull requests panel | 4 | 4 | Shipped | Create, edit, comment (markdown), toggle draft, and merge reviews per worktree on GitHub, GitLab, and Azure DevOps; GitHub native stack discovery, workspace-driven PR creation, linking, and atomic merge are included |
+| Pull requests panel | 4 | 4 | Shipped | Create, edit, comment (markdown), toggle draft, and merge reviews per worktree on GitHub, GitLab, and Azure DevOps; GitHub native stack discovery, workspace-driven PR creation, linking, and atomic merge are included; Watch and Fix sends one agent prompt for failed checks, unresolved review threads, and merge conflicts inside a remembered scope, and Watch, Fix and Merge merges once that scope is clear |
 | Checks panel (CI/CD) | 4 | 4 | Shipped | CI checks grouped by status with drill-down details on GitHub, GitLab, and Azure DevOps |
 | GitHub Projects integration | 4 | 3 | Planned | Full project board with columns, cards, filtering, inline editing |
 | Linear integration | 4 | 2 | Planned | Linear SDK, issue workspace, item drawer, team selection |

--- a/test/unit/alera_settings_test.dart
+++ b/test/unit/alera_settings_test.dart
@@ -2,6 +2,7 @@ import 'package:alera/src/features/ai_assist/domain/ai_assist_settings.dart';
 import 'package:alera/src/features/settings/domain/alera_settings.dart';
 import 'package:alera/src/features/settings/domain/editor_syntax_theme_catalog.dart';
 import 'package:alera/src/features/settings/domain/terminal_theme_catalog.dart';
+import 'package:alera/src/features/pull_requests/domain/pull_request_agent_watch_scope.dart';
 import 'package:dart_mappable/dart_mappable.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -47,6 +48,13 @@ void main() {
       expect(general.showTrayBadge, isTrue);
       expect(general.showPullRequestStatusInSidebar, isTrue);
       expect(general.pullRequestFailureNotificationsEnabled, isFalse);
+      expect(
+        general.pullRequestAgentWatchScope,
+        PullRequestAgentWatchScope.defaults,
+      );
+      expect(general.pullRequestAgentWatchScope.checks, isTrue);
+      expect(general.pullRequestAgentWatchScope.comments, isTrue);
+      expect(general.pullRequestAgentWatchScope.conflicts, isTrue);
     });
 
     test('agent defaults are conservative', () {
@@ -162,6 +170,10 @@ void main() {
       expect(general.showDockBadge, isTrue);
       expect(general.showPullRequestStatusInSidebar, isTrue);
       expect(general.pullRequestFailureNotificationsEnabled, isFalse);
+      expect(
+        general.pullRequestAgentWatchScope,
+        PullRequestAgentWatchScope.defaults,
+      );
       expect(agents.agentStatusHooks.codex, isTrue);
       expect(agents.agentStatusHooks.claude, isFalse);
       expect(agents.agentStatusHooks.copilot, isTrue);

--- a/test/unit/forge_provider_comments_test.dart
+++ b/test/unit/forge_provider_comments_test.dart
@@ -90,7 +90,7 @@ void main() {
 [[{"id":1,"user":{"login":"alice"},"body":"General note","created_at":"2026-07-16T12:00:00Z","html_url":"https://github.com/leynier/alera/pull/123#issuecomment-1"}]]
 '''),
         _ok('''
-{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[{"id":"T1","isResolved":true,"line":null,"originalLine":17,"comments":{"nodes":[{"databaseId":2,"author":{"login":"bob"},"body":"Change this line","createdAt":"2026-07-16T11:00:00Z","url":"https://github.com/leynier/alera/pull/123#discussion_r2","path":"lib/a.dart"}]}}]}}}}}
+{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[{"id":"T1","isResolved":true,"isOutdated":true,"line":null,"originalLine":17,"comments":{"nodes":[{"databaseId":2,"author":{"login":"bob"},"body":"Change this line","createdAt":"2026-07-16T11:00:00Z","url":"https://github.com/leynier/alera/pull/123#discussion_r2","path":"lib/a.dart"}]}}]}}}}}
 '''),
         _ok('''
 [[{"id":3,"user":{"login":"carol"},"body":"LGTM","state":"APPROVED","submitted_at":"2026-07-16T13:00:00Z","html_url":"https://github.com/leynier/alera/pull/123#pullrequestreview-3"}]]
@@ -110,7 +110,9 @@ void main() {
       expect(comments.first.path, 'lib/a.dart');
       expect(comments.first.line, 17);
       expect(comments.first.resolved, isTrue);
+      expect(comments.first.outdated, isTrue);
       expect(comments[1].body, 'General note');
+      expect(comments[1].outdated, isFalse);
       expect(comments.last.body, 'LGTM');
       expect(
         runner.calls.first.arguments,

--- a/test/unit/pull_request_agent_watch_concerns_test.dart
+++ b/test/unit/pull_request_agent_watch_concerns_test.dart
@@ -1,0 +1,172 @@
+import 'package:alera/src/features/pull_requests/domain/pull_request_agent_prompts.dart';
+import 'package:alera/src/features/pull_requests/domain/pull_request_agent_watch.dart';
+import 'package:alera/src/features/pull_requests/domain/pull_request_agent_watch_scope.dart';
+import 'package:alera/src/features/pull_requests/domain/review_comment.dart';
+import 'package:alera/src/features/pull_requests/domain/review_thread_backlog.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'pull_request_agent_watch_fixtures.dart';
+
+void main() {
+  group('prompts', () {
+    test('failed checks prompt names the pull request and omits logs', () {
+      final prompt = pullRequestFailedChecksPrompt(42);
+      expect(prompt, contains('Pull request #42 checks failed'));
+      expect(prompt, contains('Please fix them.'));
+      expect(prompt.toLowerCase(), isNot(contains('log')));
+      expect(prompt.toLowerCase(), isNot(contains('payload')));
+      expect(prompt, isNot(contains('ci.yml')));
+    });
+
+    test('watch prompt matches the failed checks prompt for checks only', () {
+      expect(
+        pullRequestAgentWatchPrompt(
+          reviewNumber: 42,
+          concerns: const PullRequestAgentWatchConcerns(checksFailed: true),
+          baseBranch: 'main',
+        ),
+        pullRequestFailedChecksPrompt(42),
+      );
+    });
+
+    test('watch prompt names every concern without comment bodies', () {
+      final prompt = pullRequestAgentWatchPrompt(
+        reviewNumber: 42,
+        concerns: const PullRequestAgentWatchConcerns(
+          checksFailed: true,
+          conflict: true,
+          threads: <PendingReviewThread>[
+            PendingReviewThread(id: 'T1', path: 'lib/a.dart'),
+            PendingReviewThread(id: 'T2'),
+          ],
+        ),
+        baseBranch: 'main',
+      );
+      expect(
+        prompt,
+        'Pull request #42 has merge conflicts with main, failing checks, and '
+        '2 unresolved review threads. Please resolve the conflicts, fix the '
+        'checks, and address the review comments. Resolve each review thread '
+        'once its fix is pushed.',
+      );
+      expect(prompt, isNot(contains('`')));
+    });
+
+    test('watch prompt stays readable when nothing is pending', () {
+      expect(
+        pullRequestAgentWatchPrompt(
+          reviewNumber: 42,
+          concerns: const PullRequestAgentWatchConcerns(),
+        ),
+        'Please check pull request #42 and fix anything that blocks it.',
+      );
+    });
+
+    test('watch prompt handles a single thread and an unknown base', () {
+      expect(
+        pullRequestAgentWatchPrompt(
+          reviewNumber: 7,
+          concerns: const PullRequestAgentWatchConcerns(
+            conflict: true,
+            threads: <PendingReviewThread>[PendingReviewThread(id: 'T1')],
+          ),
+        ),
+        'Pull request #7 has merge conflicts with its base branch and '
+        '1 unresolved review thread. Please resolve the conflicts and address '
+        'the review comments. Resolve each review thread once its fix is '
+        'pushed.',
+      );
+    });
+  });
+
+  test('labels both watch modes', () {
+    expect(pullRequestAgentWatchModeLabel(.fix), 'Watching: Fix');
+    expect(
+      pullRequestAgentWatchModeLabel(.fixAndMerge),
+      'Watching: Fix and Merge',
+    );
+  });
+
+  group('pullRequestAgentWatchConcerns', () {
+    test('collects every concern inside the scope', () {
+      final concerns = pullRequestAgentWatchConcerns(
+        snapshot: pullRequestWatchSnapshot(
+          rollup: .failure,
+          mergeable: .conflicting,
+          comments: <ReviewComment>[pullRequestWatchThread('T1')],
+        ),
+        scope: PullRequestAgentWatchScope.defaults,
+      );
+      expect(concerns.checksFailed, isTrue);
+      expect(concerns.conflict, isTrue);
+      expect(concerns.threadIds, <String>{'T1'});
+      expect(pullRequestAgentWatchInjectsOnStart(concerns), isTrue);
+    });
+
+    test('ignores concerns outside the scope', () {
+      final concerns = pullRequestAgentWatchConcerns(
+        snapshot: pullRequestWatchSnapshot(
+          rollup: .failure,
+          mergeable: .conflicting,
+          comments: <ReviewComment>[pullRequestWatchThread('T1')],
+        ),
+        scope: const PullRequestAgentWatchScope(
+          checks: false,
+          comments: false,
+          conflicts: false,
+        ),
+      );
+      expect(concerns.isEmpty, isTrue);
+      expect(pullRequestAgentWatchInjectsOnStart(concerns), isFalse);
+    });
+
+    test('does not treat unknown mergeability as a conflict', () {
+      final concerns = pullRequestAgentWatchConcerns(
+        snapshot: pullRequestWatchSnapshot(mergeable: .unknown),
+        scope: PullRequestAgentWatchScope.defaults,
+      );
+      expect(concerns.conflict, isFalse);
+    });
+
+    test('skips threads written only by the pull request author', () {
+      final concerns = pullRequestAgentWatchConcerns(
+        snapshot: pullRequestWatchSnapshot(
+          comments: <ReviewComment>[
+            pullRequestWatchThread('T1', author: 'leynier'),
+          ],
+        ),
+        scope: PullRequestAgentWatchScope.defaults,
+      );
+      expect(concerns.isEmpty, isTrue);
+    });
+  });
+
+  test(
+    'accumulates the dispatch mark on one head and resets on a new head',
+    () {
+      const first = PullRequestAgentWatchDispatchMark(
+        headSha: 'abc123',
+        checksFailed: true,
+        threadIds: <String>{'T1'},
+      );
+      final same = pullRequestAgentWatchDispatchMark(
+        previous: first,
+        headSha: 'abc123',
+        concerns: const PullRequestAgentWatchConcerns(
+          threads: <PendingReviewThread>[PendingReviewThread(id: 'T2')],
+        ),
+      );
+      expect(same.checksFailed, isTrue);
+      expect(same.threadIds, <String>{'T1', 'T2'});
+
+      final next = pullRequestAgentWatchDispatchMark(
+        previous: first,
+        headSha: 'def456',
+        concerns: const PullRequestAgentWatchConcerns(conflict: true),
+      );
+      expect(next.checksFailed, isFalse);
+      expect(next.conflict, isTrue);
+      expect(next.threadIds, isEmpty);
+    },
+  );
+}

--- a/test/unit/pull_request_agent_watch_concerns_test.dart
+++ b/test/unit/pull_request_agent_watch_concerns_test.dart
@@ -79,6 +79,21 @@ void main() {
     });
   });
 
+  test('watch scope reports emptiness and round-trips through json', () {
+    const none = PullRequestAgentWatchScope(
+      checks: false,
+      comments: false,
+      conflicts: false,
+    );
+    expect(none.isEmpty, isTrue);
+    expect(PullRequestAgentWatchScope.defaults.isEmpty, isFalse);
+    expect(
+      PullRequestAgentWatchScope.fromJson(<String, Object?>{'comments': false}),
+      const PullRequestAgentWatchScope(comments: false),
+    );
+    expect(PullRequestAgentWatchScope.fromJson(none.toMap()), none);
+  });
+
   test('labels both watch modes', () {
     expect(pullRequestAgentWatchModeLabel(.fix), 'Watching: Fix');
     expect(

--- a/test/unit/pull_request_agent_watch_fixtures.dart
+++ b/test/unit/pull_request_agent_watch_fixtures.dart
@@ -1,0 +1,66 @@
+import 'package:alera/src/features/agent_task_dispatch/domain/agent_task_dispatch.dart';
+import 'package:alera/src/features/pull_requests/domain/hosted_review.dart';
+import 'package:alera/src/features/pull_requests/domain/pull_request_agent_watch.dart';
+import 'package:alera/src/features/pull_requests/domain/review_check.dart';
+import 'package:alera/src/features/pull_requests/domain/review_comment.dart';
+import 'package:alera/src/features/pull_requests/domain/workspace_pull_request_scope.dart';
+
+const pullRequestWatchTestScope = WorkspacePullRequestScope(
+  workspaceId: 'workspace-1',
+  repoPath: '/repo',
+);
+
+const pullRequestWatchTestDispatchResult = AgentTaskDispatchResult(
+  workspaceId: 'workspace-1',
+  tabId: 'tab-2',
+  openedNewTab: true,
+  label: 'Codex Builder',
+  profileId: 'profile-1',
+);
+
+/// Pull request #42 by `leynier`, as the watch sees it on one poll.
+PullRequestAgentWatchSnapshot pullRequestWatchSnapshot({
+  HostedReviewState state = HostedReviewState.open,
+  HostedReviewMergeable mergeable = HostedReviewMergeable.unknown,
+  ReviewChecksRollup rollup = ReviewChecksRollup.none,
+  String headSha = 'abc123',
+  List<ReviewComment> comments = const <ReviewComment>[],
+}) {
+  return PullRequestAgentWatchSnapshot(
+    review: HostedReview(
+      provider: .github,
+      number: 42,
+      title: 'feat: example',
+      state: state,
+      url: 'https://github.com/leynier/alera/pull/42',
+      author: 'leynier',
+      headSha: headSha,
+      mergeable: mergeable,
+    ),
+    checksRollup: rollup,
+    comments: comments,
+  );
+}
+
+/// One inline review comment in thread [id].
+ReviewComment pullRequestWatchThread(
+  String id, {
+  String author = 'pullfrog',
+  bool resolved = false,
+}) {
+  return ReviewComment(
+    id: 'thread:$id:1',
+    author: author,
+    body: 'Remove the unused alias.',
+    createdAt: DateTime.utc(2026, 9, 12),
+    kind: .review,
+    path: 'lib/a.dart',
+    line: 3,
+    resolved: resolved,
+    locator: ReviewCommentLocator(
+      source: .reviewThread,
+      commentId: '1',
+      parentId: id,
+    ),
+  );
+}

--- a/test/unit/pull_request_agent_watch_test.dart
+++ b/test/unit/pull_request_agent_watch_test.dart
@@ -1,159 +1,325 @@
 import 'package:alera/src/features/agent_task_dispatch/domain/agent_task_dispatch.dart';
-import 'package:alera/src/features/pull_requests/domain/hosted_review.dart';
-import 'package:alera/src/features/pull_requests/domain/pull_request_agent_prompts.dart';
 import 'package:alera/src/features/pull_requests/domain/pull_request_agent_watch.dart';
-import 'package:alera/src/features/pull_requests/domain/workspace_pull_request_scope.dart';
+import 'package:alera/src/features/pull_requests/domain/pull_request_agent_watch_scope.dart';
+import 'package:alera/src/features/pull_requests/domain/review_comment.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'pull_request_agent_watch_fixtures.dart';
+
+const _session = PullRequestAgentWatchSession(
+  workspaceId: 'workspace-1',
+  reviewNumber: 42,
+  mode: .fix,
+  binding: AgentTaskDispatchBinding(tabId: 'tab-1'),
+  scope: pullRequestWatchTestScope,
+);
+
 void main() {
-  const scope = WorkspacePullRequestScope(
-    workspaceId: 'workspace-1',
-    repoPath: '/repo',
-  );
-  const session = PullRequestAgentWatchSession(
-    workspaceId: 'workspace-1',
-    reviewNumber: 42,
-    mode: .fix,
-    binding: AgentTaskDispatchBinding(tabId: 'tab-1'),
-    scope: scope,
-  );
-
-  group('pullRequestFailedChecksPrompt', () {
-    test('names the pull request and omits check logs', () {
-      final prompt = pullRequestFailedChecksPrompt(42);
-      expect(prompt, contains('Pull request #42 checks failed'));
-      expect(prompt, contains('Please fix them.'));
-      expect(prompt.toLowerCase(), isNot(contains('log')));
-      expect(prompt.toLowerCase(), isNot(contains('payload')));
-      expect(prompt, isNot(contains('ci.yml')));
-      expect(pullRequestAgentWatchPrompt(42), prompt);
-    });
-  });
-
-  group('pullRequestAgentWatchModeLabel', () {
-    test('labels both watch modes', () {
-      expect(pullRequestAgentWatchModeLabel(.fix), 'Watching: Fix');
-      expect(
-        pullRequestAgentWatchModeLabel(.fixAndMerge),
-        'Watching: Fix and Merge',
-      );
-    });
-  });
-
-  group('pullRequestAgentWatchInjectsOnStart', () {
-    test('injects only when checks have already failed', () {
-      expect(pullRequestAgentWatchInjectsOnStart(.failure), isTrue);
-      expect(pullRequestAgentWatchInjectsOnStart(.none), isFalse);
-      expect(pullRequestAgentWatchInjectsOnStart(.pending), isFalse);
-      expect(pullRequestAgentWatchInjectsOnStart(.success), isFalse);
-    });
-  });
-
   group('evaluatePullRequestAgentWatch', () {
     test('dispatches once per failing head sha', () {
+      final snapshot = pullRequestWatchSnapshot(rollup: .failure);
       final first = evaluatePullRequestAgentWatch(
-        session: session,
-        snapshot: PullRequestAgentWatchSnapshot(
-          review: _review(),
-          checksRollup: .failure,
-        ),
+        session: _session,
+        snapshot: snapshot,
       );
-      expect(first.action, PullRequestAgentWatchAction.dispatchFix);
-      expect(first.failureSignature, '42:abc123');
+      expect(first.action, PullRequestAgentWatchAction.dispatch);
+      expect(first.concerns.checksFailed, isTrue);
 
-      final repeat = evaluatePullRequestAgentWatch(
-        session: PullRequestAgentWatchSession(
-          workspaceId: session.workspaceId,
-          reviewNumber: session.reviewNumber,
-          mode: session.mode,
-          binding: session.binding,
-          scope: session.scope,
-          lastDispatchedFailureSignature: first.failureSignature,
-        ),
-        snapshot: PullRequestAgentWatchSnapshot(
-          review: _review(),
-          checksRollup: .failure,
+      final dispatched = _afterDispatch(_session, first);
+      expect(
+        evaluatePullRequestAgentWatch(
+          session: dispatched,
+          snapshot: snapshot,
+        ).action,
+        PullRequestAgentWatchAction.none,
+      );
+      expect(
+        evaluatePullRequestAgentWatch(
+          session: dispatched,
+          snapshot: pullRequestWatchSnapshot(
+            rollup: .failure,
+            headSha: 'def456',
+          ),
+        ).action,
+        PullRequestAgentWatchAction.dispatch,
+      );
+    });
+
+    test('does not repeat a check rerun on the same head sha', () {
+      final dispatched = _afterDispatch(
+        _session,
+        evaluatePullRequestAgentWatch(
+          session: _session,
+          snapshot: pullRequestWatchSnapshot(rollup: .failure),
         ),
       );
-      expect(repeat.action, PullRequestAgentWatchAction.none);
+      expect(
+        evaluatePullRequestAgentWatch(
+          session: dispatched,
+          snapshot: pullRequestWatchSnapshot(rollup: .pending),
+        ).action,
+        PullRequestAgentWatchAction.none,
+      );
+      expect(
+        evaluatePullRequestAgentWatch(
+          session: dispatched,
+          snapshot: pullRequestWatchSnapshot(rollup: .failure),
+        ).action,
+        PullRequestAgentWatchAction.none,
+      );
+    });
+
+    test('dispatches for merge conflicts even when checks are green', () {
+      final evaluation = evaluatePullRequestAgentWatch(
+        session: _session,
+        snapshot: pullRequestWatchSnapshot(
+          rollup: .success,
+          mergeable: .conflicting,
+        ),
+      );
+      expect(evaluation.action, PullRequestAgentWatchAction.dispatch);
+      expect(evaluation.concerns.conflict, isTrue);
+      expect(evaluation.concerns.checksFailed, isFalse);
+
+      final dispatched = _afterDispatch(_session, evaluation);
+      expect(
+        evaluatePullRequestAgentWatch(
+          session: dispatched,
+          snapshot: pullRequestWatchSnapshot(mergeable: .unknown),
+        ).action,
+        PullRequestAgentWatchAction.none,
+      );
+      expect(
+        evaluatePullRequestAgentWatch(
+          session: dispatched,
+          snapshot: pullRequestWatchSnapshot(mergeable: .conflicting),
+        ).action,
+        PullRequestAgentWatchAction.none,
+      );
+    });
+
+    test('dispatches for unresolved review threads', () {
+      final evaluation = evaluatePullRequestAgentWatch(
+        session: _session,
+        snapshot: pullRequestWatchSnapshot(
+          rollup: .success,
+          comments: <ReviewComment>[
+            pullRequestWatchThread('T1'),
+            pullRequestWatchThread('T2'),
+          ],
+        ),
+      );
+      expect(evaluation.action, PullRequestAgentWatchAction.dispatch);
+      expect(evaluation.concerns.threadIds, <String>{'T1', 'T2'});
+    });
+
+    test('dispatches again only when a new thread appears', () {
+      final dispatched = _afterDispatch(
+        _session,
+        evaluatePullRequestAgentWatch(
+          session: _session,
+          snapshot: pullRequestWatchSnapshot(
+            comments: <ReviewComment>[
+              pullRequestWatchThread('T1'),
+              pullRequestWatchThread('T2'),
+            ],
+          ),
+        ),
+      );
+
+      final resolvedOne = evaluatePullRequestAgentWatch(
+        session: dispatched,
+        snapshot: pullRequestWatchSnapshot(
+          comments: <ReviewComment>[
+            pullRequestWatchThread('T1', resolved: true),
+            pullRequestWatchThread('T2'),
+          ],
+        ),
+      );
+      expect(resolvedOne.action, PullRequestAgentWatchAction.none);
+
+      final newThread = evaluatePullRequestAgentWatch(
+        session: dispatched,
+        snapshot: pullRequestWatchSnapshot(
+          comments: <ReviewComment>[
+            pullRequestWatchThread('T1'),
+            pullRequestWatchThread('T2'),
+            pullRequestWatchThread('T3'),
+          ],
+        ),
+      );
+      expect(newThread.action, PullRequestAgentWatchAction.dispatch);
+      expect(newThread.concerns.threadIds, <String>{'T1', 'T2', 'T3'});
+    });
+
+    test('adds a new concern on the same head sha', () {
+      final dispatched = _afterDispatch(
+        _session,
+        evaluatePullRequestAgentWatch(
+          session: _session,
+          snapshot: pullRequestWatchSnapshot(rollup: .failure),
+        ),
+      );
+      final evaluation = evaluatePullRequestAgentWatch(
+        session: dispatched,
+        snapshot: pullRequestWatchSnapshot(
+          rollup: .failure,
+          mergeable: .conflicting,
+        ),
+      );
+      expect(evaluation.action, PullRequestAgentWatchAction.dispatch);
+      expect(evaluation.concerns.checksFailed, isTrue);
+      expect(evaluation.concerns.conflict, isTrue);
+    });
+
+    test('ignores review threads outside the scope', () {
+      const session = PullRequestAgentWatchSession(
+        workspaceId: 'workspace-1',
+        reviewNumber: 42,
+        mode: .fixAndMerge,
+        binding: AgentTaskDispatchBinding(profileId: 'profile-1'),
+        scope: pullRequestWatchTestScope,
+        watchScope: PullRequestAgentWatchScope(comments: false),
+      );
+      final evaluation = evaluatePullRequestAgentWatch(
+        session: session,
+        snapshot: pullRequestWatchSnapshot(
+          rollup: .success,
+          mergeable: .mergeable,
+          comments: <ReviewComment>[pullRequestWatchThread('T1')],
+        ),
+      );
+      expect(evaluation.action, PullRequestAgentWatchAction.merge);
     });
 
     test('merges a green open pull request in fix-and-merge mode', () {
       final evaluation = evaluatePullRequestAgentWatch(
-        session: const PullRequestAgentWatchSession(
-          workspaceId: 'workspace-1',
-          reviewNumber: 42,
-          mode: .fixAndMerge,
-          binding: AgentTaskDispatchBinding(profileId: 'profile-1'),
-          scope: scope,
-        ),
-        snapshot: PullRequestAgentWatchSnapshot(
-          review: _review(mergeable: .mergeable),
-          checksRollup: .success,
+        session: _mergeSession(),
+        snapshot: pullRequestWatchSnapshot(
+          rollup: .success,
+          mergeable: .mergeable,
         ),
       );
       expect(evaluation.action, PullRequestAgentWatchAction.merge);
       expect(evaluation.headSha, 'abc123');
     });
 
+    test('waits for pending review threads before merging', () {
+      final dispatched = _afterDispatch(
+        _mergeSession(),
+        evaluatePullRequestAgentWatch(
+          session: _mergeSession(),
+          snapshot: pullRequestWatchSnapshot(
+            rollup: .success,
+            mergeable: .mergeable,
+            comments: <ReviewComment>[pullRequestWatchThread('T1')],
+          ),
+        ),
+      );
+      expect(
+        evaluatePullRequestAgentWatch(
+          session: dispatched,
+          snapshot: pullRequestWatchSnapshot(
+            rollup: .success,
+            mergeable: .mergeable,
+            comments: <ReviewComment>[pullRequestWatchThread('T1')],
+          ),
+        ).action,
+        PullRequestAgentWatchAction.none,
+      );
+      expect(
+        evaluatePullRequestAgentWatch(
+          session: dispatched,
+          snapshot: pullRequestWatchSnapshot(
+            rollup: .success,
+            mergeable: .mergeable,
+            comments: <ReviewComment>[
+              pullRequestWatchThread('T1', resolved: true),
+            ],
+          ),
+        ).action,
+        PullRequestAgentWatchAction.merge,
+      );
+    });
+
     test('does not merge the same head sha twice', () {
       final evaluation = evaluatePullRequestAgentWatch(
-        session: const PullRequestAgentWatchSession(
-          workspaceId: 'workspace-1',
-          reviewNumber: 42,
-          mode: .fixAndMerge,
-          binding: AgentTaskDispatchBinding(profileId: 'profile-1'),
-          scope: scope,
-          lastMergedHeadSha: 'abc123',
-        ),
-        snapshot: PullRequestAgentWatchSnapshot(
-          review: _review(mergeable: .mergeable),
-          checksRollup: .success,
+        session: _mergeSession(lastMergedHeadSha: 'abc123'),
+        snapshot: pullRequestWatchSnapshot(
+          rollup: .success,
+          mergeable: .mergeable,
         ),
       );
       expect(evaluation.action, PullRequestAgentWatchAction.none);
     });
 
-    test('keeps the watch eligible after a failed dispatch or merge', () {
-      const result = AgentTaskDispatchResult(
-        workspaceId: 'workspace-1',
-        tabId: 'tab-2',
-        openedNewTab: true,
-        label: 'Codex Builder',
-        profileId: 'profile-1',
+    test('stops when the pull request is merged or unlinked', () {
+      expect(
+        evaluatePullRequestAgentWatch(
+          session: _session,
+          snapshot: pullRequestWatchSnapshot(state: .merged, rollup: .success),
+        ).action,
+        PullRequestAgentWatchAction.stop,
       );
+      expect(
+        evaluatePullRequestAgentWatch(
+          session: _session,
+          snapshot: pullRequestWatchSnapshot(state: .closed, rollup: .failure),
+        ).action,
+        PullRequestAgentWatchAction.stop,
+      );
+      expect(
+        evaluatePullRequestAgentWatch(
+          session: _session,
+          snapshot: const PullRequestAgentWatchSnapshot(),
+        ).action,
+        PullRequestAgentWatchAction.stop,
+      );
+      expect(
+        evaluatePullRequestAgentWatch(session: _session, snapshot: null).action,
+        PullRequestAgentWatchAction.none,
+      );
+    });
+  });
+
+  group('session updates', () {
+    test('keeps the watch eligible after a failed dispatch or merge', () {
+      const concerns = PullRequestAgentWatchConcerns(checksFailed: true);
       expect(
         identical(
           pullRequestAgentWatchAfterDispatch(
-            session: session,
+            session: _session,
             result: null,
-            failureSignature: '42:abc123',
+            concerns: concerns,
+            headSha: 'abc123',
           ),
-          session,
+          _session,
         ),
         isTrue,
       );
       final dispatched = pullRequestAgentWatchAfterDispatch(
-        session: session,
-        result: result,
-        failureSignature: '42:abc123',
+        session: _session,
+        result: pullRequestWatchTestDispatchResult,
+        concerns: concerns,
+        headSha: 'abc123',
       );
-      expect(dispatched.lastDispatchedFailureSignature, '42:abc123');
+      expect(dispatched.lastDispatch?.headSha, 'abc123');
+      expect(dispatched.lastDispatch?.checksFailed, isTrue);
       expect(dispatched.binding.tabId, 'tab-2');
       expect(
         identical(
           pullRequestAgentWatchAfterMerge(
-            session: session,
+            session: _session,
             merged: false,
             headSha: 'abc123',
           ),
-          session,
+          _session,
         ),
         isTrue,
       );
       expect(
         pullRequestAgentWatchAfterMerge(
-          session: session,
+          session: _session,
           merged: true,
           headSha: 'abc123',
         ).lastMergedHeadSha,
@@ -161,87 +327,47 @@ void main() {
       );
     });
 
-    test('keeps prior signatures when a successful result omits them', () {
+    test('keeps prior values when a successful result omits them', () {
       const prior = PullRequestAgentWatchSession(
         workspaceId: 'workspace-1',
         reviewNumber: 42,
         mode: .fixAndMerge,
         binding: AgentTaskDispatchBinding(tabId: 'tab-1'),
-        scope: scope,
-        lastDispatchedFailureSignature: '42:oldsha',
+        scope: pullRequestWatchTestScope,
+        watchScope: PullRequestAgentWatchScope(conflicts: false),
         lastMergedHeadSha: 'oldsha',
       );
-      const result = AgentTaskDispatchResult(
-        workspaceId: 'workspace-1',
-        tabId: 'tab-2',
-        openedNewTab: false,
-        label: 'Codex',
+      final merged = pullRequestAgentWatchAfterMerge(
+        session: prior,
+        merged: true,
+        headSha: null,
       );
-      expect(
-        pullRequestAgentWatchAfterDispatch(
-          session: prior,
-          result: result,
-          failureSignature: null,
-        ).lastDispatchedFailureSignature,
-        '42:oldsha',
-      );
-      expect(
-        pullRequestAgentWatchAfterMerge(
-          session: prior,
-          merged: true,
-          headSha: null,
-        ).lastMergedHeadSha,
-        'oldsha',
-      );
-    });
-
-    test('stops when the pull request is merged or unlinked', () {
-      expect(
-        evaluatePullRequestAgentWatch(
-          session: session,
-          snapshot: PullRequestAgentWatchSnapshot(
-            review: _review(state: .merged),
-            checksRollup: .success,
-          ),
-        ).action,
-        PullRequestAgentWatchAction.stop,
-      );
-      expect(
-        evaluatePullRequestAgentWatch(
-          session: session,
-          snapshot: PullRequestAgentWatchSnapshot(
-            review: _review(state: .closed),
-            checksRollup: .failure,
-          ),
-        ).action,
-        PullRequestAgentWatchAction.stop,
-      );
-      expect(
-        evaluatePullRequestAgentWatch(
-          session: session,
-          snapshot: const PullRequestAgentWatchSnapshot(),
-        ).action,
-        PullRequestAgentWatchAction.stop,
-      );
-      expect(
-        evaluatePullRequestAgentWatch(session: session, snapshot: null).action,
-        PullRequestAgentWatchAction.none,
-      );
+      expect(merged.lastMergedHeadSha, 'oldsha');
+      expect(merged.watchScope.conflicts, isFalse);
     });
   });
 }
 
-HostedReview _review({
-  HostedReviewState state = HostedReviewState.open,
-  HostedReviewMergeable mergeable = HostedReviewMergeable.unknown,
-}) {
-  return HostedReview(
-    provider: .github,
-    number: 42,
-    title: 'feat: example',
-    state: state,
-    url: 'https://github.com/leynier/alera/pull/42',
-    headSha: 'abc123',
-    mergeable: mergeable,
+PullRequestAgentWatchSession _mergeSession({String? lastMergedHeadSha}) {
+  return PullRequestAgentWatchSession(
+    workspaceId: 'workspace-1',
+    reviewNumber: 42,
+    mode: .fixAndMerge,
+    binding: const AgentTaskDispatchBinding(profileId: 'profile-1'),
+    scope: pullRequestWatchTestScope,
+    lastMergedHeadSha: lastMergedHeadSha,
+  );
+}
+
+PullRequestAgentWatchSession _afterDispatch(
+  PullRequestAgentWatchSession session,
+  PullRequestAgentWatchEvaluation evaluation,
+) {
+  expect(evaluation.action, PullRequestAgentWatchAction.dispatch);
+  return pullRequestAgentWatchAfterDispatch(
+    session: session,
+    result: pullRequestWatchTestDispatchResult,
+    concerns: evaluation.concerns,
+    headSha: evaluation.headSha,
   );
 }

--- a/test/unit/review_thread_backlog_test.dart
+++ b/test/unit/review_thread_backlog_test.dart
@@ -1,0 +1,104 @@
+import 'package:alera/src/features/pull_requests/domain/review_comment.dart';
+import 'package:alera/src/features/pull_requests/domain/review_thread_backlog.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('pendingReviewThreads', () {
+    test('groups comments by thread and keeps the first location', () {
+      final threads = pendingReviewThreads(
+        comments: <ReviewComment>[
+          _comment('T1', author: 'pullfrog', path: 'lib/a.dart', line: 3),
+          _comment('T1', author: 'leynier', path: 'lib/a.dart', line: 3),
+          _comment('T2', author: 'pullfrog', path: 'lib/b.dart', line: 9),
+        ],
+        reviewAuthor: 'leynier',
+      );
+
+      expect(threads.map((thread) => thread.id), <String>['T1', 'T2']);
+      expect(threads.first.path, 'lib/a.dart');
+      expect(threads.first.line, 3);
+    });
+
+    test('ignores comments that belong to no thread', () {
+      final threads = pendingReviewThreads(
+        comments: <ReviewComment>[
+          _comment(null, author: 'alice'),
+          _comment('', author: 'alice'),
+        ],
+      );
+
+      expect(threads, isEmpty);
+    });
+
+    test('drops resolved threads', () {
+      final threads = pendingReviewThreads(
+        comments: <ReviewComment>[
+          _comment('T1', author: 'alice', resolved: true),
+          _comment('T1', author: 'bob', resolved: true),
+        ],
+      );
+
+      expect(threads, isEmpty);
+    });
+
+    test('drops a thread only when every comment is outdated', () {
+      final threads = pendingReviewThreads(
+        comments: <ReviewComment>[
+          _comment('T1', author: 'alice', outdated: true),
+          _comment('T2', author: 'alice', outdated: true),
+          _comment('T2', author: 'bob'),
+        ],
+      );
+
+      expect(threads.map((thread) => thread.id), <String>['T2']);
+    });
+
+    test('drops threads written only by the pull request author', () {
+      final threads = pendingReviewThreads(
+        comments: <ReviewComment>[
+          _comment('T1', author: 'Leynier'),
+          _comment('T1', author: 'leynier'),
+          _comment('T2', author: 'leynier'),
+          _comment('T2', author: 'pullfrog'),
+        ],
+        reviewAuthor: 'leynier',
+      );
+
+      expect(threads.map((thread) => thread.id), <String>['T2']);
+    });
+
+    test('keeps author threads when the author is unknown', () {
+      final threads = pendingReviewThreads(
+        comments: <ReviewComment>[_comment('T1', author: 'leynier')],
+      );
+
+      expect(threads.map((thread) => thread.id), <String>['T1']);
+    });
+  });
+}
+
+ReviewComment _comment(
+  String? threadId, {
+  required String author,
+  String? path,
+  int? line,
+  bool resolved = false,
+  bool outdated = false,
+}) {
+  return ReviewComment(
+    id: 'thread:$threadId:$author',
+    author: author,
+    body: 'Please change this.',
+    createdAt: DateTime.utc(2026, 9, 12),
+    kind: threadId == null ? .conversation : .review,
+    path: path,
+    line: line,
+    resolved: resolved,
+    outdated: outdated,
+    locator: ReviewCommentLocator(
+      source: threadId == null ? .conversation : .reviewThread,
+      commentId: author,
+      parentId: threadId,
+    ),
+  );
+}

--- a/test/unit/settings_controller_test.dart
+++ b/test/unit/settings_controller_test.dart
@@ -5,6 +5,7 @@ import 'package:alera/src/features/settings/domain/alera_settings.dart';
 import 'package:alera/src/features/settings/domain/editor_syntax_theme_catalog.dart';
 import 'package:alera/src/features/settings/infra/drift_settings_repository.dart';
 import 'package:alera/src/shared/infra/storage/drift_database.dart';
+import 'package:alera/src/features/pull_requests/domain/pull_request_agent_watch_scope.dart';
 import 'package:drift/native.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -245,6 +246,9 @@ void main() {
         await controller.setShowTrayBadge(false);
         await controller.setShowPullRequestStatusInSidebar(false);
         await controller.setPullRequestFailureNotificationsEnabled(true);
+        await controller.setPullRequestAgentWatchScope(
+          const PullRequestAgentWatchScope(comments: false),
+        );
 
         final restored = await repository.load();
         expect(
@@ -282,6 +286,10 @@ void main() {
         expect(restored.general.showTrayBadge, isFalse);
         expect(restored.general.showPullRequestStatusInSidebar, isFalse);
         expect(restored.general.pullRequestFailureNotificationsEnabled, isTrue);
+        expect(
+          restored.general.pullRequestAgentWatchScope,
+          const PullRequestAgentWatchScope(comments: false),
+        );
       },
     );
 

--- a/test/widget/pull_request_review_agent_actions_test.dart
+++ b/test/widget/pull_request_review_agent_actions_test.dart
@@ -168,6 +168,52 @@ void main() {
     expect(watchCalls, 0);
   });
 
+  testWidgets('enables watch modes as soon as a scope is checked', (
+    tester,
+  ) async {
+    final watchFixScopes = <PullRequestAgentWatchScope>[];
+    await tester.pumpWidget(
+      _wrap(
+        agentWatchScope: const PullRequestAgentWatchScope(
+          checks: false,
+          comments: false,
+          conflicts: false,
+        ),
+        onWatchAndFix: watchFixScopes.add,
+      ),
+    );
+
+    await _openAskAgentMenu(tester);
+    await tester.tap(find.text('Merge Conflicts'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Watch and Fix'));
+    await tester.pumpAndSettle();
+    expect(watchFixScopes, <PullRequestAgentWatchScope>[
+      const PullRequestAgentWatchScope(checks: false, comments: false),
+    ]);
+  });
+
+  testWidgets('disables watch modes once every scope is unchecked', (
+    tester,
+  ) async {
+    var watchCalls = 0;
+    await tester.pumpWidget(_wrap(onWatchAndFix: (_) => watchCalls++));
+
+    await _openAskAgentMenu(tester);
+    for (final label in <String>[
+      'Failed Checks',
+      'Review Comments',
+      'Merge Conflicts',
+    ]) {
+      await tester.tap(find.text(label));
+      await tester.pumpAndSettle();
+    }
+    await tester.tap(find.text('Watch and Fix'), warnIfMissed: false);
+    await tester.pumpAndSettle();
+    expect(watchCalls, 0);
+    expect(find.text('Watch and Fix'), findsOneWidget);
+  });
+
   testWidgets('offers stop watching while a watch is active', (tester) async {
     var stopCalls = 0;
     await tester.pumpWidget(

--- a/test/widget/pull_request_review_agent_actions_test.dart
+++ b/test/widget/pull_request_review_agent_actions_test.dart
@@ -1,5 +1,6 @@
 import 'package:alera/src/features/pull_requests/domain/hosted_review.dart';
 import 'package:alera/src/features/pull_requests/domain/pull_request_agent_watch.dart';
+import 'package:alera/src/features/pull_requests/domain/pull_request_agent_watch_scope.dart';
 import 'package:alera/src/features/pull_requests/domain/review_check.dart';
 import 'package:alera/src/features/pull_requests/domain/review_check_details.dart';
 import 'package:alera/src/features/pull_requests/domain/review_comment.dart';
@@ -20,9 +21,12 @@ const _review = HostedReview(
 Widget _wrap({
   List<ReviewCheck> checks = const <ReviewCheck>[],
   PullRequestAgentWatchMode? agentWatchMode,
+  PullRequestAgentWatchScope agentWatchScope =
+      PullRequestAgentWatchScope.defaults,
+  ValueChanged<PullRequestAgentWatchScope>? onAgentWatchScopeChanged,
   VoidCallback? onFixFailedChecks,
-  VoidCallback? onWatchAndFix,
-  VoidCallback? onWatchFixAndMerge,
+  ValueChanged<PullRequestAgentWatchScope>? onWatchAndFix,
+  ValueChanged<PullRequestAgentWatchScope>? onWatchFixAndMerge,
   VoidCallback? onStopAgentWatch,
 }) {
   return MaterialApp(
@@ -46,6 +50,8 @@ Widget _wrap({
         onUpdate: (_) async => const UpdateReviewSuccess(_review),
         onLoadCheckDetails: (_) async => const ReviewCheckDetails(),
         agentWatchMode: agentWatchMode,
+        agentWatchScope: agentWatchScope,
+        onAgentWatchScopeChanged: onAgentWatchScopeChanged,
         onFixFailedChecks: onFixFailedChecks,
         onWatchAndFix: onWatchAndFix,
         onWatchFixAndMerge: onWatchFixAndMerge,
@@ -55,61 +61,140 @@ Widget _wrap({
   );
 }
 
+Future<void> _openAskAgentMenu(WidgetTester tester) async {
+  await tester.tap(find.byTooltip('Ask Agent'));
+  await tester.pumpAndSettle();
+}
+
 void main() {
-  testWidgets('offers failed-check dispatch and watch actions', (tester) async {
+  testWidgets('keeps the failed-check dispatch in the checks section', (
+    tester,
+  ) async {
     var fixCalls = 0;
-    var watchFixCalls = 0;
-    var watchMergeCalls = 0;
     await tester.pumpWidget(
       _wrap(
         checks: const <ReviewCheck>[
           ReviewCheck(name: 'build', status: .completed, conclusion: .failure),
         ],
         onFixFailedChecks: () => fixCalls++,
-        onWatchAndFix: () => watchFixCalls++,
-        onWatchFixAndMerge: () => watchMergeCalls++,
+        onWatchAndFix: (_) {},
       ),
     );
 
-    expect(find.text('Fix Failed Checks'), findsOneWidget);
     await tester.tap(find.text('Fix Failed Checks'));
     await tester.pump();
     expect(fixCalls, 1);
-
-    await tester.tap(find.byTooltip('Ask Agent'));
-    await tester.pumpAndSettle();
-    expect(find.text('Watch and Fix'), findsOneWidget);
-    expect(find.text('Watch, Fix and Merge'), findsOneWidget);
-    await tester.tap(find.text('Watch and Fix'));
-    await tester.pumpAndSettle();
-    expect(watchFixCalls, 1);
-    expect(watchMergeCalls, 0);
-
-    await tester.tap(find.byTooltip('Ask Agent'));
-    await tester.pumpAndSettle();
-    await tester.tap(find.text('Watch, Fix and Merge'));
-    await tester.pumpAndSettle();
-    expect(watchMergeCalls, 1);
   });
 
-  testWidgets('shows stop watching while a watch is active', (tester) async {
+  testWidgets('places Ask Agent in the pull request header', (tester) async {
+    await tester.pumpWidget(_wrap(onWatchAndFix: (_) {}));
+
+    final askAgent = tester.getTopLeft(find.byTooltip('Ask Agent'));
+    final openInBrowser = tester.getTopLeft(find.byTooltip('Open In Browser'));
+    final checksHeader = tester.getTopLeft(find.text('Checks'));
+    expect(askAgent.dy, openInBrowser.dy);
+    expect(askAgent.dy, lessThan(checksHeader.dy));
+  });
+
+  testWidgets('starts either watch mode with the chosen scope', (tester) async {
+    final watchFixScopes = <PullRequestAgentWatchScope>[];
+    final watchMergeScopes = <PullRequestAgentWatchScope>[];
+    await tester.pumpWidget(
+      _wrap(
+        onWatchAndFix: watchFixScopes.add,
+        onWatchFixAndMerge: watchMergeScopes.add,
+      ),
+    );
+
+    await _openAskAgentMenu(tester);
+    expect(find.text('Failed Checks'), findsOneWidget);
+    expect(find.text('Review Comments'), findsOneWidget);
+    expect(find.text('Merge Conflicts'), findsOneWidget);
+    await tester.tap(find.text('Watch and Fix'));
+    await tester.pumpAndSettle();
+    expect(watchFixScopes, <PullRequestAgentWatchScope>[
+      PullRequestAgentWatchScope.defaults,
+    ]);
+
+    await _openAskAgentMenu(tester);
+    await tester.tap(find.text('Watch, Fix and Merge'));
+    await tester.pumpAndSettle();
+    expect(watchMergeScopes, <PullRequestAgentWatchScope>[
+      PullRequestAgentWatchScope.defaults,
+    ]);
+  });
+
+  testWidgets('toggling a scope keeps the menu open', (tester) async {
+    final changes = <PullRequestAgentWatchScope>[];
+    final watchFixScopes = <PullRequestAgentWatchScope>[];
+    await tester.pumpWidget(
+      _wrap(
+        onAgentWatchScopeChanged: changes.add,
+        onWatchAndFix: watchFixScopes.add,
+      ),
+    );
+
+    await _openAskAgentMenu(tester);
+    await tester.tap(find.text('Review Comments'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Watch and Fix'), findsOneWidget);
+    expect(changes, <PullRequestAgentWatchScope>[
+      const PullRequestAgentWatchScope(comments: false),
+    ]);
+    await tester.tap(find.text('Watch and Fix'));
+    await tester.pumpAndSettle();
+    expect(watchFixScopes, <PullRequestAgentWatchScope>[
+      const PullRequestAgentWatchScope(comments: false),
+    ]);
+  });
+
+  testWidgets('disables watch modes for an empty scope', (tester) async {
+    var watchCalls = 0;
+    await tester.pumpWidget(
+      _wrap(
+        agentWatchScope: const PullRequestAgentWatchScope(
+          checks: false,
+          comments: false,
+          conflicts: false,
+        ),
+        onWatchAndFix: (_) => watchCalls++,
+      ),
+    );
+
+    await _openAskAgentMenu(tester);
+    await tester.tap(find.text('Watch and Fix'), warnIfMissed: false);
+    await tester.pumpAndSettle();
+    expect(watchCalls, 0);
+  });
+
+  testWidgets('offers stop watching while a watch is active', (tester) async {
     var stopCalls = 0;
     await tester.pumpWidget(
-      _wrap(agentWatchMode: .fix, onStopAgentWatch: () => stopCalls++),
+      _wrap(
+        checks: const <ReviewCheck>[
+          ReviewCheck(name: 'build', status: .completed, conclusion: .failure),
+        ],
+        agentWatchMode: .fix,
+        onFixFailedChecks: () {},
+        onStopAgentWatch: () => stopCalls++,
+      ),
     );
 
     expect(find.text('Watching: Fix'), findsOneWidget);
     expect(find.text('Fix Failed Checks'), findsNothing);
+    expect(find.byTooltip('Ask Agent'), findsNothing);
+    await tester.tap(find.byTooltip('Watching: Fix'));
+    await tester.pumpAndSettle();
     await tester.tap(find.text('Stop Watching'));
-    await tester.pump();
+    await tester.pumpAndSettle();
     expect(stopCalls, 1);
   });
 
-  testWidgets('shows stop watching for fix-and-merge mode', (tester) async {
+  testWidgets('labels fix-and-merge mode while watching', (tester) async {
     await tester.pumpWidget(
       _wrap(agentWatchMode: .fixAndMerge, onStopAgentWatch: () {}),
     );
     expect(find.text('Watching: Fix and Merge'), findsOneWidget);
-    expect(find.text('Stop Watching'), findsOneWidget);
   });
 }


### PR DESCRIPTION
Closes #755.

## Summary

Watch and Fix and Watch, Fix and Merge used to react only to failing checks. They now also dispatch the bound agent for unresolved review threads and merge conflicts, reusing the existing watcher, polling, and dispatch binding.

- **Scope:** the Ask Agent menu has checkboxes for Failed Checks, Review Comments, and Merge Conflicts (all on by default). The choice is stored in `GeneralSettings.pullRequestAgentWatchScope`. The control moved from the Checks header to the pull request header; the `Watching: ...` label sits under the title.
- **Pending threads:** unresolved, not outdated, and not written only by the pull request author. GitHub now requests `isOutdated`; GitLab and Azure DevOps have no equivalent, so their threads always count.
- **One combined prompt** per dispatch, naming every pending concern without comment bodies or CI logs. The checks-only prompt is unchanged. The agent resolves the threads it fixes; Alera only reads `resolved`.
- **Dedupe by watermark, not signature:** the watch re-dispatches only when something new appears (new head sha, new failure, new conflict, new thread id). A reviewer resolving a thread does not re-dispatch. `mergeable == unknown` is not a conflict, since GitHub recomputes it after every push.
- **Merge gate:** open, checks green, mergeable, new head sha, and no pending threads when Review Comments is in scope.
- `pollSignature` now includes `mergeable` and `resolved`, so those changes reset the poll interval.
- New design-system `AleraDropdownToggleEntry` (checkbox menu entry that does not close the menu) with its preview.

## Validation

- `dart run build_runner build`, EOF normalization, `dart format`, `dart analyze` on the changed files: clean.
- `flutter test`: 3280 passed, 1 skipped.
- `dart run tool/quality/check_max_lines.dart`: passes.
- Manual E2E still pending: resolving a thread must not re-dispatch, a real conflict against `main` must dispatch, and Watch, Fix and Merge must wait while a thread is pending.

## Risks

- Unchecking every scope while the menu is open does not disable the mode entries (a menu route does not rebuild); starting a watch then shows a toast and does nothing.
- Azure DevOps conversation threads count as pending because they are resolvable there; the author filter keeps self-notes out.
- If agents do not resolve threads on their own, the fix is a provider-specific hint in `pull_request_agent_prompts.dart`.
